### PR TITLE
Apply spatial_extent=EXTENSIVE to LETM phenotype in NMOSD

### DIFF
--- a/kb/disorders/Neuromyelitis_Optica_Spectrum_Disorder.yaml
+++ b/kb/disorders/Neuromyelitis_Optica_Spectrum_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Neuromyelitis Optica Spectrum Disorder
 creation_date: '2026-01-15T00:00:04Z'
-updated_date: '2026-02-27T21:53:01Z'
+updated_date: '2026-04-10T00:00:00Z'
 category: Neurological Disorder
 parents:
 - Autoimmune Disorder
@@ -153,16 +153,16 @@ phenotypes:
     for NMOSD.
   frequency: VERY_FREQUENT
   phenotype_term:
-    preferred_term: myelitis
+    preferred_term: longitudinally extensive transverse myelitis
     term:
       id: HP:0012486
       label: Myelitis
+    spatial_extent: EXTENSIVE
   notes: >
-    Annotated with general HP:0012486 (Myelitis) as HPO lacks a specific term
-    for longitudinally extensive myelitis. The spatial extent qualifier
-    "longitudinally extensive" (≥3 vertebral segments) is documented in the
-    description and name fields. See issue #222 for schema enhancement to
-    support spatial extent qualifiers.
+    HPO lacks a specific term for longitudinally extensive transverse myelitis,
+    so the general HP:0012486 (Myelitis) is used together with the
+    spatial_extent=EXTENSIVE qualifier (≥3 contiguous vertebral segments).
+    A more specific preferred_term conveys the clinical concept.
   evidence:
   - reference: PMID:26092914
     reference_title: "International consensus diagnostic criteria for neuromyelitis optica spectrum disorders."
@@ -348,13 +348,11 @@ treatments:
 datasets:
 references:
 - reference: DOI:10.1038/s41598-024-53661-5
-  title: Anti-aquaporin-4 immune complex stimulates complement-dependent Th17
-    cytokine release in neuromyelitis optica spectrum disorders
+  title: Anti-aquaporin-4 immune complex stimulates complement-dependent Th17 cytokine release in neuromyelitis optica spectrum disorders
   findings: []
 - reference: DOI:10.3390/ijms251910625
   title: Blood–Brain Barrier Disruption in Neuroimmunological Disease
   findings: []
 - reference: DOI:10.4103/nrr.nrr-d-23-01325
-  title: 'Aquaporin-4-IgG-seropositive neuromyelitis optica spectrum disorders: progress
-    of experimental models based on disease pathogenesis'
+  title: 'Aquaporin-4-IgG-seropositive neuromyelitis optica spectrum disorders: progress of experimental models based on disease pathogenesis'
   findings: []


### PR DESCRIPTION
## Summary

- The `SpatialExtentEnum` and `Descriptor.spatial_extent` slot were added in PR #188 to address this issue's schema need, but the canonical use case the issue calls out — NMOSD's "Longitudinally Extensive Transverse Myelitis" phenotype — was still using the workaround note referencing #222.
- This PR applies `spatial_extent: EXTENSIVE` to the LETM `phenotype_term` in `Neuromyelitis_Optica_Spectrum_Disorder.yaml`, promotes `preferred_term` to the clinically specific "longitudinally extensive transverse myelitis", and rewrites the `notes` paragraph to describe the new annotation (rather than pointing at an unresolved issue).

The base HPO anchor (`HP:0012486` Myelitis) is unchanged — HPO still lacks a specific LETM term, and `spatial_extent` is exactly the qualifier slot designed for this gap.

## Test plan

- [x] `just validate kb/disorders/Neuromyelitis_Optica_Spectrum_Disorder.yaml` — schema, term, and reference validation all pass
- [x] Pre-commit yamlfix/yamllint/codespell pass

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)