### PR TITLE
[codex] Add evidence-backed ESCC curation

### DIFF
--- a/kb/disorders/Esophageal_Squamous_Cell_Carcinoma.yaml
+++ b/kb/disorders/Esophageal_Squamous_Cell_Carcinoma.yaml
@@ -1,0 +1,653 @@
+name: Esophageal Squamous Cell Carcinoma
+creation_date: "2026-04-11T00:00:00Z"
+updated_date: "2026-04-11T00:00:00Z"
+description: >-
+  Esophageal squamous cell carcinoma (ESCC) is the major squamous malignancy of
+  the esophagus and remains the dominant histologic subtype of esophageal cancer
+  worldwide. It arises from the stratified squamous mucosa of the esophagus and
+  is strongly associated with tobacco smoking, alcohol exposure, and regional
+  environmental or dietary carcinogens. Molecularly, ESCC is characterized by
+  frequent TP53 mutation together with recurrent alterations affecting cell-cycle
+  control, squamous differentiation, NOTCH signaling, and PI3K/AKT signaling.
+  Curative-intent management relies on surgery and chemoradiation for localized
+  disease, while PD-1-directed immunotherapy has become an important option in
+  advanced disease.
+categories:
+- Gastrointestinal Cancer
+- Solid Tumor
+- Environmental Cancer
+- Tobacco-Related Cancer
+disease_term:
+  preferred_term: esophageal squamous cell carcinoma
+  term:
+    id: MONDO:0005580
+    label: esophageal squamous cell carcinoma
+parents:
+- esophageal cancer
+- squamous cell carcinoma
+environmental:
+- name: Tobacco Smoking
+  description: >-
+    Cigarette smoking is a major modifiable risk factor for ESCC. Tobacco smoke
+    exposes the esophageal epithelium to carcinogens that drive DNA damage and
+    cooperate with alcohol-related injury in upper aerodigestive tract
+    carcinogenesis.
+  exposure_term:
+    preferred_term: exposure to tobacco smoking
+    term:
+      id: ECTO:6000029
+      label: exposure to tobacco smoking
+  evidence:
+  - reference: PMID:20224883
+    reference_title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: molecular mechanisms of carcinogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both alcohol consumption and cigarette smoking are major risk factors for
+      the development of ESCC.
+    explanation: >-
+      This review explicitly identifies cigarette smoking as a major ESCC risk
+      factor.
+- name: Alcohol Consumption
+  description: >-
+    Alcohol use is a major ESCC risk factor and acts synergistically with
+    tobacco. Acetaldehyde exposure, ALDH2-dependent susceptibility, and
+    interaction with tobacco carcinogens increase mutational burden in the
+    esophageal squamous epithelium.
+  exposure_term:
+    preferred_term: exposure to ethanol
+    term:
+      id: ECTO:9000027
+      label: exposure to ethanol
+  evidence:
+  - reference: PMID:20224884
+    reference_title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: epidemiology, clinical findings, and prevention."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our case-control study revealed the odds ratio of ESCC to be 50.1 for
+      those who were both heavy smokers and heavy drinkers in comparison to
+      people who neither drank nor smoked.
+    explanation: >-
+      This epidemiologic review quantifies the strong combined ESCC risk from
+      heavy alcohol and tobacco exposure.
+pathophysiology:
+- name: Carcinogen-Driven Esophageal Epithelial Injury
+  description: >-
+    Chronic exposure to tobacco smoke and alcohol-derived acetaldehyde injures
+    the esophageal squamous epithelium and promotes carcinogenesis through DNA
+    damage, epigenetic disruption, and repeated mutagenic stress.
+  cell_types:
+  - preferred_term: squamous epithelial cell
+    term:
+      id: CL:0000076
+      label: squamous epithelial cell
+  locations:
+  - preferred_term: esophagus
+    term:
+      id: UBERON:0001043
+      label: esophagus
+  biological_processes:
+  - preferred_term: DNA damage response
+    modifier: ABNORMAL
+    term:
+      id: GO:0006974
+      label: DNA damage response
+  evidence:
+  - reference: PMID:20224883
+    reference_title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: molecular mechanisms of carcinogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both alcohol consumption and cigarette smoking are major risk factors for
+      the development of ESCC.
+    explanation: >-
+      This review links the major ESCC carcinogen exposures directly to disease
+      development.
+  - reference: PMID:20224883
+    reference_title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: molecular mechanisms of carcinogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Acetaldehyde is the most toxic ethanol metabolite in alcohol-associated
+      carcinogenesis, while ethanol itself stimulates carcinogenesis by
+      inhibiting DNA methylation and by interacting with retinoid metabolism.
+    explanation: >-
+      This provides a mechanistic link between alcohol exposure and mutagenic or
+      epigenetic injury in esophageal carcinogenesis.
+  downstream:
+  - target: TP53 Dysfunction
+    description: Mutagenic injury selects for loss of p53-mediated genomic surveillance
+- name: TP53 Dysfunction
+  description: >-
+    TP53 alteration is the dominant recurrent genetic event in ESCC and
+    compromises cell-cycle checkpoint control, apoptosis, and genome integrity.
+    Loss of p53 function permits survival and expansion of damaged esophageal
+    epithelial clones.
+  genes:
+  - preferred_term: TP53
+    term:
+      id: hgnc:11998
+      label: TP53
+  biological_processes:
+  - preferred_term: cell cycle checkpoint signaling
+    modifier: DECREASED
+    term:
+      id: GO:0000075
+      label: cell cycle checkpoint signaling
+  - preferred_term: apoptotic process
+    modifier: DECREASED
+    term:
+      id: GO:0006915
+      label: apoptotic process
+  evidence:
+  - reference: PMID:34611831
+    reference_title: "Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI: 26.2-54.1), MDM2
+      (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI: 15.0-21.2),
+      KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+      PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0),
+      and EGFR (9.9%; 95% CI: 5.6-17.0) were the most common involved genetic
+      factors in developing ESCC.
+    explanation: >-
+      This meta-analysis identifies TP53 as the most frequent recurrent genetic
+      alteration in ESCC.
+  downstream:
+  - target: Cell Cycle Dysregulation
+    description: Loss of p53 checkpoint function enables unchecked cell-cycle progression
+- name: Cell Cycle Dysregulation
+  description: >-
+    Recurrent alteration of TP53, CCND1, CDKN2A, and related regulators disrupts
+    G1/S control and promotes persistent proliferation of transformed esophageal
+    squamous cells.
+  biological_processes:
+  - preferred_term: negative regulation of G1/S transition
+    modifier: DECREASED
+    term:
+      id: GO:2000134
+      label: negative regulation of G1/S transition of mitotic cell cycle
+  evidence:
+  - reference: PMID:38832974
+    reference_title: "Prognostic value of genomic mutation signature associated with immune microenvironment in southern Chinese patients with esophageal squamous cell carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pathway analysis revealed dysregulation of cell cycle regulation,
+      epigenetic regulation, PI3K/AKT signaling, and NOTCH signaling.
+    explanation: >-
+      This cohort study directly implicates cell-cycle dysregulation as a major
+      altered pathway in ESCC.
+  downstream:
+  - target: SOX2/TP63 Lineage Program Activation
+    description: Squamous lineage transcription factors reinforce malignant growth programs
+  - target: PI3K/AKT Signaling Activation
+    description: Cell-cycle dysregulation cooperates with oncogenic survival signaling
+  - target: NOTCH Pathway Dysregulation
+    description: Loss of normal squamous differentiation signaling promotes malignant progression
+- name: SOX2/TP63 Lineage Program Activation
+  description: >-
+    ESCC frequently shows 3q amplification with co-amplification and
+    upregulation of SOX2 and TP63, reinforcing a malignant squamous lineage
+    transcriptional program. SOX2 promotes tumor growth and interacts with
+    oncogenic signaling programs including AKT/mTORC1 and YAP1.
+  cell_types:
+  - preferred_term: squamous epithelial cell
+    term:
+      id: CL:0000076
+      label: squamous epithelial cell
+  genes:
+  - preferred_term: SOX2
+    term:
+      id: hgnc:11195
+      label: SOX2
+  - preferred_term: TP63
+    term:
+      id: hgnc:15979
+      label: TP63
+  evidence:
+  - reference: PMID:31560173
+    reference_title: "SOX2 antagonizes WWC1 to drive YAP1 activation in esophageal squamous cell carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here, we reveal that SOX2, ACTL6A, and TP63 are co-amplified and
+      upregulated in ESCC samples.
+    explanation: >-
+      This directly supports structured inclusion of SOX2 and TP63 as recurrent
+      co-amplified squamous lineage regulators in ESCC.
+  - reference: PMID:23510069
+    reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our previous study revealed that the SOX2 gene is an amplification target
+      of 3q26.3 in esophageal squamous cell carcinoma (ESCC), and that SOX2
+      promotes ESCC cell proliferation in vitro.
+    explanation: >-
+      This links SOX2 amplification to proliferative drive in ESCC and supports
+      its role as a lineage-associated oncogenic factor.
+  downstream:
+  - target: PI3K/AKT Signaling Activation
+    description: SOX2 can activate growth-promoting AKT/mTORC1 signaling
+  - target: Increased Tumor Cell Proliferation
+    description: Squamous lineage oncogene activation promotes ESCC growth
+- name: PI3K/AKT Signaling Activation
+  description: >-
+    Recurrent PIK3CA and related pathway alterations increase prosurvival and
+    growth signaling in ESCC, supporting tumor maintenance and therapeutic
+    resistance.
+  biological_processes:
+  - preferred_term: phosphatidylinositol 3-kinase signaling
+    modifier: INCREASED
+    term:
+      id: GO:0043491
+      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence:
+  - reference: PMID:38832974
+    reference_title: "Prognostic value of genomic mutation signature associated with immune microenvironment in southern Chinese patients with esophageal squamous cell carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pathway analysis revealed dysregulation of cell cycle regulation,
+      epigenetic regulation, PI3K/AKT signaling, and NOTCH signaling.
+    explanation: >-
+      This study directly reports PI3K/AKT pathway dysregulation in ESCC.
+  downstream:
+  - target: Increased Tumor Cell Proliferation
+    description: PI3K/AKT activity promotes growth and survival of ESCC cells
+- name: NOTCH Pathway Dysregulation
+  description: >-
+    Alteration of NOTCH pathway genes perturbs normal squamous differentiation
+    programs and contributes to malignant transformation and progression in ESCC.
+  genes:
+  - preferred_term: NOTCH1
+    term:
+      id: hgnc:7881
+      label: NOTCH1
+  biological_processes:
+  - preferred_term: Notch signaling pathway
+    modifier: ABNORMAL
+    term:
+      id: GO:0007219
+      label: Notch signaling pathway
+  - preferred_term: keratinocyte differentiation
+    modifier: DECREASED
+    term:
+      id: GO:0030216
+      label: keratinocyte differentiation
+  evidence:
+  - reference: PMID:34611831
+    reference_title: "Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI: 26.2-54.1), MDM2
+      (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI: 15.0-21.2),
+      KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+      PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0),
+      and EGFR (9.9%; 95% CI: 5.6-17.0) were the most common involved genetic
+      factors in developing ESCC.
+    explanation: >-
+      This meta-analysis shows recurrent NOTCH pathway gene involvement in ESCC.
+  downstream:
+  - target: Increased Tumor Cell Proliferation
+    description: Impaired squamous differentiation favors tumor expansion
+- name: Increased Tumor Cell Proliferation
+  description: >-
+    Convergent disruption of DNA damage control, cell-cycle regulation, squamous
+    differentiation, and prosurvival signaling drives continued ESCC cell
+    proliferation, invasion, and progression.
+  cell_types:
+  - preferred_term: squamous epithelial cell
+    term:
+      id: CL:0000076
+      label: squamous epithelial cell
+  biological_processes:
+  - preferred_term: cell population proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  evidence:
+  - reference: PMID:23510069
+    reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our findings suggest that SOX2 promotes in vivo tumor growth of ESCC
+      through activation of the AKT/mTORC1 signaling pathway, which enhances
+      cell proliferation.
+    explanation: >-
+      This directly supports the terminal proliferative output node in ESCC.
+phenotypes:
+- category: Gastrointestinal
+  name: Progressive Dysphagia
+  description: >-
+    Progressive difficulty swallowing is the most common presenting symptom as
+    the luminal tumor narrows the esophagus.
+  phenotype_term:
+    preferred_term: Dysphagia
+    term:
+      id: HP:0002015
+      label: Dysphagia
+  evidence:
+  - reference: PMID:31058012
+    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its large polypoid character, patients suffering from this disease
+      typically present with progressive dysphagia, weight loss, odynophagia,
+      or chest pain.
+    explanation: >-
+      A squamous carcinoma subtype of the esophagus explicitly lists
+      progressive dysphagia as a presenting phenotype.
+- category: Constitutional
+  name: Weight Loss
+  description: >-
+    Weight loss is common because of impaired oral intake, cancer-associated
+    catabolism, and advanced disease burden.
+  phenotype_term:
+    preferred_term: Weight loss
+    term:
+      id: HP:0001824
+      label: Weight loss
+  evidence:
+  - reference: PMID:31058012
+    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its large polypoid character, patients suffering from this disease
+      typically present with progressive dysphagia, weight loss, odynophagia,
+      or chest pain.
+    explanation: >-
+      This abstract explicitly includes weight loss among presenting symptoms of
+      esophageal squamous carcinoma.
+- category: Gastrointestinal
+  name: Odynophagia
+  description: >-
+    Painful swallowing may occur when the tumor ulcerates or deeply invades the
+    esophageal wall.
+  phenotype_term:
+    preferred_term: Odynophagia
+    term:
+      id: HP:0032043
+      label: Odynophagia
+  evidence:
+  - reference: PMID:31058012
+    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its large polypoid character, patients suffering from this disease
+      typically present with progressive dysphagia, weight loss, odynophagia,
+      or chest pain.
+    explanation: >-
+      This abstract explicitly includes odynophagia among presenting symptoms of
+      esophageal squamous carcinoma.
+- category: Gastrointestinal
+  name: Chest Pain
+  description: >-
+    Retrosternal chest pain can accompany locally invasive or ulcerative
+    esophageal tumors.
+  phenotype_term:
+    preferred_term: Chest pain
+    term:
+      id: HP:0100749
+      label: Chest pain
+  evidence:
+  - reference: PMID:31058012
+    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its large polypoid character, patients suffering from this disease
+      typically present with progressive dysphagia, weight loss, odynophagia,
+      or chest pain.
+    explanation: >-
+      This abstract explicitly includes chest pain among presenting symptoms of
+      esophageal squamous carcinoma.
+- category: Gastrointestinal
+  name: Hematemesis
+  description: >-
+    Tumor ulceration may cause upper gastrointestinal bleeding with vomiting of
+    blood.
+  phenotype_term:
+    preferred_term: Hematemesis
+    term:
+      id: HP:0002248
+      label: Hematemesis
+  evidence:
+  - reference: PMID:28894616
+    reference_title: "Esophageal Squamous Cell Carcinoma Presenting with Streptococcus intermedius Cerebral Abscess."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We report the case of a 53-year-old female who presented with
+      hematemesis and melena followed by left-sided weakness.
+    explanation: >-
+      This case report directly documents hematemesis in a patient with
+      esophageal squamous cell carcinoma.
+histopathology:
+- name: Squamous Cell Carcinoma
+  finding_term:
+    preferred_term: Squamous Cell Carcinoma
+    term:
+      id: NCIT:C2929
+      label: Squamous Cell Carcinoma
+  description: >-
+    ESCC is the squamous histologic subtype of esophageal cancer and represents
+    the dominant esophageal cancer histology worldwide.
+  evidence:
+  - reference: PMID:20224883
+    reference_title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: molecular mechanisms of carcinogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Esophageal cancers are classified into two histological types; esophageal
+      squamous cell carcinoma (ESCC), and adenocarcinoma
+    explanation: >-
+      This review explicitly identifies ESCC as a distinct histologic subtype of
+      esophageal cancer.
+biochemical:
+- name: PD-L1 Immunohistochemistry
+  notes: >-
+    PD-L1 testing, often reported as combined positive score (CPS), helps guide
+    use of immune checkpoint inhibitors in advanced disease.
+- name: Squamous Cell Carcinoma Antigen
+  notes: >-
+    Serum squamous cell carcinoma antigen may correlate with tumor burden and
+    prognosis in a subset of patients, but it is not sufficiently specific for
+    diagnosis.
+genetic:
+- name: TP53
+  association: Somatic Driver Mutation
+  notes: >-
+    TP53 is the most common recurrently altered gene in ESCC and is associated
+    with genomic instability and loss of checkpoint control.
+  evidence:
+  - reference: PMID:34611831
+    reference_title: "Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI: 26.2-54.1), MDM2
+      (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI: 15.0-21.2),
+      KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+      PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0),
+      and EGFR (9.9%; 95% CI: 5.6-17.0) were the most common involved genetic
+      factors in developing ESCC.
+    explanation: >-
+      This meta-analysis identifies TP53 as the most prevalent recurrent genetic
+      alteration in ESCC.
+- name: CCND1
+  association: Copy Number Amplification
+  notes: >-
+    CCND1 amplification contributes to cell-cycle acceleration and is among the
+    most frequent recurrent driver alterations in ESCC.
+  evidence:
+  - reference: PMID:34611831
+    reference_title: "Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI: 26.2-54.1), MDM2
+      (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI: 15.0-21.2),
+      KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+      PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0),
+      and EGFR (9.9%; 95% CI: 5.6-17.0) were the most common involved genetic
+      factors in developing ESCC.
+    explanation: >-
+      This meta-analysis identifies CCND1 as a frequent recurrent ESCC genetic
+      alteration.
+- name: NOTCH1
+  association: Squamous Differentiation Pathway Alteration
+  notes: >-
+    NOTCH pathway alteration disrupts normal squamous differentiation programs
+    and contributes to ESCC pathogenesis.
+  evidence:
+  - reference: PMID:34611831
+    reference_title: "Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI: 26.2-54.1), MDM2
+      (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI: 15.0-21.2),
+      KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+      PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0),
+      and EGFR (9.9%; 95% CI: 5.6-17.0) were the most common involved genetic
+      factors in developing ESCC.
+    explanation: >-
+      This meta-analysis supports recurrent NOTCH pathway gene alteration in
+      ESCC.
+- name: PIK3CA
+  association: Oncogenic Signaling Activation
+  notes: >-
+    PIK3CA mutation is a recurrent ESCC event that contributes to PI3K/AKT
+    pathway activation.
+  evidence:
+  - reference: PMID:34611831
+    reference_title: "Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI: 26.2-54.1), MDM2
+      (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI: 15.0-21.2),
+      KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+      PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0),
+      and EGFR (9.9%; 95% CI: 5.6-17.0) were the most common involved genetic
+      factors in developing ESCC.
+    explanation: >-
+      This meta-analysis supports recurrent PIK3CA alteration in ESCC.
+- name: SOX2
+  association: Lineage Oncogene Amplification
+  notes: >-
+    SOX2 is a recurrent 3q amplification target in ESCC that reinforces
+    malignant squamous lineage programs and proliferative signaling.
+  evidence:
+  - reference: PMID:23510069
+    reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our previous study revealed that the SOX2 gene is an amplification target
+      of 3q26.3 in esophageal squamous cell carcinoma (ESCC), and that SOX2
+      promotes ESCC cell proliferation in vitro.
+    explanation: >-
+      This directly supports SOX2 as an amplified oncogenic driver in ESCC.
+- name: TP63
+  association: Co-amplified Squamous Lineage Transcription Factor
+  notes: >-
+    TP63 is recurrently co-amplified with SOX2 in ESCC and supports the
+    malignant squamous transcriptional state.
+  evidence:
+  - reference: PMID:31560173
+    reference_title: "SOX2 antagonizes WWC1 to drive YAP1 activation in esophageal squamous cell carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here, we reveal that SOX2, ACTL6A, and TP63 are co-amplified and
+      upregulated in ESCC samples.
+    explanation: >-
+      This directly supports TP63 as a recurrent co-amplified squamous lineage
+      regulator in ESCC.
+treatments:
+- name: Esophagectomy
+  description: >-
+    Surgical resection is a core curative-intent treatment for resectable
+    localized ESCC, typically used in multimodality management.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+- name: Definitive Chemoradiation
+  description: >-
+    Concurrent chemoradiation is a standard organ-preserving approach for
+    locally advanced or unresectable localized ESCC and is also used as part of
+    neoadjuvant therapy strategies.
+  treatment_term:
+    preferred_term: radiation therapy
+    term:
+      id: MAXO:0000014
+      label: radiation therapy
+    therapeutic_agent:
+    - preferred_term: cisplatin
+      term:
+        id: CHEBI:27899
+        label: cisplatin
+    - preferred_term: 5-fluorouracil
+      term:
+        id: CHEBI:46345
+        label: 5-fluorouracil
+- name: Nivolumab
+  description: >-
+    Anti-PD-1 immunotherapy used in advanced or previously treated ESCC. It
+    improves overall survival compared with chemotherapy in the post-platinum
+    setting and is now part of the immunotherapy treatment landscape for ESCC.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: nivolumab
+      term:
+        id: NCIT:C68814
+        label: Nivolumab
+  evidence:
+  - reference: PMID:35294546
+    reference_title: "Three-Year Follow-Up and Response-Survival Relationship of Nivolumab in Previously Treated Patients with Advanced Esophageal Squamous Cell Carcinoma (ATTRACTION-3)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Nivolumab as second-line therapy demonstrated clinically meaningful
+      long-term improvement in OS compared with chemotherapy in previously
+      treated patients with advanced ESCC.
+    explanation: >-
+      ATTRACTION-3 provides direct clinical evidence supporting nivolumab use in
+      previously treated advanced ESCC.
+- name: Pembrolizumab-Based Therapy
+  description: >-
+    Pembrolizumab-containing regimens are used in advanced ESCC, particularly in
+    biomarker-selected settings and combination regimens involving chemotherapy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: pembrolizumab
+      term:
+        id: NCIT:C106432
+        label: Pembrolizumab
+classifications:
+  icdo_morphology:
+    classification_value: Squamous Cell Carcinoma
+  harrisons_chapter:
+  - classification_value: cancer
+  - classification_value: solid tumor

--- a/kb/disorders/Esophageal_Squamous_Cell_Carcinoma.yaml
+++ b/kb/disorders/Esophageal_Squamous_Cell_Carcinoma.yaml
@@ -1,6 +1,6 @@
 name: Esophageal Squamous Cell Carcinoma
 creation_date: "2026-04-11T00:00:00Z"
-updated_date: "2026-04-11T00:00:00Z"
+updated_date: "2026-04-12T04:52:15Z"
 description: >-
   Esophageal squamous cell carcinoma (ESCC) is the major squamous malignancy of
   the esophagus and remains the dominant histologic subtype of esophageal cancer
@@ -221,14 +221,12 @@ pathophysiology:
   - reference: PMID:23510069
     reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: >-
-      Our previous study revealed that the SOX2 gene is an amplification target
-      of 3q26.3 in esophageal squamous cell carcinoma (ESCC), and that SOX2
-      promotes ESCC cell proliferation in vitro.
+      SOX2 promotes ESCC cell proliferation in vitro.
     explanation: >-
-      This links SOX2 amplification to proliferative drive in ESCC and supports
-      its role as a lineage-associated oncogenic factor.
+      This cell-based evidence supports a mechanistic contribution of SOX2 to
+      proliferative squamous lineage programs in ESCC.
   downstream:
   - target: PI3K/AKT Signaling Activation
     description: SOX2 can activate growth-promoting AKT/mTORC1 signaling
@@ -312,16 +310,26 @@ pathophysiology:
       id: GO:0008283
       label: cell population proliferation
   evidence:
-  - reference: PMID:23510069
-    reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
+  - reference: PMID:38832974
+    reference_title: "Prognostic value of genomic mutation signature associated with immune microenvironment in southern Chinese patients with esophageal squamous cell carcinoma."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Our findings suggest that SOX2 promotes in vivo tumor growth of ESCC
-      through activation of the AKT/mTORC1 signaling pathway, which enhances
-      cell proliferation.
+      Pathway analysis revealed dysregulation of cell cycle regulation,
+      epigenetic regulation, PI3K/AKT signaling, and NOTCH signaling.
     explanation: >-
-      This directly supports the terminal proliferative output node in ESCC.
+      This human ESCC cohort directly supports recurrent dysregulation of
+      cell-cycle programs underlying increased tumor proliferation.
+  - reference: PMID:23510069
+    reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      In mouse xenografts, SOX2 promoted in vivo tumor growth of ESCC, which
+      was dependent on AKT/mTORC1 activation.
+    explanation: >-
+      This mouse xenograft study supports the proliferative consequence of
+      SOX2-driven oncogenic signaling in ESCC.
 phenotypes:
 - category: Gastrointestinal
   name: Progressive Dysphagia
@@ -334,17 +342,27 @@ phenotypes:
       id: HP:0002015
       label: Dysphagia
   evidence:
-  - reference: PMID:31058012
-    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
+  - reference: PMID:20448378
+    reference_title: "Delay in the diagnosis of esophageal carcinoma: experience of a single unit from a developing country."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Due to its large polypoid character, patients suffering from this disease
-      typically present with progressive dysphagia, weight loss, odynophagia,
-      or chest pain.
+      First symptom was progressive dysphagia in all patients.
     explanation: >-
-      A squamous carcinoma subtype of the esophagus explicitly lists
-      progressive dysphagia as a presenting phenotype.
+      This prospective clinical cohort documents progressive dysphagia as the
+      leading presenting symptom in esophageal carcinoma, including squamous
+      cases.
+  - reference: PMID:20950882
+    reference_title: "Adding external beam to intra-luminal brachytherapy improves palliation in obstructive squamous cell oesophageal cancer: a prospective multi-centre randomized trial of the International Atomic Energy Agency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In longitudinal regression analyses, scores for dysphagia (p=0.00005),
+      odynophagia (p=0.006), regurgitation (p=0.00005), chest pain (p=0.0038)
+      and performance status (p=0.0015) were all significantly improved.
+    explanation: >-
+      This multicenter randomized trial in squamous oesophageal cancer confirms
+      dysphagia as a core symptom burden in conventional SCC.
 - category: Constitutional
   name: Weight Loss
   description: >-
@@ -356,17 +374,17 @@ phenotypes:
       id: HP:0001824
       label: Weight loss
   evidence:
-  - reference: PMID:31058012
-    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
+  - reference: PMID:20448378
+    reference_title: "Delay in the diagnosis of esophageal carcinoma: experience of a single unit from a developing country."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Due to its large polypoid character, patients suffering from this disease
-      typically present with progressive dysphagia, weight loss, odynophagia,
-      or chest pain.
+      Subsidiary symptoms were, weight loss in 83.3% (n = 40), abdominal /
+      chest pain in 10 (20.8%), regurgitation in 14 (29.2%), odynophagia in
+      three (6.2%)
     explanation: >-
-      This abstract explicitly includes weight loss among presenting symptoms of
-      esophageal squamous carcinoma.
+      This prospective clinical cohort reports weight loss as a frequent
+      presenting symptom in esophageal carcinoma, including squamous cases.
 - category: Gastrointestinal
   name: Odynophagia
   description: >-
@@ -378,17 +396,17 @@ phenotypes:
       id: HP:0032043
       label: Odynophagia
   evidence:
-  - reference: PMID:31058012
-    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
-    supports: PARTIAL
+  - reference: PMID:20950882
+    reference_title: "Adding external beam to intra-luminal brachytherapy improves palliation in obstructive squamous cell oesophageal cancer: a prospective multi-centre randomized trial of the International Atomic Energy Agency."
+    supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Due to its large polypoid character, patients suffering from this disease
-      typically present with progressive dysphagia, weight loss, odynophagia,
-      or chest pain.
+      In longitudinal regression analyses, scores for dysphagia (p=0.00005),
+      odynophagia (p=0.006), regurgitation (p=0.00005), chest pain (p=0.0038)
+      and performance status (p=0.0015) were all significantly improved.
     explanation: >-
-      This abstract explicitly includes odynophagia among presenting symptoms of
-      esophageal squamous carcinoma.
+      This multicenter randomized trial in squamous oesophageal cancer
+      documents odynophagia among the core disease-related symptoms.
 - category: Gastrointestinal
   name: Chest Pain
   description: >-
@@ -400,17 +418,17 @@ phenotypes:
       id: HP:0100749
       label: Chest pain
   evidence:
-  - reference: PMID:31058012
-    reference_title: "Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus."
-    supports: PARTIAL
+  - reference: PMID:20950882
+    reference_title: "Adding external beam to intra-luminal brachytherapy improves palliation in obstructive squamous cell oesophageal cancer: a prospective multi-centre randomized trial of the International Atomic Energy Agency."
+    supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Due to its large polypoid character, patients suffering from this disease
-      typically present with progressive dysphagia, weight loss, odynophagia,
-      or chest pain.
+      In longitudinal regression analyses, scores for dysphagia (p=0.00005),
+      odynophagia (p=0.006), regurgitation (p=0.00005), chest pain (p=0.0038)
+      and performance status (p=0.0015) were all significantly improved.
     explanation: >-
-      This abstract explicitly includes chest pain among presenting symptoms of
-      esophageal squamous carcinoma.
+      This multicenter randomized trial in squamous oesophageal cancer
+      documents chest pain among the core disease-related symptoms.
 - category: Gastrointestinal
   name: Hematemesis
   description: >-
@@ -549,16 +567,16 @@ genetic:
     SOX2 is a recurrent 3q amplification target in ESCC that reinforces
     malignant squamous lineage programs and proliferative signaling.
   evidence:
-  - reference: PMID:23510069
-    reference_title: "SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway."
+  - reference: PMID:31560173
+    reference_title: "SOX2 antagonizes WWC1 to drive YAP1 activation in esophageal squamous cell carcinoma."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Our previous study revealed that the SOX2 gene is an amplification target
-      of 3q26.3 in esophageal squamous cell carcinoma (ESCC), and that SOX2
-      promotes ESCC cell proliferation in vitro.
+      Here, we reveal that SOX2, ACTL6A, and TP63 are co-amplified and
+      upregulated in ESCC samples.
     explanation: >-
-      This directly supports SOX2 as an amplified oncogenic driver in ESCC.
+      This directly supports SOX2 as a recurrent amplified lineage oncogene in
+      ESCC.
 - name: TP63
   association: Co-amplified Squamous Lineage Transcription Factor
   notes: >-
@@ -591,7 +609,7 @@ treatments:
     locally advanced or unresectable localized ESCC and is also used as part of
     neoadjuvant therapy strategies.
   treatment_term:
-    preferred_term: radiation therapy
+    preferred_term: concurrent chemoradiation
     term:
       id: MAXO:0000014
       label: radiation therapy
@@ -604,6 +622,18 @@ treatments:
       term:
         id: CHEBI:46345
         label: 5-fluorouracil
+  evidence:
+  - reference: PMID:40507565
+    reference_title: "Clinical Features and Prognosis of Cervical Esophageal Cancer."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Conclusions: Although cervical ESCC had a poor prognosis due to its
+      higher T-stage and worse differentiation compared to other locations,
+      outcomes were similar when treated with definitive chemoradiotherapy.
+    explanation: >-
+      This ESCC cohort directly documents definitive chemoradiotherapy as an
+      established treatment modality.
 - name: Nivolumab
   description: >-
     Anti-PD-1 immunotherapy used in advanced or previously treated ESCC. It
@@ -645,6 +675,22 @@ treatments:
       term:
         id: NCIT:C106432
         label: Pembrolizumab
+  evidence:
+  - reference: PMID:34454674
+    reference_title: "Pembrolizumab plus chemotherapy versus chemotherapy alone for first-line treatment of advanced oesophageal cancer (KEYNOTE-590): a randomised, placebo-controlled, phase 3 study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Compared with placebo plus chemotherapy, pembrolizumab plus chemotherapy
+      improved overall survival in patients with previously untreated, advanced
+      oesophageal squamous cell carcinoma and PD-L1 CPS of 10 or more, and
+      overall survival and progression-free survival in patients with
+      oesophageal squamous cell carcinoma, PD-L1 CPS of 10 or more, and in all
+      randomised patients regardless of histology, and had a manageable safety
+      profile in the total as-treated population.
+    explanation: >-
+      KEYNOTE-590 provides direct phase 3 clinical evidence supporting
+      pembrolizumab-based therapy in advanced ESCC.
 classifications:
   icdo_morphology:
     classification_value: Squamous Cell Carcinoma

--- a/references_cache/PMID_20224883.md
+++ b/references_cache/PMID_20224883.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:20224883"
+title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: molecular mechanisms of carcinogenesis."
+authors:
+- Toh Y
+- Oki E
+- Ohgaki K
+- Sakamoto Y
+- Ito S
+- Egashira A
+- Saeki H
+- Kakeji Y
+- Morita M
+- Sakaguchi Y
+- Okamura T
+- Maehara Y
+journal: Int J Clin Oncol
+year: '2010'
+doi: 10.1007/s10147-010-0057-6
+keywords:
+- "Alcohol Drinking/adverse effects, epidemiology"
+- "Carcinoma, Squamous Cell/epidemiology, etiology, genetics, metabolism"
+- "Cell Transformation, Neoplastic/chemically induced, genetics, metabolism"
+- "Esophageal Neoplasms/epidemiology, etiology, genetics, metabolism"
+- Genetic Predisposition to Disease
+- Humans
+- Risk Assessment
+- Risk Factors
+- "Smoking/adverse effects, epidemiology"
+content_type: abstract_only
+---
+
+# Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: molecular mechanisms of carcinogenesis.
+**Authors:** Toh Y, Oki E, Ohgaki K, Sakamoto Y, Ito S, Egashira A, Saeki H, Kakeji Y, Morita M, Sakaguchi Y, Okamura T, Maehara Y
+**Journal:** Int J Clin Oncol (2010)
+**DOI:** [10.1007/s10147-010-0057-6](https://doi.org/10.1007/s10147-010-0057-6)
+
+## Content
+
+1. Int J Clin Oncol. 2010 Apr;15(2):135-44. doi: 10.1007/s10147-010-0057-6. Epub
+2010 Mar 12.
+
+Alcohol drinking, cigarette smoking, and the development of squamous cell
+carcinoma of the esophagus: molecular mechanisms of carcinogenesis.
+
+Toh Y(1), Oki E, Ohgaki K, Sakamoto Y, Ito S, Egashira A, Saeki H, Kakeji Y,
+Morita M, Sakaguchi Y, Okamura T, Maehara Y.
+
+Author information:
+(1)Department of Gastroenterological Surgery, National Kyushu Cancer Center,
+3-1-1 Notame, Minami-ku, Fukuoka 811-1395, Japan. ytoh@nk-cc.go.jp
+
+Esophageal cancer is the eighth most common incident cancer in the world and
+ranks sixth among all cancers in mortality. Esophageal cancers are classified
+into two histological types; esophageal squamous cell carcinoma (ESCC), and
+adenocarcinoma, and the incidences of these types show a striking variety of
+geographic distribution, possibly reflecting differences in exposure to specific
+environmental factors. Both alcohol consumption and cigarette smoking are major
+risk factors for the development of ESCC. Acetaldehyde is the most toxic ethanol
+metabolite in alcohol-associated carcinogenesis, while ethanol itself stimulates
+carcinogenesis by inhibiting DNA methylation and by interacting with retinoid
+metabolism. Cigarette smoke contains more than 60 carcinogens and there are
+strong links between some of these carcinogens and various smoking-induced
+cancers; these mechanisms are well established. Synergistic effects of cigarette
+smoking and alcohol consumption are also observed in carcinogenesis of the upper
+aerodigestive tract. Of note, intensive molecular biological studies have
+revealed the molecular mechanisms involved in the development of ESCC, including
+genetic and epigenetic alterations. However, a wide range of molecular changes
+is associated with ESCC, possibly because the esophagus is exposed to many kinds
+of carcinogens including alcohol and cigarette smoke, and it remains unclear
+which alterations are the most critical for esophageal carcinogenesis. This
+brief review summarizes the general mechanisms of alcohol- and smoking-induced
+carcinogenesis and then discusses the mechanisms of the development of ESCC,
+with special attention to alcohol consumption and cigarette smoking.
+
+DOI: 10.1007/s10147-010-0057-6
+PMID: 20224883 [Indexed for MEDLINE]

--- a/references_cache/PMID_20224884.md
+++ b/references_cache/PMID_20224884.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:20224884"
+title: "Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: epidemiology, clinical findings, and prevention."
+authors:
+- Morita M
+- Kumashiro R
+- Kubo N
+- Nakashima Y
+- Yoshida R
+- Yoshinaga K
+- Saeki H
+- Emi Y
+- Kakeji Y
+- Sakaguchi Y
+- Toh Y
+- Maehara Y
+journal: Int J Clin Oncol
+year: '2010'
+doi: 10.1007/s10147-010-0056-7
+keywords:
+- "Alcohol Drinking/adverse effects, epidemiology"
+- Aldehyde Dehydrogenase/genetics
+- "Aldehyde Dehydrogenase, Mitochondrial"
+- Animals
+- "Carcinoma, Squamous Cell/diagnosis, epidemiology, etiology, genetics, prevention & control"
+- Case-Control Studies
+- Early Detection of Cancer
+- "Esophageal Neoplasms/diagnosis, epidemiology, etiology, genetics, prevention & control"
+- Esophagoscopy
+- Female
+- Flushing/etiology
+- Genetic Predisposition to Disease
+- Humans
+- Male
+- Odds Ratio
+- "Polymorphism, Genetic"
+- Predictive Value of Tests
+- Risk Assessment
+- Risk Factors
+- "Smoking/adverse effects, epidemiology"
+content_type: abstract_only
+---
+
+# Alcohol drinking, cigarette smoking, and the development of squamous cell carcinoma of the esophagus: epidemiology, clinical findings, and prevention.
+**Authors:** Morita M, Kumashiro R, Kubo N, Nakashima Y, Yoshida R, Yoshinaga K, Saeki H, Emi Y, Kakeji Y, Sakaguchi Y, Toh Y, Maehara Y
+**Journal:** Int J Clin Oncol (2010)
+**DOI:** [10.1007/s10147-010-0056-7](https://doi.org/10.1007/s10147-010-0056-7)
+
+## Content
+
+1. Int J Clin Oncol. 2010 Apr;15(2):126-34. doi: 10.1007/s10147-010-0056-7. Epub
+2010 Mar 12.
+
+Alcohol drinking, cigarette smoking, and the development of squamous cell
+carcinoma of the esophagus: epidemiology, clinical findings, and prevention.
+
+Morita M(1), Kumashiro R, Kubo N, Nakashima Y, Yoshida R, Yoshinaga K, Saeki H,
+Emi Y, Kakeji Y, Sakaguchi Y, Toh Y, Maehara Y.
+
+Author information:
+(1)Department of Surgery and Science, Graduate School of Medical Sciences,
+Kyushu University, 3-1-1 Maidashi, Higashi-ku, Fukuoka 812-8582, Japan.
+masarum@surg2.med.kyushu-u.ac.jp
+
+Both cigarette smoking and alcohol drinking are well-established risk factors
+for esophageal squamous cell carcinoma (ESCC), and the relationship of dose to
+cancer risk has already been described. Furthermore, the synergistic effect of
+these two factors has been reported. Our case-control study revealed the odds
+ratio of ESCC to be 50.1 for those who were both heavy smokers and heavy
+drinkers in comparison to people who neither drank nor smoked. In patients with
+ESCC, head and neck cancers as well as dysplastic lesions are frequently
+observed. Heavy smoking and heavy drinking are closely related to such
+multicentric carcinogenesis events in the upper aerodigestive tract (UADT),
+including the esophagus and head andneck region. Polymorphisms in acetaldehyde
+dehydrogenase 2 (ALDH2) are reported to be a key event in deciding individual
+susceptibility to UADT cancer. Patients with inactive ALDH2, in whom facial
+flushing is usually observed after the drinking of alcohol, are at high risk for
+ESCC as well as multiple UADT cancers. For the early detection of the disease,
+effective follow up using endoscopy with Lugol staining or narrow band imaging
+endoscopy is strongly recommended for high-risk populations, such as smokers,
+heavy drinkers, people with experience of flushing after the drinking of
+alcohol, and patients with UADT cancer.
+
+DOI: 10.1007/s10147-010-0056-7
+PMID: 20224884 [Indexed for MEDLINE]

--- a/references_cache/PMID_20448378.md
+++ b/references_cache/PMID_20448378.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:20448378"
+title: "Delay in the diagnosis of esophageal carcinoma: experience of a single unit from a developing country."
+authors:
+- Subasinghe D
+- Samarasekera DN
+journal: Indian J Cancer
+year: '2010'
+doi: 10.4103/0019-509X.63009
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Carcinoma, Squamous Cell/diagnosis"
+- Developing Countries
+- Esophageal Neoplasms/diagnosis
+- Female
+- Health Services Accessibility
+- Humans
+- Male
+- Middle Aged
+- Neoplasm Staging
+- Prognosis
+- Prospective Studies
+content_type: abstract_only
+---
+
+# Delay in the diagnosis of esophageal carcinoma: experience of a single unit from a developing country.
+**Authors:** Subasinghe D, Samarasekera DN
+**Journal:** Indian J Cancer (2010)
+**DOI:** [10.4103/0019-509X.63009](https://doi.org/10.4103/0019-509X.63009)
+
+## Content
+
+1. Indian J Cancer. 2010 Apr-Jun;47(2):151-5. doi: 10.4103/0019-509X.63009.
+
+Delay in the diagnosis of esophageal carcinoma: experience of a single unit from
+a developing country.
+
+Subasinghe D(1), Samarasekera DN.
+
+Author information:
+(1)University Surgical Unit, The National Hospital of Sri Lanka, Colombo, Sri
+Lanka.
+
+OBJECTIVES: Main objective was to analyze the time delay between the onset of
+symptoms and the histological diagnosis of esophageal cancer. The subsidiary
+objective was to analyze the relationship between the time delay and stage of
+the disease at the time of definitive treatment. STUDY DESIGN, SETTING, AND
+METHODS: A prospective analysis of patients with esophageal cancer presenting to
+a single unit over a period of 24 months was performed. Interval from the onset
+of symptoms to the histological diagnosis and stage at presentation was
+analyzed.
+RESULTS: There were 48 patients (male = 26) with a median age of 59.5 (range 43
+- 84) years. First symptom was progressive dysphagia in all patients. Subsidiary
+symptoms were, weight loss in 83.3% (n = 40), abdominal / chest pain in 10
+(20.8%), regurgitation in 14 (29.2%), odynophagia in three (6.2%), abdominal
+discomfort in two (3%), and dyspepsia in two (3%). The mean delay from the
+appearance of the first symptoms to the end point was 14.9 weeks (range 3 - 37
+weeks). Total delay was due to patient delay in 82%, endoscopy delay in 7%, and
+delay in histological diagnosis in 11%.
+CONCLUSIONS: As the majority (82%) in our study showed patient delay, a
+community education program may help in their early presentation to the
+hospital. However, there is also a notable delay in endoscopy and histology
+(15%) services, mainly due to a shortage of endoscopy units and qualified
+histopathologists in the state sector.
+
+DOI: 10.4103/0019-509X.63009
+PMID: 20448378 [Indexed for MEDLINE]

--- a/references_cache/PMID_20950882.md
+++ b/references_cache/PMID_20950882.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:20950882"
+title: "Adding external beam to intra-luminal brachytherapy improves palliation in obstructive squamous cell oesophageal cancer: a prospective multi-centre randomized trial of the International Atomic Energy Agency."
+authors:
+- Rosenblatt E
+- Jones G
+- Sur RK
+- Donde B
+- Salvajoli JV
+- Ghosh-Laskar S
+- Frobe A
+- Suleiman A
+- Xiao Z
+- Nag S
+journal: Radiother Oncol
+year: '2010'
+doi: 10.1016/j.radonc.2010.09.001
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Brachytherapy
+- "Carcinoma, Squamous Cell/complications, mortality, radiotherapy"
+- Deglutition Disorders/etiology
+- "Esophageal Neoplasms/complications, mortality, radiotherapy"
+- Female
+- Humans
+- Male
+- Middle Aged
+- Palliative Care
+- Quality of Life
+- Radiation Injuries/etiology
+- Survival Rate
+- Young Adult
+content_type: abstract_only
+---
+
+# Adding external beam to intra-luminal brachytherapy improves palliation in obstructive squamous cell oesophageal cancer: a prospective multi-centre randomized trial of the International Atomic Energy Agency.
+**Authors:** Rosenblatt E, Jones G, Sur RK, Donde B, Salvajoli JV, Ghosh-Laskar S, Frobe A, Suleiman A, Xiao Z, Nag S
+**Journal:** Radiother Oncol (2010)
+**DOI:** [10.1016/j.radonc.2010.09.001](https://doi.org/10.1016/j.radonc.2010.09.001)
+
+## Content
+
+1. Radiother Oncol. 2010 Dec;97(3):488-94. doi: 10.1016/j.radonc.2010.09.001.
+Epub  2010 Oct 13.
+
+Adding external beam to intra-luminal brachytherapy improves palliation in
+obstructive squamous cell oesophageal cancer: a prospective multi-centre
+randomized trial of the International Atomic Energy Agency.
+
+Rosenblatt E(1), Jones G, Sur RK, Donde B, Salvajoli JV, Ghosh-Laskar S, Frobe
+A, Suleiman A, Xiao Z, Nag S.
+
+Author information:
+(1)International Atomic Energy Agency, Vienna, Austria. e.rosenblatt@iaea.org
+
+BACKGROUND: Whether the combination of high dose-rate brachytherapy (HDRBT) and
+External Beam Radiation Therapy (EBRT) is superior to HDRBT alone for the
+palliation of oesophageal cancer has only been explored in a previous IAEA pilot
+randomized trial.
+METHODS: Two hundred and nineteen patients were randomized to adding EBRT or
+not, after receiving two fractions of HDRBT within 1 week. Each HDRBT consisted
+of 8 Gy prescribed at 1cm from source centre. Patients randomized to EBRT
+received 30 Gy in 10 fractions. The primary outcome was dysphagia-relief
+experience (DRE). Additional outcomes included various scores, performance
+status, weight and adverse events. A majority of charts, imaging and
+radiotherapy plans were externally audited.
+RESULTS: Median follow-up was 197 days, with a median OS of 188 days and an 18%
+survival rate at 1 year. DRE was significantly improved with combined therapy,
+for an absolute benefit of +18% at 200 days from randomization (p=0.019). In
+longitudinal regression analyses, scores for dysphagia (p=0.00005), odynophagia
+(p=0.006), regurgitation (p=0.00005), chest pain (p=0.0038) and performance
+status (p=0.0015) were all significantly improved. In contrast, weight,
+toxicities and overall survival were not different between study arms.
+CONCLUSION: Symptom improvement occurs with the addition of EBRT to standard
+HDRBT. The combination is well tolerated and relatively safe.
+
+Copyright © 2010 Elsevier Ireland Ltd. All rights reserved.
+
+DOI: 10.1016/j.radonc.2010.09.001
+PMID: 20950882 [Indexed for MEDLINE]

--- a/references_cache/PMID_23510069.md
+++ b/references_cache/PMID_23510069.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:23510069"
+title: SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway.
+authors:
+- Gen Y
+- Yasui K
+- Nishikawa T
+- Yoshikawa T
+journal: Cancer Sci
+year: '2013'
+doi: 10.1111/cas.12155
+keywords:
+- Animals
+- "Carcinoma, Squamous Cell/genetics, metabolism, pathology"
+- "Cell Line, Tumor"
+- Cell Proliferation/drug effects
+- Cell Survival/drug effects
+- Chromones/pharmacology
+- "Esophageal Neoplasms/genetics, metabolism, pathology"
+- Esophageal Squamous Cell Carcinoma
+- Heterografts
+- Humans
+- MAP Kinase Signaling System/drug effects
+- Male
+- Mechanistic Target of Rapamycin Complex 1
+- Mice
+- "Mice, Inbred BALB C"
+- "Mice, Nude"
+- Morpholines/pharmacology
+- "Multiprotein Complexes/antagonists & inhibitors, genetics, metabolism"
+- "Phosphatidylinositol 3-Kinases/genetics, metabolism"
+- Phosphoinositide-3 Kinase Inhibitors
+- Phosphorylation/drug effects
+- "Proto-Oncogene Proteins c-akt/genetics, metabolism"
+- "SOXB1 Transcription Factors/genetics, metabolism"
+- Signal Transduction
+- Sirolimus/pharmacology
+- "TOR Serine-Threonine Kinases/antagonists & inhibitors, genetics, metabolism"
+content_type: abstract_only
+---
+
+# SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the AKT/mammalian target of rapamycin complex 1 signaling pathway.
+**Authors:** Gen Y, Yasui K, Nishikawa T, Yoshikawa T
+**Journal:** Cancer Sci (2013)
+**DOI:** [10.1111/cas.12155](https://doi.org/10.1111/cas.12155)
+
+## Content
+
+1. Cancer Sci. 2013 Jul;104(7):810-6. doi: 10.1111/cas.12155. Epub 2013 Apr 16.
+
+SOX2 promotes tumor growth of esophageal squamous cell carcinoma through the
+AKT/mammalian target of rapamycin complex 1 signaling pathway.
+
+Gen Y(1), Yasui K, Nishikawa T, Yoshikawa T.
+
+Author information:
+(1)Department of Molecular Gastroenterology and Hepatology, Graduate School of
+Medical Science, Kyoto Prefectural University of Medicine, Kyoto, Japan.
+
+The transcription factor SOX2 is essential for the maintenance of embryonic stem
+cells and normal development of the esophagus. Our previous study revealed that
+the SOX2 gene is an amplification target of 3q26.3 in esophageal squamous cell
+carcinoma (ESCC), and that SOX2 promotes ESCC cell proliferation in vitro. In
+the present study, we aimed to identify the mechanisms by which SOX2 promotes
+proliferation of ESCC cells. Using a phosphoprotein array, we assayed multiple
+signaling pathways activated by SOX2 and determined that SOX2 activated the
+AKT/mammalian target of rapamycin complex 1 (mTORC1) signaling pathway.
+LY294002, an inhibitor of phosphatidylinositol 3-kinase, and rapamycin, an
+inhibitor of mTORC1, suppressed the ability of SOX2 to enhance proliferation of
+ESCC cells in vitro. Effects of SOX2 knockdown, including reduced levels of
+phosphorylated AKT and decreased ESCC cell proliferation, were reversed with
+constitutive activation of AKT with knockdown of phosphatase and tensin homolog.
+In mouse xenografts, SOX2 promoted in vivo tumor growth of ESCC, which was
+dependent on AKT/mTORC1 activation. LY294002 suppressed the ability of SOX2 to
+enhance tumor growth of ESCC by reducing cell proliferation, but not by
+enhancing apoptosis. Furthermore, tissue microarray analysis of 61 primary ESCC
+tumors showed a positive correlation between expression levels of SOX2 and
+phosphorylated AKT. Our findings suggest that SOX2 promotes in vivo tumor growth
+of ESCC through activation of the AKT/mTORC1 signaling pathway, which enhances
+cell proliferation.
+
+© 2013 Japanese Cancer Association.
+
+DOI: 10.1111/cas.12155
+PMCID: PMC7657236
+PMID: 23510069 [Indexed for MEDLINE]

--- a/references_cache/PMID_28894616.md
+++ b/references_cache/PMID_28894616.md
@@ -1,0 +1,55 @@
+---
+reference_id: "PMID:28894616"
+title: Esophageal Squamous Cell Carcinoma Presenting with Streptococcus intermedius Cerebral Abscess.
+authors:
+- Nayfe R
+- Ascha MS
+- Rehmus EH
+journal: Case Rep Pathol
+year: '2017'
+doi: 10.1155/2017/5819676
+content_type: abstract_only
+---
+
+# Esophageal Squamous Cell Carcinoma Presenting with Streptococcus intermedius Cerebral Abscess.
+**Authors:** Nayfe R, Ascha MS, Rehmus EH
+**Journal:** Case Rep Pathol (2017)
+**DOI:** [10.1155/2017/5819676](https://doi.org/10.1155/2017/5819676)
+
+## Content
+
+1. Case Rep Pathol. 2017;2017:5819676. doi: 10.1155/2017/5819676. Epub 2017 Aug
+15.
+
+Esophageal Squamous Cell Carcinoma Presenting with Streptococcus intermedius
+Cerebral Abscess.
+
+Nayfe R(1), Ascha MS(2), Rehmus EH(3).
+
+Author information:
+(1)Department of Geriatrics, UT Southwestern Medical Center, Dallas, TX, USA.
+(2)Department of Physiology and Biophysics, Case Western Reserve University,
+Cleveland, OH, USA.
+(3)McDowell Cancer Institute, Cleveland Clinic Akron General, Akron, OH, USA.
+
+BACKGROUND: Cerebral abscess is caused by inoculation of an organism into the
+brain parenchyma from a site distant from the central nervous system.
+Streptococcus intermedius (S. intermedius) is a commensal organism that is
+normally present in the aerodigestive tract and was reported to be the cause of
+brain abscesses after esophageal dilatation or upper endoscopy.
+CASE PRESENTATION: We report the case of a 53-year-old female who presented with
+hematemesis and melena followed by left-sided weakness. Initially, her
+hemiplegia was found to be secondary to a right thalamic brain abscess caused by
+S. intermedius. Investigations led to the diagnosis of a mid-esophageal squamous
+cell carcinoma. We hypothesize that the cause of the abscess with this bacterium
+that naturally resides in the digestive tract and oral cavity is secondary to
+hematogenous spread from breach in the mucosal integrity from ulceration due to
+the cancer.
+CONCLUSION: To our knowledge, our case is the first in the literature to
+describe a brain abscess caused by S. intermedius in association with a
+previously undiagnosed esophageal squamous cell carcinoma without any prior
+esophageal intervention.
+
+DOI: 10.1155/2017/5819676
+PMCID: PMC5574295
+PMID: 28894616

--- a/references_cache/PMID_31058012.md
+++ b/references_cache/PMID_31058012.md
@@ -1,0 +1,49 @@
+---
+reference_id: "PMID:31058012"
+title: Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus.
+authors:
+- Phelps BJ
+- Tiley YM
+- Skrove JL
+- Berry AC
+- Mohan K
+journal: Cureus
+year: '2019'
+doi: 10.7759/cureus.4129
+content_type: abstract_only
+---
+
+# Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus.
+**Authors:** Phelps BJ, Tiley YM, Skrove JL, Berry AC, Mohan K
+**Journal:** Cureus (2019)
+**DOI:** [10.7759/cureus.4129](https://doi.org/10.7759/cureus.4129)
+
+## Content
+
+1. Cureus. 2019 Feb 25;11(2):e4129. doi: 10.7759/cureus.4129.
+
+Acute Dysphagia Caused by Sarcomatoid Squamous Cell Carcinoma of the Esophagus.
+
+Phelps BJ(1), Tiley YM(1), Skrove JL(2), Berry AC(3), Mohan K(4).
+
+Author information:
+(1)Internal Medicine, Palmetto General Hospital, Hialeah, USA.
+(2)Internal Medicine, Larkin Community Hospital, South Miami, USA.
+(3)Gastroenterology, Larkin Community Hospital, South Miami, USA.
+(4)Gastroenterology, Palmetto General Hospital, Hialeah, USA.
+
+Sarcomatoid squamous cell carcinoma of the esophagus is a rare etiology of
+esophageal cancer. Due to its large polypoid character, patients suffering from
+this disease typically present with progressive dysphagia, weight loss,
+odynophagia, or chest pain. Risk factors for esophageal cancer include smoking,
+alcohol use, and chronic gastroesophageal reflux disease. We present a case of
+an elderly female who presented to our hospital with a one-week history of
+progressive dysphagia secondary to a large esophageal sarcomatoid squamous cell
+carcinoma.
+
+DOI: 10.7759/cureus.4129
+PMCID: PMC6485518
+PMID: 31058012
+
+Conflict of interest statement: The authors have declared that no competing
+interests exist.

--- a/references_cache/PMID_31560173.md
+++ b/references_cache/PMID_31560173.md
@@ -1,0 +1,150 @@
+---
+reference_id: "PMID:31560173"
+title: SOX2 antagonizes WWC1 to drive YAP1 activation in esophageal squamous cell carcinoma.
+authors:
+- Chai Y
+- Li Q
+- Zhao H
+- Zhang Z
+- Yu X
+- Pang L
+- Liu Z
+- Zhao J
+- Wang L
+- Li F
+journal: Cancer Med
+year: '2019'
+doi: 10.1002/cam4.2569
+keywords:
+- Actins/genetics
+- "Adaptor Proteins, Signal Transducing/genetics, metabolism"
+- Animals
+- "Cell Line, Tumor"
+- Cell Movement
+- Cell Survival
+- "Chromosomal Proteins, Non-Histone/genetics"
+- DNA-Binding Proteins/genetics
+- "Esophageal Neoplasms/genetics, metabolism"
+- "Esophageal Squamous Cell Carcinoma/genetics, metabolism"
+- Female
+- "Gene Expression Regulation, Neoplastic"
+- Humans
+- Intracellular Signaling Peptides and Proteins/genetics
+- "Mice, Inbred BALB C"
+- "Mice, Nude"
+- "SOXB1 Transcription Factors/genetics, metabolism"
+- "Transcription Factors/genetics, metabolism"
+- Tumor Suppressor Proteins/genetics
+- YAP-Signaling Proteins
+content_type: full_text_xml
+---
+
+# SOX2 antagonizes WWC1 to drive YAP1 activation in esophageal squamous cell carcinoma.
+**Authors:** Chai Y, Li Q, Zhao H, Zhang Z, Yu X, Pang L, Liu Z, Zhao J, Wang L, Li F
+**Journal:** Cancer Med (2019)
+**DOI:** [10.1002/cam4.2569](https://doi.org/10.1002/cam4.2569)
+
+## Content
+
+1. Cancer Med. 2019 Nov;8(16):7055-7064. doi: 10.1002/cam4.2569. Epub 2019 Sep
+27.
+
+SOX2 antagonizes WWC1 to drive YAP1 activation in esophageal squamous cell
+carcinoma.
+
+Chai Y(1), Li Q(1), Zhao H(2), Zhang Z(1)(2), Yu X(1)(3), Pang L(1), Liu Z(2),
+Zhao J(1), Wang L(1), Li F(1)(2).
+
+Author information:
+(1)Department of Pathology and Key Laboratory of Xinjiang Endemic and Ethnic
+Diseases/the First Affiliated Hospital, Shihezi University School of Medicine,
+Shihezi, China.
+(2)Department of Pathology and Medical Research Center, Beijing Chaoyang
+Hospital, Capital Medical University, Beijing, China.
+(3)Department of Stomatology, The First Affiliated Hospital, Shihezi University
+School of Medicine, Shihezi, China.
+
+Whether SOX2 and ACTL6A/TP63 interact with the Hippo-YAP1 pathway in esophageal
+squamous cell carcinoma (ESCC) remains unclear. Here, we reveal that SOX2,
+ACTL6A, and TP63 are co-amplified and upregulated in ESCC samples. Multiple SOX2
+binding peaks in the locus of WWC1, a Hippo-YAP1 regulator, and an inverse
+correlation between the expression of SOX2 and WWC1 are identified, suggesting
+direct repression of WWC1 by SOX2. Expression scores of SOX2 are higher in
+tumors than normal tissues and positively correlated with nuclear YAP1 staining
+in primary ESCC. Moreover, SOX2 gain-of-function significantly promotes nuclear
+YAP1 expression in ESCC cells while silencing of SOX2 expression inhibits YAP1
+activation. SOX2 overexpression leads to a significant enhancement of cell
+migration and invasion as well as chemoresistance to cisplatin, whereas
+knockdown of SOX2 or ectopic expression of WWC1 suppresses the SOX2-induced
+migration ability and invasive potential. Disruption of this SOX2-WWC1-YAP1 axis
+could be a therapeutic strategy for SOX2-dependent tumors.
+
+© 2019 The Authors. Cancer Medicine published by John Wiley & Sons Ltd.
+
+DOI: 10.1002/cam4.2569
+PMCID: PMC6853808
+PMID: 31560173 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.
+
+Esophageal cancer is one of the most common gastrointestinal malignancies in the world. According to GLOBOCAN 2018, this disease ranks as the seventh most frequently diagnosed cancer (572 000 new cases) and the sixth leading cause of cancer death (509 000 deaths), with an estimated 1 in every 20 cancer deaths due to esophageal cancer.1 The two major histological types of esophageal cancer are esophageal squamous cell carcinoma (ESCC) and esophageal adenocarcinoma. ESCC accounts for 90% of patients with esophageal cancer worldwide, especially in the East, East Africa, and South America. The 5‐year survival rate of all patients with esophageal cancer is less than 20% even in developed countries.2 The occurrence of esophageal cancer is a multi‐factor, including environmental factors (such as smoking and drinking)3, 4 and genetic variants (such as chromosomal changes and methylation),5, 6 and multi‐step process.2 However, the detailed molecular mechanisms in ESCC development and progression remain to be fully elucidated.
+
+SOX (SRY‐related HMG box) is a family of SRY (sex determination region of y chromosome) related genes, encoding a series of transcription factors involved in embryonic development and cellular regulation.7 SOX2 is a member of the SOX family B1 group and is located on chromosome 3q26.3~q27.8 Abnormal expression of SOX2 may be associated with human squamous cell carcinomas of the lung and esophagus (caused by amplification of the SOX2 locus),9, 10 human osteosarcoma,11 and melanoma.12 Moreover, the TP63 locus is frequently co‐amplified with SOX2, given that TP63 is located approximately 7 Mb from the SOX2 locus.13 SOX2 and p63 may be co‐localized on the genome in SCC and collaboratively regulate gene expression in squamous cell carcinoma.13 ACTL6A, which is located approximately 10 Mb apart on chromosome 3q, is frequently co‐amplified and co‐expressed with TP63 in a substantial proportion of head and neck squamous cell carcinomas (HNSCC).14
+
+
+The Hippo signaling pathway is a potent regulator of cell proliferation, differentiation, and tissue homeostasis.15 The core components of the Hippo kinase/transcription modules are evolutionarily conserved. Yes‐associated protein 1 (YAP1) and its paralog transcriptional co‐activator with PDZ‐binding motif (TAZ; also known as WWTR1) are two major downstream effectors of the Hippo kinase cascade.16, 17 YAP1/TAZ function as transcriptional co‑activators that induce transcription of downstream cell‐proliferative and anti‐apoptotic genes via interactions with transcription factors, primarily TEA domain family members (TEAD) in the nucleus.18 Activation of the Hippo kinase cascade by various stimuli phosphorylate and inactivate YAP1 by triggering either the cytoplasmic retention or the degradation of YAP1, ultimately preventing the transcriptional output module.15 Kidney and brain expressed protein (KIBRA; also known as WWC1) acts as an upstream tumor suppressor that form a complex with neurofibromatosis 2 (NF2; also known as Merlin) to activate the Hippo kinase cassette and prevent YAP1 and TAZ activation.19, 20, 21
+
+
+It has been reported that the Hippo pathway effector YAP1 is a direct transcriptional target of SOX2 in mesenchymal stem cells and osteoprogenitors22; WWC1 and NF2, two Hippo activators, appear to be directly repressed at the transcriptional level by SOX2 in human osteosarcomas.23 Moreover, ACTL6A and p63 could physically interact, cooperatively suppressing WWC1 transcription to activate the Hippo‐YAP1 pathway and thus promoting tumorigenesis in HNSCC.14 However, whether and how SOX2, ACTL6A, or TP63 interacts with the Hippo‐YAP1 pathway in ESCC remain to be determined.
+
+Herein, we sought to identify the genetic alterations and expression profiles of related genes in ESCC. We have also used in vitro gain‐of‐function model to assess the regulation mechanism.
+
+A total of 101 ESCC and 40 non‐cancerous adjacent tissue samples were obtained from the First Affiliated Hospital of Shihezi University School of Medicine, Xinjiang Yili Prefecture Friendship Hospital, and the People's Hospital of Xinjiang Uyghur Autonomous Region in the years 2004‐2013. Informed consents were obtained from the patients, and the study was approved by the Ethics Committee of the First Affiliated Hospital, Shihezi University School of Medicine.
+
+Immunohistochemical stainings of SOX2 and YAP1 were performed using primary antibodies against SOX2 (#2748, Cell Signaling Technology) and YAP1 (#14074, Cell Signaling Technology) on a BOND‐MAX Automated IHC/ISH Stainer (Leica) according to previously established protocols.24 Following staining, tissue microarray sections were dehydrated in graded alcohol, cleared in xylene, and mounted.
+
+Immunostaining degree of each sample was scored as previously described by pathologists based on nuclear staining intensity (intensity score) and percentage of positive cells (extent score).6 The final immunoreactivity score for each case is the product of the intensity score and the extent score.
+
+ESCC cell lines including Eca109, EC9706, TE‐1, and KYSE150 were purchased from the Cell Bank of Type Culture Collection of Chinese Academy of Sciences. All cells were maintained in RPMI 1640 medium supplemented with 10% fetal bovine serum at 37°C in a humidified incubator under 5% CO2 atmosphere. Eca109 cells stably expressing SOX2 (Eca109‐SOX2) were developed by transducing parental cells with SOX2 lentiviruses and selecting with 5 μg/mL Puromycin.
+
+Total protein or nuclear and cytoplasmic fractions were isolated from cultured cells using RIPA buffer (#R0010) or a Nuclear and Cytoplasmic Protein Extraction Kit (#P0027, Beyotime Biotechnology) supplemented with protease inhibitors following the manufacturers’ instructions, respectively. Equal amounts of lysates were electrophoretically resolved and transferred to PVDF membranes. After blocking with 5% skimmed milk, the membranes were incubated with primary antibodies against SOX 2 (#2748, 1:500; Cell Signaling Technology), YAP1 (#14074, 1:1000; Cell Signaling Technology), TAZ (#4883, 1:1000; Cell Signaling Technology), β‐actin (1E9A3, 1:1000; ZSGB‐BIO), α‐tubulin (AF0001, Beyotime Biotechnology), Lamin B1 (AF1408, Beyotime Biotechnology), and appropriate peroxidase‐conjugated secondary antibodies. The signals were detected using enhanced chemiluminescence (Millipore).
+
+Cells cultured on glass coverslips were fixed with 4% paraformaldehyde followed by permeabilization with 0.1% Triton X‐100. Subsequently, cells were blocked with 1% BSA and incubated with YAP1 antibody, washed with PBS, incubated with Alexa Fluor 594‐Conjugated Goat anti‐Rabbit IgG (H + L) (#ZF‐0516, ZSGB‐BIO) as the secondary antibody, and counterstained with DAPI (#C1002, Beyotime Biotechnology). Images were taken at 60X magnification.
+
+Migration and invasion assays were carried out using Transwell chambers (Corning) according to our previous work.25 Migratory or invasive cells on the lower membrane surface were fixed, stained with 1% crystal violet and counted under a light microscope in five random fields.
+
+Cell viability in the presence of increasing concentrations of cisplatin was measured using the Cell Counting Kit‐8 (CCK‐8) as previously described.25 Absorbance at 450 nm was measured with a microplate reader (BIO‐RAD xMark).
+
+Five‐week‐old female BALB/C nude mice (Beijing Vital River Laboratory Animal Technology) were used in this study. One million KYSE150 cells grown at logarithm phase were subcutaneously injected into the armpit of mice to establish ESCC xenografts. Tumor volume was measured with a caliper and calculated using the formula length × width2 × π/6. The mice were sacrificed at the end of the experiments, and the tumors were excised and weighed. All procedures were performed with approval from the Animal Experimental Ethical Inspection of First Affiliated Hospital, Shihezi University School of Medicine.
+
+Statistical analyses were performed using GraphPad Prism 7 or IBM SPSS Statistics. Pearson and Spearman's correlations were used to evaluate the significance of the association. Comparison between groups was conducted using a Mann‐Whitney U‐test or two‐tailed Student's t test. Numerical data were presented as means ± SEM unless stressed. A P value of <.05 was considered significant.
+
+It has been previously suggested that SOX2 and ACTL6A/TP63 can control the activation of the Hippo‐YAP1 pathway. As a first step toward uncovering the functional contribution of SOX2, ACTL6A, and TP63 to Hippo‐YAP1 pathway in ESCC, we analyzed the genetic alterations of ESCC patients from the Cancer Genome Atlas Network (TCGA). A substantial proportion of the samples (34 cases; 35.4%) exhibit co‐amplification of the SOX2, ACTL6A, and TP63 loci, while WWC1, NF2, and YAP1, components of the Hippo‐YAP1 signaling, were barely mutated among these patients (Figure 1A). Moreover, expression of SOX2, ACTL6A, and TP63 correlated with their copy number status across ESCC tumors in the TCGA dataset, respectively (Figure 1B–D).
+
+
+SOX2 is amplified and upregulated together with ACTL6A and TP63 in ESCC. (A) Gene copy‐number and mutation data from the TCGA for ESCC, showing frequent co‐amplification of SOX2, ACTL6A, and TP63. (B–D) SOX2, ACTL6A, and TP63 mRNA expression correlate with their gene copy number, respectively. Data obtained from RNAseqV2 and GISTIC, respectively, of the TCGA ESCC (n = 96)
+
+To understand the transcriptional regulation involved in the YAP1 activation in ESCC, we first assessed chromatin immunoprecipitation/high‐throughput sequencing (ChIP‐seq) data of endogenous SOX2 and p63 in ESCC cell line TT, then integrated with RNA‐seq data from human ESCC in the TCGA dataset (Figure 2). Intriguingly, ChIP‐seq data for SOX2 binding showed multiple SOX2 binding peaks in the loci of WWC1, NF2, and YAP1 (Figure 2A). However, among these candidate transcription targets, significant inverse correlation with SOX2 expression was only identified for WWC1 (Pearson r = −.255, P = .0125; Spearman r = −.338, P = .0008), but not for NF2 and YAP1 (P > .05; Figure 2C). Although a reverse trend between ACTL6A/TP63 and WWC1 was observed in the in vivo context (Figure 2D), there was no binding site of p63 to the WWC1 locus (Figure 2B). Together, these findings suggest WWC1 locus being a direct target of SOX2.
+
+SOX2 is a direct transcriptional suppressor of the Hippo regulator WWC1. (A‐B) Trace from SOX2 (A) and p63 (B) ChIP‐seq data in ESCC cell line TT showing binding peaks around the indicated genes. (C) Correlation between SOX2 and WWC1, YAP1, and NF2 in SCC samples from the TCGA Esophageal Cancer (ESCA). (D) Correlation between ACTL6A, TP63, and WWC1 in SCC samples from ESCA dataset
+
+To provide further evidence for the control of Hippo‐YAP1 signaling pathway mediated by SOX2 in human ESCC, we characterized SOX2 and YAP1 expression by immunohistochemistry staining in a tissue microarray derived from an ESCC cohort of 101 patients. Results showed that SOX2 protein was mainly located in the nucleus of ESCC cells and the expression scores of SOX2 in ESCC were significantly higher than that in adjacent normal tissues (Figure 3A). Among them, 40 cases (40/101, 39.6%) of ESCC showed high expression score (>median) of SOX2 protein, whereas only 5 cases (5/40, 12.5%) of normal tissues exhibited high SOX2 expression. Stronger immunosignal in the nucleus of tumor cells was also observed for YAP1.6 Importantly, we found increased nuclear YAP1 staining in primary ESCC specimens with high levels of SOX2 (Figure 3B). Quantification of this series of samples showed that nuclear YAP1 expression was higher in ESCC with high SOX2 scores than that with low expression of SOX2 (Figure 3C). Furthermore, nuclear YAP1 expression score was positively associated with elevated SOX2 (Pearson r = .313, P = .0025; Spearman r = .233, P = .0262; Figure 3D).
+
+SOX2 regulates YAP1 activity in vivo in ESCC. (A) Representative immunohistochemistry staining and statistical analysis of SOX2 expression in a panel of 101 primary ESCC and 40 adjacent normal squamous epithelium tissues. (B) Representative images of YAP1 expression measured by immunohistochemistry in SOX2 high and SOX2 low ESCC samples. (C) Statistical analysis of nuclear YAP1 expression score in SOX2 high and SOX2 low ESCC samples. The cutoff value for high vs low SOX2 levels was set at the median. (D) Scatterplot representing the correlation between nuclear YAP1 and SOX2 expression scores in the ESCC cohort (n = 91). *P < .05, **P < .01
+
+Next, we sought to determine whether SOX2 gain‐of‐function was associated with YAP1 regulation in ESCC cells. Among a panel of ESCC cell lines, the expression of endogenous SOX2 protein was low in Eca109 and EC9706 cells (Figure 4A). Eca109 cells inoculated with SOX2‐overexpressing lentivirus (Eca109‐SOX2) showed higher expression of SOX2 protein than cells treated with a lentiviral vector (Eca109‐vector) as expected. The expression of total YAP1 protein increased after overexpression of SOX2 in Eca109 cells as detected by Western blotting (Figure 4B). Remarkably, immunofluorescence assay for YAP1 showed that the percentage of Eca109 cells staining nuclear YAP1 was significantly increased following overexpression of SOX2 (Figure 4C). We also analyzed YAP1 localization by immunoblot analysis of fractionated lysates from ESCC cells. SOX2 overexpression led to increased nuclear YAP1 level in Eca109‐SOX2 cells, while YAP1 was mainly in the cytoplasm in parental cells (Figure 4D). Conversely, knockdown of SOX2 expression by shRNAs in KYSE150 cells inhibited the nuclear levels of YAP1, but not TAZ (Figure 4E,F), confirming the control of YAP1 localization by SOX2.
+
+SOX2 controls endogenous YAP1 localization in ESCC cells. (A) Western blot analysis of endogenous SOX2 expression in a panel of ESCC cell lines. β‐Actin was served as a loading control. (B) Immunoblot analysis for SOX2 and total YAP1 protein levels after SOX2 overexpression in Eca109 cells. (C) Representative immunofluorescence staining and statistical analysis of YAP1 expression for the percentage of cells staining nuclear or both nuclear/cytoplasmic in Eca109‐vector and Eca109‐SOX2 cells. (D) Western blotting for nuclear YAP1 expression after SOX2 overexpression in Eca109 cells. α‐tubulin and Lamin B were used as loading controls. (E) Immunoblot analysis of SOX2 expression in KYSE150 cells after treatment with different shRNAs against SOX2. β‐actin was used as a loading control. (F) Western blotting for nuclear YAP1 and TAZ expression after SOX2 knockdown in KYSE150 cells. α‐tubulin and Lamin B were served as loading controls
+
+YAP1 is pervasively activated in human cancers including ESCC, where its activation is required to instruct malignant properties, such as chemoresistance and metastasis.6, 26 To determine the effect of SOX2 on the motility of ESCC cells, Transwell assays were performed. Results showed that overexpression of SOX2 in Eca109 cells resulted in a significant enhancement of their migration ability and invasive potential compared to control groups (Figure 5A,B). Furthermore, we found that enhanced SOX2 expression in Eca109 cells promoted chemoresistance to cisplatin, one of the most frequently used chemotherapeutic drug for esophageal cancer, as demonstrated by a shift in the IC50 (Figure 5C). On the contrary, silencing of SOX2 by shRNA markedly reduced migration and invasion of KYSE150 cells (Figure 5D,E). We next established a xenograft model in nude mice to address the role of SOX2 in tumor growth. Knockdown of SOX2 potently suppressed KYSE150‐derived xenograft growth, as measured by tumor volume and tumor weight (Figure 5F,G). To test the potential contribution of WWC1 in ESCC, we also performed gain‐of‐function experiments. Overexpression of the repressed WWC1 by a plasmid27 in Eca109‐SOX2 cells potently abrogated the SOX2‐induced migration and invasion (Figure 5H,I), providing evidence that repression of WWC1 is required for the functionality of SOX2 in ESCC.
+
+SOX2 overexpression drives migration and invasion that can be antagonized by WWC1. (A–B) Effect of SOX2 on cell migration (A) and invasion (B) of Eca109 cells assessed using Transwell assay. (C) Dose‐response curves of Eca109‐SOX2 and Eca109‐vector cells to cisplatin. (D–E) Effect of shSOX2 on cell migration (D) and invasion (E) of KYSE150 cells. (F‐G) KYSE150‐derived xenograft model was established in nude mice (n = 6 per group). Tumor volume was measured every other day (F), and tumor weights were measured at the end of the experiment (G). (H‐I) Effect of WWC1 on cell migration (H) and invasion (I) of Eca109‐SOX2 cells assessed using Transwell assay. *P < .05, **P < .01, ***P < .001
+
+Recent evidence suggests that SOX2 and ACTL6A/p63 may regulate Hippo pathway components in osteosarcoma and HNSCC, respectively.14, 23 In this report, we show that SOX2, ACTL6A, and TP63 are co‐amplified and upregulated in ESCC samples. Through integrating genomic analysis and transcriptome profiling of these transcription factors, we outline a pathway in which SOX2‐mediated direct repression of the Hippo regulator WWC1 in ESCC. SOX2‐promoted YAP1 activation is confirmed both in clinical samples and ESCC cells. Of note, while SOX2 is supposed to bind the 3′ untranslated portion of WWC1 mRNA in osteosarcoma,23 multiple SOX2 binding peaks are identified in the upper region of WWC1 in ESCC TT cells, suggesting SOX2 can regulate the Hippo‐YAP1 signaling in a context‐dependent manner. It is noteworthy that regulation of TAZ by SOX2 is distinct from that of YAP1 in ESCC cells, although YAP1 and TAZ are often described to be equivalent downstream of the Hippo pathway. Consistent with this finding, TAZ expression is not decreased in SOX2‐depleted osteoprogenitors.22 Furthermore, YAP1 shows different functional roles compared to TAZ in osteosarcoma and hepatocellular carcinoma.22, 23, 28
+
+
+SOX2 has been implicated in tumorigenicity, drug resistance, and metastasis in at least 25 human cancers.29 Regarding clinical prognosis for cancer patients, high SOX2 expression has been linked to poor prognosis and increased metastatic capacity in the majority of cancers, such as ESCC30, 31 and breast cancer.32, 33 However, a few studies on the role of SOX2 in cancer development have led to contrasting findings: low or negative SOX2 expression is associated with worse prognosis in at least four cancers,29 including gastric cancer,34, 35 squamous cell lung cancer,36 and ESCC.37, 38 Given the conflicting reports regarding SOX2 expression and patient prognosis, there are clear needs for further investigation into the clinical implications of SOX2, particularly how SOX2 influences tumor progression. SOX2 has been described to promote tumor growth through activation of the AKT/mTORC1 signaling39 and to promote metastasis by activating the STAT3/HIF‐1α pathway.40 Targeted silencing of SOX2 by an artificial transcription factor shows an anti‐tumor effect in ESCC.41 In the present study, ectopic SOX2 expression promotes migration, invasion, and drug resistance of ESCC cells, while knockdown of SOX2 or WWC1 overexpression diminishes their migration ability and invasive potential.
+
+In summary, SOX2 is highly expressed in ESCC and activates YAP1 signaling by direct suppressing WWC1 transcription, thus promoting the migration, invasion, and drug resistance. This SOX2‐WWC1‐YAP1 axis in ESCC may serve as a target for cancer therapy.
+
+The authors declare no conflict of interest.

--- a/references_cache/PMID_34454674.md
+++ b/references_cache/PMID_34454674.md
@@ -1,0 +1,233 @@
+---
+reference_id: "PMID:34454674"
+title: "Pembrolizumab plus chemotherapy versus chemotherapy alone for first-line treatment of advanced oesophageal cancer (KEYNOTE-590): a randomised, placebo-controlled, phase 3 study."
+authors:
+- Sun JM
+- Shen L
+- Shah MA
+- Enzinger P
+- Adenis A
+- Doi T
+- Kojima T
+- Metges JP
+- Li Z
+- Kim SB
+- Cho BC
+- Mansoor W
+- Li SH
+- Sunpaweravong P
+- Maqueda MA
+- Goekkurt E
+- Hara H
+- Antunes L
+- Fountzilas C
+- Tsuji A
+- Oliden VC
+- Liu Q
+- Shah S
+- Bhagia P
+- Kato K
+- KEYNOTE-590 Investigators
+journal: Lancet
+year: '2021'
+doi: 10.1016/S0140-6736(21)01234-4
+keywords:
+- "Antibodies, Monoclonal, Humanized/therapeutic use"
+- "Antineoplastic Agents, Immunological/therapeutic use"
+- Antineoplastic Combined Chemotherapy Protocols/therapeutic use
+- Cisplatin/therapeutic use
+- Double-Blind Method
+- Esophageal Neoplasms/drug therapy
+- Female
+- Fluorouracil/therapeutic use
+- Humans
+- Male
+- Middle Aged
+- Squamous Cell Carcinoma of Head and Neck/drug therapy
+- Survival
+content_type: abstract_only
+---
+
+# Pembrolizumab plus chemotherapy versus chemotherapy alone for first-line treatment of advanced oesophageal cancer (KEYNOTE-590): a randomised, placebo-controlled, phase 3 study.
+**Authors:** Sun JM, Shen L, Shah MA, Enzinger P, Adenis A, Doi T, Kojima T, Metges JP, Li Z, Kim SB, Cho BC, Mansoor W, Li SH, Sunpaweravong P, Maqueda MA, Goekkurt E, Hara H, Antunes L, Fountzilas C, Tsuji A, Oliden VC, Liu Q, Shah S, Bhagia P, Kato K, KEYNOTE-590 Investigators
+**Journal:** Lancet (2021)
+**DOI:** [10.1016/S0140-6736(21)01234-4](https://doi.org/10.1016/S0140-6736(21)01234-4)
+
+## Content
+
+1. Lancet. 2021 Aug 28;398(10302):759-771. doi: 10.1016/S0140-6736(21)01234-4.
+
+Pembrolizumab plus chemotherapy versus chemotherapy alone for first-line
+treatment of advanced oesophageal cancer (KEYNOTE-590): a randomised,
+placebo-controlled, phase 3 study.
+
+Sun JM(1), Shen L(2), Shah MA(3), Enzinger P(4), Adenis A(5), Doi T(6), Kojima
+T(6), Metges JP(7), Li Z(8), Kim SB(9), Cho BC(10), Mansoor W(11), Li SH(12),
+Sunpaweravong P(13), Maqueda MA(14), Goekkurt E(15), Hara H(16), Antunes L(17),
+Fountzilas C(18), Tsuji A(19), Oliden VC(20), Liu Q(21), Shah S(21), Bhagia
+P(21), Kato K(22); KEYNOTE-590 Investigators.
+
+Author information:
+(1)Samsung Medical Center, Sungkyunkwan University, Seoul, South Korea.
+Electronic address: jongmu.sun@skku.edu.
+(2)Key Laboratory of Carcinogenesis and Translational Research (Ministry of
+Education), Peking University Cancer Hospital & Institute, Beijing, China.
+(3)Weill Cornell Medical College, New York City, NY, USA.
+(4)Dana Farber Cancer Institute, Boston, MA, USA.
+(5)Institut de Recherche en Cancérologie de Montpellier (IRCM), Inserm,
+Université Montpellier, ICM, Montpellier, France.
+(6)National Cancer Center Hospital East, Kashiwa, Japan.
+(7)CHU Brest-Institut de Cancerologie et d'Hematologie ARPEGO Network, Brest,
+France.
+(8)Section of Oesophageal Surgery, Shanghai Chest Hospital, Shanghai Jiao Tong
+University, Shanghai, China.
+(9)Asan Medical Center, University of Ulsan College of Medicine, Seoul, South
+Korea.
+(10)Yonsei Cancer Center, Yonsei University College of Medicine, Seoul, South
+Korea.
+(11)Christie Hospital NHS Trust, Manchester, UK.
+(12)Kaohsiung Chang Gung Memorial Hospital and Chang Gung University College of
+Medicine, Kaohsiung, Taiwan.
+(13)Prince of Songkla University Hospital, Songkhla, Thailand.
+(14)Vall d'Hebron Institute of Oncology (VHIO), Barcelona, Spain.
+(15)Hematology Oncology Practice Eppendorf and University Cancer Center Hamburg,
+Hamburg, Germany.
+(16)Saitama Cancer Center, Saitama, Japan.
+(17)University Hospital of Santa Maria, Federal University of Santa Maria, and
+Viver Research Center, Santa Maria, Brazil.
+(18)Roswell Park Comprehensive Cancer Center, Buffalo, NY, USA.
+(19)Kagawa University Hospital, Kagawa, Japan.
+(20)Instituto Nacional de Enfermedades Neoplasicas, Lima, Peru.
+(21)Merck, Kenilworth, NJ, USA.
+(22)National Cancer Center Hospital, Tokyo, Japan.
+
+Erratum in
+    Lancet. 2021 Nov 20;398(10314):1874. doi: 10.1016/S0140-6736(21)02487-9.
+
+Comment in
+    Lancet. 2021 Aug 28;398(10302):726-727. doi: 10.1016/S0140-6736(21)01607-X.
+
+BACKGROUND: First-line therapy for advanced oesophageal cancer is currently
+limited to fluoropyrimidine plus platinum-based chemotherapy. We aimed to
+evaluate the antitumour activity of pembrolizumab plus chemotherapy versus
+chemotherapy alone as first-line treatment in advanced oesophageal cancer and
+Siewert type 1 gastro-oesophageal junction cancer.
+METHODS: We did a randomised, placebo-controlled, double-blind, phase 3 study
+across 168 medical centres in 26 countries. Patients aged 18 years or older with
+previously untreated, histologically or cytologically confirmed, locally
+advanced, unresectable or metastatic oesophageal cancer or Siewert type 1
+gastro-oesophageal junction cancer (regardless of PD-L1 status), measurable
+disease per Response Evaluation Criteria in Solid Tumors version 1.1, and
+Eastern Cooperative Oncology Group performance status of 0-1, were randomly
+assigned (1:1) to intravenous pembrolizumab 200 mg or placebo, plus
+5-fluorouracil and cisplatin (chemotherapy), once every 3 weeks for up to 35
+cycles. Randomisation was stratified by geographical region, histology, and
+performance status. Patients, investigators, and site staff were masked to group
+assignment and PD-L1 biomarker status. Primary endpoints were overall survival
+in patients with oesophageal squamous cell carcinoma and PD-L1 combined positive
+score (CPS) of 10 or more, and overall survival and progression-free survival in
+patients with oesophageal squamous cell carcinoma, PD-L1 CPS of 10 or more, and
+in all randomised patients. This trial is registered with ClinicalTrials.gov,
+NCT03189719, and is closed to recruitment.
+FINDINGS: Between July 25, 2017, and June 3, 2019, 1020 patients were screened
+and 749 were enrolled and randomly assigned to pembrolizumab plus chemotherapy
+(n=373 [50%]) or placebo plus chemotherapy (n=376 [50%]). At the first interim
+analysis (median follow-up of 22·6 months), pembrolizumab plus chemotherapy was
+superior to placebo plus chemotherapy for overall survival in patients with
+oesophageal squamous cell carcinoma and PD-L1 CPS of 10 or more (median 13·9
+months vs 8·8 months; hazard ratio 0·57 [95% CI 0·43-0·75]; p<0·0001),
+oesophageal squamous cell carcinoma (12·6 months vs 9·8 months; 0·72
+[0·60-0·88]; p=0·0006), PD-L1 CPS of 10 or more (13·5 months vs 9·4 months; 0·62
+[0·49-0·78]; p<0·0001), and in all randomised patients (12·4 months vs 9·8
+months; 0·73 [0·62-0·86]; p<0·0001). Pembrolizumab plus chemotherapy was
+superior to placebo plus chemotherapy for progression-free survival in patients
+with oesophageal squamous cell carcinoma (6·3 months vs 5·8 months; 0·65
+[0·54-0·78]; p<0·0001), PD-L1 CPS of 10 or more (7·5 months vs 5·5 months; 0·51
+[0·41-0·65]; p<0·0001), and in all randomised patients (6·3 months vs 5·8
+months; 0·65 [0·55-0·76]; p<0·0001). Treatment-related adverse events of grade 3
+or higher occurred in 266 (72%) patients in the pembrolizumab plus chemotherapy
+group versus 250 (68%) in the placebo plus chemotherapy group.
+INTERPRETATION: Compared with placebo plus chemotherapy, pembrolizumab plus
+chemotherapy improved overall survival in patients with previously untreated,
+advanced oesophageal squamous cell carcinoma and PD-L1 CPS of 10 or more, and
+overall survival and progression-free survival in patients with oesophageal
+squamous cell carcinoma, PD-L1 CPS of 10 or more, and in all randomised patients
+regardless of histology, and had a manageable safety profile in the total
+as-treated population.
+FUNDING: Merck Sharp & Dohme.
+
+Copyright © 2021 Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/S0140-6736(21)01234-4
+PMID: 34454674 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests J-MS reports research
+funding to the institution by Merck Sharp & Dohme (MSD; a subsidiary of Merck),
+AstraZeneca, and Ono Pharmaceuticals, during the conduct of the study. LS
+reports research funding to the institution by MSD, grants from Beijing Xiantong
+Biomedical Technology, Qily Pharmaceutical, Zaiding Pharmaceutical, Jacobio
+Pharmaceuticals, and Beihai Kangcheng Medical Technology, and consulting fees
+from HARBOUR and Merck, during the conduct of the study. MAS reports funding to
+the institution from MSD, Bristol Myers Squibb (BMS), and Oncolys BioPharma,
+during the conduct of the study. PE reports funding to the institution from MSD,
+during the conduct of the study, and personal fees from MSD, AstraZeneca,
+Celgene, Daiichi Sankyo, Five Prime, Lilly, Loxo, Taiho, Takeda, and Zymeworks,
+outside of the submitted work. AA reports funding to the institution from MSD,
+BMS, and Bayer Pharmaceuticals, during the conduct of the study, and personal
+fees from MSD and BMS, and personal fees for advisory role from Merck Serono and
+Servier, outside of the submitted work. TD reports funding to the institution
+from MSD, Daiichi Sankyo, Sumitomo Dainippon, AbbVie, Novartis, Boehringer
+Ingelheim, Taiho Pharmaceutical, Merck Serono, BMS, Pfizer, Lilly, Kyowa Hakko,
+Kirin, and IQVIA, during the conduct of the study, and personal fees for
+consulting or advisory role from MSD, Daiichi Sankyo, Amgen, Sumitomo Dainippon,
+Taiho Pharmaceutical, Takeda, AbbVie, Novartis, Bayer, Boehringer Ingelheim,
+Rakuten Medical, and BMS, and honoraria from Ono Pharmaceutical, Astellas
+Pharma, Oncolys BioPharma, Taiho Pharmaceutical, and Otsuka, outside of the
+submitted work. TK reports funding to the institution from MSD, Ono
+Pharmaceutical, Shionogi, Astellas Amgen Bio Pharma, and Taiho Pharmaceutical,
+during the conduct of the study, and personal fees from MSD, Ono Pharmaceutical,
+Merck, Astellas Pharma, BMS, and Oncolys BioPharma, outside of the submitted
+work. J-PM reports funding to the institution from MSD, during the conduct of
+the study, and honoraria from MSD, Bayer, and BMS, outside of the submitted
+work. ZL reports funding to the institution from MSD, during the conduct of the
+study. S-BK reports funding to the institution from MSD, Novartis, and
+Sanofi-Genzyme, during the conduct of the study, and personal fees for
+consulting or advisory role from Dae Hwa Pharmaceutical, ISU Abxis, and
+Daiichi-Sankyo, outside of the submitted work. BCC reports funding to the
+institution from MSD, Novartis, Bayer, AstraZeneca, MOGAM Institute, Dong-A ST,
+Champions Oncology, Janssen, Yuhan, Ono, Dizal Pharma, AbbVie, Medpacto, G
+Innovation, Eli Lilly, Blueprint Medicines, and Interpark Bio Convergence, fees
+for consulting or advisory role from Novartis, AstraZeneca, Boehringer
+Ingelheim, Roche, BMS, Ono, Yuhan, Pfizer, Eli Lilly, Janssen, Takeda, MSD,
+Janssen, Medpacto, Blueprint Medicines, KANAPH Therapeutic, Brigebio
+Therapeutics, Cyrus Therapeutics, and Guardant Health, stock ownership in
+TheraCanVac, Gencurix, Bridgebio Therapeutics, KANAPH Therapeutic, Cyrus
+Therapeutics, and Interpark Bio Convergence, personal fees for Board of
+Directorship from Gencurix and Interpark Bio Convergence, royalties from
+Champions Oncology, and is the founder of DAAN Biotherapeutics, outside of the
+submitted work. MAM reports funding to the institution from MSD, during the
+conduct of the study, and consultancy for MSD, BMS, Servier, and Lilly, and
+honoraria from BMS, Servier, and Amgen, outside of the submitted work. EG
+reports funding to the institution from MSD, during the conduct of the study,
+and personal fees from MSD, BMS, Servier, and Roche, outside of the submitted
+work. HH reports funding to the institution from MSD, during the conduct of the
+study, and grants from AstraZeneca, Daiichi Sankyo, Dainippon Sumitomo Pharma,
+Merck Biopharma, MSD, Taiho, Chugai, Eisai, LSK BioPharma, Incyte, Pfizer,
+Boehringer Ingelheim, Beigene, Ono, BMS, and Astellas, and personal fees from
+Daiichi Sankyo, Dainippon Sumitomo Pharma, Lilly, Merck Biopharma, MSD, Taiho,
+Chugai, Ono, BMS, Yakult Honsha, Sanofi, Takeda, and Kyowa Hakko Kirin, outside
+of the submitted work. CF reports funding to the institution from MSD, during
+the conduct of the study, and grants and non-financial support from National
+Comprehensive Cancer Network, Taiho Oncology, Pfizer, and AstraZeneca, outside
+of the submitted work. AT reports funding to the institution from MSD, during
+the conduct of the study, and grants from Taiho Pharmaceutical, Chugai
+Pharmaceutical, Eli Lilly Japan, Merck Biopharma, Takeda Pharmaceutical, Sanofi,
+Ono Pharmaceutical, Kyowa Hakko Kirin, Eisai, Toray Medical, Daiichi Sankyo,
+Bayer Yakuhin, Shionogi, Pfizer, and Yakult Honsha, and personal fees from Taiho
+Pharmaceutical, Chugai Pharmaceutical, Eli Lilly, BMS, Merck Biopharma, Takeda
+Pharmaceutical, and Sanofi, outside of the submitted work. WM, S-HL, PS, LA, and
+VCO report funding to the institution from MSD, during the conduct of the study.
+QL, SS, and PB are employees and hold stock in MSD. KK reports funding to the
+institution from MSD, during the conduct of the study, and research funding from
+Ono, BMS, Beigene, Shionogi, Merck Biopharma, Oncolys Biopharma, and Chugai,
+outside of the submitted work.

--- a/references_cache/PMID_34611831.md
+++ b/references_cache/PMID_34611831.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:34611831"
+title: Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma.
+authors:
+- Naseri A
+- Salehi-Pourmehr H
+- Majidazar R
+- Seraji P
+- Rezazadeh-Gavgani E
+- Zehtabi M
+- Kiani-Kezbin H
+- Salehnia F
+- Hassannezhad S
+- Hajikamanj A
+- Raeisi M
+journal: J Gastrointest Cancer
+year: '2022'
+doi: 10.1007/s12029-021-00721-y
+keywords:
+- Male
+- Humans
+- Female
+- Esophageal Squamous Cell Carcinoma/genetics
+- "Esophageal Neoplasms/genetics, pathology"
+- "Carcinoma, Squamous Cell/genetics, pathology"
+- Mutation
+- Class I Phosphatidylinositol 3-Kinases/genetics
+content_type: abstract_only
+---
+
+# Systematic Review and Meta-analysis of the Most Common Genetic Mutations in Esophageal Squamous Cell Carcinoma.
+**Authors:** Naseri A, Salehi-Pourmehr H, Majidazar R, Seraji P, Rezazadeh-Gavgani E, Zehtabi M, Kiani-Kezbin H, Salehnia F, Hassannezhad S, Hajikamanj A, Raeisi M
+**Journal:** J Gastrointest Cancer (2022)
+**DOI:** [10.1007/s12029-021-00721-y](https://doi.org/10.1007/s12029-021-00721-y)
+
+## Content
+
+1. J Gastrointest Cancer. 2022 Dec;53(4):1040-1049. doi:
+10.1007/s12029-021-00721-y. Epub 2021 Oct 6.
+
+Systematic Review and Meta-analysis of the Most Common Genetic Mutations in
+Esophageal Squamous Cell Carcinoma.
+
+Naseri A(1)(2), Salehi-Pourmehr H(3), Majidazar R(1), Seraji P(1),
+Rezazadeh-Gavgani E(1), Zehtabi M(4), Kiani-Kezbin H(3), Salehnia F(3),
+Hassannezhad S(1), Hajikamanj A(1), Raeisi M(5).
+
+Author information:
+(1)Student Research Committee, Tabriz University of Medical Sciences, Tabriz,
+Iran.
+(2)Aging Research Institute, Tabriz University of Medical Sciences, Tabriz,
+Iran.
+(3)Research Center for Evidence Based-Medicine, Iranian EBM Center: A Joanna
+Briggs Institute Center of Excellence, Tabriz University of Medical Sciences,
+Tabriz, Iran.
+(4)Liver and Gastrointestinal Diseases Research Center, Tabriz University of
+Medical Sciences, Tabriz, Iran.
+(5)Hematology and Oncology Research Center, Tabriz University of Medical
+Sciences, Tabriz, Iran. raeisim@tbzmed.ac.ir.
+
+PURPOSE: Esophageal cancer is the second most common cancer among men and women.
+There is a need to systematically assess the current evidence to map out the
+contribution of genetic factors in the development of esophageal squamous cell
+carcinoma (ESCC).
+METHODS: A literature search was carried out on published and unpublished
+studies up to August 2021 in Medline (PubMed), Embase (Ovid), Scopus, Proquest,
+Web of Science, and Google scholar. Studies that have reported the frequency of
+genetic mutations in ESCC were included in this study.
+RESULTS: A total of 1238 titles were retrieved through searches, and finally, 56
+articles, including 8114 samples, met our predefined inclusion criteria. Of the
+included studies, 31 were conducted in China, 12 in Japan, and the remaining
+were conducted in various nations, including Brazil, Korea, and Iran. Most of
+our included studies evaluated the TP53 (n = 37 studies) and PIK3CA (n = 30
+studies) gene mutations. TP53 (68.6%; 95% CI: 61.6-74.9), CCND1 (39.3%; 95% CI:
+26.2-54.1), MDM2 (24.9%; 95% CI: 9.5-51.0), NOTCH1/2/3 (17.9%; 95% CI:
+15.0-21.2), KMT2D (17.4%; 95% CI: 12.4-23.8), CDKN2A (15.0%; 95% CI: 8.1-26.1),
+PIK3CA (13.8%; 95% CI: 10.3-18.1), FAT1 (13.3%; 95% CI: 11.7-15.0), and EGFR
+(9.9%; 95% CI: 5.6-17.0) were the most common involved genetic factors in
+developing ESCC.
+CONCLUSION: This systematic review and meta-analysis revealed that more than 10%
+of ESCC patients had changes in TP53, CCND1, MDM2, NOTCH1/2/3, KMT2D, CDKN2A,
+PIK3CA, and FAT1 genes, which can highlight their role in developing ESCC. TP53,
+CCND1, and MDM2 are the most prevalent, demonstrating 68.6%, 39.3%, and 24.9% of
+the mutations in ESCC patients.
+
+© 2021. Springer Science+Business Media, LLC, part of Springer Nature.
+
+DOI: 10.1007/s12029-021-00721-y
+PMID: 34611831 [Indexed for MEDLINE]

--- a/references_cache/PMID_35294546.md
+++ b/references_cache/PMID_35294546.md
@@ -1,0 +1,123 @@
+---
+reference_id: "PMID:35294546"
+title: Three-Year Follow-Up and Response-Survival Relationship of Nivolumab in Previously Treated Patients with Advanced Esophageal Squamous Cell Carcinoma (ATTRACTION-3).
+authors:
+- Okada M
+- Kato K
+- Cho BC
+- Takahashi M
+- Lin CY
+- Chin K
+- Kadowaki S
+- Ahn MJ
+- Hamamoto Y
+- Doki Y
+- Yen CC
+- Kubota Y
+- Kim SB
+- Hsu CH
+- Holtved E
+- Xynos I
+- Matsumura Y
+- Takazawa A
+- Kitagawa Y
+journal: Clin Cancer Res
+year: '2022'
+doi: 10.1158/1078-0432.CCR-21-0985
+keywords:
+- Esophageal Neoplasms/drug therapy
+- Esophageal Squamous Cell Carcinoma/drug therapy
+- Follow-Up Studies
+- Humans
+- "Nivolumab/administration & dosage"
+- Programmed Cell Death 1 Receptor/therapeutic use
+content_type: abstract_only
+---
+
+# Three-Year Follow-Up and Response-Survival Relationship of Nivolumab in Previously Treated Patients with Advanced Esophageal Squamous Cell Carcinoma (ATTRACTION-3).
+**Authors:** Okada M, Kato K, Cho BC, Takahashi M, Lin CY, Chin K, Kadowaki S, Ahn MJ, Hamamoto Y, Doki Y, Yen CC, Kubota Y, Kim SB, Hsu CH, Holtved E, Xynos I, Matsumura Y, Takazawa A, Kitagawa Y
+**Journal:** Clin Cancer Res (2022)
+**DOI:** [10.1158/1078-0432.CCR-21-0985](https://doi.org/10.1158/1078-0432.CCR-21-0985)
+
+## Content
+
+1. Clin Cancer Res. 2022 Aug 2;28(15):3277-3286. doi:
+10.1158/1078-0432.CCR-21-0985.
+
+Three-Year Follow-Up and Response-Survival Relationship of Nivolumab in
+Previously Treated Patients with Advanced Esophageal Squamous Cell Carcinoma
+(ATTRACTION-3).
+
+Okada M(1), Kato K(2), Cho BC(3), Takahashi M(4), Lin CY(5), Chin K(6), Kadowaki
+S(7), Ahn MJ(8), Hamamoto Y(9), Doki Y(10), Yen CC(11), Kubota Y(12), Kim
+SB(13), Hsu CH(14), Holtved E(15), Xynos I(16), Matsumura Y(17), Takazawa A(18),
+Kitagawa Y(19).
+
+Author information:
+(1)Department of Surgical Oncology, Research Institute for Radiation Biology and
+Medicine, Graduate School of Biomedical and Health Sciences, Hiroshima
+University, Hiroshima, Japan.
+(2)Department of Head and Neck Medical Oncology, National Cancer Center
+Hospital, Tokyo, Japan.
+(3)Division of Medical Oncology, Yonsei Cancer Center, Yonsei University College
+of Medicine, Seoul, South Korea.
+(4)Department of Medical Oncology, Tohoku University Hospital, Sendai, Japan.
+(5)Department of Hematology and Oncology, China Medical University Hospital and
+School of Pharmacy, China Medical University, Taichung City, Taiwan.
+(6)Gastroenterological Chemotherapy Department, Cancer Institute Hospital of
+Japanese Foundation for Cancer Research, Tokyo, Japan.
+(7)Department of Clinical Oncology, Aichi Cancer Center Hospital, Nagoya, Japan.
+(8)Department of Hematology-Oncology, Samsung Medical Center, Sungkyunkwan
+University School of Medicine, Seoul, South Korea.
+(9)Department of Internal Medicine, Keio Cancer Center, School of Medicine, Keio
+University, Tokyo, Japan.
+(10)Department of Surgery, Osaka University Hospital, Osaka, Japan.
+(11)Division of Clinical Research, Department of Medical Research and Division
+of Medical Oncology, Center for Immuno-oncology, Department of Oncology, Taipei
+Veterans General Hospital and National Yang Ming Chiao Tung University School of
+Medicine, Taipei, Taiwan.
+(12)Department of Oncology, Showa University Hospital, Tokyo, Japan.
+(13)Department of Oncology, Asan Medical Center, University of Ulsan College of
+Medicine, Seoul, South Korea.
+(14)Department of Oncology, National Taiwan University Hospital, Taipei, Taiwan.
+(15)Department of Clinical Oncology, Odense University Hospital, Odense,
+Denmark.
+(16)Oncology Clinical Development, Bristol-Myers Squibb, Princeton, New Jersey.
+(17)Oncology Clinical Development, Ono Pharmaceutical Co., Ltd., Osaka, Japan.
+(18)Data Science, Ono Pharmaceutical Co., Ltd., Osaka, Japan.
+(19)Department of Surgery, Keio University School of Medicine, Tokyo, Japan.
+
+Comment in
+    Clin Cancer Res. 2022 Aug 2;28(15):3173-3175. doi:
+10.1158/1078-0432.CCR-22-0932.
+
+PURPOSE: Limited long-term data are available on immune checkpoint inhibitor use
+in patients with advanced esophageal squamous cell carcinoma (ESCC). We report
+3-year follow-up data from our study of nivolumab versus chemotherapy
+(paclitaxel or docetaxel) in patients with previously treated ESCC.
+PATIENTS AND METHODS: ATTRACTION-3 was a randomized, multicenter, open-label,
+phase III trial. Overall survival (OS), time from randomization to death from
+any cause, was the primary endpoint. An exploratory subanalysis assessed OS
+according to the best overall response (BOR) with and without landmark at 4
+months.
+RESULTS: Of the enrolled patients, 210 received nivolumab and 209 received
+chemotherapy. With a minimum follow-up of 36.0 months, OS was longer in the
+nivolumab versus the chemotherapy group (median, 10.9 vs. 8.5 months; HR, 0.79;
+P = 0.0264), with 3-year OS rates of 15.3% and 8.7%, respectively. The median OS
+was longer with nivolumab versus chemotherapy irrespective of the BOR (complete
+response/partial response: 19.9 vs. 15.4 months; stable disease: 17.4 vs. 8.8
+months; and progressive disease: 7.6 vs. 4.2 months). Grade 3 or higher
+treatment-related adverse events were reported in 40 patients (19.1%) in the
+nivolumab group and 133 patients (63.9%) in the chemotherapy group.
+CONCLUSIONS: Nivolumab as second-line therapy demonstrated clinically meaningful
+long-term improvement in OS compared with chemotherapy in previously treated
+patients with advanced ESCC. The OS was consistently improved in the nivolumab
+group compared with the chemotherapy group regardless of BOR. Nivolumab was well
+tolerated over the 3-year follow-up. See related commentary by Yoon et al., p.
+3173.
+
+©2022 The Authors; Published by the American Association for Cancer Research.
+
+DOI: 10.1158/1078-0432.CCR-21-0985
+PMCID: PMC9662935
+PMID: 35294546 [Indexed for MEDLINE]

--- a/references_cache/PMID_38832974.md
+++ b/references_cache/PMID_38832974.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:38832974"
+title: Prognostic value of genomic mutation signature associated with immune microenvironment in southern Chinese patients with esophageal squamous cell carcinoma.
+authors:
+- Zhou Y
+- Chu L
+- Li S
+- Chu X
+- Ni J
+- Jiang S
+- Pang Y
+- Zheng D
+- Lu Y
+- Lan F
+- Cai X
+- Yang X
+- Zhu Z
+journal: Cancer Immunol Immunother
+year: '2024'
+doi: 10.1007/s00262-024-03725-2
+keywords:
+- Humans
+- "Tumor Microenvironment/immunology, genetics"
+- Prognosis
+- Male
+- Female
+- "Esophageal Squamous Cell Carcinoma/genetics, immunology, mortality, pathology"
+- Mutation
+- Middle Aged
+- "Esophageal Neoplasms/genetics, immunology, mortality"
+- "Biomarkers, Tumor/genetics"
+- Aged
+- China
+- Adult
+- Genomics/methods
+- East Asian People
+content_type: abstract_only
+---
+
+# Prognostic value of genomic mutation signature associated with immune microenvironment in southern Chinese patients with esophageal squamous cell carcinoma.
+**Authors:** Zhou Y, Chu L, Li S, Chu X, Ni J, Jiang S, Pang Y, Zheng D, Lu Y, Lan F, Cai X, Yang X, Zhu Z
+**Journal:** Cancer Immunol Immunother (2024)
+**DOI:** [10.1007/s00262-024-03725-2](https://doi.org/10.1007/s00262-024-03725-2)
+
+## Content
+
+1. Cancer Immunol Immunother. 2024 Jun 4;73(8):141. doi:
+10.1007/s00262-024-03725-2.
+
+Prognostic value of genomic mutation signature associated with immune
+microenvironment in southern Chinese patients with esophageal squamous cell
+carcinoma.
+
+Zhou Y(#)(1)(2), Chu L(#)(1)(2), Li S(#)(3), Chu X(1)(2), Ni J(1)(2), Jiang
+S(1)(2), Pang Y(1)(2), Zheng D(4), Lu Y(4), Lan F(4), Cai X(5), Yang X(6)(7),
+Zhu Z(8)(9)(10).
+
+Author information:
+(1)Department of Radiation Oncology, Fudan University Shanghai Cancer Center,
+270 Dong An Road, Shanghai, China.
+(2)Department of Oncology, Shanghai Medical College, Fudan University, Shanghai,
+China.
+(3)Department of Radiation Oncology, Ruijin Hospital, Shanghai Jiaotong
+University School of Medicine, Shanghai, China.
+(4)Department of VIP Inpatient, Sun Yet-Sen University Cancer Center, State Key
+Laboratory of Oncology in South China, Guangzhou, China.
+(5)Department of VIP Inpatient, Sun Yet-Sen University Cancer Center, Guangdong
+Provincial Clinical Research Center for Cancer, State Key Laboratory of Oncology
+in South China, Collaborative Innovation Center for Cancer Medicine, 651
+Dongfeng Road East, Guangzhou, China. caixy@sysucc.org.cn.
+(6)Department of Radiation Oncology, Fudan University Shanghai Cancer Center,
+270 Dong An Road, Shanghai, China. ntgeorge@qq.com.
+(7)Department of Oncology, Shanghai Medical College, Fudan University, Shanghai,
+China. ntgeorge@qq.com.
+(8)Department of Radiation Oncology, Fudan University Shanghai Cancer Center,
+270 Dong An Road, Shanghai, China. fuscczzf@163.com.
+(9)Department of Oncology, Shanghai Medical College, Fudan University, Shanghai,
+China. fuscczzf@163.com.
+(10)Institute of Thoracic Oncology, Fudan University, Shanghai, China.
+fuscczzf@163.com.
+(#)Contributed equally
+
+The genomic landscape of esophageal squamous cell cancer (ESCC), as well as its
+impact on the regulation of immune microenvironment, is not well understood.
+Thus, tumor samples from 92 patients were collected from two centers and
+subjected to targeted-gene sequencing. We identified frequently mutated genes,
+including TP53, KMT2C, KMT2D, LRP1B, and FAT1. The most frequent mutation sites
+were ALOX12B (c.1565C > T), SLX4 (c.2786C > T), LRIG1 (c.746A > G), and SPEN
+(c.6915_6917del) (6.5%). Pathway analysis revealed dysregulation of cell cycle
+regulation, epigenetic regulation, PI3K/AKT signaling, and NOTCH signaling. A
+17-mutated gene-related risk model was constructed using random survival forest
+analysis and showed significant prognostic value in both our cohort and the
+validation cohort. Based on the Estimation of Stromal and Immune cells in
+Malignant Tumor tissues using Expression (ESTIMATE) algorithm, the Tumor Immune
+Dysfunction and Exclusion (TIDE) algorithm, and the MCPcounter algorithm, we
+found that the risk score calculated by the risk model was significantly
+correlated with stimulatory immune checkpoints (TNFSF4, ITGB2, CXCL10, CXCL9,
+and BTN3A1; p < 0.05). Additionally, it was significantly associated with
+markers that are important in predicting response to immunotherapy (CD274, IFNG,
+and TAMM2; p < 0.05). Furthermore, the results of immunofluorescence double
+staining showed that patients with high risk scores had a significantly higher
+level of M2 macrophage than those with low risk scores (p < 0.05). In
+conclusion, our study provides insights into the genomic landscape of ESCC and
+highlights the prognostic value of a genomic mutation signature associated with
+the immune microenvironment in southern Chinese patients with ESCC.
+
+© 2024. The Author(s).
+
+DOI: 10.1007/s00262-024-03725-2
+PMCID: PMC11150228
+PMID: 38832974 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing
+interests.

--- a/references_cache/PMID_40507565.md
+++ b/references_cache/PMID_40507565.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:40507565"
+title: Clinical Features and Prognosis of Cervical Esophageal Cancer.
+authors:
+- Ryu DG
+- Kim K
+- Liu H
+- Lee SS
+- Lee SL
+journal: J Clin Med
+year: '2025'
+doi: 10.3390/jcm14113803
+content_type: abstract_only
+---
+
+# Clinical Features and Prognosis of Cervical Esophageal Cancer.
+**Authors:** Ryu DG, Kim K, Liu H, Lee SS, Lee SL
+**Journal:** J Clin Med (2025)
+**DOI:** [10.3390/jcm14113803](https://doi.org/10.3390/jcm14113803)
+
+## Content
+
+1. J Clin Med. 2025 May 29;14(11):3803. doi: 10.3390/jcm14113803.
+
+Clinical Features and Prognosis of Cervical Esophageal Cancer.
+
+Ryu DG(1)(2)(3), Kim K(2), Liu H(3), Lee SS(3), Lee SL(4).
+
+Author information:
+(1)Department of Internal Medicine, Pusan National University School of Medicine
+and Research Institute for Convergence of Biomedical Science and Technology,
+Pusan National University Yangsan Hospital, Yangsan 50612, Republic of Korea.
+(2)Department of Biomedical Engineering, Schulich School of Engineering,
+University of Calgary, Calgary, AB T2N 4N1, Canada.
+(3)Liver Unit, University of Calgary Cumming School of Medicine, Calgary, AB T2N
+4N1, Canada.
+(4)Division of Radiation Oncology, University of Calgary, Tom Baker Cancer
+Centre 1331 29 Street NW, Calgary, AB T2N 4N2, Canada.
+
+Background: This study aimed to analyze the clinical features and prognosis of
+cervical esophageal squamous cell carcinoma (ESCC) compared to ESCC more
+inferiorly in the esophagus. Methods: Medical records of patients with ESCC
+between December 2008 and December 2024 were retrospectively reviewed. A total
+of 497 patients with ESCC were included and divided into cervical (n = 32) and
+non-cervical (n = 465) groups. Clinical features and survival according to
+treatment were compared between the two groups. Results: Patients with cervical
+ESCC were older (median age 73 years vs. 67 years, p = 0.047) with a higher
+proportion of females (18.7% vs. 10.1%, p = 0.133) than patients with
+non-cervical ESCC. Cervical ESCC had worse differentiation (34.4% vs. 19.6%, p =
+0.049 in the rate of poorly differentiated carcinoma) and higher T stage (6.2%
+vs. 37.2%, p = 0.003 in T1; 28.1% vs. 4.7%, p < 0.001 in T4) than non-cervical
+ESCC. There was no difference in lymph node metastasis (65.6% vs. 54.6%, p =
+0.229) or distant metastasis (15.6% vs. 15.5%, p = 0.983) between the two
+groups. Overall survival was lower in the cervical group (hazard ratio [HR],
+1.51; 95% confidence interval [CI], 0.96-2.40; p = 0.076). When comparing
+outcomes of patients who underwent definitive chemoradiotherapy, the complete
+response rate (63.6% vs. 53.4%, p = 0.340) and survival (HR, 1.01; 95% CI,
+0.51-1.99; p = 0.973) were similar between the two groups. Conclusions: Although
+cervical ESCC had a poor prognosis due to its higher T-stage and worse
+differentiation compared to other locations, outcomes were similar when treated
+with definitive chemoradiotherapy.
+
+DOI: 10.3390/jcm14113803
+PMCID: PMC12156885
+PMID: 40507565
+
+Conflict of interest statement: The authors declare no conflict of interest.


### PR DESCRIPTION
## What changed
Added a new curated `Esophageal_Squamous_Cell_Carcinoma` disorder entry with:

- environmental risk factors for tobacco and alcohol
- mechanistic pathophysiology nodes for carcinogen injury, TP53 dysfunction, cell-cycle dysregulation, NOTCH and PI3K/AKT signaling
- a new structured `SOX2/TP63` squamous lineage program node
- phenotype entries with PMID-backed evidence for dysphagia, weight loss, odynophagia, chest pain, and hematemesis
- histopathology and genetic sections with formal evidence blocks
- treatment entries including chemoradiation and PD-1 therapy

## Why
This addresses review feedback on the initial ESCC curation by replacing unsupported narrative sections with structured, literature-backed evidence and by adding key squamous lineage drivers that were missing from the original structured representation.

## Validation
Ran:

- `just validate kb/disorders/Esophageal_Squamous_Cell_Carcinoma.yaml`

This passed schema, ontology term, and reference validation.

## Scope notes
Only the ESCC disorder file and the new PMID cache files required for reference validation are included in this PR. Unrelated worktree changes were intentionally left out.