### PR TITLE
feat: add optional evidence_type ECO term slot to EvidenceItem

### DIFF
--- a/conf/oak_config.yaml
+++ b/conf/oak_config.yaml
@@ -45,6 +45,9 @@ ontology_adapters:
   # NCI Thesaurus (cancer/treatment concepts, large ~506MB database)
   NCIT: sqlite:obo:ncit
 
+  # Evidence & Conclusion Ontology (evidence type annotations on EvidenceItem)
+  ECO: sqlite:obo:eco
+
   # Exposure ontologies
   ECTO: sqlite:obo:ecto
   ExO: sqlite:obo:ecto  # ExO is bundled with ECTO

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -29,6 +29,7 @@ prefixes:
   ICD10CM: http://purl.obolibrary.org/obo/ICD10CM_
   icd11f: http://purl.obolibrary.org/obo/icd11f_
   NCIT: http://purl.obolibrary.org/obo/NCIT_
+  ECO: http://purl.obolibrary.org/obo/ECO_
   OPL: http://purl.obolibrary.org/obo/OPL_
   GENO: http://purl.obolibrary.org/obo/GENO_
   ECTO: http://purl.obolibrary.org/obo/ECTO_
@@ -374,6 +375,17 @@ enums:
     reachable_from:
       source_nodes:
         - OBI:0000070  ## assay
+      is_direct: false
+      relationship_types:
+        - rdfs:subClassOf
+  EvidenceTypeTerm:
+    description: >-
+      A term from the Evidence & Conclusion Ontology (ECO) characterising
+      the type of evidence used to support a statement (e.g., author statement,
+      experimental assay, computational inference).
+    reachable_from:
+      source_nodes:
+        - ECO:0000000  ## evidence
       is_direct: false
       relationship_types:
         - rdfs:subClassOf
@@ -1100,6 +1112,21 @@ slots:
     description: Origin of the evidence item (human clinical, model organism, in vitro, or computational)
     range: EvidenceSourceEnum
     recommended: false
+  evidence_type:
+    description: >-
+      Optional ontology-grounded evidence type annotation from the Evidence & Conclusion
+      Ontology (ECO). Complements `evidence_source` with richer, fine-grained provenance
+      (e.g., "author statement supported from referenced clinical study"). Usable as a
+      filtering mechanism when propagating evidence into downstream knowledge graphs.
+    range: Term
+    inlined: true
+    recommended: false
+    examples:
+      - value: "ECO:0006016"
+    bindings:
+      - binds_value_of: id
+        range: EvidenceTypeTerm
+        obligation_level: RECOMMENDED
   snippet:
     description: An exact excerpt/quote from the referenced publication that supports or refutes the claim
     examples:
@@ -2932,6 +2959,7 @@ classes:
       - reference_title
       - supports
       - evidence_source
+      - evidence_type
       - snippet
       - explanation
   CausalEdge:


### PR DESCRIPTION
## Summary

- Adds an optional `evidence_type` slot on `EvidenceItem`, bound to a new dynamic `EvidenceTypeTerm` enum rooted at `ECO:0000000` (evidence)
- Complements the existing `evidence_source` enum with richer ontology-grounded evidence typing (e.g., `ECO:0006016` "author statement supported from referenced clinical study") — usable as a filtering mechanism when propagating evidence into downstream KGs
- Registers the `ECO` prefix in the schema and adds `ECO: sqlite:obo:eco` to `conf/oak_config.yaml` so `linkml-term-validator` can validate ECO references

## Scope

Purely additive. No existing disorder files need changes. The slot is optional and `recommended: false`.

## Prior art

PR monarch-initiative/dismech#512 by @sierra-moxon implemented essentially the same change on 2026-03-04 but is currently in `CONFLICTING` merge state after ~1030 commits on main. This PR is a clean, rebased implementation of the same idea so maintainers have a mergeable option. Happy to close this in favor of #512 if it gets rebased.

Differences vs #512 (minor):
- Slot binding is attached at slot definition (via `bindings:`) rather than `slot_usage` — either works, definition-level binding is slightly more discoverable
- Adds `inlined: true` so nested `{id, label}` deserialisation matches the existing `term` slot convention
- Includes an example value on the slot

## Validation

- `uv run linkml-validate --schema src/dismech/schema/dismech.yaml --target-class Disease kb/disorders/Asthma.yaml` → No issues found
- `uv run linkml-validate` on Sickle_Cell_Disease.yaml → No issues found
- `uv run gen-pydantic src/dismech/schema/dismech.yaml` → succeeds
- `uv run pytest tests/test_data.py` → 2987 passed
- SchemaView confirms `EvidenceItem` now exposes `evidence_type` with range `Term` and the enum resolves to `EvidenceTypeTerm` (reachable_from `ECO:0000000`)

## Out of scope (intentional)

Not bundling #222 (mapping `EvidenceSourceEnum` permissible values → ECO `meaning` fields). That was suggested in the triage note on #510 as related work but is a separate change; keeping this PR tightly scoped.

## Test plan

- [x] Schema loads and validates
- [x] pytest test_data suite passes
- [x] Pydantic generation succeeds
- [ ] CI term-validation picks up ECO adapter via `conf/oak_config.yaml`
- [ ] Full `just validate-all` in CI

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)