### PR TITLE
Dependency updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ dynamic = ["version"]
 dependencies = [
   "beautifulsoup4>=4.14.3",
   "httpx>=0.28.1",
-  "koza>=2.2.0",
+  "koza>=2.3.1",
   "linkml-data-qc[viz]",
-  "linkml-reference-validator>=0.1.7",
+  "linkml-reference-validator>=0.1.8",
   "linkml-runtime >=1.9.4",
   "linkml-term-validator>=0.4.0rc1",
   "ndex2>=3.9.0,<4",
@@ -38,7 +38,7 @@ dev = [
     "mkdocs-material>=8.2.8",
     "jupyter>=1.0.0",
     "mknotebooks>=0.8.0",
-    "deep-research-client[cyberian]>=0.2.3",
+    "deep-research-client[cyberian]>=0.2.4",
 ]
 export = [
     "biolink-model>=4.3.1",


### PR DESCRIPTION
Tighten pins on deep-research-client, linkml-reference-validator, and koza.