### PR TITLE
[codex] Fix strict schema term validation for ontology-backed enums

### DIFF
--- a/src/dismech/schema/classifications/harrisons_chapters.yaml
+++ b/src/dismech/schema/classifications/harrisons_chapters.yaml
@@ -46,12 +46,16 @@ enums:
         description: Structural or functional valve disease (stenosis or regurgitation)
           affecting cardiac hemodynamics.
         is_a: cardiovascular disorder
+        aliases:
+          - heart valve disorder
         meaning: MONDO:0002869
       vascular disease:
         title: Diseases of arteries and veins (aneurysm, PAD, DVT)
         description: Arterial or venous disorders such as aneurysm, peripheral artery
           disease, or thrombosis.
         is_a: cardiovascular disorder
+        aliases:
+          - vascular disorder
         meaning: MONDO:0005385
       respiratory system disorder:
         title: Diseases of the lungs and airways
@@ -91,6 +95,8 @@ enums:
         description: Acid-related disorders of the esophagus, stomach, or duodenum
           such as GERD and peptic ulcer disease.
         is_a: digestive system disorder
+        aliases:
+          - peptic ulcer disease
         meaning: MONDO:0004247
       liver disorder:
         title: Diseases of the liver, gallbladder, and biliary system
@@ -107,6 +113,8 @@ enums:
         description: Diseases of the glomerulus causing hematuria, proteinuria, or
           nephrotic/nephritic syndromes.
         is_a: kidney disorder
+        aliases:
+          - glomerular disorder
         meaning: MONDO:0019722
       hematologic disorder:
         title: Diseases of blood and blood-forming organs
@@ -123,6 +131,8 @@ enums:
         description: Bleeding or thrombotic disorders from clotting factor, platelet,
           or regulatory defects.
         is_a: hematologic disorder
+        aliases:
+          - blood coagulation disease
         meaning: MONDO:0001531
       cancer:
         title: Neoplastic diseases and cancer
@@ -134,6 +144,8 @@ enums:
         description: Cancers of blood, bone marrow, and lymphoid tissues such as leukemia
           or lymphoma.
         is_a: cancer
+        aliases:
+          - hematopoietic and lymphoid system neoplasm
         meaning: MONDO:0002334
       solid tumor:
         title: Carcinomas, sarcomas, other solid neoplasms
@@ -171,6 +183,8 @@ enums:
         description: Infections due to Mycobacterium species, including tuberculosis
           and non-tuberculous mycobacteria.
         is_a: infectious disease
+        aliases:
+          - mycobacterial infectious disease
         meaning: MONDO:0020590
       immune system disorder:
         title: Diseases of the immune system including autoimmunity
@@ -203,12 +217,16 @@ enums:
         description: Thyroid gland dysfunction or structural disease altering metabolic
           control.
         is_a: endocrine system disorder
+        aliases:
+          - thyroid gland disorder
         meaning: MONDO:0003240
       adrenal disorder:
         title: Cushing's, Addison's, pheochromocytoma
         description: Adrenal cortex or medulla disorders causing hormone excess or
           deficiency.
         is_a: endocrine system disorder
+        aliases:
+          - adrenal gland disorder
         meaning: MONDO:0005495
       nervous system disorder:
         title: Diseases of the central and peripheral nervous system
@@ -261,6 +279,8 @@ enums:
         description: Systemic autoimmune connective tissue disorders affecting skin,
           joints, vessels, and organs.
         is_a: musculoskeletal system disorder
+        aliases:
+          - connective tissue disorder
         meaning: MONDO:0003900
       skin disorder:
         title: Diseases of the skin and appendages

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -157,6 +157,8 @@ enums:
       VERY_FREQUENT:
         title: Very frequent (80-99%)
         description: Present in most cases (80-99% of patients)
+        aliases:
+          - Very frequent
         meaning: HP:0040281
       FREQUENT:
         title: Frequent (30-79%)
@@ -169,6 +171,8 @@ enums:
       VERY_RARE:
         title: Very rare (<5%)
         description: Present in rare cases (<5% of patients)
+        aliases:
+          - Very rare
         meaning: HP:0040284
   ClinicalSignificanceEnum:
     description: The clinical significance of a variant for a condition (ACMG guidelines)
@@ -176,22 +180,32 @@ enums:
       PATHOGENIC:
         title: Pathogenic
         description: Variant is pathogenic for the condition (ACMG class 5)
+        aliases:
+          - pathogenic_for_condition
         meaning: GENO:0000840
       LIKELY_PATHOGENIC:
         title: Likely pathogenic
         description: Variant is likely pathogenic for the condition (ACMG class 4)
+        aliases:
+          - likely_pathogenic_for_condition
         meaning: GENO:0000841
       BENIGN:
         title: Benign
         description: Variant is benign for the condition (ACMG class 1)
+        aliases:
+          - benign_for_condition
         meaning: GENO:0000843
       LIKELY_BENIGN:
         title: Likely benign
         description: Variant is likely benign for the condition (ACMG class 2)
+        aliases:
+          - likely_benign_for_condition
         meaning: GENO:0000844
       UNCERTAIN_SIGNIFICANCE:
         title: Uncertain significance
         description: Clinical significance of the variant is uncertain (ACMG class 3)
+        aliases:
+          - has_uncertain_significance_for_condition
         meaning: GENO:0000845
   RegulatoryVariantCategoryEnum:
     description: >-
@@ -753,6 +767,8 @@ enums:
         meaning: HP:0003584
       PUERPERAL:
         description: Puerperal onset
+        aliases:
+          - Puerpural onset
         meaning: HP:4000040
   ZygosityEnum:
     description: Zygosity categories from GENO


### PR DESCRIPTION
## Summary

This PR makes strict schema term validation pass for ontology-backed enum permissible values without changing the existing human-facing titles and descriptions.

It adds canonical ontology-label aliases for the enum entries that were failing `linkml-term-validator validate-schema` label checks in:

- `HarrisonsChapterEnum`
- `FrequencyEnum`
- `ClinicalSignificanceEnum`
- `OnsetEnum`

## Why

The schema currently uses some humanized or example-driven labels for enum values, while `validate-schema` compares each `meaning` against the ontology label plus any permitted aliases.

That meant the schema passed CI's current unresolved-term check, but failed stricter label validation for cases like:

- Harrison chapter values such as `Leukemia, lymphoma, myeloma` vs MONDO `hematopoietic and lymphoid system neoplasm`
- ACMG-style clinical significance labels vs GENO canonical labels such as `pathogenic_for_condition`
- HPO frequency and onset labels where the canonical ontology label differs from the display text

Adding aliases preserves the current display-oriented schema labels while making the ontology grounding explicit.

## Impact

- strict schema-term validation now passes cleanly
- existing user-facing enum titles and descriptions stay unchanged
- this reduces the gap between local strict validation and current CI behavior

## Validation

Ran strict schema validation via the Python API:

```bash
uv run python - <<'PY'
from pathlib import Path
from linkml_term_validator.models import ValidationConfig
from linkml_term_validator.validator import EnumValidator
schema=Path('src/dismech/schema/dismech.yaml')
validator=EnumValidator(ValidationConfig(oak_config_path=Path('conf/oak_config.yaml'), cache_labels=False))
res=validator.validate_schema(schema)
print('errors', res.error_count())
print('warnings', res.warning_count())
raise SystemExit(1 if res.error_count() or res.warning_count() else 0)
PY
```

Result:

- `errors 0`
- `warnings 0`