### PR TITLE
[codex] Curate PMM2-congenital disorder of glycosylation

### DIFF
--- a/kb/disorders/PMM2-congenital_Disorder_of_Glycosylation.yaml
+++ b/kb/disorders/PMM2-congenital_Disorder_of_Glycosylation.yaml
@@ -1,0 +1,476 @@
+name: PMM2-congenital disorder of glycosylation
+category: Mendelian
+creation_date: '2026-04-13T01:19:08Z'
+updated_date: '2026-04-13T01:19:08Z'
+description: >
+  PMM2-congenital disorder of glycosylation (PMM2-CDG; historical
+  CDG-Ia) is the most common congenital disorder of glycosylation caused by
+  biallelic pathogenic variants in PMM2, which encodes phosphomannomutase 2.
+  PMM2 converts mannose-6-phosphate to mannose-1-phosphate, an upstream
+  metabolite required for normal protein N-linked glycosylation. Reduced PMM2
+  activity lowers mannose flux into N-glycan biosynthesis and produces
+  multisystem hypoglycosylation with a core neurologic phenotype of
+  developmental delay, cerebellar atrophy, ataxia, seizures, hypotonia, and
+  peripheral neuropathy, often accompanied by growth failure, liver
+  involvement, and coagulation abnormalities.
+notes: >-
+  This entry is scoped to classical multisystem PMM2-CDG (historical CDG-Ia /
+  Jaeken syndrome). It intentionally does not lump the distinct tissue-restricted
+  PMM2 promoter-related hyperinsulinism/polycystic kidney disease phenotype into
+  MONDO:0008907.
+disease_term:
+  preferred_term: PMM2-congenital disorder of glycosylation
+  term:
+    id: MONDO:0008907
+    label: PMM2-congenital disorder of glycosylation
+synonyms:
+- PMM2-CDG
+- CDG-Ia
+- phosphomannomutase 2 deficiency
+- carbohydrate-deficient glycoprotein syndrome type Ia
+- Jaeken syndrome
+parents:
+- Congenital Disorder of Glycosylation
+- Inborn Error of Metabolism
+inheritance:
+- name: Autosomal recessive
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  evidence:
+  - reference: PMID:39105373
+    reference_title: "Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency (PMM2-CDG)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PMM2-CDG (formerly CDG-1a), the most common type of congenital disorders of glycosylation, is inherited in an autosomal recessive pattern."
+    explanation: This prospective human cohort explicitly states the autosomal recessive inheritance pattern.
+prevalence:
+- population: Estonia
+  percentage: 1 in 77,000
+  notes: >-
+    Population-based estimate derived from PMM2 carrier frequencies and
+    diagnosed patients in Estonia. Global prevalence remains uncertain and
+    likely varies by ancestry and ascertainment.
+  evidence:
+  - reference: PMID:28685491
+    reference_title: "The Prevalence of PMM2-CDG in Estonia Based on Population Carrier Frequencies and Diagnosed Patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The expected frequency of the disease in Estonian population is 1/77,000."
+    explanation: This abstract provides a direct population prevalence estimate for PMM2-CDG.
+pathophysiology:
+- name: PMM2 enzymatic activity deficiency
+  description: >-
+    Biallelic pathogenic variants in PMM2 reduce phosphomannomutase activity,
+    weakening conversion of mannose-6-phosphate to mannose-1-phosphate.
+  genes:
+  - preferred_term: PMM2
+    term:
+      id: hgnc:9115
+      label: PMM2
+  molecular_functions:
+  - preferred_term: phosphomannomutase activity
+    term:
+      id: GO:0004615
+      label: phosphomannomutase activity
+  evidence:
+  - reference: PMID:26014514
+    reference_title: "The Effects of PMM2-CDG-Causing Mutations on the Folding, Activity, and Stability of the PMM2 Protein."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Congenital disorder of glycosylation type Ia (PMM2-CDG), the most common form of CDG, is caused by mutations in the PMM2 gene that reduce phosphomannomutase 2 (PMM2) activity."
+    explanation: Functional studies of recurrent mutant proteins directly support reduced PMM2 catalytic activity as the proximal molecular lesion.
+  downstream:
+  - target: Reduced mannose-1-phosphate production
+    description: Reduced phosphomannomutase activity limits mannose-1-phosphate availability.
+- name: Reduced mannose-1-phosphate production
+  description: >-
+    PMM2 deficiency lowers production of mannose-1-phosphate, a critical
+    upstream metabolite for normal protein N-linked glycosylation.
+  biological_processes:
+  - preferred_term: mannose metabolic process
+    term:
+      id: GO:0006013
+      label: mannose metabolic process
+  evidence:
+  - reference: PMID:39053125
+    reference_title: "In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores N-glycosylation in PMM2-CDG patient-derived fibroblasts."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "PMM2 converts mannose-6-phosphate (M6P) to mannose-1-phosphate (M1P), which is a critical upstream metabolite for proper protein N-glycosylation."
+    explanation: This patient-fibroblast rescue study explicitly links PMM2 activity to mannose-1-phosphate supply for glycosylation.
+  downstream:
+  - target: Impaired protein N-linked glycosylation
+    description: Reduced mannose-1-phosphate supply lowers mannose flux into N-glycan biosynthesis.
+- name: Impaired protein N-linked glycosylation
+  description: >-
+    Reduced mannose flux into the glycosylation pathway causes underoccupied and
+    compositionally abnormal N-glycans on plasma and cellular glycoproteins.
+  biological_processes:
+  - preferred_term: protein N-linked glycosylation
+    term:
+      id: GO:0006487
+      label: protein N-linked glycosylation
+  evidence:
+  - reference: PMID:21949237
+    reference_title: "Phosphomannose isomerase inhibitors improve N-glycosylation in selected phosphomannomutase-deficient fibroblasts."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "PMM2 (mannose 6-phosphate → mannose 1-phosphate) and MPI (mannose 6-phosphate ⇔ fructose 6-phosphate) deficiencies reduce the metabolic flux of mannose 6-phosphate (Man-6-P) into glycosylation, resulting in unoccupied N-glycosylation sites."
+    explanation: This cell-based study directly supports impaired glycosylation flux and underoccupied N-glycosylation sites downstream of PMM2 deficiency.
+  - reference: PMID:39053125
+    reference_title: "In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores N-glycosylation in PMM2-CDG patient-derived fibroblasts."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "This treatment normalized intracellular GDP-mannose, increased the relative glycoprotein mannosylation content and TNFα-induced ICAM-1 expression."
+    explanation: Biochemical rescue of GDP-mannose and glycoprotein mannosylation in patient fibroblasts supports glycosylation failure as the central biochemical defect.
+  downstream:
+  - target: Decreased activation of protein C
+    description: Hypoglycosylation reduces function of glycosylated endothelial anticoagulant pathway components.
+  - target: Endothelial barrier dysfunction
+    description: Hypoglycosylation destabilizes endothelial junction integrity and increases permeability.
+- name: Decreased activation of protein C
+  description: >-
+    N-glycosylation deficiency impairs activated protein C generation because
+    endothelial thrombomodulin and endothelial protein C receptor expression are
+    reduced.
+  biological_processes:
+  - preferred_term: blood coagulation
+    term:
+      id: GO:0007596
+      label: blood coagulation
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  evidence:
+  - reference: PMID:35717947
+    reference_title: "N-Glycosylation Deficiency Reduces the Activation of Protein C and Disrupts Endothelial Barrier Integrity."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The resulting PMM2low cells were less able to generate activated protein C (APC), due to lower surface expression of thrombomodulin and endothelial protein C receptor."
+    explanation: Endothelial PMM2 knockdown directly impaired the protein C anticoagulant pathway.
+- name: Endothelial barrier dysfunction
+  description: >-
+    PMM2 deficiency disrupts endothelial junctional integrity and increases
+    thrombin-induced permeability.
+  biological_processes:
+  - preferred_term: cell adhesion
+    term:
+      id: GO:0007155
+      label: cell adhesion
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  evidence:
+  - reference: PMID:35717947
+    reference_title: "N-Glycosylation Deficiency Reduces the Activation of Protein C and Disrupts Endothelial Barrier Integrity."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "PMM2 knockdown was also associated with impaired integrity of the endothelial cell monolayer-partly due to an alteration in the structure of VE-cadherin in adherens junctions."
+    explanation: This endothelial cell model shows a direct permeability mechanism downstream of glycosylation deficiency.
+phenotypes:
+- category: Neurologic
+  name: Developmental delay
+  frequency: OBLIGATE
+  description: >-
+    Early developmental impairment is a core and near-universal clinical feature
+    of classical PMM2-CDG.
+  phenotype_term:
+    preferred_term: Developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Developmental delay is a constant phenotype."
+    explanation: Author wording "constant phenotype" maps to the OBLIGATE frequency band.
+- category: Neurologic
+  name: Ataxia
+  frequency: VERY_FREQUENT
+  description: >-
+    Cerebellar ataxia is a dominant long-term neurologic manifestation of
+    PMM2-CDG.
+  phenotype_term:
+    preferred_term: Ataxia
+    term:
+      id: HP:0001251
+      label: Ataxia
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestation included ataxia (90.2%), myopathy (82.4%), seizures (56.9%), neuropathy (52.9%), microcephaly (19.1%), extrapyramidal symptoms (27.5%), stroke-like episodes (SLE) (15.7%), and spasticity (13.7%)."
+    explanation: 90.2% falls in the VERY_FREQUENT frequency band.
+- category: Neurologic
+  name: Cerebellar atrophy
+  frequency: VERY_FREQUENT
+  description: >-
+    Progressive cerebellar atrophy is the characteristic neuroimaging
+    abnormality in PMM2-CDG.
+  phenotype_term:
+    preferred_term: Cerebellar atrophy
+    term:
+      id: HP:0001272
+      label: Cerebellar atrophy
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Progressive cerebellar atrophy is the characteristic neuroimaging finding."
+    explanation: Author wording "characteristic" maps to the VERY_FREQUENT band under the dismech qualitative mapping.
+- category: Neurologic
+  name: Hypotonia
+  description: >-
+    Reduced tone is common from infancy and contributes to delayed motor
+    acquisition.
+  phenotype_term:
+    preferred_term: Hypotonia
+    term:
+      id: HP:0001252
+      label: Hypotonia
+  evidence:
+  - reference: PMID:39105373
+    reference_title: "Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency (PMM2-CDG)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical features of PMM2-CDG in this cohort were neurodevelopmental disorders, faltering growth, hypotonia, cerebellar atrophy, peripheral neuropathy, movement disorders, ophthalmological abnormalities, and auditory function differences."
+    explanation: Prospective deep phenotyping supports hypotonia as part of the recurrent neurologic phenotype.
+- category: Neurologic
+  name: Peripheral neuropathy
+  frequency: FREQUENT
+  description: >-
+    Peripheral nerve involvement emerges in a substantial subset of patients and
+    contributes to progressive motor disability.
+  phenotype_term:
+    preferred_term: Peripheral neuropathy
+    term:
+      id: HP:0009830
+      label: Peripheral neuropathy
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestation included ataxia (90.2%), myopathy (82.4%), seizures (56.9%), neuropathy (52.9%), microcephaly (19.1%), extrapyramidal symptoms (27.5%), stroke-like episodes (SLE) (15.7%), and spasticity (13.7%)."
+    explanation: 52.9% falls in the FREQUENT frequency band.
+- category: Neurologic
+  name: Seizures
+  frequency: FREQUENT
+  description: >-
+    Seizures can occur across the life course and are a major contributor to
+    neurologic morbidity.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestation included ataxia (90.2%), myopathy (82.4%), seizures (56.9%), neuropathy (52.9%), microcephaly (19.1%), extrapyramidal symptoms (27.5%), stroke-like episodes (SLE) (15.7%), and spasticity (13.7%)."
+    explanation: 56.9% falls in the FREQUENT frequency band.
+- category: Neurologic
+  name: Stroke-like episodes
+  frequency: OCCASIONAL
+  description: >-
+    Transient focal neurologic episodes occur in a minority of patients and are
+    often associated with preceding seizures or fever.
+  phenotype_term:
+    preferred_term: Stroke-like episode
+    term:
+      id: HP:0002401
+      label: Stroke-like episode
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestation included ataxia (90.2%), myopathy (82.4%), seizures (56.9%), neuropathy (52.9%), microcephaly (19.1%), extrapyramidal symptoms (27.5%), stroke-like episodes (SLE) (15.7%), and spasticity (13.7%)."
+    explanation: 15.7% falls in the OCCASIONAL frequency band.
+- category: Growth
+  name: Growth delay
+  frequency: FREQUENT
+  description: >-
+    Growth failure is common, especially in individuals with early multisystem
+    disease.
+  phenotype_term:
+    preferred_term: Growth delay
+    term:
+      id: HP:0001510
+      label: Growth delay
+  evidence:
+  - reference: PMID:40555085
+    reference_title: "Multiorgan involvement and genetic spectrum of 20 Chinese patients with PMM2-CDG."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Dystaxia, growth retardation and liver damage were also common phenotypes."
+    explanation: Author wording "common" maps to the FREQUENT frequency band.
+- category: Hematologic
+  name: Abnormality of coagulation
+  frequency: FREQUENT
+  description: >-
+    Coagulation defects are among the most consistently abnormal laboratory
+    features in large PMM2-CDG cohorts.
+  phenotype_term:
+    preferred_term: Abnormality of coagulation
+    term:
+      id: HP:0001928
+      label: Abnormality of coagulation
+  evidence:
+  - reference: PMID:40225925
+    reference_title: "Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patient phenotypes were characterized via the Nijmegen Progression CDG Rating Scale (NPCRS), together with biochemical parameters, the most consistently dysregulated of which were coagulation factors, specifically antithrombin (below normal in 79.5%, 93 of 117), in addition to Factor XI and protein C activity."
+    explanation: 79.5% falls in the FREQUENT frequency band and directly supports coagulation pathway abnormalities.
+- category: Hepatic
+  name: Hepatomegaly
+  frequency: FREQUENT
+  description: >-
+    Liver involvement is common in PMM2-CDG and often includes hepatomegaly and
+    elevated aminotransferases.
+  phenotype_term:
+    preferred_term: Hepatomegaly
+    term:
+      id: HP:0002240
+      label: Hepatomegaly
+  evidence:
+  - reference: PMID:36965289
+    reference_title: "Liver transplantation recovers hepatic N-glycosylation with persistent IgG glycosylation abnormalities: Three-year follow-up in a patient with phosphomannomutase-2-congenital disorder of glycosylation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Liver abnormalities occur in in almost all patients and frequently include hepatomegaly and elevated aminotransferases, although only a minority of patients develop progressive hepatic fibrosis and liver failure."
+    explanation: Author wording "frequently include hepatomegaly" maps to the FREQUENT frequency band.
+genetic:
+- name: PMM2 pathogenic variants causing PMM2-CDG
+  inheritance:
+  - name: Autosomal recessive
+    evidence:
+    - reference: PMID:39105373
+      reference_title: "Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency (PMM2-CDG)."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PMM2-CDG (formerly CDG-1a), the most common type of congenital disorders of glycosylation, is inherited in an autosomal recessive pattern."
+      explanation: Human cohort evidence confirms autosomal recessive inheritance.
+  variants:
+  - name: PMM2 p.Arg141His
+    description: >-
+      Most common variant in the large international natural history cohort and
+      a major recurrent allele in European-ancestry series.
+    evidence:
+    - reference: PMID:40225925
+      reference_title: "Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A total of 137 participants had complete genotype information, representing 60 unique variants, of which the most common were found to be p.Arg141His in 58.4% (n = 80) of participants, followed by p.Pro113Leu (21.2%, n = 29), and p.Phe119Leu (12.4%, n = 17), consistent with previous studies."
+      explanation: This large multicenter cohort identifies p.Arg141His as the most frequent PMM2-CDG allele.
+  - name: PMM2 p.Cys241Ser
+    description: >-
+      Variant associated with milder disease in the international
+      genotype-phenotype analysis.
+    evidence:
+    - reference: PMID:40225925
+      reference_title: "Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The second approach characterized genotype by the predicted pathogenic mechanism and/or individual variants when paired with a subset of severe nonfunctioning variants and uncovered correlations with both NPCRS and biochemical parameters, demonstrating that p.Cys241Ser was associated with milder disease, while p.Val231Met, dimerization, and folding variants with more severe disease."
+      explanation: The natural history study directly supports p.Cys241Ser as a milder modifier allele.
+  - name: PMM2 p.Val231Met
+    description: >-
+      Variant associated with more severe disease in the international
+      genotype-phenotype analysis.
+    evidence:
+    - reference: PMID:40225925
+      reference_title: "Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The second approach characterized genotype by the predicted pathogenic mechanism and/or individual variants when paired with a subset of severe nonfunctioning variants and uncovered correlations with both NPCRS and biochemical parameters, demonstrating that p.Cys241Ser was associated with milder disease, while p.Val231Met, dimerization, and folding variants with more severe disease."
+      explanation: The same genotype-phenotype analysis identifies p.Val231Met as a severe modifier allele.
+  features: >-
+    PMM2-CDG is genetically heterogeneous. In the 137-participant multicenter
+    cohort, 60 unique PMM2 variants were observed, and genotype effects tracked
+    with catalytic/activation, folding, and dimerization mechanisms rather than
+    with a single simple severity axis.
+  evidence:
+  - reference: PMID:40225925
+    reference_title: "Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patient genotypes were classified based upon the predicted pathogenetic mechanism of disease-associated mutations, of which most were found in the catalysis/activation, folding, or dimerization regions of the PMM2 enzyme."
+    explanation: This large natural history study supports mutation-class-based modifiers centered on catalytic, folding, and dimerization mechanisms.
+treatments:
+- name: Acetazolamide
+  description: >-
+    Off-label symptomatic therapy for neurologic manifestations. In the reported
+    sub-cohort it improved speech fluency, but objective ataxia scores did not
+    improve significantly.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: acetazolamide
+      term:
+        id: CHEBI:27690
+        label: acetazolamide
+  evidence:
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "\"Off-label\" acetazolamide therapy in a smaller sub-cohort resulted in improvement in speech fluency but did not show statistically significant improvement in objective ataxia scores."
+    explanation: Human follow-up data support symptomatic benefit in speech fluency but only partial support for ataxia improvement.
+  - reference: PMID:37955240
+    reference_title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Acetazolamide is well tolerated."
+    explanation: The natural history cohort explicitly reports tolerability.
+- name: Liver transplantation
+  description: >-
+    Rescue therapy for the rare PMM2-CDG patient with end-stage liver disease.
+    Published human follow-up showed normalization of liver enzymes, coagulation
+    parameters, and carbohydrate-deficient transferrin after transplant.
+  treatment_term:
+    preferred_term: organ transplantation
+    term:
+      id: MAXO:0010039
+      label: organ transplantation
+  evidence:
+  - reference: PMID:36965289
+    reference_title: "Liver transplantation recovers hepatic N-glycosylation with persistent IgG glycosylation abnormalities: Three-year follow-up in a patient with phosphomannomutase-2-congenital disorder of glycosylation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Liver transplant should be considered as a treatment option for PMM2-CDG patients with end-stage liver disease, however these patients may be at increased risk for recurrent bacterial infections post-transplant."
+    explanation: This case report provides direct human evidence for liver transplantation as a rescue option in end-stage hepatic PMM2-CDG.
+- name: Liposomal mannose-1-phosphate (GLM101)
+  description: >-
+    Experimental substrate-replacement strategy intended to bypass PMM2 and
+    restore glycosylation precursors. Evidence is currently limited to
+    patient-derived fibroblasts and preclinical pharmacokinetics.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  evidence:
+  - reference: PMID:39053125
+    reference_title: "In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores N-glycosylation in PMM2-CDG patient-derived fibroblasts."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Taken as a whole, the results described in this report support further exploration of GLM101's safety, tolerability, and efficacy in PMM2-CDG patients."
+    explanation: Patient-fibroblast rescue data support GLM101 as an experimental disease-modifying strategy, but current evidence remains preclinical.

--- a/references_cache/PMID_21949237.md
+++ b/references_cache/PMID_21949237.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:21949237"
+title: Phosphomannose isomerase inhibitors improve N-glycosylation in selected phosphomannomutase-deficient fibroblasts.
+authors:
+- Sharma V
+- Ichikawa M
+- He P
+- Scott DA
+- Bravo Y
+- Dahl R
+- Ng BG
+- Cosford ND
+- Freeze HH
+journal: J Biol Chem
+year: '2011'
+doi: 10.1074/jbc.M111.285502
+keywords:
+- Animals
+- "Congenital Disorders of Glycosylation/drug therapy, enzymology, genetics"
+- "Enzyme Inhibitors/pharmacology, therapeutic use"
+- Fibroblasts/enzymology
+- Glycosylation/drug effects
+- HeLa Cells
+- Humans
+- "Mannose/genetics, metabolism"
+- "Mannose-6-Phosphate Isomerase/antagonists & inhibitors, genetics, metabolism"
+- "Mannosephosphates/genetics, metabolism"
+- Mutation
+- Phosphotransferases (Phosphomutases)/genetics
+- "Zebrafish/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Phosphomannose isomerase inhibitors improve N-glycosylation in selected phosphomannomutase-deficient fibroblasts.
+**Authors:** Sharma V, Ichikawa M, He P, Scott DA, Bravo Y, Dahl R, Ng BG, Cosford ND, Freeze HH
+**Journal:** J Biol Chem (2011)
+**DOI:** [10.1074/jbc.M111.285502](https://doi.org/10.1074/jbc.M111.285502)
+
+## Content
+
+1. J Biol Chem. 2011 Nov 11;286(45):39431-8. doi: 10.1074/jbc.M111.285502. Epub
+2011 Sep 26.
+
+Phosphomannose isomerase inhibitors improve N-glycosylation in selected
+phosphomannomutase-deficient fibroblasts.
+
+Sharma V(1), Ichikawa M, He P, Scott DA, Bravo Y, Dahl R, Ng BG, Cosford ND,
+Freeze HH.
+
+Author information:
+(1)Sanford Children's Health Research Center, Sanford-Burnham Medical Research
+Institute, La Jolla, California 92037, USA.
+
+Erratum in
+    J Biol Chem. 2011 Dec 16;286(50):43588. Scott, David A [added].
+
+Congenital disorders of glycosylation (CDG) are rare genetic disorders due to
+impaired glycosylation. The patients with subtypes CDG-Ia and CDG-Ib have
+mutations in the genes encoding phosphomannomutase 2 (PMM2) and phosphomannose
+isomerase (MPI or PMI), respectively. PMM2 (mannose 6-phosphate → mannose
+1-phosphate) and MPI (mannose 6-phosphate ⇔ fructose 6-phosphate) deficiencies
+reduce the metabolic flux of mannose 6-phosphate (Man-6-P) into glycosylation,
+resulting in unoccupied N-glycosylation sites. Both PMM2 and MPI compete for the
+same substrate, Man-6-P. Daily mannose doses reverse most of the symptoms of
+MPI-deficient CDG-Ib patients. However, CDG-Ia patients do not benefit from
+mannose supplementation because >95% Man-6-P is catabolized by MPI. We
+hypothesized that inhibiting MPI enzymatic activity would provide more Man-6-P
+for glycosylation and possibly benefit CDG-Ia patients with residual PMM2
+activity. Here we show that MLS0315771, a potent MPI inhibitor from the
+benzoisothiazolone series, diverts Man-6-P toward glycosylation in various cell
+lines including fibroblasts from CDG-Ia patients and improves N-glycosylation.
+Finally, we show that MLS0315771 increases mannose metabolic flux toward
+glycosylation in zebrafish embryos.
+
+DOI: 10.1074/jbc.M111.285502
+PMCID: PMC3234766
+PMID: 21949237 [Indexed for MEDLINE]

--- a/references_cache/PMID_26014514.md
+++ b/references_cache/PMID_26014514.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:26014514"
+title: "The Effects of PMM2-CDG-Causing Mutations on the Folding, Activity, and Stability of the PMM2 Protein."
+authors:
+- Yuste-Checa P
+- Gámez A
+- Brasil S
+- Desviat LR
+- Ugarte M
+- Pérez-Cerdá C
+- Pérez B
+journal: Hum Mutat
+year: '2015'
+doi: 10.1002/humu.22817
+keywords:
+- Animals
+- "Congenital Disorders of Glycosylation/genetics, metabolism"
+- Enzyme Activation/genetics
+- Enzyme Stability/genetics
+- Fibroblasts
+- Gene Expression
+- Humans
+- Mice
+- Mutation
+- "Phosphotransferases (Phosphomutases)/chemistry, genetics, metabolism"
+- Protein Folding
+- Protein Multimerization
+- Proteolysis
+- "Recombinant Fusion Proteins/chemistry, genetics, metabolism"
+content_type: abstract_only
+---
+
+# The Effects of PMM2-CDG-Causing Mutations on the Folding, Activity, and Stability of the PMM2 Protein.
+**Authors:** Yuste-Checa P, Gámez A, Brasil S, Desviat LR, Ugarte M, Pérez-Cerdá C, Pérez B
+**Journal:** Hum Mutat (2015)
+**DOI:** [10.1002/humu.22817](https://doi.org/10.1002/humu.22817)
+
+## Content
+
+1. Hum Mutat. 2015 Sep;36(9):851-60. doi: 10.1002/humu.22817. Epub 2015 Jul 23.
+
+The Effects of PMM2-CDG-Causing Mutations on the Folding, Activity, and
+Stability of the PMM2 Protein.
+
+Yuste-Checa P(1), Gámez A(1), Brasil S(1), Desviat LR(1), Ugarte M(1),
+Pérez-Cerdá C(1), Pérez B(1).
+
+Author information:
+(1)Centro de Diagnóstico de Enfermedades Moleculares, Centro de Biología
+Molecular-SO UAM-CSIC, Universidad Autónoma de Madrid, Campus de Cantoblanco,
+28049 Madrid/Centro de Investigación Biomédica en Red de Enfermedades Raras
+(CIBERER), Instituto de Investigación Sanitaria IdiPaZ, Madrid, Spain.
+
+Congenital disorder of glycosylation type Ia (PMM2-CDG), the most common form of
+CDG, is caused by mutations in the PMM2 gene that reduce phosphomannomutase 2
+(PMM2) activity. No curative treatment is available. The present work describes
+the functional analysis of nine human PMM2 mutant proteins frequently found in
+PMM2-CDG patients and also two murine Pmm2 mutations carried by the unique
+PMM2-CDG mouse model described to overcome embryonic lethality. The effects of
+the mutations on PMM2/Pmm2 stability, oligomerization, and enzyme activity were
+explored in an optimized bacterial system. The mutant proteins were associated
+with an enzymatic activity of up to 47.3% as compared with wild type (WT).
+Stability analysis performed using differential scanning fluorimetry and a
+bacterial transcription-translation-coupled system allowed the identification of
+several destabilizing mutations (p.V44A, p.D65Y, p.R123Q, p.R141H, p.R162W,
+p.F207S, p.T237M, p.C241S). Exclusion chromatography identified one mutation,
+p.P113L, that affected dimer interaction. Expression analysis of the p.V44A,
+p.D65Y, p.R162W, and p.T237M mutations in a eukaryotic expression system under
+permissive folding conditions showed the possibility of recovering their
+associated PMM2 activity. Together, the results suggest that some
+loss-of-function mutations detected in PMM2-CDG patients could be destabilizing,
+and therefore PMM2 activity could be, in certain cases, rescuable via the use of
+synergetic proteostasis modulators and/or chaperones.
+
+© 2015 WILEY PERIODICALS, INC.
+
+DOI: 10.1002/humu.22817
+PMID: 26014514 [Indexed for MEDLINE]

--- a/references_cache/PMID_28685491.md
+++ b/references_cache/PMID_28685491.md
@@ -1,0 +1,63 @@
+---
+reference_id: "PMID:28685491"
+title: The Prevalence of PMM2-CDG in Estonia Based on Population Carrier Frequencies and Diagnosed Patients.
+authors:
+- Vals MA
+- Pajusalu S
+- Kals M
+- Mägi R
+- Õunap K
+journal: JIMD Rep
+year: '2018'
+doi: 10.1007/8904_2017_41
+content_type: abstract_only
+---
+
+# The Prevalence of PMM2-CDG in Estonia Based on Population Carrier Frequencies and Diagnosed Patients.
+**Authors:** Vals MA, Pajusalu S, Kals M, Mägi R, Õunap K
+**Journal:** JIMD Rep (2018)
+**DOI:** [10.1007/8904_2017_41](https://doi.org/10.1007/8904_2017_41)
+
+## Content
+
+1. JIMD Rep. 2018;39:13-17. doi: 10.1007/8904_2017_41. Epub 2017 Jul 7.
+
+The Prevalence of PMM2-CDG in Estonia Based on Population Carrier Frequencies
+and Diagnosed Patients.
+
+Vals MA(1)(2)(3), Pajusalu S(4)(5), Kals M(6), Mägi R(6), Õunap K(4)(5).
+
+Author information:
+(1)Department of Clinical Genetics, United Laboratories, Tartu University
+Hospital, Tartu, Estonia. mari-anne.vals@kliinikum.ee.
+(2)Department of Clinical Genetics, Institute of Clinical Medicine, University
+of Tartu, Tartu, Estonia. mari-anne.vals@kliinikum.ee.
+(3)Children's Clinic, Tartu University Hospital, Tartu, Estonia.
+mari-anne.vals@kliinikum.ee.
+(4)Department of Clinical Genetics, United Laboratories, Tartu University
+Hospital, Tartu, Estonia.
+(5)Department of Clinical Genetics, Institute of Clinical Medicine, University
+of Tartu, Tartu, Estonia.
+(6)Estonian Genome Center, University of Tartu, Tartu, Estonia.
+
+PMM2-CDG (MIM#212065) is the most common type of congenital disorders of
+glycosylation (CDG) caused by mutations in PMM2 (MIM#601785). In Estonia, five
+patients from three families have been diagnosed with PMM2-CDG. Our aim was to
+evaluate the presence of different PMM2-CDG-causing mutations in a
+population-based cohort and to calculate the expected frequency of PMM2-CDG in
+Estonia. Also, we analyzed the prevalence of PMM2-CDG based on our patient group
+data. To calculate the expected frequency of PMM2-CDG, we used the whole genome
+sequencing data of 2,244 participants from biobank of the Estonian Genome
+Center, University of Tartu. Nineteen individuals carried mutated PMM2 alleles
+and altogether, five different mutations were identified. The observed carrier
+frequency for all PMM2 disease-causing mutations was thus 1/118, and for the
+most frequent mutation p.R141H, 1/224. The expected frequency of the disease in
+Estonian population is 1/77,000. It is comparable to the current prevalence of
+PMM2-CDG for the less than 18 years age group, which is 1/79,000. In conclusion,
+the frequency of PMM2-CDG in Estonia is lower than in other European populations
+reported thus far. We demonstrate that biobank data can be useful for gaining
+new information about the epidemiology of the PMM2-CDG.
+
+DOI: 10.1007/8904_2017_41
+PMCID: PMC5953896
+PMID: 28685491

--- a/references_cache/PMID_35717947.md
+++ b/references_cache/PMID_35717947.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:35717947"
+title: N-Glycosylation Deficiency Reduces the Activation of Protein C and Disrupts Endothelial Barrier Integrity.
+authors:
+- Pascreau T
+- Saller F
+- Bianchini EP
+- Lasne D
+- Bruneel A
+- Reperant C
+- Foulquier F
+- Denis CV
+- De Lonlay P
+- Borgel D
+journal: Thromb Haemost
+year: '2022'
+doi: 10.1055/s-0042-1744378
+keywords:
+- Congenital Disorders of Glycosylation
+- Endothelium
+- Glycosylation
+- Humans
+- Phosphotransferases (Phosphomutases)/deficiency
+- Protein C
+- Thrombin
+content_type: abstract_only
+---
+
+# N-Glycosylation Deficiency Reduces the Activation of Protein C and Disrupts Endothelial Barrier Integrity.
+**Authors:** Pascreau T, Saller F, Bianchini EP, Lasne D, Bruneel A, Reperant C, Foulquier F, Denis CV, De Lonlay P, Borgel D
+**Journal:** Thromb Haemost (2022)
+**DOI:** [10.1055/s-0042-1744378](https://doi.org/10.1055/s-0042-1744378)
+
+## Content
+
+1. Thromb Haemost. 2022 Sep;122(9):1469-1478. doi: 10.1055/s-0042-1744378. Epub
+2022 Jun 19.
+
+N-Glycosylation Deficiency Reduces the Activation of Protein C and Disrupts
+Endothelial Barrier Integrity.
+
+Pascreau T(1)(2), Saller F(1), Bianchini EP(1), Lasne D(1)(2), Bruneel A(3)(4),
+Reperant C(1), Foulquier F(5), Denis CV(1), De Lonlay P(6), Borgel D(1)(2).
+
+Author information:
+(1)HITh, UMR_S 1176, Institut National de la Santé et de la Recherche Médicale,
+Université Paris-Saclay, Le Kremlin-Bicêtre, France.
+(2)Laboratoire d'Hématologie, AP-HP, Hôpital Necker-Enfants malades, Paris,
+France.
+(3)Biochimie Métabolique et Cellulaire, AP-HP, Hôpital Bichat-Claude Bernard,
+Paris, France.
+(4)INSERM UMR1193, Université Paris-Saclay, Châtenay-Malabry, France.
+(5)Université de Lille, CNRS, UMR 8576-UGSF - Unité de Glycobiologie Structurale
+et Fonctionnelle, Lille, France.
+(6)Centre de référence des maladies héréditaires du métabolisme de l'enfant et
+de l'adulte - MAMEA, Filière G2M, MetabERN, Imagine Institute, AP-HP, Hôpital
+Necker-Enfants Maladies, University Paris-Descartes, Paris, France.
+
+Phosphomannomutase 2 (PMM2) deficiency is the most prevalent congenital disorder
+of glycosylation. It is associated with coagulopathy, including protein C
+deficiency. Since all components of the anticoagulant and cytoprotective protein
+C system are glycosylated, we sought to investigate the impact of an
+N-glycosylation deficiency on this system as a whole. To this end, we developed
+a PMM2 knockdown model in the brain endothelial cell line hCMEC/D3. The
+resulting PMM2low cells were less able to generate activated protein C (APC),
+due to lower surface expression of thrombomodulin and endothelial protein C
+receptor. The low protein levels were due to downregulated transcription of the
+corresponding genes (THBD and PROCR, respectively), which itself was related to
+downregulation of transcription regulators Krüppel-like factors 2 and 4 and
+forkhead box C2. PMM2 knockdown was also associated with impaired integrity of
+the endothelial cell monolayer-partly due to an alteration in the structure of
+VE-cadherin in adherens junctions. The expression of protease-activated receptor
+1 (involved in the cytoprotective effects of APC on the endothelium) was not
+affected by PMM2 knockdown. Thrombin stimulation induced hyperpermeability in
+PMM2low cells. However, pretreatment of cells with APC before thrombin
+simulation was still associated with a barrier-protecting effect. Taken as a
+whole, our results show that the partial loss of PMM2 in hCMEC/D3 cells is
+associated with impaired activation of protein C and a relative increase in
+barrier permeability.
+
+Thieme. All rights reserved.
+
+DOI: 10.1055/s-0042-1744378
+PMID: 35717947 [Indexed for MEDLINE]
+
+Conflict of interest statement: None declared.

--- a/references_cache/PMID_36965289.md
+++ b/references_cache/PMID_36965289.md
@@ -1,0 +1,99 @@
+---
+reference_id: "PMID:36965289"
+title: "Liver transplantation recovers hepatic N-glycosylation with persistent IgG glycosylation abnormalities: Three-year follow-up in a patient with phosphomannomutase-2-congenital disorder of glycosylation."
+authors:
+- Tahata S
+- Weckwerth J
+- Ligezka A
+- He M
+- Lee HE
+- Heimbach J
+- Ibrahim SH
+- Kozicz T
+- Furuya K
+- Morava E
+journal: Mol Genet Metab
+year: '2023'
+doi: 10.1016/j.ymgme.2023.107559
+keywords:
+- "Congenital Disorders of Glycosylation/complications, genetics"
+- "Phosphotransferases (Phosphomutases)/genetics, deficiency"
+- Humans
+- Follow-Up Studies
+- Liver/metabolism
+- Liver Transplantation
+- Glycosylation
+- "Child, Preschool"
+- Immunoglobulin G
+- Female
+content_type: abstract_only
+---
+
+# Liver transplantation recovers hepatic N-glycosylation with persistent IgG glycosylation abnormalities: Three-year follow-up in a patient with phosphomannomutase-2-congenital disorder of glycosylation.
+**Authors:** Tahata S, Weckwerth J, Ligezka A, He M, Lee HE, Heimbach J, Ibrahim SH, Kozicz T, Furuya K, Morava E
+**Journal:** Mol Genet Metab (2023)
+**DOI:** [10.1016/j.ymgme.2023.107559](https://doi.org/10.1016/j.ymgme.2023.107559)
+
+## Content
+
+1. Mol Genet Metab. 2023 Apr;138(4):107559. doi: 10.1016/j.ymgme.2023.107559.
+Epub  2023 Mar 17.
+
+Liver transplantation recovers hepatic N-glycosylation with persistent IgG
+glycosylation abnormalities: Three-year follow-up in a patient with
+phosphomannomutase-2-congenital disorder of glycosylation.
+
+Tahata S(1), Weckwerth J(2), Ligezka A(3), He M(4), Lee HE(5), Heimbach J(6),
+Ibrahim SH(2), Kozicz T(7), Furuya K(8), Morava E(9).
+
+Author information:
+(1)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, United States of
+America; Division of Medical Genetics, Stanford University, CA, United States of
+America.
+(2)Division of Pediatric Gastroenterology and Hepatology, Mayo Clinic,
+Rochester, MN, United States of America.
+(3)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, United States of
+America.
+(4)Metabolic and Advanced Diagnostics, Children's Hospital of Philadelphia,
+Philadelphia, PA, United States of America.
+(5)Division of Anatomic Pathology, Mayo Clinic, Rochester, MN, United States of
+America.
+(6)Division of Transplant Surgery, Mayo Clinic, Rochester, MN, United States of
+America.
+(7)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, United States of
+America; Department of Laboratory Medicine and Pathology, Mayo Clinic,
+Rochester, MN, United States of America.
+(8)Pediatric Liver Transplant Program, University of Wisconsin Health, Madison,
+WI, United States of America.
+(9)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, United States of
+America; Department of Laboratory Medicine and Pathology, Mayo Clinic,
+Rochester, MN, United States of America. Electronic address:
+morava-kozicz.eva@mayo.edu.
+
+Phosphomannomutase-2-congenital disorder of glycosylation (PMM2-CDG) is the most
+common CDG and presents with highly variable features ranging from isolated
+neurologic involvement to severe multi-organ dysfunction. Liver abnormalities
+occur in in almost all patients and frequently include hepatomegaly and elevated
+aminotransferases, although only a minority of patients develop progressive
+hepatic fibrosis and liver failure. No curative therapies are currently
+available for PMM2-CDG, although investigation into several novel therapies is
+ongoing. We report the first successful liver transplantation in a 4-year-old
+patient with PMM2-CDG. Over a 3-year follow-up period, she demonstrated improved
+growth and neurocognitive development and complete normalization of liver
+enzymes, coagulation parameters, and carbohydrate-deficient transferrin profile,
+but persistently abnormal IgG glycosylation and recurrent upper airway
+infections that did not require hospitalization. Liver transplant should be
+considered as a treatment option for PMM2-CDG patients with end-stage liver
+disease, however these patients may be at increased risk for recurrent bacterial
+infections post-transplant.
+
+Copyright © 2023 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ymgme.2023.107559
+PMCID: PMC10164344
+PMID: 36965289 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of Competing Interest The authors
+Shawn Tahata, MD, Jody Weckwerth, PA-C, Anna Ligezka, Miao He, PhD, Hee Eun Lee,
+MD, PhD6 Julie Heimbach, MD, Samar H Ibrahim, M.B.Ch.B, Tamas Kozicz, MD PhD,
+Katryn Furuya, MD, Eva Morava, MD, PhD have no conflicts of interest to declare.

--- a/references_cache/PMID_37955240.md
+++ b/references_cache/PMID_37955240.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:37955240"
+title: "Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions."
+authors:
+- Muthusamy K
+- Perez-Ortiz JM
+- Ligezka AN
+- Altassan R
+- Johnsen C
+- Schultz MJ
+- Patterson MC
+- Morava E
+journal: Genet Med
+year: '2024'
+doi: 10.1016/j.gim.2023.101027
+keywords:
+- Adult
+- Humans
+- "Child, Preschool"
+- "Congenital Disorders of Glycosylation/drug therapy, genetics"
+- Acetazolamide/therapeutic use
+- Follow-Up Studies
+- Prospective Studies
+- Cerebellar Ataxia
+- Stroke
+- Phosphotransferases (Phosphomutases)/deficiency
+content_type: abstract_only
+---
+
+# Neurological manifestations in PMM2-congenital disorders of glycosylation (PMM2-CDG): Insights into clinico-radiological characteristics, recommendations for follow-up, and future directions.
+**Authors:** Muthusamy K, Perez-Ortiz JM, Ligezka AN, Altassan R, Johnsen C, Schultz MJ, Patterson MC, Morava E
+**Journal:** Genet Med (2024)
+**DOI:** [10.1016/j.gim.2023.101027](https://doi.org/10.1016/j.gim.2023.101027)
+
+## Content
+
+1. Genet Med. 2024 Feb;26(2):101027. doi: 10.1016/j.gim.2023.101027. Epub 2023
+Nov  10.
+
+Neurological manifestations in PMM2-congenital disorders of glycosylation
+(PMM2-CDG): Insights into clinico-radiological characteristics, recommendations
+for follow-up, and future directions.
+
+Muthusamy K(1), Perez-Ortiz JM(2), Ligezka AN(3), Altassan R(4), Johnsen C(5),
+Schultz MJ(6), Patterson MC(7), Morava E(8).
+
+Author information:
+(1)Department of Clinical Genomics, Mayo Clinic, Jacksonville, FL. Electronic
+address: muthusamy.karthik@mayo.edu.
+(2)Department of Pediatric and Adolescent Medicine, Mayo Clinic, Rochester, MN;
+Department of Neurology, Mayo Clinic, Rochester, MN.
+(3)Department of Clinical Genomics, Mayo Clinic, Rochester, MN.
+(4)Department of Medical Genomics, Centre for Genomic Medicine, King Faisal
+Specialist Hospital and Research Center, Riyadh, Saudi Arabia; College of
+Medicine, Alfaisal University, Riyadh, Saudi Arabia.
+(5)Department of Clinical Genomics, Mayo Clinic, Rochester, MN; Department of
+Pediatrics and Adolescent Medicine, University Medical Centre, Göttingen,
+Germany.
+(6)Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN.
+(7)Department of Pediatric and Adolescent Medicine, Mayo Clinic, Rochester, MN;
+Department of Neurology, Mayo Clinic, Rochester, MN; Department of Clinical
+Genomics, Mayo Clinic, Rochester, MN.
+(8)Department of Clinical Genomics, Mayo Clinic, Rochester, MN; Laboratory
+Medicine and Pathology, Mayo Clinic, Rochester, MN; Department of Medical
+Genetics, University Medical School, Pecs, Hungary.
+
+PURPOSE: In the absence of prospective data on neurological symptoms, disease
+outcome, or guidelines for system specific management in phosphomannomutase
+2-congenital disorders of glycosylation (PMM2-CDG), we aimed to collect and
+review natural history data.
+METHODS: Fifty-one molecularly confirmed individuals with PMM2-CDG enrolled in
+the Frontiers of Congenital Disorders of Glycosylation natural history study
+were reviewed. In addition, we prospectively reviewed a smaller cohort of these
+individuals with PMM2-CDG on off-label acetazolamide treatment.
+RESULTS: Mean age at diagnosis was 28.04 months. Developmental delay is a
+constant phenotype. Neurological manifestation included ataxia (90.2%), myopathy
+(82.4%), seizures (56.9%), neuropathy (52.9%), microcephaly (19.1%),
+extrapyramidal symptoms (27.5%), stroke-like episodes (SLE) (15.7%), and
+spasticity (13.7%). Progressive cerebellar atrophy is the characteristic
+neuroimaging finding. Additionally, supratentorial white matter changes were
+noted in adult age. No correlation was observed between the seizure severity and
+SLE risk, although all patients with SLE have had seizures in the past.
+"Off-label" acetazolamide therapy in a smaller sub-cohort resulted in
+improvement in speech fluency but did not show statistically significant
+improvement in objective ataxia scores.
+CONCLUSION: Clinical and radiological findings suggest both neurodevelopmental
+and neurodegenerative pathophysiology. Seizures may manifest at any age and are
+responsive to levetiracetam monotherapy in most cases. Febrile seizure is the
+most common trigger for SLEs. Acetazolamide is well tolerated.
+
+Copyright © 2023 American College of Medical Genetics and Genomics. Published by
+Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.gim.2023.101027
+PMID: 37955240 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of Interest Mayo Clinic and Eva Morava
+have a financial interest related to this research. This research has been
+reviewed by the Mayo Clinic Conflict of Interest Review Board and is being
+conducted in compliance with Mayo Clinic Conflict of Interest policies. This
+work was funded by the grant titled Frontiers in Congenital Disorders of
+Glycosylation (1U54NS115198-01) from the National Institute of Neurological
+Diseases and Stroke (NINDS) and the National Center for Advancing Translational
+Sciences (NCATS), and the Rare Disorders Clinical Research Network (RDCRN), at
+the National Institute of Health. All other authors declare no conflicts of
+interest.

--- a/references_cache/PMID_39053125.md
+++ b/references_cache/PMID_39053125.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:39053125"
+title: In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores N-glycosylation in PMM2-CDG patient-derived fibroblasts.
+authors:
+- Shirakura T
+- Krishnamoorthy L
+- Paliwal P
+- Hird G
+- McCluskie K
+- McWilliams P
+- He M
+- Ismaili MHA
+journal: Mol Genet Metab
+year: '2024'
+doi: 10.1016/j.ymgme.2024.108531
+keywords:
+- Humans
+- "Fibroblasts/metabolism, drug effects"
+- Liposomes
+- "Congenital Disorders of Glycosylation/drug therapy, genetics, pathology, metabolism"
+- Glycosylation/drug effects
+- Mannosephosphates/metabolism
+- "Phosphotransferases (Phosphomutases)/genetics, metabolism"
+- Mutation
+- "Cells, Cultured"
+- "Intercellular Adhesion Molecule-1/genetics, metabolism"
+content_type: abstract_only
+---
+
+# In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores N-glycosylation in PMM2-CDG patient-derived fibroblasts.
+**Authors:** Shirakura T, Krishnamoorthy L, Paliwal P, Hird G, McCluskie K, McWilliams P, He M, Ismaili MHA
+**Journal:** Mol Genet Metab (2024)
+**DOI:** [10.1016/j.ymgme.2024.108531](https://doi.org/10.1016/j.ymgme.2024.108531)
+
+## Content
+
+1. Mol Genet Metab. 2024 Sep-Oct;143(1-2):108531. doi:
+10.1016/j.ymgme.2024.108531.  Epub 2024 Jul 1.
+
+In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores
+N-glycosylation in PMM2-CDG patient-derived fibroblasts.
+
+Shirakura T(1), Krishnamoorthy L(1), Paliwal P(1), Hird G(1), McCluskie K(1),
+McWilliams P(1), He M(2), Ismaili MHA(3).
+
+Author information:
+(1)Glycomine Inc., San Carlos, CA, USA.
+(2)Children's Hospital of Philadelphia, Philadelphia, PA, USA.
+(3)Glycomine Inc., San Carlos, CA, USA. Electronic address:
+halaoui@glcyomine.com.
+
+PMM2-CDG is the most common congenital disorder of glycosylation (CDG). Patients
+with this disease often carry compound heterozygous mutations of the gene
+encoding the phosphomannomutase 2 (PMM2) enzyme. PMM2 converts
+mannose-6-phosphate (M6P) to mannose-1-phosphate (M1P), which is a critical
+upstream metabolite for proper protein N-glycosylation. Therapeutic options for
+PMM2-CDG patients are limited to management of the disease symptoms, as no drug
+is currently approved to treat this disease. GLM101 is a M1P-loaded liposomal
+formulation being developed as a candidate drug to treat PMM2-CDG. This report
+describes the effect of GLM101 treatment on protein N-glycosylation of PMM2-CDG
+patient-derived fibroblasts. This treatment normalized intracellular
+GDP-mannose, increased the relative glycoprotein mannosylation content and
+TNFα-induced ICAM-1 expression. Moreover, glycomics profiling revealed that
+GLM101 treatment of PMM2-CDG fibroblasts resulted in normalization of most high
+mannose glycans and partial correction of multiple complex and hybrid glycans.
+In vivo characterization of GLM101 revealed its favorable pharmacokinetics,
+liver-targeted biodistribution, and tolerability profile with achieved systemic
+concentrations significantly greater than its effective in vitro potency. Taken
+as a whole, the results described in this report support further exploration of
+GLM101's safety, tolerability, and efficacy in PMM2-CDG patients.
+
+Copyright © 2024. Published by Elsevier Inc.
+
+DOI: 10.1016/j.ymgme.2024.108531
+PMID: 39053125 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest None.

--- a/references_cache/PMID_39105373.md
+++ b/references_cache/PMID_39105373.md
@@ -1,0 +1,92 @@
+---
+reference_id: "PMID:39105373"
+title: Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency (PMM2-CDG).
+authors:
+- Weixel T
+- Adedipe D
+- Muldoon G
+- Lam C
+- Krasnewich D
+- Thurm A
+- Wolfe L
+journal: J Inherit Metab Dis
+year: '2025'
+doi: 10.1002/jimd.12782
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Male
+- Young Adult
+- "Congenital Disorders of Glycosylation/genetics, diagnosis"
+- "Developmental Disabilities/etiology, genetics"
+- Intellectual Disability/genetics
+- "Neurodevelopmental Disorders/genetics, etiology"
+- Phenotype
+- "Phosphotransferases (Phosphomutases)/deficiency, genetics"
+- Prospective Studies
+content_type: abstract_only
+---
+
+# Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency (PMM2-CDG).
+**Authors:** Weixel T, Adedipe D, Muldoon G, Lam C, Krasnewich D, Thurm A, Wolfe L
+**Journal:** J Inherit Metab Dis (2025)
+**DOI:** [10.1002/jimd.12782](https://doi.org/10.1002/jimd.12782)
+
+## Content
+
+1. J Inherit Metab Dis. 2025 Jan;48(1):e12782. doi: 10.1002/jimd.12782. Epub 2024
+ Aug 6.
+
+Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency
+(PMM2-CDG).
+
+Weixel T(1)(2), Adedipe D(3)(4), Muldoon G(3)(5), Lam C(6), Krasnewich D(7),
+Thurm A(3), Wolfe L(1).
+
+Author information:
+(1)National Human Genome Research Institute, National Institutes of Health,
+Bethesda, Maryland, USA.
+(2)Department of Psychological Sciences, Kent State University, Kent, Ohio, USA.
+(3)Neurodevelopmental and Behavioral Phenotyping Service, Intramural Research
+Program, National Institute of Mental Health, Bethesda, Maryland, USA.
+(4)Nisonger Center, The Ohio State University, Columbus, Ohio, USA.
+(5)Social Work, Boston, Massachusetts, USA.
+(6)Division of Genetic Medicine, Department of Pediatrics, University of
+Washington School of Medicine, Seattle, Washington, USA.
+(7)National Institute of General Medical Sciences, National Institutes of
+Health, Bethesda, Maryland, USA.
+
+PMM2-CDG (formerly CDG-1a), the most common type of congenital disorders of
+glycosylation, is inherited in an autosomal recessive pattern. PMM2-CDG
+frequently presents in infancy with multisystemic clinical involvement, and it
+has been diagnosed in over 1000 people worldwide. There have been few natural
+history studies reporting neurodevelopmental characterization of PMM2-CDG. Thus,
+a prospective study was conducted that included neurodevelopmental assessments
+as part of deep phenotyping. This study, Clinical and Basic Investigations into
+Known and Suspected Congenital Disorders of Glycosylation (NCT02089789),
+included 14 participants (8 males and 6 females ages 2-33 years) with a
+confirmed molecular diagnosis of PMM2-CDG. Clinical features of PMM2-CDG in this
+cohort were neurodevelopmental disorders, faltering growth, hypotonia,
+cerebellar atrophy, peripheral neuropathy, movement disorders, ophthalmological
+abnormalities, and auditory function differences. All PMM2-CDG participants met
+criteria for intellectual disability (or global developmental delay if younger
+than age 5). The majority never attained certain gross motor and language
+milestones. Only two participants were ambulatory, and almost all were
+considered minimally verbal. Overall, individuals with PMM2-CDG present with a
+complex neurodevelopmental profile characterized by intellectual disability and
+multisystemic presentations. This systematic quantification of the
+neurodevelopmental profile of PMM2-CDG expands our understanding of the range in
+impairments associated with PMM2-CDG and will help guide management strategies.
+
+© 2024 The Author(s). Journal of Inherited Metabolic Disease published by John
+Wiley & Sons Ltd on behalf of SSIEM.
+
+DOI: 10.1002/jimd.12782
+PMCID: PMC11670447
+PMID: 39105373 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_40225925.md
+++ b/references_cache/PMID_40225925.md
@@ -1,0 +1,162 @@
+---
+reference_id: "PMID:40225925"
+title: "Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG."
+authors:
+- Pajusalu S
+- Vals MA
+- Serrano M
+- Witters P
+- Cechova A
+- Honzik T
+- Edmondson AC
+- Ficicioglu C
+- Barone R
+- De Lonlay P
+- Bérat CM
+- Vuillaumier-Barrot S
+- Lam C
+- Patterson MC
+- Janssen MCH
+- Martins E
+- Quelhas D
+- Sykut-Cegielska J
+- Mousa J
+- Urreizti R
+- McWilliams P
+- Vernhes F
+- Plotkin H
+- Morava E
+- Õunap K
+journal: Hum Mutat
+year: '2024'
+doi: 10.1155/2024/8813121
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- Male
+- Young Adult
+- "Congenital Disorders of Glycosylation/genetics, diagnosis"
+- Genetic Association Studies
+- Genotype
+- Mutation
+- Phenotype
+- "Phosphotransferases (Phosphomutases)/genetics, chemistry"
+content_type: abstract_only
+---
+
+# Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG.
+**Authors:** Pajusalu S, Vals MA, Serrano M, Witters P, Cechova A, Honzik T, Edmondson AC, Ficicioglu C, Barone R, De Lonlay P, Bérat CM, Vuillaumier-Barrot S, Lam C, Patterson MC, Janssen MCH, Martins E, Quelhas D, Sykut-Cegielska J, Mousa J, Urreizti R, McWilliams P, Vernhes F, Plotkin H, Morava E, Õunap K
+**Journal:** Hum Mutat (2024)
+**DOI:** [10.1155/2024/8813121](https://doi.org/10.1155/2024/8813121)
+
+## Content
+
+1. Hum Mutat. 2024 Oct 3;2024:8813121. doi: 10.1155/2024/8813121. eCollection
+2024.
+
+Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG.
+
+Pajusalu S(1)(2), Vals MA(2)(3), Serrano M(4)(5), Witters P(6)(7), Cechova A(8),
+Honzik T(8), Edmondson AC(9), Ficicioglu C(9), Barone R(10)(11), De Lonlay
+P(12), Bérat CM(13), Vuillaumier-Barrot S(13), Lam C(14)(15), Patterson MC(16),
+Janssen MCH(17), Martins E(18), Quelhas D(18), Sykut-Cegielska J(19), Mousa
+J(20), Urreizti R(5), McWilliams P(21), Vernhes F(21), Plotkin H(21), Morava
+E(16)(22)(23), Õunap K(1)(2).
+
+Author information:
+(1)Genetics and Personalized Medicine Clinic, Tartu University Hospital, L.
+Puusepa Street 2, Tartu, Estonia.
+(2)Department of Genetics and Personalized Medicine, Institute of Clinical
+Medicine, University of Tartu, L. Puusepa Street 2, Tartu, Estonia.
+(3)Children's Clinic, Tartu University Hospital, N. Lunini Street 6, Tartu,
+Estonia.
+(4)Pediatric Neurology Department and Clinical Biochemistry and Genetics Units,
+Hospital Sant Joan de Déu, Institut de Recerca Sant Joan de Déu, Barcelona,
+Spain.
+(5)U-703 Centre for Biomedical Research on Rare Diseases (CIBER-ER), Instituto
+de Salud Carlos III, Barcelona, Spain.
+(6)Department of Paediatrics, Metabolic Disease Center, University Hospitals
+Leuven, Leuven, Belgium.
+(7)Department of Development and Regeneration, Faculty of Medicine, KU Leuven,
+Leuven, Belgium.
+(8)Department of Pediatrics and Inherited Metabolic Disorders, First Faculty of
+Medicine, Charles University and General University Hospital in Prague, Prague,
+Czech Republic.
+(9)Division of Human Genetics, Department of Pediatrics, Children's Hospital of
+Philadelphia, Pennsylvania, USA.
+(10)Child Neuropsychiatry Unit, Department of Clinical and Experimental
+Medicine, University of Catania, Catania, Italy.
+(11)Research Unit of Rare Diseases and Neurodevelopmental Disorders, Oasi
+Research Institute-IRCCS, Troina, Italy.
+(12)Reference Center for Inborn Errors of Metabolism, Necker Hospital, APHP,
+University of Paris, Inserm UMR_S1163, INEM, and Institut Imagine, Filière G2M,
+MetabERN, Paris, France.
+(13)Biochemistry and Genetics Department, Bichat-Claude Bernard Hospital, AP-HP,
+University of Paris and Inserm U1149, Paris, France.
+(14)Center for Integrative Brain Research, Seattle Children's Research
+Institute, Seattle, Washington, USA.
+(15)Division of Genetic Medicine, Department of Pediatrics, University of
+Washington School of Medicine, Seattle, Washington, USA.
+(16)Departments of Neurology and Pediatric and Adolescent Medicine, Mayo Clinic,
+Rochester, Minnesota, USA.
+(17)Department of Internal Medicine, Radboud University Medical Centre,
+Nijmegen, Netherlands.
+(18)Centro de Genética Médica, Centro Hospitalar Universitário de Santo António,
+Porto, Portugal.
+(19)Department of Inborn Errors of Metabolism and Paediatrics, The Institute of
+Mother and Child, Warsaw, Poland.
+(20)Department of Clinical Genomics, Mayo Clinic, Rochester, Minnesota, USA.
+(21)Glycomine, Inc., San Francisco, California, USA.
+(22)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester,
+Minnesota, USA.
+(23)Department of Genetics and Genomics Sciences, Icahn School of Medicine at
+Mount Sinai, New York City, New York, USA.
+
+We report on the largest single dataset of patients with PMM2-CDG enrolled in an
+ongoing international, multicenter natural history study collecting genetic,
+clinical, and biological information to evaluate similarities with previous
+studies, report on novel findings, and, additionally, examine potential
+genotype/phenotype correlations. A total of 137 participants had complete
+genotype information, representing 60 unique variants, of which the most common
+were found to be p.Arg141His in 58.4% (n = 80) of participants, followed by
+p.Pro113Leu (21.2%, n = 29), and p.Phe119Leu (12.4%, n = 17), consistent with
+previous studies. Interestingly, six new variants were reported, comprised of
+five missense variants (p.Pro20Leu, p.Tyr64Ser, p.Phe68Cys, p.Tyr76His, and
+p.Arg238His) and one frameshift (c.696del p.Ala233Argfs∗100). Patient phenotypes
+were characterized via the Nijmegen Progression CDG Rating Scale (NPCRS),
+together with biochemical parameters, the most consistently dysregulated of
+which were coagulation factors, specifically antithrombin (below normal in
+79.5%, 93 of 117), in addition to Factor XI and protein C activity. Patient
+genotypes were classified based upon the predicted pathogenetic mechanism of
+disease-associated mutations, of which most were found in the
+catalysis/activation, folding, or dimerization regions of the PMM2 enzyme. Two
+different approaches were used to uncover genotype/phenotype relationships. The
+first characterized genotype only by the predicted pathogenic mechanisms and
+uncovered associated changes in biochemical parameters, not apparent using only
+NPCRS, involving catalysis/activation, dimerization, folding, and no protein
+variants. The second approach characterized genotype by the predicted pathogenic
+mechanism and/or individual variants when paired with a subset of severe
+nonfunctioning variants and uncovered correlations with both NPCRS and
+biochemical parameters, demonstrating that p.Cys241Ser was associated with
+milder disease, while p.Val231Met, dimerization, and folding variants with more
+severe disease. Although determining comprehensive genotype/phenotype
+relationships has previously proven challenging for PMM2-CDG, the larger sample
+size, plus inclusion of biochemical parameters in the current study, has
+provided new insights into the interplay of genetics with disease. Trial
+Registration: NCT03173300.
+
+Copyright © 2024 Sander Pajusalu et al.
+
+DOI: 10.1155/2024/8813121
+PMCID: PMC11922042
+PMID: 40225925 [Indexed for MEDLINE]
+
+Conflict of interest statement: Peter McWilliams is a full-time employee of
+Glycomine, Inc. Frederique Vernhes is a paid statistics consultant for
+Glycomine, Inc. Horacio Plotkin was previously a full-time employee of
+Glycomine, Inc. The other authors declare no conflicts of interest.

--- a/references_cache/PMID_40555085.md
+++ b/references_cache/PMID_40555085.md
@@ -1,0 +1,105 @@
+---
+reference_id: "PMID:40555085"
+title: Multiorgan involvement and genetic spectrum of 20 Chinese patients with PMM2-CDG.
+authors:
+- Zhang H
+- Zhang J
+- Ma W
+- Ma X
+- He R
+- Ding Y
+- Liu Y
+- Zhang W
+- Dong H
+- Zhang Y
+- He M
+- Yang Y
+journal: Mol Genet Metab
+year: '2025'
+doi: 10.1016/j.ymgme.2025.109178
+keywords:
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- Male
+- China
+- "Congenital Disorders of Glycosylation/genetics, pathology"
+- Genotype
+- Mutation
+- Phenotype
+- "Phosphotransferases (Phosphomutases)/genetics, deficiency"
+- Retrospective Studies
+- East Asian People/genetics
+content_type: abstract_only
+---
+
+# Multiorgan involvement and genetic spectrum of 20 Chinese patients with PMM2-CDG.
+**Authors:** Zhang H, Zhang J, Ma W, Ma X, He R, Ding Y, Liu Y, Zhang W, Dong H, Zhang Y, He M, Yang Y
+**Journal:** Mol Genet Metab (2025)
+**DOI:** [10.1016/j.ymgme.2025.109178](https://doi.org/10.1016/j.ymgme.2025.109178)
+
+## Content
+
+1. Mol Genet Metab. 2025 Aug;145(4):109178. doi: 10.1016/j.ymgme.2025.109178.
+Epub  2025 Jun 15.
+
+Multiorgan involvement and genetic spectrum of 20 Chinese patients with
+PMM2-CDG.
+
+Zhang H(1), Zhang J(1), Ma W(1), Ma X(1), He R(2), Ding Y(3), Liu Y(4), Zhang
+W(5), Dong H(1), Zhang Y(1), He M(6), Yang Y(7).
+
+Author information:
+(1)Children's Medical Center, Peking University First Hospital, Beijing 102600,
+China.
+(2)Department of Respiration, Beijing Children's Hospital, Capital Medical
+University, Beijing 100045, China.
+(3)Department of Endocrinology, Genetics and Metabolism, Beijing Children's
+Hospital, Capital Medical University, Beijing 100045, China.
+(4)Department of Pediatrics, Peking University People's Hospital, Beijing
+100044, China.
+(5)Michael Palmieri Metabolic and Advanced Diagnostic Laboratory and the
+Children's Hospital of Philadelphia, Philadelphia PA19104, USA.
+(6)Michael Palmieri Metabolic and Advanced Diagnostic Laboratory and the
+Children's Hospital of Philadelphia, Philadelphia PA19104, USA. Electronic
+address: HeM@chop.edu.
+(7)Children's Medical Center, Peking University First Hospital, Beijing 102600,
+China. Electronic address: yanlingy@bjmu.edu.cn.
+
+OBJECTIVE: The most common congenital disorders of glycosylation (CDG) is the
+phosphomannomutase 2 (PMM2) deficiency (PMM2-CDG). PMM2-CDG is a complex genetic
+disorder that often found in infancy or early childhood with a clinically
+heterogeneous variety of neurological and non- neurological symptoms. To expand
+the phenotypic and genetic spectrum of PMM2-CDG, we summarized the
+characteristics of 20 Chinese patients.
+METHODS: All patients were diagnosed by genetic analysis. Clinical
+characteristics, genotypes, imaging, electrophysiological, and metabolic data
+were analyzed retrospectively.
+RESULTS: Twelve males and eight females with PMM2-CDG were included. The median
+age at diagnosis was 12.0 (ranging from 6.0 to 52.0) months, while the median
+age at final follow-up was 10.3 (ranging from 5.1 to 12.8) years. All patients
+exhibited multisystem symptoms and various neurological symptoms were observed.
+Developmental delay was the primary initial symptoms. Dystaxia, growth
+retardation and liver damage were also common phenotypes. Cerebellar atrophy was
+the characteristic abnormality on brain imaging. Fourteen variants of the PMM2
+gene were identified, of which five, c.82A > G (p.M28V), c.551C > T (p. P184L),
+c.640G > T (p.G214C), c.656A > T (p.E219V) and c.712C > G (p.R238G), were newly
+reported. The most prevalent variant was c.430 T > C (p.F144L), which was
+identified in 65.0 % of patients, followed by c.395 T > C (p.I132T). Consistent
+with reports from other populations, missense variants constituted the
+predominant type of PMM2 gene alterations.
+CONCLUSION: PMM2-CDG presents as a multi-system disease with diverse clinical
+phenotypes, posing challenges to early identification and diagnosis. The most
+common pathogenic variant in this Chinese cohort was c.430 T > C (p.F144L),
+which is close to, but different from, the common pathogenic variant c.422G > A
+(p.R141H) among European PMM2-CDG patients.
+
+Copyright © 2025. Published by Elsevier Inc.
+
+DOI: 10.1016/j.ymgme.2025.109178
+PMID: 40555085 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest The authors
+declare no conflicts of interest.

--- a/research/PMM2-congenital_Disorder_of_Glycosylation-deep-research-manual.md
+++ b/research/PMM2-congenital_Disorder_of_Glycosylation-deep-research-manual.md
@@ -1,0 +1,94 @@
+# PMM2-congenital disorder of glycosylation deep research
+
+## Scope decision
+
+- Curated entity: `MONDO:0008907` PMM2-congenital disorder of glycosylation.
+- Disease framing: classical multisystem PMM2-CDG / historical CDG-Ia.
+- Explicitly excluded from this root: the distinct PMM2 promoter-related hyperinsulinism/polycystic-kidney phenotype, because its tissue-restricted presentation and mechanistic framing differ from the canonical type I N-glycosylation disorder.
+
+## Main mechanistic story
+
+1. PMM2 pathogenic variants reduce phosphomannomutase activity.
+   Supporting PMID: `26014514`.
+   Key abstract sentence: PMM2-CDG is caused by PMM2 mutations that reduce phosphomannomutase 2 activity.
+2. Reduced PMM2 activity lowers conversion of mannose-6-phosphate to mannose-1-phosphate.
+   Supporting PMID: `39053125`.
+   Key abstract sentence: PMM2 converts M6P to M1P, a critical upstream metabolite for proper protein N-glycosylation.
+3. Lower mannose flux into glycosylation causes underoccupied N-glycosylation sites.
+   Supporting PMID: `21949237`.
+   Key abstract sentence: PMM2 deficiency reduces mannose-6-phosphate flux into glycosylation, resulting in unoccupied N-glycosylation sites.
+4. Downstream vascular consequences are experimentally supported.
+   Supporting PMID: `35717947`.
+   Findings used in YAML: reduced activated protein C generation and impaired endothelial monolayer integrity after PMM2 knockdown.
+
+## Genetics and modifier takeaways
+
+- Large cohort anchor: PMID `40225925` (`n=137`, `60` unique variants).
+- Common allele in the multicenter cohort: `p.Arg141His` in `58.4%`.
+- Modifier evidence worth carrying into YAML:
+  - `p.Cys241Ser` associated with milder disease.
+  - `p.Val231Met` associated with more severe disease.
+  - Folding and dimerization-class variants also tracked with greater severity.
+- Take-home framing: genotype effects are better modeled by mutation mechanism classes (catalysis/activation, folding, dimerization) than by a single binary severe/mild split.
+
+## Phenotype curation choices
+
+- Strong neurologic anchors came from PMID `37955240` and PMID `39105373`.
+- Added with direct frequency support:
+  - developmental delay
+  - ataxia
+  - seizures
+  - peripheral neuropathy
+  - stroke-like episodes
+- Added with qualitative frequency mapping:
+  - cerebellar atrophy as a characteristic imaging finding
+  - growth delay as a common phenotype
+  - hepatomegaly as a frequent hepatic manifestation
+- Added without forcing a frequency band:
+  - hypotonia
+- Deliberately not overexpanded in YAML:
+  - broad ophthalmologic abnormalities
+  - endocrine manifestations
+  - skeletal deformities
+  - retinitis pigmentosa
+  These are real parts of the literature but I left them out of the first pass unless the abstract evidence was direct enough for a clean disease-level assertion.
+
+## Treatment landscape
+
+- Included in YAML:
+  - `Acetazolamide` for symptomatic neurologic treatment.
+    Anchor PMID: `37955240`.
+    Rationale: direct human follow-up data; benefit was partial, so evidence is marked `PARTIAL`.
+  - `Liver transplantation` as rescue treatment for end-stage liver disease.
+    Anchor PMID: `36965289`.
+    Rationale: human case report with clear post-transplant biochemical improvement.
+  - `GLM101` / liposomal mannose-1-phosphate as an experimental substrate-replacement concept.
+    Anchor PMID: `39053125`.
+    Rationale: strong preclinical fibroblast rescue, but still `IN_VITRO` only.
+- Intentionally not included in YAML:
+  - `D-galactose` and `oral mannose` were reviewed during literature collection, but I did not include them in the disease entry because the evidence base is mixed and I did not need them to achieve a coherent, validator-safe treatment section.
+
+## Evidence sourcing choices
+
+- `HUMAN_CLINICAL`:
+  - multicenter natural history and genotype-phenotype studies
+  - prospective neurodevelopmental and neurologic cohorts
+  - liver-transplant case report
+- `IN_VITRO`:
+  - mutant-protein functional assays
+  - patient-derived fibroblast rescue studies
+  - endothelial PMM2 knockdown experiments
+- Avoided mixing human and preclinical evidence inside a single evidence item when the abstract made the distinction clear enough to separate.
+
+## References used in the YAML
+
+- PMID `21949237` Phosphomannose isomerase inhibitors improve N-glycosylation in selected phosphomannomutase-deficient fibroblasts.
+- PMID `26014514` The Effects of PMM2-CDG-Causing Mutations on the Folding, Activity, and Stability of the PMM2 Protein.
+- PMID `28685491` The Prevalence of PMM2-CDG in Estonia Based on Population Carrier Frequencies and Diagnosed Patients.
+- PMID `35717947` N-Glycosylation Deficiency Reduces the Activation of Protein C and Disrupts Endothelial Barrier Integrity.
+- PMID `36965289` Liver transplantation recovers hepatic N-glycosylation with persistent IgG glycosylation abnormalities.
+- PMID `37955240` Neurological manifestations in PMM2-CDG.
+- PMID `39053125` In vitro treatment with liposome-encapsulated Mannose-1-phosphate restores N-glycosylation in PMM2-CDG patient-derived fibroblasts.
+- PMID `39105373` Neurodevelopmental profiles of 14 individuals with phosphomannomutase deficiency.
+- PMID `40225925` Genotype/Phenotype Relationship: Lessons From 137 Patients With PMM2-CDG.
+- PMID `40555085` Multiorgan involvement and genetic spectrum of 20 Chinese patients with PMM2-CDG.


### PR DESCRIPTION
## Summary
- add a new disease-level dismech curation for PMM2-congenital disorder of glycosylation (`MONDO:0008907`)
- model the core mechanism as atomic PMM2 loss of enzymatic activity -> reduced mannose-1-phosphate production -> impaired protein N-linked glycosylation, with downstream endothelial anticoagulant/barrier defects
- add a PMM2-focused deep research note and the PMID cache entries needed for the cited evidence

## Why
- closes the open curation gap for PMM2-CDG in dismech
- captures disease framing, genotype-phenotype anchors, and treatment evidence with exact PMID-backed quotes and ontology-grounded terms

## Validation
- `just validate kb/disorders/PMM2-congenital_Disorder_of_Glycosylation.yaml`
- `just validate-references kb/disorders/PMM2-congenital_Disorder_of_Glycosylation.yaml`
- `just validate-terms kb/disorders/PMM2-congenital_Disorder_of_Glycosylation.yaml`
- `uv run pytest tests/test_data.py -v`

Closes #1175