### PR TITLE
[codex] Deepen Fabry disease cardiac mechanism coverage

### DIFF
--- a/kb/disorders/Fabry_Disease.yaml
+++ b/kb/disorders/Fabry_Disease.yaml
@@ -1,13 +1,12 @@
 name: Fabry disease
 creation_date: '2026-01-08T17:12:45Z'
-updated_date: '2026-02-16T20:19:38Z'
+updated_date: '2026-04-12T22:12:40Z'
 category: Mendelian
 disease_term:
   preferred_term: Fabry disease
   term:
     id: MONDO:0010526
     label: Fabry disease
-
 parents:
 - "Lysosomal storage diseases"
 - "X-linked genetic disorders"
@@ -18,6 +17,8 @@ description: >
   (Gb3) and its deacylated derivative globotriaosylsphingosine (lyso-Gb3). Substrate accumulation initiates a network of
   cellular stress responses including endoplasmic reticulum stress, autophagy impairment, mitochondrial dysfunction, and
   activation of innate immune pathways, leading to progressive organ damage in kidney, heart, vasculature, and nervous system.
+  In the heart, Fabry disease typically progresses from pre-hypertrophic sphingolipid storage and coronary microvascular
+  dysfunction to left ventricular hypertrophy, myocardial inflammation, replacement fibrosis, conduction disease, and heart failure.
 
 prevalence:
 - population: Global clinically recognized populations
@@ -82,6 +83,9 @@ pathophysiology:
     term:
       id: hgnc:4296
       label: GLA
+  downstream:
+  - target: Cardiomyocyte glycosphingolipid storage and hypertrophic remodeling
+  - target: Coronary microvascular dysfunction and subendocardial ischemia
 
 - name: Endoplasmic reticulum stress and unfolded protein response
   description: >
@@ -221,6 +225,151 @@ pathophysiology:
       id: hgnc:11766
       label: TGFB1
 
+- name: Cardiomyocyte glycosphingolipid storage and hypertrophic remodeling
+  description: >
+    Progressive sphingolipid storage within cardiomyocytes drives a cardiac remodeling program that starts before overt
+    hypertrophy and ultimately produces the Fabry cardiomyopathy phenotype. Low native T1 reflects myocardial storage,
+    while later increases in wall thickness and papillary muscle mass represent the hypertrophic response to intracellular
+    storage and growth-promoting signaling.
+  evidence:
+  - reference: PMID:31269811
+    reference_title: "Quantitative Myocardial Perfusion in Fabry Disease."
+    supports: SUPPORT
+    snippet: "Key myocardial processes that lead to adverse outcomes in FD include storage, hypertrophy, inflammation, and fibrosis."
+    explanation: "This human CMR study explicitly identifies storage and hypertrophy as core myocardial processes in Fabry cardiomyopathy."
+  - reference: PMID:16469946
+    reference_title: "Cardiac and vascular hypertrophy in Fabry disease: evidence for a new mechanism independent of blood pressure and glycosphingolipid deposition."
+    supports: SUPPORT
+    snippet: "LVH and CCA IMT occur concomitantly in Fabry suggesting common pathogenesis. The underlying cause may be a circulating growth-promoting factor whose presence has been confirmed in vitro."
+    explanation: "This study supports hypertrophic remodeling as an active pathogenic process in Fabry disease rather than a purely passive consequence of afterload."
+  cell_types:
+  - preferred_term: cardiomyocyte
+    term:
+      id: CL:0000746
+      label: cardiac muscle cell
+  locations:
+  - preferred_term: left ventricle
+    term:
+      id: UBERON:0002084
+      label: heart left ventricle
+  biological_processes:
+  - preferred_term: regulation of heart contraction
+    term:
+      id: GO:0008016
+      label: regulation of heart contraction
+  downstream:
+  - target: Myocardial inflammation
+
+- name: Coronary microvascular dysfunction and subendocardial ischemia
+  description: >
+    Fabry cardiac involvement includes an early coronary microvascular phenotype driven by endothelial and vascular smooth
+    muscle involvement. Stress myocardial blood flow falls before overt hypertrophy, is most reduced in the subendocardium,
+    and likely contributes to angina, chronic myocyte injury, and later scar formation.
+  evidence:
+  - reference: PMID:23818648
+    reference_title: "Coronary microvascular dysfunction is an early feature of cardiac involvement in patients with Anderson-Fabry disease."
+    supports: SUPPORT
+    snippet: "Coronary microvascular function is markedly impaired in AFD patients irrespective of LVH and gender. CMD may represent the only sign of cardiac involvement in AFD patients, with potentially important implications for clinical management."
+    explanation: "This PET study shows that coronary microvascular dysfunction is an early and sex-independent component of Fabry cardiac disease."
+  - reference: PMID:32514567
+    reference_title: "The myocardial phenotype of Fabry disease pre-hypertrophy and pre-detectable storage."
+    supports: SUPPORT
+    snippet: "There is a pre-LVH, pre-detectable storage phase of cardiac involvement in FD characterized by subtle abnormalities of microvascular dysfunction, impaired LV mechanics and altered atrial depolarization and ventricular repolarization intervals."
+    explanation: "This study supports a very early cardiac stage in Fabry disease in which microvascular dysfunction precedes overt hypertrophy."
+  cell_types:
+  - preferred_term: blood vessel endothelial cell
+    term:
+      id: CL:0000071
+      label: blood vessel endothelial cell
+  - preferred_term: blood vessel smooth muscle cell
+    term:
+      id: CL:0019018
+      label: blood vessel smooth muscle cell
+  locations:
+  - preferred_term: left ventricle
+    term:
+      id: UBERON:0002084
+      label: heart left ventricle
+  biological_processes:
+  - preferred_term: vasodilation
+    term:
+      id: GO:0042311
+      label: vasodilation
+    modifier: DECREASED
+  downstream:
+  - target: Myocardial inflammation
+  - target: Myocardial fibrosis and arrhythmogenic remodeling
+
+- name: Myocardial inflammation
+  description: >
+    After the storage phase, Fabry hearts develop a focal inflammatory phenotype, typically involving the basal inferolateral
+    myocardium, with late gadolinium enhancement, elevated T2, and chronic troponin release. This inflammatory activity can
+    persist despite enzyme replacement and appears to bridge storage to irreversible scar formation.
+  evidence:
+  - reference: PMID:31826677
+    reference_title: "Myocardial Storage, Inflammation, and Cardiac Phenotype in Fabry Disease After One Year of Enzyme Replacement Therapy."
+    supports: SUPPORT
+    snippet: "Low native T1 in Fabry disease represents sphingolipid accumulation; late gadolinium enhancement with high T2 and troponin elevation reflects inflammation."
+    explanation: "This longitudinal human CMR study directly links the Fabry cardiac inflammatory phase to LGE, elevated T2, and troponin release."
+  - reference: PMID:33602475
+    reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+    supports: SUPPORT
+    snippet: "Progress in imaging techniques have improved diagnosis and staging of FD-related cardiac disease, suggesting a central role for myocardial inflammation and setting the stage for further research."
+    explanation: "This cardiac-focused review supports myocardial inflammation as a central organizing feature of Fabry cardiomyopathy progression."
+  cell_types:
+  - preferred_term: cardiomyocyte
+    term:
+      id: CL:0000746
+      label: cardiac muscle cell
+  locations:
+  - preferred_term: left ventricle
+    term:
+      id: UBERON:0002084
+      label: heart left ventricle
+  biological_processes:
+  - preferred_term: inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  downstream:
+  - target: Myocardial fibrosis and arrhythmogenic remodeling
+
+- name: Myocardial fibrosis and arrhythmogenic remodeling
+  description: >
+    Chronic inflammation and microvascular injury culminate in interstitial and replacement fibrosis, especially in the
+    basal inferolateral left ventricle. Progressive scar burden creates the substrate for malignant ventricular arrhythmias,
+    atrial fibrillation, conduction disease, and late heart failure.
+  evidence:
+  - reference: PMID:37626912
+    reference_title: "Circulated TGF-β1 and VEGF-A as Biomarkers for Fabry Disease-Associated Cardiomyopathy."
+    supports: SUPPORT
+    snippet: "Elevation of TGF-β1 provides evidence of the chronic inflammatory state as a cause of myocardial fibrosis in FD patients; thus, it is a potential marker of early cardiac fibrosis detected even prior to hypertrophy."
+    explanation: "This study links chronic inflammatory signaling to early myocardial fibrosis in Fabry disease."
+  - reference: PMID:25073565
+    reference_title: "Relation of burden of myocardial fibrosis to malignant ventricular arrhythmias and outcomes in Fabry disease."
+    supports: SUPPORT
+    snippet: "Logistic multivariate regression analysis revealed that the annual increase in fibrosis during follow-up was the only independent predictor of MVAs."
+    explanation: "This outcome study directly supports progressive fibrosis as the key arrhythmogenic substrate in Fabry cardiomyopathy."
+  cell_types:
+  - preferred_term: cardiac fibroblast
+    term:
+      id: CL:0002548
+      label: fibroblast of cardiac tissue
+  locations:
+  - preferred_term: left ventricle
+    term:
+      id: UBERON:0002084
+      label: heart left ventricle
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  - preferred_term: cardiac conduction
+    term:
+      id: GO:0061337
+      label: cardiac conduction
+
 phenotypes:
 - name: Acrodystrophic neuropathic pain
   category: Neurological
@@ -307,10 +456,27 @@ phenotypes:
     snippet: "Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias, which limit quality of life and represent the most common causes of death"
     explanation: "Confirms that left ventricular hypertrophy is a major cardiac manifestation of Fabry disease"
   phenotype_term:
-    preferred_term: Cardiomyopathy
+    preferred_term: Left ventricular hypertrophy
     term:
-      id: HP:0001638
-      label: cardiomyopathy
+      id: HP:0001712
+      label: Left ventricular hypertrophy
+
+- name: Myocardial fibrosis
+  category: Cardiac
+  description: >
+    Replacement and interstitial fibrosis, typically highlighted by basal inferolateral late gadolinium enhancement on
+    cardiac MRI. This reflects progression from inflammation to scar and is a major determinant of ventricular arrhythmia risk.
+  evidence:
+  - reference: PMID:33602475
+    reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+    supports: SUPPORT
+    snippet: "Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias, which limit quality of life and represent the most common causes of death"
+    explanation: "This review explicitly identifies myocardial fibrosis as a core cardiac manifestation of Fabry disease."
+  phenotype_term:
+    preferred_term: Myocardial fibrosis
+    term:
+      id: HP:0001685
+      label: Myocardial fibrosis
 
 - name: Cardiac arrhythmia
   category: Cardiac
@@ -319,16 +485,50 @@ phenotypes:
     remodeling that create arrhythmogenic substrate.
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:31939530
-    reference_title: "Fabry disease: genetics, pathology, and treatment."
-    supports: NO_EVIDENCE
-    snippet: "Subsequently, symptoms related to progressive impairment appear, such as angiokeratomas, cornea verticillata, left ventricular hypertrophy, myocardial fibrosis, proteinuria, and renal insufficiency"
-    explanation: "Snippet supports myocardial fibrosis but does not directly report arrhythmia as a phenotype."
+  - reference: PMID:33602475
+    reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+    supports: SUPPORT
+    snippet: "Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias, which limit quality of life and represent the most common causes of death"
+    explanation: "This review directly identifies arrhythmias as a major cardiac manifestation of Fabry disease."
   phenotype_term:
     preferred_term: Arrhythmia
     term:
       id: HP:0011675
       label: Arrhythmia
+
+- name: Cardiac conduction abnormality
+  category: Cardiac
+  description: >
+    Fabry cardiomyopathy can produce early accelerated atrioventricular conduction followed later by sinus node dysfunction,
+    bundle branch block, or higher-grade atrioventricular block as storage and fibrosis involve the conduction system.
+  evidence:
+  - reference: PMID:22886820
+    reference_title: "Arrhythmias in Fabry cardiomyopathy."
+    supports: SUPPORT
+    snippet: "Implant indications included symptomatic bradycardia, nonsustained ventricular tachycardia, conduction abnormalities, palpitations, and syncope."
+    explanation: "This Fabry cardiomyopathy cohort documents clinically significant conduction abnormalities severe enough to prompt device therapy."
+  phenotype_term:
+    preferred_term: Cardiac conduction abnormality
+    term:
+      id: HP:0031546
+      label: Cardiac conduction abnormality
+
+- name: Heart failure
+  category: Cardiac
+  description: >
+    Progressive hypertrophy, fibrosis, microvascular ischemia, and rhythm disturbances eventually reduce cardiac reserve
+    and cause symptomatic heart failure, usually late in the disease course.
+  evidence:
+  - reference: PMID:33602475
+    reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+    supports: SUPPORT
+    snippet: "Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias, which limit quality of life and represent the most common causes of death"
+    explanation: "This review directly identifies heart failure as a major late cardiac manifestation of Fabry disease."
+  phenotype_term:
+    preferred_term: Congestive heart failure
+    term:
+      id: HP:0001635
+      label: Congestive heart failure
 
 - name: Stroke
   category: Neurological
@@ -391,7 +591,7 @@ genetic:
       snippet: "Fabry disease (FD) is a recessive monogenic inheritance disease linked to chromosome X, secondary to mutations in the GLA gene"
       explanation: "Confirms X-linked recessive inheritance pattern of Fabry disease"
     - reference: PMID:32723516
-      reference_title: "When and How to Diagnose Fabry Disease in Clinical Pratice."
+      reference_title: "When and How to Diagnose Fabry Disease in Clinical Practice."
       supports: SUPPORT
       snippet: "In male, diagnosis is made with alpha-galactosidase A enzyme activity dosage in leukocyte, that is very low or null in classical forms and under 30 percent in late-onset forms"
       explanation: "Describes enzyme activity testing thresholds for diagnosis in males based on disease form severity"

--- a/kb/disorders/Fabry_Disease.yaml
+++ b/kb/disorders/Fabry_Disease.yaml
@@ -1,6 +1,6 @@
 name: Fabry disease
 creation_date: '2026-01-08T17:12:45Z'
-updated_date: '2026-04-12T22:12:40Z'
+updated_date: '2026-04-12T22:56:30Z'
 category: Mendelian
 disease_term:
   preferred_term: Fabry disease
@@ -84,8 +84,8 @@ pathophysiology:
       id: hgnc:4296
       label: GLA
   downstream:
-  - target: Cardiomyocyte glycosphingolipid storage and hypertrophic remodeling
-  - target: Coronary microvascular dysfunction and subendocardial ischemia
+  - target: Cardiomyocyte glycosphingolipid storage
+  - target: Coronary microvascular dysfunction
 
 - name: Endoplasmic reticulum stress and unfolded protein response
   description: >
@@ -198,6 +198,8 @@ pathophysiology:
     term:
       id: GO:0061756
       label: leukocyte adhesion to vascular endothelial cell
+  downstream:
+  - target: Coronary microvascular dysfunction
 
 - name: Fibrosis and extracellular matrix remodeling
   description: >
@@ -225,23 +227,22 @@ pathophysiology:
       id: hgnc:11766
       label: TGFB1
 
-- name: Cardiomyocyte glycosphingolipid storage and hypertrophic remodeling
+- name: Cardiomyocyte glycosphingolipid storage
   description: >
-    Progressive sphingolipid storage within cardiomyocytes drives a cardiac remodeling program that starts before overt
-    hypertrophy and ultimately produces the Fabry cardiomyopathy phenotype. Low native T1 reflects myocardial storage,
-    while later increases in wall thickness and papillary muscle mass represent the hypertrophic response to intracellular
-    storage and growth-promoting signaling.
+    Progressive sphingolipid storage accumulates within cardiomyocytes early in Fabry cardiac disease, before overt
+    hypertrophy is established. Low native T1 reflects myocardial storage and marks the intracellular substrate-loading
+    phase of Fabry cardiomyopathy.
   evidence:
   - reference: PMID:31269811
     reference_title: "Quantitative Myocardial Perfusion in Fabry Disease."
     supports: SUPPORT
     snippet: "Key myocardial processes that lead to adverse outcomes in FD include storage, hypertrophy, inflammation, and fibrosis."
-    explanation: "This human CMR study explicitly identifies storage and hypertrophy as core myocardial processes in Fabry cardiomyopathy."
-  - reference: PMID:16469946
-    reference_title: "Cardiac and vascular hypertrophy in Fabry disease: evidence for a new mechanism independent of blood pressure and glycosphingolipid deposition."
+    explanation: "This human CMR study identifies myocardial storage as a core process in Fabry cardiomyopathy."
+  - reference: PMID:31826677
+    reference_title: "Myocardial Storage, Inflammation, and Cardiac Phenotype in Fabry Disease After One Year of Enzyme Replacement Therapy."
     supports: SUPPORT
-    snippet: "LVH and CCA IMT occur concomitantly in Fabry suggesting common pathogenesis. The underlying cause may be a circulating growth-promoting factor whose presence has been confirmed in vitro."
-    explanation: "This study supports hypertrophic remodeling as an active pathogenic process in Fabry disease rather than a purely passive consequence of afterload."
+    snippet: "Low native T1 in Fabry disease represents sphingolipid accumulation; late gadolinium enhancement with high T2 and troponin elevation reflects inflammation."
+    explanation: "This longitudinal CMR study directly supports cardiomyocyte sphingolipid storage as a distinct myocardial disease phase."
   cell_types:
   - preferred_term: cardiomyocyte
     term:
@@ -252,19 +253,38 @@ pathophysiology:
     term:
       id: UBERON:0002084
       label: heart left ventricle
-  biological_processes:
-  - preferred_term: regulation of heart contraction
+  downstream:
+  - target: Cardiomyocyte hypertrophic remodeling
+
+- name: Cardiomyocyte hypertrophic remodeling
+  description: >
+    After the myocardial storage phase, cardiomyocytes undergo hypertrophic remodeling with progressive wall thickening and
+    increased papillary muscle contribution to left ventricular mass. This represents an active growth response rather than
+    a simple passive consequence of pressure load.
+  evidence:
+  - reference: PMID:16469946
+    reference_title: "Cardiac and vascular hypertrophy in Fabry disease: evidence for a new mechanism independent of blood pressure and glycosphingolipid deposition."
+    supports: SUPPORT
+    snippet: "LVH and CCA IMT occur concomitantly in Fabry suggesting common pathogenesis. The underlying cause may be a circulating growth-promoting factor whose presence has been confirmed in vitro."
+    explanation: "This study supports hypertrophic remodeling as an active pathogenic process in Fabry disease."
+  cell_types:
+  - preferred_term: cardiomyocyte
     term:
-      id: GO:0008016
-      label: regulation of heart contraction
+      id: CL:0000746
+      label: cardiac muscle cell
+  locations:
+  - preferred_term: left ventricle
+    term:
+      id: UBERON:0002084
+      label: heart left ventricle
   downstream:
   - target: Myocardial inflammation
 
-- name: Coronary microvascular dysfunction and subendocardial ischemia
+- name: Coronary microvascular dysfunction
   description: >
     Fabry cardiac involvement includes an early coronary microvascular phenotype driven by endothelial and vascular smooth
-    muscle involvement. Stress myocardial blood flow falls before overt hypertrophy, is most reduced in the subendocardium,
-    and likely contributes to angina, chronic myocyte injury, and later scar formation.
+    muscle involvement. Stress myocardial blood flow falls before overt hypertrophy and may be the earliest detectable
+    sign of cardiac involvement in some patients.
   evidence:
   - reference: PMID:23818648
     reference_title: "Coronary microvascular dysfunction is an early feature of cardiac involvement in patients with Anderson-Fabry disease."
@@ -297,8 +317,37 @@ pathophysiology:
       label: vasodilation
     modifier: DECREASED
   downstream:
+  - target: Subendocardial ischemic injury
+
+- name: Subendocardial ischemic injury
+  description: >
+    Reduced stress perfusion in Fabry disease is most pronounced in the subendocardium, indicating ischemic myocardial
+    injury in the vulnerable inner ventricular wall. This ischemic injury helps connect coronary microvascular dysfunction
+    to inflammation, scar formation, angina, and progressive loss of myocardial reserve.
+  evidence:
+  - reference: PMID:31269811
+    reference_title: "Quantitative Myocardial Perfusion in Fabry Disease."
+    supports: SUPPORT
+    snippet: "FD patients have reduced perfusion, particularly in the subendocardium with greater reductions with LVH, storage, edema, and scar. Perfusion is reduced even without LVH suggesting it is an early disease marker."
+    explanation: "This study directly supports subendocardial hypoperfusion as a discrete downstream consequence of Fabry microvascular disease."
+  cell_types:
+  - preferred_term: cardiomyocyte
+    term:
+      id: CL:0000746
+      label: cardiac muscle cell
+  locations:
+  - preferred_term: left ventricle
+    term:
+      id: UBERON:0002084
+      label: heart left ventricle
+  biological_processes:
+  - preferred_term: response to hypoxia
+    term:
+      id: GO:0001666
+      label: response to hypoxia
+  downstream:
   - target: Myocardial inflammation
-  - target: Myocardial fibrosis and arrhythmogenic remodeling
+  - target: Myocardial fibrosis
 
 - name: Myocardial inflammation
   description: >
@@ -321,6 +370,10 @@ pathophysiology:
     term:
       id: CL:0000746
       label: cardiac muscle cell
+  - preferred_term: macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
   locations:
   - preferred_term: left ventricle
     term:
@@ -332,24 +385,19 @@ pathophysiology:
       id: GO:0006954
       label: inflammatory response
   downstream:
-  - target: Myocardial fibrosis and arrhythmogenic remodeling
+  - target: Myocardial fibrosis
 
-- name: Myocardial fibrosis and arrhythmogenic remodeling
+- name: Myocardial fibrosis
   description: >
     Chronic inflammation and microvascular injury culminate in interstitial and replacement fibrosis, especially in the
-    basal inferolateral left ventricle. Progressive scar burden creates the substrate for malignant ventricular arrhythmias,
-    atrial fibrillation, conduction disease, and late heart failure.
+    basal inferolateral left ventricle. Once established, this scar burden is only weakly reversible and marks the transition
+    from inflammatory injury to fixed structural remodeling.
   evidence:
   - reference: PMID:37626912
     reference_title: "Circulated TGF-β1 and VEGF-A as Biomarkers for Fabry Disease-Associated Cardiomyopathy."
     supports: SUPPORT
     snippet: "Elevation of TGF-β1 provides evidence of the chronic inflammatory state as a cause of myocardial fibrosis in FD patients; thus, it is a potential marker of early cardiac fibrosis detected even prior to hypertrophy."
     explanation: "This study links chronic inflammatory signaling to early myocardial fibrosis in Fabry disease."
-  - reference: PMID:25073565
-    reference_title: "Relation of burden of myocardial fibrosis to malignant ventricular arrhythmias and outcomes in Fabry disease."
-    supports: SUPPORT
-    snippet: "Logistic multivariate regression analysis revealed that the annual increase in fibrosis during follow-up was the only independent predictor of MVAs."
-    explanation: "This outcome study directly supports progressive fibrosis as the key arrhythmogenic substrate in Fabry cardiomyopathy."
   cell_types:
   - preferred_term: cardiac fibroblast
     term:
@@ -365,10 +413,25 @@ pathophysiology:
     term:
       id: GO:0030198
       label: extracellular matrix organization
-  - preferred_term: cardiac conduction
+  downstream:
+  - target: Arrhythmogenic ventricular remodeling
+
+- name: Arrhythmogenic ventricular remodeling
+  description: >
+    Progressive ventricular scar creates a re-entry-prone substrate that increases the risk of malignant ventricular
+    arrhythmias and sudden cardiac death. In Fabry disease, the tempo of fibrosis expansion is a stronger arrhythmic
+    determinant than static scar burden alone.
+  evidence:
+  - reference: PMID:25073565
+    reference_title: "Relation of burden of myocardial fibrosis to malignant ventricular arrhythmias and outcomes in Fabry disease."
+    supports: SUPPORT
+    snippet: "Logistic multivariate regression analysis revealed that the annual increase in fibrosis during follow-up was the only independent predictor of MVAs."
+    explanation: "This outcome study directly supports progressive fibrosis as the driver of arrhythmogenic ventricular remodeling in Fabry cardiomyopathy."
+  locations:
+  - preferred_term: left ventricle
     term:
-      id: GO:0061337
-      label: cardiac conduction
+      id: UBERON:0002084
+      label: heart left ventricle
 
 phenotypes:
 - name: Acrodystrophic neuropathic pain

--- a/references_cache/PMID_16469946.md
+++ b/references_cache/PMID_16469946.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:16469946"
+title: "Cardiac and vascular hypertrophy in Fabry disease: evidence for a new mechanism independent of blood pressure and glycosphingolipid deposition."
+authors:
+- Barbey F
+- Brakch N
+- Linhart A
+- Rosenblatt-Velin N
+- Jeanrenaud X
+- Qanadli S
+- Steinmann B
+- Burnier M
+- Palecek T
+- Bultas J
+- Hayoz D
+journal: Arterioscler Thromb Vasc Biol
+year: '2006'
+doi: 10.1161/01.ATV.0000209649.60409.38
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Animals
+- Blood Pressure
+- Blood Proteins/pharmacology
+- "Carotid Artery, Common/physiopathology"
+- Cell Proliferation/drug effects
+- "Cells, Cultured"
+- Echocardiography
+- "Fabry Disease/blood, etiology, physiopathology"
+- Female
+- Glycosphingolipids/metabolism
+- Humans
+- "Hypertrophy, Left Ventricular/etiology, physiopathology"
+- Male
+- Mice
+- Middle Aged
+- "Myocytes, Cardiac/pathology"
+- Rats
+- "Tunica Intima/pathology, physiopathology"
+- "Tunica Media/pathology, physiopathology"
+content_type: abstract_only
+---
+
+# Cardiac and vascular hypertrophy in Fabry disease: evidence for a new mechanism independent of blood pressure and glycosphingolipid deposition.
+**Authors:** Barbey F, Brakch N, Linhart A, Rosenblatt-Velin N, Jeanrenaud X, Qanadli S, Steinmann B, Burnier M, Palecek T, Bultas J, Hayoz D
+**Journal:** Arterioscler Thromb Vasc Biol (2006)
+**DOI:** [10.1161/01.ATV.0000209649.60409.38](https://doi.org/10.1161/01.ATV.0000209649.60409.38)
+
+## Content
+
+1. Arterioscler Thromb Vasc Biol. 2006 Apr;26(4):839-44. doi:
+10.1161/01.ATV.0000209649.60409.38. Epub 2006 Feb 9.
+
+Cardiac and vascular hypertrophy in Fabry disease: evidence for a new mechanism
+independent of blood pressure and glycosphingolipid deposition.
+
+Barbey F(1), Brakch N, Linhart A, Rosenblatt-Velin N, Jeanrenaud X, Qanadli S,
+Steinmann B, Burnier M, Palecek T, Bultas J, Hayoz D.
+
+Author information:
+(1)Nephrology Department, University Hospital, Lausanne, Switzerland.
+
+OBJECTIVE: Fabry disease is an X-linked disorder resulting from
+alpha-galactosidase A deficiency. The cardiovascular findings include left
+ventricular hypertrophy (LVH) and increased intima-media thickness of the common
+carotid artery (CCA IMT). The current study examined the possible correlation
+between these parameters. To corroborate these clinical findings in vitro,
+plasma from Fabry patients was tested for possible proliferative effect on rat
+vascular smooth muscle cells (vascular smooth muscle cell [VSMC]) and mouse
+neonatal cardiomyocytes.
+METHODS AND RESULTS: Thirty male and 38 female patients were enrolled. LVH was
+found in 60% of men and 39% of women. Increased CCA IMT was equally present in
+males and females. There was a strong positive correlation between LV mass and
+CCA IMT (r2=0.27; P<0.0001). VSMC and neonatal cardiomyocyte proliferative
+response in vitro correlated with CCA IMT (r2=0.39; P<0.0004) and LV mass index
+(r2=0.19; P=0.028), respectively.
+CONCLUSIONS: LVH and CCA IMT occur concomitantly in Fabry suggesting common
+pathogenesis. The underlying cause may be a circulating growth-promoting factor
+whose presence has been confirmed in vitro.
+
+DOI: 10.1161/01.ATV.0000209649.60409.38
+PMID: 16469946 [Indexed for MEDLINE]

--- a/references_cache/PMID_22886820.md
+++ b/references_cache/PMID_22886820.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:22886820"
+title: Arrhythmias in Fabry cardiomyopathy.
+authors:
+- Acharya D
+- Robertson P
+- Kay GN
+- Jackson L
+- Warnock DG
+- Plumb VJ
+- Tallaj JA
+journal: Clin Cardiol
+year: '2012'
+doi: 10.1002/clc.22047
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Arrhythmias, Cardiac/etiology"
+- Cardiomyopathies/complications
+- Fabry Disease/complications
+- Female
+- Humans
+- Male
+- Middle Aged
+- Retrospective Studies
+content_type: abstract_only
+---
+
+# Arrhythmias in Fabry cardiomyopathy.
+**Authors:** Acharya D, Robertson P, Kay GN, Jackson L, Warnock DG, Plumb VJ, Tallaj JA
+**Journal:** Clin Cardiol (2012)
+**DOI:** [10.1002/clc.22047](https://doi.org/10.1002/clc.22047)
+
+## Content
+
+1. Clin Cardiol. 2012 Dec;35(12):738-40. doi: 10.1002/clc.22047. Epub 2012 Aug 9.
+
+Arrhythmias in Fabry cardiomyopathy.
+
+Acharya D(1), Robertson P, Kay GN, Jackson L, Warnock DG, Plumb VJ, Tallaj JA.
+
+Author information:
+(1)Division of Cardiovascular Diseases, University of Alabama at Birmingham,
+Birmingham, Alabama, USA. dacharya@cardiology.uab.edu
+
+BACKGROUND: Prior studies suggest that the incidence of ventricular arrhythmias
+is high in patients with Fabry cardiomyopathy. This study evaluated the
+incidence of significant arrhythmias in a series of patients with Fabry
+cardiomyopathy.
+HYPOTHESIS: Arrhythmias are important causes of morbidity and mortality in Fabry
+Cardiomyopathy.
+METHODS: This study was a retrospective chart review of 19 patients with known
+Fabry cardiomyopathy. Device interrogation reports were reviewed for those who
+had implantable devices. Electrocardiogram, Holter monitor, and event monitors
+were reviewed in those who did not have implantable devices.
+RESULTS: Eighteen of nineteen patients were on enzyme replacement therapy (ERT).
+Nine (47%) out of 19 patients had implantable devices. Implant indications
+included symptomatic bradycardia, nonsustained ventricular tachycardia,
+conduction abnormalities, palpitations, and syncope. Mean follow-up in the
+patients with devices was 50 ± 23 months. Two patients received implantable
+cardioverter-defibrillator (ICD) shocks, 1 of which was inappropriate for atrial
+fibrillation. Patients were paced in the atrium 71% ± 37% of the time and paced
+in the ventricle 49% ± 52% of the time. Four patients with devices were paced
+more than 95% of the time. Patients with an ICD had lower heart rates prior to
+ICD implant than the group that did not have devices (60 ± 10 vs 78 ± 16, P =
+0.03). Of the patients without devices, only 1 had sudden cardiac death.
+Patients with implanted devices had higher left ventricular (LV) mass indices
+compared to patients without implanted devices (136 ± 40 g/m(2) vs 93 ± 19
+g/m(2), P = 0.008).
+CONCLUSIONS: Significant ventricular arrhythmias are uncommon in patients with
+Fabry cardiomyopathy on ERT, but utilization of pacing is high. Sudden cardiac
+death in Fabry cardiomyopathy may be related to bradycardia.
+
+© 2012 Wiley Periodicals, Inc.
+
+DOI: 10.1002/clc.22047
+PMCID: PMC6652687
+PMID: 22886820 [Indexed for MEDLINE]

--- a/references_cache/PMID_23818648.md
+++ b/references_cache/PMID_23818648.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:23818648"
+title: Coronary microvascular dysfunction is an early feature of cardiac involvement in patients with Anderson-Fabry disease.
+authors:
+- Tomberli B
+- Cecchi F
+- Sciagrà R
+- Berti V
+- Lisi F
+- Torricelli F
+- Morrone A
+- Castelli G
+- Yacoub MH
+- Olivotto I
+journal: Eur J Heart Fail
+year: '2013'
+doi: 10.1093/eurjhf/hft104
+keywords:
+- Adult
+- Analysis of Variance
+- Coronary Circulation
+- Cross-Sectional Studies
+- Echocardiography/methods
+- Fabry Disease/complications
+- Female
+- "Heart Ventricles/pathology, physiopathology"
+- Humans
+- "Hypertrophy, Left Ventricular/diagnosis, etiology, physiopathology"
+- Italy
+- Male
+- Microvessels/physiopathology
+- Middle Aged
+- Positron-Emission Tomography/methods
+- Sex Factors
+content_type: abstract_only
+---
+
+# Coronary microvascular dysfunction is an early feature of cardiac involvement in patients with Anderson-Fabry disease.
+**Authors:** Tomberli B, Cecchi F, Sciagrà R, Berti V, Lisi F, Torricelli F, Morrone A, Castelli G, Yacoub MH, Olivotto I
+**Journal:** Eur J Heart Fail (2013)
+**DOI:** [10.1093/eurjhf/hft104](https://doi.org/10.1093/eurjhf/hft104)
+
+## Content
+
+1. Eur J Heart Fail. 2013 Dec;15(12):1363-73. doi: 10.1093/eurjhf/hft104. Epub
+2013  Jun 30.
+
+Coronary microvascular dysfunction is an early feature of cardiac involvement in
+patients with Anderson-Fabry disease.
+
+Tomberli B(1), Cecchi F, Sciagrà R, Berti V, Lisi F, Torricelli F, Morrone A,
+Castelli G, Yacoub MH, Olivotto I.
+
+Author information:
+(1)Department of Clinical and Experimental Medicine, University of Florence,
+Italy.
+
+AIMS: Male patients with Anderson-Fabry disease (AFD) often exhibit cardiac
+involvement, characterized by LV hypertrophy (LVH), associated with severe
+coronary microvascular dysfunction (CMD). Whether CMD is present in patients
+without LVH, particularly when female, remains unresolved. The aim of the study
+was to investigate the presence of CMD by positron emission tomography (PET) in
+AFD patients of both genders, with and without evidence of LVH.
+METHODS AND RESULTS: We assessed myocardial blood flow following dipyridamole
+infusion (Dip-MBF) with 13N-labelled ammonia by PET in 30 AFD patients (age 51 ±
+13 years; 18 females) and in 24 healthy controls. LVH was defined as
+echocardiographic maximal LV wall thickness ≥13 mm. LVH was present in 67% of
+patients (n = 20; 10 males and 10 females). Dip-MBF was reduced in all patients
+compared with controls (1.8 ± 0.5 and 3.2 ± 0.5 mL/min/g, respectively, P <
+0.001). For both genders, flow impairment was most severe in patients with LVH
+(1.4 ± 0.5 mL/min/g in males and 1.9 ± 0.5 mL/min/g in females), but was also
+evident in those without LVH (1.8 ± 0.3 mL/min/g in males and 2.1 ± 0.4 mL/min/g
+in females; overall P = 0.064 vs. patients with LVH). Analysis of variance
+(ANOVA) for the 17 LV segments showed marked regional heterogeneity of MBF in
+AFD (F = 4.46, P < 0.01), with prevalent hypoperfusion of the apical region.
+Conversely, controls showed homogeneous LV perfusion (F = 1.25, P = 0.23).
+CONCLUSIONS: Coronary microvascular function is markedly impaired in AFD
+patients irrespective of LVH and gender. CMD may represent the only sign of
+cardiac involvement in AFD patients, with potentially important implications for
+clinical management.
+
+DOI: 10.1093/eurjhf/hft104
+PMID: 23818648 [Indexed for MEDLINE]

--- a/references_cache/PMID_25073565.md
+++ b/references_cache/PMID_25073565.md
@@ -1,0 +1,91 @@
+---
+reference_id: "PMID:25073565"
+title: Relation of burden of myocardial fibrosis to malignant ventricular arrhythmias and outcomes in Fabry disease.
+authors:
+- Krämer J
+- Niemann M
+- Störk S
+- Frantz S
+- Beer M
+- Ertl G
+- Wanner C
+- Weidemann F
+journal: Am J Cardiol
+year: '2014'
+doi: 10.1016/j.amjcard.2014.06.019
+keywords:
+- Adult
+- Biomarkers/blood
+- "Cardiomyopathies/diagnosis, epidemiology, etiology"
+- Collagen/blood
+- Disease Progression
+- "Electrocardiography, Ambulatory"
+- "Fabry Disease/blood, complications, diagnosis"
+- Female
+- "Fibrosis/diagnosis, epidemiology, etiology"
+- Follow-Up Studies
+- Germany/epidemiology
+- Humans
+- "Magnetic Resonance Imaging, Cine"
+- Male
+- Myocardium/pathology
+- Prospective Studies
+- Survival Rate/trends
+- "Tachycardia, Ventricular/diagnosis, epidemiology, etiology"
+- Time Factors
+content_type: abstract_only
+---
+
+# Relation of burden of myocardial fibrosis to malignant ventricular arrhythmias and outcomes in Fabry disease.
+**Authors:** Krämer J, Niemann M, Störk S, Frantz S, Beer M, Ertl G, Wanner C, Weidemann F
+**Journal:** Am J Cardiol (2014)
+**DOI:** [10.1016/j.amjcard.2014.06.019](https://doi.org/10.1016/j.amjcard.2014.06.019)
+
+## Content
+
+1. Am J Cardiol. 2014 Sep 15;114(6):895-900. doi: 10.1016/j.amjcard.2014.06.019.
+Epub 2014 Jul 2.
+
+Relation of burden of myocardial fibrosis to malignant ventricular arrhythmias
+and outcomes in Fabry disease.
+
+Krämer J(1), Niemann M(1), Störk S(1), Frantz S(1), Beer M(2), Ertl G(1), Wanner
+C(1), Weidemann F(3).
+
+Author information:
+(1)Department of Internal Medicine I, University of Würzburg, Würzburg, Germany;
+Comprehensive Heart Failure Center, University of Würzburg, Würzburg, Germany.
+(2)Institute of Radiology, University of Ulm, Ulm, Germany.
+(3)Department of Internal Medicine I, University of Würzburg, Würzburg, Germany;
+Comprehensive Heart Failure Center, University of Würzburg, Würzburg, Germany.
+Electronic address: weidemann_f@ukw.de.
+
+The aim of this study was to investigate the impact of myocardial fibrosis in
+Fabry disease. Seventy-three patients with genetically confirmed Fabry disease
+were followed for 4.8 ± 2.4 years. In accordance with current guidelines, 57
+patients received enzyme replacement therapy (ERT) after study inclusion,
+whereas 16 did not. At baseline and latest possible follow-up, myocardial
+fibrosis was assessed noninvasively by cardiac magnetic resonance, and
+biomarkers of collagen metabolism were determined. Holter electrocardiography
+and clinical follow-up at yearly intervals were used to monitor malignant
+ventricular arrhythmias (MVAs; nonsustained and sustained ventricular
+tachycardia and sudden cardiac death). In total, 48 patients (66%) showed
+fibrosis assessed by late enhancement (LE) at baseline, and 4 patients developed
+new LE during follow-up, 2 of them despite ERT. The 2 patients receiving ERT
+(1.4 ± 1.9% vs 2.5 ± 2.6%, p <0.001) and the patients not receiving ERT (0.5 ±
+0.8% vs 0.7 ± 1.0%, p = 0.035) showed a progression of LE during follow-up. None
+of the patients displayed reductions of LE during follow-up. Collagen biomarkers
+were elevated in patients with and without LE but did not correlate with LE
+amount. Thirteen LE-positive patients at the baseline examination had documented
+MVAs (including 5 sudden cardiac deaths), whereas none of the patients without
+LE had MVAs. The yearly increase in fibrosis was 0.9 ± 0.6% in patients with
+MVAs and 0.2 ± 0.3% in patients without MVAs (p <0.001). Logistic multivariate
+regression analysis revealed that the annual increase in fibrosis during
+follow-up was the only independent predictor of MVAs. In conclusion, myocardial
+fibrosis in Fabry disease is progressive, apparently not modified by ERT, and a
+crucial outcome determinant.
+
+Copyright © 2014 The Authors. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.amjcard.2014.06.019
+PMID: 25073565 [Indexed for MEDLINE]

--- a/references_cache/PMID_31269811.md
+++ b/references_cache/PMID_31269811.md
@@ -1,0 +1,149 @@
+---
+reference_id: "PMID:31269811"
+title: Quantitative Myocardial Perfusion in Fabry Disease.
+authors:
+- Knott KD
+- Augusto JB
+- Nordin S
+- Kozor R
+- Camaioni C
+- Xue H
+- Hughes RK
+- Manisty C
+- Brown LAE
+- Kellman P
+- Ramaswami U
+- Hughes D
+- Plein S
+- Moon JC
+journal: Circ Cardiovasc Imaging
+year: '2019'
+doi: 10.1161/CIRCIMAGING.119.008872
+keywords:
+- Adult
+- "Fabry Disease/complications, physiopathology"
+- Female
+- "Heart/diagnostic imaging, physiopathology"
+- Humans
+- Male
+- Middle Aged
+- Multiparametric Magnetic Resonance Imaging/methods
+- Prospective Studies
+- "Ventricular Dysfunction, Left/complications, diagnostic imaging, physiopathology"
+content_type: full_text_xml
+---
+
+# Quantitative Myocardial Perfusion in Fabry Disease.
+**Authors:** Knott KD, Augusto JB, Nordin S, Kozor R, Camaioni C, Xue H, Hughes RK, Manisty C, Brown LAE, Kellman P, Ramaswami U, Hughes D, Plein S, Moon JC
+**Journal:** Circ Cardiovasc Imaging (2019)
+**DOI:** [10.1161/CIRCIMAGING.119.008872](https://doi.org/10.1161/CIRCIMAGING.119.008872)
+
+## Content
+
+1. Circ Cardiovasc Imaging. 2019 Jul;12(7):e008872. doi:
+10.1161/CIRCIMAGING.119.008872. Epub 2019 Jul 4.
+
+Quantitative Myocardial Perfusion in Fabry Disease.
+
+Knott KD(1)(2), Augusto JB(1)(2), Nordin S(1)(2), Kozor R(3), Camaioni C(2), Xue
+H(4), Hughes RK(1)(2), Manisty C(1)(2), Brown LAE(5), Kellman P(4), Ramaswami
+U(6), Hughes D(6), Plein S(5), Moon JC(1)(2).
+
+Author information:
+(1)Institute of Cardiovascular Science, University College London, United
+Kingdom (K.D.K., J.B.A., S.N., R.K.H., C.M., J.C.M.).
+(2)Advanced Cardiac Imaging, Barts Heart Centre, The Cardiovascular Magnetic
+Resonance Imaging Unit and The Inherited Cardiovascular Diseases Unit, St
+Bartholomew's Hospital, West Smithfield, London, United Kingdom (K.D.K., J.B.A.,
+S.N., C.C., R.K.H., C.M., J.C.M.).
+(3)Sydney Medical School, University of Sydney, Australia (R.K.).
+(4)Medical Signal and Image Processing, National Heart, Lung, and Blood
+Institute, National Institutes of Health, DHHS, Bethesda, MD (H.X., P.K.).
+(5)Department of Biomedical Imaging Science, Leeds Institute of Cardiovascular
+and Metabolic Medicine, University of Leeds, Clarendon Way, United Kingdom
+(L.A.E.B., S.P.).
+(6)Lysosomal Storage Disorder Unit, Royal Free Hospital, London, United Kingdom
+(U.R., D.H.).
+
+Comment in
+    Circ Cardiovasc Imaging. 2019 Jul;12(7):e009440. doi:
+10.1161/CIRCIMAGING.119.009440.
+
+BACKGROUND: Fabry disease (FD) is an X-linked lysosomal storage disease
+resulting in tissue accumulation of sphingolipids. Key myocardial processes that
+lead to adverse outcomes in FD include storage, hypertrophy, inflammation, and
+fibrosis. These are quantifiable by multiparametric cardiovascular magnetic
+resonance. Recent developments in cardiovascular magnetic resonance perfusion
+mapping allow rapid in-line perfusion quantification permitting broader clinical
+application, including the assessment of microvascular dysfunction. We
+hypothesized that microvascular dysfunction in FD would be associated with
+storage, fibrosis, and edema.
+METHODS: A prospective, observational study of 44 FD patients (49 years, 43%
+male, 24 [55%] with left ventricular hypertrophy [LVH]) and 27 healthy controls
+with multiparametric cardiovascular magnetic resonance including vasodilator
+stress perfusion mapping. Myocardial blood flow (MBF) was measured and its
+associations with other processes investigated.
+RESULTS: Compared with LVH- FD, LVH+ FD had higher left ventricular ejection
+fraction (73% versus 68%), more late gadolinium enhancement (85% versus 15%),
+and a lower stress MBF (1.76 versus 2.36 mL/g per minute). The reduction in
+stress MBF was more pronounced in the subendocardium than subepicardium. LVH- FD
+had lower stress MBF than controls (2.36 versus 3.00 mL/g per minute; P=0.002).
+Across all FD, late gadolinium enhancement and low native T1 were independently
+associated with reduced stress MBF. On a per-segment basis, stress MBF was
+independently associated with wall thickness, T2, extracellular volume fraction,
+and late gadolinium enhancement.
+CONCLUSIONS: FD patients have reduced perfusion, particularly in the
+subendocardium with greater reductions with LVH, storage, edema, and scar.
+Perfusion is reduced even without LVH suggesting it is an early disease marker.
+
+DOI: 10.1161/CIRCIMAGING.119.008872
+PMCID: PMC8323709
+PMID: 31269811 [Indexed for MEDLINE]
+
+Fabry disease (FD) is an X-linked lysosomal storage disease caused by mutations in the gene encoding the α-GLA (α-galactosidase A) enzyme. This results in the inability to break down sphingolipids and their accumulation in organs including the heart, skin, kidneys, and brain.1 Myocardial deposition of sphingolipids is gradual, taking decades, causing left ventricular (LV) hypertrophy (LVH) and often arrhythmias, heart failure, and death.2,3 Treatment includes oral chaperone therapy (OCT) or intravenous enzyme replacement therapy (ERT) to restore enzymatic activity, reduce sphingolipids, and prevent organ dysfunction.4–6 Multiparametric cardiovascular magnetic resonance (CMR) can characterize several processes within the cardiac FD phenotype development with an initial sphingolipid storage phase, detected as low myocardial T1,7 triggered LVH with focal, and then more widespread inflammation leading to fibrosis.8 Inflammation and fibrosis typically start in the basal inferolateral wall and can be visualized with late gadolinium enhancement (LGE)9,10 with edema detected using T2 mapping and inferred as inflammation and myocyte death by detected troponin release.11 LVH, apparently from triggered hypertrophy is more marked in males and often results pseudonormalization in myocardial T1.8 These following processes: storage, cell response, inflammation, and fibrosis are consistent with other organ involvement in FD. FD also causes endothelial storage and microvascular dysfunction,12,13 but this has not been well characterized in the FD heart.
+
+Noninvasive imaging can quantify tissue perfusion—myocardial blood flow (MBF, mL/g per minute) at rest and during vasodilator stress to detect microvascular dysfunction. Positron emission tomography (PET) has been the gold standard modality14 but is limited by inferior spatial resolution, ionizing radiation use, availability, and does not provide multiparametric detail.15,16 Recently, quantitative perfusion CMR has been developed with perfusion mapping17 where fully automated analysis occurs inline on the scanner using the Gadgetron framework18,19 generating perfusion maps similar to T1 or T2 maps—but where each pixel color represents local flow in milliliters per gram per minute. Initial validation results (eg, against PET and coronary angiography) are good20,21 and intersubject repeatability is similar to the published PET literature..22,23 CMR perfusion mapping, being fast and free from ionizing radiation, has potential in a wide range of circumstances. In hypertrophic cardiomyopathy, microvascular dysfunction is known to occur, increasing with LVH and LGE and may be early, before hypertrophy.24,25 Microvascular dysfunction in hypertrophic cardiomyopathy is linked to adverse outcomes.26 In FD, myocardial perfusion is reported as reduced in PET studies27 and not changed by ERT,28,29 but the studies to date have been small and the relationship of such changes to storage, hypertrophy, inflammation, and scar is unknown.
+
+In this study, we recruited FD patients for multiparametric CMR including vasodilator perfusion mapping for microvascular dysfunction. We hypothesized that microvascular dysfunction is an early marker in FD and would be associated with storage, fibrosis, and edema.
+
+The data that support the findings of this study are available from the corresponding author on reasonable request. The study was approved by the National Health Service Research Ethics Committee and Health Research Authority and conducted in accordance with the Declaration of Helsinki. All subjects provided written, informed consent. Forty-four patients with FD and a healthy control cohort (27 subjects) were recruited. All subjects underwent multiparametric CMR. FD exclusion criteria were aged <18 years, ischemic heart disease, severe chronic kidney disease (estimated glomerular filtration rate <30 mmol/L), contraindication to magnetic resonance imaging or adenosine. Patient cardiovascular history, symptoms, and ERT status were assessed at the time of the CMR with a questionnaire. The healthy control cohort were volunteers who had no cardiac symptoms, medications, or comorbidities.
+
+CMR scans were performed at 1.5 Tesla (Aera, Siemens Healthcare, Erlangen, Germany) using a standard clinical protocol.30 The protocol consisted of cine imaging, native T1 mapping (using a modified look-locker inversion recovery sequence), T2 mapping, stress and rest perfusion, late gadolinium enhancement (LGE), and postcontrast T1 mapping. Synthetic extracellular volume fraction (ECV) was derived from the native and postcontrast T1 maps.31 T1, T2, and ECV mapping were performed for basal, mid, and apical short axis and 3 long axis slices.
+
+Vasodilator stress perfusion was performed using a standard clinical approach. Adenosine (140 μg/kg per minute, increased to 175 μg/kg per minute for a further 2 minutes if <10% heart rate increase or no symptoms) was infused.30,32 A gadolinium-based contrast agent (gadoterate meglumine, Dotarem; Guerbet, Paris, France) was injected into a peripheral vein at 4 mL/s during peak vasodilator stress at a dose of 0.05 mmoL/kg. Sixty images were acquired for basal, mid, and apical LV short-axis slices. It was retrospectively confirmed that splenic switch off was achieved, indicating adequate stress.33 Rest perfusion images were acquired subsequently after an interval of 6 to 10 minutes. Perfusion mapping implemented using the Gadgetron streaming software image reconstruction framework is previously described.17,18
+
+CMR was analyzed using commercially available software (CVI42; Circle Cardiovascular Imaging, Calgary, AB, Canada). For parametric map analysis, endo- and epicardial contours were manually drawn and the right ventricular insertion points identified. The borders were offset by 10% and a 16 segment American Heart Association model34 created for each parameter (eg, T1, T2, stress, and rest MBF, ECV), along with a global mean value (mean across all segments). In addition, to measure possible transmural gradients, stress MBF was split into endocardial and epicardial MBF by adjusting the offsets to 50% of the myocardium. Normal ranges for T1 and T2 are sequence and scanner dependent. Normal ranges at our center have been established in accordance with the current Society for Cardiovascular Magnetic Resonance consensus statement.35
+
+LV volume analysis was performed by contouring each short axis slice in diastole and systole. Papillary muscles were excluded from the LV volume and included as LV mass. The maximal diastolic wall thickness was measured. LVH was defined as a maximum wall thickness >12 mm, as measured by CMR.36
+
+LGE was assessed for each myocardial segment. A region of interest was manually drawn in visually normal myocardium and LGE identified automatically for pixels 5 SDs above the mean signal intensity of the normal myocardium.37 The presence or absence of LGE was then noted for each segment and globally.
+
+Statistical analysis was performed in SPSS (IBM SPSS statistics, Version 25.0). Continuous variables are presented as mean±SD; categorical as absolute values and percentages. Patients were divided into those with and without LVH and analyzed compared with volunteers using ANOVA or Kruskal-Wallis for parametric and nonparametric variables, respectively, and χ2 for categorical variables. Pairwise comparisons between groups were performed using Bonferroni adjustment. A P of <0.05 and was considered significant.
+
+A simple linear regression analysis was performed to determine the factors that contribute to stress MBF. Subsequently, the variables that were significantly associated were used in a multiple linearregression analysis. The analysis was performed on a per patient basis, inputting the age, sex, treatment status, indexed EDV, indexed LV mass, left ventricular ejection fraction, mean T1, T2, ECV, the presence of LGE and LVH. An analysis was also performed on a per segment basis. In this analysis, the effect of each CMR variable on stress MBF was considered on an American Heart Association segment basis. Wall thickness, native T1, T2, ECV, and percentage of LGE were treated as continuous variables. A mixed effects linear regression controlled for subject dependency.
+
+Forty-four patients (19 males; 43%), mean age 49 years were recruited. A total of 30 patients (44%) were on treatment (ERT or OCT [9 patients]). Twenty-four patients (55%) had LVH, and 23 patients (52%) were positive for LGE. Compared with controls, patients had higher indexed LV mass (90.6 versus 52.3 g/m2; P<0.001), ejection fraction (70% versus 65%; P=0.007), lower septal T1 (959 versus 1015 ms; P<0.001), and higher septal T2 (49.3 versus 47.5 ms; P=0.025; Table 1). The control cohort (n=27) were age matched to the FD patients who did not have LVH (38.1 versus 42.3 years; P=0.264). Patients with LVH were older than those without LVH (54.6 versus 42.3 years; P=0.006) and a greater proportion were male (62.5% versus 20%; P=0.003). They had a higher ejection fraction (72.8% versus 66.7%; P=0.03) and a higher LV mass (117.4 versus 58.43 g/m2; P<0.001) than patients without LVH (Table 2). Compared with controls, a greater proportion of LVH-negative patients were females but no other significant differences (Table 2). Of the LVH-negative patients, 7 (35%) had low septal T1 (based on 1 septal segment classification). The cardiac phenotype of patients on ERT was more advanced than those on no therapy, with higher LV mass (115 versus 60 g/m2), lower T1 (933 versus 1000 ms), and a higher proportion of LGE (77% versus 21%). The OCT group was a mixture of patients who had previously been on long-term ERT (all patients on ERT had been receiving therapy for >1 year) and new-starters, with the shortest duration of therapy 6 months (the drug has only been recently introduced). Their cardiac phenotype was intermediate between ERT and no therapy patients: LV mass, 77 g/m2; T1, 959 ms; LGE, 38%.
+
+Cardiovascular risk factors were similar between LVH-positive and -negative patients with only atrial fibrillation being statistically higher in the LVH-positive group 5 (21%) versus 0 patients (0%); P=0.02. Hypertension was present in 4 (17%) versus 3 patients (15%), P=0.88; hyperlipidemia 4 (17%) versus 1 patient (5%), P=0.21; renal impairment 3 (13%) versus 1 patient (5%), P=0.40; stroke 1 (4%) versus 2 patients (10%), P=0.46 for LVH-positive and LVH-negative patients, respectively. Similarly, a minority of patients had symptoms. The most common was palpitations, which was present in 8 (33%) LVH-positive and 4 (20%) LVH-negative patients. Six (25%) of the LVH-positive patients and 1 (5%) of the LVH negative patients complained of breathlessness. Four (17%) LVH-positive patients and 2 (10%) LVH-negative patients complained of chest pain. The majority of patients were New York Heart Association functional class I (30/44, 68%), 12 patients were class II (27%), and 2 (5%) patients had mobility limited by musculoskeletal problems.
+
+Global stress MBF was lower in FD than controls (2.04 versus 3.00 mL/g per minute; P<0.001), but there was no difference in rest MBF (0.85 versus 0.86; P=0.85). Stress MBF was lower when there was LVH (1.76 versus 2.36 mL/g per minute; P=0.005), but stress MBF was also lower in LVH-negative FD compared with controls (2.36 versus 3.00 mL/g per minute; P=0.002; Figures 1 and 2). It is possible that chest pain and breathlessness may have been symptoms of microvascular dysfunction, and these patients had a lower stress MBF than those with no symptoms (1.68 versus 2.11 mL/g per minute; P=0.039).
+
+Stress MBF in FD was lower in the endocardium than epicardium (1.84 versus 2.13 mL/g per minute; P=0.022) but not in controls (3.10 versus 2.85 mL/g per minute; P=0.271). However, this was only significant in patients with LVH (1.88 versus 1.50 mL/g per minute; P=0.013); in LVH-negative patients, epicardial and endocardial stress MBF was not significantly different (2.44 versus 2.25 mL/g per minute; P=0.2078; Figure 3).
+
+To predict FD global stress MBF, a simple linear regression analysis was performed including age, sex, ERT/OCT treatment, indexed EDV, ejection fraction, indexed LV mass, presence of LGE, LVH (yes/no), T1, T2, and ECV. Of these, age, T1, T2, ECV, LGE, and LVH were significantly associated and used for the multivariate model. In this, independently associated variables were (order of association strength) the presence of LGE and low T1 (R2 for the model 0.572; P<0.001; Table 3).
+
+To predict FD segmental stress MBF (including 704 segments), a multivariate model included wall thickness, native T1, T2, ECV, and LGE, controlling for within subject dependency. The thickest myocardium was associated with the lowest stress MBF (Figure 4). In addition, high T2, high ECV, and the presence of LGE were independently associated with a lower myocardial stress MBF (Table 4).
+
+These data show that patients with Fabry disease have lower stress MBF than healthy controls even in those patients without LVH. Perfusion appears to track disease severity with LVH, inflammation (elevated T2), and scar (elevated ECV and LGE) being associated with reduced segmental MBF (Figure 1).
+
+While there have been a few small studies to date that have used quantitative PET to measure MBF in patients with FD, this is the first in which CMR has been used to quantify perfusion in the context of a multiparametric assessment. Furthermore, this is the largest study of perfusion in FD across all modalities and for the first time includes LVH-negative patients with an age-matched control group. Our results support the PET findings that found reduced stress perfusion in FD.28,29 These studies also sought treatment effect, and although 1 study was negative, the other found a correlation between pretreatment relative wall thickness and posttreatment changes in flow reserve, hypothesizing that patients treated early may gain more benefit from ERT. Such findings could be explored in greater detail using multiparametric CMR as it enables quantification of LVH, storage, inflammation, and fibrosis in addition, now, to perfusion.7,9,11
+
+The findings of our study suggest that this reduction in stress MBF occurs early in the FD disease course and is related to features of myocardial disease severity. This early reduction in stress MBF is interesting. The current study did not have the statistical power to detect if it was associated with myocardial storage before LVH—further work will be needed. It is, however, possible that abnormalities in microvascular perfusion, if related to endothelial storage and dysfunction, could precede myocyte storage and be the earliest sign of myocardial involvement in FD. Another explanation could be that our detection of myocardial storage with low T1 has a threshold effect whereby a certain amount of storage needs to occur before T1 lowers, but our imaging is more sensitive to detect MBF abnormalities. Such dysfunction may also contribute to FD patient symptoms that are hard to pin down, such as fatigue and reduced cardiopulmonary exercise test performance. Endothelial cells may be more amenable or faster to de-sphingation (clearance of sphingolipids) than myocytes (a scenario familiar in the kidney with podocytes38) so the investigation of ERT effect in preLVH disease would be particularly interesting mechanistically. This in turn could be a useful surrogate end point in drug studies and may provide insights into drivers of hypertrophy and basal lateral inflammation/scar.
+
+Structural changes in the myocardial microvasculature have been explored using biopsy. Chimenti et al39 compared endomyocardial biopsies of 13 FD patients with angina to a control cohort of FD patients with no chest pain. Although the endothelial cells were swollen and proliferating because of storage, arteriolar luminal narrowing was also because of hypertrophy and hyperplasia of the smooth muscle cells and increased fibrosis within the intimal and medial layers. In addition, this pattern was more often associated with perivascular myocardial fibrosis surrounding the most affected vessels. There was less luminal narrowing in those patients without angina. The results of our study are consistent with such processes. We have shown noninvasively that myocardial segments with increased hypertrophy, sphingolipid deposition (low T1), and fibrosis (high ECV and LGE) have the lowest myocardial perfusion. There is currently no treatment proven to be effective in microvascular dysfunction in either Fabry disease or hypertrophic cardiomyopathy. With the use of perfusion mapping, it would now be possible to assess the efficacy of ERT/OCT on improving the microvasculature. In another model of LVH—hypertension, there is the suggestion that the combination of angiotensin-converting enzyme inhibitors and thiazide diuretics improves microvascular function, and this has been shown in hypertensive rat models and small human studies40,41
+
+CMR has another advantage over PET with the resolution to better discriminate transmyocardial perfusion gradients. Here, FD impairment in perfusion was more pronounced in the subendocardium. It has been shown in healthy animal models that vasodilatory flow in the subendocardium is relatively reduced compared with the subepicardium, and this is more pronounced in heart failure models because of chronic subendocardial fibrosis.42 It is, therefore, plausible that a chronic fibrosis that preferentially affects the subendocardium is responsible for the more pronounced perfusion abnormalities in FD patients with LVH, and this would fit with the described histological findings.
+
+This is a single time-point observational study with inherent limitations. While the perfusion abnormalities detected likely reflect microvascular dysfunction, other explanations such as a specific impaired response to adenosine cannot be ruled out. In addition, without biopsy, we make assumptions that the CMR tissue characterization from these patients reflects storage, edema, and fibrosis. This is, however, consistent with previous studies.
+
+CMR perfusion mapping permits the detection of impaired myocardial perfusion in FD patients compared with healthy controls, even before the onset of LVH. Global perfusion impairment is associated with storage and LGE, with regional impairment associated also with T2 and LVH. Microvascular dysfunction is clearly an early disease marker and may be a useful parameter to distinguish the relative contribution of storage in vascular cells, particularly endothelium versus myocytes. Perfusion mapping readily allows the quantification of MBF in Fabry disease patients in a way that can be readily integrated within the clinical workflow and may be useful as a marker in clinical studies.

--- a/references_cache/PMID_31826677.md
+++ b/references_cache/PMID_31826677.md
@@ -1,0 +1,197 @@
+---
+reference_id: "PMID:31826677"
+title: "Myocardial Storage, Inflammation, and Cardiac Phenotype in Fabry Disease After One Year of Enzyme Replacement Therapy."
+authors:
+- Nordin S
+- Kozor R
+- Vijapurapu R
+- Augusto JB
+- Knott KD
+- Captur G
+- Treibel TA
+- Ramaswami U
+- Tchan M
+- Geberhiwot T
+- Steeds RP
+- Hughes DA
+- Moon JC
+journal: Circ Cardiovasc Imaging
+year: '2019'
+doi: 10.1161/CIRCIMAGING.119.009430
+keywords:
+- Adult
+- Aged
+- Disease Progression
+- Enzyme Replacement Therapy
+- "Fabry Disease/diagnostic imaging, drug therapy, enzymology, physiopathology"
+- Humans
+- "Hypertrophy, Left Ventricular/diagnostic imaging, drug therapy, enzymology, physiopathology"
+- Isoenzymes/therapeutic use
+- London
+- Magnetic Resonance Imaging
+- Middle Aged
+- "Myocardium/metabolism, pathology"
+- New South Wales
+- Phenotype
+- Prospective Studies
+- Recombinant Proteins/therapeutic use
+- Recovery of Function
+- Sphingolipids/metabolism
+- Time Factors
+- Treatment Outcome
+- "Ventricular Function, Left/drug effects"
+- Ventricular Remodeling/drug effects
+- alpha-Galactosidase/therapeutic use
+content_type: full_text_xml
+---
+
+# Myocardial Storage, Inflammation, and Cardiac Phenotype in Fabry Disease After One Year of Enzyme Replacement Therapy.
+**Authors:** Nordin S, Kozor R, Vijapurapu R, Augusto JB, Knott KD, Captur G, Treibel TA, Ramaswami U, Tchan M, Geberhiwot T, Steeds RP, Hughes DA, Moon JC
+**Journal:** Circ Cardiovasc Imaging (2019)
+**DOI:** [10.1161/CIRCIMAGING.119.009430](https://doi.org/10.1161/CIRCIMAGING.119.009430)
+
+## Content
+
+1. Circ Cardiovasc Imaging. 2019 Dec;12(12):e009430. doi:
+10.1161/CIRCIMAGING.119.009430. Epub 2019 Dec 12.
+
+Myocardial Storage, Inflammation, and Cardiac Phenotype in Fabry Disease After
+One Year of Enzyme Replacement Therapy.
+
+Nordin S(1)(2), Kozor R(3), Vijapurapu R(4), Augusto JB(1)(2), Knott KD(1)(2),
+Captur G(1)(2), Treibel TA(1)(2), Ramaswami U(5), Tchan M(6), Geberhiwot T(7),
+Steeds RP(4), Hughes DA(5), Moon JC(1)(2).
+
+Author information:
+(1)From the Institute of Cardiovascular Science, University College London,
+United Kingdom (S.N., J.B.A., K.D.K., G.C., T.A.T., J.C.M.).
+(2)Cardiology Department, Barts Heart Centre, London, United Kingdom (S.N.,
+J.B.A., K.D.K., G.C., T.A.T., J.C.M.).
+(3)Sydney Medical School, University of Sydney, Australia (R.K.).
+(4)Cardiology Department (R.V., R.P.S.), University Hospitals Birmingham, United
+Kingdom.
+(5)Lysosomal Storage Disorder Unit, Royal Free Hospital, London, United Kingdom
+(U.R., D.A.H.).
+(6)Department of Genetic Medicine, Westmead Hospital, Sydney, Australia (M.T.).
+(7)Inherited Metabolic Disorders Unit (T.G.), University Hospitals Birmingham,
+United Kingdom.
+
+Comment in
+    Circ Cardiovasc Imaging. 2019 Dec;12(12):e010045. doi:
+10.1161/CIRCIMAGING.119.010045.
+
+BACKGROUND: Cardiac response to enzyme replacement therapy (ERT) in Fabry
+disease is typically assessed by measuring left ventricular mass index using
+echocardiography or cardiovascular magnetic resonance, but neither quantifies
+myocardial biology. Low native T1 in Fabry disease represents sphingolipid
+accumulation; late gadolinium enhancement with high T2 and troponin elevation
+reflects inflammation. We evaluated the effect of ERT on myocardial storage,
+inflammation, and hypertrophy.
+METHODS: Twenty patients starting ERT (60% left ventricular
+hypertrophy-positive) were compared with 18 patients with early disease and 18
+with advanced disease over 1 year at 3 centers. Cardiovascular magnetic
+resonance (left ventricular mass index, T1, T2, global longitudinal strain, and
+late gadolinium enhancement) and biomarkers (high-sensitive troponin-T and
+NT-proBNP [N-terminal Pro-B-type natriuretic peptide]) at baseline (pre-ERT) and
+12 months were performed. Early disease controls were stable, treatment-naïve
+patients (mainly left ventricular hypertrophy-negative); advanced disease
+controls were stable, established ERT patients (mainly left ventricular
+hypertrophy-positive).
+RESULTS: Over 1 year, early disease controls increased maximum wall thickness
+and left ventricular mass index (9.8±2.7 versus 10.2±2.6 mm; P=0.010; 65±15
+versus 67±16 g/m2; P=0.005) and native T1 fell (981±58 versus 959±61 ms;
+P=0.002). Advanced disease controls increased T2 in the late gadolinium
+enhancement area (57±6 versus 60±7 ms; P=0.023) with worsening global
+longitudinal strain (-13.2±3.4 versus -12.1±4.8; P=0.039). Newly treated
+patients had a small reduction in maximum wall thickness (14.8±5.9 versus
+14.4±5.7 mm; P=0.028), stable left ventricular mass index (93±42 versus 92±40
+g/m2; P=0.186) and a reduction in T1 lowering (917±49 versus 931±54 ms;
+P=0.017).
+CONCLUSIONS: Fabry myocardial phenotype development is different at different
+disease stages. After 1 year of ERT initiation, left ventricular
+hypertrophy-positive patients have a detectable, small reduction in left
+ventricular mass and storage.
+
+DOI: 10.1161/CIRCIMAGING.119.009430
+PMCID: PMC6924943
+PMID: 31826677 [Indexed for MEDLINE]
+
+The leading cause of death in Fabry disease is now cardiac involvement. Treatment response (enzyme replacement therapy [ERT] or oral chaperone) has been typically assessed by measuring left ventricular hypertrophy (maximal wall thickness or left ventricular mass), but this does not quantify myocardial biology. Multiparametric cardiovascular magnetic resonance offers more –a low myocardial native T1 reflects sphingolipid accumulation and a high T2 in late gadolinium enhancement zones corresponds to high troponin and likely reflects inflammation. Using multiparametric cardiovascular magnetic resonance and blood biomarkers, we looked at the changes in Fabry myocardium after 1 year of initiation of ERT compared with other comparator groups (early, ERT naïve patients, and advanced, established on ERT patients). The data shows that Fabry disease myocardial phenotype changes differently with disease stage—early (untreated mainly female, mainly left ventricular hypertrophy–negative) versus advanced (treated, mainly male, mainly left ventricular hypertrophy–positive) patients. In early disease, there were increases in left ventricular mass and more storage whereas in late disease, there were increases in inflammation and reductions in strain with increases in troponin—but all changes were small. Patients starting ERT were different—with a small improvement in left ventricular mass and reduced storage. Combined, the data suggest that there is a small but clear beneficial ERT effect in Fabry disease.
+
+See Editorial by Halliday and Pennell
+
+Fabry Disease (FD) is a rare, X-linked lysosomal storage disorder leading to progressive sphingolipid accumulation affecting multiple organs including the heart.1 Cardiovascular death is the main cause of mortality,2 with left ventricular hypertrophy (LVH) and myocardial fibrosis being among the proposed risk factors for ventricular arrhythmia and sudden cardiac death.3 Enzyme replacement therapy (ERT) has been the mainstay of treatment with oral chaperone newly available for patients with amenable mutations. Timing of initiation of treatment seems important. The presence of overt LVH and myocardial fibrosis has been shown to negatively affect ERT outcome, suggesting the importance of early initiation of treatment.4,5 Cardiac response to ERT is typically assessed by measuring the left ventricular mass LVM index (LVMi) using either transthoracic echocardiography or cardiovascular magnetic resonance (CMR). However, this method does not quantify myocardial biology. The effect of treatment on myocardial storage is not widely reported, as invasive myocardial biopsy was required to measure this previously.6,7
+
+Multiparametric mapping by CMR is now a noninvasive tool to assess myocardial storage and other disease processes such as inflammation. CMR can measure 3 fundamental magnetic tissue constants, T1, T2, and T2*, and display them as color maps. Low native T1 in FD represents sphingolipid accumulation.8,9 Late gadolinium enhancement (LGE) with high T2 and troponin elevation reflect inflammation,10 characteristically initially occurring in the basal inferolateral wall.11 LGE with thinning and no T2/no troponin represents scar. Myocardial strain measured by global longitudinal strain (GLS) using feature-tracking CMR has been recently shown to be impaired with hypertrophy, storage (measured by low native T1), and LGE in FD.12 Understanding the effect of ERT on these now measurable pathways is difficult as it is not acceptable to randomize patients fulfilling treatment criteria. We, therefore, designed an observational study to map the 1-year evolution of these processes in stable untreated and stable treated disease and to compare this to the changes of a group of patients starting ERT for the first time.
+
+The data that support the findings of this study are available from the corresponding author on reasonable request.
+
+This prospective, multicenter, international observational study of 56 FD patients was a part of the Fabry400 study (NCT03199001). Participants were recruited from 3 Fabry clinics (United Kingdom: Royal Free Hospital London, Queen Elizabeth Hospital Birmingham; Australia: Westmead Hospital Sydney). The local research ethics committee approved the study. Written informed consent was obtained from all participants.
+
+Inclusion criteria included gene-positive FD males and females age 18 years who underwent assessment at baseline and 12 months. These were in 3 groups: FD participants starting ERT and 2 further groups: FD patients stable on ERT (established on ERT) and FD ERT naïve participants. These patients were selected from clinic attenders, according to availability and agreement to attend both baseline and follow-up CMR scans. FD is a disease that evolves slowly. Across the different pathological processes measured in this study and reflecting the X-linked nature of the disease and treatment guidelines, change over 1 year in the ERT naive group will reflect early untreated disease (likely more female, more LVH-negative) and changes over 1 year in the ERT treated group will reflect more advanced treated disease trajectory (likely more male, more LVH-positive). The group starting ERT will likely represent an intermediate stage group—but with the potentially powerful impact of 1 year of new ERT detectable when compared with the other 2 groups. Patients on oral chaperone were excluded.
+
+Baseline and 1-year assessment included CMR, estimated glomerular filtration rate, and blood biomarkers. These were high-sensitivity troponin T (Roche Diagnostic; normal range 0–14 ng/L for troponin T) and NT-proBNP (N-terminal pro-B-type natriuretic peptide; Roche Diagnostics; normal range according to age/gender).13 Hematocrit was also collected for extracellular volume fraction (ECV) calculation.
+
+All participants underwent CMR at 1.5 Tesla at 4 sites (London, Avanto and Aera; Birmingham, Avanto; Sydney, Avanto; Siemens Healthcare, Erlangen, Germany) using a standard clinical protocol with LGE imaging using phase-sensitive inversion recovery. T1 mapping using a modified Look-Locker inversion recovery sequence and T2 mapping were performed pre–contrast bolus administration (0.1 mmol/kg body weight, Gadoterate meglumine, Dotarem, Guerbet SA, France) on basal left ventricular short-axis slices (Table I in the Data Supplement). Post-T1 mapping was performed 15 minutes after contrast administration for ECV quantification. Contrast was not administered if estimated glomerular filtration rate <30 mL/min per 1.73 m2 or if the patient declined. Paired scans used identical sequences and magnets without upgrades, and phantom controls measured magnet stability for native T1 and T2 sequences.
+
+All images were centralized and analyzed using CVI42 software (Circle Cardiovascular Imaging Inc, Calgary, Canada). All analysis was blinded to clinical status. The assessment of LV volumes and LV mass were performed as previously described.14 LVH was defined as maximum wall thickness >12 mm in adults or increased LVMi on CMR according to age and gender-matched normal reference ranges.15 The presence of LGE was assessed by 2 independent observers (Drs Nordin and Augusto). The amount of LGE was quantified using the threshold method of 5 standard deviations above the mean remote myocardium presented in grams. Two-dimensional GLS was obtained by manually drawing epicardial and endocardial contours on the end-diastolic frame of long-axis images (4-chamber, 2-chamber, and 3-chamber views) with strain obtained using applied automatic feature-tracking algorithm as previously described.12
+
+A region of interest for native T1 and ECV was manually drawn in the septum with a 20% offset, taking care to avoid the blood-myocardial boundary. T2 at the LGE area assessment was performed by manually drawing a region of interest over areas corresponding to LGE.10 For cases without LGE, a region of interest was drawn in the basal inferolateral segment. Normal native T1 and T2 reference ranges (mean±2 SD) were defined using age- and gender-matched healthy controls from each individual center, with the group considered as a whole for T2 and split by gender for native T1 as native T1 is known to vary with gender.16,17 The normal native septal T1 ranges (mean, 1 SD, lower limit of normal) for each center were as follows: London center (Avanto), mean 1000±29 ms, lower limit 940 ms in male subgroup, and mean 1034±37 ms, lower limit 960 ms in female subgroup; London center (Aera), mean 994±18 ms, lower limit 958 ms in male subgroup, and mean 1027±22 ms, lower limit 983 ms in female subgroup; Birmingham center, mean 945±13 ms, lower limit 919 ms in males, and mean 966±19 ms, lower limit 928 ms in females; Sydney center, mean 1021±26 ms, lower limit 969 ms in males, and mean 1022±26 ms, lower limit 970 ms in females (Table II in the Data Supplement).
+
+The T1 mapping and ECV standardization in cardiovascular magnetic resonance (T1MES) phantom was scanned as part of the T1MES multicenter study according to the user manual instructions distributed to centers and as previously described.18 Scanner room temperatures were stable throughout the test period at 20±0°C for the 2 London sites and 21±1°C for Birmingham and Sydney sites. Unadjusted for temperature, serial modified Look-Locker inversion recovery T1 times across the 9 tubes were highly stable with site-specific coefficient of variation of 0.805% and 0.751% for the London sites (Avanto and Aera scanners, respectively), 0.625% Birmingham, and 0.846% Sydney. Serial T2 times across the 9 tubes were also stable with site-specific coefficient of variation of 1.10% and 1.07% for the London sites, 1.06% Birmingham, and 1.06% Sydney.
+
+FAbry STabilization indEX (FASTEX) analysis was performed to evaluate overall clinical stability or progression of FD at follow-up using an online application (www.fastex.online) as previously described.19,20 A FASTEX score of ≥20% is an indication of overall clinical worsening or clinical instability at follow-up.20
+
+Statistical analyses were performed using SPSS 24 (IBM, Armonk, NY). Continuous variables were expressed as mean±SD or median (interquartile range) according to normality using Shapiro-Wilk test; categorical variables were expressed as percentages. Data between baseline and follow-up visits were compared using either paired t test or Wilcoxon signed-rank test according to normality. The coefficient of variation between serial repeated phantom scans was calculated as a compound measure of all causes of change in the estimated native T1 and T2 of all 9 tubes. Two-way mixed ANOVA was performed to test for interaction between groups (ERT status) and time on CMR parameters and blood biomarkers. Tukey post hoc correction was applied for pairwise comparisons between groups. A P value of <0.05 was considered significant.
+
+Fifty-six participants were scanned at baseline and follow-up (mean 1.1±0.2 years). Baseline characteristics are shown in Table 1. Five additional recruited patients were excluded: one patient underwent permanent pacemaker insertion, and 4 patients who started ERT did not attend follow-up.
+
+Baseline Demographic Characteristics of the FD Cohort
+
+Twenty participants were scanned at baseline (pre-ERT) and at 1 year, mean age 49±10 years. Ten were on agalsidase alfa (Replagal) and 10 on agalsidase beta (Fabrazyme). Sixty percent (12/20) had baseline LVH; 80% (16/20) had low T1; and 74% (14/19) had LGE. One patient did not received contrast at baseline due to previous allergic reaction. Thirty-five percent (7/20) were males; 35% (7/20) had a known cardiac variant (6 N215S mutation and 1 R301Q mutation). The ERT indication was mainly LVH.
+
+Of those with LVH, 58% (7/12) were males, mean age 53±12 years. All patients with LVH had LGE at baseline. Eighty-three percent (10/12) had low T1 at baseline. The 2 LVH-positive patients with normal native T1 included a female with apical hypertrophy and a male with extensive LGE including the septal area. Eighty-three percent (10/12) had an increase in T1 value after 1 year of ERT. Eight (40%) were LVH-negative. The ERT indication in these 8 patients was still mainly cardiac, for example, LGE on CMR, but also other organ involvement, for example, transient ischemic attack, renal decline, or gastrointestinal symptoms. All LVH-negative patients started on ERT were female, mean age 43±9 years. Of the LVH-negative patients, 71% (5/7) had LGE (one patient did not receive contrast at baseline due to previous allergic reaction) and 75% (6/8) had low native T1 at baseline. Fifty percent (4/8) had an increase in T1 value after 1 year of ERT.
+
+Over 1 year of ERT initiation, there was a small reduction in maximum wall thickness (14.8±5.9 versus 14.4±5.7 mm; P=0.028) but no change in LVMi (93±42 versus 92±40 g/m2; P=0.186). There was a small reduction in T1 lowering (partial normalization; 917±49 versus 931±54 ms; P=0.017). T2 in the LGE area, LGE presence, absence or extent, septal ECV and GLS were unchanged (T2: 55±6 versus 56±6 ms, P=0.609; LGE: 5.6 [0–16.9] versus 4.3 [1.8–18.5] g/m2, P=0.193; ECV: 0.26±0.04 versus 0.26±0.04, P=0.669; and GLS: −16.6±4.0 versus −16.2±3.9, P=0.518), as were troponin and NT-proBNP levels (troponin, 20 [7–34] versus 23 [9–40] ng/L; P=0.550 and NT-proBNP, 18 (12–83) versus 27 (13–114) pmol/L; P=0.230).
+
+After 1 year of ERT, the LVH-positive group has shown a small reduction in LVMi (117±38 versus 114±36 g/m2; P=0.048) and reduction in T1 lowering (partial normalization; 902±47 versus 920±48 ms; P=0.008; Figures 1 and 2). There was no significant change in other parameters in the LVH-positive group (Table 2). All markers were unchanged in the LVH-negative group (Table 2).
+
+CMR and Blood Biomarkers Parameters LVH-Positive and LVH-Negative FD Before Initiation of ERT and 12 months
+
+Example case. A 60-year-old Fabry Disease male with left ventricular hypertrophy, low T1 (902 ms), and basal inferolateral late gadolinium enhancement (LGE) before initiation of enzyme replacement therapy (ERT). T2 corresponding to the LGE area is high at 66 ms with high troponin level. After 1 y of initiation of ERT, T1 partially normalized to 940 ms, and limited regression of left ventricular mass index (LVMi) was observed (−4 g/m2). T2 at the LGE area remained high at 67 ms with no significant troponin level change.
+
+Left ventricular mass indexed (LVMi) and native T1 before and after initiation of enzyme replacement therapy (ERT) at 12 months in left ventricular hypertrophy (LVH)–positive and LVH-negative Fabry Disease. *P<0.05= statistically significant.
+
+The 18 patients established on ERT were 53±13 years with median ERT duration of 4.2 (1.4–12.2)years. Ten were on Replagal and 8 on Fabrazyme. Eighty-three percent (15/18) had LVH, and 56% (10/18) were males. Seventy-two percent (13/18) had low T1, and 73% (11/15) had LGE. Three did not receive contrast at baseline due to poor renal function. Eleven percent (2/18) had a known cardiac variant (N215S and I901T mutations). Eighty-three percent (15/18) patients were LVH-positive of which 60% (9/15) were males. Four LVH-positive patients with normal T1 had septal LGE to explain the pseudonormal T1.
+
+Over 1 year, there was no significant difference in maximum wall thickness and LVMi (17.5±4.7 versus 17.8±4.9 mm; P=0.056 and 124±45 versus 125±45 g/m2; P=0.070, respectively). Native T1, ECV, and LGE quantification were unchanged (916±52 versus 912±50 ms, P=0.607; 0.28±0.03 versus 0.28±0.04, P=0.690; and 13 [4–28] versus 15 [6–29] g/m2, P=0.173, respectively). However, there was a significant increase in T2 in the LGE area and troponin at 1 year (T2: 57±6 versus 60±7 ms, P=0.023; troponin 43 [29–90] versus 48 [30–99] ng/L, P=0.036). GLS also became more impaired after 1 year (−13.2±3.4 versus −12.1±4.8; P=0.039), but NT-proBNP was unchanged after 1 year (60 [16–233] versus 70 [21−220] pmol/L; P=0.798). Within this group, comparing LVH-negative and -positive (baseline, follow-up) subgroups was not statistically possible as there were only 3/18 that were LVH-negative.
+
+The 18 patients not on ERT were 41±12 years. Seventeen percent (3/18) were males. Seventeen percent (3/18) had LVH. Forty-four percent (8/18) had low T1, and 21% (3/14) had LGE. Four patients declined contrast administration. Fifty percent (9/18) had a known cardiac variant (N215S mutation). Eighty-three percent (15/18) patients were LVH-negative of which 93% (14/15) were females.
+
+Over 1 year, there was a small increase in maximum wall thickness and LVMi (9.8±2.7 versus 10.2±2.6 mm; P=0.010 and 65±15 versus 67±16 g/m2; P=0.005). One participant who was LVH-negative with low native T1 at baseline scan was found to progressed to LVH. No patients developed new LGE. There was a reduction in native T1 981±58 versus 959±61 ms, P=0.002; no patient became low T1 (Figure in the Data Supplement). T2, ECV, and GLS were all normal at baseline and unchanged over 1 year (T2: 50±3 versus 50±4 ms, P=0.847; ECV: 0.29±0.04 versus 0.27±0.03, P=0.159; and GLS: −19.2±2.6 versus −19.1±2.3, P=0.880. There was an increase in troponin 1 [1–4] versus 4.5 [1–10] ng/L; P=0.018. NT-proBNP was unchanged 1 [1–12] versus 1 [1–7] pmol/L; P=0.715. Within this group, comparing LVH-positive to LVH-negative (baseline, follow-up) subgroups is not statistically possible as there were only 3/18 that were LVH-positive. Interaction between groups according to ERT status over time is shown in Table 3.
+
+Interaction Between All 3 Groups and Time With Different Parameters and Subgroup Comparisons
+
+FASTEX scores, a dynamic measure of overall clinical stability (where interval change of <20% suggest stability), were measured. The rates of a score ≥20% in the groups initiated on ERT, established on ERT, and ERT-naïve were 30%, 33%, and 39%, respectively.
+
+In this study, insight into the biology of the FD myocardium is noninvasively gained by serially evaluating the effect of ERT on the FD myocardium after 1 year of initiation using multiparametric CMR and blood biomarkers. These patients were compared with 2 stable control groups—one early untreated group and one advanced treated group. The study found that, over 1 year, early, stable (more female, mainly LVH-negative) treatment-naïve FD have an increase in LV mass and a fall in T1 and a small increase in mean troponin. More advanced, stable on treatment (more male, more LVH-positive) FD has no change in mass, T1, or LGE area—but T2 and troponin increased with increased impairment in myocardial strain (GLS). What did the new ERT treated group do? If ERT had no cardiac effect, then the expectation would be that they would be intermediate between these 2 groups: that is, no or a small increase in mass; no or a small decrease in T1 with no change; or a small increase in T2 and troponin. Instead, we found that in the LVH-positive group, in particular, had a small improvement in LV mass and a small improvement in T1 (partial normalization).
+
+Although we caution against over-interpretation, we believe the best interpretation of these data is this: first, from the advanced stable disease data, it is clear that chronic ERT use does not completely normalize LVH, T1, T2 or troponin, supporting single time point observational data and evidence that ERT in more advanced disease may be less effective.4,21 Second, that the disease is slowly progressing in both early untreated and more advanced treated disease—but in different ways (early disease, more storage, LVH developing; advanced disease more inflammation, increasingly impaired strain; both: slowly increasing troponin). Third, from the newly ERT-treated group (Figure 2), there is a clear signal of an ERT effect with a small reduction in LV mass and normalization of T1 once LVH is present. However, the effect size is small but (Figure 3A and 3B) is in the opposite direction to the treatment-naïve group. Whether the measured effects represent ERT impact solely via endothelial cell clearance (endothelial cell storage will have a small contribution to measured myocardial T1) with downstream alteration in myocardial and systemic perfusion modestly reducing LVH rather than a direct ERT effect on (terminally differentiated) myocytes is unclear. We also acknowledge that the sample size in the newly ERT-treated LVH-negative group is small (n=8); therefore, it is possible that an ERT effect can be seen in this group with a larger sample size.
+
+Left ventricular mass indexed (LVMi), native T1, T2 at late gadolinium enhancement (LGE) area or basal inferolateral (BIFL) wall if no LGE and troponin levels at baseline and 12 months in all 3 groups. *P<0.05= statistically significant. ERT indicates enzyme replacement therapy.
+
+The changes we observed in myocardial native T1 and T2 times in the study participants were unlikely due to technical instability in the CMR systems across sites or to environmental shifts, since the phantom data suggested a high level of data consistency with no drift over time. Changes were, however, small, each group was also small, and we caution against over-fitting and over-interpreting the data.
+
+The LV mass results with ERT initiation is consistent with previous findings where a decrease in LVMi was observed in FD with LVH and no change observed in those without LVH during the first year,22 although here the changes were small.6,23-25 Our findings are also consistent with a previous 10-year follow-up study where an improvement in LVMi was most apparent in FD after 1 year of ERT treatment particularly in the LVH group, suggesting a temporal effect of ERT.26 After 10 years of ERT, the reduction in LVMi was maintained in males with LVH but not in females, while in the LVH-negative patients, the LVMi was maintained.26 Reductions in LVMi and myocardial Gb3 content have been previously demonstrated by myocardial biopsy.6,7 Data on untreated FD are limited; however, previous studies have demonstrated an increase in LV mass in untreated FD.27,28
+
+Using multiparametric mapping, our group and others have previously shown that T1 is low in FD, even in LVH-negative patients.8,14,29 We have also previously demonstrated that LGE in FD without thinning is likely inflammation using T2 mapping and troponin,10 which is further supported by other studies that included blood inflammatory markers, for example, tumor necrosis factor (TNF), TNF receptor 2, interleukin-6 and matrix metalloprotease-2,30 and myocardial biopsy.31 This is the first prospective study exploring longitudinal change in native T1 and T2 in FD, here also exploring treatment impact. This requires quality control to ensure measurement system stability. The serial measurement supports proposed models of phenotype development developed out of single time point data.32 Future studies—larger, longer, or with new therapeutic approaches (chaperone/gene therapy)—will provide more insights.
+
+Study limitations include no histology, the lack of a full understanding of the quantitative link between storage and T1 lowering, the relatively small sample size reflecting the rarity of the disease, and the study design given the nonavailability of randomization. Patient recruitment will have excluded very advanced disease patients due to contraindications to CMR (for example, patients with permanent pacemaker and implantable cardioverter-defibrillator), and there is a likely recruitment bias whenever patients are recruited from clinic (more likely to recruit those on short follow-up, agreement for research more likely in those worried about their health), meaning control groups may not fully represent population averages—our patients had a more recent diagnosis of FD than we think our total cohort does (median 4 years for controls, 1.4 years for ERT initiators) and high FASTEX scores. The link between pathophysiological process and outcome is unknown.
+
+Over 1 year using multiparametric CMR and biomarkers, the FD myocardial phenotype changes. These changes are different in early (untreated mainly female, mainly LVH-negative) disease compared with more advanced (treated, mainly male, mainly LVH-positive): with early disease, small increases in LV mass and more storage, and with late disease, small increases in inflammation and small reductions in strain—both have small increases in troponin. Intermediate patients starting ERT are different with a small improvement in LV mass and a small improvement in myocardial storage, compatible with a small but clear ERT treatment effect on myocardium. Whether or how these effects translate to patient morbidity or mortality reduction with cumulative lifetime use and whether the effects represent solely endothelial or endothelial and myocardial effects remain unclear.
+
+We are grateful for the contributions of the patients and the staff members at all participating Lysosomal Storage Disorder Unit and Inherited Metabolic Disorders Unit.
+
+This study is part of the Fabry400 study, which is funded by an investigator-led research grant from Sanofi-Genzyme.
+
+None.

--- a/references_cache/PMID_32514567.md
+++ b/references_cache/PMID_32514567.md
@@ -1,0 +1,220 @@
+---
+reference_id: "PMID:32514567"
+title: The myocardial phenotype of Fabry disease pre-hypertrophy and pre-detectable storage.
+authors:
+- Augusto JB
+- Johner N
+- Shah D
+- Nordin S
+- Knott KD
+- Rosmini S
+- Lau C
+- Alfarih M
+- Hughes R
+- Seraphim A
+- Vijapurapu R
+- Bhuva A
+- Lin L
+- Ojrzyńska N
+- Geberhiwot T
+- Captur G
+- Ramaswami U
+- Steeds RP
+- Kozor R
+- Hughes D
+- Moon JC
+- Namdar M
+journal: Eur Heart J Cardiovasc Imaging
+year: '2021'
+doi: 10.1093/ehjci/jeaa101
+keywords:
+- Contrast Media
+- Fabry Disease/diagnostic imaging
+- Female
+- Gadolinium
+- Humans
+- "Hypertrophy, Left Ventricular/diagnostic imaging"
+- "Magnetic Resonance Imaging, Cine"
+- Male
+- Myocardium
+- Phenotype
+- Predictive Value of Tests
+- Prospective Studies
+- "Ventricular Function, Left"
+content_type: full_text_xml
+---
+
+# The myocardial phenotype of Fabry disease pre-hypertrophy and pre-detectable storage.
+**Authors:** Augusto JB, Johner N, Shah D, Nordin S, Knott KD, Rosmini S, Lau C, Alfarih M, Hughes R, Seraphim A, Vijapurapu R, Bhuva A, Lin L, Ojrzyńska N, Geberhiwot T, Captur G, Ramaswami U, Steeds RP, Kozor R, Hughes D, Moon JC, Namdar M
+**Journal:** Eur Heart J Cardiovasc Imaging (2021)
+**DOI:** [10.1093/ehjci/jeaa101](https://doi.org/10.1093/ehjci/jeaa101)
+
+## Content
+
+1. Eur Heart J Cardiovasc Imaging. 2021 Jun 22;22(7):790-799. doi:
+10.1093/ehjci/jeaa101.
+
+The myocardial phenotype of Fabry disease pre-hypertrophy and pre-detectable
+storage.
+
+Augusto JB(1)(2), Johner N(3), Shah D(3), Nordin S(1)(2), Knott KD(1)(2),
+Rosmini S(2), Lau C(2)(4), Alfarih M(1)(2), Hughes R(1)(2), Seraphim A(1)(2),
+Vijapurapu R(5), Bhuva A(1)(2), Lin L(2), Ojrzyńska N(2)(6), Geberhiwot T(7),
+Captur G(2), Ramaswami U(8), Steeds RP(5), Kozor R(9), Hughes D(8), Moon
+JC(1)(2), Namdar M(3).
+
+Author information:
+(1)Institute of Cardiovascular Science, University College London, London, UK.
+(2)Department of Cardiovascular Imaging, Barts Heart Centre, Barts Health NHS
+Trust, London, UK.
+(3)Cardiology Division, Geneva University Hospitals, Rue Gabrielle-Perret-Gentil
+4, 1205 Geneva, Switzerland.
+(4)William Harvey Research Institute, NIHR Barts Biomedical Research Centre,
+Queen Mary University of London, London, UK.
+(5)Cardiology Department, University Hospitals Birmingham, Birmingham, UK.
+(6)Institute of Cardiology, Warsaw, Poland.
+(7)Inherited Metabolic Disorders Unit, University Hospitals Birmingham,
+Birmingham, UK.
+(8)Royal Free London NHS Foundation Trust and University College London, London,
+UK.
+(9)Sydney Medical School, University of Sydney, Sydney, Australia.
+
+AIMS: Cardiac involvement in Fabry disease (FD) occurs prior to left ventricular
+hypertrophy (LVH) and is characterized by low myocardial native T1 with
+sphingolipid storage reflected by cardiovascular magnetic resonance (CMR) and
+electrocardiogram (ECG) changes. We hypothesize that a pre-storage myocardial
+phenotype might occur even earlier, prior to T1 lowering.
+METHODS AND RESULTS: FD patients and age-, sex-, and heart rate-matched healthy
+controls underwent same-day ECG with advanced analysis and multiparametric CMR
+[cines, global longitudinal strain (GLS), T1 and T2 mapping, stress perfusion
+(myocardial blood flow, MBF), and late gadolinium enhancement (LGE)]. One
+hundred and fourteen Fabry patients (46 ± 13 years, 61% female) and 76 controls
+(49 ± 15 years, 50% female) were included. In pre-LVH FD (n = 72, 63%), a low T1
+(n = 32/72, 44%) was associated with a constellation of ECG and functional
+abnormalities compared to normal T1 FD patients and controls. However, pre-LVH
+FD with normal T1 (n = 40/72, 56%) also had abnormalities compared to controls:
+reduced GLS (-18 ± 2 vs. -20 ± 2%, P < 0.001), microvascular changes (lower MBF
+2.5 ± 0.7 vs. 3.0 ± 0.8 mL/g/min, P = 0.028), subtle T2 elevation (50 ± 4 vs.
+48 ± 2 ms, P = 0.027), and limited LGE (%LGE 0.3 ± 1.1 vs. 0%, P = 0.004). ECG
+abnormalities included shorter P-wave duration (88 ± 12 vs. 94 ± 15 ms,
+P = 0.010) and T-wave peak time (Tonset - Tpeak; 104 ± 28 vs. 115 ± 20 ms,
+P = 0.015), resulting in a more symmetric T wave with lower T-wave time ratio
+(Tonset - Tpeak)/(Tpeak - Tend) (1.5 ± 0.4 vs. 1.8 ± 0.4, P < 0.001) compared to
+controls.
+CONCLUSION: FD has a measurable myocardial phenotype pre-LVH and pre-detectable
+myocyte storage with microvascular dysfunction, subtly impaired GLS and altered
+atrial depolarization and ventricular repolarization intervals.
+
+© The Author(s) 2020. Published by Oxford University Press on behalf of the
+European Society of Cardiology.
+
+DOI: 10.1093/ehjci/jeaa101
+PMCID: PMC8219366
+PMID: 32514567 [Indexed for MEDLINE]
+
+Fabry disease (OMIM 301500; FD) is a rare X-linked lysosomal storage disorder caused by mutations in the α-galactosidase A gene (GLA). The consequence is progressive sphingolipid accumulation1 affecting multiple organs. Since the availability of renal replacement therapy, the main cause of death has been cardiac, through heart failure or arrhythmia.2,3 Therapy is available for FD (enzyme replacement and oral chaperone therapies) but the effect is incomplete likely due to late initiation. The presence of overt left ventricular hypertrophy (LVH) and myocardial fibrosis has been shown to negatively affect treatment outcome, suggesting the importance of early initiation of treatment.4 Whilst treating all from diagnosis is not an option due to the therapeutic and financial burden,5 the optimal timing of intervention is not known. Cardiac response to treatment is typically assessed by measuring the left ventricular (LV) mass, but this method does not quantify myocardial biology or earlier stages when the benefit could be exploited. Better description of myocardial disease stages and processes might lead to a better understanding of the earliest commitment to irreversible disease and opportunity to commence treatment.4
+
+Cardiovascular magnetic resonance (CMR) is a key tool for studying cardiac manifestations of FD. Early descriptions were of LVH and late gadolinium enhancement (LGE) in the basal inferolateral wall, thought initially to reflect only fibrosis.6–8 Later, multiparametric CMR has been able to measure sphingolipid infiltration (T1 mapping, low native T1)9 and apparent oedema (T2 mapping, high native T2) with blood troponin elevation suggesting inflammation.10,11 A pre-LVH phase of cardiac FD was subsequently defined by a low T1 phenotype, occurring in up to 60% of FD patients; slightly elevated LV ejection fraction and electrocardiographic (ECG) changes were also observed pre-LVH.12,13
+
+However, as sphingolipid storage starts before birth14 and T1 mapping presumably has a detection threshold, a ‘silent’ sphingolipid accumulation stage before T1 lowers must also occur. To explore this, new techniques would be needed. By CMR, two pathways and their measurement techniques show promise. First, global longitudinal strain (GLS), which is robustly measured and changes earlier in many diseases including FD.15 Second, myocardial blood flow (MBF) measured by stress perfusion mapping, which reflects smooth muscle/endothelial changes that occur early in FD.16
+
+A third approach has also been suggested. The ‘traditional’ 12-lead ECG is informative in FD, with some of the first reports of abnormal ECG in FD being published in the 1970s.17 Since then, several ECG features have been described in FD: atrioventricular (AV) block, short and long PQ interval, changes in QRS width and repolarization abnormalities, associated with arrhythmias and disease progression.18–20 Some features, particularly with advanced ECG analysis, occur early, pre-LVH and include accelerated atrial and ventricular depolarization/conductivity (shortening of P-wave duration and QRS width),21 with sphingolipid storage as a potential cause.19
+
+Accordingly, we hypothesized that an even earlier phase of cardiac FD (pre-LVH, pre-low-T1) might be identifiable using a combination of CMR perfusion mapping, GLS assessment, and advanced 12-lead surface ECG analysis.
+
+Fabry patients were recruited from the Lysosomal Storage Disorders Unit at Royal Free Hospital (RFH) London between 2015 and 2019, as part of the prospective Fabry400 study (NCT03199001). We included all consecutive FD patients with a confirmed GLA mutation (Supplementary data online, Table S1), multiparametric CMR and same day ECG. Patients <18 years old, with standard contraindications to CMR or with known pregnancy were excluded.
+
+In addition, we included age-, sex-, and heart rate-matched healthy controls who also underwent parametric CMR and same day ECG. The healthy control group were volunteers free of any history or symptoms of cardiovascular disease or other comorbidities, and who were not taking any medications.
+
+The study conformed to the principles of the Helsinki Declaration and ethical approval was obtained for both study groups. Written informed consent was obtained from all participants.
+
+Clinical data collected included enzyme replacement and oral chaperone therapies status, GLA variant (Supplementary data online, Table S1), body surface area (BSA), and systolic and diastolic peripheral blood pressures. All FD patients had blood collected just before the scan and analysed for high-sensitivity troponin T (hsTnT, normal <15 ng/L) and NT-proBNP (brain natriuretic peptide, normal <47 pmol/L).
+
+Twelve-lead surface ECG was acquired at rest (Welch Allyn CP 200 Electrocardiograph) and independently analysed by two experts in a consensus reading (N.J. and M.N.), blinded to both clinical status (patient or healthy control) and CMR. Measurements were taken manually from the tracings at a sweep of 25 mm/s and standard criteria and normal values for ECG findings were applied (Supplementary data online, Methods).
+
+P-wave indices were recorded in lead II. Atrial dimensions are known to affect the P-wave morphology and duration, and thus the PQ interval, which is why a ‘corrected’ PQ interval was derived by measuring the PQ interval minus P-wave duration in lead II (Pend – Q), better reflecting AV conduction.22
+
+QRS axis (degrees) and the presence of left bundle branch block or right bundle branch block (RBBB), incomplete RBBB or intraventricular conduction delay (100–120 ms) were recorded. ECG LVH criteria were assessed using Sokolow–Lyon index [S-wave voltage in V1 + R-wave voltage in V5 or V6 (whichever larger) >35 mm], Cornell index [(R-wave voltage in aVL + S-wave voltage in V3) × QRS duration ≥2440 mm·ms for males (adding 8 mm for females)], and the ratio between T- and R-wave amplitudes in V5 (T-wave amplitude measured in the concordant part with R wave). R-wave amplitude in V1 was also recorded (a prominent R in V1 can be a marker of septal LVH or right ventricular hypertrophy). Presence of fractionated QRS (fQRS, a marker of intraventricular conduction delay) was checked for each patient and the number of leads with fQRS was noted.
+
+The time interval between the onset and the peak of T wave (Tonset – Tpeak) and from the peak until the end of the T wave (Tpeak – Tend, an index of transmural dispersion of ventricular repolarization23) were recorded in II or V5; in the presence of negative or biphasic T wave, the peak was measured from the nadir of the T wave and leads with T waves with less than 1.5 mm in amplitude were excluded from the analysis. A measure of T-wave skewness/symmetry was calculated as the ratio between Tonset – Tpeak and Tpeak – Tend. Pathological repolarization was defined as a discordant ST/T as compared to the main QRS axis.
+
+We also noted the presence of atrial fibrillation and atrial and/or ventricular pacing. None of the patients had higher than first degree AV block. ECG intervals of interest are summarized in Figure 1.
+
+
+Schematic illustration of ECG intervals of interest.
+
+All participants underwent CMR at 1.5 Tesla (Avanto or Aera, Siemens Healthcare, Erlangen, Germany) in one of three centres: the Heart Hospital, Barts Heart Centre, or Chenies Mews Imaging Centre. Standard cine imaging for ventricular volume analysis was performed.3 Native T1 mapping was performed on four-chamber, three-chamber views, and three (basal, mid, and apical) LV short-axis (SAX) slices using a modified Look-Locker inversion recovery sequence (MOLLI, 5b[3s]3b). Native T2 mapping was acquired on the same slices using a steady-state free-precession sequence in 99 Fabry patients and 26 controls. Adenosine stress perfusion mapping was performed in 45 Fabry patients (32 were LVH negative) and 27 controls16 (most common reason for not being performed was patient preference). Stress perfusion images were obtained in the basal, mid, and apical LV SAX slices. LGE images were acquired (not performed in eight patients due to contrast contraindication) following a bolus of 0.1 mmol/kg gadolinium contrast agent (Gadoterate meglumine, Dotarem, Guerbet S.A., France) using a phase sensitive inversion recovery sequence. Post-contrast T1 mapping was performed 15 min after gadolinium administration on the same location as native T1 for extracellular volume fraction (ECV) quantification. The T1 Mapping and ECV Standardization Program (T1MES) phantom was scanned to quality control for T1 and T2 mapping stability across all sites; the results have been published elsewhere.3,12,16
+
+All images were analysed using CVI42 software (Circle Cardiovascular Imaging Inc. v.5.9.4, Calgary, Canada). Measurements were performed by two expert readers (C.L. and M.A.F.). LV volumes, ejection fraction and mass (papillary muscles included as part of the LV mass) were measured using a semiautomated threshold-based technique and indexed. LVH was defined as a maximum wall thickness (MWT) >12 mm and/or an increased LV mass indexed to the body surface area with reference to age- and gender-adjusted CMR nomograms.24
+
+Pixel-by-pixel colour maps were displayed for T1, T2 and stress MBF mappings using custom 12-bit lookup tables. Regions of interest with 20% offset were drawn for T1 in the basal and mid septum and for T2 in the basal inferolateral (BIFL) wall. The lowest septal T1 value was considered for ‘low T1’ recognition. Normal T1 and T2 ranges for each centre are detailed in the Supplementary data online, Methods. For ECV and MBF, endo- and epicardial contours were manually drawn and the right ventricular insertion points identified. The borders were offset by 20% and a global mean value (% and mL/g/min, respectively) across all segments was recorded. Global longitudinal 2D strain (GLS) values were obtained using feature tracking analysis.15 LV LGE quantification (percentage of total LV mass) was performed in the SAX LGE slices using manually drawn endo- and epicardial borders and a cut-off of 5 SDs above the mean signal in remote myocardium (with minimal manual adjustment when needed).
+
+Statistical analysis was performed using SPSS (version 24.0, IBM Corp., Armonk, NY, USA). Discrete variables are presented as absolute frequencies with percentages; continuous as mean ± standard deviation if normally distributed, otherwise as median and interquartile ranges. Data were checked for normal distribution using Kolmogorov–Smirnov test and visual Q–Q plots assessment. Comparisons between groups were performed using Students’ t-test or Mann–Whitney U test as appropriate. Categorical variables were compared using Fisher’s exact test. Correlations between continuous variables were assessed using Pearson’s correlation (r). Reproducibility analysis for CMR is detailed in the Supplementary data online, Methods and Table S2. Two-sided P-values <0.05 were considered significant.
+
+Logistic regression analysis was performed to assess the determinants of very early cardiac involvement in FD (pre-hypertrophy and normal T1 mapping) vs. healthy controls; independent variables were selected based on their relevance in the baseline tables. Significant factors in univariable analysis (P < 0.05) were selected for the multivariable model and inputted using an ‘enter’ method. Receiver-operator characteristics (ROC) analysis was performed to test the performance of different CMR and ECG parameters to detect very early cardiac involvement (Supplementary data online, Methods).
+
+One hundred and fourteen Fabry patients (age 46 ± 13 years, 61% female) and 76 healthy controls (age 49 ± 15 years, 50% female, P = 0.153 for age and P = 0.180 for sex vs. FD) were recruited. Average heart rate was similar between FD and healthy controls (61 ± 12 vs. 64 ± 11 bpm, P = 0.178). Forty-two (37%) Fabry patients had LVH. Among the 72 Fabry patients with no LVH (‘pre-LVH’) (63%), 32 had low T1 (44%) and 40 had normal T1 (56%) (see Tables 1 and 2 and Supplementary data online, Tables S3–S5).
+
+
+Clinical and cardiovascular magnetic resonance findings in healthy controls and Fabry patients without LVH
+
+BIFL, basal inferolateral wall; BNP, brain natriuretic peptide; BSA, body surface area; CMR, cardiovascular magnetic resonance; DBP, diastolic blood pressure; ECV, extracellular volume fraction; EDVI, end-diastolic volume index; ERT, enzyme replacement therapy; GLS, global longitudinal strain; hs-TnT, high-sensitivity troponin T; LGE, late gadolinium enhancement; LVEF, left ventricular ejection fraction; LVH, left ventricular hypertrophy; LVMI, left ventricular mass index; MBF, myocardial blood flow; MWT, maximum wall thickness; NA, not available/not applicable; OCT, oral chaperone therapy; SBP, systolic blood pressure.
+
+Non-normally distributed variable.
+
+Electrocardiographic findings in healthy controls and Fabry patients without LVH
+
+Additional electrocardiographic features as detailed in Supplementary data online, Table S5.
+
+fQRS, fractionated QRS; HR, heart rate; LVH, left ventricular hypertrophy; SLI, Sokolow–Lyon index.
+
+Fabry patients with LVH (overt disease), had lower MBF, GLS and T1, and higher T2 and %LGE than those without LVH (Supplementary data online, Results and Tables S3 and S4). ECG changes were also pronounced with LVH and included longer P wave, QRS and QT times, negative T wave/pathological repolarization, and LVH voltage criteria (Supplementary data online, Results and Tables S3 and S4).
+
+Pre-LVH Fabry patients with low T1 (vs. normal T1) had higher LV mass index (67 ± 14 vs 59 ± 10g/m2, P = 0.011) and MWT [, 10 (9–11) vs. 8 (7–9)mm, P = 0.001]. Both hsTnT and NT-proBNP were normal for both groups, Table 1. Low T1 patients had higher maximum Q-wave amplitude [2 (1–2) vs. 1 (1–2) mm, P < 0.001], R-wave amplitude in V1 [3 (2–4) vs. 2 (1–3) mm, P = 0.003], greater Sokolow–Lyon [22 (16–28) vs. 17 (13–23) mm, P = 0.031] and Cornell indexes [911 (590–1330) vs. 578 (433–984) mm·ms, P = 0.042], longer R-wave peak times in V5 (42 ± 6 vs. 39 ± 5 ms, P = 0.006), and a higher prevalence of fQRS (44 vs. 18%, P = 0.020) (see Table 2, Figure 2 and Supplementary data online, Table S5). Of note, GLS was significantly lower in these low T1 patients compared to healthy controls (−18.7 ± 2.5 vs. −20.3 ± 2.3%, P = 0.003).
+
+
+Boxplots of maximum Q-wave amplitude (A), R-wave amplitude in V1 (B), Cornell index (C), Sokolow–Lyon index (D), and R-wave duration in V5 (E) according to T1 status in pre-hypertrophic Fabry patients. SL, Sokolow–Lyon.
+
+FD with no LVH and a normal T1 still had a lower T1 compared to controls (1000 ± 28 vs. 1029 ± 38 ms, P < 0.001, Table 1). These FD patients had lower Sokolow–Lyon [17 (13–23) vs. 19 (16–27) mm, P = 0.040] and Cornell index [578 (433–984) vs. 990 (600–1310) mm·ms, P = 0.006] (Tables 1 and 2). GLS was lower (−18.3 ± 2.1 vs. −20.3 ± 2.3%, P < 0.001) as was stress MBF (2.5 ± 0.7 vs. 3.0 ± 0.8 mL/g/min, P = 0.028). There was slightly higher BIFL T2 (50 ± 4 vs. 48 ± 2 ms, P = 0.027), ECV (26 ± 2 vs. 24 ± 3%, P = 0.029), and %LGE (0.3 ± 1.1 vs. 0%, P = 0.004) than controls. PQ was shorter (152 ± 27 vs. 163 ± 22ms, P = 0.017), mostly due to shorter P-wave duration (88 ± 12 vs. 94 ± 15 ms, P = 0.010) with lower T-wave amplitudes [3 (2–4) vs. 4 (3–6) mm, P < 0.001] and shorter Tonset – Tpeak (104 ± 28 vs. 115 ± 20 ms, P = 0.015) but longer Tpeak – Tend (72 ± 14 vs. 67 ± 12 ms, P = 0.053), resulting in significantly lower (Tonset – Tpeak)/(Tpeak – Tend) ratio (1.5 ± 0.4 vs. 1.8 ± 0.4, P < 0.001) than controls (Table 2 and Supplementary data online, Table S5).
+
+To assess the robustness of these changes, biomarkers of interest (GLS, MBF, T2, ECV, %LV LGE, PQ interval, P-wave duration, Tonset – Tpeak, Tpeak – Tend, [Tonset – Tpeak]/[Tpeak – Tend] and T-wave amplitude) were selected for regression analysis (Table 3). GLS [2.9, 95% confidence interval (1.2–7.2), P = 0.026], P-wave duration [1.2 (1.0–1.5), P = 0.029] and (Tonset – Tpeak)/(Tpeak – Tend) ratio [976 (2.2–425219), P = 0.026] predict very early cardiac FD involvement (pre-LVH normal T1) in multivariable regression analysis. The three aforementioned variables were computed in ROC curve analysis, either isolated or in combination (Figure 3, Supplementary data online, Results). The best discriminative ability however was a ROC curve that used the logit value of all three variables combined (see Supplementary data online, Results)—area under the curve (AUC) 0.87 (0.79–0.95, P < 0.001), significantly superior to other curves’ AUC (P < 0.05 for all). A selection of findings across subgroups is summarized in Figure 4.
+
+
+Receiver-operator characteristic curves and corresponding AUCs for detection of cardiac involvement in pre-hypertrophic normal T1 Fabry disease. AUC, area under the curve; CI, confidence interval; GLS, global longitudinal strain.
+
+Multiparametric cardiovascular magnetic resonance and electrocardiographic assessment in patients with FD and healthy controls. Left to right—steady-state free precession cines, native T1 mapping, stress MBF mapping, GLS, P-wave duration, and T-wave ratio. (A) Healthy control, no LVH, normal T1, MBF, GLS, P-wave time, and T-wave ratio. (B) FD with normal T1 and without LVH; MBF and GLS are mildly reduced, P wave is short and T-wave ratio reduced. (C) FD with low T1 and without LVH, low MBF and GLS, P-wave duration, and T-wave ratio are no different from control. (D) FD with LVH; T1 is low, MBF and GLS are significantly impaired, P wave is long and T-wave ratio increased.
+
+Uni- and multivariable regression analysis of the determinants of very early cardiac involvement in Fabry disease (pre-LVH and normal T1 mapping)
+
+BIFL, basal inferolateral; CI, confidence interval; ECV, extracellular volume fraction; FD, Fabry disease; GLS, global longitudinal strain; LGE, late gadolinium enhancement; LV, left ventricular; LVH, LV hypertrophy; MBF, myocardial blood flow.
+
+P-wave duration was included instead.
+
+T-wave time ratio was included instead.
+
+In recent years, a pre-hypertrophic phase of FD with ECG abnormalities and sphingolipid storage detected by T1 mapping has been described. Here, we sought an even earlier phase of cardiac FD pre-LVH and pre-detectable storage by using advanced ECG analysis and two CMR methods, GLS measurement and quantitative perfusion mapping. In both overt and pre-LVH disease with storage, we found the expected changes in all parameters. For pre-LVH, pre-detectable storage there was an identifiable phenotype with lower ECG conventional voltages than healthy volunteers, and a number of other more robust features: reduced MBF and GLS, PQ shortening (mainly from a shorter P-wave duration), and a shorter Tonset – Tpeak time (with a shorter (Tonset – Tpeak)/(Tpeak – Tend) ratio also). Prior staging of Fabry cardiomyopathy3 included a pre-LVH stage (accumulation/storage) and two LVH stages (hypertrophy and inflammation; fibrosis and impairment). Here we define a silent (pre-clinical) pre-LVH phase, with two stages: accumulation/storage and an even earlier stage microvascular/pre-detectable storage (Figure 5).
+
+
+Proposed stages of cardiac involvement in Fabry disease. A new pre-storage stage is proposed.
+
+Sphingolipid storage has been shown to start before birth14 and some cells including endothelial cells may be more susceptible to sphingolipid storage than myocytes, hence an early degree of microvascular dysfunction would be plausible. Similarly, a shorter P-wave duration pre-storage likely reflects a phenomenon of accelerated intra-atrial conduction with sphingolipids19 which has not yet been counterbalanced by extracellular expansion and/or atrial electroanatomical remodelling processes. At this very early stage, T-wave amplitude was lower than in healthy controls, Tpeak – Tend intervals longer (indicating ventricular repolarization dispersion, a marker for ventricular arrhythmias23) and Tonset – Tpeak times shorter, both resulting in a lower (Tonset – Tpeak)/(Tpeak – Tend) ratio and thus more symmetric T waves. Of note, a normal T wave is asymmetric with a steeper downslope (second half, Tpeak – Tend) than its upslope (first half, Tonset – Tpeak) and is a result of transmural endo-epicardial action potential gradients and their duration, endocardial ones being physiologically slightly longer.25 Any alteration of the myocardial microarchitecture and its perfusion instantaneously entails changes in resting gradients (increased), maximal potentials (decreased), and action potential duration (endocardial shortening).23 To this effect, the observed T wave changes make sense and are in line with our concomitant CMR findings.
+
+But what about GLS and the reduced MBF? To interpret these, whole organism changes should be considered. Before overt cardiac diseases, FD patients manifest small fibre changes (acroparesthesia, GI disturbance, alterations in sweating, and other autonomic abnormalities), but they also show vascular changes and other features that are not so easily quantified—these could include microvascular disease, here expressed by a very early reduced MBF. Whilst slightly reduced GLS might be a primary cardiac phenomenon, it may reflect altered myocardial coupling to the systemic vasculature due to systemic endothelial and smooth muscle changes. Both of these hypotheses are testable and further work is needed.
+
+In the later disease stages, our results corroborate previous findings that sphingolipid storage impairs GLS,15 MBF16 and may result in myocardial oedema, fibrosis and LV impairment3 (Figure 5). Here, we have now described for the first time novel ECG features of cardiac involvement in FD that occur even before native T1 mapping lowering and overt LVH.
+
+With low T1, electrocardiographic indexes of hypertrophy become more pronounced, and ventricular depolarization is delayed (longer QRS and R-wave peak times more fQRS) and so does atrial depolarization (longer P-wave duration). These observations may seem counterintuitive, since one would expect an increase in the diameter of conducting cells with storage eventually leading to faster conduction velocities19 and thus shorter depolarization times. However, P-wave duration, for instance, follows an interesting ‘biphasic’ pattern with disease progression. It first gets shorter pre-detectable storage, reflecting accelerated intra-atrial conduction, but with progressive storage also comes extracellular expansion and left atrial remodelling, progressively slowing down intra-atrial conduction, first ‘pseudonormalizing’ P-wave duration, and finally prolonging it. This sort of pattern hinders ECG interpretation in FD patients who have a ‘normal’ P-wave duration and may be misclassified as not having cardiac involvement, but low T1 is able to rule in cardiac involvement in such patients.
+
+This is a cross-sectional single time-point analysis. Longitudinal changes (e.g. how P-wave might behave overtime) are therefore hypothesized rather than observed. The Fabry population with pacemaker is not represented in this study as some CMR parameters (e.g. T1, T2 mapping) would likely be affected by the metallic artefact and introduce error in the analysis. Tissue characterization assumptions (microvascular disease, storage, oedema, and fibrosis) are based on CMR rather than biopsy and may have more than one biological explanation—for example stress blood flow reduction could be capillary rarefaction or insensitivity to adenosine instead of alteration in endothelial/smooth muscle behaviour. However, we believe that some histological findings would only be present in a later stage and are likely not sensitive enough to detect some very early changes such as cardiac electrophysiological involvement. A more comprehensive blood biomarker analysis (e.g. proteomics) could also have a role in understanding pathophysiology and detection of early forms of cardiac involvement in FD (see Figure 5, bottom), but further studies are needed.
+
+There is a pre-LVH, pre-detectable storage phase of cardiac involvement in FD characterized by subtle abnormalities of microvascular dysfunction, impaired LV mechanics and altered atrial depolarization and ventricular repolarization intervals. Further studies are required to understand whether this observation provides a window for optimal therapeutic intervention.
+
+The data that support the findings of this study are available from the corresponding author upon reasonable request.
+
+
+Supplementary data are available at European Heart Journal - Cardiovascular Imaging online.
+
+
+Conflict of interest: U.R. has received travel grants and honoraria for lectures and advisory boards from Takeda, Sanofi-Genzyme, Amicus, Idorsia, and Chiesi. All other authors report no disclosures relevant to the contents of this article.
+
+Click here for additional data file.

--- a/references_cache/PMID_37626912.md
+++ b/references_cache/PMID_37626912.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:37626912"
+title: Circulated TGF-β1 and VEGF-A as Biomarkers for Fabry Disease-Associated Cardiomyopathy.
+authors:
+- Ivanova MM
+- Dao J
+- Slayeh OA
+- Friedman A
+- Goker-Alpan O
+journal: Cells
+year: '2023'
+doi: 10.3390/cells12162102
+keywords:
+- Male
+- Humans
+- Female
+- Transforming Growth Factor beta1
+- Vascular Endothelial Growth Factor A
+- "Fabry Disease/complications, diagnosis"
+- Fibroblast Growth Factor 2
+- Cardiomyopathies
+- "Cardiomyopathy, Hypertrophic"
+- Transforming Growth Factor beta
+- Biomarkers
+- Hypertrophy
+content_type: abstract_only
+---
+
+# Circulated TGF-β1 and VEGF-A as Biomarkers for Fabry Disease-Associated Cardiomyopathy.
+**Authors:** Ivanova MM, Dao J, Slayeh OA, Friedman A, Goker-Alpan O
+**Journal:** Cells (2023)
+**DOI:** [10.3390/cells12162102](https://doi.org/10.3390/cells12162102)
+
+## Content
+
+1. Cells. 2023 Aug 19;12(16):2102. doi: 10.3390/cells12162102.
+
+Circulated TGF-β1 and VEGF-A as Biomarkers for Fabry Disease-Associated
+Cardiomyopathy.
+
+Ivanova MM(1), Dao J(1), Slayeh OA(1), Friedman A(1), Goker-Alpan O(1).
+
+Author information:
+(1)Lysosomal & Rare Disorders Research and Treatment Center, 3702 Pender Drive,
+Ste 170, Fairfax, VA 22030, USA.
+
+Fabry disease (FD) is a lysosomal disorder caused by α-galactosidase A
+deficiency, resulting in the accumulation of globotriaosylceramide (Gb-3) and
+its metabolite globotriaosylsphingosine (Lyso-Gb-3). Cardiovascular
+complications and hypertrophic cardiomyopathy (HCM) are the most frequent
+manifestations of FD. While an echocardiogram and cardiac MRI are clinical tools
+to assess cardiac involvement, hypertrophic pattern variations and fibrosis make
+it crucial to identify biomarkers to predict early cardiac outcomes. This study
+aims to investigate potential biomarkers associated with HCM in FD: transforming
+growth factor-β1 (TGF-β1), TGF-β active form (a-TGF-β), vascular endothelial
+growth factor (VEGF-A), and fibroblast growth factor (FGF2) in 45 patients with
+FD, categorized into cohorts based on the HCM severity. TGF-β1, a-TGF-β, FGF2,
+and VEGF-A were elevated in FD. While the association of TGF-β1 with HCM was not
+gender-related, VEGF was elevated in males with FD and HCM. Female patients with
+abnormal electrocardiograms but without overt HCM also have elevated TGF-β1.
+Lyso-Gb3 is correlated with TGF-β1, VEGF-A, and a-TGF-β1. Elevation of TGF-β1
+provides evidence of the chronic inflammatory state as a cause of myocardial
+fibrosis in FD patients; thus, it is a potential marker of early cardiac
+fibrosis detected even prior to hypertrophy. TGF-β1 and VEGF biomarkers may be
+prognostic indicators of adverse cardiovascular events in FD.
+
+DOI: 10.3390/cells12162102
+PMCID: PMC10453505
+PMID: 37626912 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest. The
+funders had no role in the design of the study; in the collection, analyses, or
+interpretation of data; in the writing of the manuscript; or in the decision to
+publish the results.


### PR DESCRIPTION
## What changed
- deepened the Fabry disease cardiac pathophysiology section with a more explicit progression from cardiomyocyte glycosphingolipid storage to microvascular dysfunction, myocardial inflammation, fibrosis, and arrhythmogenic remodeling
- added stronger cardiac phenotype coverage for myocardial fibrosis, conduction abnormalities, and heart failure
- tightened the left ventricular hypertrophy phenotype mapping and replaced weak cardiac evidence with direct Fabry cardiac citations
- added the fetched PubMed reference cache files required for deterministic reference validation

## Why
The Fabry entry had broad disease-mechanism coverage, but its cardiac section was still mostly phenotype-level. This refresh makes the cardiac disease course more mechanistic and better aligned with the imaging and outcomes literature.

## Impact
- improves the quality and specificity of Fabry cardiac mechanism coverage in the KB
- strengthens machine-readable cardiac phenotype and mechanism assertions
- preserves local validation for the Fabry entry

## Validation
- `just validate kb/disorders/Fabry_Disease.yaml`

## Notes
- the worktree contains unrelated local cache changes that were intentionally excluded from this PR
- repo-wide `just validate-graphs` still reports pre-existing issues in other disorders and was not changed by this PR