### PR TITLE
[codex] Add MONDO curation prioritizer

### DIFF
--- a/conf/mondo_prioritizer.yaml
+++ b/conf/mondo_prioritizer.yaml
@@ -31,6 +31,8 @@ heuristics:
   grouping_term_patterns:
     - "\\bsusceptibility\\b"
     - "\\bpredisposition\\b"
+    # Backstop for candidate exports that carry obsolete terms in the label but
+    # do not populate `is_obsolete: true`.
     - "^obsolete\\b"
   subtype_series_patterns:
     - "^(?P<stem>.+?),\\s*type\\s+[IVX0-9A-Za-z-]+$"

--- a/conf/mondo_prioritizer.yaml
+++ b/conf/mondo_prioritizer.yaml
@@ -1,0 +1,39 @@
+weights:
+  missing_from_dismech: 35
+  has_definition: 6
+  synonym_count: 1.5
+  xref_count: 0.5
+  clingen_definitive_count: 12
+  clingen_strong_count: 6
+  subset_match_count: 5
+  orphanet_match_count: 4
+  broad_parent_bonus: 8
+  subtype_series_penalty: -18
+  grouping_term_penalty: -28
+  over_specific_leaf_penalty: -10
+  obsolete_penalty: -100
+  already_curated_penalty: -80
+
+caps:
+  synonym_count: 5
+  xref_count: 8
+  clingen_definitive_count: 3
+  clingen_strong_count: 3
+  subset_match_count: 3
+  orphanet_match_count: 3
+
+thresholds:
+  broad_parent_min_children: 4
+  subtype_series_min_family_size: 2
+  over_specific_leaf_min_words: 7
+
+heuristics:
+  grouping_term_patterns:
+    - "\\bsusceptibility\\b"
+    - "\\bpredisposition\\b"
+    - "^obsolete\\b"
+  subtype_series_patterns:
+    - "^(?P<stem>.+?),\\s*type\\s+[IVX0-9A-Za-z-]+$"
+    - "^(?P<stem>.+?)\\s+type\\s+[IVX0-9A-Za-z-]+$"
+    - "^(?P<stem>.+?),\\s*[0-9]+[A-Za-z]?$"
+    - "^(?P<stem>.+?)\\s+[0-9]+[A-Za-z]?$"

--- a/docs/mondo-prioritizer.md
+++ b/docs/mondo-prioritizer.md
@@ -1,0 +1,120 @@
+# MONDO Prioritizer
+
+The MONDO prioritizer builds a curation queue from MONDO disease rows rather than
+from ad hoc checklist issues. It scores candidate diseases against local dismech
+coverage, then applies a small set of explicit specificity heuristics to suggest
+whether a term should be curated as a root, lumped into a parent, or dropped.
+
+The goal is practical queue construction:
+
+- reward missing diseases that already have useful MONDO metadata
+- reward external evidence signals when they are available in the input rows
+- penalize terms that are already curated, obsolete, or likely bad roots
+- make every score component inspectable and easy to retune
+
+## CLI
+
+```bash
+uv run dismech-mondo-prioritize \
+  examples/mondo_prioritizer_candidates.tsv \
+  --format table
+```
+
+Example with a custom config and TSV output:
+
+```bash
+uv run dismech-mondo-prioritize \
+  examples/mondo_prioritizer_candidates.tsv \
+  --config examples/mondo_prioritizer_config.yaml \
+  --format tsv \
+  --output /tmp/mondo_priority.tsv
+```
+
+## Expected Input
+
+The prioritizer accepts `tsv`, `csv`, `json`, or `jsonl` candidate rows. The
+only required fields are:
+
+- `mondo_id`
+- `label`
+
+Optional fields become weighted signals when present:
+
+- `definition`
+- `synonyms`
+- `parents`
+- `xrefs`
+- `child_count`
+- `clingen_definitive_count`
+- `clingen_strong_count`
+- `subset_match_count`
+- `orphanet_match_count`
+- `is_obsolete`
+
+Field aliases such as `id`, `name`, `disease_mondo`, and `term_label` are also
+accepted. Multi-valued columns can use `;` or `|`.
+
+## Scoring Dimensions
+
+Default weights live in `conf/mondo_prioritizer.yaml`.
+
+By default the scorer uses:
+
+- `missing_from_dismech`: positive base reward for uncurated roots
+- `has_definition`: reward for a candidate that already has a MONDO definition
+- `synonym_count`, `xref_count`: small metadata completeness rewards
+- `clingen_definitive_count`, `clingen_strong_count`: optional evidence boosts when those counts are supplied in the MONDO candidate export
+- `subset_match_count`, `orphanet_match_count`: optional prioritization boosts when the upstream pipeline already tagged the disease as belonging to an important slice
+- `already_curated_penalty`, `obsolete_penalty`: strong penalties for terms we should not queue
+
+Count-based features are capped so a row with very large synonym or xref counts
+does not dominate the queue.
+
+## Specificity Heuristics
+
+The prioritizer also emits a `specificity_bucket` and `recommended_action`.
+
+Default buckets are:
+
+- `already_curated`
+- `obsolete`
+- `grouping_term`
+- `subtype_series`
+- `broad_parent`
+- `over_specific_leaf`
+- `root_candidate`
+
+The default heuristic rules are intentionally conservative:
+
+- `grouping_term`: regex match on high-confidence phrases such as `susceptibility`, `predisposition`, or `obsolete`
+- `subtype_series`: label matches a configurable subtype suffix pattern such as `long QT syndrome 1` or `Noonan syndrome 1`, and the same stem appears multiple times
+- `broad_parent`: candidate has many children and is not already classified as a subtype series or grouping term
+- `over_specific_leaf`: leaf term with a long conjunction-heavy label, which is a useful review flag for phenotype-enumerating leaves
+
+This does not try to solve lump-vs-split perfectly. It surfaces explicit review
+recommendations such as `CURATE_ROOT_WITH_SUBTYPES`, `LUMP_INTO_PARENT`, and
+`REVIEW_AGAINST_PARENT` so the queue is defensible and inspectable.
+
+## Example Interpretation
+
+With the bundled example candidates:
+
+- `long QT syndrome` scores as a missing broad parent and is recommended as `CURATE_ROOT_WITH_SUBTYPES`
+- `long QT syndrome 1` and `long QT syndrome 3` score as `LUMP_INTO_PARENT`
+- `autism, susceptibility to, X-linked 3` is flagged as a `grouping_term`
+- `Noonan syndrome` is heavily penalized as `ALREADY_CURATED`
+- `obsolete unclassified cardiomyopathy` is dropped as obsolete
+
+## Why This Helps
+
+Issue-driven checklists are useful prompts, but they mix roots, subtype series,
+grouping terms, and questionable leaves. A MONDO-first prioritizer gives us a
+reusable way to:
+
+- start from MONDO terms and metadata
+- layer in optional external evidence counts
+- compare against current dismech coverage
+- generate a tuneable queue with transparent reasons
+
+That makes it easier to review prioritization choices and to adjust weights as
+our curation objectives change.

--- a/examples/mondo_prioritizer_candidates.tsv
+++ b/examples/mondo_prioritizer_candidates.tsv
@@ -1,0 +1,8 @@
+mondo_id	label	definition	synonyms	parents	xrefs	child_count	clingen_definitive_count	clingen_strong_count	subset_match_count	orphanet_match_count	is_obsolete
+MONDO:0002442	long QT syndrome	Inherited cardiac repolarization disorder with prolonged QT interval and ventricular arrhythmia risk.	LQTS; long-qt syndrome	cardiac channelopathy; arrhythmia syndrome	OMIM:192500|Orphanet:101019	16	3	0	1	1	false
+MONDO:0100316	long QT syndrome 1	KCNQ1-related subtype of long QT syndrome with exercise-triggered arrhythmias.	LQT1	long QT syndrome	OMIM:192500	0	1	0	1	1	false
+MONDO:0011377	long QT syndrome 3	SCN5A-related subtype of long QT syndrome with sodium-channel late current gain of function.	LQT3	long QT syndrome	OMIM:603830	0	1	0	1	1	false
+MONDO:0010342	autism, susceptibility to, X-linked 3	MECP2-linked susceptibility signal for autism spectrum presentations.	AUTSX3	neurodevelopmental disorder	OMIM:300496	0	0	0	1	0	false
+MONDO:0018997	Noonan syndrome	RASopathy with congenital heart disease, short stature, and characteristic facies.	Noonan syndrome 1 spectrum	RASopathy	OMIM:163950|Orphanet:648	6	3	1	1	1	false
+MONDO:0060577	neurodevelopmental disorder with microcephaly, ataxia, and seizures	Rare syndromic neurodevelopmental disease defined by severe neurologic phenotype triad.	microcephaly-ataxia-seizures syndrome	neurodevelopmental disorder	OMIM:620114	0	1	0	1	0	false
+MONDO:0016343	obsolete unclassified cardiomyopathy	Deprecated umbrella cardiomyopathy term retained for mapping history.		deprecated cardiomyopathy		0	0	0	0	0	true

--- a/examples/mondo_prioritizer_config.yaml
+++ b/examples/mondo_prioritizer_config.yaml
@@ -1,3 +1,4 @@
+# Example override config for tuning the bundled sample candidate table.
 weights:
   missing_from_dismech: 30
   has_definition: 4

--- a/examples/mondo_prioritizer_config.yaml
+++ b/examples/mondo_prioritizer_config.yaml
@@ -1,0 +1,39 @@
+weights:
+  missing_from_dismech: 30
+  has_definition: 4
+  synonym_count: 1
+  xref_count: 0.25
+  clingen_definitive_count: 16
+  clingen_strong_count: 8
+  subset_match_count: 3
+  orphanet_match_count: 4
+  broad_parent_bonus: 12
+  subtype_series_penalty: -12
+  grouping_term_penalty: -35
+  over_specific_leaf_penalty: -8
+  obsolete_penalty: -120
+  already_curated_penalty: -90
+
+caps:
+  synonym_count: 4
+  xref_count: 6
+  clingen_definitive_count: 3
+  clingen_strong_count: 3
+  subset_match_count: 2
+  orphanet_match_count: 2
+
+thresholds:
+  broad_parent_min_children: 3
+  subtype_series_min_family_size: 2
+  over_specific_leaf_min_words: 7
+
+heuristics:
+  grouping_term_patterns:
+    - "\\bsusceptibility\\b"
+    - "\\bpredisposition\\b"
+    - "^obsolete\\b"
+  subtype_series_patterns:
+    - "^(?P<stem>.+?),\\s*type\\s+[IVX0-9A-Za-z-]+$"
+    - "^(?P<stem>.+?)\\s+type\\s+[IVX0-9A-Za-z-]+$"
+    - "^(?P<stem>.+?),\\s*[0-9]+[A-Za-z]?$"
+    - "^(?P<stem>.+?)\\s+[0-9]+[A-Za-z]?$"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ validation:
 nav:
   - Home: index.md
   - CX2 and NDEx Publishing: cx2-ndex-publishing.md
+  - MONDO Prioritizer: mondo-prioritizer.md
   - Schema Reference: schema/schemas/dismech.md
 
 exclude_docs: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.scripts]
 clingen-go = "dismech.clingen.cli:main"
 dismech-cx2 = "dismech.export.cx2_export:main"
+dismech-mondo-prioritize = "dismech.compare.mondo_priority:main"
 
 [dependency-groups]
 dev = [

--- a/src/dismech/compare/mondo_priority.py
+++ b/src/dismech/compare/mondo_priority.py
@@ -73,6 +73,7 @@ class CoverageIndex:
     curated_ids: set[str]
     curated_labels: set[str]
     label_to_file: dict[str, str]
+    id_to_file: dict[str, str]
 
 
 @dataclass
@@ -225,12 +226,14 @@ def build_coverage_index(kb_dir: Path) -> CoverageIndex:
     curated_ids: set[str] = set()
     curated_labels: set[str] = set()
     label_to_file: dict[str, str] = {}
+    id_to_file: dict[str, str] = {}
 
     for path in iter_disease_files(kb_dir):
         data = load_yaml_object(path)
         disease_id = get_disease_term_id(data)
         if disease_id:
             curated_ids.add(disease_id)
+            id_to_file[disease_id] = path.name
 
         labels = [
             _normalize_text(data.get("name")),
@@ -247,6 +250,7 @@ def build_coverage_index(kb_dir: Path) -> CoverageIndex:
         curated_ids=curated_ids,
         curated_labels=curated_labels,
         label_to_file=label_to_file,
+        id_to_file=id_to_file,
     )
 
 
@@ -351,7 +355,9 @@ def score_candidates(
         normalized_label = _normalize_text(candidate.label)
         curated_match = None
         if candidate.mondo_id in coverage.curated_ids:
-            curated_match = coverage.label_to_file.get(normalized_label)
+            curated_match = coverage.label_to_file.get(
+                normalized_label
+            ) or coverage.id_to_file.get(candidate.mondo_id)
         elif normalized_label in coverage.curated_labels:
             curated_match = coverage.label_to_file.get(normalized_label)
 
@@ -533,7 +539,7 @@ def _write_output(
     try:
         selected = results[:top] if top else results
         if format == "table":
-            stream.write(_render_table(results, top=top))
+            stream.write(_render_table(selected))
             stream.write("\n")
         elif format == "json":
             json.dump(

--- a/src/dismech/compare/mondo_priority.py
+++ b/src/dismech/compare/mondo_priority.py
@@ -1,0 +1,642 @@
+"""Prioritize MONDO disease candidates for dismech curation."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+from .support import default_kb_dir
+from .support import get_disease_term_id
+from .support import iter_disease_files
+from .support import load_yaml_object
+
+app = typer.Typer(
+    name="dismech-mondo-prioritize",
+    help="Score MONDO disease candidates for dismech curation.",
+)
+
+_FIELD_ALIASES = {
+    "mondo_id": ["mondo_id", "id", "term_id", "disease_mondo"],
+    "label": ["label", "name", "term_label", "disease_name"],
+    "definition": ["definition", "def", "description"],
+    "synonyms": ["synonyms", "exact_synonyms", "related_synonyms"],
+    "parents": ["parents", "parent_labels", "direct_parents"],
+    "xrefs": ["xrefs", "mappings", "exact_mappings"],
+    "child_count": ["child_count", "children", "direct_child_count"],
+    "is_obsolete": ["is_obsolete", "obsolete", "deprecated"],
+    "clingen_definitive_count": [
+        "clingen_definitive_count",
+        "definitive_gene_count",
+    ],
+    "clingen_strong_count": ["clingen_strong_count", "strong_gene_count"],
+    "subset_match_count": ["subset_match_count", "priority_subset_count"],
+    "orphanet_match_count": ["orphanet_match_count", "orphanet_count"],
+}
+
+_DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parents[3] / "conf" / "mondo_prioritizer.yaml"
+)
+_TRUE_VALUES = {"1", "true", "t", "yes", "y"}
+_CONJUNCTION_PATTERN = re.compile(r"\b(with|and|or)\b", re.IGNORECASE)
+
+
+@dataclass
+class CandidateTerm:
+    """MONDO candidate row with normalized fields."""
+
+    mondo_id: str
+    label: str
+    definition: str = ""
+    synonyms: list[str] = field(default_factory=list)
+    parents: list[str] = field(default_factory=list)
+    xrefs: list[str] = field(default_factory=list)
+    child_count: int = 0
+    is_obsolete: bool = False
+    clingen_definitive_count: int = 0
+    clingen_strong_count: int = 0
+    subset_match_count: int = 0
+    orphanet_match_count: int = 0
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CoverageIndex:
+    """Local dismech coverage keyed by MONDO and label."""
+
+    curated_ids: set[str]
+    curated_labels: set[str]
+    label_to_file: dict[str, str]
+
+
+@dataclass
+class ScoredCandidate:
+    """Candidate score with supporting explanations."""
+
+    mondo_id: str
+    label: str
+    score: float
+    recommended_action: str
+    specificity_bucket: str
+    curated_match: str | None
+    family_stem: str | None
+    family_size: int
+    reasons: list[str]
+    raw: dict[str, Any]
+
+
+def _normalize_text(text: str | None) -> str:
+    if not text:
+        return ""
+    normalized = text.casefold().replace("_", " ")
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    return " ".join(normalized.split())
+
+
+def _split_multi_value(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value).strip()
+    if not text:
+        return []
+    if "|" in text:
+        parts = text.split("|")
+    elif ";" in text:
+        parts = text.split(";")
+    else:
+        parts = [text]
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _parse_int(value: Any) -> int:
+    if value in (None, ""):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return 0
+    try:
+        return int(float(text))
+    except ValueError:
+        return 0
+
+
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    return str(value).strip().casefold() in _TRUE_VALUES
+
+
+def _get_first(row: dict[str, Any], aliases: list[str], default: Any = "") -> Any:
+    for alias in aliases:
+        if alias in row and row[alias] not in (None, ""):
+            return row[alias]
+    return default
+
+
+def _sniff_delimiter(path: Path) -> str:
+    if path.suffix == ".tsv":
+        return "\t"
+    sample = path.read_text(encoding="utf-8")[:2048]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",\t")
+    except csv.Error:
+        return ","
+    return dialect.delimiter
+
+
+def _load_rows(path: Path) -> list[dict[str, Any]]:
+    if path.suffix == ".jsonl":
+        return [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    if path.suffix == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, list):
+            raise ValueError(f"Expected a JSON list in {path}")
+        return [dict(item) for item in payload]
+
+    delimiter = _sniff_delimiter(path)
+    with path.open(encoding="utf-8", newline="") as stream:
+        return [dict(row) for row in csv.DictReader(stream, delimiter=delimiter)]
+
+
+def load_candidates(path: Path) -> list[CandidateTerm]:
+    """Load candidate rows from TSV, CSV, JSON, or JSONL."""
+    candidates: list[CandidateTerm] = []
+    for row in _load_rows(path):
+        mondo_id = str(_get_first(row, _FIELD_ALIASES["mondo_id"])).strip()
+        label = str(_get_first(row, _FIELD_ALIASES["label"])).strip()
+        if not mondo_id or not label:
+            raise ValueError(
+                f"Candidate rows must include MONDO id and label. Offending row: {row}"
+            )
+        candidates.append(
+            CandidateTerm(
+                mondo_id=mondo_id,
+                label=label,
+                definition=str(
+                    _get_first(row, _FIELD_ALIASES["definition"], default="")
+                ).strip(),
+                synonyms=_split_multi_value(
+                    _get_first(row, _FIELD_ALIASES["synonyms"])
+                ),
+                parents=_split_multi_value(_get_first(row, _FIELD_ALIASES["parents"])),
+                xrefs=_split_multi_value(_get_first(row, _FIELD_ALIASES["xrefs"])),
+                child_count=_parse_int(_get_first(row, _FIELD_ALIASES["child_count"])),
+                is_obsolete=_parse_bool(
+                    _get_first(row, _FIELD_ALIASES["is_obsolete"], default=False)
+                ),
+                clingen_definitive_count=_parse_int(
+                    _get_first(row, _FIELD_ALIASES["clingen_definitive_count"])
+                ),
+                clingen_strong_count=_parse_int(
+                    _get_first(row, _FIELD_ALIASES["clingen_strong_count"])
+                ),
+                subset_match_count=_parse_int(
+                    _get_first(row, _FIELD_ALIASES["subset_match_count"])
+                ),
+                orphanet_match_count=_parse_int(
+                    _get_first(row, _FIELD_ALIASES["orphanet_match_count"])
+                ),
+                raw=row,
+            )
+        )
+    return candidates
+
+
+def build_coverage_index(kb_dir: Path) -> CoverageIndex:
+    """Index current dismech disease roots by MONDO and normalized label."""
+    curated_ids: set[str] = set()
+    curated_labels: set[str] = set()
+    label_to_file: dict[str, str] = {}
+
+    for path in iter_disease_files(kb_dir):
+        data = load_yaml_object(path)
+        disease_id = get_disease_term_id(data)
+        if disease_id:
+            curated_ids.add(disease_id)
+
+        labels = [
+            _normalize_text(data.get("name")),
+            _normalize_text(
+                ((data.get("disease_term") or {}).get("term") or {}).get("label")
+            ),
+        ]
+        for label in labels:
+            if label:
+                curated_labels.add(label)
+                label_to_file.setdefault(label, path.name)
+
+    return CoverageIndex(
+        curated_ids=curated_ids,
+        curated_labels=curated_labels,
+        label_to_file=label_to_file,
+    )
+
+
+def load_config(path: Path | None = None) -> dict[str, Any]:
+    """Load prioritizer config, defaulting to the repo config."""
+    config_path = path or _DEFAULT_CONFIG_PATH
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Config at {config_path} must be a YAML object")
+    return payload
+
+
+def _extract_family_stem(label: str, subtype_series_patterns: list[str]) -> str | None:
+    for pattern in subtype_series_patterns:
+        match = re.match(pattern, label, flags=re.IGNORECASE)
+        if match:
+            stem = match.groupdict().get("stem")
+            if stem:
+                return stem.strip(" ,")
+    return None
+
+
+def _cap_count(count: int, cap: int) -> int:
+    return min(max(count, 0), max(cap, 0))
+
+
+def _grouping_term(label: str, patterns: list[str]) -> bool:
+    return any(re.search(pattern, label, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def _likely_over_specific_leaf(label: str, child_count: int, min_words: int) -> bool:
+    if child_count != 0:
+        return False
+    if len(label.split()) < min_words:
+        return False
+    return len(_CONJUNCTION_PATTERN.findall(label)) >= 2
+
+
+def _recommend_action(
+    curated_match: str | None,
+    is_obsolete: bool,
+    grouping_term: bool,
+    subtype_series: bool,
+    broad_parent: bool,
+    likely_over_specific_leaf: bool,
+    parent_present: bool,
+) -> tuple[str, str]:
+    if curated_match:
+        return "ALREADY_CURATED", "already_curated"
+    if is_obsolete:
+        return "DROP_OBSOLETE", "obsolete"
+    if grouping_term:
+        return "DROP_GROUPING_TERM", "grouping_term"
+    if subtype_series and parent_present:
+        return "LUMP_INTO_PARENT", "subtype_series"
+    if subtype_series:
+        return "REVIEW_SERIES_FOR_PARENT_ROOT", "subtype_series"
+    if broad_parent:
+        return "CURATE_ROOT_WITH_SUBTYPES", "broad_parent"
+    if likely_over_specific_leaf:
+        return "REVIEW_AGAINST_PARENT", "over_specific_leaf"
+    return "CURATE_ROOT", "root_candidate"
+
+
+def score_candidates(
+    candidates: list[CandidateTerm],
+    coverage: CoverageIndex,
+    config: dict[str, Any],
+) -> list[ScoredCandidate]:
+    """Apply weighted scoring and specificity heuristics."""
+    weights = dict(config.get("weights") or {})
+    caps = dict(config.get("caps") or {})
+    thresholds = dict(config.get("thresholds") or {})
+    heuristics = dict(config.get("heuristics") or {})
+
+    subtype_series_patterns = list(heuristics.get("subtype_series_patterns") or [])
+    grouping_patterns = list(heuristics.get("grouping_term_patterns") or [])
+
+    family_by_label: dict[str, str] = {}
+    family_sizes: dict[str, int] = {}
+    known_labels = {
+        _normalize_text(candidate.label): candidate.label for candidate in candidates
+    }
+
+    for candidate in candidates:
+        stem = _extract_family_stem(candidate.label, subtype_series_patterns)
+        if stem:
+            normalized_stem = _normalize_text(stem)
+            family_by_label[candidate.mondo_id] = stem
+            family_sizes[normalized_stem] = family_sizes.get(normalized_stem, 0) + 1
+
+    scored: list[ScoredCandidate] = []
+    broad_parent_min_children = int(thresholds.get("broad_parent_min_children", 4))
+    subtype_series_min_family_size = int(
+        thresholds.get("subtype_series_min_family_size", 2)
+    )
+    over_specific_leaf_min_words = int(
+        thresholds.get("over_specific_leaf_min_words", 8)
+    )
+
+    for candidate in candidates:
+        normalized_label = _normalize_text(candidate.label)
+        curated_match = None
+        if candidate.mondo_id in coverage.curated_ids:
+            curated_match = coverage.label_to_file.get(normalized_label)
+        elif normalized_label in coverage.curated_labels:
+            curated_match = coverage.label_to_file.get(normalized_label)
+
+        family_stem = family_by_label.get(candidate.mondo_id)
+        normalized_family_stem = _normalize_text(family_stem)
+        family_size = family_sizes.get(normalized_family_stem, 0)
+        subtype_series = bool(
+            family_stem and family_size >= subtype_series_min_family_size
+        )
+
+        parent_present = False
+        if family_stem:
+            normalized_stem = _normalize_text(family_stem)
+            parent_present = (
+                normalized_stem in known_labels
+                or normalized_stem in coverage.curated_labels
+            )
+        if not parent_present:
+            parent_present = any(
+                _normalize_text(parent) in coverage.curated_labels
+                or _normalize_text(parent) in known_labels
+                for parent in candidate.parents
+            )
+
+        grouping_term = _grouping_term(candidate.label, grouping_patterns)
+        broad_parent = (
+            candidate.child_count >= broad_parent_min_children
+            and not subtype_series
+            and not grouping_term
+        )
+        over_specific_leaf = _likely_over_specific_leaf(
+            candidate.label,
+            candidate.child_count,
+            over_specific_leaf_min_words,
+        )
+
+        recommended_action, specificity_bucket = _recommend_action(
+            curated_match=curated_match,
+            is_obsolete=candidate.is_obsolete,
+            grouping_term=grouping_term,
+            subtype_series=subtype_series,
+            broad_parent=broad_parent,
+            likely_over_specific_leaf=over_specific_leaf,
+            parent_present=parent_present,
+        )
+
+        score = 0.0
+        reasons: list[str] = []
+
+        if not curated_match:
+            value = float(weights.get("missing_from_dismech", 0))
+            score += value
+            if value:
+                reasons.append(f"+{value:g} missing from dismech root coverage")
+
+        if candidate.definition:
+            value = float(weights.get("has_definition", 0))
+            score += value
+            if value:
+                reasons.append(f"+{value:g} has MONDO definition")
+
+        synonym_count = _cap_count(
+            len(candidate.synonyms),
+            int(caps.get("synonym_count", len(candidate.synonyms))),
+        )
+        synonym_weight = float(weights.get("synonym_count", 0))
+        if synonym_count and synonym_weight:
+            contribution = synonym_count * synonym_weight
+            score += contribution
+            reasons.append(
+                f"+{contribution:g} synonym_count={synonym_count} x {synonym_weight:g}"
+            )
+
+        xref_count = _cap_count(
+            len(candidate.xrefs), int(caps.get("xref_count", len(candidate.xrefs)))
+        )
+        xref_weight = float(weights.get("xref_count", 0))
+        if xref_count and xref_weight:
+            contribution = xref_count * xref_weight
+            score += contribution
+            reasons.append(
+                f"+{contribution:g} xref_count={xref_count} x {xref_weight:g}"
+            )
+
+        for field_name in (
+            "clingen_definitive_count",
+            "clingen_strong_count",
+            "subset_match_count",
+            "orphanet_match_count",
+        ):
+            count = getattr(candidate, field_name)
+            cap = int(caps.get(field_name, count))
+            count = _cap_count(count, cap)
+            weight = float(weights.get(field_name, 0))
+            if count and weight:
+                contribution = count * weight
+                score += contribution
+                reasons.append(f"+{contribution:g} {field_name}={count} x {weight:g}")
+
+        for flag_name, active in (
+            ("broad_parent_bonus", broad_parent),
+            ("subtype_series_penalty", subtype_series),
+            ("grouping_term_penalty", grouping_term),
+            ("over_specific_leaf_penalty", over_specific_leaf),
+            ("obsolete_penalty", candidate.is_obsolete),
+            ("already_curated_penalty", curated_match is not None),
+        ):
+            value = float(weights.get(flag_name, 0))
+            if active and value:
+                score += value
+                reasons.append(f"{value:g} {flag_name}")
+
+        if subtype_series and family_stem:
+            reasons.append(
+                f"series stem '{family_stem}' observed across {family_size} candidates"
+            )
+        if broad_parent:
+            reasons.append(
+                f"child_count={candidate.child_count} exceeds broad parent threshold"
+            )
+        if grouping_term:
+            reasons.append("label matched grouping-term regex")
+        if over_specific_leaf:
+            reasons.append("leaf label is long and conjunction-heavy")
+        if curated_match:
+            reasons.append(f"already curated in {curated_match}")
+
+        scored.append(
+            ScoredCandidate(
+                mondo_id=candidate.mondo_id,
+                label=candidate.label,
+                score=round(score, 2),
+                recommended_action=recommended_action,
+                specificity_bucket=specificity_bucket,
+                curated_match=curated_match,
+                family_stem=family_stem,
+                family_size=family_size,
+                reasons=reasons,
+                raw=candidate.raw,
+            )
+        )
+
+    return sorted(scored, key=lambda item: (-item.score, item.label.casefold()))
+
+
+def _render_table(results: list[ScoredCandidate], top: int | None = None) -> str:
+    display = results[:top] if top else results
+    header = (
+        "score\tmondo_id\tlabel\trecommended_action\tspecificity_bucket\tcurated_match"
+    )
+    rows = [
+        "\t".join(
+            [
+                f"{item.score:.2f}",
+                item.mondo_id,
+                item.label,
+                item.recommended_action,
+                item.specificity_bucket,
+                item.curated_match or "",
+            ]
+        )
+        for item in display
+    ]
+    return "\n".join([header, *rows])
+
+
+def _write_output(
+    results: list[ScoredCandidate],
+    format: str,
+    output: Path | None,
+    top: int | None = None,
+) -> None:
+    stream = (
+        output.open("w", encoding="utf-8")
+        if output
+        else typer.get_text_stream("stdout")
+    )
+    close_stream = output is not None
+    try:
+        selected = results[:top] if top else results
+        if format == "table":
+            stream.write(_render_table(results, top=top))
+            stream.write("\n")
+        elif format == "json":
+            json.dump(
+                [
+                    {
+                        "mondo_id": item.mondo_id,
+                        "label": item.label,
+                        "score": item.score,
+                        "recommended_action": item.recommended_action,
+                        "specificity_bucket": item.specificity_bucket,
+                        "curated_match": item.curated_match,
+                        "family_stem": item.family_stem,
+                        "family_size": item.family_size,
+                        "reasons": item.reasons,
+                    }
+                    for item in selected
+                ],
+                stream,
+                indent=2,
+            )
+            stream.write("\n")
+        elif format == "tsv":
+            writer = csv.DictWriter(
+                stream,
+                fieldnames=[
+                    "score",
+                    "mondo_id",
+                    "label",
+                    "recommended_action",
+                    "specificity_bucket",
+                    "curated_match",
+                    "family_stem",
+                    "family_size",
+                    "reasons",
+                ],
+                delimiter="\t",
+            )
+            writer.writeheader()
+            for item in selected:
+                writer.writerow(
+                    {
+                        "score": f"{item.score:.2f}",
+                        "mondo_id": item.mondo_id,
+                        "label": item.label,
+                        "recommended_action": item.recommended_action,
+                        "specificity_bucket": item.specificity_bucket,
+                        "curated_match": item.curated_match or "",
+                        "family_stem": item.family_stem or "",
+                        "family_size": item.family_size,
+                        "reasons": " | ".join(item.reasons),
+                    }
+                )
+        else:
+            raise typer.BadParameter("format must be one of: table, json, tsv")
+    finally:
+        if close_stream:
+            stream.close()
+
+
+@app.command("score")
+def score_command(
+    candidates: Path = typer.Argument(
+        ...,
+        help="TSV/CSV/JSON/JSONL file of MONDO candidates.",
+    ),
+    kb_dir: Path = typer.Option(
+        default_kb_dir(),
+        "--kb-dir",
+        help="Path to kb/disorders for local coverage checks.",
+    ),
+    config: Path = typer.Option(
+        _DEFAULT_CONFIG_PATH,
+        "--config",
+        help="YAML config file with weights, caps, and heuristics.",
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        help="Output format: table, json, or tsv.",
+    ),
+    top: int | None = typer.Option(
+        None,
+        "--top",
+        help="Optional number of top-scoring rows to emit.",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Optional output file path.",
+    ),
+) -> None:
+    """Score MONDO candidates against dismech coverage and specificity heuristics."""
+    candidate_rows = load_candidates(candidates)
+    coverage = build_coverage_index(kb_dir)
+    loaded_config = load_config(config)
+    results = score_candidates(candidate_rows, coverage=coverage, config=loaded_config)
+    _write_output(results, format=format, output=output, top=top)
+
+
+def main() -> None:
+    """Entrypoint for console_scripts."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mondo_prioritizer.py
+++ b/tests/test_mondo_prioritizer.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import csv
+import json
 from copy import deepcopy
 from pathlib import Path
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -37,6 +39,17 @@ def _write_candidate_tsv(path: Path, rows: list[dict[str, str]]) -> None:
         writer = csv.DictWriter(stream, fieldnames=fieldnames, delimiter="\t")
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _write_json(path: Path, payload: list[dict[str, str]]) -> None:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, str]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _build_candidate_rows() -> list[dict[str, str]]:
@@ -204,6 +217,36 @@ def test_scoring_assigns_expected_specificity_buckets_and_actions(
     assert by_label["obsolete unclassified cardiomyopathy"].score < 0
 
 
+def test_mondo_id_match_falls_back_to_file_when_label_differs(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    kb_dir.mkdir()
+    _write_yaml(
+        kb_dir / "Long_QT_Syndrome.yaml",
+        {
+            "name": "LQT Syndrome",
+            "disease_term": {
+                "term": {"id": "MONDO:0002442", "label": "long QT syndrome"}
+            },
+        },
+    )
+    candidate_path = tmp_path / "candidates.tsv"
+    _write_candidate_tsv(
+        candidate_path,
+        [row for row in _build_candidate_rows() if row["mondo_id"] == "MONDO:0002442"],
+    )
+
+    results = score_candidates(
+        load_candidates(candidate_path),
+        coverage=build_coverage_index(kb_dir),
+        config=load_config(),
+    )
+
+    assert len(results) == 1
+    assert results[0].recommended_action == "ALREADY_CURATED"
+    assert results[0].curated_match == "Long_QT_Syndrome.yaml"
+    assert results[0].score < 0
+
+
 def test_config_override_changes_weighted_score(tmp_path: Path) -> None:
     kb_dir = _build_kb_dir(tmp_path)
     candidate_path = tmp_path / "candidates.tsv"
@@ -232,6 +275,42 @@ def test_config_override_changes_weighted_score(tmp_path: Path) -> None:
     assert (
         rescored["long QT syndrome 1"].score - baseline["long QT syndrome 1"].score
     ) == 20
+
+
+def test_load_candidates_accepts_json_and_jsonl(tmp_path: Path) -> None:
+    rows = _build_candidate_rows()[:2]
+    json_path = tmp_path / "candidates.json"
+    jsonl_path = tmp_path / "candidates.jsonl"
+    _write_json(json_path, rows)
+    _write_jsonl(jsonl_path, rows)
+
+    json_candidates = load_candidates(json_path)
+    jsonl_candidates = load_candidates(jsonl_path)
+
+    assert [candidate.mondo_id for candidate in json_candidates] == [
+        "MONDO:0002442",
+        "MONDO:0100316",
+    ]
+    assert [candidate.mondo_id for candidate in jsonl_candidates] == [
+        "MONDO:0002442",
+        "MONDO:0100316",
+    ]
+
+
+def test_load_candidates_rejects_rows_missing_required_fields(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad.json"
+    _write_json(
+        bad_path,
+        [
+            {
+                "label": "missing mondo id",
+                "definition": "invalid candidate row",
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="MONDO id and label"):
+        load_candidates(bad_path)
 
 
 def test_cli_scores_candidates_end_to_end(tmp_path: Path) -> None:

--- a/tests/test_mondo_prioritizer.py
+++ b/tests/test_mondo_prioritizer.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import csv
+from copy import deepcopy
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from dismech.compare.mondo_priority import app
+from dismech.compare.mondo_priority import build_coverage_index
+from dismech.compare.mondo_priority import load_candidates
+from dismech.compare.mondo_priority import load_config
+from dismech.compare.mondo_priority import score_candidates
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_candidate_tsv(path: Path, rows: list[dict[str, str]]) -> None:
+    fieldnames = [
+        "mondo_id",
+        "label",
+        "definition",
+        "synonyms",
+        "parents",
+        "xrefs",
+        "child_count",
+        "clingen_definitive_count",
+        "clingen_strong_count",
+        "subset_match_count",
+        "orphanet_match_count",
+        "is_obsolete",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _build_candidate_rows() -> list[dict[str, str]]:
+    return [
+        {
+            "mondo_id": "MONDO:0002442",
+            "label": "long QT syndrome",
+            "definition": "Inherited repolarization disorder with ventricular arrhythmia risk.",
+            "synonyms": "LQTS; long-qt syndrome",
+            "parents": "cardiac channelopathy; arrhythmia syndrome",
+            "xrefs": "OMIM:192500|Orphanet:101019",
+            "child_count": "16",
+            "clingen_definitive_count": "3",
+            "clingen_strong_count": "0",
+            "subset_match_count": "1",
+            "orphanet_match_count": "1",
+            "is_obsolete": "false",
+        },
+        {
+            "mondo_id": "MONDO:0100316",
+            "label": "long QT syndrome 1",
+            "definition": "KCNQ1-related subtype of long QT syndrome.",
+            "synonyms": "LQT1",
+            "parents": "long QT syndrome",
+            "xrefs": "OMIM:192500",
+            "child_count": "0",
+            "clingen_definitive_count": "1",
+            "clingen_strong_count": "0",
+            "subset_match_count": "1",
+            "orphanet_match_count": "1",
+            "is_obsolete": "false",
+        },
+        {
+            "mondo_id": "MONDO:0011377",
+            "label": "long QT syndrome 3",
+            "definition": "SCN5A-related subtype of long QT syndrome.",
+            "synonyms": "LQT3",
+            "parents": "long QT syndrome",
+            "xrefs": "OMIM:603830",
+            "child_count": "0",
+            "clingen_definitive_count": "1",
+            "clingen_strong_count": "0",
+            "subset_match_count": "1",
+            "orphanet_match_count": "1",
+            "is_obsolete": "false",
+        },
+        {
+            "mondo_id": "MONDO:0010342",
+            "label": "autism, susceptibility to, X-linked 3",
+            "definition": "MECP2-linked susceptibility signal for autism spectrum presentations.",
+            "synonyms": "AUTSX3",
+            "parents": "neurodevelopmental disorder",
+            "xrefs": "OMIM:300496",
+            "child_count": "0",
+            "clingen_definitive_count": "0",
+            "clingen_strong_count": "0",
+            "subset_match_count": "1",
+            "orphanet_match_count": "0",
+            "is_obsolete": "false",
+        },
+        {
+            "mondo_id": "MONDO:0018997",
+            "label": "Noonan syndrome",
+            "definition": "RASopathy with congenital heart disease and characteristic facies.",
+            "synonyms": "Noonan syndrome 1 spectrum",
+            "parents": "RASopathy",
+            "xrefs": "OMIM:163950|Orphanet:648",
+            "child_count": "6",
+            "clingen_definitive_count": "3",
+            "clingen_strong_count": "1",
+            "subset_match_count": "1",
+            "orphanet_match_count": "1",
+            "is_obsolete": "false",
+        },
+        {
+            "mondo_id": "MONDO:0060577",
+            "label": "neurodevelopmental disorder with microcephaly, ataxia, and seizures",
+            "definition": "Rare syndromic neurodevelopmental disease defined by severe neurologic phenotype triad.",
+            "synonyms": "microcephaly-ataxia-seizures syndrome",
+            "parents": "neurodevelopmental disorder",
+            "xrefs": "OMIM:620114",
+            "child_count": "0",
+            "clingen_definitive_count": "1",
+            "clingen_strong_count": "0",
+            "subset_match_count": "1",
+            "orphanet_match_count": "0",
+            "is_obsolete": "false",
+        },
+        {
+            "mondo_id": "MONDO:0016343",
+            "label": "obsolete unclassified cardiomyopathy",
+            "definition": "Deprecated umbrella cardiomyopathy term retained for mapping history.",
+            "synonyms": "",
+            "parents": "deprecated cardiomyopathy",
+            "xrefs": "",
+            "child_count": "0",
+            "clingen_definitive_count": "0",
+            "clingen_strong_count": "0",
+            "subset_match_count": "0",
+            "orphanet_match_count": "0",
+            "is_obsolete": "true",
+        },
+    ]
+
+
+def _build_kb_dir(tmp_path: Path) -> Path:
+    kb_dir = tmp_path / "kb"
+    kb_dir.mkdir()
+    _write_yaml(
+        kb_dir / "Noonan_Syndrome.yaml",
+        {
+            "name": "Noonan Syndrome",
+            "disease_term": {
+                "term": {"id": "MONDO:0018997", "label": "Noonan syndrome"}
+            },
+        },
+    )
+    return kb_dir
+
+
+def test_scoring_assigns_expected_specificity_buckets_and_actions(
+    tmp_path: Path,
+) -> None:
+    kb_dir = _build_kb_dir(tmp_path)
+    candidate_path = tmp_path / "candidates.tsv"
+    _write_candidate_tsv(candidate_path, _build_candidate_rows())
+
+    config = load_config()
+    coverage = build_coverage_index(kb_dir)
+    results = score_candidates(load_candidates(candidate_path), coverage, config)
+    by_label = {row.label: row for row in results}
+
+    assert (
+        by_label["long QT syndrome"].recommended_action == "CURATE_ROOT_WITH_SUBTYPES"
+    )
+    assert by_label["long QT syndrome"].specificity_bucket == "broad_parent"
+
+    assert by_label["long QT syndrome 1"].recommended_action == "LUMP_INTO_PARENT"
+    assert by_label["long QT syndrome 1"].specificity_bucket == "subtype_series"
+
+    assert (
+        by_label["autism, susceptibility to, X-linked 3"].recommended_action
+        == "DROP_GROUPING_TERM"
+    )
+    assert (
+        by_label["autism, susceptibility to, X-linked 3"].specificity_bucket
+        == "grouping_term"
+    )
+
+    assert by_label["Noonan syndrome"].recommended_action == "ALREADY_CURATED"
+    assert by_label["Noonan syndrome"].curated_match == "Noonan_Syndrome.yaml"
+
+    assert (
+        by_label[
+            "neurodevelopmental disorder with microcephaly, ataxia, and seizures"
+        ].recommended_action
+        == "REVIEW_AGAINST_PARENT"
+    )
+
+    assert by_label["long QT syndrome"].score > by_label["long QT syndrome 1"].score
+    assert (
+        by_label["long QT syndrome 1"].score
+        > by_label["autism, susceptibility to, X-linked 3"].score
+    )
+    assert by_label["obsolete unclassified cardiomyopathy"].score < 0
+
+
+def test_config_override_changes_weighted_score(tmp_path: Path) -> None:
+    kb_dir = _build_kb_dir(tmp_path)
+    candidate_path = tmp_path / "candidates.tsv"
+    _write_candidate_tsv(candidate_path, _build_candidate_rows())
+    candidates = load_candidates(candidate_path)
+    coverage = build_coverage_index(kb_dir)
+
+    baseline_config = load_config()
+    baseline = {
+        row.label: row
+        for row in score_candidates(
+            candidates, coverage=coverage, config=baseline_config
+        )
+    }
+
+    custom_config = deepcopy(baseline_config)
+    custom_config["weights"]["subset_match_count"] = 25
+    rescored = {
+        row.label: row
+        for row in score_candidates(candidates, coverage=coverage, config=custom_config)
+    }
+
+    assert (
+        rescored["long QT syndrome"].score - baseline["long QT syndrome"].score
+    ) == 20
+    assert (
+        rescored["long QT syndrome 1"].score - baseline["long QT syndrome 1"].score
+    ) == 20
+
+
+def test_cli_scores_candidates_end_to_end(tmp_path: Path) -> None:
+    kb_dir = _build_kb_dir(tmp_path)
+    candidate_path = tmp_path / "candidates.tsv"
+    _write_candidate_tsv(candidate_path, _build_candidate_rows())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            str(candidate_path),
+            "--kb-dir",
+            str(kb_dir),
+            "--format",
+            "table",
+            "--top",
+            "3",
+        ],
+    )
+
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.strip().splitlines() if line]
+    assert lines[0].startswith("score\tmondo_id\tlabel")
+    assert "long QT syndrome" in lines[1]
+    assert "CURATE_ROOT_WITH_SUBTYPES" in lines[1]


### PR DESCRIPTION
## Summary
This adds a practical MONDO-first prioritizer for building dismech curation queues from candidate disease rows instead of from raw checklist issues.

## What Changed
- Added a new CLI: `dismech-mondo-prioritize`
- Added scorer implementation in `src/dismech/compare/mondo_priority.py`
- Added default config in `conf/mondo_prioritizer.yaml`
- Added docs in `docs/mondo-prioritizer.md` and MkDocs navigation entry
- Added example candidate/config files under `examples/`
- Added tests covering scoring, specificity heuristics, config overrides, and CLI behavior

## Scoring Dimensions
The scorer uses explicit weighted signals so the queue is easy to inspect and retune:
- `missing_from_dismech`: base reward for MONDO terms not already covered as dismech roots
- `has_definition`: reward for candidate terms with a MONDO definition
- `synonym_count` and `xref_count`: small metadata completeness rewards with caps
- `clingen_definitive_count` and `clingen_strong_count`: optional boosts when upstream MONDO candidate exports include those evidence counts
- `subset_match_count` and `orphanet_match_count`: optional boosts for candidates already tagged as belonging to priority slices
- `already_curated_penalty` and `obsolete_penalty`: strong penalties for terms that should not rise in the queue

## Default Weights
Default weights live in `conf/mondo_prioritizer.yaml` and are intentionally conservative:
- strong positive weight for missing-from-dismech roots
- modest metadata rewards for definitions, synonyms, and xrefs
- stronger positive weights for ClinGen and subset-style evidence counts when supplied
- clear penalties for already curated terms, subtype-series leaves, grouping terms, over-specific leaves, and obsolete terms

Count-based features are capped to stop large synonym/xref counts from swamping the queue.

## Specificity Heuristics
The prioritizer emits both a numeric score and an advisory recommendation.

Specificity buckets:
- `already_curated`
- `obsolete`
- `grouping_term`
- `subtype_series`
- `broad_parent`
- `over_specific_leaf`
- `root_candidate`

Recommended actions:
- `CURATE_ROOT`
- `CURATE_ROOT_WITH_SUBTYPES`
- `LUMP_INTO_PARENT`
- `REVIEW_SERIES_FOR_PARENT_ROOT`
- `REVIEW_AGAINST_PARENT`
- `DROP_GROUPING_TERM`
- `DROP_OBSOLETE`
- `ALREADY_CURATED`

Default heuristics stay simple and explicit:
- grouping terms are matched by configurable high-confidence regexes such as `susceptibility`, `predisposition`, and `obsolete`
- subtype series are detected from configurable label suffix patterns such as `long QT syndrome 1`
- broad parents are detected from child-count thresholds
- likely over-specific leaves are flagged when they are leaf terms with long conjunction-heavy labels

## Why This Helps
This gives us a reusable MONDO-first substrate for triaging candidates before curation:
- it compares MONDO candidates to current dismech root coverage
- it distinguishes likely root targets from subtype-series leaves and grouping terms
- it keeps the prioritization logic transparent and tuneable rather than burying decisions in issue-specific analysis

## Validation
- `uv run pytest tests/test_mondo_prioritizer.py -q`
- `uv run pytest tests/test_g2p_gene_audit.py -q`
- `uv run dismech-mondo-prioritize examples/mondo_prioritizer_candidates.tsv --format table --top 5`
