### PR TITLE
[codex] Improve mediatoropathy pathograph specificity

### DIFF
--- a/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
+++ b/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Mediator Complex Neurodevelopmental Disorder
 creation_date: "2026-04-11T00:00:00Z"
-updated_date: "2026-04-12T16:20:00Z"
+updated_date: "2026-04-12T16:39:21Z"
 description: >-
   A group of neurodevelopmental disorders caused by germline mutations in genes encoding
   subunits of the Mediator complex, a multi-protein assembly required for RNA polymerase
@@ -329,8 +329,8 @@ pathophysiology:
   - reference: PMID:37516429
     supports: SUPPORT
     evidence_source: OTHER
-    snippet: "Some MED subunits have been found altered in the brain, although their specific functions in neurodegenerative diseases are not fully understood."
-    explanation: Confirms that Mediator subunit alterations are found in the brain, supporting neurodevelopmental transcriptional dysregulation.
+    snippet: "Mutations in MED subunits were associated with a wide range of genetic diseases for MED12, MED13, MED13L, MED20, MED23, MED25, and CDK8 genes."
+    explanation: Confirms disease-causation for MED12, MED13, MED13L, and MED23 genes in the mediatoropathy spectrum, supporting a shared neurodevelopmental transcriptional dysregulation mechanism.
   - reference: PMID:41663567
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
@@ -1495,7 +1495,7 @@ genetic:
     explanation: Supports the statement that most MED13L pathogenic variants arise de novo.
   - reference: PMID:40500968
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: COMPUTATIONAL
     snippet: "3D protein modeling suggested that these missense variants may disrupt MED13L's interaction with the CDK8 kinase module, leading to functional deficits."
     explanation: Provides gene-specific mechanistic evidence that pathogenic MED13L missense variants can perturb CKM interactions.
 

--- a/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
+++ b/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
@@ -433,10 +433,15 @@ phenotypes:
         term:
           id: hgnc:22474
           label: MED13
-    severity: MILD
     notes: >-
-      Mildly impaired intellectual development is typical. Most patients function
-      in the borderline to mild ID range.
+      Intellectual disability severity is variable in MED13-related disorder,
+      with current reports ranging from mild to severe.
+    evidence:
+    - reference: PMID:36087421
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Mutations in the MED13 gene are reported in the literature in association with clinically variable, neurodevelopmental disorders, which are characterized by mild-to-severe intellectual disability, autism spectrum disorder, attention deficit/hyperactivity disorder, epilepsy, ocular or skeletal abnormalities, congenital cardiac defects, and facial dysmorphisms."
+      explanation: Supports a variable MED13 intellectual disability severity spectrum rather than a single fixed severity band.
   - subtype: MED13L
     genetic_context:
       gene:
@@ -444,9 +449,15 @@ phenotypes:
         term:
           id: hgnc:22962
           label: MED13L
-    severity: PROFOUND
     notes: >-
-      Ranges from mild to profound. Many patients have moderate to severe ID.
+      MED13L syndrome spans a wide severity range from mild to profound
+      developmental delay and intellectual disability.
+    evidence:
+    - reference: PMID:40228085
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "MED13L syndrome is characterized by mild-to-profound developmental delay, intellectual disability, and hypotonia."
+      explanation: Supports the broad severity range of intellectual disability in MED13L syndrome.
   - subtype: MED12
     genetic_context:
       gene:
@@ -454,9 +465,15 @@ phenotypes:
         term:
           id: hgnc:11957
           label: MED12
-    severity: SEVERE
     notes: >-
-      Moderate to severe intellectual disability is characteristic of FG syndrome.
+      FG syndrome cognitive impairment is variable from borderline to severe,
+      although all mutation-confirmed individuals have cognitive disability.
+    evidence:
+    - reference: PMID:19938245
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The degree of intellectual disability is variable from borderline to severe."
+      explanation: Supports a variable but consistently abnormal intellectual phenotype in MED12-confirmed FG syndrome.
   - subtype: MED23
     genetic_context:
       gene:
@@ -464,9 +481,14 @@ phenotypes:
         term:
           id: hgnc:2372
           label: MED23
-    severity: SEVERE
     notes: >-
-      Variable from mild to severe. Some patients have profound cognitive impairment.
+      MED23-related intellectual disability is variable from mild to severe.
+    evidence:
+    - reference: PMID:30847200
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Affected patients manifest with axial hypotonia, choreoathetosis, dystonia, Global Developmental Delay (GDD), mental retardation, microcephaly, mild to severe ID, spasticity, with or without seizure."
+      explanation: Supports a variable MED23 cognitive severity spectrum.
 
 - category: Neurologic
   name: Speech and Language Delay
@@ -496,9 +518,9 @@ phenotypes:
 - category: Behavioral
   name: Autism Spectrum Disorder
   description: >-
-    ASD features are reported in MED13, MED13L, and MED12 subtypes but are
-    not characteristic of MED23-related disorder.
-  frequency: FREQUENT
+    ASD features are reported in MED13 and MED13L subtypes. Evidence is weaker
+    for MED12, and ASD is not currently established as part of the MED23 core phenotype.
+  frequency: OCCASIONAL
   phenotype_term:
     preferred_term: Autism spectrum disorder
     term:
@@ -523,8 +545,14 @@ phenotypes:
         term:
           id: hgnc:22474
           label: MED13
-    frequency: FREQUENT
-    notes: ASD is a prominent behavioral feature in MED13 patients.
+    frequency: OCCASIONAL
+    notes: ASD is a recurrent but non-universal behavioral feature in MED13 patients.
+    evidence:
+    - reference: PMID:29740699
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other features that were reported in two or more patients include autism spectrum disorder, attention deficit hyperactivity disorder, optic nerve abnormalities, Duane anomaly, hypotonia, mild congenital heart abnormalities, and dysmorphisms."
+      explanation: Two or more affected individuals in the syndrome-defining MED13 cohort support ASD as an occasional feature.
   - subtype: MED13L
     genetic_context:
       gene:
@@ -533,25 +561,13 @@ phenotypes:
           id: hgnc:22962
           label: MED13L
     frequency: FREQUENT
-    notes: Autistic features frequently reported alongside agitation and self-harm.
-  - subtype: MED12
-    genetic_context:
-      gene:
-        preferred_term: MED12
-        term:
-          id: hgnc:11957
-          label: MED12
-    frequency: FREQUENT
-    notes: Behavioral abnormalities including autistic features and aggression.
-  - subtype: MED23
-    genetic_context:
-      gene:
-        preferred_term: MED23
-        term:
-          id: hgnc:2372
-          label: MED23
-    frequency: EXCLUDED
-    notes: ASD features are not a characteristic finding in MED23-related disorder.
+    notes: Autistic features are part of the MED13L neurobehavioral spectrum.
+    evidence:
+    - reference: PMID:28645799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Further common signs include abnormal MRI findings of myelination defects and abnormal corpus callosum, ataxia and coordination problems, autistic features, seizures/abnormal EEG, or congenital heart defects, present in about 20-50% of the patients."
+      explanation: Supports autistic features as a recurrent MED13L finding; the reported 20-50% range overlaps the FREQUENT band and is described as a common sign.
 
 - category: Behavioral
   name: Attention Deficit-Hyperactivity Disorder
@@ -610,8 +626,14 @@ phenotypes:
         term:
           id: hgnc:22962
           label: MED13L
-    frequency: VERY_FREQUENT
+    frequency: FREQUENT
     notes: Hypotonia is a common feature of MED13L syndrome.
+    evidence:
+    - reference: PMID:28645799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Review of the reported patients with MED13L haploinsufficiency indicates moderate to severe ID and facial anomalies in all patients, as well as severe speech delay and muscular hypotonia in the majority."
+      explanation: Author wording "majority" maps to FREQUENT for MED13L hypotonia.
   - subtype: MED12
     genetic_context:
       gene:
@@ -621,6 +643,12 @@ phenotypes:
           label: MED12
     frequency: VERY_FREQUENT
     notes: Congenital hypotonia is a cardinal feature of FG syndrome.
+    evidence:
+    - reference: PMID:19938245
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Congenital hypotonia and poor gastrointestinal function, including feeding difficulties that required medical or occupational/ physical therapy, poor oral motor function, decreased gastric motility, reflux, and chronic constipation, are characteristic of FG syndrome and were present in all affected individuals."
+      explanation: Supports VERY_FREQUENT hypotonia in mutation-confirmed FG syndrome.
   - subtype: MED23
     genetic_context:
       gene:
@@ -630,6 +658,12 @@ phenotypes:
           label: MED23
     frequency: FREQUENT
     notes: Axial hypotonia reported in MED23 patients.
+    evidence:
+    - reference: PMID:30847200
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Affected patients manifest with axial hypotonia, choreoathetosis, dystonia, Global Developmental Delay (GDD), mental retardation, microcephaly, mild to severe ID, spasticity, with or without seizure."
+      explanation: Supports hypotonia as a recurrent feature of MED23-related disorder.
   evidence:
   - reference: PMID:40228085
     supports: SUPPORT
@@ -677,8 +711,14 @@ phenotypes:
         term:
           id: hgnc:22962
           label: MED13L
-    frequency: FREQUENT
+    frequency: OCCASIONAL
     notes: Seizures reported in a subset of MED13L patients.
+    evidence:
+    - reference: PMID:28645799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Further common signs include abnormal MRI findings of myelination defects and abnormal corpus callosum, ataxia and coordination problems, autistic features, seizures/abnormal EEG, or congenital heart defects, present in about 20-50% of the patients."
+      explanation: The reported 20-50% range overlaps OCCASIONAL and FREQUENT; OCCASIONAL is used conservatively for subtype-specific seizure frequency.
   - subtype: MED12
     genetic_context:
       gene:
@@ -686,7 +726,19 @@ phenotypes:
         term:
           id: hgnc:11957
           label: MED12
-    frequency: EXCLUDED
+    frequency: OCCASIONAL
+    notes: Seizures are not a core FG syndrome feature but are reported in some MED12-confirmed individuals.
+    evidence:
+    - reference: PMID:19938245
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Febrile seizures, from the age of 3 years, were followed by afebrile seizures."
+      explanation: Supports seizure occurrence in at least one MED12-confirmed individual, so seizures should not be excluded from the subtype.
+    - reference: PMID:19938245
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Myoclonic seizures, diagnosed at 37 years of age, are worse with stress, fatigue, or cold."
+      explanation: A second mutation-confirmed FG syndrome individual with seizures supports an occasional rather than excluded MED12 seizure phenotype.
   - subtype: MED23
     genetic_context:
       gene:
@@ -694,8 +746,14 @@ phenotypes:
         term:
           id: hgnc:2372
           label: MED23
-    frequency: FREQUENT
+    frequency: OCCASIONAL
     notes: Epilepsy is a variable feature; OMIM designation includes "with or without epilepsy."
+    evidence:
+    - reference: PMID:36824420
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Besides global developmental delay, axial hypotonia and peripheral increased muscular tone, absent speech, and generalized tonic seizures, which fit well MRT18, the occurrence of postnatal progressive microcephaly has been here documented."
+      explanation: Supports seizure occurrence in MED23-related disorder, while the syndrome remains explicitly variable for epilepsy.
   evidence:
   - reference: PMID:36087421
     supports: SUPPORT
@@ -745,8 +803,14 @@ phenotypes:
         term:
           id: hgnc:22962
           label: MED13L
-    frequency: FREQUENT
+    frequency: OCCASIONAL
     notes: Thin or absent corpus callosum on brain imaging.
+    evidence:
+    - reference: PMID:28645799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Further common signs include abnormal MRI findings of myelination defects and abnormal corpus callosum, ataxia and coordination problems, autistic features, seizures/abnormal EEG, or congenital heart defects, present in about 20-50% of the patients."
+      explanation: The reported 20-50% range overlaps OCCASIONAL and FREQUENT; OCCASIONAL is used conservatively for subtype-specific corpus callosum anomalies.
   - subtype: MED12
     genetic_context:
       gene:
@@ -754,8 +818,14 @@ phenotypes:
         term:
           id: hgnc:11957
           label: MED12
-    frequency: FREQUENT
+    frequency: OBLIGATE
     notes: Agenesis or hypoplasia of the corpus callosum is a cardinal feature of FG syndrome.
+    evidence:
+    - reference: PMID:19938245
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The most characteristic anomalies were agenesis or hypoplasia of the corpus callosum (13 of 13), anal fistula, stenosis and atresia (11 of 19), and congenital cardiac anomalies (11 of 18)."
+      explanation: 13/13 mutation-confirmed individuals places corpus callosum anomalies in the OBLIGATE band for the characterized FG syndrome cohort.
   - subtype: MED23
     genetic_context:
       gene:
@@ -765,6 +835,12 @@ phenotypes:
           label: MED23
     frequency: OCCASIONAL
     notes: Thin corpus callosum reported in some patients.
+    evidence:
+    - reference: PMID:30847200
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The MRI of the brain may be normal or it may show temporal lobe hypomyelination, delayed myelination, pontine hypoplasia, and thin corpus callosum."
+      explanation: Supports occasional corpus callosum anomalies in MED23-related disorder.
   evidence:
   - reference: PMID:28645799
     supports: SUPPORT
@@ -799,6 +875,12 @@ phenotypes:
           label: MED13L
     frequency: OCCASIONAL
     notes: Delayed or absent myelination, periventricular and subcortical white matter abnormalities.
+    evidence:
+    - reference: PMID:28645799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Further common signs include abnormal MRI findings of myelination defects and abnormal corpus callosum, ataxia and coordination problems, autistic features, seizures/abnormal EEG, or congenital heart defects, present in about 20-50% of the patients."
+      explanation: Supports white matter/myelination abnormalities as a recurrent but non-universal MED13L imaging finding.
   - subtype: MED23
     genetic_context:
       gene:
@@ -808,6 +890,12 @@ phenotypes:
           label: MED23
     frequency: OCCASIONAL
     notes: Temporal lobe hypomyelination and pontine hypoplasia.
+    evidence:
+    - reference: PMID:30847200
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The MRI of the brain may be normal or it may show temporal lobe hypomyelination, delayed myelination, pontine hypoplasia, and thin corpus callosum."
+      explanation: Supports occasional white matter abnormalities in MED23-related disorder.
   evidence:
   - reference: PMID:28645799
     supports: SUPPORT
@@ -941,10 +1029,16 @@ phenotypes:
         term:
           id: hgnc:22962
           label: MED13L
-    frequency: FREQUENT
+    frequency: OCCASIONAL
     notes: >-
       Variable penetrance. Ranges from patent foramen ovale to ASD, VSD,
       and transposition of the great arteries.
+    evidence:
+    - reference: PMID:28645799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "showed reduced penetrance for congenital heart defects"
+      explanation: Supports non-universal congenital heart involvement in MED13L syndrome; OCCASIONAL is used conservatively for the subtype context.
   - subtype: MED12
     genetic_context:
       gene:

--- a/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
+++ b/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Mediator Complex Neurodevelopmental Disorder
 creation_date: "2026-04-11T00:00:00Z"
-updated_date: "2026-04-12T04:47:18Z"
+updated_date: "2026-04-12T15:06:24Z"
 description: >-
   A group of neurodevelopmental disorders caused by germline mutations in genes encoding
   subunits of the Mediator complex, a multi-protein assembly required for RNA polymerase
@@ -186,6 +186,11 @@ pathophysiology:
     term:
       id: CL:0000540
       label: neuron
+  subtypes:
+  - MED13
+  - MED13L
+  - MED12
+  - MED23
   biological_processes:
   - preferred_term: Transcription by RNA polymerase II
     term:
@@ -217,10 +222,6 @@ pathophysiology:
     description: >-
       Variants in MED23 perturb a tail-module arm of Mediator-dependent transcriptional
       regulation.
-  - target: Cardiac Developmental Defects
-    description: >-
-      Mediator complex disruption affects transcription factor programs required for
-      cardiac morphogenesis, particularly in MED13L and MED12 subtypes.
 
 - name: CDK8 Kinase Module Dysfunction
   description: >-
@@ -243,6 +244,10 @@ pathophysiology:
     term:
       id: hgnc:22962
       label: MED13L
+  subtypes:
+  - MED13
+  - MED13L
+  - MED12
   cell_types:
   - preferred_term: migratory neural crest cell
     term:
@@ -275,6 +280,11 @@ pathophysiology:
     description: >-
       CDK8 module dysfunction disrupts Wnt and Notch signaling programs critical
       for neuronal and neural crest cell differentiation.
+  - target: Cardiac Developmental Defects
+    description: >-
+      CKM dysfunction is the main upstream branch for the recurrent cardiac
+      developmental defects seen especially in MED13L and MED12, with milder
+      involvement in some MED13 cases.
 
 - name: Neurodevelopmental Transcriptional Dysregulation
   description: >-
@@ -289,6 +299,11 @@ pathophysiology:
     term:
       id: CL:0000540
       label: neuron
+  subtypes:
+  - MED13
+  - MED13L
+  - MED12
+  - MED23
   biological_processes:
   - preferred_term: Neuron migration
     term:
@@ -321,12 +336,70 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: "We found that silencing Med13 in cortical neurons impaired its radial migration and contralateral projection as well as dendritic complexity in mice."
     explanation: Directly links Med13 dysfunction to neuronal migration, projection, and dendritic defects in a cortical development model.
+  downstream:
+  - target: Cortical Neuron Migration and Projection Defects
+    description: >-
+      In MED13-associated disorder, dysregulated developmental transcription
+      programs impair cortical neuron migration, callosal projection, and
+      dendritic elaboration.
+
+- name: Cortical Neuron Migration and Projection Defects
+  description: >-
+    MED13 deficiency disrupts cortical neuron radial migration, contralateral
+    projection, and dendritic complexity during corticogenesis. Experimental
+    rescue of migration and callosal projection by PLXNA4 overexpression
+    suggests that altered axon-guidance and projection programs are a specific
+    downstream mechanism within the broader CKM-mediated neurodevelopmental defect.
+  genes:
+  - preferred_term: MED13
+    term:
+      id: hgnc:22474
+      label: MED13
+  subtypes:
+  - MED13
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: cerebral cortex
+    term:
+      id: UBERON:0000956
+      label: cerebral cortex
+  biological_processes:
+  - preferred_term: Neuron migration
+    term:
+      id: GO:0001764
+      label: neuron migration
+    modifier: DYSREGULATED
+  - preferred_term: Neuron projection development
+    term:
+      id: GO:0031175
+      label: neuron projection development
+    modifier: DYSREGULATED
+  - preferred_term: Dendrite development
+    term:
+      id: GO:0016358
+      label: dendrite development
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:41663567
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "We found that silencing Med13 in cortical neurons impaired its radial migration and contralateral projection as well as dendritic complexity in mice."
+    explanation: Directly supports a MED13-linked cortical migration and projection mechanism.
+  - reference: PMID:41663567
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Notably, the impaired radial migration and callosal projection, but not dendritic complexity, were largely restored by overexpression of PlxnA4 in Med13 knock-down neurons."
+    explanation: PLXNA4 rescue localizes part of the MED13 mechanism to cortical migration and callosal projection programs.
 
 - name: Cardiac Developmental Defects
   description: >-
     Congenital heart defects are a prominent feature of MED13L syndrome and are also
-    recurrent in MED12/FG syndrome, with more variable involvement in MED13- and
-    MED23-related disorder. MED13L is highly expressed in the developing heart, and
+    recurrent in MED12/FG syndrome, with milder involvement in some MED13 cases.
+    MED13L is highly expressed in the developing heart, and
     Mediator dysfunction affects transcription factor programs (e.g., NKX2-5, GATA4,
     TBX5) required for cardiac septation, outflow tract development, and valve
     formation. Cardiac phenotypes range from patent foramen ovale to septal defects
@@ -336,6 +409,15 @@ pathophysiology:
     term:
       id: CL:0000746
       label: cardiac muscle cell
+  subtypes:
+  - MED13
+  - MED13L
+  - MED12
+  locations:
+  - preferred_term: heart
+    term:
+      id: UBERON:0000948
+      label: heart
   biological_processes:
   - preferred_term: Heart morphogenesis
     term:
@@ -372,6 +454,8 @@ pathophysiology:
     term:
       id: hgnc:2372
       label: MED23
+  subtypes:
+  - MED23
   biological_processes:
   - preferred_term: Immediate-early gene transcription
     term:

--- a/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
+++ b/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Mediator Complex Neurodevelopmental Disorder
 creation_date: "2026-04-11T00:00:00Z"
-updated_date: "2026-04-11T12:00:00Z"
+updated_date: "2026-04-12T04:47:18Z"
 description: >-
   A group of neurodevelopmental disorders caused by germline mutations in genes encoding
   subunits of the Mediator complex, a multi-protein assembly required for RNA polymerase
@@ -25,15 +25,15 @@ disease_term:
   term:
     id: MONDO:0002320
     label: congenital nervous system disorder
-
 prevalence:
 - population: Global
   percentage: Rare
   notes: >-
     Each subtype is individually ultra-rare. MED13L syndrome is the most commonly
-    reported, with over 100 cases in the literature. MED13 (MRD61) has approximately
-    12 reported patients. MED12-related disorders (FG syndrome) have several hundred
-    reported cases. MED23-related ID has fewer than 20 reported families.
+    reported, with over 100 cases in the literature. MED13 (MRD61) had at least
+    26 reported cases by 2025. MED12-related disorders, especially FG syndrome type 1,
+    have several hundred reported cases. MED23-related disorder remains limited to a
+    small number of reported families.
 
 inheritance:
 - name: Autosomal Dominant
@@ -45,11 +45,12 @@ has_subtypes:
   display_name: MED13-related intellectual developmental disorder (MRD61)
   classification: molecular
   description: >-
-    Caused by heterozygous (mostly de novo) variants in MED13, encoding a subunit of
-    the CDK8 kinase module of the Mediator complex. Characterized by mild intellectual
+    Caused by heterozygous (usually de novo) variants in MED13, encoding a subunit of
+    the CDK8 kinase module of the Mediator complex. Characterized by intellectual
     disability, expressive speech delay, behavioral abnormalities (ASD, ADHD), nonspecific
-    dysmorphic features, obstipation, and poor overall growth. The mildest and least
-    syndromic of the Mediator complex disorders.
+    dysmorphic features, obstipation, and poor overall growth. This subtype often falls
+    at the milder end of the Mediator spectrum, but severe presentations with epilepsy,
+    structural brain anomalies, and additional congenital complications have also been reported.
   subtype_term:
     preferred_term: Intellectual developmental disorder 61
     term:
@@ -62,6 +63,17 @@ has_subtypes:
       label: MED13
   inheritance:
   - name: Autosomal Dominant
+  evidence:
+  - reference: PMID:41195223
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Intellectual developmental disorder type 61 (MRD61) is an extremely rare autosomal dominant disorder caused by variants in the MED13 gene."
+    explanation: Directly defines MRD61 as an autosomal dominant MED13-related disorder.
+  - reference: PMID:29740699
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Here we describe a GeneMatcher collaboration which led to a cohort of 13 affected individuals harboring protein-altering variants, 11 of which are de novo, in MED13; the only inherited variant was transmitted to an affected child from an affected mother."
+    explanation: Syndrome-defining cohort establishing recurrent, mostly de novo MED13-associated neurodevelopmental disease.
 
 - name: MED13L
   display_name: MED13L syndrome (MRFACD)
@@ -85,6 +97,17 @@ has_subtypes:
       label: MED13L
   inheritance:
   - name: Autosomal Dominant
+  evidence:
+  - reference: PMID:40228085
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The diagnosis of MED13L syndrome is established in a proband with a heterozygous pathogenic variant in MED13L identified by molecular genetic testing."
+    explanation: Directly defines MED13L syndrome as the heterozygous MED13L-associated disorder.
+  - reference: PMID:28645799
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Review of the reported patients with MED13L haploinsufficiency indicates moderate to severe ID and facial anomalies in all patients, as well as severe speech delay and muscular hypotonia in the majority."
+    explanation: Human review further delineating the recurrent MED13L syndrome phenotype.
 
 - name: MED12
   display_name: MED12-related intellectual disability (FG syndrome / Opitz-Kaveggia)
@@ -108,6 +131,12 @@ has_subtypes:
       label: MED12
   inheritance:
   - name: X-linked Recessive
+  evidence:
+  - reference: PMID:19938245
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "FG syndrome is a rare X-linked multiple congenital anomaly-cognitive impairment disorder caused by the p.R961W mutation in the MED12 gene."
+    explanation: Establishes the best-characterized MED12-related mediatoropathy form as an X-linked MED12 disorder.
 
 - name: MED23
   display_name: MED23-related intellectual disability (MRT18)
@@ -130,6 +159,17 @@ has_subtypes:
       label: MED23
   inheritance:
   - name: Autosomal Recessive
+  evidence:
+  - reference: PMID:36824420
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Biallelic loss-of-function variants in MED23 cause a recessive syndromic intellectual disability condition with or without epilepsy (MRT18)."
+    explanation: Directly defines MED23-related MRT18 as a recessive syndromic intellectual disability disorder.
+  - reference: PMID:21868677
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Here, we report a missense mutation (p. R617Q) in MED23 that cosegregates with nonsyndromic autosomal recessive intellectual disability."
+    explanation: Original human genetic evidence linking MED23 to recessive intellectual disability.
 
 pathophysiology:
 - name: Mediator Complex Disruption
@@ -169,14 +209,18 @@ pathophysiology:
     snippet: "MED23 is a subunit of the Mediator complex, a key regulator of protein-coding gene expression."
     explanation: Establishes the Mediator complex as a key regulator of gene expression.
   downstream:
-  - target: Neurodevelopmental Transcriptional Dysregulation
+  - target: CDK8 Kinase Module Dysfunction
     description: >-
-      Disrupted Mediator function leads to aberrant expression of genes critical for
-      neuronal differentiation, migration, and synaptic function.
+      Variants in MED12, MED13, and MED13L perturb the dissociable CDK8 kinase
+      module, a regulatory submodule of the Mediator complex.
+  - target: Tail Module Disruption and Immediate Early Gene Dysregulation
+    description: >-
+      Variants in MED23 perturb a tail-module arm of Mediator-dependent transcriptional
+      regulation.
   - target: Cardiac Developmental Defects
     description: >-
       Mediator complex disruption affects transcription factor programs required for
-      cardiac morphogenesis, particularly in MED13L subtype.
+      cardiac morphogenesis, particularly in MED13L and MED12 subtypes.
 
 - name: CDK8 Kinase Module Dysfunction
   description: >-
@@ -235,8 +279,9 @@ pathophysiology:
 - name: Neurodevelopmental Transcriptional Dysregulation
   description: >-
     Mediator subunit mutations lead to broad transcriptional dysregulation affecting
-    genes required for neuronal differentiation, cortical layering, dendritic
-    arborization, and synaptogenesis. This manifests as intellectual disability
+    genes required for neuronal differentiation, cortical layering, radial migration,
+    callosal projection, dendritic arborization, and synaptogenesis. This manifests as
+    intellectual disability
     and speech delay across all subtypes, with severity correlating with the degree
     of transcriptional disruption.
   cell_types:
@@ -245,6 +290,11 @@ pathophysiology:
       id: CL:0000540
       label: neuron
   biological_processes:
+  - preferred_term: Neuron migration
+    term:
+      id: GO:0001764
+      label: neuron migration
+    modifier: DYSREGULATED
   - preferred_term: Neuron projection development
     term:
       id: GO:0031175
@@ -266,15 +316,21 @@ pathophysiology:
     evidence_source: OTHER
     snippet: "Some MED subunits have been found altered in the brain, although their specific functions in neurodegenerative diseases are not fully understood."
     explanation: Confirms that Mediator subunit alterations are found in the brain, supporting neurodevelopmental transcriptional dysregulation.
+  - reference: PMID:41663567
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "We found that silencing Med13 in cortical neurons impaired its radial migration and contralateral projection as well as dendritic complexity in mice."
+    explanation: Directly links Med13 dysfunction to neuronal migration, projection, and dendritic defects in a cortical development model.
 
 - name: Cardiac Developmental Defects
   description: >-
-    Congenital heart defects are a prominent feature of MED13L syndrome and occur
-    variably in MED23-related disorder. MED13L is highly expressed in the developing
-    heart, and its disruption affects transcription factor programs (e.g., NKX2-5,
-    GATA4, TBX5) required for cardiac septation, outflow tract development, and
-    valve formation. Cardiac phenotypes range from patent foramen ovale to septal
-    defects and transposition of the great arteries.
+    Congenital heart defects are a prominent feature of MED13L syndrome and are also
+    recurrent in MED12/FG syndrome, with more variable involvement in MED13- and
+    MED23-related disorder. MED13L is highly expressed in the developing heart, and
+    Mediator dysfunction affects transcription factor programs (e.g., NKX2-5, GATA4,
+    TBX5) required for cardiac septation, outflow tract development, and valve
+    formation. Cardiac phenotypes range from patent foramen ovale to septal defects
+    and transposition of the great arteries.
   cell_types:
   - preferred_term: cardiac muscle cell
     term:
@@ -297,6 +353,11 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Distal limb and/or digit anomalies, ocular manifestations and vision issues, and congenital heart defects have been reported."
     explanation: GeneReviews confirms congenital heart defects as a reported feature of MED13L syndrome.
+  - reference: PMID:19938245
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most characteristic anomalies were agenesis or hypoplasia of the corpus callosum (13 of 13), anal fistula, stenosis and atresia (11 of 19), and congenital cardiac anomalies (11 of 18)."
+    explanation: Documents congenital cardiac anomalies in the majority of MED12-confirmed FG syndrome patients.
 
 - name: Tail Module Disruption and Immediate Early Gene Dysregulation
   description: >-
@@ -328,6 +389,11 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: "Transcriptional dysregulation of these genes was also observed in cells derived from patients presenting with other neurological disorders linked to mutations in other Mediator subunits or proteins interacting with MED."
     explanation: Suggests IEG dysregulation may be a common molecular hallmark across Mediator subunit disorders.
+  downstream:
+  - target: Neurodevelopmental Transcriptional Dysregulation
+    description: >-
+      Tail-module dysfunction converges on impaired neuronal gene-expression programs,
+      including immediate-early gene responses.
 
 phenotypes:
 # === SHARED PHENOTYPES (all or most subtypes) ===
@@ -513,8 +579,8 @@ phenotypes:
 - category: Neurologic
   name: Hypotonia
   description: >-
-    Muscular hypotonia is characteristic of MED13L, MED12, and MED23 subtypes.
-    Congenital hypotonia is a hallmark of FG syndrome (MED12).
+    Muscular hypotonia is common in MED13L and MED12, reported in MED23, and can
+    occur in a subset of MED13 cases. Congenital hypotonia is a hallmark of FG syndrome (MED12).
   frequency: FREQUENT
   phenotype_term:
     preferred_term: Hypotonia
@@ -529,8 +595,14 @@ phenotypes:
         term:
           id: hgnc:22474
           label: MED13
-    frequency: EXCLUDED
-    notes: Hypotonia is not a characteristic feature of MED13/MRD61.
+    frequency: OCCASIONAL
+    notes: Hypotonia is recurrent but not universal in MED13/MRD61.
+    evidence:
+    - reference: PMID:29740699
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other features that were reported in two or more patients include autism spectrum disorder, attention deficit hyperactivity disorder, optic nerve abnormalities, Duane anomaly, hypotonia, mild congenital heart abnormalities, and dysmorphisms."
+      explanation: Supports hypotonia as a recurrent but non-core MED13 phenotype.
   - subtype: MED13L
     genetic_context:
       gene:
@@ -573,8 +645,9 @@ phenotypes:
 - category: Neurologic
   name: Seizures
   description: >-
-    Seizures and epilepsy occur in MED13L and MED23 subtypes. MED23-related
-    intellectual disability is formally designated "with or without epilepsy."
+    Seizures and epilepsy occur in MED13L and MED23 subtypes and can also emerge
+    in more severe MED13 presentations. MED23-related intellectual disability is
+    formally designated "with or without epilepsy."
   frequency: FREQUENT
   phenotype_term:
     preferred_term: Seizure
@@ -589,7 +662,14 @@ phenotypes:
         term:
           id: hgnc:22474
           label: MED13
-    frequency: EXCLUDED
+    frequency: OCCASIONAL
+    notes: Epilepsy appears to be an uncommon but established severe manifestation of MED13-related disorder.
+    evidence:
+    - reference: PMID:36087421
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "From a literature review, it emerged that epilepsy is described in only one out of nineteen of previously reported patients with a phenotype of generalized, drug-resistant epilepsy with myoclonic-atonic seizures."
+      explanation: Supports epilepsy as an occasional rather than excluded MED13 phenotype.
   - subtype: MED13L
     genetic_context:
       gene:
@@ -633,8 +713,9 @@ phenotypes:
   name: Corpus Callosum Anomalies
   description: >-
     Structural anomalies of the corpus callosum (thinning, hypoplasia, or agenesis)
-    are seen in MED13L, MED12, and MED23 subtypes, reflecting the role of Mediator
-    complex in transcriptional programs governing midline brain development.
+    are seen in MED13L, MED12, and MED23 subtypes and have also been reported in
+    MED13-related disorder, reflecting the role of Mediator complex in transcriptional
+    programs governing midline brain development.
   frequency: FREQUENT
   phenotype_term:
     preferred_term: Abnormality of the corpus callosum
@@ -649,7 +730,14 @@ phenotypes:
         term:
           id: hgnc:22474
           label: MED13
-    frequency: EXCLUDED
+    frequency: OCCASIONAL
+    notes: Corpus callosum anomalies are not universal in MED13 but are part of the expanded reported spectrum.
+    evidence:
+    - reference: PMID:36087421
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Microcephaly, developmental delay, hypotonia, corpus callosum abnormalities, deafness, and retinal atrophy were common features in the previously described cases."
+      explanation: Literature review supports corpus callosum abnormalities as a recurrent MED13 finding.
   - subtype: MED13L
     genetic_context:
       gene:
@@ -821,8 +909,9 @@ phenotypes:
   description: >-
     Congenital heart defects with variable penetrance are characteristic of
     MED13L syndrome, ranging from patent foramen ovale to atrial and ventricular
-    septal defects to transposition of the great arteries. Cardiac defects also
-    occur occasionally in MED23-related disorder.
+    septal defects to transposition of the great arteries. Congenital cardiac
+    anomalies are also recurrent in MED12/FG syndrome and occur occasionally in
+    MED13- and MED23-related disorder.
   frequency: FREQUENT
   phenotype_term:
     preferred_term: Congenital heart defect
@@ -837,7 +926,14 @@ phenotypes:
         term:
           id: hgnc:22474
           label: MED13
-    frequency: EXCLUDED
+    frequency: OCCASIONAL
+    notes: Mild congenital heart abnormalities are reported in a subset of MED13 patients.
+    evidence:
+    - reference: PMID:29740699
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other features that were reported in two or more patients include autism spectrum disorder, attention deficit hyperactivity disorder, optic nerve abnormalities, Duane anomaly, hypotonia, mild congenital heart abnormalities, and dysmorphisms."
+      explanation: Supports occasional congenital heart involvement in MED13.
   - subtype: MED13L
     genetic_context:
       gene:
@@ -856,7 +952,14 @@ phenotypes:
         term:
           id: hgnc:11957
           label: MED12
-    frequency: EXCLUDED
+    frequency: FREQUENT
+    notes: Congenital cardiac anomalies are a recurrent part of the MED12/FG syndrome phenotype.
+    evidence:
+    - reference: PMID:19938245
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The most characteristic anomalies were agenesis or hypoplasia of the corpus callosum (13 of 13), anal fistula, stenosis and atresia (11 of 19), and congenital cardiac anomalies (11 of 18)."
+      explanation: Supports frequent congenital heart defects in MED12-confirmed FG syndrome.
   - subtype: MED23
     genetic_context:
       gene:
@@ -866,6 +969,12 @@ phenotypes:
           label: MED23
     frequency: OCCASIONAL
     notes: Congenital heart disease reported in some patients.
+    evidence:
+    - reference: PMID:30847200
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The patients had severe ID, spasticity, congenital heart diseases, brain abnormalities, and atypical electroencephalography."
+      explanation: Supports occasional congenital heart disease in previously reported MED23 cases.
   evidence:
   - reference: PMID:28645799
     supports: SUPPORT
@@ -877,6 +986,11 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Distal limb and/or digit anomalies, ocular manifestations and vision issues, and congenital heart defects have been reported."
     explanation: GeneReviews confirms congenital heart defects as a feature of MED13L syndrome.
+  - reference: PMID:19938245
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most characteristic anomalies were agenesis or hypoplasia of the corpus callosum (13 of 13), anal fistula, stenosis and atresia (11 of 19), and congenital cardiac anomalies (11 of 18)."
+    explanation: Demonstrates that congenital heart defects are also a frequent feature of MED12-confirmed FG syndrome.
 
 # === MED12-SPECIFIC PHENOTYPES ===
 - category: Craniofacial
@@ -1044,8 +1158,9 @@ genetic:
   features: Heterozygous loss-of-function variants (nonsense, frameshift, missense, in-frame deletion); most de novo
   notes: >-
     MED13 encodes mediator complex subunit 13, a component of the CDK8 kinase module.
-    Approximately 12 patients reported with 3 nonsense, 2 frameshift, 6 missense, and
-    1 in-frame deletion variants.
+    The original syndrome-defining cohort included 13 affected individuals with 3
+    nonsense, 2 frameshift, 6 missense, and 1 in-frame deletion variants; by 2025,
+    at least 26 MRD61 cases had been reported.
   evidence:
   - reference: PMID:29740699
     supports: SUPPORT

--- a/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
+++ b/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Mediator Complex Neurodevelopmental Disorder
 creation_date: "2026-04-11T00:00:00Z"
-updated_date: "2026-04-12T15:06:24Z"
+updated_date: "2026-04-12T16:20:00Z"
 description: >-
   A group of neurodevelopmental disorders caused by germline mutations in genes encoding
   subunits of the Mediator complex, a multi-protein assembly required for RNA polymerase
@@ -850,6 +850,60 @@ phenotypes:
     snippet: "Other reported features include seizures and/or hearing impairment."
     explanation: GeneReviews confirms seizures as a reported feature of MED13L syndrome.
 
+- category: Audiologic
+  name: Hearing Impairment
+  description: >-
+    Hearing impairment is reported in MED13L syndrome and in a subset of more
+    severely affected MED13 patients.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  phenotype_contexts:
+  - subtype: MED13
+    genetic_context:
+      gene:
+        preferred_term: MED13
+        term:
+          id: hgnc:22474
+          label: MED13
+    frequency: OCCASIONAL
+    notes: Hearing involvement is part of the expanded MED13 phenotype but is not universal.
+    evidence:
+    - reference: PMID:36087421
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Microcephaly, developmental delay, hypotonia, corpus callosum abnormalities, deafness, and retinal atrophy were common features in the previously described cases."
+      explanation: Supports established hearing involvement in previously reported MED13 patients while not implying obligate occurrence across the whole subtype.
+  - subtype: MED13L
+    genetic_context:
+      gene:
+        preferred_term: MED13L
+        term:
+          id: hgnc:22962
+          label: MED13L
+    frequency: OCCASIONAL
+    notes: Hearing impairment is a reported but non-core MED13L feature.
+    evidence:
+    - reference: PMID:40228085
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other reported features include seizures and/or hearing impairment."
+      explanation: GeneReviews directly supports hearing impairment as part of the MED13L phenotype spectrum.
+  evidence:
+  - reference: PMID:36087421
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Microcephaly, developmental delay, hypotonia, corpus callosum abnormalities, deafness, and retinal atrophy were common features in the previously described cases."
+    explanation: Documents hearing involvement in the expanded MED13 phenotype.
+  - reference: PMID:40228085
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported features include seizures and/or hearing impairment."
+    explanation: Documents hearing impairment as a reported MED13L feature.
+
 # === BRAIN STRUCTURAL ANOMALIES ===
 - category: Neurologic
   name: Corpus Callosum Anomalies
@@ -1012,6 +1066,24 @@ phenotypes:
     snippet: "The main symptoms are intellectual disability (ID) of varying degrees, developmental delay (DD), hypotonia during infancy, facial dysmorphism, language impairment, restricted growth, skeletal and limb abnormalities, and behavioral abnormalities."
     explanation: Literature review of 26 MRD61 cases explicitly lists restricted growth as a main symptom of MED13-related disorder.
 
+- category: Skeletal
+  name: Skeletal Abnormalities
+  description: >-
+    Skeletal and limb abnormalities are part of the broader MED13/MRD61
+    phenotype, although the exact manifestations are variable across reported cases.
+  subtype: MED13
+  phenotype_term:
+    preferred_term: Abnormality of the skeletal system
+    term:
+      id: HP:0000924
+      label: Abnormality of the skeletal system
+  evidence:
+  - reference: PMID:41195223
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The main symptoms are intellectual disability (ID) of varying degrees, developmental delay (DD), hypotonia during infancy, facial dysmorphism, language impairment, restricted growth, skeletal and limb abnormalities, and behavioral abnormalities."
+    explanation: Review of 26 MRD61 cases supports skeletal involvement as part of the MED13 clinical spectrum.
+
 - category: Gastrointestinal
   name: Obstipation
   description: >-
@@ -1075,6 +1147,25 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Dysmorphic facial features, including depressed nasal bridge, bulbous nose, and hypotonic open mouth, are present in most individuals."
     explanation: GeneReviews confirms distinctive facial features are present in most MED13L patients.
+
+- category: Neurologic
+  name: Ataxia and Coordination Problems
+  description: >-
+    Ataxia and impaired coordination are recurrent but non-universal neurologic
+    findings in MED13L syndrome.
+  frequency: OCCASIONAL
+  subtype: MED13L
+  phenotype_term:
+    preferred_term: Ataxia
+    term:
+      id: HP:0001251
+      label: Ataxia
+  evidence:
+  - reference: PMID:28645799
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Further common signs include abnormal MRI findings of myelination defects and abnormal corpus callosum, ataxia and coordination problems, autistic features, seizures/abnormal EEG, or congenital heart defects, present in about 20-50% of the patients."
+    explanation: Supports ataxia and coordination problems as established but non-universal MED13L findings.
 
 - category: Cardiovascular
   name: Congenital Heart Defects
@@ -1255,6 +1346,25 @@ phenotypes:
 
 # === MED23-SPECIFIC PHENOTYPES ===
 - category: Neurologic
+  name: Absent Speech
+  description: >-
+    Some MED23 patients have no spoken language, representing a severe end of the
+    communication phenotype beyond simple speech delay.
+  frequency: OCCASIONAL
+  subtype: MED23
+  phenotype_term:
+    preferred_term: Absent speech
+    term:
+      id: HP:0001344
+      label: Absent speech
+  evidence:
+  - reference: PMID:36824420
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Besides global developmental delay, axial hypotonia and peripheral increased muscular tone, absent speech, and generalized tonic seizures, which fit well MRT18, the occurrence of postnatal progressive microcephaly has been here documented."
+    explanation: Directly supports complete absence of speech in at least a subset of MED23-related disorder.
+
+- category: Neurologic
   name: Spasticity
   description: >-
     Spasticity is a distinguishing feature of MED23-related intellectual disability,
@@ -1364,7 +1474,9 @@ genetic:
   features: Heterozygous loss-of-function and missense variants; whole-gene deletions; most de novo
   notes: >-
     MED13L is a paralog of MED13, also in the CDK8 kinase module. Recurrent missense
-    variant p.Arg1416His identified in multiple unrelated patients. Over 100 cases reported.
+    variant p.Asp860Gly has been documented, and newer functional work supports
+    pathogenic missense effects through reduced protein stability and impaired
+    interaction with the CDK8 kinase module. Over 100 cases reported.
   evidence:
   - reference: PMID:28645799
     supports: SUPPORT
@@ -1376,6 +1488,16 @@ genetic:
     evidence_source: HUMAN_CLINICAL
     snippet: "the second patient shows, for the first time, recurrence of a MED13L missense mutation (p.(Asp860Gly))."
     explanation: Documents recurrent missense mutations in MED13L, supporting functional significance.
+  - reference: PMID:40228085
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The majority of probands reported to date whose parents have undergone molecular genetic testing have the disorder as the result of a pathogenic variant that occurred as a de novo event in the proband."
+    explanation: Supports the statement that most MED13L pathogenic variants arise de novo.
+  - reference: PMID:40500968
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "3D protein modeling suggested that these missense variants may disrupt MED13L's interaction with the CDK8 kinase module, leading to functional deficits."
+    explanation: Provides gene-specific mechanistic evidence that pathogenic MED13L missense variants can perturb CKM interactions.
 
 - name: MED12 Hemizygous Variants
   association: Causative
@@ -1391,12 +1513,19 @@ genetic:
   notes: >-
     MED12 is on the X chromosome. FG syndrome type 1 (Opitz-Kaveggia syndrome) is
     caused by the recurrent p.R961W missense variant in the opa repeat domain.
+    MED12 is also allelic with Lujan syndrome through p.N1007S and likely other
+    X-linked intellectual disability presentations.
   evidence:
   - reference: PMID:19938245
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "We ascertained 23 males with the p.R961W mutation in MED12 from 9 previously reported FG syndrome families and 1 new family."
     explanation: Largest clinical characterization of MED12 p.R961W-confirmed FG syndrome patients.
+  - reference: PMID:17369503
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The original Lujan syndrome family has a novel missense mutation (p.N1007S) in the MED12 gene."
+    explanation: Directly supports the allelic MED12-Lujan syndrome relationship already noted in the variant summary.
 
 - name: MED23 Biallelic Variants
   association: Causative
@@ -1424,6 +1553,11 @@ genetic:
     evidence_source: IN_VITRO
     snippet: "These findings highlight the crucial role of Mediator in brain development and functioning and suggest that altered IEG expression might be a common molecular hallmark of cognitive deficit."
     explanation: Establishes the molecular mechanism linking MED23 to intellectual disability via IEG dysregulation.
+  - reference: PMID:36824420
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Here, we report a 5-year-old girl with compound heterozygous for two additional MED23 variants."
+    explanation: Adds direct human evidence that MED23-related disorder can also arise through compound heterozygous biallelic variation.
 
 datasets:
 - accession: "geo:GSE277054"

--- a/references_cache/PMID_17369503.md
+++ b/references_cache/PMID_17369503.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:17369503"
+title: The original Lujan syndrome family has a novel missense mutation (p.N1007S) in the MED12 gene.
+authors:
+- Schwartz CE
+- Tarpey PS
+- Lubs HA
+- Verloes A
+- May MM
+- Risheg H
+- Friez MJ
+- Futreal PA
+- Edkins S
+- Teague J
+- Briault S
+- Skinner C
+- Bauer-Carlin A
+- Simensen RJ
+- Joseph SM
+- Jones JR
+- Gecz J
+- Stratton MR
+- Raymond FL
+- Stevenson RE
+journal: J Med Genet
+year: '2007'
+doi: 10.1136/jmg.2006.048637
+keywords:
+- "Abnormalities, Multiple/genetics, pathology"
+- Humans
+- Male
+- Mediator Complex
+- "X-Linked Intellectual Disability/genetics, pathology"
+- "Mutation, Missense/genetics"
+- Pedigree
+- Phenotype
+- "Receptors, Thyroid Hormone/genetics"
+content_type: abstract_only
+---
+
+# The original Lujan syndrome family has a novel missense mutation (p.N1007S) in the MED12 gene.
+**Authors:** Schwartz CE, Tarpey PS, Lubs HA, Verloes A, May MM, Risheg H, Friez MJ, Futreal PA, Edkins S, Teague J, Briault S, Skinner C, Bauer-Carlin A, Simensen RJ, Joseph SM, Jones JR, Gecz J, Stratton MR, Raymond FL, Stevenson RE
+**Journal:** J Med Genet (2007)
+**DOI:** [10.1136/jmg.2006.048637](https://doi.org/10.1136/jmg.2006.048637)
+
+## Content
+
+1. J Med Genet. 2007 Jul;44(7):472-7. doi: 10.1136/jmg.2006.048637. Epub 2007 Mar
+ 16.
+
+The original Lujan syndrome family has a novel missense mutation (p.N1007S) in
+the MED12 gene.
+
+Schwartz CE, Tarpey PS, Lubs HA, Verloes A, May MM, Risheg H, Friez MJ, Futreal
+PA, Edkins S, Teague J, Briault S, Skinner C, Bauer-Carlin A, Simensen RJ,
+Joseph SM, Jones JR, Gecz J, Stratton MR, Raymond FL, Stevenson RE.
+
+A novel missense mutation in the mediator of RNA polymerase II transcription
+subunit 12 (MED12) gene has been found in the original family with Lujan
+syndrome and in a second family (K9359) that was initially considered to have
+Opitz-Kaveggia (FG) syndrome. A different missense mutation in the MED12 gene
+has been reported previously in the original family with FG syndrome and in five
+other families with compatible clinical findings. Neither sequence alteration
+has been found in over 1400 control X chromosomes. Lujan (Lujan-Fryns) syndrome
+is characterised by tall stature with asthenic habitus, macrocephaly, a tall
+narrow face, maxillary hypoplasia, a high narrow palate with dental crowding, a
+small or receding chin, long hands with hyperextensible digits, hypernasal
+speech, hypotonia, mild-to-moderate mental retardation, behavioural aberrations
+and dysgenesis of the corpus callosum. Although Lujan syndrome has not been
+previously considered to be in the differential diagnosis of FG syndrome, there
+are some overlapping clinical manifestations. Specifically, these are dysgenesis
+of the corpus callosum, macrocephaly/relative macrocephaly, a tall forehead,
+hypotonia, mental retardation and behavioural disturbances. Thus, it seems that
+these two X-linked mental retardation syndromes are allelic, with mutations in
+the MED12 gene.
+
+DOI: 10.1136/jmg.2006.048637
+PMCID: PMC2597996
+PMID: 17369503 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None.

--- a/references_cache/PMID_40500968.md
+++ b/references_cache/PMID_40500968.md
@@ -1,0 +1,93 @@
+---
+reference_id: "PMID:40500968"
+title: "MED13L pathogenic missense variants impair protein stability and interaction, underlying diverse clinical outcomes."
+authors:
+- Smol T
+- Frenois F
+- Billotte M
+- Caumes R
+- Menke LA
+- Nassar-Sheikh Rashid A
+- Thuillier C
+- Monté D
+- Petit F
+- Verger A
+- Ghoumid J
+journal: HGG Adv
+year: '2025'
+doi: 10.1016/j.xhgg.2025.100467
+keywords:
+- Humans
+- "Mediator Complex/genetics, metabolism, chemistry"
+- "Mutation, Missense"
+- Protein Stability
+- Male
+- Female
+- Phenotype
+- Intellectual Disability/genetics
+- Epilepsy/genetics
+- Child
+content_type: abstract_only
+---
+
+# MED13L pathogenic missense variants impair protein stability and interaction, underlying diverse clinical outcomes.
+**Authors:** Smol T, Frenois F, Billotte M, Caumes R, Menke LA, Nassar-Sheikh Rashid A, Thuillier C, Monté D, Petit F, Verger A, Ghoumid J
+**Journal:** HGG Adv (2025)
+**DOI:** [10.1016/j.xhgg.2025.100467](https://doi.org/10.1016/j.xhgg.2025.100467)
+
+## Content
+
+1. HGG Adv. 2025 Jul 10;6(3):100467. doi: 10.1016/j.xhgg.2025.100467. Epub 2025
+Jun  11.
+
+MED13L pathogenic missense variants impair protein stability and interaction,
+underlying diverse clinical outcomes.
+
+Smol T(1), Frenois F(2), Billotte M(2), Caumes R(2), Menke LA(3), Nassar-Sheikh
+Rashid A(3), Thuillier C(2), Monté D(4), Petit F(2), Verger A(4), Ghoumid J(5).
+
+Author information:
+(1)University Lille, CHU Lille, ULR7364 - RADEME - Maladies Rares du
+Développement Embryonnaire, 59000 Lille, France. Electronic address:
+thomas.smol@univ-lille.fr.
+(2)University Lille, CHU Lille, ULR7364 - RADEME - Maladies Rares du
+Développement Embryonnaire, 59000 Lille, France.
+(3)Amsterdam UMC, location University of Amsterdam, Emma Children's Hospital,
+Department of Pediatrics, Emma Center for Personalized Medicine, Amsterdam
+Neuroscience - Cellular & Molecular Mechanism, Amsterdam Reproduction &
+Development, Meibergdreef 9, Amsterdam, the Netherlands.
+(4)CNRS EMR 9002 Integrative Structural Biology, INSERM U1167 - RID-AGE,
+University Lille, CHU Lille, Institut Pasteur de Lille, 59000 Lille, France.
+(5)University Lille, CHU Lille, ULR7364 - RADEME - Maladies Rares du
+Développement Embryonnaire, 59000 Lille, France. Electronic address:
+jamal.ghoumid@univ-lille.fr.
+
+Heterozygous pathogenic variants in the Mediator complex subunit 13-like gene
+located in the locus 12q21.21 (MED13L) are associated with intellectual
+disability, developmental delay, and distinctive facial features. While nonsense
+and frameshift variants typically cause haploinsufficiency, resulting in a
+well-characterized clinical presentation, missense variants have been associated
+with a broader range of phenotypes, including epilepsy and severe motor delay.
+In this study, we investigated five pathogenic missense variants in
+MED13L-c.2597C>T p.Pro866Leu, c.2605C>T p.Pro869Ser, c.3392G>A p.Cys1131Tyr,
+c.5695G>A p.Gly1899Arg, and c.6485C>T p.Thr2162Met-associated with different
+clinical severities. We identified significant reductions in protein stability
+across these variants, with some exhibiting aberrant cytoplasmic localization,
+suggesting disruptions in structural integrity and function. In particular, exon
+15 variants (p.Pro866Leu and p.Pro869Ser) correlated with severe phenotypes,
+including epilepsy and severe motor impairment, whereas p.Gly1899Arg and
+p.Thr2162Met were associated with milder manifestations. 3D protein modeling
+suggested that these missense variants may disrupt MED13L's interaction with the
+CDK8 kinase module, leading to functional deficits. Our findings highlight
+different pathogenic mechanisms, ranging from protein instability to altered
+molecular interactions, that contribute to the clinical variability observed in
+MED13L-related disorders.
+
+Copyright © 2025 The Author(s). Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.xhgg.2025.100467
+PMCID: PMC12221883
+PMID: 40500968 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests The authors declare no
+competing interests.

--- a/references_cache/PMID_41663567.md
+++ b/references_cache/PMID_41663567.md
@@ -1,0 +1,100 @@
+---
+reference_id: "PMID:41663567"
+title: Med13 is involved in the radial migration and contralateral projection of cortical neurons via PlxnA4.
+authors:
+- Li ZX
+- Tu SX
+- Li YW
+- Hu ZB
+- Liu WT
+- Tao YC
+- Zhao L
+- Song NN
+- Chen JY
+- Zhang Q
+- Qi CC
+- Zhu HW
+- Ding YQ
+- Hu L
+journal: Commun Biol
+year: '2026'
+doi: 10.1038/s42003-026-09704-w
+keywords:
+- Animals
+- "Mediator Complex/metabolism, genetics"
+- "Neurons/metabolism, physiology, cytology"
+- Mice
+- "Cerebral Cortex/metabolism, cytology, embryology"
+- Cell Movement
+- Humans
+- "Cell Line, Tumor"
+- Female
+content_type: abstract_only
+---
+
+# Med13 is involved in the radial migration and contralateral projection of cortical neurons via PlxnA4.
+**Authors:** Li ZX, Tu SX, Li YW, Hu ZB, Liu WT, Tao YC, Zhao L, Song NN, Chen JY, Zhang Q, Qi CC, Zhu HW, Ding YQ, Hu L
+**Journal:** Commun Biol (2026)
+**DOI:** [10.1038/s42003-026-09704-w](https://doi.org/10.1038/s42003-026-09704-w)
+
+## Content
+
+1. Commun Biol. 2026 Feb 9;9(1):394. doi: 10.1038/s42003-026-09704-w.
+
+Med13 is involved in the radial migration and contralateral projection of
+cortical neurons via PlxnA4.
+
+Li ZX(#)(1)(2), Tu SX(#)(1), Li YW(2), Hu ZB(2)(3), Liu WT(4), Tao YC(3), Zhao
+L(3), Song NN(2), Chen JY(2), Zhang Q(2), Qi CC(2), Zhu HW(5), Ding YQ(6)(7)(8),
+Hu L(9)(10).
+
+Author information:
+(1)Center for Medical Research and Innovation, Shanghai Pudong Hospital, Fudan
+University Pudong Medical Center, Shanghai, China.
+(2)Laboratory Animal Center and MOE Laboratory Mouse Resource Center, Fudan
+University, Shanghai, China.
+(3)State Key Laboratory of Brain Function and Disorders, Institutes of Brain
+Science, Fudan University, Shanghai, China.
+(4)Shanghai Institute of Infectious Disease and Biosecurity, Fudan University,
+Shanghai, China.
+(5)Precise Genome Engineering Center, School of Life Sciences, Guangzhou
+University, Guangzhou, China.
+(6)Laboratory Animal Center and MOE Laboratory Mouse Resource Center, Fudan
+University, Shanghai, China. dingyuqiang@vip.163.com.
+(7)State Key Laboratory of Brain Function and Disorders, Institutes of Brain
+Science, Fudan University, Shanghai, China. dingyuqiang@vip.163.com.
+(8)Huashan Institute of Medicine (HS-IOM), Huashan Hospital, Fudan University,
+Shanghai, China. dingyuqiang@vip.163.com.
+(9)Center for Medical Research and Innovation, Shanghai Pudong Hospital, Fudan
+University Pudong Medical Center, Shanghai, China. 06huling@163.com.
+(10)Laboratory Animal Center and MOE Laboratory Mouse Resource Center, Fudan
+University, Shanghai, China. 06huling@163.com.
+(#)Contributed equally
+
+Mediator complex (MED) is an important auxiliary factor in the RNA polymerase II
+transcription apparatus, and MED13 is a subunit in the CDK8-kinase module of the
+complex. Currently, extensive clinical evidence has implicated its involvement
+in the pathogenesis of neurodevelopmental disorders (NDDs). However, the
+mechanism by which dysfunction of MED13 contributes to NDDs remains poorly
+understood. Here, we specifically knocked down Med13 expression in cortical
+neurons using in-utero electroporation to examine its function in cortical
+development and utilized mass spectrum to explore the downstream molecules
+involved in cortical development. We found that silencing Med13 in cortical
+neurons impaired its radial migration and contralateral projection as well as
+dendritic complexity in mice. Differential protein analysis of human
+neuroblastoma cells (SH-SY5Y) with MED13 deletion revealed a large number of
+dysregulated proteins, including PLXNA4. Notably, the impaired radial migration
+and callosal projection, but not dendritic complexity, were largely restored by
+overexpression of PlxnA4 in Med13 knock-down neurons. Collectively, our findings
+establish that Med13 regulates cortical neuronal radial migration and callosal
+projection at least in part through PlxnA4, shedding light on the molecular
+mechanisms underlying the pathogenesis of MED13-associated NDDs.
+
+© 2026. The Author(s).
+
+DOI: 10.1038/s42003-026-09704-w
+PMCID: PMC13000170
+PMID: 41663567 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: The authors declare no
+competing interests.

--- a/references_cache/clinicaltrials_NCT01238250.md
+++ b/references_cache/clinicaltrials_NCT01238250.md
@@ -1,0 +1,11 @@
+---
+reference_id: "clinicaltrials:NCT01238250"
+title: "Online Study of People Who Have Genetic Changes and Features of Autism: Simons Searchlight"
+content_type: summary
+---
+
+# Online Study of People Who Have Genetic Changes and Features of Autism: Simons Searchlight
+
+## Content
+
+Simons Searchlight is an observational, online, international research program for families with rare genetic variants that cause neurodevelopmental disorders and may be associated with autism. Simons Searchlight collects medical, behavioral, learning, and developmental information from people who have these rare genetic changes. The goal of this study is to improve the clinical care and treatment for these people. Simons Searchlight partners with families to collect data and distribute it to qualified researchers.

--- a/src/dismech/graph.py
+++ b/src/dismech/graph.py
@@ -568,6 +568,17 @@ def _extract_node_metadata(item: dict[str, Any]) -> dict[str, Any]:
     if gene_labels:
         meta["genes"] = list(dict.fromkeys(gene_labels))
 
+    # Subtype applicability
+    subtype_labels: list[str] = []
+    subtype = item.get("subtype")
+    if subtype:
+        subtype_labels.append(str(subtype))
+    subtypes = item.get("subtypes", []) or []
+    if subtypes:
+        subtype_labels.extend(str(value) for value in subtypes if value)
+    if subtype_labels:
+        meta["subtypes"] = list(dict.fromkeys(subtype_labels))
+
     # Role (pathophysiology)
     if item.get("role"):
         meta["role"] = item["role"]

--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -2040,6 +2040,7 @@
             if (meta.biological_processes && meta.biological_processes.length) metaParts.push('<span>Processes: ' + escapeHtml(meta.biological_processes.join(", ")) + '</span>');
             if (meta.molecular_functions && meta.molecular_functions.length) metaParts.push('<span>Functions: ' + escapeHtml(meta.molecular_functions.join(", ")) + '</span>');
             if (meta.genes && meta.genes.length) metaParts.push('<span>Genes: ' + escapeHtml(meta.genes.join(", ")) + '</span>');
+            if (meta.subtypes && meta.subtypes.length) metaParts.push('<span>Subtypes: ' + escapeHtml(meta.subtypes.join(", ")) + '</span>');
             if (meta.locations && meta.locations.length) metaParts.push('<span>Location: ' + escapeHtml(meta.locations.join(", ")) + '</span>');
             if (meta.association) metaParts.push('<span>Association: ' + escapeHtml(meta.association) + '</span>');
             if (meta.frequency) metaParts.push('<span>Frequency: ' + escapeHtml(meta.frequency) + '</span>');

--- a/src/dismech/templates/module.html.j2
+++ b/src/dismech/templates/module.html.j2
@@ -746,6 +746,7 @@
             if (meta.biological_processes && meta.biological_processes.length) metaParts.push('<span>Processes: ' + escapeHtml(meta.biological_processes.join(", ")) + '</span>');
             if (meta.molecular_functions && meta.molecular_functions.length) metaParts.push('<span>Functions: ' + escapeHtml(meta.molecular_functions.join(", ")) + '</span>');
             if (meta.genes && meta.genes.length) metaParts.push('<span>Genes: ' + escapeHtml(meta.genes.join(", ")) + '</span>');
+            if (meta.subtypes && meta.subtypes.length) metaParts.push('<span>Subtypes: ' + escapeHtml(meta.subtypes.join(", ")) + '</span>');
             if (meta.locations && meta.locations.length) metaParts.push('<span>Location: ' + escapeHtml(meta.locations.join(", ")) + '</span>');
             if (meta.role) metaParts.push('<span>Role: ' + escapeHtml(meta.role) + '</span>');
             if (meta.conditions && meta.conditions.length) metaParts.push('<span>Conditions: ' + escapeHtml(meta.conditions.join(", ")) + '</span>');

--- a/tests/test_render_pathograph_payload.py
+++ b/tests/test_render_pathograph_payload.py
@@ -135,6 +135,74 @@ def test_rendered_stargardt_pathograph_payload_includes_treatments_and_genetics(
     assert f">Pathograph {len(graph_data['nodes'])}</a>" in html
 
 
+def test_rendered_mediator_complex_pathograph_payload_is_hierarchical_and_subtyped(
+    tmp_path: Path,
+) -> None:
+    """Mediatoropathy graph should preserve branch hierarchy and subtype metadata."""
+    repo_root = Path(__file__).resolve().parents[1]
+    disorder_path = (
+        repo_root
+        / "kb"
+        / "disorders"
+        / "Mediator_Complex_Neurodevelopmental_Disorder.yaml"
+    )
+    output_path = (
+        tmp_path
+        / "pages"
+        / "disorders"
+        / "Mediator_Complex_Neurodevelopmental_Disorder.html"
+    )
+
+    render_disorder(disorder_path, output_path=output_path)
+    html = output_path.read_text()
+    graph_data = _extract_graph_data(html)
+    edges = {(edge["source"], edge["target"]) for edge in graph_data["edges"]}
+    node_meta = {node["id"]: node.get("meta", {}) for node in graph_data["nodes"]}
+
+    assert ("Mediator Complex Disruption", "CDK8 Kinase Module Dysfunction") in edges
+    assert (
+        "Mediator Complex Disruption",
+        "Tail Module Disruption and Immediate Early Gene Dysregulation",
+    ) in edges
+    assert (
+        "CDK8 Kinase Module Dysfunction",
+        "Neurodevelopmental Transcriptional Dysregulation",
+    ) in edges
+    assert ("CDK8 Kinase Module Dysfunction", "Cardiac Developmental Defects") in edges
+    assert (
+        "Tail Module Disruption and Immediate Early Gene Dysregulation",
+        "Neurodevelopmental Transcriptional Dysregulation",
+    ) in edges
+    assert (
+        "Neurodevelopmental Transcriptional Dysregulation",
+        "Cortical Neuron Migration and Projection Defects",
+    ) in edges
+
+    assert (
+        "Mediator Complex Disruption",
+        "Neurodevelopmental Transcriptional Dysregulation",
+    ) not in edges
+    assert ("Mediator Complex Disruption", "Cardiac Developmental Defects") not in edges
+
+    assert node_meta["CDK8 Kinase Module Dysfunction"]["subtypes"] == [
+        "MED13",
+        "MED13L",
+        "MED12",
+    ]
+    assert node_meta["Tail Module Disruption and Immediate Early Gene Dysregulation"][
+        "subtypes"
+    ] == ["MED23"]
+    assert node_meta["Cortical Neuron Migration and Projection Defects"][
+        "subtypes"
+    ] == ["MED13"]
+    assert node_meta["Cardiac Developmental Defects"]["subtypes"] == [
+        "MED13",
+        "MED13L",
+        "MED12",
+    ]
+    assert "Subtypes:" in html
+
+
 @pytest.mark.parametrize(
     ("filename", "expected_edges", "expected_nodes", "expected_functions"),
     [


### PR DESCRIPTION
## Summary

This PR improves the `Mediator_Complex_Neurodevelopmental_Disorder` pathograph so the rendered mechanism graph is more explicit and less misleading.

## What changed

- restructured the mediatoropathy pathograph into a clear hierarchy
  - `Mediator Complex Disruption -> CDK8 Kinase Module Dysfunction`
  - `Mediator Complex Disruption -> Tail Module Disruption and Immediate Early Gene Dysregulation`
  - `CDK8 Kinase Module Dysfunction -> Neurodevelopmental Transcriptional Dysregulation`
  - `CDK8 Kinase Module Dysfunction -> Cardiac Developmental Defects`
  - `Tail Module Disruption and Immediate Early Gene Dysregulation -> Neurodevelopmental Transcriptional Dysregulation`
- added a MED13-specific downstream node for cortical neuron migration/projection defects, supported by the Med13 cortical development paper
- annotated key pathophysiology nodes with subtype applicability so graph metadata can distinguish CKM-associated (`MED13`, `MED13L`, `MED12`) from `MED23`-specific mechanisms
- exposed subtype metadata in pathograph tooltips in the disorder and module templates
- added a regression test to lock in the intended mediatoropathy graph structure and subtype-tagged node metadata

## Why

The merged mediatoropathy page was mixing the whole Mediator complex and the CDK8 kinase module as if they were peer complexes. This PR makes the CKM branch visibly subordinate to the broader Mediator lesion, keeps the MED23 tail-module branch distinct, and adds one concrete MED13-specific mechanistic node so the graph is not just an umbrella transcription diagram.

## Validation

- `just validate kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml`
- `uv run pytest tests/test_render_pathograph_payload.py -k mediator_complex_pathograph -v`

## Not changed

- no derived HTML pages were committed
- no broader repo-wide graph cleanup was attempted here
