### PR TITLE
docs: define therapeutic_agent pattern for pharmacotherapy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,93 @@ Use OAK to search for MAXO terms:
 uv run runoak -i sqlite:obo:maxo search "physical therapy"
 ```
 
+#### Therapeutic Agent Pattern (drug + drug class on pharmacotherapy)
+
+MAXO treatment terms describe the **medical action** (e.g., pharmacotherapy, chemotherapy,
+vaccination) but not the specific agent involved. When the action is generic but a
+specific drug or drug class is involved, combine the MAXO action term with the
+`therapeutic_agent` slot, which is multivalued and bindable to CHEBI (for specific drugs)
+or NCIT (for drug classes).
+
+**When to use `therapeutic_agent`:**
+- `treatment_term` is a generic MAXO action like `MAXO:0000058` (pharmacotherapy),
+  `MAXO:0000647` (chemotherapy), `MAXO:0001017` (vaccination), or `MAXO:0000014` (radiation therapy)
+- A specific drug, chemical, or drug class is referenced in the `name` / `description`
+- You want the treatment to be machine-queryable by drug identity
+
+**Ontology selection:**
+- **CHEBI**: preferred for specific small-molecule drugs (`CHEBI:36796` duloxetine, `CHEBI:46345` 5-fluorouracil)
+- **NCIT**: use for drug classes, or for biologics/newer drugs that lack a CHEBI term
+  (`NCIT:C20401` Monoclonal Antibody, `NCIT:C2322` Corticosteroid, `NCIT:C65216` Adalimumab)
+- Leave `therapeutic_agent` absent when the treatment is non-pharmacological
+  (surgery, physical therapy, counseling, dietary intervention — use `dietary_modifications` for the latter)
+
+**Example — single specific drug (CHEBI):**
+```yaml
+treatments:
+- name: Duloxetine
+  description: SNRI, FDA-approved for fibromyalgia chronic pain management.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: duloxetine
+      term:
+        id: CHEBI:36796
+        label: duloxetine
+```
+
+**Example — drug class (NCIT) when CHEBI is too specific:**
+```yaml
+treatments:
+- name: Anti-TNF Biologic Therapy
+  description: TNF inhibitors such as adalimumab or infliximab.
+  treatment_term:
+    preferred_term: anti-TNF biologic therapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: monoclonal antibody
+      term:
+        id: NCIT:C20401
+        label: Monoclonal Antibody
+```
+
+**Example — combination therapy (multivalued):**
+```yaml
+treatments:
+- name: FOLFIRINOX
+  description: Combination chemotherapy regimen for pancreatic adenocarcinoma.
+  treatment_term:
+    preferred_term: chemotherapy
+    term:
+      id: MAXO:0000647
+      label: chemotherapy
+    therapeutic_agent:
+    - preferred_term: fluorouracil
+      term:
+        id: CHEBI:46345
+        label: 5-fluorouracil
+    - preferred_term: irinotecan
+      term:
+        id: CHEBI:80630
+        label: irinotecan
+    - preferred_term: oxaliplatin
+      term:
+        id: CHEBI:31941
+        label: oxaliplatin
+```
+
+**Guidelines:**
+- `therapeutic_agent` is optional at the schema level but **recommended whenever `treatment_term` is MAXO:0000058** or another generic action term where a specific drug is involved.
+- Use OAK to verify CHEBI terms: `uv run runoak -i sqlite:obo:chebi search "duloxetine"`
+- For NCIT drug-class terms, the local `ncit` adapter is configured in `conf/oak_config.yaml`.
+- A dedicated `treatment.name` (e.g., "Duloxetine") should still match common clinical usage; `therapeutic_agent` carries the machine-readable identifier.
+- Do NOT put the drug name in `preferred_term` on `treatment_term` — `preferred_term` describes the action (pharmacotherapy), `therapeutic_agent.preferred_term` describes the agent.
+
 ### Subtype Naming Conventions
 
 The `name` field on `Subtype` (in `has_subtypes`) serves as the **foreign key target** — other sections


### PR DESCRIPTION
## Summary

- Adds a dedicated **"Therapeutic Agent Pattern"** subsection to `CLAUDE.md` under `### Treatment Terms (MAXO)`.
- Documents *when* and *how* to populate the existing `TreatmentDescriptor.therapeutic_agent` slot alongside a generic MAXO action term (pharmacotherapy, chemotherapy, vaccination, radiation therapy).
- No schema changes — the `therapeutic_agent` slot has existed for a while and is already in use in ~140 disorder files. This PR closes the documentation gap that has kept adoption inconsistent.

## What the new section covers

1. **When to use `therapeutic_agent`** — generic MAXO action + specific drug/class referenced in name/description.
2. **Ontology selection:**
   - CHEBI for specific small-molecule drugs (`CHEBI:36796` duloxetine, `CHEBI:46345` 5-fluorouracil)
   - NCIT for drug classes and biologics lacking CHEBI terms (`NCIT:C20401` Monoclonal Antibody, `NCIT:C2322` Corticosteroid, `NCIT:C65216` Adalimumab)
3. **Three worked examples:**
   - Single CHEBI drug (Duloxetine)
   - NCIT drug class (Monoclonal Antibody for anti-TNF therapy)
   - Multivalued combination therapy (FOLFIRINOX — fluorouracil + irinotecan + oxaliplatin)
4. **Guidelines** clarifying that `preferred_term` on `treatment_term` describes the *action* while `preferred_term` on `therapeutic_agent` describes the *agent*.

## Verification

All 7 CURIEs referenced in the new section were verified via OAK before committing, to avoid enshrining hallucinated terms in documentation:

```
CHEBI:36796  duloxetine               ✓
CHEBI:46345  5-fluorouracil           ✓
CHEBI:80630  irinotecan               ✓
CHEBI:31941  oxaliplatin              ✓
NCIT:C20401  Monoclonal Antibody      ✓
NCIT:C2322   Corticosteroid           ✓
NCIT:C65216  Adalimumab               ✓
```

(Initial draft of the section had three incorrect CURIEs copied from memory; those were caught and corrected by running `runoak info` against each ID before commit.)

## Intentionally out of scope

- Backfilling `therapeutic_agent` on the hundreds of pharmacotherapy entries that lack it (separate follow-up).
- Schema constraint making `therapeutic_agent` required when `treatment_term.id == MAXO:0000058` (mentioned as "optional" in the triage thread).
- Compliance/dashboard metric tracking `therapeutic_agent` coverage.

The issue explicitly scopes this PR to pattern definition; those larger items are listed as medium-term follow-ups in the issue discussion.

## Test plan

- [x] `CLAUDE.md` renders as intended (manually reviewed final section)
- [x] All CHEBI CURIEs verified via `runoak -i sqlite:obo:chebi info`
- [x] All NCIT CURIEs verified via `runoak -i sqlite:obo:ncit info`
- [x] Pre-commit hooks pass (trailing whitespace, EOF, codespell)
- [x] No schema or code changed, so no validation run required

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)