### PR TITLE
Add structured genetics slots (relationship_type, variant_origin)

### DIFF
--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -279,6 +279,101 @@ enums:
         description: >-
           A cluster of regulatory elements that controls expression of a
           gene cluster (e.g., the beta-globin LCR).
+  GeneDiseaseRelationshipEnum:
+    description: >-
+      The qualitative relationship between a gene (or locus) and a disease.
+      Use to constrain the free-text `association` slot to a controlled
+      vocabulary aligned with ClinGen gene-disease validity concepts and
+      common cancer/somatic driver classifications. The free-text
+      `association` slot may still be used for narrative detail.
+    permissible_values:
+      CAUSATIVE:
+        title: Causative
+        description: >-
+          Variants in the gene are sufficient to cause the disease in a
+          mendelian or near-mendelian sense (corresponds to ClinGen
+          "Definitive" or "Strong" gene-disease validity).
+      RISK_FACTOR:
+        title: Risk factor
+        description: >-
+          Variants in the gene increase risk of disease but are neither
+          necessary nor sufficient to cause it. Includes common-variant
+          associations and HLA risk alleles.
+      PROTECTIVE:
+        title: Protective
+        description: >-
+          Variants in the gene reduce the risk or severity of disease.
+      MODIFIER:
+        title: Modifier
+        description: >-
+          Variants in the gene modify the severity, age of onset, or
+          expressivity of disease without being a primary driver.
+      SUSCEPTIBILITY:
+        title: Susceptibility
+        description: >-
+          Variants in the gene confer susceptibility to disease in
+          combination with other genetic or environmental factors. Used
+          for polygenic susceptibility loci such as GWAS hits.
+      SOMATIC_DRIVER:
+        title: Somatic driver
+        description: >-
+          Somatic alterations in the gene drive tumor initiation or
+          progression (e.g., recurrent oncogenic drivers in cancer).
+      COOPERATING:
+        title: Cooperating alteration
+        description: >-
+          Co-occurring somatic or germline alterations that cooperate with
+          a primary driver to shape disease behavior or therapy response.
+      BIOMARKER:
+        title: Biomarker
+        description: >-
+          Gene whose expression, mutation, or amplification status serves
+          as a diagnostic, prognostic, or predictive biomarker without a
+          required causal role.
+      DISPUTED:
+        title: Disputed
+        description: >-
+          Reported gene-disease association whose validity is contested
+          (corresponds to ClinGen "Disputed" or "Refuted").
+      UNKNOWN:
+        title: Unknown
+        description: >-
+          The relationship between the gene and the disease is unclear or
+          not yet classified.
+  VariantOriginEnum:
+    description: >-
+      The origin of variation in a gene with respect to a disease entry.
+      Bound to GENO allele origin terms.
+    permissible_values:
+      GERMLINE:
+        title: Germline
+        description: germline allele origin
+        notes:
+          - Variant present in the germline (inherited or constitutional).
+        meaning: GENO:0000888
+      SOMATIC:
+        title: Somatic
+        description: somatic allele origin
+        notes:
+          - Variant acquired in somatic tissue after fertilization.
+        meaning: GENO:0000882
+      DE_NOVO:
+        title: De novo
+        description: de novo allele origin
+        notes:
+          - Variant arising as a new mutation in the proband, not present in parents.
+        meaning: GENO:0000880
+      GERMLINE_AND_SOMATIC:
+        title: Germline and somatic
+        description: >-
+          The gene is implicated by both germline and somatic variants in
+          the disease (e.g., tumor suppressors with two-hit mechanisms).
+      UNKNOWN:
+        title: Unknown
+        description: unknown allele origin
+        notes:
+          - Origin of the variant is unspecified or not determined.
+        meaning: GENO:0000881
   ModifierEnum:
     description: Qualifiers for direction, intensity, or pathological state of a descriptor
     permissible_values:
@@ -1456,9 +1551,27 @@ slots:
     range: string
     multivalued: true
   association:
+    description: >-
+      Free-text descriptor of how the gene is associated with the disease.
+      For a controlled vocabulary, also set `relationship_type`.
     examples:
       - value: Susceptibility
     range: string
+  relationship_type:
+    description: >-
+      Controlled-vocabulary classification of the gene-disease relationship
+      (e.g., causative, risk factor, modifier, somatic driver). Use this in
+      addition to the free-text `association` slot when possible.
+    examples:
+      - value: RISK_FACTOR
+    range: GeneDiseaseRelationshipEnum
+  variant_origin:
+    description: >-
+      The origin of disease-associated variation in this gene (germline,
+      somatic, de novo, or both). Bound to GENO allele origin terms.
+    examples:
+      - value: SOMATIC
+    range: VariantOriginEnum
   inheritance:
     examples:
       - value: Autosomal Dominant
@@ -3190,6 +3303,8 @@ classes:
       - presence
       - evidence
       - association
+      - relationship_type
+      - variant_origin
       - review_notes
       - subtype
       - frequency

--- a/tests/test_genetic_schema.py
+++ b/tests/test_genetic_schema.py
@@ -1,0 +1,121 @@
+"""Tests for the structured genetics slots/enums added for issue #126.
+
+These tests pin down the data-model improvements that constrain the
+previously free-text `association` slot in the `Genetic` class to a
+controlled vocabulary, and add a `variant_origin` slot bound to GENO
+allele origin terms.
+"""
+
+from pathlib import Path
+
+import pytest
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml_runtime.utils.schemaview import SchemaView
+
+ROOT_DIR = Path(__file__).parent.parent
+SCHEMA_PATH = ROOT_DIR / "src" / "dismech" / "schema" / "dismech.yaml"
+
+
+@pytest.fixture(scope="module")
+def schema_view() -> SchemaView:
+    return SchemaView(str(SCHEMA_PATH))
+
+
+@pytest.fixture(scope="module")
+def validator() -> Validator:
+    # Use closed=True so unknown enum values are flagged as errors. This is
+    # required to demonstrate that the new enum constraints actually bite.
+    return Validator(
+        SCHEMA_PATH,
+        validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+    )
+
+
+def test_gene_disease_relationship_enum_defined(schema_view):
+    """The new GeneDiseaseRelationshipEnum exists with the expected values."""
+    enum = schema_view.get_enum("GeneDiseaseRelationshipEnum")
+    assert enum is not None
+    expected = {
+        "CAUSATIVE",
+        "RISK_FACTOR",
+        "PROTECTIVE",
+        "MODIFIER",
+        "SUSCEPTIBILITY",
+        "SOMATIC_DRIVER",
+        "COOPERATING",
+        "BIOMARKER",
+        "DISPUTED",
+        "UNKNOWN",
+    }
+    actual = set(enum.permissible_values.keys())
+    missing = expected - actual
+    assert not missing, f"Missing enum values: {missing}"
+
+
+def test_variant_origin_enum_bound_to_geno(schema_view):
+    """VariantOriginEnum exists and binds GERMLINE/SOMATIC to GENO terms."""
+    enum = schema_view.get_enum("VariantOriginEnum")
+    assert enum is not None
+    pvs = enum.permissible_values
+    assert "GERMLINE" in pvs and "SOMATIC" in pvs
+    # GENO bindings verified via OAK against sqlite:obo:geno
+    assert pvs["GERMLINE"].meaning == "GENO:0000888"
+    assert pvs["SOMATIC"].meaning == "GENO:0000882"
+    assert pvs["DE_NOVO"].meaning == "GENO:0000880"
+    assert pvs["UNKNOWN"].meaning == "GENO:0000881"
+
+
+def test_genetic_class_has_new_slots(schema_view):
+    """The Genetic class includes the new structured slots."""
+    cls = schema_view.get_class("Genetic")
+    assert cls is not None
+    induced = schema_view.class_induced_slots("Genetic")
+    slot_names = {s.name for s in induced}
+    assert "relationship_type" in slot_names
+    assert "variant_origin" in slot_names
+    # Free-text association slot is preserved for backward compatibility
+    assert "association" in slot_names
+
+
+def test_genetic_record_validates_with_structured_fields(validator):
+    """A minimal Disease using the new structured fields validates."""
+    disease = {
+        "name": "Test Disease For Issue 126",
+        "genetic": [
+            {
+                "name": "BRCA1",
+                "association": "Germline pathogenic loss-of-function variants",
+                "relationship_type": "CAUSATIVE",
+                "variant_origin": "GERMLINE",
+            },
+            {
+                "name": "TP53",
+                "relationship_type": "SOMATIC_DRIVER",
+                "variant_origin": "SOMATIC",
+            },
+            {
+                "name": "HLA-B51",
+                "relationship_type": "RISK_FACTOR",
+            },
+        ],
+    }
+    report = validator.validate(disease, target_class="Disease")
+    errors = [r for r in report.results if r.severity.name == "ERROR"]
+    assert not errors, f"Unexpected validation errors: {[str(e) for e in errors]}"
+
+
+def test_invalid_relationship_type_rejected(validator):
+    """An out-of-vocabulary relationship_type fails validation."""
+    disease = {
+        "name": "Test Disease Invalid",
+        "genetic": [
+            {
+                "name": "FOO",
+                "relationship_type": "TOTALLY_MADE_UP_VALUE",
+            }
+        ],
+    }
+    report = validator.validate(disease, target_class="Disease")
+    errors = [r for r in report.results if r.severity.name == "ERROR"]
+    assert errors, "Expected validation error for invalid relationship_type"


### PR DESCRIPTION
## Summary
- Adds `GeneDiseaseRelationshipEnum` (CAUSATIVE, RISK_FACTOR, PROTECTIVE, MODIFIER, SUSCEPTIBILITY, SOMATIC_DRIVER, COOPERATING, BIOMARKER, DISPUTED, UNKNOWN) — a controlled vocabulary aligned with ClinGen gene-disease validity concepts to constrain the previously free-text `association` slot on `Genetic`.
- Adds `VariantOriginEnum` (GERMLINE, SOMATIC, DE_NOVO, GERMLINE_AND_SOMATIC, UNKNOWN) bound to GENO allele origin terms (`GENO:0000888`, `GENO:0000882`, `GENO:0000880`, `GENO:0000881`).
- Wires two new slots, `relationship_type` and `variant_origin`, into the `Genetic` class. Free-text `association` is preserved for backward compatibility, so all 55 existing disorder files validate unchanged.
- New `tests/test_genetic_schema.py` covers enum definition, slot wiring, GENO bindings, and positive/negative validation (the negative test uses `JsonschemaValidationPlugin(closed=True)` so out-of-vocabulary values are rejected).

## Why
Per the original review comment in #88, the genetics section needed "better data model support for terms for genetics component of yaml". Today the `association` slot is a free string that mixes (a) gene-disease relationship type, (b) variant origin (germline vs somatic), and (c) mutation mechanism — making cross-disorder comparison and downstream filtering impossible. Adding structured slots alongside the existing free-text descriptor lets curators incrementally adopt the new vocabulary without breaking any data.

## What I deliberately did NOT do
- I did not migrate existing disorder files. The new slots are additive; backfilling the 55 files is a separate, larger task.
- I did not bind `GeneDiseaseRelationshipEnum` values to ontology meanings. ClinGen gene-disease validity is not in an OBO ontology, and I did not want to fabricate IDs.
- I did not modify `Variant.regulatory_category` (the existing mutation-mechanism enum). That slot is at the variant level; this PR addresses the gene-disease level only.

## Test plan
- [x] `uv run pytest tests/test_genetic_schema.py` — all 5 new tests pass
- [x] `uv run pytest tests/test_data.py` — 2987 existing tests pass (no KB regressions)
- [x] `just validate-terms-schema` — new GENO bindings validate cleanly (warning count drops 22 → 18; remaining 18 are pre-existing)

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)