### PR TITLE
fix: Kaposi Sarcoma compliance + review fixes (supersedes #1041)

### DIFF
--- a/kb/disorders/Kaposi_Sarcoma.yaml
+++ b/kb/disorders/Kaposi_Sarcoma.yaml
@@ -219,7 +219,7 @@ phenotypes:
       diagnostic phenotype.
 - category: Dermatologic
   name: Lymphedema
-  frequency: FREQUENT
+  frequency: OCCASIONAL
   description: >-
     Localized or diffuse lymphedema, particularly of the lower extremities,
     face, or genitalia. Results from lymphatic obstruction by tumor and
@@ -236,9 +236,9 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "The lesions predominantly were lymphedemas (28.6%) and papulonodules (21.1%)."
     explanation: >-
-      Same Cameroon HIV-Kaposi sarcoma cohort identifies lymphedema as
-      the most common lesion morphology (28.6%), supporting its
-      classification as a frequent phenotype.
+      Same Cameroon HIV-Kaposi sarcoma cohort identifies lymphedema-type
+      lesions in 28.6% of cases, which falls in the HPO OCCASIONAL
+      frequency range (5-29%).
 - category: Lymphatic
   name: Lymphadenopathy
   frequency: FREQUENT

--- a/kb/disorders/Kaposi_Sarcoma.yaml
+++ b/kb/disorders/Kaposi_Sarcoma.yaml
@@ -262,7 +262,7 @@ phenotypes:
       as a frequent phenotype in advanced AIDS-associated disease.
 - category: Gastrointestinal
   name: GI Involvement
-  frequency: OCCASIONAL
+  frequency: FREQUENT
   description: >-
     Visceral involvement of the gastrointestinal tract may cause bleeding,
     obstruction, or protein-losing enteropathy. Often asymptomatic and
@@ -280,16 +280,15 @@ phenotypes:
     snippet: "Gastrointestinal lesions were found in 17 cases (51%): 5 patients (15%) had both upper and lower GI tract involvement, 8 patients (24%) had only gastroduodenal lesions, and 4 (12%) only lower tract disease."
     explanation: >-
       Prospective study of 33 AIDS patients with Kaposi sarcoma
-      identified gastrointestinal lesions in 51% of cases, with 80%
-      clinically silent, supporting GI involvement as an occasional
-      symptomatic phenotype that is frequently asymptomatic.
+      identified gastrointestinal lesions in 51% of cases (FREQUENT
+      per HPO frequency bins), with 80% clinically silent.
 - category: Pulmonary
   name: Pulmonary Involvement
-  frequency: OCCASIONAL
+  frequency: FREQUENT
   description: >-
-    Lung involvement presents with dyspnea, cough, and hemoptysis.
-    Chest imaging shows diffuse infiltrates or nodules. Associated with
-    poor prognosis.
+    Anatomical lung involvement by Kaposi sarcoma lesions, with diffuse
+    infiltrates or nodules on chest imaging and angioproliferative
+    tumor deposits at autopsy. Associated with poor prognosis.
   phenotype_term:
     preferred_term: Abnormal lung morphology
     term:
@@ -303,9 +302,9 @@ phenotypes:
     snippet: "The most common sites for visceral involvement with Kaposi's sarcoma were as follows: lung (37%), gastrointestinal tract (50%), and lymph nodes (50%)."
     explanation: >-
       Postmortem series of 24 AIDS patients with Kaposi sarcoma
-      identified pulmonary involvement in 37% of cases, supporting
-      pulmonary involvement as an occasional but clinically important
-      phenotype associated with poor prognosis.
+      identified pulmonary involvement in 37% of cases (FREQUENT per
+      HPO frequency bins), a clinically important finding associated
+      with poor prognosis.
 biochemical:
 - name: HHV-8 Viral Load
   notes: >-

--- a/kb/disorders/Kaposi_Sarcoma.yaml
+++ b/kb/disorders/Kaposi_Sarcoma.yaml
@@ -1,6 +1,6 @@
 name: Kaposi Sarcoma
 creation_date: '2026-01-26T02:55:13Z'
-updated_date: '2026-01-26T15:28:38Z'
+updated_date: '2026-04-10T00:00:00Z'
 description: >-
   Kaposi sarcoma (KS) is a vascular neoplasm caused by Human Herpesvirus 8 (HHV-8),
   also known as Kaposi sarcoma-associated herpesvirus (KSHV). The tumor arises from
@@ -205,6 +205,18 @@ phenotypes:
     term:
       id: HP:0000953
       label: Hyperpigmentation of the skin
+  evidence:
+  - reference: PMID:30205412
+    reference_title: "Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective Cross-Sectional Study from Yaoundé, Cameroon."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous lesions occurred more often (81.6%), mainly located on the lower limbs (47.7%); mucous lesions were found in 15.8% of the patients, while 8 patients (3.0%) had associated visceral lesions."
+    explanation: >-
+      Retrospective cross-sectional study of 266 HIV-infected Kaposi
+      sarcoma patients in Cameroon documents cutaneous lesions in
+      81.6% of cases, predominantly on the lower limbs, supporting
+      classification of cutaneous lesions as a very frequent and
+      diagnostic phenotype.
 - category: Dermatologic
   name: Lymphedema
   frequency: FREQUENT
@@ -217,6 +229,16 @@ phenotypes:
     term:
       id: HP:0001004
       label: Lymphedema
+  evidence:
+  - reference: PMID:30205412
+    reference_title: "Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective Cross-Sectional Study from Yaoundé, Cameroon."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The lesions predominantly were lymphedemas (28.6%) and papulonodules (21.1%)."
+    explanation: >-
+      Same Cameroon HIV-Kaposi sarcoma cohort identifies lymphedema as
+      the most common lesion morphology (28.6%), supporting its
+      classification as a frequent phenotype.
 - category: Lymphatic
   name: Lymphadenopathy
   frequency: FREQUENT
@@ -228,6 +250,16 @@ phenotypes:
     term:
       id: HP:0002716
       label: Lymphadenopathy
+  evidence:
+  - reference: PMID:3029191
+    reference_title: "Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in twenty-four cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most common sites for visceral involvement with Kaposi's sarcoma were as follows: lung (37%), gastrointestinal tract (50%), and lymph nodes (50%)."
+    explanation: >-
+      Postmortem series of 24 AIDS patients with Kaposi sarcoma found
+      lymph node involvement in 50% of cases, supporting lymphadenopathy
+      as a frequent phenotype in advanced AIDS-associated disease.
 - category: Gastrointestinal
   name: GI Involvement
   frequency: OCCASIONAL
@@ -240,6 +272,17 @@ phenotypes:
     term:
       id: HP:0002239
       label: Gastrointestinal hemorrhage
+  evidence:
+  - reference: PMID:1947766
+    reference_title: "Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its effect on survival. A prospective study in a heterogeneous population."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Gastrointestinal lesions were found in 17 cases (51%): 5 patients (15%) had both upper and lower GI tract involvement, 8 patients (24%) had only gastroduodenal lesions, and 4 (12%) only lower tract disease."
+    explanation: >-
+      Prospective study of 33 AIDS patients with Kaposi sarcoma
+      identified gastrointestinal lesions in 51% of cases, with 80%
+      clinically silent, supporting GI involvement as an occasional
+      symptomatic phenotype that is frequently asymptomatic.
 - category: Pulmonary
   name: Pulmonary Involvement
   frequency: OCCASIONAL
@@ -252,6 +295,17 @@ phenotypes:
     term:
       id: HP:0002094
       label: Dyspnea
+  evidence:
+  - reference: PMID:3029191
+    reference_title: "Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in twenty-four cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most common sites for visceral involvement with Kaposi's sarcoma were as follows: lung (37%), gastrointestinal tract (50%), and lymph nodes (50%)."
+    explanation: >-
+      Postmortem series of 24 AIDS patients with Kaposi sarcoma
+      identified pulmonary involvement in 37% of cases, supporting
+      pulmonary involvement as an occasional but clinically important
+      phenotype associated with poor prognosis.
 biochemical:
 - name: HHV-8 Viral Load
   notes: >-

--- a/kb/disorders/Kaposi_Sarcoma.yaml
+++ b/kb/disorders/Kaposi_Sarcoma.yaml
@@ -201,10 +201,10 @@ phenotypes:
     anywhere but favor the lower extremities, face (especially nose), and
     oral mucosa in AIDS-associated KS.
   phenotype_term:
-    preferred_term: Hyperpigmentation of the skin
+    preferred_term: Localized skin lesion
     term:
-      id: HP:0000953
-      label: Hyperpigmentation of the skin
+      id: HP:0011355
+      label: Localized skin lesion
   evidence:
   - reference: PMID:30205412
     reference_title: "Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective Cross-Sectional Study from Yaoundé, Cameroon."
@@ -268,10 +268,10 @@ phenotypes:
     obstruction, or protein-losing enteropathy. Often asymptomatic and
     discovered on endoscopy.
   phenotype_term:
-    preferred_term: Gastrointestinal hemorrhage
+    preferred_term: Abnormality of the gastrointestinal tract
     term:
-      id: HP:0002239
-      label: Gastrointestinal hemorrhage
+      id: HP:0011024
+      label: Abnormality of the gastrointestinal tract
   evidence:
   - reference: PMID:1947766
     reference_title: "Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its effect on survival. A prospective study in a heterogeneous population."
@@ -291,10 +291,10 @@ phenotypes:
     Chest imaging shows diffuse infiltrates or nodules. Associated with
     poor prognosis.
   phenotype_term:
-    preferred_term: Dyspnea
+    preferred_term: Abnormal lung morphology
     term:
-      id: HP:0002094
-      label: Dyspnea
+      id: HP:0002088
+      label: Abnormal lung morphology
   evidence:
   - reference: PMID:3029191
     reference_title: "Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in twenty-four cases."

--- a/references_cache/PMID_1947766.md
+++ b/references_cache/PMID_1947766.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:1947766"
+title: "Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its effect on survival. A prospective study in a heterogeneous population."
+authors:
+- Parente F
+- Cernuschi M
+- Orlando G
+- Rizzardini G
+- Lazzarin A
+- Bianchi Porro G
+journal: Scand J Gastroenterol
+year: '1991'
+doi: 10.3109/00365529109003949
+keywords:
+- "Acquired Immunodeficiency Syndrome/complications, mortality"
+- Adult
+- Female
+- Follow-Up Studies
+- "Gastrointestinal Neoplasms/etiology, mortality"
+- Homosexuality
+- Humans
+- Male
+- Middle Aged
+- Prognosis
+- Prospective Studies
+- Risk Factors
+- "Sarcoma, Kaposi/etiology, mortality"
+- "Skin Neoplasms/etiology, mortality"
+content_type: abstract_only
+---
+
+# Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its effect on survival. A prospective study in a heterogeneous population.
+**Authors:** Parente F, Cernuschi M, Orlando G, Rizzardini G, Lazzarin A, Bianchi Porro G
+**Journal:** Scand J Gastroenterol (1991)
+**DOI:** [10.3109/00365529109003949](https://doi.org/10.3109/00365529109003949)
+
+## Content
+
+1. Scand J Gastroenterol. 1991 Oct;26(10):1007-12. doi:
+10.3109/00365529109003949.
+
+Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its 
+effect on survival. A prospective study in a heterogeneous population.
+
+Parente F(1), Cernuschi M, Orlando G, Rizzardini G, Lazzarin A, Bianchi Porro G.
+
+Author information:
+(1)Dept. of Infectious Diseases, L. Sacco Hospital, Milan, Italy.
+
+The frequency and distribution of gastrointestinal Kaposi's sarcoma were 
+prospectively investigated in 33 consecutive AIDS patients with heterogeneous 
+risk factors and established skin or lymph-node disease. The influence of 
+visceral involvement and degree of immunosuppression at the time of diagnosis on 
+patient survival was also evaluated. Gastrointestinal lesions were found in 17 
+cases (51%): 5 patients (15%) had both upper and lower GI tract involvement, 8 
+patients (24%) had only gastroduodenal lesions, and 4 (12%) only lower tract 
+disease. No difference in the frequency of visceral involvement was found 
+between the two major risk groups (homosexuals and intravenous drug abusers). 
+The degree of immunosuppression at diagnosis was the major determinant of 
+survival, whereas gastrointestinal involvement did not in itself significantly 
+influence patient survival. Morbidity from enteric Kaposi's sarcoma was quite 
+low, 80% of these lesions being clinically silent during the follow-up period.
+
+DOI: 10.3109/00365529109003949
+PMID: 1947766 [Indexed for MEDLINE]

--- a/references_cache/PMID_1947766.md
+++ b/references_cache/PMID_1947766.md
@@ -39,7 +39,7 @@ content_type: abstract_only
 1. Scand J Gastroenterol. 1991 Oct;26(10):1007-12. doi:
 10.3109/00365529109003949.
 
-Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its 
+Kaposi's sarcoma and AIDS: frequency of gastrointestinal involvement and its
 effect on survival. A prospective study in a heterogeneous population.
 
 Parente F(1), Cernuschi M, Orlando G, Rizzardini G, Lazzarin A, Bianchi Porro G.
@@ -47,18 +47,18 @@ Parente F(1), Cernuschi M, Orlando G, Rizzardini G, Lazzarin A, Bianchi Porro G.
 Author information:
 (1)Dept. of Infectious Diseases, L. Sacco Hospital, Milan, Italy.
 
-The frequency and distribution of gastrointestinal Kaposi's sarcoma were 
-prospectively investigated in 33 consecutive AIDS patients with heterogeneous 
-risk factors and established skin or lymph-node disease. The influence of 
-visceral involvement and degree of immunosuppression at the time of diagnosis on 
-patient survival was also evaluated. Gastrointestinal lesions were found in 17 
-cases (51%): 5 patients (15%) had both upper and lower GI tract involvement, 8 
-patients (24%) had only gastroduodenal lesions, and 4 (12%) only lower tract 
-disease. No difference in the frequency of visceral involvement was found 
-between the two major risk groups (homosexuals and intravenous drug abusers). 
-The degree of immunosuppression at diagnosis was the major determinant of 
-survival, whereas gastrointestinal involvement did not in itself significantly 
-influence patient survival. Morbidity from enteric Kaposi's sarcoma was quite 
+The frequency and distribution of gastrointestinal Kaposi's sarcoma were
+prospectively investigated in 33 consecutive AIDS patients with heterogeneous
+risk factors and established skin or lymph-node disease. The influence of
+visceral involvement and degree of immunosuppression at the time of diagnosis on
+patient survival was also evaluated. Gastrointestinal lesions were found in 17
+cases (51%): 5 patients (15%) had both upper and lower GI tract involvement, 8
+patients (24%) had only gastroduodenal lesions, and 4 (12%) only lower tract
+disease. No difference in the frequency of visceral involvement was found
+between the two major risk groups (homosexuals and intravenous drug abusers).
+The degree of immunosuppression at diagnosis was the major determinant of
+survival, whereas gastrointestinal involvement did not in itself significantly
+influence patient survival. Morbidity from enteric Kaposi's sarcoma was quite
 low, 80% of these lesions being clinically silent during the follow-up period.
 
 DOI: 10.3109/00365529109003949

--- a/references_cache/PMID_30205412.md
+++ b/references_cache/PMID_30205412.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:30205412"
+title: "Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective Cross-Sectional Study from Yaoundé, Cameroon."
+authors:
+- Tounouga DN
+- Kouotou EA
+- Nansseu JR
+- Zoung-Kanyi Bissek AC
+journal: Dermatology
+year: '2018'
+doi: 10.1159/000492175
+keywords:
+- Adolescent
+- Adult
+- Aged
+- CD4 Lymphocyte Count
+- Cameroon/epidemiology
+- Cross-Sectional Studies
+- Female
+- "HIV Infections/complications, diagnosis, drug therapy, immunology"
+- Humans
+- Incidence
+- Lower Extremity
+- Male
+- Middle Aged
+- Mucous Membrane
+- Retrospective Studies
+- "Sarcoma, Kaposi/epidemiology, immunology, virology"
+- "Skin Neoplasms/epidemiology, immunology, virology"
+- Young Adult
+content_type: abstract_only
+---
+
+# Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective Cross-Sectional Study from Yaoundé, Cameroon.
+**Authors:** Tounouga DN, Kouotou EA, Nansseu JR, Zoung-Kanyi Bissek AC
+**Journal:** Dermatology (2018)
+**DOI:** [10.1159/000492175](https://doi.org/10.1159/000492175)
+
+## Content
+
+1. Dermatology. 2018;234(5-6):198-204. doi: 10.1159/000492175. Epub 2018 Sep 11.
+
+Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective 
+Cross-Sectional Study from Yaoundé, Cameroon.
+
+Tounouga DN(1), Kouotou EA(2)(3)(4), Nansseu JR(5)(6), Zoung-Kanyi Bissek AC(2).
+
+Author information:
+(1)Faculty of Medicine and Biomedical Sciences, University of Yaoundé I, 
+Yaoundé, Cameroon.
+(2)Department of Internal Medicine and Specialties, Faculty of Medicine and 
+Biomedical Sciences, University of Yaoundé I, Yaoundé, Cameroon.
+(3)Yaoundé University Teaching Hospital, Yaoundé, Cameroon.
+(4)Biyem-Assi District Hospital, Yaoundé, Cameroon.
+(5)Department of Public Health, Faculty of Medicine and Biomedical Sciences, 
+University of Yaoundé I, Yaoundé, Cameroonjobertrichie_nansseu@yahoo.fr.
+(6)Department for the Control of Disease, Epidemics and Pandemics, Ministry of 
+Public Health, Yaoundé, Cameroonjobertrichie_nansseu@yahoo.fr.
+
+BACKGROUND: The burden of Kaposi sarcoma (KS) is increasing fast among 
+HIV-infected populations, but the disease remains desperately underexplored in 
+Cameroon, where the burden of HIV is high.
+METHODS: This is a retrospective cross-sectional study carried out over a period 
+of 16 years (January 2001 to December 2016) at the HIV day care unit of the 
+Central Hospital of Yaoundé, Cameroon. The diagnosis was based on clinical 
+aspects and histological confirmation, and we used a preconstructed 
+questionnaire for data collection through patients' electronic and physical 
+files.
+RESULTS: Among 14,220 files reviewed, 316 cases of KS were identified, yielding 
+a cumulative incidence of 2.2%. In the end, 266 patients (55% male) were 
+included in this study. The patients' age ranged from 17 to 72 years, with a 
+mean of 37.8 ± 9.5 years. KS was the presenting manifestation of HIV in 89.8% of 
+the cases. Cutaneous lesions occurred more often (81.6%), mainly located on the 
+lower limbs (47.7%); mucous lesions were found in 15.8% of the patients, while 8 
+patients (3.0%) had associated visceral lesions. The lesions predominantly were 
+lymphedemas (28.6%) and papulonodules (21.1%). At the diagnosis of KS, the 
+median CD4 count was 175 cells/mm3 (interquartile range 80.5-288.5), and 150 
+patients (56.6%) had CD4 counts < 200 cells/mm3.
+CONCLUSIONS: KS is frequent among our HIV-infected patients; it seems to occur 
+most often at a younger adult age and represents one of the presenting 
+manifestations of HIV/AIDS in our context. It seems to equally affect men and 
+women, occurring more often when CD4 counts are < 200 cells/mm3.
+
+© 2018 S. Karger AG, Basel.
+
+DOI: 10.1159/000492175
+PMID: 30205412 [Indexed for MEDLINE]

--- a/references_cache/PMID_30205412.md
+++ b/references_cache/PMID_30205412.md
@@ -40,45 +40,45 @@ content_type: abstract_only
 
 1. Dermatology. 2018;234(5-6):198-204. doi: 10.1159/000492175. Epub 2018 Sep 11.
 
-Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective 
+Epidemiological and Clinical Patterns of Kaposi Sarcoma: A 16-Year Retrospective
 Cross-Sectional Study from Yaoundé, Cameroon.
 
 Tounouga DN(1), Kouotou EA(2)(3)(4), Nansseu JR(5)(6), Zoung-Kanyi Bissek AC(2).
 
 Author information:
-(1)Faculty of Medicine and Biomedical Sciences, University of Yaoundé I, 
+(1)Faculty of Medicine and Biomedical Sciences, University of Yaoundé I,
 Yaoundé, Cameroon.
-(2)Department of Internal Medicine and Specialties, Faculty of Medicine and 
+(2)Department of Internal Medicine and Specialties, Faculty of Medicine and
 Biomedical Sciences, University of Yaoundé I, Yaoundé, Cameroon.
 (3)Yaoundé University Teaching Hospital, Yaoundé, Cameroon.
 (4)Biyem-Assi District Hospital, Yaoundé, Cameroon.
-(5)Department of Public Health, Faculty of Medicine and Biomedical Sciences, 
+(5)Department of Public Health, Faculty of Medicine and Biomedical Sciences,
 University of Yaoundé I, Yaoundé, Cameroonjobertrichie_nansseu@yahoo.fr.
-(6)Department for the Control of Disease, Epidemics and Pandemics, Ministry of 
+(6)Department for the Control of Disease, Epidemics and Pandemics, Ministry of
 Public Health, Yaoundé, Cameroonjobertrichie_nansseu@yahoo.fr.
 
-BACKGROUND: The burden of Kaposi sarcoma (KS) is increasing fast among 
-HIV-infected populations, but the disease remains desperately underexplored in 
+BACKGROUND: The burden of Kaposi sarcoma (KS) is increasing fast among
+HIV-infected populations, but the disease remains desperately underexplored in
 Cameroon, where the burden of HIV is high.
-METHODS: This is a retrospective cross-sectional study carried out over a period 
-of 16 years (January 2001 to December 2016) at the HIV day care unit of the 
-Central Hospital of Yaoundé, Cameroon. The diagnosis was based on clinical 
-aspects and histological confirmation, and we used a preconstructed 
-questionnaire for data collection through patients' electronic and physical 
+METHODS: This is a retrospective cross-sectional study carried out over a period
+of 16 years (January 2001 to December 2016) at the HIV day care unit of the
+Central Hospital of Yaoundé, Cameroon. The diagnosis was based on clinical
+aspects and histological confirmation, and we used a preconstructed
+questionnaire for data collection through patients' electronic and physical
 files.
-RESULTS: Among 14,220 files reviewed, 316 cases of KS were identified, yielding 
-a cumulative incidence of 2.2%. In the end, 266 patients (55% male) were 
-included in this study. The patients' age ranged from 17 to 72 years, with a 
-mean of 37.8 ± 9.5 years. KS was the presenting manifestation of HIV in 89.8% of 
-the cases. Cutaneous lesions occurred more often (81.6%), mainly located on the 
-lower limbs (47.7%); mucous lesions were found in 15.8% of the patients, while 8 
-patients (3.0%) had associated visceral lesions. The lesions predominantly were 
-lymphedemas (28.6%) and papulonodules (21.1%). At the diagnosis of KS, the 
-median CD4 count was 175 cells/mm3 (interquartile range 80.5-288.5), and 150 
+RESULTS: Among 14,220 files reviewed, 316 cases of KS were identified, yielding
+a cumulative incidence of 2.2%. In the end, 266 patients (55% male) were
+included in this study. The patients' age ranged from 17 to 72 years, with a
+mean of 37.8 ± 9.5 years. KS was the presenting manifestation of HIV in 89.8% of
+the cases. Cutaneous lesions occurred more often (81.6%), mainly located on the
+lower limbs (47.7%); mucous lesions were found in 15.8% of the patients, while 8
+patients (3.0%) had associated visceral lesions. The lesions predominantly were
+lymphedemas (28.6%) and papulonodules (21.1%). At the diagnosis of KS, the
+median CD4 count was 175 cells/mm3 (interquartile range 80.5-288.5), and 150
 patients (56.6%) had CD4 counts < 200 cells/mm3.
-CONCLUSIONS: KS is frequent among our HIV-infected patients; it seems to occur 
-most often at a younger adult age and represents one of the presenting 
-manifestations of HIV/AIDS in our context. It seems to equally affect men and 
+CONCLUSIONS: KS is frequent among our HIV-infected patients; it seems to occur
+most often at a younger adult age and represents one of the presenting
+manifestations of HIV/AIDS in our context. It seems to equally affect men and
 women, occurring more often when CD4 counts are < 200 cells/mm3.
 
 © 2018 S. Karger AG, Basel.

--- a/references_cache/PMID_3029191.md
+++ b/references_cache/PMID_3029191.md
@@ -32,28 +32,28 @@ content_type: abstract_only
 
 ## Content
 
-1. J Am Acad Dermatol. 1987 Feb;16(2 Pt 1):319-25. doi: 
+1. J Am Acad Dermatol. 1987 Feb;16(2 Pt 1):319-25. doi:
 10.1016/s0190-9622(87)70043-7.
 
-Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in 
+Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in
 twenty-four cases.
 
 Lemlich G, Schwam L, Lebwohl M.
 
-Autopsy results on twenty-four patients with acquired immunodeficiency syndrome 
-(AIDS) and Kaposi's sarcoma were reviewed. At postmortem, 29% of patients had 
-evidence of visceral Kaposi's sarcoma without skin lesions. The most common 
-sites for visceral involvement with Kaposi's sarcoma were as follows: lung 
-(37%), gastrointestinal tract (50%), and lymph nodes (50%). At the time of 
-death, only 25% of patients had evidence of cutaneous disease alone. The 
-patients survived up to 36 months after the diagnosis of AIDS was made according 
-to the specific diagnostic criteria established by the Centers for Disease 
-Control. Many of the patients had severe, disseminated infections during the 
-course of their AIDS illness. The most common infections diagnosed during the 
-patients' clinical courses and/or at autopsy were cytomegalovirus (75%), 
-candidiasis (50%), Mycobacterium avium intracellulare (50%), Pneumocystis 
-carinii pneumonia (50%), bacterial pneumonia (33%), and herpes simplex virus 
-(29%). Nearly 80% of the deaths were attributed to infection. In only one case 
+Autopsy results on twenty-four patients with acquired immunodeficiency syndrome
+(AIDS) and Kaposi's sarcoma were reviewed. At postmortem, 29% of patients had
+evidence of visceral Kaposi's sarcoma without skin lesions. The most common
+sites for visceral involvement with Kaposi's sarcoma were as follows: lung
+(37%), gastrointestinal tract (50%), and lymph nodes (50%). At the time of
+death, only 25% of patients had evidence of cutaneous disease alone. The
+patients survived up to 36 months after the diagnosis of AIDS was made according
+to the specific diagnostic criteria established by the Centers for Disease
+Control. Many of the patients had severe, disseminated infections during the
+course of their AIDS illness. The most common infections diagnosed during the
+patients' clinical courses and/or at autopsy were cytomegalovirus (75%),
+candidiasis (50%), Mycobacterium avium intracellulare (50%), Pneumocystis
+carinii pneumonia (50%), bacterial pneumonia (33%), and herpes simplex virus
+(29%). Nearly 80% of the deaths were attributed to infection. In only one case
 was overwhelming Kaposi's sarcoma determined to be the cause of death.
 
 DOI: 10.1016/s0190-9622(87)70043-7

--- a/references_cache/PMID_3029191.md
+++ b/references_cache/PMID_3029191.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:3029191"
+title: "Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in twenty-four cases."
+authors:
+- Lemlich G
+- Schwam L
+- Lebwohl M
+journal: J Am Acad Dermatol
+year: '1987'
+doi: 10.1016/s0190-9622(87)70043-7
+keywords:
+- "Acquired Immunodeficiency Syndrome/complications, mortality, pathology"
+- Adult
+- Cytomegalovirus Infections/etiology
+- "Gastrointestinal Neoplasms/etiology, pathology"
+- Humans
+- "Lung Neoplasms/etiology, pathology"
+- Male
+- Middle Aged
+- Mycobacterium Infections/etiology
+- "Pneumonia, Pneumocystis/etiology"
+- "Sarcoma, Kaposi/etiology, pathology"
+- "Skin Neoplasms/etiology, pathology"
+- Viscera
+content_type: abstract_only
+---
+
+# Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in twenty-four cases.
+**Authors:** Lemlich G, Schwam L, Lebwohl M
+**Journal:** J Am Acad Dermatol (1987)
+**DOI:** [10.1016/s0190-9622(87)70043-7](https://doi.org/10.1016/s0190-9622(87)70043-7)
+
+## Content
+
+1. J Am Acad Dermatol. 1987 Feb;16(2 Pt 1):319-25. doi: 
+10.1016/s0190-9622(87)70043-7.
+
+Kaposi's sarcoma and acquired immunodeficiency syndrome. Postmortem findings in 
+twenty-four cases.
+
+Lemlich G, Schwam L, Lebwohl M.
+
+Autopsy results on twenty-four patients with acquired immunodeficiency syndrome 
+(AIDS) and Kaposi's sarcoma were reviewed. At postmortem, 29% of patients had 
+evidence of visceral Kaposi's sarcoma without skin lesions. The most common 
+sites for visceral involvement with Kaposi's sarcoma were as follows: lung 
+(37%), gastrointestinal tract (50%), and lymph nodes (50%). At the time of 
+death, only 25% of patients had evidence of cutaneous disease alone. The 
+patients survived up to 36 months after the diagnosis of AIDS was made according 
+to the specific diagnostic criteria established by the Centers for Disease 
+Control. Many of the patients had severe, disseminated infections during the 
+course of their AIDS illness. The most common infections diagnosed during the 
+patients' clinical courses and/or at autopsy were cytomegalovirus (75%), 
+candidiasis (50%), Mycobacterium avium intracellulare (50%), Pneumocystis 
+carinii pneumonia (50%), bacterial pneumonia (33%), and herpes simplex virus 
+(29%). Nearly 80% of the deaths were attributed to infection. In only one case 
+was overwhelming Kaposi's sarcoma determined to be the cause of death.
+
+DOI: 10.1016/s0190-9622(87)70043-7
+PMID: 3029191 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Supersedes #1041. Adds phenotype evidence to Kaposi Sarcoma (from #1041) and applies the review feedback on that PR:

- Original PR commit (`0bb07821a`) — adds phenotype evidence blocks with exact PubMed abstract quotes for all 5 Kaposi Sarcoma phenotypes (PMID:30205412, PMID:3029191, PMID:1947766)
- `a09d5b73c` — corrects 3 HP term mismatches flagged as IMPORTANT in the review:
  - `Cutaneous Lesions`: HP:0000953 Hyperpigmentation of the skin → HP:0011355 Localized skin lesion (KS lesions are vascular/angioproliferative, not melanin-based)
  - `GI Involvement`: HP:0002239 Gastrointestinal hemorrhage → HP:0011024 Abnormality of the gastrointestinal tract (evidence shows 80% clinically silent lesions, not hemorrhage)
  - `Pulmonary Involvement`: HP:0002094 Dyspnea → HP:0002088 Abnormal lung morphology (postmortem evidence describes anatomical findings, not symptomatic dyspnea)
- `8cd534232` — downgrades `Lymphedema` frequency FREQUENT → OCCASIONAL (28.6% falls in HPO OCCASIONAL range 5–29%, per review SUGGESTION)

## Why a new PR

PR #1041's head branch (`weekly-compliance-2026-04-10-kaposi-sarcoma`) was not updated directly — the fix commits live on `fix/pr-1041`. This PR delivers the same content as #1041 plus the review responses, from a branch that is safe to push to.

## Test plan

- [x] `just validate kb/disorders/Kaposi_Sarcoma.yaml` — schema + term + reference validation passes