### PR TITLE
[codex] curate COPA syndrome

### DIFF
--- a/kb/disorders/COPA_Syndrome.yaml
+++ b/kb/disorders/COPA_Syndrome.yaml
@@ -1,0 +1,333 @@
+name: COPA Syndrome
+creation_date: "2026-04-12T17:08:20Z"
+updated_date: "2026-04-12T17:50:51Z"
+category: Mendelian
+synonyms:
+- autoimmune interstitial lung disease-arthritis syndrome
+- autoimmune interstitial lung, joint, and kidney disease
+- AILJK
+description: >
+  COPA syndrome is an autosomal dominant inborn error of immunity caused by
+  heterozygous pathogenic variants in COPA. It is defined by interstitial lung
+  disease with frequent diffuse alveolar hemorrhage, inflammatory arthritis,
+  autoantibody positivity, and variable immune-mediated kidney disease. Disease
+  pathogenesis reflects impaired COPI-mediated Golgi-to-ER retrieval, abnormal
+  STING activation, constitutive type I interferon signaling, and TH17-skewed
+  adaptive immune dysregulation.
+disease_term:
+  preferred_term: COPA syndrome
+  term:
+    id: MONDO:0014629
+    label: autoimmune interstitial lung disease-arthritis syndrome
+parents:
+- Autoinflammatory diseases
+- Inborn errors of immunity
+- Interstitial lung disease
+pathophysiology:
+- name: COPA pathogenic variants
+  description: >
+    Heterozygous deleterious COPA variants affecting the WD40 cargo-recognition
+    domain of coatomer subunit alpha impair COPI-dependent retrograde trafficking
+    and initiate the molecular cascade underlying COPA syndrome.
+  gene:
+    preferred_term: COPA
+    term:
+      id: hgnc:2230
+      label: COPA
+  downstream:
+  - target: Impaired Golgi-to-ER protein retrieval
+  evidence:
+  - reference: PMID:25894502
+    reference_title: "COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We identified four unique deleterious variants in the COPA gene (encoding coatomer subunit α) affecting the same functional domain."
+    explanation: Landmark discovery study identifying recurrent pathogenic COPA variants in affected families.
+- name: Impaired Golgi-to-ER protein retrieval
+  description: >
+    Mutant COPA compromises retrograde retrieval of client proteins from the
+    Golgi to the endoplasmic reticulum, perturbing ER-Golgi homeostasis and
+    contributing to ER stress.
+  biological_processes:
+  - preferred_term: retrograde Golgi-to-ER transport
+    term:
+      id: GO:0006890
+      label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
+    modifier: ABNORMAL
+  - preferred_term: response to endoplasmic reticulum stress
+    term:
+      id: GO:0034976
+      label: response to endoplasmic reticulum stress
+    modifier: ABNORMAL
+  downstream:
+  - target: STING accumulation at the Golgi and constitutive type I interferon signaling
+  evidence:
+  - reference: PMID:25894502
+    reference_title: "COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "COPA variants impair binding to proteins targeted for retrograde Golgi-to-ER transport."
+    explanation: Mechanistic cell data show that mutant COPA disrupts cargo recognition needed for COPI-mediated retrieval.
+  - reference: PMID:25894502
+    reference_title: "COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "expression of mutant COPA results in ER stress and the upregulation of cytokines priming for a T helper type 17 (TH17) response."
+    explanation: Mutant COPA induces ER stress in experimental systems, linking trafficking failure to inflammatory reprogramming.
+- name: STING accumulation at the Golgi and constitutive type I interferon signaling
+  description: >
+    Loss of normal COPA-mediated retrieval causes ER-resident STING to accumulate
+    at the Golgi, driving persistent STING-dependent type I interferon signaling
+    and a systemic interferon signature.
+  biological_processes:
+  - preferred_term: type I interferon-mediated signaling pathway
+    term:
+      id: GO:0060337
+      label: type I interferon-mediated signaling pathway
+    modifier: ABNORMAL
+  downstream:
+  - target: TH17-skewed adaptive immune dysregulation
+  evidence:
+  - reference: PMID:32725128
+    reference_title: "Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "mutant COPA was associated with an accumulation of ER-resident STING at the Golgi."
+    explanation: Experimental evidence links COPA dysfunction directly to aberrant STING localization.
+  - reference: PMID:32725128
+    reference_title: "Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We observed elevated levels of ISGs and IFN-α in blood of symptomatic COPA patients."
+    explanation: Patient blood profiling demonstrates the interferon signature expected from constitutive STING activation.
+- name: TH17-skewed adaptive immune dysregulation
+  description: >
+    COPA dysfunction promotes cytokine programs that favor TH17 differentiation
+    and sustains autoantibody-positive inflammation, contributing to chronic
+    injury in the lungs, joints, and kidneys.
+  cell_types:
+  - preferred_term: CD4+ T cell
+    term:
+      id: CL:0000624
+      label: CD4-positive, alpha-beta T cell
+  biological_processes:
+  - preferred_term: T-helper 17 cell differentiation
+    term:
+      id: GO:0072539
+      label: T-helper 17 cell differentiation
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:25894502
+    reference_title: "COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Patient-derived CD4(+) T cells also demonstrate significant skewing toward a TH17 phenotype that is implicated in autoimmunity."
+    explanation: Patient-derived T-cell data provide direct evidence of TH17-biased adaptive immune activation in COPA syndrome.
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All but 1 patient tested positive for autoantibodies, and increased interferon signalling was noted in all those tested."
+    explanation: Large cohort data confirm the characteristic combination of autoantibody positivity and interferon activation in clinically affected patients.
+phenotypes:
+- name: Interstitial lung disease
+  category: Respiratory
+  frequency: VERY_FREQUENT
+  description: >
+    Pulmonary disease is the dominant organ manifestation and is most often an
+    interstitial lung disease pattern.
+  phenotype_term:
+    preferred_term: Interstitial lung disease
+    term:
+      id: HP:0006530
+      label: Abnormal pulmonary interstitial morphology
+  evidence:
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pulmonary involvement was observed in 34 patients, with interstitial lung disease in most cases (n = 31) and diffuse alveolar haemorrhage in 11 individuals."
+    explanation: Multicenter European cohort confirms interstitial lung disease as the most common organ manifestation; 31/38 symptomatic patients had ILD, which is 82% and falls in the VERY_FREQUENT band.
+- name: Diffuse alveolar hemorrhage
+  category: Respiratory
+  frequency: OCCASIONAL
+  description: >
+    Alveolar hemorrhage may be clinically overt or insidious and is a distinctive
+    pulmonary complication of COPA syndrome.
+  phenotype_term:
+    preferred_term: Diffuse alveolar hemorrhage
+    term:
+      id: HP:0025420
+      label: Diffuse alveolar hemorrhage
+  evidence:
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pulmonary involvement was observed in 34 patients, with interstitial lung disease in most cases (n = 31) and diffuse alveolar haemorrhage in 11 individuals."
+    explanation: The same cohort explicitly documents diffuse alveolar hemorrhage as a core pulmonary feature; 11/38 symptomatic patients had diffuse alveolar hemorrhage, which is 29% and falls in the OCCASIONAL band.
+- name: Pulmonary fibrosis
+  category: Respiratory
+  description: >
+    Progressive pulmonary fibrosis can develop within the interstitial lung
+    disease spectrum of COPA syndrome, including nonspecific interstitial
+    pneumonia and lymphocytic interstitial pneumonia patterns.
+  phenotype_term:
+    preferred_term: Pulmonary fibrosis
+    term:
+      id: HP:0002206
+      label: Pulmonary fibrosis
+  evidence:
+  - reference: PMID:37821196
+    reference_title: "COPA Syndrome from Diagnosis to Treatment: A Clinician's Guide."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Onset is usually in early childhood, with unique disease features including alveolar hemorrhage, which can be insidious, pulmonary cyst formation, and progressive pulmonary fibrosis in nonspecific interstitial pneumonia or lymphocytic interstitial pneumonia patterns."
+    explanation: Review abstract identifies progressive pulmonary fibrosis as a distinctive pulmonary manifestation within the COPA syndrome ILD spectrum.
+- name: Pulmonary cyst formation
+  category: Respiratory
+  description: >
+    Cystic lung changes are a recognized pulmonary feature of COPA syndrome and
+    may accompany chronic interstitial lung disease.
+  phenotype_term:
+    preferred_term: Pulmonary cyst formation
+    term:
+      id: HP:0032445
+      label: Pulmonary cyst
+  evidence:
+  - reference: PMID:37821196
+    reference_title: "COPA Syndrome from Diagnosis to Treatment: A Clinician's Guide."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Onset is usually in early childhood, with unique disease features including alveolar hemorrhage, which can be insidious, pulmonary cyst formation, and progressive pulmonary fibrosis in nonspecific interstitial pneumonia or lymphocytic interstitial pneumonia patterns."
+    explanation: Review abstract identifies pulmonary cyst formation as a characteristic COPA syndrome lung feature.
+- name: Arthritis
+  category: Musculoskeletal
+  frequency: FREQUENT
+  description: >
+    Inflammatory joint disease is a common extrapulmonary manifestation and can
+    precede or accompany lung disease.
+  phenotype_term:
+    preferred_term: Arthritis
+    term:
+      id: HP:0001369
+      label: Arthritis
+  evidence:
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Twenty-six patients demonstrated joint involvement, and 7 had documented kidney disease."
+    explanation: Cohort data show that inflammatory joint involvement is common among symptomatic patients; 26/38 affected individuals had joint involvement, which is 68% and falls in the FREQUENT band.
+- name: Glomerulonephritis
+  category: Renal
+  description: >
+    Immune-mediated kidney disease occurs in a subset of patients and may present
+    as ANCA-associated, lupus-like, or immune-complex glomerulonephritis.
+  phenotype_term:
+    preferred_term: Glomerulonephritis
+    term:
+      id: HP:0000099
+      label: Glomerulonephritis
+  evidence:
+  - reference: PMID:41932423
+    reference_title: "Kidney Transplant Outcomes in Coatomer Protein Complex Subunit Alpha (COPA) Syndrome: Report of Five Patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Kidney involvement was heterogenous between patients (ANCA-associated vasculitis-like disease, lupus or immune-complex mediated glomerulonephritis or overlapping phenotypes), and all had advanced histological damage at clinical presentation."
+    explanation: Kidney transplant case series demonstrates that glomerulonephritis is part of the renal disease spectrum in COPA syndrome.
+biochemical:
+- name: Autoantibodies
+  presence: Elevated
+  context: >
+    High-titer autoantibodies are characteristic and seropositivity is present in
+    nearly all tested symptomatic patients.
+  evidence:
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All but 1 patient tested positive for autoantibodies, and increased interferon signalling was noted in all those tested."
+    explanation: Large cohort data support autoantibody positivity as a defining immunologic feature.
+- name: Type I interferon signature
+  presence: Elevated
+  context: >
+    Increased ISG expression and interferon signaling are central molecular
+    biomarkers of disease activity.
+  evidence:
+  - reference: PMID:32725128
+    reference_title: "Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We observed elevated levels of ISGs and IFN-α in blood of symptomatic COPA patients."
+    explanation: Patient blood assays demonstrate a systemic type I interferon signature.
+genetic:
+- name: COPA
+  gene_term:
+    preferred_term: COPA
+    term:
+      id: hgnc:2230
+      label: COPA
+  association: Causative
+  presence: PRESENT
+  inheritance:
+  - name: Autosomal dominant
+  notes: >
+    Heterozygous pathogenic COPA variants, typically missense changes affecting
+    the WD40 cargo-recognition domain, cause COPA syndrome by disrupting
+    COPI-mediated retrograde trafficking and downstream immune regulation.
+  evidence:
+  - reference: PMID:25894502
+    reference_title: "COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We identified four unique deleterious variants in the COPA gene (encoding coatomer subunit α) affecting the same functional domain."
+    explanation: Original family-based genetic study establishes COPA as the causative disease gene.
+inheritance:
+- name: Autosomal dominant
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  penetrance: INCOMPLETE
+  expressivity: VARIABLE
+  description: >
+    COPA syndrome follows autosomal dominant inheritance with incomplete
+    penetrance and broad inter-individual variability in pulmonary, articular,
+    and renal involvement.
+  evidence:
+  - reference: PMID:37821196
+    reference_title: "COPA Syndrome from Diagnosis to Treatment: A Clinician's Guide."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "COPA syndrome is a recently described autosomal dominant inborn error of immunity characterized by high titer autoantibodies and interstitial lung disease, with many individuals also having arthritis and nephritis."
+    explanation: Review abstract explicitly states the autosomal dominant inheritance pattern and core phenotype.
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Among the 46 individuals carrying a COPA mutation, 38 had at least 1 clinical manifestation likely related to their mutant state (clinical penetrance of 83%)."
+    explanation: Cohort data support incomplete penetrance among mutation carriers.
+treatments:
+- name: Janus kinase inhibitor therapy
+  description: >
+    JAK inhibitors are being used to target the interferon-driven inflammatory
+    state in COPA syndrome and have shown promising cohort-level efficacy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: JAK inhibitor
+      term:
+        id: NCIT:C172200
+        label: JAK Inhibitor
+  evidence:
+  - reference: PMID:41395910
+    reference_title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Twenty-two patients were treated with Janus kinase inhibitors with promising efficacy."
+    explanation: Large European cohort provides the strongest available abstract-level support for JAK inhibitor use in COPA syndrome.

--- a/kb/disorders/COPA_Syndrome.yaml
+++ b/kb/disorders/COPA_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: COPA Syndrome
 creation_date: "2026-04-12T17:08:20Z"
-updated_date: "2026-04-12T17:50:51Z"
+updated_date: "2026-04-12T18:28:04Z"
 category: Mendelian
 synonyms:
 - autoimmune interstitial lung disease-arthritis syndrome
@@ -60,7 +60,7 @@ pathophysiology:
       label: response to endoplasmic reticulum stress
     modifier: ABNORMAL
   downstream:
-  - target: STING accumulation at the Golgi and constitutive type I interferon signaling
+  - target: STING accumulation at the Golgi
   evidence:
   - reference: PMID:25894502
     reference_title: "COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis."
@@ -74,11 +74,24 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: "expression of mutant COPA results in ER stress and the upregulation of cytokines priming for a T helper type 17 (TH17) response."
     explanation: Mutant COPA induces ER stress in experimental systems, linking trafficking failure to inflammatory reprogramming.
-- name: STING accumulation at the Golgi and constitutive type I interferon signaling
+- name: STING accumulation at the Golgi
   description: >
-    Loss of normal COPA-mediated retrieval causes ER-resident STING to accumulate
-    at the Golgi, driving persistent STING-dependent type I interferon signaling
-    and a systemic interferon signature.
+    Loss of normal COPA-mediated retrieval causes ER-resident STING to
+    accumulate at the Golgi, creating the proximal trafficking defect that
+    precedes downstream inflammatory signaling.
+  downstream:
+  - target: Constitutive type I interferon signaling
+  evidence:
+  - reference: PMID:32725128
+    reference_title: "Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "mutant COPA was associated with an accumulation of ER-resident STING at the Golgi."
+    explanation: Experimental evidence links COPA dysfunction directly to aberrant STING localization.
+- name: Constitutive type I interferon signaling
+  description: >
+    Golgi-retained STING drives persistent type I interferon pathway activation
+    and produces the interferon signature observed in symptomatic patients.
   biological_processes:
   - preferred_term: type I interferon-mediated signaling pathway
     term:
@@ -88,12 +101,6 @@ pathophysiology:
   downstream:
   - target: TH17-skewed adaptive immune dysregulation
   evidence:
-  - reference: PMID:32725128
-    reference_title: "Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling."
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: "mutant COPA was associated with an accumulation of ER-resident STING at the Golgi."
-    explanation: Experimental evidence links COPA dysfunction directly to aberrant STING localization.
   - reference: PMID:32725128
     reference_title: "Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling."
     supports: SUPPORT

--- a/references_cache/PMID_25894502.md
+++ b/references_cache/PMID_25894502.md
@@ -1,0 +1,159 @@
+---
+reference_id: "PMID:25894502"
+title: COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis.
+authors:
+- Watkin LB
+- Jessen B
+- Wiszniewski W
+- Vece TJ
+- Jan M
+- Sha Y
+- Thamsen M
+- Santos-Cortez RL
+- Lee K
+- Gambin T
+- Forbes LR
+- Law CS
+- Stray-Pedersen A
+- Cheng MH
+- Mace EM
+- Anderson MS
+- Liu D
+- Tang LF
+- Nicholas SK
+- Nahmod K
+- Makedonas G
+- Canter DL
+- Kwok PY
+- Hicks J
+- Jones KD
+- Penney S
+- Jhangiani SN
+- Rosenblum MD
+- Dell SD
+- Waterfield MR
+- Papa FR
+- Muzny DM
+- Zaitlen N
+- Leal SM
+- Gonzaga-Jauregui C
+- Baylor-Hopkins Center for Mendelian Genomics
+- Boerwinkle E
+- Eissa NT
+- Gibbs RA
+- Lupski JR
+- Orange JS
+- Shum AK
+journal: Nat Genet
+year: '2015'
+doi: 10.1038/ng.3279
+keywords:
+- Amino Acid Sequence
+- Arthritis/genetics
+- Autoimmune Diseases/genetics
+- "Child, Preschool"
+- Coatomer Protein/genetics
+- Endoplasmic Reticulum/metabolism
+- Endoplasmic Reticulum Stress
+- Female
+- Genetic Association Studies
+- Genetic Predisposition to Disease
+- Golgi Apparatus/metabolism
+- HEK293 Cells
+- Humans
+- Infant
+- Lod Score
+- "Lung Diseases, Interstitial/genetics"
+- Male
+- Molecular Sequence Data
+- Pedigree
+- Protein Transport
+content_type: abstract_only
+---
+
+# COPA mutations impair ER-Golgi transport and cause hereditary autoimmune-mediated lung disease and arthritis.
+**Authors:** Watkin LB, Jessen B, Wiszniewski W, Vece TJ, Jan M, Sha Y, Thamsen M, Santos-Cortez RL, Lee K, Gambin T, Forbes LR, Law CS, Stray-Pedersen A, Cheng MH, Mace EM, Anderson MS, Liu D, Tang LF, Nicholas SK, Nahmod K, Makedonas G, Canter DL, Kwok PY, Hicks J, Jones KD, Penney S, Jhangiani SN, Rosenblum MD, Dell SD, Waterfield MR, Papa FR, Muzny DM, Zaitlen N, Leal SM, Gonzaga-Jauregui C, Baylor-Hopkins Center for Mendelian Genomics, Boerwinkle E, Eissa NT, Gibbs RA, Lupski JR, Orange JS, Shum AK
+**Journal:** Nat Genet (2015)
+**DOI:** [10.1038/ng.3279](https://doi.org/10.1038/ng.3279)
+
+## Content
+
+1. Nat Genet. 2015 Jun;47(6):654-60. doi: 10.1038/ng.3279. Epub 2015 Apr 20.
+
+COPA mutations impair ER-Golgi transport and cause hereditary
+autoimmune-mediated lung disease and arthritis.
+
+Watkin LB(1), Jessen B(2), Wiszniewski W(3), Vece TJ(4), Jan M(2), Sha Y(5),
+Thamsen M(2), Santos-Cortez RL(6), Lee K(6), Gambin T(3), Forbes LR(1), Law
+CS(2), Stray-Pedersen A(7), Cheng MH(2), Mace EM(1), Anderson MS(2), Liu D(1),
+Tang LF(8), Nicholas SK(1), Nahmod K(1), Makedonas G(1), Canter DL(1), Kwok
+PY(9), Hicks J(10), Jones KD(11), Penney S(3), Jhangiani SN(12), Rosenblum
+MD(13), Dell SD(14), Waterfield MR(15), Papa FR(2), Muzny DM(12), Zaitlen N(2),
+Leal SM(6), Gonzaga-Jauregui C(3); Baylor-Hopkins Center for Mendelian Genomics;
+Boerwinkle E(16), Eissa NT(5), Gibbs RA(17), Lupski JR(18), Orange JS(1), Shum
+AK(19).
+
+Author information:
+(1)1] Department of Pediatrics, Baylor College of Medicine, Houston, Texas, USA.
+[2] Texas Children's Hospital Center for Human Immuno-Biology, Houston, Texas,
+USA.
+(2)Department of Medicine, University of California, San Francisco, San
+Francisco, California, USA.
+(3)Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, Texas, USA.
+(4)Department of Pediatrics, Baylor College of Medicine, Houston, Texas, USA.
+(5)Department of Medicine, Baylor College of Medicine, Houston, Texas, USA.
+(6)Center for Statistical Genetics, Baylor College of Medicine, Houston, Texas,
+USA.
+(7)1] Texas Children's Hospital Center for Human Immuno-Biology, Houston, Texas,
+USA. [2] Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, Texas, USA.
+(8)Cardiovascular Research Institute, University of California, San Francisco,
+San Francisco, California, USA.
+(9)1] Cardiovascular Research Institute, University of California, San
+Francisco, San Francisco, California, USA. [2] Department of Dermatology,
+University of California, San Francisco, San Francisco, California, USA.
+(10)Department of Pathology, Texas Children's Hospital, Houston, Texas, USA.
+(11)Department of Pathology, University of California, San Francisco, San
+Francisco, California, USA.
+(12)Human Genome Sequencing Center, Baylor College of Medicine, Houston, Texas,
+USA.
+(13)Department of Dermatology, University of California, San Francisco, San
+Francisco, California, USA.
+(14)Division of Respiratory Medicine, Hospital for Sick Children, Toronto,
+Ontario, Canada.
+(15)Department of Pediatrics, University of California, San Francisco, San
+Francisco, California, USA.
+(16)1] Human Genome Sequencing Center, Baylor College of Medicine, Houston,
+Texas, USA. [2] Human Genetics Center and Institute of Molecular Medicine,
+University of Texas-Houston Health Science Center, Houston, Texas, USA.
+(17)1] Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, Texas, USA. [2] Human Genome Sequencing Center, Baylor College of
+Medicine, Houston, Texas, USA.
+(18)1] Department of Pediatrics, Baylor College of Medicine, Houston, Texas,
+USA. [2] Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, Texas, USA. [3] Human Genome Sequencing Center, Baylor College of
+Medicine, Houston, Texas, USA.
+(19)1] Department of Medicine, University of California, San Francisco, San
+Francisco, California, USA. [2] Cardiovascular Research Institute, University of
+California, San Francisco, San Francisco, California, USA.
+
+Unbiased genetic studies have uncovered surprising molecular mechanisms in human
+cellular immunity and autoimmunity. We performed whole-exome sequencing and
+targeted sequencing in five families with an apparent mendelian syndrome of
+autoimmunity characterized by high-titer autoantibodies, inflammatory arthritis
+and interstitial lung disease. We identified four unique deleterious variants in
+the COPA gene (encoding coatomer subunit α) affecting the same functional
+domain. Hypothesizing that mutant COPA leads to defective intracellular
+transport via coat protein complex I (COPI), we show that COPA variants impair
+binding to proteins targeted for retrograde Golgi-to-ER transport. Additionally,
+expression of mutant COPA results in ER stress and the upregulation of cytokines
+priming for a T helper type 17 (TH17) response. Patient-derived CD4(+) T cells
+also demonstrate significant skewing toward a TH17 phenotype that is implicated
+in autoimmunity. Our findings uncover an unexpected molecular link between a
+vesicular transport protein and a syndrome of autoimmunity manifested by lung
+and joint disease.
+
+DOI: 10.1038/ng.3279
+PMCID: PMC4513663
+PMID: 25894502 [Indexed for MEDLINE]

--- a/references_cache/PMID_32725128.md
+++ b/references_cache/PMID_32725128.md
@@ -1,0 +1,172 @@
+---
+reference_id: "PMID:32725128"
+title: Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling.
+authors:
+- Lepelley A
+- Martin-Niclós MJ
+- Le Bihan M
+- Marsh JA
+- Uggenti C
+- Rice GI
+- Bondet V
+- Duffy D
+- Hertzog J
+- Rehwinkel J
+- Amselem S
+- Boulisfane-El Khalifi S
+- Brennan M
+- Carter E
+- Chatenoud L
+- Chhun S
+- "Coulomb l'Hermine A"
+- Depp M
+- Legendre M
+- Mackenzie KJ
+- Marey J
+- McDougall C
+- McKenzie KJ
+- Molina TJ
+- Neven B
+- Seabra L
+- Thumerelle C
+- Wislez M
+- Nathan N
+- Manel N
+- Crow YJ
+- Frémond ML
+journal: J Exp Med
+year: '2020'
+doi: 10.1084/jem.20200600
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Coatomer Protein/genetics, metabolism"
+- Endoplasmic Reticulum/metabolism
+- Female
+- Gene Knockout Techniques
+- Golgi Apparatus/metabolism
+- HEK293 Cells
+- Humans
+- Interferon Type I/metabolism
+- Male
+- "Membrane Proteins/genetics, metabolism"
+- Middle Aged
+- "Mutation, Missense"
+- Protein Transport/genetics
+- Signal Transduction/genetics
+- THP-1 Cells
+- Transfection
+- Young Adult
+- STING Protein
+content_type: abstract_only
+---
+
+# Mutations in COPA lead to abnormal trafficking of STING to the Golgi and interferon signaling.
+**Authors:** Lepelley A, Martin-Niclós MJ, Le Bihan M, Marsh JA, Uggenti C, Rice GI, Bondet V, Duffy D, Hertzog J, Rehwinkel J, Amselem S, Boulisfane-El Khalifi S, Brennan M, Carter E, Chatenoud L, Chhun S, Coulomb l'Hermine A, Depp M, Legendre M, Mackenzie KJ, Marey J, McDougall C, McKenzie KJ, Molina TJ, Neven B, Seabra L, Thumerelle C, Wislez M, Nathan N, Manel N, Crow YJ, Frémond ML
+**Journal:** J Exp Med (2020)
+**DOI:** [10.1084/jem.20200600](https://doi.org/10.1084/jem.20200600)
+
+## Content
+
+1. J Exp Med. 2020 Nov 2;217(11):e20200600. doi: 10.1084/jem.20200600.
+
+Mutations in COPA lead to abnormal trafficking of STING to the Golgi and
+interferon signaling.
+
+Lepelley A(1), Martin-Niclós MJ(1), Le Bihan M(2), Marsh JA(3), Uggenti C(4),
+Rice GI(5), Bondet V(6)(7), Duffy D(6)(7), Hertzog J(8), Rehwinkel J(8), Amselem
+S(9)(10), Boulisfane-El Khalifi S(11), Brennan M(12), Carter E(4), Chatenoud
+L(13)(14)(15), Chhun S(13)(14)(15), Coulomb l'Hermine A(16), Depp M(4), Legendre
+M(9)(10), Mackenzie KJ(3), Marey J(17), McDougall C(18), McKenzie KJ(19), Molina
+TJ(13)(20), Neven B(13)(21)(22), Seabra L(1), Thumerelle C(23), Wislez
+M(17)(24), Nathan N(9)(25), Manel N(2), Crow YJ(1)(4), Frémond ML(1).
+
+Author information:
+(1)Laboratory of Neurogenetics and Neuroinflammation, Imagine Institute, Paris,
+France.
+(2)Immunity and Cancer Department, Institut Curie, Paris-Sciences-et-Lettres
+Research University, Institut National de la Santé et de la Recherche Médicale
+U932, Paris, France.
+(3)Medical Research Council Human Genetics Unit, Medical Research Council
+Institute of Genetics and Molecular Medicine, The University of Edinburgh,
+Edinburgh, UK.
+(4)Centre for Genomic and Experimental Medicine, Medical Research Council
+Institute of Genetics and Molecular Medicine, The University of Edinburgh,
+Edinburgh, UK.
+(5)Division of Evolution and Genomic Sciences, School of Biological Sciences,
+Faculty of Biology, Medicine and Health, University of Manchester, Manchester
+Academic Health Science Centre, Manchester, UK.
+(6)Immunobiology of Dendritic Cells, Institut Pasteur, Paris, France.
+(7)Institut National de la Santé et de la Recherche Médicale U1223, Paris,
+France.
+(8)Medical Research Council Human Immunology Unit, Medical Research Council
+Weatherall Institute of Molecular Medicine, Radcliffe Department of Medicine,
+University of Oxford, Oxford, UK.
+(9)Sorbonne Université, Institut National de la Santé et de la Recherche
+Médicale/UMRS_933, Trousseau University Hospital, Paris, France.
+(10)Genetics Department, Trousseau University Hospital, Assistance
+Publique-Hôpitaux de Paris, Sorbonne Université, Paris, France.
+(11)Emergency, Infectious Disease and Pediatric Rheumatology Department, Centre
+Hospitalier Régional Universitaire Lille, University of Lille, Lille, France.
+(12)Department of Paediatric Rheumatology, Royal Hospital for Sick Children,
+Edinburgh, UK.
+(13)Paris Descartes University, Université de Paris, Sorbonne-Paris-Cité, Paris,
+France.
+(14)Laboratory of Immunology, Hôpital Necker-Enfants Malades, Assistance
+Publique-Hôpitaux de Paris, Centre-Université de Paris, Paris, France.
+(15)Institut Necker-Enfants Malades, Centre National de la Recherche
+Scientifique UMR8253, Institut National de la Santé et de la Recherche Médicale
+UMR1151, Team Immunoregulation and Immunopathology, Paris, France.
+(16)Pathology Department, Trousseau University Hospital, Assistance
+Publique-Hôpitaux de Paris, Sorbonne Université, Paris, France.
+(17)Pneumology Department, Cochin Hospital, Assistance Publique-Hôpitaux de
+Paris, Centre-Université de Paris, Paris, France.
+(18)Department of Paediatric Respiratory Medicine, Royal Hospital for Sick
+Children, Edinburgh, UK.
+(19)Paediatric Pathology Department, Royal Infirmary of Edinburgh, Edinburgh,
+UK.
+(20)Pathology Department, Hôpital Necker-Enfants Malades, Assistance
+Publique-Hôpitaux de Paris, Centre-Université de Paris, Paris, France.
+(21)Pediatric Hematology-Immunology and Rheumatology Department, Hôpital
+Necker-Enfants Malades, Assistance Publique-Hôpitaux de Paris, Centre-Université
+de Paris, Paris, France.
+(22)Institut National de la Santé et de la Recherche Médicale UMR 1163,
+Laboratory of Immunogenetics of Paediatric Autoimmunity, Imagine Institute,
+Paris, France.
+(23)Pediatric Pneumology Department, Hôpital Jeanne de Flandre, Centre
+Hospitalier Régional Universitaire Lille, Lille, France.
+(24)Cordeliers Research Center, Université Paris Descartes, Université de Paris,
+UMRS1138 Inflammation, Complement and Cancer Team, Paris, France.
+(25)Pediatric Pulmonology Department and Reference Center for Rare Lung Disease
+RespiRare, Trousseau University Hospital, Assistance Publique-Hôpitaux de Paris,
+Sorbonne Université, Paris, France.
+
+Comment in
+    J Exp Med. 2020 Nov 2;217(11):e20201517. doi: 10.1084/jem.20201517.
+
+Heterozygous missense mutations in coatomer protein subunit α, COPA, cause a
+syndrome overlapping clinically with type I IFN-mediated disease due to
+gain-of-function in STING, a key adaptor of IFN signaling. Recently, increased
+levels of IFN-stimulated genes (ISGs) were described in COPA syndrome. However,
+the link between COPA mutations and IFN signaling is unknown. We observed
+elevated levels of ISGs and IFN-α in blood of symptomatic COPA patients. In
+vitro, both overexpression of mutant COPA and silencing of COPA induced
+STING-dependent IFN signaling. We detected an interaction between COPA and
+STING, and mutant COPA was associated with an accumulation of ER-resident STING
+at the Golgi. Given the known role of the coatomer protein complex I, we
+speculate that loss of COPA function leads to enhanced type I IFN signaling due
+to a failure of Golgi-to-ER STING retrieval. These data highlight the importance
+of the ER-Golgi axis in the control of autoinflammation and inform therapeutic
+strategies in COPA syndrome.
+
+© 2020 Lepelley et al.
+
+DOI: 10.1084/jem.20200600
+PMCID: PMC7596811
+PMID: 32725128 [Indexed for MEDLINE]
+
+Conflict of interest statement: Disclosures: M. Wislez reported personal fees
+from Boeringher Ingelheim, Roche, MSD, BMS, Astra Zeneca, and Amgen outside the
+submitted work. Y.J. Crow reported "other" from Biogen outside the submitted
+work. No other disclosures were reported.

--- a/references_cache/PMID_37821196.md
+++ b/references_cache/PMID_37821196.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:37821196"
+title: "COPA Syndrome from Diagnosis to Treatment: A Clinician's Guide."
+authors:
+- Simchoni N
+- Vogel TP
+- Shum AK
+journal: Rheum Dis Clin North Am
+year: '2023'
+doi: 10.1016/j.rdc.2023.06.005
+keywords:
+- "Child, Preschool"
+- Humans
+- "Lung Diseases, Interstitial/diagnosis, genetics"
+content_type: abstract_only
+---
+
+# COPA Syndrome from Diagnosis to Treatment: A Clinician's Guide.
+**Authors:** Simchoni N, Vogel TP, Shum AK
+**Journal:** Rheum Dis Clin North Am (2023)
+**DOI:** [10.1016/j.rdc.2023.06.005](https://doi.org/10.1016/j.rdc.2023.06.005)
+
+## Content
+
+1. Rheum Dis Clin North Am. 2023 Nov;49(4):789-804. doi:
+10.1016/j.rdc.2023.06.005.  Epub 2023 Jul 21.
+
+COPA Syndrome from Diagnosis to Treatment: A Clinician's Guide.
+
+Simchoni N(1), Vogel TP(2), Shum AK(3).
+
+Author information:
+(1)Pulmonary Division, Department of Medicine, University of California, San
+Francisco, 555 Mission Bay Boulevard South, CVRI 284F, Box 3118, San Francisco,
+CA 94158, USA.
+(2)Division of Rheumatology, Department of Pediatrics, Baylor College of
+Medicine and Center for Human Immunobiology, Texas Children's Hospital, 1102
+Bates Avenue Suite 330, Houston, TX 77030, USA.
+(3)Pulmonary Division, Department of Medicine, University of California, San
+Francisco, 555 Mission Bay Boulevard South, CVRI 284F, Box 3118, San Francisco,
+CA 94158, USA; Cardiovascular Research Institute, University of California, San
+Francisco, 555 Mission Bay Boulevard South, CVRI 284F, Box 3118, San Francisco,
+CA 94158, USA. Electronic address: Anthony.shum@ucsf.edu.
+
+COPA syndrome is a recently described autosomal dominant inborn error of
+immunity characterized by high titer autoantibodies and interstitial lung
+disease, with many individuals also having arthritis and nephritis. Onset is
+usually in early childhood, with unique disease features including alveolar
+hemorrhage, which can be insidious, pulmonary cyst formation, and progressive
+pulmonary fibrosis in nonspecific interstitial pneumonia or lymphocytic
+interstitial pneumonia patterns. This review explores the clinical presentation,
+genetics, molecular mechanisms, organ manifestations, and treatment approaches
+for COPA syndrome, and presents a diagnostic framework of suggested indications
+for patient testing.
+
+Copyright © 2023 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.rdc.2023.06.005
+PMCID: PMC10866555
+PMID: 37821196 [Indexed for MEDLINE]

--- a/references_cache/PMID_41395910.md
+++ b/references_cache/PMID_41395910.md
@@ -1,0 +1,268 @@
+---
+reference_id: "PMID:41395910"
+title: "Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome."
+authors:
+- David C
+- Nathan N
+- Al-Abadi E
+- Arkwright PD
+- Bader-Meunier B
+- Becker S
+- Belot A
+- Brennan M
+- Breton S
+- Bondet V
+- Cadranel J
+- "Coulomb l'Hermine A"
+- De Almeida S
+- Duffy D
+- Poch TC
+- de Becdelièvre A
+- El Khalifi-Boulisfane S
+- Gattorno M
+- Gispert-Saüch M
+- Gothe F
+- Hatchuel Y
+- Herdliczko D
+- Kilinc AA
+- Koucky V
+- Labouret G
+- Manna R
+- Maillard H
+- Matoses Ruipérez ML
+- Matucci-Cerinic C
+- Mensa-Vilaro A
+- Michel K
+- Molina TJ
+- Lopez Montesinos B
+- Newman WG
+- Papenkort J
+- Rapp C
+- Rames C
+- Rice GI
+- Rose MA
+- Reumaux H
+- Sailler L
+- Schwerk N
+- Seabra L
+- Sellam J
+- Taddio A
+- Thumerelle C
+- Tommasini A
+- Tusseau M
+- Volpi S
+- Wetzke M
+- Weiss L
+- Welfringer-Morin A
+- Wislez M
+- Griese M
+- Crow YJ
+- Frémond ML
+journal: Ann Rheum Dis
+year: '2026'
+doi: 10.1016/j.ard.2025.09.013
+keywords:
+- Humans
+- Female
+- Male
+- Child
+- Adult
+- Adolescent
+- "Child, Preschool"
+- Infant
+- Young Adult
+- Middle Aged
+- "Hereditary Autoinflammatory Diseases/genetics, drug therapy, immunology"
+- Phenotype
+- Mutation
+- Coatomer Protein/genetics
+- Europe
+- "Infant, Newborn"
+- Cohort Studies
+- Syndrome
+content_type: abstract_only
+---
+
+# Insights from a novel monogenic autoinflammatory disease: overview of a multicentric European cohort of 38 patients with COPA syndrome.
+**Authors:** David C, Nathan N, Al-Abadi E, Arkwright PD, Bader-Meunier B, Becker S, Belot A, Brennan M, Breton S, Bondet V, Cadranel J, Coulomb l'Hermine A, De Almeida S, Duffy D, Poch TC, de Becdelièvre A, El Khalifi-Boulisfane S, Gattorno M, Gispert-Saüch M, Gothe F, Hatchuel Y, Herdliczko D, Kilinc AA, Koucky V, Labouret G, Manna R, Maillard H, Matoses Ruipérez ML, Matucci-Cerinic C, Mensa-Vilaro A, Michel K, Molina TJ, Lopez Montesinos B, Newman WG, Papenkort J, Rapp C, Rames C, Rice GI, Rose MA, Reumaux H, Sailler L, Schwerk N, Seabra L, Sellam J, Taddio A, Thumerelle C, Tommasini A, Tusseau M, Volpi S, Wetzke M, Weiss L, Welfringer-Morin A, Wislez M, Griese M, Crow YJ, Frémond ML
+**Journal:** Ann Rheum Dis (2026)
+**DOI:** [10.1016/j.ard.2025.09.013](https://doi.org/10.1016/j.ard.2025.09.013)
+
+## Content
+
+1. Ann Rheum Dis. 2026 Mar;85(3):547-557. doi: 10.1016/j.ard.2025.09.013. Epub
+2025  Oct 25.
+
+Insights from a novel monogenic autoinflammatory disease: overview of a
+multicentric European cohort of 38 patients with COPA syndrome.
+
+David C(1), Nathan N(2), Al-Abadi E(3), Arkwright PD(4), Bader-Meunier B(5),
+Becker S(6), Belot A(7), Brennan M(8), Breton S(9), Bondet V(10), Cadranel
+J(11), Coulomb l'Hermine A(12), De Almeida S(13), Duffy D(10), Poch TC(14), de
+Becdelièvre A(15), El Khalifi-Boulisfane S(16), Gattorno M(17), Gispert-Saüch
+M(14), Gothe F(18), Hatchuel Y(19), Herdliczko D(20), Kilinc AA(21), Koucky
+V(22), Labouret G(23), Manna R(24), Maillard H(25), Matoses Ruipérez ML(26),
+Matucci-Cerinic C(27), Mensa-Vilaro A(28), Michel K(18), Molina TJ(29), Lopez
+Montesinos B(30), Newman WG(31), Papenkort J(32), Rapp C(18), Rames C(33), Rice
+GI(34), Rose MA(32), Reumaux H(35), Sailler L(13), Schwerk N(36), Seabra L(37),
+Sellam J(38), Taddio A(39), Thumerelle C(40), Tommasini A(39), Tusseau M(41),
+Volpi S(27), Wetzke M(36), Weiss L(42), Welfringer-Morin A(43), Wislez M(44),
+Griese M(18), Crow YJ(45), Frémond ML(46).
+
+Author information:
+(1)Laboratory of Neurogenetics and Neuroinflammation, Imagine Institute, Paris,
+France; Department of Internal Medicine, Hôpital Bichat-Claude Bernard,
+Assistance Publique-Hôpitaux de Paris, Université Paris Cité, Paris, France.
+(2)Paediatric Pulmonology Department and Reference Centre for Rare Lung Diseases
+RespiRare, INSERM UMR_S933 Laboratory of Childhood Genetic Diseases, Armand
+Trousseau Hospital, Sorbonne University and APHP, Paris, France.
+(3)Childhood Arthritis and Rheumatic Diseases Unit, Birmingham Women's and
+Children's Hospital NHSFT, Birmingham, UK.
+(4)Lydia Becker Institute of Immunology and Inflammation, University of
+Manchester, Manchester, UK.
+(5)Department of Paediatric Haematology-Immunology and Rheumatology,
+Necker-Enfants Malades Hospital, Assistance Publique - Hôpitaux de Paris (APHP),
+and Reference Centre for Inflammatory Rheumatism, Autoimmune Diseases and
+Systemic Interferonopathies in Children (RAISE), Université Paris Cité, Paris,
+France.
+(6)Pneumology Department, Darmstädter Kinderkliniken Prinzessin Margaret,
+Darmstadt, Germany; Member of the chILD-EU Register Group.
+(7)National Reference Center for Inflammatory Rheumatism, Autoimmune Diseases
+and Systemic Interferonopathies (RAISE), Paediatric Nephrology, Rheumatology,
+Dermatology Unit, Hospital of Mother and Child, Hospices Civils of Lyon, Lyon,
+France.
+(8)Paediatric & Adolescent Rheumatology, Royal Hospital for Children & Young
+People, Edinburgh, UK.
+(9)Pediatric Radiology Department, Hôpital Necker-Enfants Malades, AP-HP
+Centre-Université de Paris, Paris, France.
+(10)Translational Immunology Unit, Institut Pasteur, Université Paris Cité,
+Paris, France.
+(11)Department of Pneumology and Thoracic Oncology, Tenon Hospital, Assistance
+Publique-Hôpitaux de Paris (AP-HP) Sorbonne Université, Paris, France.
+(12)Pathology Department, Trousseau University Hospital, Assistance
+Publique-Hôpitaux de Paris, Sorbonne Université, Paris, France.
+(13)Department of Internal Medicine, CHU de Toulouse, Toulouse, France.
+(14)UF Paediatric Rheumatology Department, Hospital Doctor Trueta, Girona,
+Spain.
+(15)Laboratory of Genetics, Henri Mondor University Hospital, APHP, University
+Paris Est Creteil, INSERM, IMRB, Creteil, France.
+(16)Emergency, Infectious Disease and Paediatric Rheumatology Department, Centre
+Hospitalier Régional Universitaire Lille, University of Lille, Lille, France.
+(17)UOC Reumatologia e Malattie Autoinfiammatore, IRCCS Istituto Giannina
+Gaslini, Genova, Italy.
+(18)Member of the chILD-EU Register Group; Pediatric Pneumology, Dr von Hauner
+Children´s Hospital, University of Munich, German Center for Lung Research
+(DZL), Munich, Germany.
+(19)Department of General Paediatrics, Competence Centre for Inflammatory
+Rheumatism, Autoimmune Diseases and Systemic Interferonopathies (RAISE)
+Antilles-Guyane, EpiCliV Research Unit, University of the French West Indies,
+Martinique University Hospital, Fort-de France, France.
+(20)Rheumatology, Universitäts - Kinderspital Zürich, Zurich, Switzerland.
+(21)Member of the chILD-EU Register Group; Istanbul University-Cerrahpasa,
+Cerrahpasa Faculty of Medicine, Division of Pediatric Pulmonology, Istanbul,
+Turkey.
+(22)Member of the chILD-EU Register Group; Department of Paediatrics, 2nd
+Faculty of Medicine, Charles University and Motol University Hospital, Prague,
+Czech Republic.
+(23)Paediatric Pulmonology Department, University Hospital for Children,
+Toulouse, France.
+(24)Periodic Fevers Research Center, Catholic University, Rome, Italy.
+(25)Department of Internal Medicine and Clinical Immunology, Referral Centre for
+Rare Systemic Autoimmune Diseases in the North of France, Northwest,
+Mediterranean and Guadeloupe (CeRAINOM), CHU de Lille, Lille, France.
+(26)Section of Pediatric Nephrology, Hospital Universitari i Politècnic (HUIP)
+La Fe, Valencia, Spain.
+(27)UOC Reumatologia e Malattie Autoinfiammatore, IRCCS Istituto Giannina
+Gaslini, Genova, Italy; Department of Neurosciences, Rehabilitation,
+Ophthalmology, Genetics, Maternal and Child Health (DINOGMI), University of
+Genoa, Genoa, Italy.
+(28)Department of Immunology-CDB, Hospital Clínic-IDIBAPS, Barcelona, Spain.
+(29)Pathology Department, Hôpital Necker-Enfants Malades, Assistance
+Publique-Hôpitaux de Paris, Centre-Université de Paris, Paris, France.
+(30)Section of Pediatric Rheumatology, Hospital Universitari i Politècnic (HUIP)
+La Fe, Valencia, Spain.
+(31)Lydia Becker Institute of Immunology and Inflammation, University of
+Manchester, Manchester, UK; Manchester Centre for Genomic Medicine, Manchester
+University NHS Foundation Trust, Manchester, UK; Division of Evolution Infection
+& Genomic Sciences, School of Biological Sciences, Faculty of Biology, Medicine
+and Health, University of Manchester, Manchester, UK.
+(32)Member of the chILD-EU Register Group; Stuttgart Children's Hospital, Center
+for Congenital Lung Diseases, Stuttgart, Germany.
+(33)Paediatric Pneumology and Allergology Unit, CHU of Amiens, Amiens, France.
+(34)Division of Evolution Infection & Genomic Sciences, School of Biological
+Sciences, Faculty of Biology, Medicine and Health, University of Manchester,
+Manchester, UK.
+(35)Paediatric Rheumatology Unit, University of Lille, Jeanne de Flandre
+Hospital, Lille, France.
+(36)Member of the chILD-EU Register Group; Department of Paediatrics, German
+Center for Lung Research, Medical University of Hannover, Hannover, Germany.
+(37)Laboratory of Neurogenetics and Neuroinflammation, Imagine Institute, Paris,
+France.
+(38)Department of Rheumatology, Saint-Antoine Hospital, APHP, Centre de
+Recherche Saint-Antoine (CRSA) Inserm UMRS_938, Sorbonne Université, Paris,
+France.
+(39)Department of Pediatrics, Institute for Maternal and Child Health IRCCS
+"Burlo Garofolo", Trieste, Italy; Department of Medical, Surgical and Health
+Sciences University of Trieste, Trieste, Italy.
+(40)Paediatric Pulmonology and Allergy Department, Hôpital Jeanne de Flandre,
+CHU Lille, Univ. Lille, Lille, France.
+(41)Centre International de Recherche en Infectiologie, Inserm, U1111,
+University Claude Bernard, Lyon 1, UMR5308, ENS de Lyon, Lyon, France; Hospices
+Civils de Lyon, Department of Medical Genetics, University Hospital of Lyon,
+Lyon, France.
+(42)Pediatric Pulmonology, Strasbourg University Hospital, Strasbourg, France.
+(43)Department of Dermatology, Reference Centre for Genodermatoses and Rare Skin
+Disease (MAGEC), Necker-Enfants Malades Hospital, Assistance Publique-Hôpitaux
+de Paris, Université Paris Cité, Paris, France.
+(44)Service de Pneumologie, Hôpital Cochin, AP-HP, Inserm U1138, Université
+Paris Cité, Paris, France.
+(45)Laboratory of Neurogenetics and Neuroinflammation, Imagine Institute, Paris,
+France; MRC Human Genetics Unit, Institute of Genetics and Cancer, University of
+Edinburgh, Edinburgh, UK.
+(46)Laboratory of Neurogenetics and Neuroinflammation, Imagine Institute, Paris,
+France; Department of Paediatric Haematology-Immunology and Rheumatology,
+Necker-Enfants Malades Hospital, Assistance Publique - Hôpitaux de Paris (APHP),
+and Reference Centre for Inflammatory Rheumatism, Autoimmune Diseases and
+Systemic Interferonopathies in Children (RAISE), Université Paris Cité, Paris,
+France. Electronic address: marie-louise.fremond@aphp.fr.
+
+OBJECTIVES: COPA (coatomer subunit alpha) syndrome is a rare monogenic
+autoinflammatory disease due to heterozygous mutations in COPA. It has
+phenotypic overlap with STING (Stimulator of interferon genes)-associated
+vasculopathy with onset in infancy (SAVI), although the spectrum of clinical
+manifestations is not yet fully defined. Our aim was to better delineate the
+clinical phenotype of this rare disorder in a European cohort.
+METHODS: Methods include assessment of clinical, imaging, and immunological data
+from 46 individuals (29 families) carrying a COPA mutation.
+RESULTS: Among the 46 individuals carrying a COPA mutation, 38 had at least 1
+clinical manifestation likely related to their mutant state (clinical penetrance
+of 83%). Twenty-two (58%) symptomatic patients were female, with a median age at
+disease onset of 3 years (range 0-50 years). Pulmonary involvement was observed
+in 34 patients, with interstitial lung disease in most cases (n = 31) and
+diffuse alveolar haemorrhage in 11 individuals. Twenty-six patients demonstrated
+joint involvement, and 7 had documented kidney disease. Previously undescribed
+features included skin (n = 12), cardiac (n = 8), gastrointestinal (n = 7), and
+hepatic involvement (n = 5). All but 1 patient tested positive for
+autoantibodies, and increased interferon signalling was noted in all those
+tested. Twenty-two patients were treated with Janus kinase inhibitors with
+promising efficacy.
+CONCLUSIONS: We report a large European cohort of patients with COPA syndrome.
+While confirming the core organ features (lung, joint, and kidney) of the
+disease, our data expand the phenotype to include cardiac, skin, and
+gastrointestinal features, further demonstrating the clinical overlap with SAVI
+and other type I interferonopathies.
+
+Copyright © 2025 European Alliance of Associations for Rheumatology (EULAR).
+Published by Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.ard.2025.09.013
+PMCID: PMC7618534
+PMID: 41395910 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests All authors declare they
+have no competing interests. Patient consent for publication: Written consent
+was obtained for pictures appearing in the manuscript. Ethics approval: The
+study was approved by the Comité de Protection des Personnes
+(ID-RCB/EUDRACT:2014-A01017-40; revalidated in 2022). Written informed consent
+was obtanied for all patients. Provenance and peer review: Not commissioned;
+externally peer reviewed.

--- a/references_cache/PMID_41932423.md
+++ b/references_cache/PMID_41932423.md
@@ -1,0 +1,112 @@
+---
+reference_id: "PMID:41932423"
+title: "Kidney Transplant Outcomes in Coatomer Protein Complex Subunit Alpha (COPA) Syndrome: Report of Five Patients."
+authors:
+- Triaille C
+- Côté K
+- Coulombe J
+- Daroux M
+- David C
+- Frémond ML
+- Haddad E
+- Khan N
+- Kokta V
+- Lapeyraque AL
+- Lebas C
+- Matoses Ruipérez ML
+- Montesinos BL
+- Reumaux H
+- Vogel TP
+- Morin MP
+- Phan V
+journal: Am J Kidney Dis
+year: '2026'
+doi: 10.1053/j.ajkd.2025.12.007
+content_type: abstract_only
+---
+
+# Kidney Transplant Outcomes in Coatomer Protein Complex Subunit Alpha (COPA) Syndrome: Report of Five Patients.
+**Authors:** Triaille C, Côté K, Coulombe J, Daroux M, David C, Frémond ML, Haddad E, Khan N, Kokta V, Lapeyraque AL, Lebas C, Matoses Ruipérez ML, Montesinos BL, Reumaux H, Vogel TP, Morin MP, Phan V
+**Journal:** Am J Kidney Dis (2026)
+**DOI:** [10.1053/j.ajkd.2025.12.007](https://doi.org/10.1053/j.ajkd.2025.12.007)
+
+## Content
+
+1. Am J Kidney Dis. 2026 Apr 1:S0272-6386(26)00837-1. doi:
+10.1053/j.ajkd.2025.12.007. Online ahead of print.
+
+Kidney Transplant Outcomes in Coatomer Protein Complex Subunit Alpha (COPA)
+Syndrome: Report of Five Patients.
+
+Triaille C(1), Côté K(2), Coulombe J(3), Daroux M(4), David C(5), Frémond ML(6),
+Haddad E(7), Khan N(8), Kokta V(2), Lapeyraque AL(9), Lebas C(10), Matoses
+Ruipérez ML(11), Montesinos BL(12), Reumaux H(13), Vogel TP(14), Morin MP(15),
+Phan V(9).
+
+Author information:
+(1)Pediatric rheumatology and immunology, Department of Pediatric, CHU
+Sainte-Justine, Université de Montréal, Montreal, Quebec, Canada; Pôle de
+pathologies rhumatismales systémiques et inflammatoires (RUMA), Institut de
+Recherche Expérimentale et Clinique (IREC), Université catholique de Louvain,
+Brussels, Belgium. Electronic address: clement.triaille@uclouvain.be.
+(2)Pathology Division, CHU Sainte-Justine, Department of Pediatrics, University
+of Montreal, Montreal, QC, Canada.
+(3)Dermatology, Department of Pediatric, CHU Sainte-Justine, Université de
+Montréal, Montreal, Quebec, Canada.
+(4)Department of Nephrology, Duchenne Hospital, Boulogne-Sur-Mer, France.
+(5)Département de Médecine Interne, Hôpital Bichat, Assistance Publique Hôpitaux
+de Paris, Paris, France; Laboratory of Neurogenetics and Neuroinflammation,
+Imagine Institute, Inserm U1163, Paris, France; COPA study group.
+(6)Laboratory of Neurogenetics and Neuroinflammation, Imagine Institute, Inserm
+U1163, Paris, France; COPA study group; Paediatric Immunology-Hematology and
+Rheumatology Unit, Necker Hospital, APHP Centre, Université Paris-Cité, Paris,
+and Reference Centre for Inflammatory Rheumatism, Autoimmune Diseases and
+Systemic Interferonopathies in Children (RAISE), France.
+(7)Pediatric rheumatology and immunology, Department of Pediatric, CHU
+Sainte-Justine, Université de Montréal, Montreal, Quebec, Canada; Department of
+Pediatrics, Department of microbiology, immunology and infectious diseases, CHU
+Sainte-Justine Azrieli Research Center, Université de Montréal, Montreal,
+Quebec, Canada.
+(8)Medical City Transplant, Dallas renal group, Dallas, Texas, USA.
+(9)Pediatric Nephrology, Department of Pediatric, CHU Sainte-Justine, Université
+de Montréal, Montreal, Quebec, Canada.
+(10)Department of Nephrology, CHU de Lille, Lille, France.
+(11)Section of Pediatric Rheumatology. Hospital Universitario y Politécnico la
+Fe, Valencia, Spain.
+(12)Pediatric Rheumatology Unit. Hospital Universitario y Policlínico La Fe, La
+Fe Health Research Institute, Valencia, Spain.
+(13)Pediatric Rheumatology, Jeanne de Flandre Hospital, CHU Lille, Lille,
+France.
+(14)Division of Rheumatology, Department of Pediatrics, Baylor College of
+Medicine, Houston, TX, USA; Center for Human Immunobiology, Texas Children's
+Hospital, Houston, TX, USA.
+(15)Pediatric rheumatology and immunology, Department of Pediatric, CHU
+Sainte-Justine, Université de Montréal, Montreal, Quebec, Canada.
+
+COPA (coatomer protein complex subunit α) syndrome is a rare inborn error of
+immunity associated with constitutive activation of type I interferon signaling.
+Organ inflammation and damage (i.e. lungs, kidneys, joints) usually develops
+early in life. Kidney involvement occurs in a subset of COPA syndrome patients,
+with the potential for rapid progression to kidney failure. Through an
+international collaboration, we identified COPA syndrome patients who developed
+kidney failure and underwent a kidney transplantation. The aim of the present
+report was to describe (i) the kidney involvement at presentation, (ii) the
+immunosuppressive strategies used before and after transplant, (iii) the kidney
+graft outcomes, and (iv) the evolution of the underlying COPA disease after
+transplantation. Five COPA syndrome patients were included. Kidney failure
+manifested at young age (range: 5 - 40 years). Kidney involvement was
+heterogenous between patients (ANCA-associated vasculitis-like disease, lupus or
+immune-complex mediated glomerulonephritis or overlapping phenotypes), and all
+had advanced histological damage at clinical presentation. Pulmonary disease of
+variable severity was also present in all patients. Kidney disease responded
+poorly to multiple lines of immunosuppression justifying kidney transplantation
+between the ages of 7.5 and 42 years. After a follow-up of 10 months-12 years,
+we report favorable graft outcomes in all patients (CKD stage 2-3b) but one
+patient developed polyomavirus infection (skin, kidney graft), and another died
+of progressive lung disease.
+
+Copyright © 2026 National Kidney Foundation, Inc. Published by Elsevier Inc. All
+rights reserved.
+
+DOI: 10.1053/j.ajkd.2025.12.007
+PMID: 41932423


### PR DESCRIPTION
## Summary
Curate a new COPA syndrome disorder entry in the dismech knowledge base.

## What Changed
- add `kb/disorders/COPA_Syndrome.yaml`
- add five supporting PubMed cache files required for deterministic reference validation
- capture COPA genetics, STING/interferon/TH17 pathophysiology, core pulmonary/joint/renal phenotypes, inheritance, and JAK inhibitor treatment evidence
- add frequency qualifiers where the cohort abstract supports a defensible band assignment

## Why
COPA syndrome was missing as a curated disorder entry despite being an in-scope monogenic immune dysregulation syndrome with characteristic lung, joint, and kidney involvement.

## Validation
- `just validate kb/disorders/COPA_Syndrome.yaml`
- pre-commit hooks passed during commit