### PR TITLE
Support multiple subtypes on phenotype/biochemical entries

### DIFF
--- a/src/dismech/datamodel/dismech.py
+++ b/src/dismech/datamodel/dismech.py
@@ -1,5 +1,5 @@
 # Auto generated from dismech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-06T12:41:14
+# Generation date: 2026-04-10T17:39:19
 # Schema: dismech
 #
 # id: https://w3id.org/monarch-initiative/dismech
@@ -2315,6 +2315,7 @@ class Phenotype(YAMLRoot):
     severity: Optional[str] = None
     notes: Optional[str] = None
     subtype: Optional[str] = None
+    subtypes: Optional[Union[str, list[str]]] = empty_list()
     phenotype_contexts: Optional[Union[Union[dict, PhenotypeContext], list[Union[dict, PhenotypeContext]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -2358,6 +2359,10 @@ class Phenotype(YAMLRoot):
         if self.subtype is not None and not isinstance(self.subtype, str):
             self.subtype = str(self.subtype)
 
+        if not isinstance(self.subtypes, list):
+            self.subtypes = [self.subtypes] if self.subtypes is not None else []
+        self.subtypes = [v if isinstance(v, str) else str(v) for v in self.subtypes]
+
         if not isinstance(self.phenotype_contexts, list):
             self.phenotype_contexts = [self.phenotype_contexts] if self.phenotype_contexts is not None else []
         self.phenotype_contexts = [v if isinstance(v, PhenotypeContext) else PhenotypeContext(**as_dict(v)) for v in self.phenotype_contexts]
@@ -2383,6 +2388,7 @@ class Biochemical(YAMLRoot):
     notes: Optional[str] = None
     context: Optional[str] = None
     subtype: Optional[str] = None
+    subtypes: Optional[Union[str, list[str]]] = empty_list()
     cell_types: Optional[Union[Union[dict, CellTypeDescriptor], list[Union[dict, CellTypeDescriptor]]]] = empty_list()
     assays: Optional[Union[Union[dict, AssayDescriptor], list[Union[dict, AssayDescriptor]]]] = empty_list()
     mappings_list: Optional[Union[Union[dict, ModelVariableDescriptor], list[Union[dict, ModelVariableDescriptor]]]] = empty_list()
@@ -2415,6 +2421,10 @@ class Biochemical(YAMLRoot):
 
         if self.subtype is not None and not isinstance(self.subtype, str):
             self.subtype = str(self.subtype)
+
+        if not isinstance(self.subtypes, list):
+            self.subtypes = [self.subtypes] if self.subtypes is not None else []
+        self.subtypes = [v if isinstance(v, str) else str(v) for v in self.subtypes]
 
         if not isinstance(self.cell_types, list):
             self.cell_types = [self.cell_types] if self.cell_types is not None else []

--- a/src/dismech/datamodel/dismech_pydantic.py
+++ b/src/dismech/datamodel/dismech_pydantic.py
@@ -1,4 +1,4 @@
-from __future__ import annotations 
+from __future__ import annotations
 
 import re
 import sys
@@ -7,8 +7,8 @@ from datetime import (
     datetime,
     time
 )
-from decimal import Decimal 
-from enum import Enum 
+from decimal import Decimal
+from enum import Enum
 from typing import (
     Any,
     ClassVar,
@@ -6868,9 +6868,10 @@ class Pathophysiology(ConfiguredBaseModel):
                        'Pathophysiology',
                        'AnimalModel'],
          'examples': [{'value': '[{preferred_term: HLA-DQ2}, {preferred_term: INS}]'}]} })
-    subtypes: Optional[list[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'subtypes',
-         'domain_of': ['Pathophysiology'],
-         'examples': [{'value': "['DENV-1', 'DENV-2', 'DENV-3', 'DENV-4']"}]} })
+    subtypes: Optional[list[str]] = Field(default=None, description="""Names of subtypes (foreign keys to this disease's `has_subtypes[].name`) associated with a phenotype, biochemical finding, pathophysiology node, or other subtyped entry. Use this multivalued form when an item is characteristic of more than one subtype with overlapping features. For single-subtype associations, the scalar `subtype` slot may still be used.""", json_schema_extra = { "linkml_meta": {'alias': 'subtypes',
+         'domain_of': ['Pathophysiology', 'Phenotype', 'Biochemical'],
+         'examples': [{'value': "['DENV-1', 'DENV-2', 'DENV-3', 'DENV-4']"},
+                      {'value': "['Type 1', 'Type 2']"}]} })
     cellular_components: Optional[list[CellularComponentDescriptor]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'cellular_components',
          'domain_of': ['Pathophysiology'],
          'examples': [{'value': '[{preferred_term: Peroxisome}]'}]} })
@@ -7161,6 +7162,10 @@ class Phenotype(ConfiguredBaseModel):
                        'HistopathologyFinding',
                        'Genetic'],
          'examples': [{'value': 'Eyelid Myoclonia with Absences'}]} })
+    subtypes: Optional[list[str]] = Field(default=None, description="""Names of subtypes (foreign keys to this disease's `has_subtypes[].name`) associated with a phenotype, biochemical finding, pathophysiology node, or other subtyped entry. Use this multivalued form when an item is characteristic of more than one subtype with overlapping features. For single-subtype associations, the scalar `subtype` slot may still be used.""", json_schema_extra = { "linkml_meta": {'alias': 'subtypes',
+         'domain_of': ['Pathophysiology', 'Phenotype', 'Biochemical'],
+         'examples': [{'value': "['DENV-1', 'DENV-2', 'DENV-3', 'DENV-4']"},
+                      {'value': "['Type 1', 'Type 2']"}]} })
     phenotype_contexts: Optional[list[PhenotypeContext]] = Field(default=None, description="""Context-specific qualifications of this phenotype's frequency, severity, or onset. Each context can optionally specify a genetic context, demographic stratum, or disease subtype. When no context qualifiers are set, provides evidence for the base frequency/severity claim (addressing the frequency-evidence separation problem).""", json_schema_extra = { "linkml_meta": {'alias': 'phenotype_contexts', 'domain_of': ['Phenotype']} })
 
 
@@ -7318,6 +7323,10 @@ class Biochemical(ConfiguredBaseModel):
                        'HistopathologyFinding',
                        'Genetic'],
          'examples': [{'value': 'Eyelid Myoclonia with Absences'}]} })
+    subtypes: Optional[list[str]] = Field(default=None, description="""Names of subtypes (foreign keys to this disease's `has_subtypes[].name`) associated with a phenotype, biochemical finding, pathophysiology node, or other subtyped entry. Use this multivalued form when an item is characteristic of more than one subtype with overlapping features. For single-subtype associations, the scalar `subtype` slot may still be used.""", json_schema_extra = { "linkml_meta": {'alias': 'subtypes',
+         'domain_of': ['Pathophysiology', 'Phenotype', 'Biochemical'],
+         'examples': [{'value': "['DENV-1', 'DENV-2', 'DENV-3', 'DENV-4']"},
+                      {'value': "['Type 1', 'Type 2']"}]} })
     cell_types: Optional[list[CellTypeDescriptor]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'cell_types',
          'domain_of': ['ExperimentalModel', 'Pathophysiology', 'Biochemical'],
          'examples': [{'value': '[{preferred_term: Macrophage}, {preferred_term: T '
@@ -12556,4 +12565,3 @@ ComorbidityHypothesis.model_rebuild()
 UpstreamConditionHypothesis.model_rebuild()
 MechanisticHypothesis.model_rebuild()
 DiseaseCollection.model_rebuild()
-

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -1274,8 +1274,16 @@ slots:
     range: GeneDescriptor
     inlined_as_list: true
   subtypes:
+    description: >-
+      Names of subtypes (foreign keys to this disease's `has_subtypes[].name`)
+      associated with a phenotype, biochemical finding, pathophysiology node,
+      or other subtyped entry. Use this multivalued form when an item is
+      characteristic of more than one subtype with overlapping features.
+      For single-subtype associations, the scalar `subtype` slot may still
+      be used.
     examples:
       - value: '[''DENV-1'', ''DENV-2'', ''DENV-3'', ''DENV-4'']'
+      - value: '[''Type 1'', ''Type 2'']'
     multivalued: true
     range: string
   has_subtypes:
@@ -3133,6 +3141,7 @@ classes:
       - severity
       - notes
       - subtype
+      - subtypes
       - phenotype_contexts
   Biochemical:
     slots:
@@ -3145,6 +3154,7 @@ classes:
       - notes
       - context
       - subtype
+      - subtypes
       - cell_types
       - assays
       - mappings_list

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -322,6 +322,10 @@ def test_subtype_foreign_keys(filepath):
             val = item.get("subtype")
             if val and val not in valid_subtypes:
                 errors.append(f"{section}[{i}].subtype={val!r}")
+            # Multivalued `subtypes` (plural) — issue #963
+            for k, sval in enumerate(item.get("subtypes", []) or []):
+                if sval and sval not in valid_subtypes:
+                    errors.append(f"{section}[{i}].subtypes[{k}]={sval!r}")
             # Also check phenotype_contexts
             for j, ctx in enumerate(item.get("phenotype_contexts", [])):
                 val = ctx.get("subtype")
@@ -342,6 +346,57 @@ def test_subtype_foreign_keys(filepath):
         f"Subtype FK mismatches in {Path(filepath).name}. "
         f"Valid subtypes: {valid_subtypes}. Bad refs: {errors}"
     )
+
+
+def test_phenotype_multivalued_subtypes_validates(validator, tmp_path):
+    """Issue #963: a phenotype may be associated with multiple subtypes.
+
+    A phenotype using the multivalued `subtypes` slot with a list of subtype
+    names should validate against the schema, and the FK check should accept
+    list values.
+    """
+    disease = {
+        "name": "Test Multi-Subtype Disease",
+        "disease_term": {
+            "term": {"id": "MONDO:0000001", "label": "disease or disorder"}
+        },
+        "has_subtypes": [
+            {"name": "Type 1", "description": "Subtype one."},
+            {"name": "Type 2", "description": "Subtype two."},
+        ],
+        "phenotypes": [
+            {
+                "name": "Shared phenotype",
+                "description": "A phenotype seen in both subtypes.",
+                "subtypes": ["Type 1", "Type 2"],
+            },
+        ],
+    }
+
+    report = validator.validate(disease, target_class="Disease")
+    errors = [r for r in report.results if r.severity.name == "ERROR"]
+    assert not errors, f"Unexpected validation errors: {[str(e) for e in errors]}"
+
+    # Reuse the FK check logic by writing to disk and invoking the test fn.
+    fake_path = tmp_path / "TestMulti.yaml"
+    fake_path.write_text(yaml.safe_dump(disease, sort_keys=False))
+    test_subtype_foreign_keys(str(fake_path))
+
+
+def test_phenotype_multivalued_subtypes_fk_catches_bad_refs(tmp_path):
+    """Bad subtype name in the multivalued `subtypes` list must be caught."""
+    disease = {
+        "name": "Bad Multi-Subtype",
+        "has_subtypes": [{"name": "Type 1"}],
+        "phenotypes": [
+            {"name": "P", "subtypes": ["Type 1", "Type 99 (not declared)"]},
+        ],
+    }
+    fake_path = tmp_path / "BadMulti.yaml"
+    fake_path.write_text(yaml.safe_dump(disease, sort_keys=False))
+
+    with pytest.raises(AssertionError, match="Type 99"):
+        test_subtype_foreign_keys(str(fake_path))
 
 
 @pytest.mark.parametrize("filepath", DISORDER_FILES)


### PR DESCRIPTION
## Summary

Fixes #963

- Adds the existing multivalued `subtypes` slot to `Phenotype` and `Biochemical` so one phenotype / biochemical finding can reference multiple subtypes (for overlapping features across subtypes).
- Retains the singular `subtype` slot for backward compatibility — existing KB data is unchanged and still valid.
- Updates the foreign-key test (`test_subtype_foreign_keys`) to validate the new multivalued `subtypes` list against `has_subtypes[].name`, plus two new unit tests covering the happy path and FK-mismatch cases.
- Regenerates the auto-generated `dismech.py` / `dismech_pydantic.py` via `just gen-python`.

This is an additive, narrowly scoped fix — no data migration required. Users can opt in to `subtypes: [...]` on a per-entry basis as multi-subtype overlaps are identified.

### Example

```yaml
phenotypes:
- name: Joint hypermobility
  description: Seen in both the classical and hypermobile forms.
  subtypes:
    - Classical EDS
    - Hypermobile EDS
```

## Test plan

- [x] `uv run pytest tests/test_data.py` — 2989 passed (including two new multi-subtype tests)
- [x] `just gen-python` — datamodel regenerates cleanly with only the expected `subtypes` additions on `Phenotype` and `Biochemical`
- [x] Existing disorder files (42 with singular `subtype:`) continue to validate unchanged
- [ ] CI: full validation + term + reference checks