### PR TITLE
fix: strengthen H3 K27-altered diffuse midline glioma evidence

### DIFF
--- a/kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml
+++ b/kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml
@@ -25,7 +25,7 @@ has_subtypes:
     The most common form, arising in the pons with characteristic diffuse
     infiltration of pontine structures. Presents with classic triad of cranial
     nerve deficits, ataxia, and long tract signs. Diagnosis often made on imaging
-    without biopsy. Median survival 9-11 months.
+    without biopsy. Median survival is less than 12 months.
   evidence:
   - reference: PMID:19338403
     reference_title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
@@ -345,8 +345,8 @@ treatments:
 - name: Radiation Therapy
   description: >-
     Focal radiation therapy (54-59.4 Gy) is the only treatment with established
-    benefit, providing temporary tumor control and symptom improvement. Typically
-    extends survival by 2-3 months compared to supportive care alone.
+    benefit, providing transient neurological improvement and progression-free
+    survival benefit without improving overall survival.
   treatment_term:
     preferred_term: radiation therapy
     term:
@@ -384,7 +384,7 @@ treatments:
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
     snippet: "Five (22.7%) patients, all of whom initiated ONC201 following radiation and prior to recurrence, were alive at 2 years from diagnosis."
-    explanation: This phase I pediatric trial showed ONC201 was well tolerated and provided an encouraging early survival signal, supporting it as a promising but still investigational treatment.
+    explanation: This phase I pediatric trial showed an encouraging early survival signal after ONC201 initiation following radiation, supporting it as a promising but still investigational treatment.
 notes: >-
   The WHO 2021 classification expanded this entity from H3 K27M-mutant to H3 K27-altered
   to include tumors with H3K27me3 loss through other mechanisms (e.g., EZHIP

--- a/kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml
+++ b/kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml
@@ -1,6 +1,6 @@
 name: Diffuse Midline Glioma, H3 K27-Altered
 creation_date: '2026-01-26T02:55:13Z'
-updated_date: '2026-04-03T00:00:00Z'
+updated_date: '2026-04-07T16:21:17Z'
 description: >-
   Diffuse midline glioma, H3 K27-altered, is a highly aggressive CNS tumor
   predominantly affecting children and young adults, arising in midline structures
@@ -26,16 +26,38 @@ has_subtypes:
     infiltration of pontine structures. Presents with classic triad of cranial
     nerve deficits, ataxia, and long tract signs. Diagnosis often made on imaging
     without biopsy. Median survival 9-11 months.
+  evidence:
+  - reference: PMID:19338403
+    reference_title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Diffuse intrinsic pontine gliomas constitute ~ 60-75% of tumors found within the pediatric brainstem. These malignant lesions present with rapidly progressive symptoms such as cranial nerve, long tract, or cerebellar dysfunctions."
+    explanation: This review identifies DIPG as the dominant pediatric brainstem glioma subtype and describes the rapidly progressive cranial nerve, long tract, and cerebellar presentation summarized in this subtype.
 - name: Thalamic H3 K27M-Mutant Glioma
   description: >-
-    H3 K27-altered glioma arising in the thalamus. May present with hemiparesis,
-    hydrocephalus, or cognitive changes. Bilateral thalamic involvement can occur.
-    Slightly better prognosis than DIPG in some series.
+    H3 K27-altered glioma arising in the thalamus, often in children,
+    adolescents, and younger adults. May present with hemiparesis,
+    hydrocephalus, or cognitive changes. Bilateral thalamic involvement can
+    occur.
+  evidence:
+  - reference: PMID:24285547
+    reference_title: "H3F3A K27M mutations in thalamic gliomas from young adult patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We found that high-grade thalamic gliomas from young adults, like those from children and adolescents, frequently had H3F3A K27M."
+    explanation: This thalamic glioma cohort directly establishes H3 K27M-altered thalamic tumors as a recognized midline subgroup enriched in younger patients.
 - name: Spinal Cord H3 K27M-Mutant Glioma
   description: >-
     H3 K27-altered glioma arising in the spinal cord. Presents with progressive
-    myelopathy. May have better prognosis than pontine tumors, particularly with
-    focal disease amenable to radiation.
+    sensory or motor deficits from intramedullary cord involvement. This subtype
+    is rare and clinically aggressive.
+  evidence:
+  - reference: PMID:35079510
+    reference_title: "Spinal Cord Diffuse Midline Glioma, H3K27M- mutant Effectively Treated with Bevacizumab: A Report of Two Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spinal cord DMG, H3K27M-mutant is relatively rare, with poor prognosis, and there are no effective treatment protocols."
+    explanation: This case report identifies spinal cord H3 K27M-mutant diffuse midline glioma as a rare aggressive spinal subtype.
 pathophysiology:
 - name: H3 K27M Oncohistone Mutation
   description: >-
@@ -156,6 +178,13 @@ phenotypes:
     term:
       id: HP:0006824
       label: Cranial nerve paralysis
+  evidence:
+  - reference: PMID:19338403
+    reference_title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These malignant lesions present with rapidly progressive symptoms such as cranial nerve, long tract, or cerebellar dysfunctions."
+    explanation: This review lists cranial nerve dysfunction among hallmark rapidly progressive DIPG symptoms, supporting cranial nerve palsy as a common neurological manifestation.
 - category: Neurological
   name: Ataxia
   frequency: VERY_FREQUENT
@@ -167,6 +196,13 @@ phenotypes:
     term:
       id: HP:0001251
       label: Ataxia
+  evidence:
+  - reference: PMID:19338403
+    reference_title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These malignant lesions present with rapidly progressive symptoms such as cranial nerve, long tract, or cerebellar dysfunctions."
+    explanation: Cerebellar dysfunction is a core presentation of DIPG and commonly manifests clinically as ataxia, supporting this phenotype.
 - category: Neurological
   name: Long Tract Signs
   frequency: VERY_FREQUENT
@@ -178,6 +214,13 @@ phenotypes:
     term:
       id: HP:0001269
       label: Hemiparesis
+  evidence:
+  - reference: PMID:19338403
+    reference_title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These malignant lesions present with rapidly progressive symptoms such as cranial nerve, long tract, or cerebellar dysfunctions."
+    explanation: This review identifies long tract dysfunction as a hallmark of DIPG presentation; in this entry it is represented by pyramidal weakness and hemiparesis.
 - category: Neurological
   name: Headache
   frequency: FREQUENT
@@ -255,23 +298,43 @@ genetic:
     with H3.3 K27M. Associated with worse prognosis.
 - name: PPM1D
   association: Somatic Mutation
+  evidence:
+  - reference: PMID:35105861
+    reference_title: "PPM1D mutations are oncogenic drivers of de novo diffuse midline glioma formation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "truncating mutations in PPM1D that increase the stability of its phosphatase are clonal driver events in 11% of Diffuse Midline Gliomas (DMGs) and are enriched in primary pontine tumors."
+    explanation: Human whole-genome analysis identifies truncating PPM1D mutations as recurrent clonal driver events in diffuse midline glioma, particularly pontine tumors.
   notes: >-
     PPM1D (protein phosphatase Mg2+/Mn2+ dependent 1D) truncating mutations occur
     in approximately 10-15% of DIPG, functionally similar to TP53 loss.
 - name: PDGFRA
   association: Amplification/Mutation
   evidence:
-  - reference: PMID:24705254
-    reference_title: "Genomic analysis of diffuse intrinsic pontine gliomas identifies three molecular subgroups and recurrent activating ACVR1 mutations."
+  - reference: PMID:23970477
+    reference_title: "Novel oncogenic PDGFRA mutations in pediatric high-grade gliomas."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "K27M-H3.3 with PDGFRA amplifications (OR = 8.0, p = 0.0127)"
-    explanation: "Reports significant co-occurrence of PDGFRA amplifications with H3.3 K27M mutations in DIPG."
+    snippet: "Genome-wide analyses of copy number imbalances previously showed that platelet-derived growth factor receptor α (PDGFRA) is the most frequent target of focal amplification in pediatric HGGs, including DIPGs."
+    explanation: This pediatric high-grade glioma study identifies PDGFRA as the most frequent focal amplification target in pediatric high-grade gliomas, including DIPG.
+  - reference: PMID:23970477
+    reference_title: "Novel oncogenic PDGFRA mutations in pediatric high-grade gliomas."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Somatic-activating mutations were identified in 14.4% (13 of 90) of nonbrainstem pediatric HGGs and 4.7% (2 of 43) of DIPGs, including missense mutations and in-frame deletions and insertions not previously described."
+    explanation: The same cohort study also documents activating PDGFRA mutations in DIPG, supporting the mutation component of this genetic association.
   notes: >-
     PDGFRA amplification or activating mutations occur in approximately 30% of
     DIPG. Drives proliferation through RTK signaling.
 - name: EZHIP
   association: Overexpression
+  evidence:
+  - reference: PMID:36882456
+    reference_title: "Histone H3-wild type diffuse midline gliomas with H3K27me3 loss are a distinct entity with exclusive EGFR or ACVR1 mutation and differential methylation of homeobox genes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We show that these tumours have recurrent and mutually exclusive mutations in either ACVR1 or EGFR and are characterised by high expression of EZHIP associated to its promoter hypomethylation."
+    explanation: This molecular profiling study shows that H3-wild-type H3K27me3-loss diffuse midline gliomas are marked by EZHIP overexpression, supporting EZHIP-driven H3 K27-altered disease in the absence of canonical H3 K27M mutations.
   notes: >-
     EZHIP (EZH inhibitory protein) overexpression can cause H3K27me3 loss in the
     absence of H3 K27M mutation. Defines a subset of H3 K27-altered tumors that
@@ -287,6 +350,13 @@ treatments:
     term:
       id: MAXO:0000014
       label: radiation therapy
+  evidence:
+  - reference: PMID:19338403
+    reference_title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Standard therapy involves radiotherapy, which produces transient neurological improvement with a progression-free survival benefit, but provides no improvement in overall survival."
+    explanation: This treatment review identifies radiotherapy as the standard modality for DIPG, providing temporary neurologic improvement and delaying progression without curing the disease.
 - name: Corticosteroids
   description: >-
     Dexamethasone reduces peritumoral edema and provides symptomatic relief.
@@ -306,6 +376,13 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  evidence:
+  - reference: PMID:36382108
+    reference_title: "Phase I dose escalation and expansion trial of single agent ONC201 in pediatric diffuse midline gliomas following radiotherapy."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Five (22.7%) patients, all of whom initiated ONC201 following radiation and prior to recurrence, were alive at 2 years from diagnosis."
+    explanation: This phase I pediatric trial showed ONC201 was well tolerated and provided an encouraging early survival signal, supporting it as a promising but still investigational treatment.
 notes: >-
   The WHO 2021 classification expanded this entity from H3 K27M-mutant to H3 K27-altered
   to include tumors with H3K27me3 loss through other mechanisms (e.g., EZHIP

--- a/kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml
+++ b/kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml
@@ -69,6 +69,7 @@ pathophysiology:
   - reference: PMID:41528563
     reference_title: "Early distant progression in adult Histone-3 K27-altered diffuse midline gliomas."
     supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
     snippet: H3 K27-altered diffuse midline glioma (DMG) is a molecularly defined, highly aggressive tumor entity since the 2016 revision of the World Health Organization (WHO) classification of tumors of the central nervous system (CNS).
     explanation: This abstract defines H3 K27-altered DMG as a molecularly defined aggressive entity, supporting the disease context for this mutation-driven tumor.
   cell_types:
@@ -162,6 +163,7 @@ histopathology:
   - reference: PMID:35169084
     reference_title: "[Diffuse midline glioma]."
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "Diffuse midline glioma(DMG), H3 K27M-mutant is an infiltrative midline"
     explanation: Abstract describes H3 K27M-mutant diffuse midline glioma as infiltrative and midline.
 

--- a/references_cache/PMID_19338403.md
+++ b/references_cache/PMID_19338403.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:19338403"
+title: "Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies."
+authors:
+- Frazier JL
+- Lee J
+- Thomale UW
+- Noggle JC
+- Cohen KJ
+- Jallo GI
+journal: J Neurosurg Pediatr
+year: '2009'
+doi: 10.3171/2008.11.PEDS08281
+keywords:
+- Animals
+- "Antineoplastic Agents/administration & dosage"
+- "Brain Stem Neoplasms/drug therapy, pathology, radiotherapy"
+- "Chemotherapy, Adjuvant"
+- Child
+- Drug Delivery Systems
+- "Glioma/drug therapy, pathology, radiotherapy"
+- Humans
+- "Radiotherapy, Adjuvant"
+- Rats
+- Treatment Failure
+content_type: abstract_only
+---
+
+# Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future strategies.
+**Authors:** Frazier JL, Lee J, Thomale UW, Noggle JC, Cohen KJ, Jallo GI
+**Journal:** J Neurosurg Pediatr (2009)
+**DOI:** [10.3171/2008.11.PEDS08281](https://doi.org/10.3171/2008.11.PEDS08281)
+
+## Content
+
+1. J Neurosurg Pediatr. 2009 Apr;3(4):259-69. doi: 10.3171/2008.11.PEDS08281.
+
+Treatment of diffuse intrinsic brainstem gliomas: failed approaches and future
+strategies.
+
+Frazier JL(1), Lee J, Thomale UW, Noggle JC, Cohen KJ, Jallo GI.
+
+Author information:
+(1)Departments of Neurosurgery, Johns Hopkins University School of Medicine,
+Baltimore, MD, USA.
+
+Comment in
+    J Neurosurg Pediatr. 2010 Jan;5(1):140-1; author reply 141-2. doi:
+10.3171/2009.5.PEDS09265.
+
+Diffuse intrinsic pontine gliomas constitute ~ 60-75% of tumors found within the
+pediatric brainstem. These malignant lesions present with rapidly progressive
+symptoms such as cranial nerve, long tract, or cerebellar dysfunctions. Magnetic
+resonance imaging is usually sufficient to establish the diagnosis and obviates
+the need for surgical biopsy in most cases. The prognosis of the disease is
+dismal, and the median survival is < 12 months. Resection is not a viable
+option. Standard therapy involves radiotherapy, which produces transient
+neurological improvement with a progression-free survival benefit, but provides
+no improvement in overall survival. Clinical trials have been conducted to
+assess the efficacy of chemotherapeutic and biological agents in the treatment
+of diffuse pontine gliomas. In this review, the authors discuss recent studies
+in which systemic therapy was administered prior to, concomitantly with, or
+after radiotherapy. For future perspective, the discussion includes a rationale
+for stereotactic biopsies as well as possible therapeutic options of local
+chemotherapy in these lesions.
+
+DOI: 10.3171/2008.11.PEDS08281
+PMID: 19338403 [Indexed for MEDLINE]

--- a/references_cache/PMID_23970477.md
+++ b/references_cache/PMID_23970477.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:23970477"
+title: Novel oncogenic PDGFRA mutations in pediatric high-grade gliomas.
+authors:
+- Paugh BS
+- Zhu X
+- Qu C
+- Endersby R
+- Diaz AK
+- Zhang J
+- Bax DA
+- Carvalho D
+- Reis RM
+- Onar-Thomas A
+- Broniscer A
+- Wetmore C
+- Zhang J
+- Jones C
+- Ellison DW
+- Baker SJ
+journal: Cancer Res
+year: '2013'
+doi: 10.1158/0008-5472.CAN-13-1491
+keywords:
+- Adolescent
+- Animals
+- "Brain Neoplasms/genetics, pathology"
+- Child
+- "Child, Preschool"
+- Gene Expression Profiling
+- Genome-Wide Association Study
+- "Glioma/genetics, pathology"
+- Humans
+- Mice
+- Mutation
+- "Receptor, Platelet-Derived Growth Factor alpha/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Novel oncogenic PDGFRA mutations in pediatric high-grade gliomas.
+**Authors:** Paugh BS, Zhu X, Qu C, Endersby R, Diaz AK, Zhang J, Bax DA, Carvalho D, Reis RM, Onar-Thomas A, Broniscer A, Wetmore C, Zhang J, Jones C, Ellison DW, Baker SJ
+**Journal:** Cancer Res (2013)
+**DOI:** [10.1158/0008-5472.CAN-13-1491](https://doi.org/10.1158/0008-5472.CAN-13-1491)
+
+## Content
+
+1. Cancer Res. 2013 Oct 15;73(20):6219-29. doi: 10.1158/0008-5472.CAN-13-1491.
+Epub  2013 Aug 22.
+
+Novel oncogenic PDGFRA mutations in pediatric high-grade gliomas.
+
+Paugh BS(1), Zhu X, Qu C, Endersby R, Diaz AK, Zhang J, Bax DA, Carvalho D, Reis
+RM, Onar-Thomas A, Broniscer A, Wetmore C, Zhang J, Jones C, Ellison DW, Baker
+SJ.
+
+Author information:
+(1)Authors' Affiliations: Departments of Developmental Neurobiology,
+Computational Biology, Biostatistics, Oncology, and Pathology, St. Jude
+Children's Research Hospital; Interdisciplinary Biomedical Science Program,
+University of Tennessee Health Sciences Center, Memphis, Tennessee; Telethon
+Institute for Child Health Research, Centre for Child Health Research, The
+University of Western Australia, Perth, Australia; Divisions of Molecular
+Pathology and Cancer Therapeutics, The Institute of Cancer Research, London,
+United Kingdom; and Molecular Oncology Research Center, Barretos Cancer
+Hospital, Barretos, São Paulo, Brazil.
+
+The outcome for children with high-grade gliomas (HGG) remains dismal, with a
+2-year survival rate of only 10% to 30%. Diffuse intrinsic pontine glioma (DIPG)
+comprise a subset of HGG that arise in the brainstem almost exclusively in
+children. Genome-wide analyses of copy number imbalances previously showed that
+platelet-derived growth factor receptor α (PDGFRA) is the most frequent target
+of focal amplification in pediatric HGGs, including DIPGs. To determine whether
+PDGFRA is also targeted by more subtle mutations missed by copy number analysis,
+we sequenced all PDGFRA coding exons from a cohort of pediatric HGGs.
+Somatic-activating mutations were identified in 14.4% (13 of 90) of nonbrainstem
+pediatric HGGs and 4.7% (2 of 43) of DIPGs, including missense mutations and
+in-frame deletions and insertions not previously described. Forty percent of
+tumors with mutation showed concurrent amplification, whereas 60% carried
+heterozygous mutations. Six different mutations impacting different domains all
+resulted in ligand-independent receptor activation that was blocked by small
+molecule inhibitors of PDGFR. Expression of mutants in p53-null primary mouse
+astrocytes conferred a proliferative advantage in vitro and generated HGGs in
+vivo with complete penetrance when implanted into brain. The gene expression
+signatures of these murine HGGs reflected the spectrum of human diffuse HGGs.
+PDGFRA intragenic deletion of exons 8 and 9 were previously shown in adult HGG,
+but were not detected in 83 nonbrainstem pediatric HGG and 57 DIPGs. Thus, a
+distinct spectrum of mutations confers constitutive receptor activation and
+oncogenic activity to PDGFRα in childhood HGG.
+
+©2013 AACR.
+
+DOI: 10.1158/0008-5472.CAN-13-1491
+PMCID: PMC3800209
+PMID: 23970477 [Indexed for MEDLINE]

--- a/references_cache/PMID_35079510.md
+++ b/references_cache/PMID_35079510.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:35079510"
+title: "Spinal Cord Diffuse Midline Glioma, H3K27M- mutant Effectively Treated with Bevacizumab: A Report of Two Cases."
+authors:
+- Yabuno S
+- Kawauchi S
+- Umakoshi M
+- Uneda A
+- Fujii K
+- Ishida J
+- Otani Y
+- Hattori Y
+- Tsuboi N
+- Kohno S
+- Noujima M
+- Toji T
+- Yanai H
+- Yasuhara T
+- Date I
+journal: NMC Case Rep J
+year: '2021'
+doi: 10.2176/nmccrj.cr.2021-0033
+content_type: abstract_only
+---
+
+# Spinal Cord Diffuse Midline Glioma, H3K27M- mutant Effectively Treated with Bevacizumab: A Report of Two Cases.
+**Authors:** Yabuno S, Kawauchi S, Umakoshi M, Uneda A, Fujii K, Ishida J, Otani Y, Hattori Y, Tsuboi N, Kohno S, Noujima M, Toji T, Yanai H, Yasuhara T, Date I
+**Journal:** NMC Case Rep J (2021)
+**DOI:** [10.2176/nmccrj.cr.2021-0033](https://doi.org/10.2176/nmccrj.cr.2021-0033)
+
+## Content
+
+1. NMC Case Rep J. 2021 Aug 21;8(1):505-511. doi: 10.2176/nmccrj.cr.2021-0033.
+eCollection 2021.
+
+Spinal Cord Diffuse Midline Glioma, H3K27M- mutant Effectively Treated with
+Bevacizumab: A Report of Two Cases.
+
+Yabuno S(1), Kawauchi S(1), Umakoshi M(1), Uneda A(1), Fujii K(1), Ishida J(1),
+Otani Y(1), Hattori Y(2), Tsuboi N(1), Kohno S(3), Noujima M(4), Toji T(4),
+Yanai H(4), Yasuhara T(1), Date I(1).
+
+Author information:
+(1)Department of Neurological Surgery, Okayama University Graduate School of
+Medicine, Dentistry, and Pharmaceutical Sciences, Okayama, Okayama, Japan.
+(2)Department of Neurological Surgery, Sumitomo Besshi Hospital, Niihama, Ehime,
+Japan.
+(3)Department of Neurosurgery, Japanese Red Cross Society Himeji Hospital,
+Himeji, Hyogo, Japan.
+(4)Department of Diagnostic Pathology, Okayama University Graduate School of
+Medicine, Dentistry, and Pharmaceutical Sciences, Okayama, Okayama, Japan.
+
+"Diffuse midline glioma (DMG), H3K27M-mutant" was newly classified in the
+revised World Health Organization (WHO) 2016 classification of central nervous
+system tumors. Spinal cord DMG, H3K27M-mutant is relatively rare, with poor
+prognosis, and there are no effective treatment protocols. In this study, we
+report two cases of spinal cord DMG, H3K27M-mutant treated with bevacizumab. The
+two patients were women in their 40s who initially presented with sensory
+impairment. MRI showed spinal intramedullary tumors, and each patient underwent
+laminectomy/laminoplasty and biopsy of the tumors. Histological examination
+initially suggested low-grade astrocytoma in case 1 and glioblastoma in case 2.
+Upon further immunohistochemical examination in case 1 and molecular examination
+in case 2, however, both cases were diagnosed as DMG, H3K27M-mutant. Case 1 was
+treated with radiation therapy and temozolomide (TMZ) chemotherapy, which
+induced a transient improvement of symptoms; 3 months after surgery, however,
+the patient's symptoms rapidly deteriorated. MRI showed tumor enlargement with
+edema to the medulla. Triweekly administration of bevacizumab improved her
+symptoms for the following 12 months. Case 2 was treated with bevacizumab from
+the beginning because of acute deterioration of breathing. After bevacizumab
+administration, both cases showed tumor regression on MRI and drastic
+improvement of symptoms within a few days. Although spinal cord DMG,
+H3K27M-mutant has an aggressive clinical course and poor prognosis, bevacizumab
+administration may offer the significant clinical benefit of alleviating edema,
+which improves patient's capacity for activities of daily life.
+
+© 2021 The Japan Neurosurgical Society.
+
+DOI: 10.2176/nmccrj.cr.2021-0033
+PMCID: PMC8769434
+PMID: 35079510
+
+Conflict of interest statement: Conflicts of Interest Disclosure The authors
+declare that they have no conflict of interest.

--- a/references_cache/PMID_35105861.md
+++ b/references_cache/PMID_35105861.md
@@ -1,0 +1,196 @@
+---
+reference_id: "PMID:35105861"
+title: PPM1D mutations are oncogenic drivers of de novo diffuse midline glioma formation.
+authors:
+- Khadka P
+- Reitman ZJ
+- Lu S
+- Buchan G
+- Gionet G
+- Dubois F
+- Carvalho DM
+- Shih J
+- Zhang S
+- Greenwald NF
+- Zack T
+- Shapira O
+- Pelton K
+- Hartley R
+- Bear H
+- Georgis Y
+- Jarmale S
+- Melanson R
+- Bonanno K
+- Schoolcraft K
+- Miller PG
+- Condurat AL
+- Gonzalez EM
+- Qian K
+- Morin E
+- Langhnoja J
+- Lupien LE
+- Rendo V
+- Digiacomo J
+- Wang D
+- Zhou K
+- Kumbhani R
+- Guerra Garcia ME
+- Sinai CE
+- Becker S
+- Schneider R
+- Vogelzang J
+- Krug K
+- Goodale A
+- Abid T
+- Kalani Z
+- Piccioni F
+- Beroukhim R
+- Persky NS
+- Root DE
+- Carcaboso AM
+- Ebert BL
+- Fuller C
+- Babur O
+- Kieran MW
+- Jones C
+- Keshishian H
+- Ligon KL
+- Carr SA
+- Phoenix TN
+- Bandopadhayay P
+journal: Nat Commun
+year: '2022'
+doi: 10.1038/s41467-022-28198-8
+keywords:
+- Adolescent
+- Adult
+- Animals
+- Brain Stem Neoplasms/genetics
+- Carcinogenesis/genetics
+- Cell Cycle
+- Child
+- "Child, Preschool"
+- DNA Damage
+- "Disease Models, Animal"
+- Female
+- Glioma/genetics
+- HEK293 Cells
+- Humans
+- Infant
+- Male
+- Mice
+- Mutation
+- Oncogenes/genetics
+- Protein Phosphatase 2C/genetics
+- Proto-Oncogene Proteins c-mdm2
+- Transcriptome
+- Tumor Suppressor Protein p53/genetics
+- Young Adult
+content_type: abstract_only
+---
+
+# PPM1D mutations are oncogenic drivers of de novo diffuse midline glioma formation.
+**Authors:** Khadka P, Reitman ZJ, Lu S, Buchan G, Gionet G, Dubois F, Carvalho DM, Shih J, Zhang S, Greenwald NF, Zack T, Shapira O, Pelton K, Hartley R, Bear H, Georgis Y, Jarmale S, Melanson R, Bonanno K, Schoolcraft K, Miller PG, Condurat AL, Gonzalez EM, Qian K, Morin E, Langhnoja J, Lupien LE, Rendo V, Digiacomo J, Wang D, Zhou K, Kumbhani R, Guerra Garcia ME, Sinai CE, Becker S, Schneider R, Vogelzang J, Krug K, Goodale A, Abid T, Kalani Z, Piccioni F, Beroukhim R, Persky NS, Root DE, Carcaboso AM, Ebert BL, Fuller C, Babur O, Kieran MW, Jones C, Keshishian H, Ligon KL, Carr SA, Phoenix TN, Bandopadhayay P
+**Journal:** Nat Commun (2022)
+**DOI:** [10.1038/s41467-022-28198-8](https://doi.org/10.1038/s41467-022-28198-8)
+
+## Content
+
+1. Nat Commun. 2022 Feb 1;13(1):604. doi: 10.1038/s41467-022-28198-8.
+
+PPM1D mutations are oncogenic drivers of de novo diffuse midline glioma
+formation.
+
+Khadka P(#)(1)(2)(3), Reitman ZJ(#)(4)(5)(6), Lu S(7), Buchan G(7), Gionet G(7),
+Dubois F(1)(2), Carvalho DM(8), Shih J(2), Zhang S(2), Greenwald NF(1), Zack
+T(1), Shapira O(1), Pelton K(9), Hartley R(10), Bear H(11), Georgis Y(7),
+Jarmale S(7), Melanson R(2), Bonanno K(2), Schoolcraft K(9), Miller PG(2)(12),
+Condurat AL(7), Gonzalez EM(2)(7), Qian K(7), Morin E(7), Langhnoja J(10),
+Lupien LE(7), Rendo V(1), Digiacomo J(7), Wang D(7), Zhou K(7), Kumbhani R(7),
+Guerra Garcia ME(5), Sinai CE(9), Becker S(9), Schneider R(9), Vogelzang J(9),
+Krug K(2), Goodale A(2), Abid T(2), Kalani Z(2), Piccioni F(2), Beroukhim
+R(1)(2), Persky NS(2), Root DE(2), Carcaboso AM(13), Ebert BL(2)(12)(14), Fuller
+C(15), Babur O(16), Kieran MW(7)(17), Jones C(8), Keshishian H(2), Ligon KL(9),
+Carr SA(2), Phoenix TN(18)(19), Bandopadhayay P(20)(21)(22).
+
+Author information:
+(1)Department of Cancer Biology, Dana Farber Cancer Institute, Boston, MA,
+02215, USA.
+(2)Broad Institute of MIT and Harvard, Cambridge, MA, 02142, USA.
+(3)Harvard Biological and Biomedical Sciences PhD Program, Harvard University,
+Cambridge, MA, 02138, USA.
+(4)Department of Radiation Oncology, Duke University, Durham, NC, 27710, USA.
+(5)Duke Cancer Institute, Duke University, Durham, NC, 27710, USA.
+(6)The Preston Robert Tisch Brain Tumor Center at Duke, Duke University, Durham,
+NC, 27710, USA.
+(7)Dana-Farber/Boston Children's Cancer and Blood Disorders Center, Boston, MA,
+02215, USA.
+(8)Division of Molecular Pathology, Institute of Cancer Research, London, UK.
+(9)Department of Oncologic Pathology, Dana Farber Cancer Institute, Boston, MA,
+02215, USA.
+(10)Division of Pharmaceutical Sciences, James L. Winkle College of Pharmacy,
+University of Cincinnati, Cincinnati, OH, 45267, USA.
+(11)Research in Patient Services, Cincinnati Children's Hospital Medical Center,
+Cincinnati, OH, 45267, USA.
+(12)Department of Medical Oncology, Dana-Farber Cancer Institute, Boston, MA,
+02215, USA.
+(13)Department of Pediatric Hematology and Oncology, Hospital Sant Joan de Deu,
+Institut de Recerca Sant Joan de Deu, Barcelona, 08950, Spain.
+(14)Howard Hughes Medical Institute, Chevy Chase, MD, 20815, USA.
+(15)Department of Pathology, Cincinnati Children's Hospital Medical Center,
+Cincinnati, OH, 45267, USA.
+(16)College of Science and Mathematics, University of Massachusetts Boston,
+Boston, MA, 02125, USA.
+(17)Bristol Myers Squibb, Boston, Devens, MA, 01434, USA.
+(18)Division of Pharmaceutical Sciences, James L. Winkle College of Pharmacy,
+University of Cincinnati, Cincinnati, OH, 45267, USA. phoenity@ucmail.uc.edu.
+(19)Research in Patient Services, Cincinnati Children's Hospital Medical Center,
+Cincinnati, OH, 45267, USA. phoenity@ucmail.uc.edu.
+(20)Broad Institute of MIT and Harvard, Cambridge, MA, 02142, USA.
+Pratiti_bandopadhayay@dfci.harvard.edu.
+(21)Dana-Farber/Boston Children's Cancer and Blood Disorders Center, Boston, MA,
+02215, USA. Pratiti_bandopadhayay@dfci.harvard.edu.
+(22)Department of Pediatrics, Harvard Medical School, Boston, MA, 02215, USA.
+Pratiti_bandopadhayay@dfci.harvard.edu.
+(#)Contributed equally
+
+The role of PPM1D mutations in de novo gliomagenesis has not been systematically
+explored. Here we analyze whole genome sequences of 170 pediatric high-grade
+gliomas and find that truncating mutations in PPM1D that increase the stability
+of its phosphatase are clonal driver events in 11% of Diffuse Midline Gliomas
+(DMGs) and are enriched in primary pontine tumors. Through the development of
+DMG mouse models, we show that PPM1D mutations potentiate gliomagenesis and that
+PPM1D phosphatase activity is required for in vivo oncogenesis. Finally, we
+apply integrative phosphoproteomic and functional genomics assays and find that
+oncogenic effects of PPM1D truncation converge on regulators of cell cycle, DNA
+damage response, and p53 pathways, revealing therapeutic vulnerabilities
+including MDM2 inhibition.
+
+© 2022. The Author(s).
+
+DOI: 10.1038/s41467-022-28198-8
+PMCID: PMC8807747
+PMID: 35105861 [Indexed for MEDLINE]
+
+Conflict of interest statement: R.B. and P.B. receive grant funding from the
+Novartis Institute of Biomedical Research for an unrelated project. P.B. has
+received grant funding from Deerfield and reports a consulting role for QED
+Therapeutics, R.B. reports consulting or advisory role for Novartis, Merck (I),
+Gilead Sciences (I), ViiV Healthcare (I); research funding from Novartis;
+patents, royalties, other intellectual property—Prognostic Marker for
+Endometrial Carcinoma (US patent application 13/911456, filed June 6, 2013),
+SF3B1 Suppression as a Therapy for Tumors Harboring SF3B1 Copy Loss
+(international application No. WO/2017/177191, PCT/US2017/026693, filed July 4,
+2017), Compositions and Methods for Screening Pediatric Gliomas and Methods of
+Treatment Thereof (international application No. WO/2017/132574,
+PCT/US2017/015448, filed 1/27/2017). M.W.K. is now an employee of Bristol-Myers
+Squibb. F.P. is now an employee of Merck Research Laboratories. S.A.C. is a
+member of the scientific advisory boards of Kymera, PTM BioLabs and Seer and a
+scientific advisor to Pfizer and Biogen. D.E.R. receives research funding from
+Abbvie, Jannsen, Merck, and Vir through the Functional Genomics Consortium and
+serves on the board of directors of Addgene. B.L.E. has received research
+funding from Celgene and Deerfield. He has also received consulting fees from
+GRAIL, and he serves on the scientific advisory boards for and holds equity in
+Skyhawk Therapeutics and Exo Therapeutics. (I) denotes a competing interest
+involving a first degree relative of the author. All the remaining authors
+declare no competing interests.

--- a/references_cache/PMID_36382108.md
+++ b/references_cache/PMID_36382108.md
@@ -1,0 +1,110 @@
+---
+reference_id: "PMID:36382108"
+title: Phase I dose escalation and expansion trial of single agent ONC201 in pediatric diffuse midline gliomas following radiotherapy.
+authors:
+- Gardner SL
+- Tarapore RS
+- Allen J
+- McGovern SL
+- Zaky W
+- Odia Y
+- Daghistani D
+- Diaz Z
+- Hall MD
+- Khatib Z
+- Koschmann C
+- Cantor E
+- Kurokawa R
+- MacDonald TJ
+- Aguilera D
+- Vitanza NA
+- Mueller S
+- Kline C
+- Lu G
+- Allen JE
+- Khatua S
+journal: Neurooncol Adv
+year: '2022'
+doi: 10.1093/noajnl/vdac143
+content_type: abstract_only
+---
+
+# Phase I dose escalation and expansion trial of single agent ONC201 in pediatric diffuse midline gliomas following radiotherapy.
+**Authors:** Gardner SL, Tarapore RS, Allen J, McGovern SL, Zaky W, Odia Y, Daghistani D, Diaz Z, Hall MD, Khatib Z, Koschmann C, Cantor E, Kurokawa R, MacDonald TJ, Aguilera D, Vitanza NA, Mueller S, Kline C, Lu G, Allen JE, Khatua S
+**Journal:** Neurooncol Adv (2022)
+**DOI:** [10.1093/noajnl/vdac143](https://doi.org/10.1093/noajnl/vdac143)
+
+## Content
+
+1. Neurooncol Adv. 2022 Sep 13;4(1):vdac143. doi: 10.1093/noajnl/vdac143.
+eCollection 2022 Jan-Dec.
+
+Phase I dose escalation and expansion trial of single agent ONC201 in pediatric
+diffuse midline gliomas following radiotherapy.
+
+Gardner SL(1)(2)(3), Tarapore RS(4)(5), Allen J(1), McGovern SL(3), Zaky W(3),
+Odia Y(6), Daghistani D(6), Diaz Z(6), Hall MD(6)(7)(8), Khatib Z(9), Koschmann
+C(10), Cantor E(10)(11), Kurokawa R(10), MacDonald TJ(12), Aguilera D(12),
+Vitanza NA(13)(14), Mueller S(15), Kline C(16)(17), Lu G(4), Allen JE(4)(5),
+Khatua S(18).
+
+Author information:
+(1)NYU Langone Medical Center and School of Medicine, New York, NY, USA.
+(2)Department of Pediatrics, NYU Grossman School of Medicine, New York, NY, USA.
+(3)The University of Texas MD Anderson Cancer Center, Houston, TX, USA.
+(4)Clinical Development, Oncoceutics, Philadelphia, PA, USA.
+(5)Clinical Development, Chimerix Inc., Durham, NC, USA.
+(6)Miami Cancer Institute, Baptist Health South Florida, Miami, FL, USA.
+(7)Department of Radiation Oncology, Nicklaus Children's Hospital, Miami, FL,
+USA.
+(8)Department of Radiation Oncology, Miami Cancer Institute, Baptist Health
+South Florida, Miami, FL, USA.
+(9)Department of Neuro-Oncology, Nicklaus Children's Hospital, Miami, FL.
+(10)Michigan Medicine, University of Michigan Medical School, Ann Arbor, MI,
+USA.
+(11)University of Connecticut School of Medicine, Farmington, CT.
+(12)Children's Healthcare of Atlanta, Emory University School of Medicine,
+Atlanta, GA, USA.
+(13)Ben Towne Center for Childhood Cancer Research, Seattle Children's Research
+Institute, Seattle, WA, USA.
+(14)Department of Pediatrics, Seattle Children's Hospital, University of
+Washington, Seattle, WA, USA.
+(15)Department of Neurology, Neurosurgery and Pediatrics, University of
+California San Francisco.
+(16)Department of Pediatrics, University of California San Francisco, San
+Francisco, CA, USA.
+(17)Department of Neurology, University of California San Francisco, San
+Francisco, CA, USA.
+(18)Pediatric Hematology/Oncology, Mayo Clinic, Rochester, MN, USA.
+
+BACKGROUND: ONC201, a dopamine receptor D2 (DRD2) antagonist and caseinolytic
+protease P (ClpP) agonist, has induced durable tumor regressions in adults with
+recurrent H3 K27M-mutant glioma. We report results from the first phase I
+pediatric clinical trial of ONC201.
+METHODS: This open-label, multi-center clinical trial (NCT03416530) of ONC201
+for pediatric H3 K27M-mutant diffuse midline glioma (DMG) or diffuse intrinsic
+pontine glioma (DIPG) employed a dose-escalation and dose-expansion design. The
+primary endpoint was the recommended phase II dose (RP2D). A standard 3 + 3 dose
+escalation design was implemented. The target dose was the previously
+established adult RP2D (625 mg), scaled by body weight. Twenty-two pediatric
+patients with DMG/DIPG were treated following radiation; prior lines of systemic
+therapy in addition to radiation were permitted providing sufficient time had
+elapsed prior to study treatment.
+RESULTS: The RP2D of orally administered ONC201 in this pediatric population was
+determined to be the adult RP2D (625 mg), scaled by body weight; no
+dose-limiting toxicities (DLT) occurred. The most frequent treatment-emergent
+Grade 1-2 AEs were headache, nausea, vomiting, dizziness and increase in alanine
+aminotransferase. Pharmacokinetics were determined following the first dose: T
+1/2, 8.4 h; T max, 2.1 h; C max, 2.3 µg/mL; AUC0-tlast, 16.4 hµg/mL. Median
+duration of treatment was 20.6 weeks (range 5.1-129). Five (22.7%) patients, all
+of whom initiated ONC201 following radiation and prior to recurrence, were alive
+at 2 years from diagnosis.
+CONCLUSIONS: The adult 625 mg weekly RP2D of ONC201 scaled by body weight was
+well tolerated. Further investigation of ONC201 for DMG/DIPG is warranted.
+
+© The Author(s) 2022. Published by Oxford University Press, the Society for
+Neuro-Oncology and the European Association of Neuro-Oncology.
+
+DOI: 10.1093/noajnl/vdac143
+PMCID: PMC9639395
+PMID: 36382108

--- a/references_cache/PMID_36882456.md
+++ b/references_cache/PMID_36882456.md
@@ -1,0 +1,138 @@
+---
+reference_id: "PMID:36882456"
+title: Histone H3-wild type diffuse midline gliomas with H3K27me3 loss are a distinct entity with exclusive EGFR or ACVR1 mutation and differential methylation of homeobox genes.
+authors:
+- Ajuyah P
+- Mayoh C
+- Lau LMS
+- Barahona P
+- Wong M
+- Chambers H
+- Valdes-Mora F
+- Senapati A
+- Gifford AJ
+- "D'Arcy C"
+- Hansford JR
+- Manoharan N
+- Nicholls W
+- Williams MM
+- Wood PJ
+- Cowley MJ
+- Tyrrell V
+- Haber M
+- Ekert PG
+- Ziegler DS
+- Khuong-Quang DA
+journal: Sci Rep
+year: '2023'
+doi: 10.1038/s41598-023-30395-4
+keywords:
+- Child
+- Humans
+- "Genes, Homeobox"
+- Histones/genetics
+- Methylation
+- Glioma/genetics
+- Mutation
+- ErbB Receptors/genetics
+- "Activin Receptors, Type I"
+content_type: abstract_only
+---
+
+# Histone H3-wild type diffuse midline gliomas with H3K27me3 loss are a distinct entity with exclusive EGFR or ACVR1 mutation and differential methylation of homeobox genes.
+**Authors:** Ajuyah P, Mayoh C, Lau LMS, Barahona P, Wong M, Chambers H, Valdes-Mora F, Senapati A, Gifford AJ, D'Arcy C, Hansford JR, Manoharan N, Nicholls W, Williams MM, Wood PJ, Cowley MJ, Tyrrell V, Haber M, Ekert PG, Ziegler DS, Khuong-Quang DA
+**Journal:** Sci Rep (2023)
+**DOI:** [10.1038/s41598-023-30395-4](https://doi.org/10.1038/s41598-023-30395-4)
+
+## Content
+
+1. Sci Rep. 2023 Mar 7;13(1):3775. doi: 10.1038/s41598-023-30395-4.
+
+Histone H3-wild type diffuse midline gliomas with H3K27me3 loss are a distinct
+entity with exclusive EGFR or ACVR1 mutation and differential methylation of
+homeobox genes.
+
+Ajuyah P(#)(1), Mayoh C(#)(1)(2)(3), Lau LMS(1)(2)(3)(4), Barahona P(1), Wong
+M(1)(2)(3), Chambers H(5), Valdes-Mora F(1)(2), Senapati A(4), Gifford
+AJ(1)(2)(6), D'Arcy C(5), Hansford JR(7)(8)(9)(10)(11)(12)(13), Manoharan
+N(2)(4), Nicholls W(14), Williams MM(7), Wood PJ(15), Cowley MJ(1)(2)(3),
+Tyrrell V(1)(2), Haber M(1)(2)(3), Ekert PG(1)(2)(3)(16)(17), Ziegler
+DS(#)(18)(19)(20)(21), Khuong-Quang DA(#)(22)(23).
+
+Author information:
+(1)Lowy Cancer Research Centre, Children's Cancer Institute, UNSW Sydney,
+Kensington, NSW, Australia.
+(2)School of Clinical Medicine, UNSW Medicine & Health, UNSW Sydney, Kensington,
+NSW, Australia.
+(3)University of New South Wales Centre for Childhood Cancer Research, UNSW,
+Kensington, NSW, Australia.
+(4)Kids Cancer Centre, Sydney Children's Hospital, High Street, Randwick, NSW,
+2031, Australia.
+(5)Department of Anatomical Pathology, Royal Children's Hospital, University of
+Melbourne, Melbourne, VIC, Australia.
+(6)Anatomical Pathology, NSW Health Pathology, Prince of Wales Hospital,
+Randwick, NSW, Australia.
+(7)Children's Cancer Centre, Royal Children's Hospital, 50 Flemington Road,
+Parkville, VIC, 3052, Australia.
+(8)Murdoch Children's Research Institute, Royal Children's Hospital, Parkville,
+VIC, Australia.
+(9)Department of Paediatrics, University of Melbourne, Parkville, VIC,
+Australia.
+(10)Michael Rice Cancer Centre, Women's and Children's Hospital, Adelaide, SA,
+Australia.
+(11)South Australia Health and Medical Research Institute, Adelaide, SA,
+Australia.
+(12)South Australia Immunogenomics Cancer Institute, Adelaide, SA, Australia.
+(13)University of Adelaide, Adelaide, SA, Australia.
+(14)Oncology Service, Children's Health Queensland Hospital & Health Service,
+Brisbane, QLD, Australia.
+(15)Department of Paediatrics, School of Clinical Sciences at Monash Health,
+Monash University, Clayton, VIC, Australia.
+(16)Cancer Immunology Program, Peter MacCallum Cancer Centre, Parkville, VIC,
+Australia.
+(17)The Sir Peter MacCallum Department of Oncology, University of Melbourne,
+Parkville, VIC, Australia.
+(18)Lowy Cancer Research Centre, Children's Cancer Institute, UNSW Sydney,
+Kensington, NSW, Australia. d.ziegler@unsw.edu.au.
+(19)School of Clinical Medicine, UNSW Medicine & Health, UNSW Sydney,
+Kensington, NSW, Australia. d.ziegler@unsw.edu.au.
+(20)University of New South Wales Centre for Childhood Cancer Research, UNSW,
+Kensington, NSW, Australia. d.ziegler@unsw.edu.au.
+(21)Kids Cancer Centre, Sydney Children's Hospital, High Street, Randwick, NSW,
+2031, Australia. d.ziegler@unsw.edu.au.
+(22)Children's Cancer Centre, Royal Children's Hospital, 50 Flemington Road,
+Parkville, VIC, 3052, Australia. donganh.khuongquang@rch.org.au.
+(23)Murdoch Children's Research Institute, Royal Children's Hospital, Parkville,
+VIC, Australia. donganh.khuongquang@rch.org.au.
+(#)Contributed equally
+
+Diffuse midline gliomas (DMG) harbouring H3K27M mutation are paediatric tumours
+with a dismal outcome. Recently, a new subtype of midline gliomas has been
+described with similar features to DMG, including loss of H3K27 trimethylation,
+but lacking the canonical H3K27M mutation (H3-WT). Here, we report a cohort of
+five H3-WT tumours profiled by whole-genome sequencing, RNA sequencing and DNA
+methylation profiling and combine their analysis with previously published
+cases. We show that these tumours have recurrent and mutually exclusive
+mutations in either ACVR1 or EGFR and are characterised by high expression of
+EZHIP associated to its promoter hypomethylation. Affected patients share a
+similar poor prognosis as patients with H3K27M DMG. Global molecular analysis
+of H3-WT and H3K27M DMG reveal distinct transcriptome and methylome profiles
+including differential methylation of homeobox genes involved in development and
+cellular differentiation. Patients have distinct clinical features, with a trend
+demonstrating ACVR1 mutations occurring in H3-WT tumours at an older age. This
+in-depth exploration of H3-WT tumours further characterises this novel DMG,
+H3K27-altered sub-group, characterised by a specific immunohistochemistry
+profile with H3K27me3 loss, wild-type H3K27M and positive EZHIP. It also gives
+new insights into the possible mechanism and pathway regulation in these
+tumours, potentially opening new therapeutic avenues for these tumours which
+have no known effective treatment. This study has been retrospectively
+registered on clinicaltrial.gov on 8 November 2017 under the registration number
+NCT03336931 ( https://clinicaltrials.gov/ct2/show/NCT03336931 ).
+
+© 2023. The Author(s).
+
+DOI: 10.1038/s41598-023-30395-4
+PMCID: PMC9992705
+PMID: 36882456 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.


### PR DESCRIPTION
## Summary
- strengthen the rereview target for issue #903: `H3_K27_Altered_Diffuse_Midline_Glioma.yaml`
- add validated evidence for the remaining unsupported genetic entries (`PPM1D`, `EZHIP`) and replace the residual weak `PDGFRA` support with abstract-backed evidence
- add evidence to all three listed subtypes, core presenting phenotypes, and the supported treatment items (`Radiation Therapy`, `ONC201`)
- update `updated_date` and cache the new PMID references required for deterministic validation

## Why
Issue #903 re-reviewed merged PR #847. That PR fixed the reviewer-blocked genetic snippet problems, but it left the disorder entry with major compliance gaps in subtype, phenotype, treatment, and remaining genetic evidence coverage. This follow-up improves the disorder entry directly.

## Validation
- `just validate kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml`
- `just validate-references kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml`
- `just validate-terms kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml`
- `just compliance kb/disorders/H3_K27_Altered_Diffuse_Midline_Glioma.yaml` → weighted compliance `83.1%` (up from `61.1%` before this fix)

## Not Changed
- left unrelated local modifications (`cache/...`, `references_cache/clinicaltrials_*.md`) unstaged and out of this PR
- did not try to fill every remaining gap; `datasets`, some `pathophysiology` / `downstream` evidence, `Corticosteroids`, `Headache`, `Diplopia`, and classification evidence remain for future follow-up

Closes #903
