### PR TITLE
[codex] Curate Zellweger spectrum disorder

### DIFF
--- a/kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
+++ b/kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
@@ -258,7 +258,7 @@ pathophysiology:
     reference_title: "Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid Synthesis and Zellweger Spectrum Disorders."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Accumulation of these potentially hepatotoxic metabolites and the reduction in bile acid-dependent bile flow from the lack of primary bile acids may lead to liver injury"
+    snippet: "Accumulation of these potentially hepatotoxic metabolites and the reduction in bile acid–dependent bile flow from the lack of primary bile acids may lead to liver injury"
     explanation: Directly links accumulated bile acid intermediates to liver injury in ZSD.
   - reference: PMID:30793331
     reference_title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
@@ -288,7 +288,7 @@ pathophysiology:
   - reference: PMID:15868469
     reference_title: "Peroxisome biogenesis disorders: the role of peroxisomes and metabolic dysfunction in developing brain."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: MODEL_ORGANISM
     snippet: "Peroxisome biogenesis disorders, of which Zellweger syndrome is the most severe, result in severe neurological dysfunction associated with abnormal CNS neuronal migrations due to the lack of functional peroxisomes."
     explanation: Directly supports neuronal migration defects as a developmentally early CNS mechanism in ZSD.
 - name: Cerebral and cerebellar white matter disease
@@ -514,7 +514,7 @@ biochemical:
   - reference: PMID:36293220
     reference_title: "Diagnostic Odyssey in an Adult Patient with Ophthalmologic Abnormalities and Hearing Loss: Contribution of RNA-Seq to the Diagnosis of a PEX1 Deficiency."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Multiple peroxisomal pathways are impaired, and very long chain fatty acids (VLCFA) are the first line biomarkers for the diagnosis."
     explanation: Supports elevated VLCFA as the canonical biochemical marker for ZSD/PBD diagnosis.
   - reference: PMID:26287655

--- a/kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
+++ b/kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
@@ -1,513 +1,129 @@
-name: Peroxisome Biogenesis Disorder
+name: Zellweger Spectrum Disorder
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-02-17T21:53:14Z'
-category: Genetic
+updated_date: '2026-04-13T01:27:06Z'
+category: Mendelian
+synonyms:
+- Zellweger syndrome spectrum
+- Zellweger spectrum disorders
+- PBD-ZSD
+- peroxisome biogenesis disorder in the Zellweger spectrum
+disease_term:
+  preferred_term: Zellweger spectrum disorder
+  term:
+    id: MONDO:0019234
+    label: peroxisome biogenesis disorder
+description: >-
+  Zellweger spectrum disorder (ZSD) is an autosomal recessive peroxisome
+  biogenesis disease continuum caused by biallelic pathogenic variants in 13
+  PEX genes. The core mechanism is failure of peroxisome assembly and matrix
+  protein import, which produces global peroxisomal dysfunction with downstream
+  defects in very-long-chain fatty acid oxidation, ether lipid synthesis, and
+  bile acid side-chain shortening. Clinical expression ranges from severe
+  neonatal multisystem disease to attenuated adolescent/adult presentations with
+  progressive white matter disease, sensory loss, adrenal insufficiency, and
+  liver involvement.
 parents:
 - Inborn Error of Metabolism
 - Peroxisomal Disorder
-prevalence:
-- population: Global
-  percentage: Very Rare
-  evidence:
-  - reference: PMID:8914632
-    reference_title: "Incidence of peroxisomal disorders in Japan."
-    supports: SUPPORT
-    snippet: The incidence of peroxisome-deficient disorders was estimated to be
-      approximately 1 in 800,000 births which is far less than that in the USA.
-    explanation: The literature quantifies peroxisome-deficient disorders as
-      occurring approximately 1 in 800,000 births globally, supporting the claim
-      that the prevalence is very rare.
-  - reference: PMID:34628380
-    reference_title: "IMPAIRMENT OF PEROXISOME BIOGENESIS IN THE SPECTRUM OF ZELLWEGER SYNDROME (CLINICAL CASE)."
-    supports: SUPPORT
-    snippet: The incidence of rare diseases is approximately two cases per
-      10,000 people.
-    explanation: The literature states that the incidence of rare diseases is
-      approximately two cases per 10,000 people, which aligns with the statement
-      that Peroxisome Biogenesis Disorders are very rare globally.
 inheritance:
 - name: Autosomal recessive
+  description: ZSD is inherited in an autosomal recessive manner.
   evidence:
-  - reference: PMID:14527301
-    reference_title: "Peroxisome biogenesis disorders."
+  - reference: PMID:11389485
+    reference_title: "Disorders of peroxisome biogenesis due to mutations in PEX1: phenotypes and PEX1 protein levels."
     supports: SUPPORT
-    snippet: The peroxisome biogenesis disorders (PBDs) comprise 12 autosomal
-      recessive complementation groups (CGs).
-    explanation: This reference directly states that peroxisome biogenesis
-      disorders are autosomal recessive.
-  - reference: PMID:9264803
-    reference_title: "[Peroxisomal hereditary diseases]."
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Inheritance of these disorders is autosomal recessive."
+    explanation: Directly supports autosomal recessive inheritance for the Zellweger spectrum.
+progression:
+- phase: Severe neonatal presentation
+  notes: >-
+    The severe end of the spectrum presents shortly after birth with profound
+    hypotonia, seizures, developmental failure, and multisystem disease.
+  evidence:
+  - reference: PMID:28784167
+    reference_title: "Identification of a novel mutation in PEX10 in a patient with attenuated Zellweger spectrum disorder: a case report."
     supports: SUPPORT
-    snippet: With the exception of X-bound adrenoleukodystrophy, all diseases
-      are based on autosomally recessive type of inheritance...
-    explanation: This reference also confirms the autosomal recessive
-      inheritance of peroxisomal diseases, including PBDs.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These patients present with hypotonia and seizures shortly after birth."
+    explanation: Supports early neonatal presentation at the severe end of the ZSD continuum.
+- phase: Attenuated adolescent/adult progression
+  notes: >-
+    Milder presentations can survive into adulthood but may later develop gait
+    disturbance, progressive white matter disease, neuropathy, retinal disease,
+    and hearing loss.
+  evidence:
+  - reference: PMID:26287655
+    reference_title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Disease progression usually manifests in adolescence as a gait disorder, caused by central and/or peripheral nervous system involvement."
+    explanation: Defines a later progressive phase in attenuated ZSD.
+  - reference: PMID:26750748
+    reference_title: "Peroxisome biogenesis disorders in the Zellweger spectrum: An overview of current diagnosis, clinical manifestations, and treatment guidelines."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "The extreme variability in disease manifestation ranging from onset of profound neurologic symptoms in newborns to progressive degenerative disease in adults presents practical challenges in disease diagnosis and medical management."
+    explanation: Review-level evidence supporting one disease continuum spanning severe neonatal and attenuated adult phenotypes.
 pathophysiology:
-- name: Peroxisome Biogenesis Defect
-  description: Mutations in PEX genes disrupt the assembly and function of
-    peroxisomes, leading to impaired metabolic processes.
-  cellular_components:
-  - preferred_term: Peroxisome
+- name: Impaired peroxisome biogenesis and matrix protein import
+  description: >-
+    Biallelic pathogenic variants in ZSD-associated PEX genes impair peroxisome
+    membrane assembly, matrix protein import, receptor recycling, or organelle
+    division, reducing the pool of import-competent peroxisomes.
+  genes:
+  - preferred_term: PEX1
     term:
-      id: GO:0005777
-      label: peroxisome
-  evidence:
-  - reference: PMID:33417206
-    reference_title: "Peroxisome Biogenesis Disorders."
-    supports: SUPPORT
-    snippet: Impaired peroxisome biogenesis, including defects of membrane
-      assembly, import of peroxisomal matrix proteins, and division of
-      peroxisome, causes peroxisome biogenesis disorders (PBDs).
-    explanation: This reference highlights that mutations affecting peroxisome
-      biogenesis lead to dysfunction of peroxisomes and consequently to
-      metabolic impairments.
-  - reference: PMID:28409474
-    reference_title: "Generation of Peroxisome-Deficient Somatic Animal Cell Mutants."
-    supports: SUPPORT
-    snippet: More than a dozen complementation groups of animal somatic mutant
-      cells defective in peroxisome biogenesis have been successfully isolated
-      in Chinese hamster ovary (CHO) cells and used as a model system reflecting
-      fatal human severe genetic disorders named peroxisome biogenesis disorders
-      (PBD).
-    explanation: Defective peroxisome biogenesis due to mutations in PEX genes
-      supports the statement about peroxisomal disorders and impaired metabolic
-      processes.
-  - reference: PMID:28320181
-    reference_title: "Ataxic form of autosomal recessive PEX10-related peroxisome biogenesis disorders with a novel compound heterozygous gene mutation and characteristic clinical phenotype."
-    supports: SUPPORT
-    snippet: Peroxisome biogenesis factor 10 (PEX10) is involved in the import
-      of peroxisomal matrix proteins, and the mutation of this gene causes 3
-      subtypes of peroxisome biogenesis disorders...
-    explanation: The reference details how mutations in PEX10 affect peroxisomal
-      import, aligning with the statement's assertion about disrupted peroxisome
-      function.
-  - reference: PMID:36249295
-    reference_title: "PEX6 Mutations in Peroxisomal Biogenesis Disorders: An Usher Syndrome Mimic."
-    supports: SUPPORT
-    snippet: Peroxisomal biogenesis disorders (PBDs) represent a spectrum of
-      conditions that result in vision loss, sensorineural hearing loss,
-      neurologic dysfunction, and other abnormalities resulting from aberrant
-      peroxisomal function caused by mutations in PEX genes.
-    explanation: The study confirms that mutations in PEX genes disrupt
-      peroxisomal functions, leading to various metabolic and physiological
-      impairments.
-  - reference: PMID:34804114
-    reference_title: "Edgetic Perturbations Contribute to Phenotypic Variability in PEX26 Deficiency."
-    supports: SUPPORT
-    snippet: Pathogenic variants in the PEX26 gene lead to peroxisomal disorders
-      of the full Zellweger spectrum continuum.
-    explanation: PEX26 mutations, which lead to peroxisomal biogenesis
-      disorders, confirm the link between PEX gene defects and impaired
-      peroxisomal function.
-  - reference: PMID:9458170
-    reference_title: "Peroxisomal disorders: genotype, phenotype, major neuropathologic lesions, and pathogenesis."
-    supports: SUPPORT
-    snippet: Neurological dysfunction is a prominent feature of most peroxisomal
-      disorders. Enormous progress in defining their gene defects has been
-      achieved. The genes and gene products, peroxins (PEX), in five of the
-      complementation groups have been defined.
-    explanation: This reference illustrates the role of PEX genes in peroxisomal
-      disorders, supporting the claim of their involvement in cellular and
-      metabolic disruption.
-- name: Accumulation of Toxic Metabolites
-  description: The inability to break down very long-chain fatty acids (VLCFAs)
-    and other compounds leads to their accumulation in tissues.
-  biological_processes:
-  - preferred_term: fatty acid beta-oxidation
+      id: hgnc:8850
+      label: PEX1
+  - preferred_term: PEX2
     term:
-      id: GO:0006635
-      label: fatty acid beta-oxidation
-  - preferred_term: very long-chain fatty acid metabolic process
+      id: hgnc:9717
+      label: PEX2
+  - preferred_term: PEX3
     term:
-      id: GO:0000038
-      label: very long-chain fatty acid metabolic process
-  chemical_entities:
-  - preferred_term: VLCFAs
-  - preferred_term: Bile Acid Intermediates
-  - preferred_term: Phytanic Acid
+      id: hgnc:8858
+      label: PEX3
+  - preferred_term: PEX5
     term:
-      id: CHEBI:16285
-      label: phytanic acid
-  evidence:
-  - reference: PMID:19933170
-    reference_title: "Drosophila models of peroxisomal biogenesis disorder: peroxins are required for spermatogenesis and very-long-chain fatty acid metabolism."
-    supports: PARTIAL
-    snippet: Peroxisomes are vital eukaryotic organelles that participate in
-      lipid metabolism, in particular the metabolism of very-long-chain fatty
-      acids (VLCFA)... including impaired peroxisomal protein import, elevated
-      VLCFA levels and growth retardation.
-    explanation: The reference supports the accumulation of VLCFAs as part of
-      the pathophysiology of Peroxisome Biogenesis Disorders but does not
-      mention bile acid intermediates or phytanic acid.
-  - reference: PMID:3119940
-    reference_title: "Zellweger syndrome: biochemical procedures in diagnosis, prevention and treatment."
-    supports: PARTIAL
-    snippet: In patients with cerebro-hepato-renal (Zellweger) syndrome, the
-      absence of peroxisomes results in an impairment of metabolic processes...
-      These include the catabolism of very long chain (greater than C22) fatty
-      acids... the catabolism of phytanic acid and the catabolism of pipecolic
-      acid.
-    explanation: This reference supports the accumulation of VLCFAs and phytanic
-      acid in peroxisomal disorders but does not mention bile acid
-      intermediates.
-  - reference: PMID:22978395
-    reference_title: "Peroxisomes, peroxisomal diseases, and the hepatotoxicity induced by peroxisomal metabolites."
-    supports: PARTIAL
-    snippet: By comparing the different peroxisomal disorders, we provide
-      evidence suggesting that the main hepatotoxic metabolites responsible for
-      the liver pathology found in patients, are the bile acid synthesis
-      intermediates di- and trihydroxycholestanoic acid (DHCA and THCA).
-    explanation: This reference supports the accumulation of bile acid
-      intermediates in peroxisomal disorders but does not mention VLCFAs or
-      phytanic acid.
-- name: Deficiency of Essential Compounds
-  description: Impaired synthesis of plasmalogens and other essential compounds
-    disrupts normal cellular functions.
-  biological_processes:
-  - preferred_term: ether lipid biosynthetic process
+      id: hgnc:9719
+      label: PEX5
+  - preferred_term: PEX6
     term:
-      id: GO:0008611
-      label: ether lipid biosynthetic process
-  - preferred_term: bile acid biosynthetic process
+      id: hgnc:8859
+      label: PEX6
+  - preferred_term: PEX10
     term:
-      id: GO:0006699
-      label: bile acid biosynthetic process
-  chemical_entities:
-  - preferred_term: Plasmalogen
-  - preferred_term: Docosahexaenoic acid
+      id: hgnc:8851
+      label: PEX10
+  - preferred_term: PEX11B
     term:
-      id: CHEBI:36005
-      label: docosahexaenoic acid
-  evidence:
-  - reference: PMID:36720320
-    reference_title: "Regulation of plasmalogen biosynthesis in mammalian cells and tissues."
-    supports: SUPPORT
-    snippet: The absence of plasmalogens in several organs of patients with
-      deficiency in peroxisome biogenesis suggests that de novo synthesis of
-      plasmalogens contributes significantly to plasmalogen homeostasis in
-      humans.
-    explanation: The literature indicates that plasmalogen biosynthesis is
-      significantly affected in patients with peroxisome biogenesis disorders,
-      which supports the statement regarding impaired synthesis of plasmalogens
-      disrupting normal cellular functions.
-  - reference: PMID:32165495
-    reference_title: "A peroxisome deficiency-induced reductive cytosol state up-regulates the brain-derived neurotrophic factor pathway."
-    supports: SUPPORT
-    snippet: The peroxisome is a subcellular organelle that functions in
-      essential metabolic pathways, including biosynthesis of plasmalogens,
-      fatty acid beta-oxidation of very-long-chain fatty acids, and degradation
-      of hydrogen peroxide. Peroxisome biogenesis disorders (PBDs) manifest as
-      severe dysfunction in multiple organs, including the central nervous
-      system (CNS), but the pathogenic mechanisms in PBDs are largely unknown.
-    explanation: This study reinforces that impaired peroxisome function,
-      including the biosynthesis of plasmalogens, leads to a broad spectrum of
-      cellular dysfunctions.
-  - reference: PMID:33417206
-    reference_title: "Peroxisome Biogenesis Disorders."
-    supports: SUPPORT
-    snippet: Peroxisomes are presented in all eukaryotic cells and play
-      essential roles in many of lipid metabolic pathways, including
-      beta-oxidation of fatty acids and synthesis of ether-linked
-      glycerophospholipids, such as plasmalogens.
-    explanation: The abstract confirms that peroxisomes are crucial for the
-      synthesis of plasmalogens and that their dysfunction could disrupt normal
-      cellular functions.
-- name: Neurological Dysfunction
-  locations:
-  - preferred_term: central nervous system
+      id: hgnc:8853
+      label: PEX11B
+  - preferred_term: PEX12
     term:
-      id: UBERON:0001017
-      label: central nervous system
-  cell_types:
-  - preferred_term: oligodendrocyte
+      id: hgnc:8854
+      label: PEX12
+  - preferred_term: PEX13
     term:
-      id: CL:0000128
-      label: oligodendrocyte
-  description: Accumulation of toxic metabolites and deficiency of essential
-    compounds lead to demyelination, neuronal migration defects, and
-    neurodegeneration.
-  evidence:
-  - reference: PMID:15868469
-    reference_title: "Peroxisome biogenesis disorders: the role of peroxisomes and metabolic dysfunction in developing brain."
-    supports: SUPPORT
-    snippet: Peroxisome biogenesis disorders, of which Zellweger syndrome is the
-      most severe, result in severe neurological dysfunction associated with
-      abnormal CNS neuronal migrations due to the lack of functional
-      peroxisomes.
-    explanation: The reference specifies that a lack of functional peroxisomes
-      leads to severe neurological dysfunction, including demyelination and
-      defects in neuronal migration, which aligns with the statement's content.
-  - reference: PMID:33417206
-    reference_title: "Peroxisome Biogenesis Disorders."
-    supports: SUPPORT
-    snippet: Impaired peroxisome biogenesis, including defects of membrane
-      assembly, import of peroxisomal matrix proteins, and division of
-      peroxisome, causes peroxisome biogenesis disorders (PBDs).
-    explanation: This reference describes PBDs leading to significant
-      neurodegeneration and psychomotor dysfunction, consistent with the
-      statement on neurological dysfunction due to the disorder.
-  - reference: PMID:22978395
-    reference_title: "Peroxisomes, peroxisomal diseases, and the hepatotoxicity induced by peroxisomal metabolites."
-    supports: PARTIAL
-    snippet: Liver pathology is a frequent finding in patients affected by a
-      peroxisomal disorder. ... we provide evidence suggesting that the main
-      hepatotoxic metabolites responsible for the liver pathology found in
-      patients, are the bile acid synthesis intermediates di- and
-      trihydroxycholestanoic acid (DHCA and THCA).
-    explanation: While this reference supports the role of toxic metabolites, it
-      focuses on liver pathology rather than CNS-specific features like
-      demyelination and neuronal migration defects.
-  - reference: PMID:7685145
-    reference_title: "Peroxisomal disorders. Neurodevelopmental and biochemical aspects."
-    supports: SUPPORT
-    snippet: Because peroxisomes are involved in the metabolism of lipids
-      critical to the functioning of the nervous system, many of the peroxisomal
-      disorders manifest with significant degrees of progressive psychomotor
-      dysfunction.
-    explanation: The reference acknowledges the impact on the nervous system and
-      describes psychomotor dysfunction, supporting the idea of neurological
-      dysfunction.
-  - reference: PMID:30739266
-    reference_title: "Peroxisomal dysfunction in neurodegenerative diseases."
-    supports: PARTIAL
-    snippet: The importance of functional peroxisomes for cellular metabolism is
-      demonstrated by the marked brain and systemic organ abnormalities occuring
-      in peroxisome biogenesis disorders and peroxisomal enzyme deficiencies
-    explanation: This reference highlights general brain abnormalities due to
-      peroxisomal dysfunction but does not specifically describe demyelination
-      and neuronal migration defects. Partial support is given as it indicates a
-      broad CNS impact.
-- name: Hepatic Dysfunction
-  locations:
-  - preferred_term: liver
+      id: hgnc:8855
+      label: PEX13
+  - preferred_term: PEX14
     term:
-      id: UBERON:0002107
-      label: liver
-  cell_types:
-  - preferred_term: hepatocyte
+      id: hgnc:8856
+      label: PEX14
+  - preferred_term: PEX16
     term:
-      id: CL:0000182
-      label: hepatocyte
-  description: Accumulation of bile acid intermediates and VLCFAs, along with
-    oxidative stress, cause hepatomegaly, fibrosis, and liver failure.
-  evidence:
-  - reference: PMID:12473763
-    reference_title: "Biochemical markers predicting survival in peroxisome biogenesis disorders."
-    supports: SUPPORT
-    snippet: Common to these three disorders are liver disease, variable
-      neurodevelopmental delay, retinopathy, and perceptive deafness.
-    explanation: The study mentions liver disease as a common symptom of
-      peroxisome biogenesis disorder (PBD), supporting hepatic dysfunction.
-  - reference: PMID:22978395
-    reference_title: "Peroxisomes, peroxisomal diseases, and the hepatotoxicity induced by peroxisomal metabolites."
-    supports: SUPPORT
-    snippet: The main hepatotoxic metabolites responsible for the liver
-      pathology found in patients, are the bile acid synthesis intermediates di-
-      and trihydroxycholestanoic acid (DHCA and THCA).
-    explanation: This reference supports the accumulation of bile acid
-      intermediates causing liver pathology in PBDs.
-  - reference: PMID:29282281
-    reference_title: "Unbalanced lipolysis results in lipotoxicity and mitochondrial damage in peroxisome-deficient Pex19 mutants."
-    supports: SUPPORT
-    snippet: They are caused by mutations of peroxisomal biogenesis factors
-      encoded by Pex genes, and result in childhood lethality
-    explanation: This reference indirectly supports the statement by discussing
-      the lethal and severe impact of PBDs, including liver dysfunction.
-  - reference: PMID:8184191
-    reference_title: "[Liver pathologies due to peroxisome disorders]."
-    supports: SUPPORT
-    snippet: Zellweger disease or cerebro-hepato-renal syndrome is characterized
-      clinically by... liver damage leading to cirrhosis.
-    explanation: This confirms hepatic dysfunction including fibrosis in PBDs.
-  - reference: PMID:8729109
-    reference_title: "Very long-chain fatty acids in diagnosis, pathogenesis, and therapy of peroxisomal disorders."
-    supports: SUPPORT
-    snippet: Abnormally high levels of very long-chain fatty acids (VLCFA) are a
-      feature in...peroxisomal disorders.
-    explanation: Supports the accumulation of VLCFAs as part of the
-      pathophysiology.
-  - reference: PMID:17682975
-    reference_title: "Inborn errors of bile acid metabolism."
-    supports: SUPPORT
-    snippet: Nine recognized inborn errors of bile acid metabolism have been
-      identified that lead to enzyme deficiencies and impaired bile acid
-      synthesis in infants, children, and adults.
-    explanation: This reference supports the accumulation of bile acid
-      intermediates, contributing to hepatic dysfunction.
-- name: Skeletal Abnormalities
-  locations:
-  - preferred_term: bones
+      id: hgnc:8857
+      label: PEX16
+  - preferred_term: PEX19
     term:
-      id: UBERON:0001474
-      label: bone element
-  - preferred_term: cartilage
+      id: hgnc:9713
+      label: PEX19
+  - preferred_term: PEX26
     term:
-      id: UBERON:0002418
-      label: cartilage tissue
-  description: Plasmalogen deficiency disrupts normal bone formation, leading to
-    rhizomelic shortening of limbs and chondrodysplasia punctata.
-  evidence:
-  - reference: PMID:10904262
-    reference_title: "Peroxisome biogenesis disorders: genetics and cell biology."
-    supports: SUPPORT
-    snippet: Zellweger syndrome, neonatal adrenoleukodystrophy, infantile Refsum
-      disease and rhizomelic chondrodysplasia punctata are progressive disorders
-      characterized by loss of multiple peroxisomal metabolic functions.
-    explanation: The context indicates that rhizomelic chondrodysplasia punctata
-      (a type of peroxisome biogenesis disorder) results from peroxisomal
-      dysfunction, supporting the connection between plasmalogen deficiency and
-      skeletal abnormalities, including rhizomelic shortening of limbs and
-      chondrodysplasia punctata.
-  - reference: PMID:10972423
-    reference_title: "Abnormal myelin formation in rhizomelic chondrodysplasia punctata type 2 (DHAPAT-deficiency)."
-    supports: SUPPORT
-    snippet: The case of a Yemeni girl with isolated peroxisomal
-      acyl-CoA:dihydroxyacetonephosphate acyltransferase (DHAPAT) deficiency is
-      reported. She had rhizomelic chondrodysplasia punctata, microcephaly,
-      failure to thrive, delayed motor and mental development, and spastic
-      quadriplegia.
-    explanation: The document discusses a case where plasmalogen biosynthesis
-      deficiency leads to rhizomelic chondrodysplasia punctata, supporting the
-      statement.
-  - reference: PMID:8507680
-    reference_title: "Ether lipid synthesis and its deficiency in peroxisomal disorders."
-    supports: SUPPORT
-    snippet: The results have clearly shown an indispensable role for
-      peroxisomes in the total process of ether lipid synthesis as evidenced by
-      a description of the cellular topography of this process.
-    explanation: The paper supports the importance of peroxisomes in lipid
-      synthesis, including plasmalogens, which are associated with diseases like
-      rhizomelic chondrodysplasia punctata that impact bone and cartilage
-      formation.
-  - reference: PMID:24172221
-    reference_title: "The neurology of rhizomelic chondrodysplasia punctata."
-    supports: SUPPORT
-    snippet: Rhizomelic chondrodysplasia punctata (RCDP); a peroxisomal disorder
-      clinically characterized by skeletal abnormalities, congenital cataracts,
-      severe growth and developmental impairments and immobility of joints.
-      Defective plasmalogen biosynthesis is the main biochemical feature.
-    explanation: This clearly supports the notion that defective plasmalogen
-      biosynthesis leads to skeletal abnormalities characteristic of rhizomelic
-      chondrodysplasia punctata, including rhizomelic shortening of limbs and
-      chondrodysplasia punctata.
-- name: Multisystem Involvement
-  description: The pervasive nature of peroxisomal dysfunction affects multiple
-    organ systems, resulting in a wide range of clinical manifestations.
-  evidence:
-  - reference: PMID:14527301
-    reference_title: "Peroxisome biogenesis disorders."
-    supports: SUPPORT
-    snippet: The multisystem clinical phenotype varies widely in severity and
-      results from disturbances in both development and metabolic homeostasis.
-    explanation: This statement supports the pervasive nature of peroxisomal
-      dysfunction affecting multiple organ systems, leading to a range of
-      clinical manifestations.
-  - reference: PMID:33417210
-    reference_title: "Potential Involvement of Peroxisome in Multiple Sclerosis and Alzheimer's Disease : Peroxisome and Neurodegeneration."
-    supports: SUPPORT
-    snippet: Peroxisomopathies are rare diseases due to dysfunctions of the
-      peroxisome in which this organelle is either absent or with impaired
-      activities. These diseases... affect the central and peripheral nervous
-      system.
-    explanation: This statement aligns with the notion that peroxisomal
-      dysfunction affects multiple organ systems.
-  - reference: PMID:26453805
-    reference_title: "Hepatic dysfunction in peroxisomal disorders."
-    supports: SUPPORT
-    snippet: The peroxisomal compartment in hepatocytes hosts several essential
-      metabolic conversions. These are defective in peroxisomal disorders...
-      including mitochondria and the ER.
-    explanation: This reference details the involvement of multiple cellular
-      compartments and metabolic pathways, illustrating multisystem impact.
-  - reference: PMID:1710072
-    reference_title: "The peroxisome and the eye."
-    supports: SUPPORT
-    snippet: Several childhood multisystem disorders with prominent
-      ophthalmological manifestations have been ascribed to the malfunction of
-      the peroxisome, a subcellular organelle.
-    explanation: It categorizes peroxisomal disorders as multisystem with
-      significant implications in different organ systems, particularly the
-      eyes.
-  - reference: PMID:15868469
-    reference_title: "Peroxisome biogenesis disorders: the role of peroxisomes and metabolic dysfunction in developing brain."
-    supports: SUPPORT
-    snippet: Peroxisome biogenesis disorders, of which Zellweger syndrome is the
-      most severe, result in severe neurological dysfunction associated with
-      abnormal CNS neuronal migrations due to the lack of functional
-      peroxisomes.
-    explanation: This echoes the impact on multiple organ systems but emphasizes
-      the neurological dysfunctions.
-  - reference: PMID:21397417
-    reference_title: "Peroxisomal disorders with infantile seizures."
-    supports: SUPPORT
-    snippet: Peroxisomal disorders (PDs) are heterogeneous groups of diseases
-      and affect many organs with varying degrees of involvement.
-    explanation: This source supports the statement by highlighting the
-      multi-organ involvement in peroxisomal disorders.
-- name: Microglial Dysfunction and Neuroinflammation
-  description: Peroxisomal defects in microglial cells induce a
-    disease-associated microglial (DAM) signature with altered lipid metabolism,
-    lipid droplet accumulation, and impaired autophagy, contributing to
-    neurodegeneration.
-  locations:
-  - preferred_term: central nervous system
-    term:
-      id: UBERON:0001017
-      label: central nervous system
-  cell_types:
-  - preferred_term: microglial cell
-    term:
-      id: CL:0000129
-      label: microglial cell
-  notes: Recent research highlights that microglial peroxisomal defects force
-    cells into a pathological phenotype that may be a key contributor to CNS
-    pathogenesis in peroxisomal disorders.
-- name: Peroxisome-Organelle Crosstalk Disruption
-  description: Disruption of peroxisome-ER-mitochondria interactions impairs
-    lipid trafficking and metabolic coordination, particularly affecting VLCFA
-    and ether-lipid flux between organelles.
-  cellular_components:
-  - preferred_term: peroxisome
-    term:
-      id: GO:0005777
-      label: peroxisome
-  - preferred_term: endoplasmic reticulum
-    term:
-      id: GO:0005783
-      label: endoplasmic reticulum
-  - preferred_term: mitochondrion
-    term:
-      id: GO:0005739
-      label: mitochondrion
-  notes: ACBD5 tethers peroxisomes to ER via VAPs, facilitating lipid flux;
-    disruption perturbs VLCFA and ether-lipid trafficking.
-- name: Retinal Pigment Epithelium Dysfunction
-  description: In peroxisome biogenesis disorders, retinal pigment epithelium
-    shows progressive lipid remodeling with decreased plasmalogens and increased
-    very-long-chain lysophosphatidylcholines, leading to structural degeneration
-    and vision loss.
-  locations:
-  - preferred_term: retina
-    term:
-      id: UBERON:0000966
-      label: retina
-  cell_types:
-  - preferred_term: retinal pigment epithelial cell
-    term:
-      id: CL:0002586
-      label: retinal pigment epithelial cell
-  - preferred_term: photoreceptor cell
-    term:
-      id: CL:0000210
-      label: photoreceptor cell
-  notes: RPE lipid changes precede structural changes and show dorsal-to-ventral
-    progression in animal models. Both RPE and photoreceptors are affected by
-    peroxisomal dysfunction.
-- name: Impaired Peroxisome Biogenesis and Import
-  description: Mutations in PEX genes disrupt the peroxisomal protein import
-    machinery, including PEX5/PEX7 receptors, the PEX13/PEX14 docking complex,
-    and the PEX1-PEX6 AAA+ ATPase export complex, preventing proper assembly and
-    function of peroxisomes.
+      id: hgnc:22965
+      label: PEX26
   cellular_components:
   - preferred_term: peroxisome
     term:
@@ -518,873 +134,512 @@ pathophysiology:
     term:
       id: GO:0016558
       label: protein import into peroxisome matrix
+    modifier: DECREASED
   - preferred_term: peroxisome organization
     term:
       id: GO:0007031
       label: peroxisome organization
-  notes: The import cycle involves PTS1/PTS2 cargo binding, docking,
-    translocation, ubiquitination of PEX5, and AAA+ ATPase-mediated extraction
-    for recycling.
-phenotypes:
-- category: Neurologic
-  name: Hypotonia
-  frequency: VERY_FREQUENT
+    modifier: ABNORMAL
   evidence:
-  - reference: PMID:7685145
-    reference_title: "Peroxisomal disorders. Neurodevelopmental and biochemical aspects."
+  - reference: PMID:40112482
+    reference_title: "Using multiple modalities to confirm diagnosis in patients with suspected peroxisome biogenesis disorders."
     supports: SUPPORT
-    snippet: These disorders should be considered in the differential diagnosis
-      of the infant with hypotonia and psychomotor delay...
-    explanation: The reference mentions hypotonia as a significant clinical
-      feature in peroxisomal disorders.
-  - reference: PMID:28320181
-    reference_title: "Ataxic form of autosomal recessive PEX10-related peroxisome biogenesis disorders with a novel compound heterozygous gene mutation and characteristic clinical phenotype."
-    supports: PARTIAL
-    snippet: '...suggest that these PEX10 mutations involve not only cerebellar but
-      also more multiple nervous systems...'
-    explanation: While the reference primarily discusses cerebellar involvement,
-      it indirectly supports the statement by implicating neurological systems
-      in PEX10-related peroxisome biogenesis disorders.
-  - reference: PMID:13129589
-    reference_title: "The floppy infant: contribution of genetic and metabolic disorders."
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Zellweger spectrum disorder (ZSD) results from biallelic variants in any one of 13 PEX genes involved in peroxisome biogenesis and function."
+    explanation: Directly supports the 13-gene peroxisome biogenesis disease mechanism underlying ZSD.
+  - reference: PMID:33417206
+    reference_title: "Peroxisome Biogenesis Disorders."
     supports: SUPPORT
-    snippet: The floppy infant syndrome is a well-recognized entity for
-      pediatricians and neonatologists. The condition refers to an infant with
-      generalized hypotonia...
-    explanation: The reference directly supports the very frequent occurrence of
-      hypotonia in infants with peroxisomal disorders.
-  - reference: PMID:38409970
-    reference_title: "Zellweger Syndrome: A Case Report."
+    evidence_source: OTHER
+    snippet: "Impaired peroxisome biogenesis, including defects of membrane assembly, import of peroxisomal matrix proteins, and division of peroxisome, causes peroxisome biogenesis disorders (PBDs)."
+    explanation: Supports the atomic initiating mechanism as impaired organelle biogenesis and matrix protein import.
+  downstream:
+  - target: Loss of functional peroxisomes
+    description: Import failure converts the genetic defect into organelle-level peroxisomal deficiency.
+- name: Loss of functional peroxisomes
+  description: >-
+    The primary biogenesis defect produces a deficiency of functional
+    peroxisomes, separating the organelle-level lesion from the downstream
+    metabolic consequences.
+  evidence:
+  - reference: PMID:30793331
+    reference_title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
     supports: SUPPORT
-    snippet: Common clinical presentations include hypotonia, seizure,
-      hepatomegaly, craniofacial dysmorphism and early death.
-    explanation: Hypotonia is listed as one of the common clinical presentations
-      in Zellweger syndrome, a type of peroxisome biogenesis disorder.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Currently, no therapies are available for Zellweger spectrum disorders (ZSDs), a group of genetic metabolic disorders characterised by a deficiency of functional peroxisomes."
+    explanation: Directly states that ZSD is defined by deficiency of functional peroxisomes.
+  downstream:
+  - target: Reduced peroxisomal beta-oxidation
+    description: Functional peroxisome loss impairs lipid oxidation pathways.
+  - target: Impaired ether lipid biosynthesis
+    description: Functional peroxisome loss impairs ether-linked glycerophospholipid synthesis.
+  - target: C27-bile acid intermediate accumulation
+    description: Side-chain shortening of bile acid precursors becomes inefficient.
+  - target: Abnormal neuronal migration
+    description: Brain development becomes vulnerable to peroxisome deficiency.
+- name: Reduced peroxisomal beta-oxidation
+  description: >-
+    Peroxisomal dysfunction reduces oxidation of very-long-chain and branched
+    chain lipids, contributing to abnormal peroxisomal biomarkers and tissue
+    injury.
+  biological_processes:
+  - preferred_term: fatty acid beta-oxidation
+    term:
+      id: GO:0006635
+      label: fatty acid beta-oxidation
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:33417206
+    reference_title: "Peroxisome Biogenesis Disorders."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Peroxisomes are presented in all eukaryotic cells and play essential roles in many of lipid metabolic pathways, including β-oxidation of fatty acids and synthesis of ether-linked glycerophospholipids, such as plasmalogens."
+    explanation: Establishes beta-oxidation as a core peroxisomal pathway lost in ZSD.
+  - reference: PMID:24503136
+    reference_title: "The Pex1-G844D mouse: a model for mild human Zellweger spectrum disorder."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "we demonstrate that murine cells homozygous for the Pex1-G844D allele respond to chaperone-like compounds, which normalizes peroxisomal β-oxidation."
+    explanation: Rescue of beta-oxidation in a ZSD model supports reduced peroxisomal beta-oxidation as a mechanistic downstream lesion.
+  downstream:
+  - target: Cerebral and cerebellar white matter disease
+    description: Lipid metabolic failure contributes to progressive CNS white matter injury.
+  - target: Retinal degeneration
+    description: Lipid metabolic failure contributes to sensory tissue vulnerability in retina.
+- name: Impaired ether lipid biosynthesis
+  description: >-
+    Peroxisomal dysfunction reduces synthesis of ether-linked
+    glycerophospholipids, including plasmalogens, disrupting membrane lipid
+    homeostasis in brain and other tissues.
+  biological_processes:
+  - preferred_term: ether lipid biosynthetic process
+    term:
+      id: GO:0008611
+      label: ether lipid biosynthetic process
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:33417206
+    reference_title: "Peroxisome Biogenesis Disorders."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Peroxisomes are presented in all eukaryotic cells and play essential roles in many of lipid metabolic pathways, including β-oxidation of fatty acids and synthesis of ether-linked glycerophospholipids, such as plasmalogens."
+    explanation: Directly supports impaired ether lipid synthesis as a downstream consequence of peroxisome loss.
+  - reference: PMID:12473763
+    reference_title: "Biochemical markers predicting survival in peroxisome biogenesis disorders."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Multiple peroxisomal functions including de novo plasmalogen synthesis, dihydroxyacetonephosphate acyltransferase (DHAPAT) activity, C26:0/C22:0 ratio, C26:0 and pristanic acid beta-oxidation, and phytanic acid alpha-oxidation were analyzed in fibroblasts from a series of patients with defined clinical phenotypes."
+    explanation: Human patient fibroblast data show plasmalogen synthesis is one of the core dysfunctional peroxisomal processes tracked across the spectrum.
+  downstream:
+  - target: Cerebral and cerebellar white matter disease
+    description: Ether lipid deficiency likely contributes to progressive white matter vulnerability.
+- name: C27-bile acid intermediate accumulation
+  description: >-
+    Defective peroxisomal side-chain shortening causes accumulation of
+    hepatotoxic C27 bile acid intermediates and reduced bile acid-dependent flow.
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  biological_processes:
+  - preferred_term: bile acid biosynthetic process
+    term:
+      id: GO:0006699
+      label: bile acid biosynthetic process
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:28644367
+    reference_title: "Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid Synthesis and Zellweger Spectrum Disorders."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Accumulation of these potentially hepatotoxic metabolites and the reduction in bile acid-dependent bile flow from the lack of primary bile acids may lead to liver injury"
+    explanation: Directly links accumulated bile acid intermediates to liver injury in ZSD.
+  - reference: PMID:30793331
+    reference_title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Bile acid synthesis was still suppressed after 21 months of CA treatment, accompanied with reduced levels of C27 -bile acid intermediates in plasma."
+    explanation: Clinical treatment-response data confirm C27 bile acid intermediates as a tracked biochemical abnormality in ZSD.
+  downstream:
+  - target: Progressive liver disease
+    description: Hepatotoxic bile acid intermediates drive chronic hepatic injury.
+- name: Abnormal neuronal migration
+  description: >-
+    Peroxisome deficiency perturbs CNS neuronal migration during development and
+    contributes to structural brain malformations.
+  locations:
+  - preferred_term: central nervous system
+    term:
+      id: UBERON:0001017
+      label: central nervous system
+  biological_processes:
+  - preferred_term: neuron migration
+    term:
+      id: GO:0001764
+      label: neuron migration
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:15868469
+    reference_title: "Peroxisome biogenesis disorders: the role of peroxisomes and metabolic dysfunction in developing brain."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Peroxisome biogenesis disorders, of which Zellweger syndrome is the most severe, result in severe neurological dysfunction associated with abnormal CNS neuronal migrations due to the lack of functional peroxisomes."
+    explanation: Directly supports neuronal migration defects as a developmentally early CNS mechanism in ZSD.
+- name: Cerebral and cerebellar white matter disease
+  description: >-
+    Attenuated ZSD often develops a progressive white matter disorder involving
+    cerebrum and cerebellum, which contributes to gait dysfunction and later
+    neurologic decline.
+  locations:
+  - preferred_term: central nervous system
+    term:
+      id: UBERON:0001017
+      label: central nervous system
+  cell_types:
+  - preferred_term: oligodendrocyte
+    term:
+      id: CL:0000128
+      label: oligodendrocyte
+  evidence:
+  - reference: PMID:26287655
+    reference_title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Disease progression may occur and is mainly due to cerebral and cerebellar white matter abnormalities, and peripheral neuropathy."
+    explanation: Directly supports progressive white matter disease as a major driver of later neurologic decline.
+  - reference: PMID:26287655
+    reference_title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Systematic MRI review revealed T2 hyperintense white matter abnormalities in the hilus of the dentate nucleus and/or peridentate region in nine out of 16 patients."
+    explanation: Imaging evidence grounds the white matter pathology in surviving patients.
+- name: Retinal degeneration
+  description: >-
+    Mild surviving patients develop progressive retinal degeneration with an
+    RP-like phenotype and sustained visual impairment.
+  locations:
+  - preferred_term: retina
+    term:
+      id: UBERON:0000966
+      label: retina
+  cell_types:
+  - preferred_term: photoreceptor cell
+    term:
+      id: CL:0000210
+      label: photoreceptor cell
+  - preferred_term: retinal pigment epithelial cell
+    term:
+      id: CL:0002586
+      label: retinal pigment epithelial cell
+  evidence:
+  - reference: PMID:38664000
+    reference_title: "Systematic study of ophthalmological findings in 10 patients with PEX1-mediated Zellweger spectrum disorder."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fundus examination revealed a variable retinitis pigmentosa (RP)-like phenotype with rounded hyperpigmentations as most prominent feature in six out of nine patients."
+    explanation: Directly supports retinal degeneration as a structured tissue-level lesion in mild ZSD.
+  - reference: PMID:38664000
+    reference_title: "Systematic study of ophthalmological findings in 10 patients with PEX1-mediated Zellweger spectrum disorder."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This study highlights the ophthalmological phenotype resembling RP with moderate to severe visual impairment in patients with mild ZSD."
+    explanation: Confirms clinically meaningful visual impairment associated with the retinal lesion.
+- name: Progressive liver disease
+  description: >-
+    Chronic hepatic injury is a core visceral complication of ZSD and can
+    progress to fibrosis or cirrhosis.
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  evidence:
+  - reference: PMID:28644367
+    reference_title: "Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid Synthesis and Zellweger Spectrum Disorders."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "ZSDs are characterized by progressive liver disease and extrahepatic manifestations such as central nervous system dysfunction"
+    explanation: Directly supports progressive liver disease as a major organ-level consequence of ZSD.
+  - reference: PMID:30793331
+    reference_title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Although CA treatment did lead to reduced levels of toxic C27 -bile acid intermediates in ZSD patients without severe liver fibrosis or cirrhosis, no improvement of clinically relevant parameters was observed after 21 months of treatment."
+    explanation: Confirms clinically persistent liver disease despite biochemical improvement, especially relevant once fibrosis/cirrhosis is present.
+phenotypes:
+- name: Hypotonia
+  description: Severe neonatal presentations commonly include profound hypotonia.
   phenotype_term:
     preferred_term: Hypotonia
     term:
       id: HP:0001252
       label: Hypotonia
-- category: Neurologic
-  name: Developmental Delay
-  frequency: VERY_FREQUENT
   evidence:
-  - reference: PMID:7685145
-    reference_title: "Peroxisomal disorders. Neurodevelopmental and biochemical aspects."
+  - reference: PMID:28784167
+    reference_title: "Identification of a novel mutation in PEX10 in a patient with attenuated Zellweger spectrum disorder: a case report."
     supports: SUPPORT
-    snippet: Because peroxisomes are involved in the metabolism of lipids
-      critical to the functioning of the nervous system, many of the peroxisomal
-      disorders manifest with significant degrees of progressive psychomotor
-      dysfunction.
-    explanation: The literature indicates that peroxisomal disorders, which
-      include Peroxisome Biogenesis Disorders (PBDs), frequently present with
-      progressive psychomotor dysfunction, supporting the statement that
-      developmental delay is a very frequent neurologic phenotype.
-  - reference: PMID:36293220
-    reference_title: "Diagnostic Odyssey in an Adult Patient with Ophthalmologic Abnormalities and Hearing Loss: Contribution of RNA-Seq to the Diagnosis of a PEX1 Deficiency."
-    supports: SUPPORT
-    snippet: The clinical presentation of PBDs may range from severe, lethal
-      multisystemic disorders to milder, late-onset disease. The vast majority
-      of PBDs belong to Zellweger Spectrum Disordes (ZSDs) and represents a
-      continuum of overlapping clinical symptoms.
-    explanation: Although this does not explicitly mention developmental delay,
-      the overall description implies a frequent occurrence of neurologic
-      dysfunction, which is often tied to developmental delays.
-  - reference: PMID:11769739
-    reference_title: "Late onset white matter disease in peroxisome biogenesis disorder."
-    supports: SUPPORT
-    snippet: Distinctive external features are variable among these three
-      disorders, and neurologic deficit has its onset at birth or in infancy.
-    explanation: The article describes neurologic deficits appearing early in
-      life, which aligns with developmental delays being a very frequent
-      phenotype.
-  - reference: PMID:38409970
-    reference_title: "Zellweger Syndrome: A Case Report."
-    supports: SUPPORT
-    snippet: Zellweger syndrome is an autosomal recessive disease within the
-      spectrum of peroxisome biogenesis disorder manifesting in the neonatal
-      period with profound dysfunction of the central nervous system, liver and
-      kidney.
-    explanation: The mention of the neonatal onset of CNS dysfunction supports
-      the frequent presence of developmental delays.
-  - reference: PMID:24172221
-    reference_title: "The neurology of rhizomelic chondrodysplasia punctata."
-    supports: SUPPORT
-    snippet: Neurodevelopmental deficits and age-related occurrence of seizures
-      are characteristic of RCDP and are related to the rest-activity in
-      plasmalogen biosynthesis.
-    explanation: RCDP is a type of peroxisomal disorder, and its characteristic
-      neurodevelopmental deficits support the statement about developmental
-      delay being a common phenotype in PBDs.
-  phenotype_term:
-    preferred_term: Developmental Delay
-    term:
-      id: HP:0001263
-      label: Global developmental delay
-- category: Neurologic
-  name: Seizures
-  frequency: FREQUENT
-  notes: Common in severe forms, particularly neonatal Zellweger syndrome
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These patients present with hypotonia and seizures shortly after birth."
+    explanation: Directly supports hypotonia as a core early phenotype.
+- name: Seizure
+  description: Seizures are frequent in the severe neonatal end of the spectrum.
   phenotype_term:
     preferred_term: Seizure
     term:
       id: HP:0001250
       label: Seizure
-- category: Neurologic
-  name: Leukodystrophy
-  frequency: FREQUENT
-  notes: White matter degeneration due to myelin lipid dependency on peroxisomal
-    function
-  phenotype_term:
-    preferred_term: Leukodystrophy
-    term:
-      id: HP:0002415
-      label: Leukodystrophy
-- category: Hepatobiliary
-  name: Hepatomegaly
-  frequency: FREQUENT
   evidence:
-  - reference: PMID:31005404
-    reference_title: "Clinical and biochemical footprints of inherited metabolic diseases. II. Metabolic liver diseases."
-    supports: PARTIAL
-    snippet: Inherited metabolic diseases account for about one third of
-      pediatric patients with hepatomegaly, acute liver failure, cirrhosis or
-      cholestasis.
-    explanation: The reference states that inherited metabolic diseases, which
-      include peroxisome biogenesis disorders, account for a substantial portion
-      of pediatric hepatomegaly cases but does not specify the frequency as
-      'frequent.'
-  - reference: PMID:22978395
-    reference_title: "Peroxisomes, peroxisomal diseases, and the hepatotoxicity induced by peroxisomal metabolites."
-    supports: PARTIAL
-    snippet: Liver pathology is a frequent finding in patients affected by a
-      peroxisomal disorder.
-    explanation: The reference mentions liver pathology as frequent but does not
-      specifically state hepatomegaly.
-  - reference: PMID:26615381
-    reference_title: "Early Onset Hepatocellular Disease in an Infant with Zellweger Syndrome."
-    supports: NO_EVIDENCE
-    snippet: ZS is a peroxisomal disorder with a multiple congenital anomalies,
-      characterized by stereotypical facies, profound hypotonia, organ
-      involvement including cerebral, retinal, hepatic, and renal.
-    explanation: The reference discusses organ involvement including hepatic
-      involvement but does not specify hepatomegaly as frequent.
+  - reference: PMID:28784167
+    reference_title: "Identification of a novel mutation in PEX10 in a patient with attenuated Zellweger spectrum disorder: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These patients present with hypotonia and seizures shortly after birth."
+    explanation: Directly supports seizures as part of the severe neonatal phenotype.
+- name: Global developmental delay
+  description: Developmental progress is markedly impaired across the spectrum.
+  phenotype_term:
+    preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  evidence:
+  - reference: PMID:27493320
+    reference_title: "Zellweger syndrome: A cause of neonatal hypotonia and seizures."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Zellweger syndrome, a paradigm of human peroxisomal disorders is characterized by dysmorphic features, hypotonia, severe neuro-developmental delay, hepatomegaly, renal cysts, sensorineural deafness and retinal dysfunction."
+    explanation: Supports severe developmental delay as a central neurological phenotype.
+- name: Retinal dystrophy
+  description: Retinal degeneration commonly produces reduced visual acuity and nyctalopia.
+  phenotype_term:
+    preferred_term: Retinal dystrophy
+    term:
+      id: HP:0000556
+      label: Retinal dystrophy
+  evidence:
+  - reference: PMID:38664000
+    reference_title: "Systematic study of ophthalmological findings in 10 patients with PEX1-mediated Zellweger spectrum disorder."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This study highlights the ophthalmological phenotype resembling RP with moderate to severe visual impairment in patients with mild ZSD."
+    explanation: Supports retinal dystrophy as a characteristic sensory phenotype in attenuated ZSD.
+- name: Sensorineural hearing impairment
+  description: Hearing loss is common and often moderately severe to severe.
+  phenotype_term:
+    preferred_term: Sensorineural hearing impairment
+    term:
+      id: HP:0000407
+      label: Sensorineural hearing impairment
+  evidence:
+  - reference: PMID:34534157
+    reference_title: "A Retrospective Study of Hearing Loss in Patients Diagnosed with Peroxisome Biogenesis Disorders in the Zellweger Spectrum."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The majority of PBD-ZSD patients in this study presented with moderately-severe to severe hearing loss and relatively slow rates of longitudinal changes in hearing sensitivity."
+    explanation: Directly supports sensorineural hearing impairment as a common phenotype across the spectrum.
+- name: Hepatomegaly
+  description: Liver enlargement is common in severe infantile presentations.
   phenotype_term:
     preferred_term: Hepatomegaly
     term:
       id: HP:0002240
       label: Hepatomegaly
-- category: Hepatobiliary
-  name: Cholestasis
-  frequency: FREQUENT
-  notes: Due to bile acid biosynthetic block and hepatic lipid handling deficits
-  phenotype_term:
-    preferred_term: Cholestasis
-    term:
-      id: HP:0001396
-      label: Cholestasis
-- category: Renal
-  name: Renal Dysfunction
-  frequency: OCCASIONAL
-  notes: Variable kidney dysfunction across the spectrum
-  phenotype_term:
-    preferred_term: Abnormal renal physiology
-    term:
-      id: HP:0012622
-      label: Chronic kidney disease
-- category: Visual
-  name: Retinopathy
-  frequency: FREQUENT
   evidence:
-  - reference: PMID:31884631
-    reference_title: "Peroxisomal Disorders and Retinal Degeneration."
+  - reference: PMID:21844578
+    reference_title: "Two novel PEX1 mutations in a patient with Zellweger syndrome: the first Korean case confirmed by biochemical, and molecular evidence."
     supports: SUPPORT
-    snippet: Retinopathy is a recurrent feature in both the severely and mildly
-      affected patients, which can be accompanied with other ophthalmological
-      pathologies.
-    explanation: The study states that retinopathy is a recurrent feature in
-      patients with peroxisomal disorders, supporting the statement that visual
-      phenotypes, specifically retinopathy, are frequent.
-  - reference: PMID:12473763
-    reference_title: "Biochemical markers predicting survival in peroxisome biogenesis disorders."
-    supports: SUPPORT
-    snippet: Common to these three disorders are liver disease, variable
-      neurodevelopmental delay, retinopathy, and perceptive deafness.
-    explanation: The study indicates that retinopathy is common in peroxisome
-      biogenesis disorders like Zellweger syndrome, neonatal
-      adrenoleukodystrophy, and infantile Refsum disease, supporting the
-      frequent occurrence of retinopathy as a visual phenotype.
-  - reference: PMID:35227579
-    reference_title: "Clinical and biochemical footprints of inherited metabolic disorders. VII. Ocular phenotypes."
-    supports: SUPPORT
-    snippet: Retinal degeneration with or without optic atrophy is the most
-      frequent phenotype, followed by oculomotor problems, involvement of the
-      cornea and lens, and refractive errors.
-    explanation: The study states that retinal degeneration is the most frequent
-      ocular phenotype observed in inherited metabolic disorders, which includes
-      peroxisome biogenesis disorders, thereby supporting the frequent
-      occurrence of retinopathy.
-  - reference: PMID:31254513
-    reference_title: "A longitudinal study of retinopathy in the PEX1-Gly844Asp mouse model for mild Zellweger Spectrum Disorder."
-    supports: SUPPORT
-    snippet: Retinopathy leading to blindness is one of the major untreatable
-      handicaps faced by patients with ZSD but is not well characterized.
-    explanation: The study highlights that retinopathy leading to blindness is a
-      significant issue in patients with Zellweger Spectrum Disorder, a type of
-      peroxisome biogenesis disorder, supporting the frequency of retinopathy as
-      a visual phenotype.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Zellweger syndrome (ZS) is the most severe form of PBD and is characterized by craniofacial abnormalities, severe hypotonia, neonatal seizures, ocular abnormalities, psychomotor retardation, hepatomegaly and increased levels of very long chain fatty acids (VLCFA)."
+    explanation: Supports hepatomegaly as part of the classic severe phenotype.
+- name: Abnormal cerebral white matter morphology
+  description: MRI commonly shows dentate/peridentate white matter signal abnormalities in surviving patients.
   phenotype_term:
-    preferred_term: Retinopathy
+    preferred_term: Abnormal cerebral white matter morphology
     term:
-      id: HP:0000488
-      label: Retinopathy
-- category: Auditory
-  name: Hearing Loss
-  frequency: FREQUENT
+      id: HP:0002500
+      label: Abnormal cerebral white matter morphology
   evidence:
-  - reference: PMID:34534157
-    reference_title: "A Retrospective Study of Hearing Loss in Patients Diagnosed with Peroxisome Biogenesis Disorders in the Zellweger Spectrum."
+  - reference: PMID:26287655
+    reference_title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
     supports: SUPPORT
-    snippet: The majority of PBD-ZSD patients in this study presented with
-      moderately-severe to severe hearing loss.
-    explanation: This study characterizes hearing loss as a common phenotype in
-      patients with Peroxisome Biogenesis Disorder within the Zellweger
-      Spectrum.
-  - reference: PMID:36291074
-    reference_title: "The Effect of a Pex3 Mutation on Hearing and Lipid Content of the Inner Ear."
-    supports: SUPPORT
-    snippet: Peroxisome biogenesis disorders (due to PEX gene mutations) are
-      associated with symptoms that range in severity and can lead to early
-      childhood death, but a common feature is hearing impairment.
-    explanation: This study also confirms hearing impairment as a frequent
-      phenotype in Peroxisome Biogenesis Disorders, further supporting the
-      statement.
-  - reference: PMID:33417209
-    reference_title: "Heimler Syndrome."
-    supports: SUPPORT
-    snippet: Heimler syndrome is a rare syndrome associating sensorineural
-      hearing loss with retinal dystrophy and amelogenesis imperfecta due to
-      PEX1 or PEX6 biallelic pathogenic variations. This syndrome is one of the
-      less severe forms of peroxisome biogenesis disorders.
-    explanation: Heimler syndrome, a less severe form of peroxisome biogenesis
-      disorders, frequently presents with sensorineural hearing loss, further
-      supporting the frequent association of hearing loss with these disorders.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Systematic MRI review revealed T2 hyperintense white matter abnormalities in the hilus of the dentate nucleus and/or peridentate region in nine out of 16 patients."
+    explanation: Direct imaging evidence supports white matter abnormalities in attenuated ZSD.
+- name: Gait disturbance
+  description: Progressive gait impairment often emerges in adolescence.
   phenotype_term:
-    preferred_term: Hearing Loss
+    preferred_term: Gait disturbance
     term:
-      id: HP:0000365
-      label: Hearing impairment
-- category: Craniofacial
-  name: Craniofacial Dysmorphism
-  frequency: OCCASIONAL
+      id: HP:0001288
+      label: Gait disturbance
   evidence:
-  - reference: PMID:23671347
-    reference_title: "Child neurology: Zellweger syndrome."
+  - reference: PMID:26287655
+    reference_title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
     supports: SUPPORT
-    snippet: Patients with ZS present in the neonatal period with a
-      characteristic phenotype of distinctive facial stigmata.
-    explanation: Distinctive facial stigmata can be considered a form of
-      craniofacial dysmorphism, supporting the statement.
-  - reference: PMID:1710072
-    reference_title: "The peroxisome and the eye."
-    supports: PARTIAL
-    snippet: Zellweger syndrome, the most lethal of the three peroxisomal
-      biogenesis disorders, causes infantile hypotonia, seizures, and death
-      within the first year.
-    explanation: While the text does not explicitly mention craniofacial
-      dysmorphism, the severity of symptoms and multisystem involvement suggest
-      potential craniofacial manifestations.
-- category: Endocrine
-  frequency: FREQUENT
-  name: Adrenal Insufficiency
-  notes: Due to adrenal gland dysfunction
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Disease progression usually manifests in adolescence as a gait disorder, caused by central and/or peripheral nervous system involvement."
+    explanation: Directly supports gait disturbance as a common manifestation of later disease progression.
+- name: Primary adrenal insufficiency
+  description: Adrenal insufficiency may be clinically silent and requires active surveillance.
+  phenotype_term:
+    preferred_term: Primary adrenal insufficiency
+    term:
+      id: HP:0008207
+      label: Primary adrenal insufficiency
   evidence:
-  - reference: PMID:36649687
-    reference_title: "Adrenal Insufficiency in Peroxisomal Disorders: A Single Institution Case Series."
-    supports: SUPPORT
-    snippet: Primary adrenal insufficiency is common in patients with PD. Based
-      on our data, patients with the compound heterozygous PEX1 pathogenic
-      variants of exon 13 (c.2097dupT and c.2528G>A) tend to have adrenal
-      insufficiency.
-    explanation: The study indicates that primary adrenal insufficiency is
-      frequent in patients with peroxisomal disorders, specifically those with
-      PEX1 pathogenic variants.
   - reference: PMID:25179809
     reference_title: "High prevalence of primary adrenal insufficiency in Zellweger spectrum disorders."
     supports: SUPPORT
-    snippet: Primary adrenal insufficiency was found in 7/24 patients examined,
-      with 4/7 being asymptomatic. Systematic evaluation of adrenal function,
-      through a Synacthen test, should be included in the clinical management of
-      these patients.
-    explanation: The study highlights a high prevalence of primary adrenal
-      insufficiency in patients with Zellweger spectrum disorders, which are a
-      type of peroxisome biogenesis disorder.
-  phenotype_term:
-    preferred_term: Adrenal Insufficiency
-    term:
-      id: HP:0000846
-      label: Adrenal insufficiency
-- category: Musculoskeletal
-  frequency: OCCASIONAL
-  name: Chondrodysplasia Punctata
-  notes: Stippling of epiphyses on X-rays
-  evidence:
-  - reference: PMID:10904262
-    reference_title: "Peroxisome biogenesis disorders: genetics and cell biology."
-    supports: SUPPORT
-    snippet: Zellweger syndrome, neonatal adrenoleukodystrophy, infantile Refsum
-      disease and rhizomelic chondrodysplasia punctata are progressive disorders
-      characterized by loss of multiple peroxisomal metabolic functions.
-    explanation: Rhizomelic chondrodysplasia punctata is a type of peroxisome
-      biogenesis disorder, supporting the statement that chondrodysplasia
-      punctata falls under the category of musculoskeletal issues associated
-      with peroxisome biogenesis disorders.
-  - reference: PMID:24030027
-    reference_title: "Zellweger syndrome: prenatal and postnatal growth failure with epiphyseal stippling."
-    supports: SUPPORT
-    snippet: We present a 2-month-old male affected by Zellweger syndrome, a
-      rare peroxisomal disorder. The diagnosis was supported by clinical and
-      radiological findings and established by biochemical tests. The
-      characteristic radiological features included anomalous ossification
-      (epiphyseal stippling).
-    explanation: This study supports the statement by indicating that epiphyseal
-      stippling (chondrodysplasia punctata) is a characteristic feature in
-      Zellweger syndrome, a type of peroxisome biogenesis disorder.
-  - reference: PMID:17671048
-    reference_title: "Chondrodysplasia punctata and maternal autoimmune disease: a new case and review of the literature."
-    supports: SUPPORT
-    snippet: Classic rhizomelic chondrodysplasia punctata is a rare, autosomal,
-      recessively inherited disorder that is characterized by proximal
-      shortening of the limbs, punctuate calcifications of the epiphyses,
-      cataracts, developmental delay, and early lethality.
-    explanation: Rhizomelic chondrodysplasia punctata is characterized by
-      punctuate calcifications of the epiphyses, supporting the statement that
-      this condition is associated with peroxisome biogenesis disorders and
-      involves stippling of epiphyses.
-- category: Hematologic
-  frequency: OCCASIONAL
-  name: Thrombocytopenia
-  notes: Low platelet count
-  evidence:
-  - reference: PMID:27941306
-    reference_title: "Peroxisome biogenesis and human peroxisome-deficiency disorders."
-    supports: NO_EVIDENCE
-    snippet: Peroxisome is a single-membrane-bounded ubiquitous organelle
-      containing a hundred different enzymes that catalyze various metabolic
-      pathways such as beta-oxidation of very long-chain fatty acids and
-      synthesis of plasmalogens.
-    explanation: The provided literature does not mention thrombocytopenia or
-      any hematologic symptoms in relation to Peroxisome Biogenesis Disorders.
-  - reference: PMID:31884631
-    reference_title: "Peroxisomal Disorders and Retinal Degeneration."
-    supports: NO_EVIDENCE
-    snippet: Peroxisomal disorders are a group of inherited metabolic diseases,
-      which can be incompatible with life in the postnatal period or allow
-      survival into adulthood. Retinopathy is a recurrent feature in both the
-      severely and mildly affected patients, which can be accompanied with other
-      ophthalmological pathologies.
-    explanation: This reference discusses peroxisomal disorders but does not
-      mention thrombocytopenia or other hematologic conditions.
-  phenotype_term:
-    preferred_term: Thrombocytopenia
-    term:
-      id: HP:0001873
-      label: Thrombocytopenia
-- category: Cardiac
-  frequency: OCCASIONAL
-  name: Cardiomyopathy
-  sequelae:
-  - target: Heart Failure
-  evidence:
-  - reference: PMID:25465824
-    reference_title: "Cardiac manifestations of primary mitochondrial disorders."
-    supports: PARTIAL
-    snippet: CI in MIDs includes cardiomyopathy, arrhythmias, heart failure,
-      pulmonary hypertension, dilation of the aortic root, pericardial effusion,
-      coronary heart disease, autonomous nervous system dysfunction, congenital
-      heart defects, or sudden cardiac death.
-    explanation: The literature confirms that cardiomyopathy and heart failure
-      are associated with mitochondrial disorders (MIDs), which are a type of
-      metabolic disorder. However, it does not specifically mention peroxisome
-      biogenesis disorders (PBDs) in this context.
-  - reference: PMID:36870438
-    reference_title: "Cardiomyopathies in children: An overview."
-    supports: NO_EVIDENCE
-    snippet: Paediatric cardiomyopathies form a heterogeneous group of disorders
-      characterized by structural and electrical abnormalities of the heart
-      muscle, commonly due to a gene variant of the myocardial cell structure.
-    explanation: This reference provides an overview of pediatric
-      cardiomyopathies but does not specifically mention peroxisome biogenesis
-      disorders (PBDs) as a cause.
-  phenotype_term:
-    preferred_term: Cardiomyopathy
-    term:
-      id: HP:0001638
-      label: Cardiomyopathy
-- category: Cardiovascular
-  name: Heart Failure
-  frequency: FREQUENT
-  phenotype_term:
-    preferred_term: Heart Failure
-    term:
-      id: HP:0001635
-      label: Congestive heart failure
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Primary adrenal insufficiency was found in 7/24 patients examined, with 4/7 being asymptomatic."
+    explanation: Direct cohort evidence supports adrenal insufficiency as an important and sometimes occult phenotype.
 biochemical:
-- name: Very Long Chain Fatty Acids (VLCFA)
-  presence: Elevated
-  context: Diagnostic marker
+- name: Very long-chain fatty acids
+  presence: INCREASED
+  context: >-
+    Elevated VLCFA are a canonical screening biomarker, although milder adult
+    patients may later normalize some blood metabolites.
   evidence:
-  - reference: PMID:8729109
-    reference_title: "Very long-chain fatty acids in diagnosis, pathogenesis, and therapy of peroxisomal disorders."
-    supports: PARTIAL
-    snippet: Abnormally high levels of very long-chain fatty acids (VLCFA) are a
-      feature in nine of the fifteen peroxisomal disorders that have been
-      identified so far.
-    explanation: This reference indicates that elevated VLCFA levels are a
-      feature in nine peroxisomal disorders but does not specify peroxisome
-      biogenesis disorders (PBD) exclusively.
-  - reference: PMID:14527301
-    reference_title: "Peroxisome biogenesis disorders."
-    supports: NO_EVIDENCE
-    snippet: The peroxisome biogenesis disorders (PBDs) comprise 12 autosomal
-      recessive complementation groups (CGs).
-    explanation: The abstract does not mention VLCFA levels in the context of
-      PBD diagnosis.
-  - reference: PMID:37567036
-    reference_title: "Dicarboxylic acylcarnitine biomarkers in peroxisome biogenesis disorders."
+  - reference: PMID:36293220
+    reference_title: "Diagnostic Odyssey in an Adult Patient with Ophthalmologic Abnormalities and Hearing Loss: Contribution of RNA-Seq to the Diagnosis of a PEX1 Deficiency."
     supports: SUPPORT
-    snippet: Multiple dicarboxylic acylcarnitines were significantly elevated in
-      PBD patients including medium to long chain (C8-DC to C18-DC) species as
-      well as previously undescribed elevations of malonylcarnitine (C3-DC) and
-      very long chain dicarboxylic acylcarnitines (C20-DC and C22-DC).
-    explanation: This study identifies elevated levels of very long chain
-      dicarboxylic acylcarnitines (a type of VLCFA) in patients with PBD.
-  - reference: PMID:19933170
-    reference_title: "Drosophila models of peroxisomal biogenesis disorder: peroxins are required for spermatogenesis and very-long-chain fatty acid metabolism."
+    evidence_source: OTHER
+    snippet: "Multiple peroxisomal pathways are impaired, and very long chain fatty acids (VLCFA) are the first line biomarkers for the diagnosis."
+    explanation: Supports elevated VLCFA as the canonical biochemical marker for ZSD/PBD diagnosis.
+  - reference: PMID:26287655
+    reference_title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
     supports: SUPPORT
-    snippet: Peroxisomes are vital eukaryotic organelles that participate in
-      lipid metabolism, in particular the metabolism of very-long-chain fatty
-      acids (VLCFA).
-    explanation: This reference supports that elevated VLCFA levels are relevant
-      in peroxisomal disorders which include peroxisome biogenesis disorders.
-  - reference: PMID:8914632
-    reference_title: "Incidence of peroxisomal disorders in Japan."
-    supports: PARTIAL
-    snippet: Very long chain fatty acid analysis in the serum sphingomyelin was
-      introduced since 1987 and was useful for the first screening of
-      peroxisomal disorders.
-    explanation: Although this reference states that VLCFA analysis is useful
-      for peroxisomal disorders, it is not specific to PBD.
-- name: Plasmalogens
-  presence: Decreased
-  context: Diagnostic marker
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Biochemical analyses in blood showed abnormal peroxisomal biomarkers in all patients in infancy and childhood, whereas in adolescence/adulthood we observed normalization of some metabolites."
+    explanation: Supports age-dependent attenuation of some blood biomarkers in milder surviving patients.
+- name: C27-bile acid intermediates
+  presence: INCREASED
+  context: >-
+    Toxic C27 intermediates are a clinically relevant hepatic biomarker and can
+    fall with cholic acid therapy.
   evidence:
-  - reference: PMID:36914043
-    reference_title: "Quantitative analysis of ethanolamine plasmalogen species in red blood cells using liquid chromatography tandem mass spectrometry for diagnosing peroxisome biogenesis disorders."
+  - reference: PMID:30793331
+    reference_title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
     supports: SUPPORT
-    snippet: Markedly reduced plasmalogens are a classic feature of peroxisome
-      biogenesis disorders (PBD) because plasmalogen synthesis requires
-      functional peroxisomes.
-    explanation: The literature clearly states that decreased levels of
-      plasmalogens are a characteristic feature of peroxisome biogenesis
-      disorders.
-  - reference: PMID:12473763
-    reference_title: "Biochemical markers predicting survival in peroxisome biogenesis disorders."
-    supports: SUPPORT
-    snippet: A poor correlation with age at death was found for de novo
-      plasmalogen synthesis.
-    explanation: The study mentions that impaired plasmalogen synthesis is one
-      of the biochemical markers analyzed in PBD patients.
-  - reference: PMID:3460088
-    reference_title: "Isolation of animal cell mutants deficient in plasmalogen biosynthesis and peroxisome assembly."
-    supports: SUPPORT
-    snippet: The results presented here support the view that there are two DHAP
-      acyltransferases in animal cells and that the peroxisome is essential for
-      the biosynthesis of plasmalogens.
-    explanation: The literature shows that peroxisomes play an essential role in
-      plasmalogen biosynthesis, indicating that their dysfunction leads to
-      decreased plasmalogen levels.
-  - reference: PMID:7957386
-    reference_title: "Clinical and biochemical characteristics of peroxisomal disorders: an update."
-    supports: SUPPORT
-    snippet: Rhizomelic chondrodysplasia punctata, its recently identified
-      variant form and glutaryl-CoA oxidase deficiency will show no
-      abnormalities and must be identified by other means.
-    explanation: The mention of specific conditions excluded from typical
-      diagnostic methods indirectly reaffirms that decreased plasmalogen levels
-      are a diagnostic marker for most PBDs.
-  - reference: PMID:33417206
-    reference_title: "Peroxisome Biogenesis Disorders."
-    supports: SUPPORT
-    snippet: Impaired peroxisome biogenesis, including defects of membrane
-      assembly, import of peroxisomal matrix proteins, and division of
-      peroxisome, causes peroxisome biogenesis disorders (PBDs).
-    explanation: The statement supports the role of peroxisomes in normal
-      cellular function, and by extension, indicates that their dysfunction
-      would likely lead to decreased plasmalogen synthesis.
-- name: Bile Acid Intermediates
-  presence: Elevated
-  context: Diagnostic marker
-  evidence:
-  - reference: PMID:37802748
-    reference_title: "Dried blood spot-based newborn screening for bile acid synthesis disorders, Zellweger spectrum disorder, and Niemann-Pick type C1 by detection of bile acid metabolites."
-    supports: SUPPORT
-    snippet: Early postnatal screening for BASDs, PBD1A and NPC1 is feasible
-      with the described DBS-based method by measuring disease specific BAs.
-    explanation: “The study states that disease-specific bile acids (BAs) can be
-      measured as markers for peroxisome biogenesis disorders (PBDs) via a dried
-      blood spot-based screening method.”
-  - reference: PMID:3119940
-    reference_title: "Zellweger syndrome: biochemical procedures in diagnosis, prevention and treatment."
-    supports: SUPPORT
-    snippet: In classic Zellweger syndrome abnormal C27-bile acids, very long
-      chain fatty acids, dicarboxylic acids and pipecolic acid accumulate in the
-      plasma of the patients.
-    explanation: The study mentions the accumulation of C27-bile acids (a type
-      of bile acid intermediate) in the plasma of patients with Zellweger
-      syndrome, a type of peroxisome biogenesis disorder.
-  - reference: PMID:3119940
-    reference_title: "Zellweger syndrome: biochemical procedures in diagnosis, prevention and treatment."
-    supports: SUPPORT
-    snippet: In patients with cerebro-hepato-renal (Zellweger) syndrome, the
-      absence of peroxisomes results in an impairment of metabolic processes in
-      which peroxisomes are normally involved. These include the catabolism of
-      very long chain (greater than C22) fatty acids, the biosynthesis of
-      ether-phospholipids and of bile acids, the catabolism of phytanic acid and
-      the catabolism of pipecolic acid.
-    explanation: The study supports the concept that certain biochemical
-      markers, including bile acid intermediates, are elevated due to the
-      metabolic process impairments in peroxisome biogenesis disorders.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Bile acid synthesis was still suppressed after 21 months of CA treatment, accompanied with reduced levels of C27 -bile acid intermediates in plasma."
+    explanation: Reduction under therapy supports elevated C27 intermediates as a tracked biochemical abnormality in untreated disease.
 genetic:
 - name: PEX1
-  association: Pathogenic Variants
+  association: Causative
+  features: >-
+    PEX1 is the most common ZSD gene. Residual PEX1 protein and the common
+    p.Gly843Asp hypomorphic allele are associated with attenuated phenotypes.
+  variants:
+  - name: PEX1 p.Gly843Asp
+    description: >-
+      Hypomorphic missense allele associated with residual PEX1 protein and
+      milder Zellweger spectrum phenotypes.
+  gene_term:
+    preferred_term: PEX1
+    term:
+      id: hgnc:8850
+      label: PEX1
   evidence:
-  - reference: PMID:33955040
-    reference_title: "Compound heterozygous p. Arg949Trp and p. Gly970Ala mutations deteriorated the function of PEX1p: A study on PEX1 in a patient with Zellweger syndrome."
+  - reference: PMID:40112482
+    reference_title: "Using multiple modalities to confirm diagnosis in patients with suspected peroxisome biogenesis disorders."
     supports: SUPPORT
-    snippet: Zellweger syndrome (ZS) is the foremost common and severe phenotype
-      within the heterogeneous ZSD. However, missense mutations encode proteins
-      with residual functions, which are associated with phenotypes that are
-      milder than ZS. Mutations in the PEX1 gene are among the most prevalent.
-    explanation: The statement is supported as it mentions that mutations in the
-      PEX1 gene are among the most prevalent causes of Zellweger syndrome, which
-      is a type of PBD.
-- name: PEX6
-  association: Pathogenic Variants
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The majority of ZSD cases result from pathogenic variants in PEX1."
+    explanation: Directly supports PEX1 as the most common disease gene in ZSD.
+  - reference: PMID:11389485
+    reference_title: "Disorders of peroxisome biogenesis due to mutations in PEX1: phenotypes and PEX1 protein levels."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Approximately 65% of the patients with PBD harbor mutations in PEX1."
+    explanation: Human cohort data quantify the dominant contribution of PEX1 to the spectrum.
+  - reference: PMID:11389485
+    reference_title: "Disorders of peroxisome biogenesis due to mutations in PEX1: phenotypes and PEX1 protein levels."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The majority of these latter patients carried at least one copy of the common G843D allele."
+    explanation: Supports the common hypomorphic PEX1 allele as a modifier of milder phenotype.
+- name: Other ZSD-associated PEX genes
+  association: Causative
+  features: >-
+    Beyond PEX1, established ZSD genes are PEX2, PEX3, PEX5, PEX6, PEX10,
+    PEX11B, PEX12, PEX13, PEX14, PEX16, PEX19, and PEX26.
   evidence:
-  - reference: PMID:17055079
-    reference_title: "Peroxisome biogenesis disorders."
+  - reference: PMID:40112482
+    reference_title: "Using multiple modalities to confirm diagnosis in patients with suspected peroxisome biogenesis disorders."
     supports: SUPPORT
-    snippet: Defects in PEX genes impair peroxisome assembly and multiple
-      metabolic pathways confined to this organelle, thus providing the
-      biochemical and molecular bases of the peroxisome biogenesis disorders
-      (PBD).
-    explanation: This statement indicates that mutations in PEX genes, including
-      PEX6, are foundational to the development of peroxisome biogenesis
-      disorders.
-  - reference: PMID:15858711
-    reference_title: "Alternative splicing suggests extended function of PEX26 in peroxisome biogenesis."
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Zellweger spectrum disorder (ZSD) results from biallelic variants in any one of 13 PEX genes involved in peroxisome biogenesis and function."
+    explanation: Supports the genetically heterogeneous 13-gene disease definition.
+  - reference: PMID:28784167
+    reference_title: "Identification of a novel mutation in PEX10 in a patient with attenuated Zellweger spectrum disorder: a case report."
     supports: SUPPORT
-    snippet: Matsumoto and colleagues recently identified PEX26 as the gene
-      responsible for complementation group 8 of the peroxisome biogenesis
-      disorders... Here, we identify new PEX26 disease alleles, localize the
-      PEX6-binding domain to the N-terminal half of the protein (aa 29-174), and
-      show that, at the cellular level, PEX26 deficiency impairs peroxisomal
-      import of both PTS1- and PTS2-targeted matrix proteins.
-    explanation: This paper discusses PEX26 in detail but also underscores the
-      critical function of PEX6 in peroxisome biogenesis.
-  - reference: PMID:36980088
-    reference_title: "PEX6 Mutation in a Child with Infantile Refsum Disease-A Case Report and Literature Review."
-    supports: SUPPORT
-    snippet: Genetic testing revealed a mutation of the PEX6 (Peroxisomal
-      Biogenesis Factor 6) gene, and the metabolic profile was consistent with
-      the diagnosis.
-    explanation: This case report directly links pathogenic variants in PEX6 to
-      a specific case of peroxisome biogenesis disorder.
-  - reference: PMID:33955040
-    reference_title: "Compound heterozygous p. Arg949Trp and p. Gly970Ala mutations deteriorated the function of PEX1p: A study on PEX1 in a patient with Zellweger syndrome."
-    supports: SUPPORT
-    snippet: Autosomal recessive disorder of the Zellweger spectrum (ZSD) is a
-      major subset of peroxisome biogenesis disorders (PBDs) that can be caused
-      by mutations in any of the 14 PEX genes. ... Mutations in the PEX1 gene
-      are among the most prevalent. PEX1 and PEX6 proteins, belonging to the AAA
-      family of ATPases, form a hexameric complex, which is associated with
-      peroxisome membranes and essential for peroxisome biology.
-    explanation: This paper confirms that mutations in PEX6, similar to those in
-      PEX1, are linked to peroxisome biogenesis disorders.
-  - reference: PMID:10408779
-    reference_title: "Genomic structure and identification of 11 novel mutations of the PEX6 (peroxisome assembly factor-2) gene in patients with peroxisome biogenesis disorders."
-    supports: SUPPORT
-    snippet: The PEX6 (peroxisome assembly factor-2, PAF-2) gene... restores
-      peroxisome assembly in fibroblasts from peroxisome biogenesis disorder
-      patients belonging to complementation group C (group 4 in the United
-      States).
-    explanation: This research clarifies the structure and mutations of PEX6,
-      noting its role in peroxisome biogenesis disorders.
-- name: PEX13
-  association: Pathogenic Variants
-  notes: PEX13 is part of the docking complex for peroxisomal protein import
-- name: PEX26
-  association: Pathogenic Variants
-  notes: PEX26 anchors the PEX1-PEX6 AAA+ ATPase complex to the peroxisomal
-    membrane
-- name: PEX2
-  association: Pathogenic Variants
-  notes: Part of the RING E3 ubiquitin ligase complex involved in PEX5
-    ubiquitination
-- name: PEX10
-  association: Pathogenic Variants
-  notes: Part of the RING E3 ubiquitin ligase complex involved in peroxisomal
-    matrix protein import
-- name: PEX12
-  association: Pathogenic Variants
-  notes: Part of the RING E3 ubiquitin ligase complex
-- name: PEX5
-  association: Pathogenic Variants
-  notes: PTS1 receptor for peroxisomal protein import
-- name: PEX7
-  association: Pathogenic Variants
-  notes: PTS2 receptor for peroxisomal protein import
-- name: Other PEX Genes
-  association: Pathogenic Variants
-  notes: Approximately 14 PEX genes are known to cause peroxisome biogenesis
-    disorders when mutated
-  evidence:
-  - reference: PMID:10904262
-    reference_title: "Peroxisome biogenesis disorders: genetics and cell biology."
-    supports: SUPPORT
-    snippet: Recent studies have identified the PEX genes that are mutated in 11
-      of the 12 known complementation groups of PBD patients.
-    explanation: This reference indicates that pathogenic variants in other PEX
-      genes are associated with Peroxisome Biogenesis Disorder (PBD).
-  - reference: PMID:32399598
-    reference_title: "Genomic sequencing highlights the diverse molecular causes of Perrault syndrome: a peroxisomal disorder (PEX6), metabolic disorders (CLPP, GGPS1), and mtDNA maintenance/translation disorders (LARS2, TFAM)."
-    supports: SUPPORT
-    snippet: For the first time, we show that pathogenic variants in PEX6 can
-      present clinically as Perrault syndrome... PEX6 encodes a peroxisomal
-      biogenesis factor.
-    explanation: Although this reference primarily discusses Perrault syndrome,
-      it confirms that variants in PEX genes such as PEX6 are associated with
-      peroxisomal biogenesis disorders.
-  - reference: PMID:34804114
-    reference_title: "Edgetic Perturbations Contribute to Phenotypic Variability in PEX26 Deficiency."
-    supports: SUPPORT
-    snippet: Pathogenic variants in the PEX26 gene lead to peroxisomal disorders
-      of the full Zellweger spectrum continuum.
-    explanation: This reference highlights PEX26 gene variants contributing to
-      peroxisomal disorders which fall under the broader category of peroxisome
-      biogenesis disorders.
-  - reference: PMID:29070486
-    reference_title: "The functions of PEX genes in peroxisome biogenesis and pathogenicity in phytopathogenic fungi."
-    supports: SUPPORT
-    snippet: The biogenesis of peroxisomes requires a category of proteins named
-      peroxins, which are encoded by the PEX genes.
-    explanation: The reference supports that PEX genes are crucial for
-      peroxisome biogenesis, implying that pathogenic variants can lead to
-      related disorders.
-environmental:
-- name: Not Applicable
-  evidence:
-  - reference: PMID:26305119
-    reference_title: "Peroxisome biogenesis in mammalian cells: The impact of genes and environment."
-    supports: NO_EVIDENCE
-    snippet: In recent years, peroxisomes have emerged as important
-      intracellular hubs for redox-, lipid-, inflammatory-, and nucleic
-      acid-mediated signaling pathways. In this review, we focus on how nature
-      and nurture modulate peroxisome biogenesis and function in mammalian
-      cells.
-    explanation: The literature discusses the interplay of genetic, epigenetic,
-      and environmental factors in peroxisome biogenesis and function but does
-      not describe peroxisome biogenesis disorders as purely environmental.
-  - reference: PMID:30656921
-    reference_title: "[Peroxisomal disorders]."
-    supports: NO_EVIDENCE
-    snippet: The disturbance of the peroxisome structure due to mutations in
-      different PEX and non-PEX genes coding functional peroxisomal proteins is
-      the pathogenic basis of the peroxisomal disorders.
-    explanation: The literature explains that peroxisome biogenesis disorders
-      are due to genetic mutations, not environmental factors.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The peroxisome biogenesis disorders, which are caused by mutations in any of 13 different PEX genes, include the Zellweger spectrum disorders."
+    explanation: Confirms that the Zellweger spectrum is the clinically relevant subset of 13-gene peroxisome biogenesis disease.
 treatments:
-- name: Symptomatic Management
-  description: Supportive care addressing specific symptoms such as physical
-    therapy for hypotonia and seizure management.
-  evidence:
-  - reference: PMID:11060787
-    reference_title: "Therapeutic developments in peroxisome biogenesis disorders."
-    supports: PARTIAL
-    snippet: Treatment of PBD patients has generally involved only supportive
-      care and symptomatic therapy.
-    explanation: The statement about supportive care and symptomatic therapy is
-      accurate but does not explicitly mention physical therapy for hypotonia
-      and seizure management.
-  - reference: PMID:38409970
-    reference_title: "Zellweger Syndrome: A Case Report."
-    supports: PARTIAL
-    snippet: Despite an absence of treatment options, prompt diagnosis of
-      Zellweger syndrome is important for providing appropriate symptomatic
-      care.
-    explanation: The statement supports symptomatic care but does not detail
-      specific treatments such as physical therapy for hypotonia or seizure
-      management.
+- name: Supportive and surveillance-based care
+  description: >-
+    Current management remains largely organ-directed and supportive, including
+    symptomatic therapy, endocrine surveillance, and rehabilitation/hearing
+    support when indicated.
   treatment_term:
-    preferred_term: physical therapy
+    preferred_term: supportive care
     term:
-      id: MAXO:0000011
-      label: physical therapy
-- name: Nutritional Support
-  description: Specialized diet and supplements to manage biochemical
-    abnormalities.
+      id: MAXO:0000950
+      label: supportive care
   evidence:
-  - reference: PMID:11060787
-    reference_title: "Therapeutic developments in peroxisome biogenesis disorders."
+  - reference: PMID:25179809
+    reference_title: "High prevalence of primary adrenal insufficiency in Zellweger spectrum disorders."
     supports: SUPPORT
-    snippet: A number of experimental therapies have been evaluated to determine
-      whether or not correction of biochemical abnormalities through dietary
-      supplementation and/or modification is of clinical benefit to PBD
-      patients.
-    explanation: This snippet indicates that dietary supplementation and/or
-      modification has been evaluated to manage biochemical abnormalities in PBD
-      patients, supporting the statement that specialized diet and supplements
-      can be a treatment strategy.
-  - reference: PMID:18758655
-    reference_title: "Treatment of inborn errors of metabolism."
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Treatment options are limited to symptomatic and supportive therapy."
+    explanation: Directly supports supportive care as the main current treatment framework.
+  - reference: PMID:34534157
+    reference_title: "A Retrospective Study of Hearing Loss in Patients Diagnosed with Peroxisome Biogenesis Disorders in the Zellweger Spectrum."
     supports: SUPPORT
-    snippet: The most important measures used to manage the intoxication present
-      in many inborn errors of intermediate metabolism were presented
-      (restriction of substrate build-up by means of diet or enzymatic
-      inhibition, removal of toxic products, stimulation of residual enzyme
-      activity, replacement of the deficient product).
-    explanation: This reference discusses the use of diet as a measure to manage
-      biochemical abnormalities in metabolic disorders, including peroxisomal
-      diseases, which supports the statement.
-  - reference: PMID:16819396
-    reference_title: "Defects in bile acid biosynthesis--diagnosis and treatment."
-    supports: NO_EVIDENCE
-    snippet: Bile-acid therapy using oral cholic acid has proven effective in
-      most of these bile acid synthetic defects making early diagnosis crucial
-      to optimum clinical prognosis.
-    explanation: While this reference discusses a specific bile-acid therapy, it
-      does not provide evidence about dietary or supplemental approaches for
-      managing biochemical abnormalities in PBDs.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Improvements in hearing thresholds were observed with use of hearing aid amplification."
+    explanation: Provides disease-specific evidence that supportive hearing interventions can improve function.
+- name: Cholic acid
+  description: >-
+    Cholic acid can lower toxic C27 bile acid intermediates and may improve
+    liver-related biochemical measures, but clinically meaningful benefit is
+    limited and is less convincing once advanced fibrosis or cirrhosis is
+    present.
   treatment_term:
-    preferred_term: dietary intervention
+    preferred_term: pharmacotherapy
     term:
-      id: MAXO:0000088
-      label: dietary intervention
-- name: Liver Transplant
-  description: Considered in severe cases with significant liver dysfunction.
+      id: MAXO:0000058
+      label: pharmacotherapy
   evidence:
-  - reference: PMID:35331403
-    reference_title: "Cell therapy in congenital inherited hepatic disorders."
+  - reference: PMID:28644367
+    reference_title: "Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid Synthesis and Zellweger Spectrum Disorders."
     supports: SUPPORT
-    snippet: Most of these disorders are currently treated by liver
-      transplantation as standard of care.
-    explanation: The reference indicates that liver transplantation is the
-      standard of care for congenital inherited hepatic disorders, which
-      includes peroxisomal disorders like Peroxisome Biogenesis Disorder (PBD),
-      supporting that liver transplant is considered in severe cases with
-      significant liver dysfunction.
-  - reference: PMID:26615381
-    reference_title: "Early Onset Hepatocellular Disease in an Infant with Zellweger Syndrome."
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oral cholic acid is a safe, efficacious, and well-tolerated treatment for BASD due to SED and ZSD."
+    explanation: Supports cholic acid as an approved disease-directed treatment used in ZSD with hepatic bile acid abnormalities.
+  - reference: PMID:30793331
+    reference_title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
     supports: PARTIAL
-    snippet: ZS should be considered in the list of differential diagnosis in
-      infants with stereotypical phenotype, neurodevelopmental delay, and severe
-      hypotonia in association with liver and other organs involvement.
-    explanation: While this reference confirms liver involvement in Peroxisome
-      Biogenesis Disorders such as Zellweger Syndrome, it does not specifically
-      mention liver transplantation as a treatment.
-  - reference: PMID:22974902
-    reference_title: "Liver transplantation for massive hepatomegaly due to polycystic liver disease: an extreme case."
-    supports: PARTIAL
-    snippet: When none of the liver parenchyma is spared, or kidney
-      insufficiency is marked, the only potentially curable treatment is liver
-      transplantation (LT).
-    explanation: This reference supports the use of liver transplantation in
-      severe liver conditions, though it does not directly mention Peroxisome
-      Biogenesis Disorder.
-  treatment_term:
-    preferred_term: organ transplantation
-    term:
-      id: MAXO:0010039
-      label: organ transplantation
-- name: Genetic Counseling
-  description: Providing information and support to families regarding
-    inheritance and implications.
-  evidence:
-  - reference: PMID:14619605
-    reference_title: "Genetic counseling."
-    supports: SUPPORT
-    snippet: Genetic counseling has developed as a discipline in response to the
-      need to educate patients, families and professionals about genetic
-      mechanisms and their application in health care. ... Genetic counseling is
-      a process of medical education based upon empathy, patient autonomy and
-      confidentiality in an atmosphere of empathy, support and understanding.
-    explanation: The literature describes genetic counseling as a discipline
-      developed to educate patients, families, and professionals about genetic
-      mechanisms and their application in healthcare, which supports the
-      statement about providing information and support to families regarding
-      inheritance and implications.
-  - reference: PMID:30237433
-    reference_title: "Expanding the concept of peroxisomal diseases and efficient diagnostic system in Japan."
-    supports: SUPPORT
-    snippet: Furthermore, it is also important to identify pre-symptomatic
-      patients by family analysis of probands by providing appropriate disease
-      information and genetic counseling, which will also lead to early
-      intervention.
-    explanation: The literature discusses the importance of providing disease
-      information and genetic counseling to families, supporting the statement
-      about providing information and support to families regarding inheritance
-      and implications in the context of peroxisomal diseases.
-  treatment_term:
-    preferred_term: genetic counseling
-    term:
-      id: MAXO:0000079
-      label: genetic counseling
-review_notes: This is a multisystem disorder affecting multiple organ systems
-  due to defective peroxisome function. The phenotypes can be quite variable,
-  but neurologic and hepatic manifestations are most prominent. Enhanced with
-  recent research (2023-2025) highlighting microglial DAM signatures,
-  peroxisome-organelle crosstalk, retinal pigment epithelium dysfunction, and
-  detailed PEX gene import machinery. Added biological process annotations for
-  fatty acid metabolism, ether lipid biosynthesis, and peroxisome organization.
-  Expanded genetic variants to include specific PEX genes (PEX2, PEX5, PEX7,
-  PEX10, PEX12, PEX13, PEX26) with functional notes. Added phenotypes including
-  seizures, leukodystrophy, cholestasis, and renal dysfunction.
-disease_term:
-  preferred_term: peroxisome biogenesis disorder
-  term:
-    id: MONDO:0019234
-    label: peroxisome biogenesis disorder
-references:
-- reference: DOI:10.1002/mgg3.2315
-  title: 'Severe Zellweger spectrum disorder due to a novel missense variant in the
-    <i>PEX13</i> gene: A case report and the literature review'
-  findings: []
-- reference: DOI:10.1007/s00418-023-02259-5
-  title: 'The peroxisome: an update on mysteries 3.0'
-  findings: []
-- reference: DOI:10.1038/s43856-024-00605-9
-  title: Lipidomic biomarkers in plasma correlate with disease severity in
-    adrenoleukodystrophy
-  findings: []
-- reference: DOI:10.1101/2024.09.05.611330
-  title: Geographic characterization of RPE structure and lipid changes in the
-    PEX1-p.Gly844Asp mouse model for Zellweger spectrum disorder
-  findings: []
-- reference: DOI:10.1186/s12887-024-05246-4
-  title: 'Normal very long-chain fatty acids level in a patient with peroxisome biogenesis
-    disorders: a case report'
-  findings: []
-- reference: DOI:10.1242/jcs.236943
-  title: Recent insights into peroxisome biogenesis and associated diseases
-  findings: []
-- reference: DOI:10.3389/fnmol.2023.1170313
-  title: Peroxisomal defects in microglial cells induce a disease-associated
-    microglial signature
-  findings: []
-- reference: DOI:10.3389/fnmol.2025.1642590
-  title: Peroxisomes as emerging clinical targets in neuroinflammatory diseases
-  findings: []
-- reference: DOI:10.3390/cells14020147
-  title: Modelling Peroxisomal Disorders in Zebrafish
-  findings: []
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Although CA treatment did lead to reduced levels of toxic C27 -bile acid intermediates in ZSD patients without severe liver fibrosis or cirrhosis, no improvement of clinically relevant parameters was observed after 21 months of treatment."
+    explanation: Clarifies that the main demonstrated benefit is biochemical, not robust reversal of overall clinical disease.
+notes: >-
+  This curation intentionally treats Zellweger syndrome, neonatal
+  adrenoleukodystrophy, infantile Refsum disease, and Heimler syndrome as
+  severity labels within one Zellweger spectrum disorder continuum rather than
+  as separate dismech disease entries. MONDO:0019234 was selected as the anchor
+  because its definition maps to the ZSD/PBD-ZSS continuum, even though the
+  ontology label is broader than the preferred disease name used here.

--- a/references_cache/PMID_11389485.md
+++ b/references_cache/PMID_11389485.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:11389485"
+title: "Disorders of peroxisome biogenesis due to mutations in PEX1: phenotypes and PEX1 protein levels."
+authors:
+- Walter C
+- Gootjes J
+- Mooijer PA
+- Portsteffen H
+- Klein C
+- Waterham HR
+- Barth PG
+- Epplen JT
+- Kunau WH
+- Wanders RJ
+- Dodt G
+journal: Am J Hum Genet
+year: '2001'
+doi: 10.1086/321265
+keywords:
+- ATPases Associated with Diverse Cellular Activities
+- "Adrenoleukodystrophy/enzymology, genetics, pathology"
+- Alleles
+- Base Sequence
+- "Cells, Cultured"
+- Child
+- "Child, Preschool"
+- Exons/genetics
+- Fibroblasts
+- Genotype
+- Humans
+- Infant
+- "Infant, Newborn"
+- Introns/genetics
+- "Membrane Proteins/chemistry, genetics, metabolism"
+- Mutation/genetics
+- "Mutation, Missense/genetics"
+- "Peroxisomal Disorders/enzymology, genetics, pathology"
+- "Peroxisomes/enzymology, pathology"
+- Phenotype
+- "Polymorphism, Single-Stranded Conformational"
+- Protein Conformation
+- Protein Folding
+- "Zellweger Syndrome/enzymology, genetics, pathology"
+content_type: abstract_only
+---
+
+# Disorders of peroxisome biogenesis due to mutations in PEX1: phenotypes and PEX1 protein levels.
+**Authors:** Walter C, Gootjes J, Mooijer PA, Portsteffen H, Klein C, Waterham HR, Barth PG, Epplen JT, Kunau WH, Wanders RJ, Dodt G
+**Journal:** Am J Hum Genet (2001)
+**DOI:** [10.1086/321265](https://doi.org/10.1086/321265)
+
+## Content
+
+1. Am J Hum Genet. 2001 Jul;69(1):35-48. doi: 10.1086/321265. Epub 2001 Jun 1.
+
+Disorders of peroxisome biogenesis due to mutations in PEX1: phenotypes and PEX1
+protein levels.
+
+Walter C(1), Gootjes J, Mooijer PA, Portsteffen H, Klein C, Waterham HR, Barth
+PG, Epplen JT, Kunau WH, Wanders RJ, Dodt G.
+
+Author information:
+(1)Institut für Physiologische Chemie, Abteilung für Zellbiochemie,
+Ruhr-Universität Bochum, Universitätsstrasse 150, 44801 Bochum, Germany.
+
+Zellweger syndrome (ZS), neonatal adrenoleukodystrophy (NALD), and infantile
+Refsum disease (IRD) are clinically overlapping syndromes, collectively called
+"peroxisome biogenesis disorders" (PBDs), with clinical features being most
+severe in ZS and least pronounced in IRD. Inheritance of these disorders is
+autosomal recessive. The peroxisome biogenesis disorders are genetically
+heterogeneous, having at least 12 different complementation groups (CGs). The
+gene affected in CG1 is PEX1. Approximately 65% of the patients with PBD harbor
+mutations in PEX1. In the present study, we used SSCP analysis to evaluate a
+series of patients belonging to CG1 for mutations in PEX1 and studied
+phenotype-genotype correlations. A complete lack of PEX1 protein was found to be
+associated with severe ZS; however, residual amounts of PEX1 protein were found
+in patients with the milder phenotypes, NALD and IRD. The majority of these
+latter patients carried at least one copy of the common G843D allele. When
+patient fibroblasts harboring this allele were grown at 30 degrees C, a two- to
+threefold increase in PEX1 protein levels was observed, associated with a
+recovery of peroxisomal function. This suggests that the G843D missense mutation
+results in a misfolded protein, which is more stable at lower temperatures. We
+conclude that the search for the factors and/or mechanisms that determine the
+stability of mutant PEX1 protein by high-throughput procedures will be a first
+step in the development of therapeutic strategies for patients with mild PBDs.
+
+DOI: 10.1086/321265
+PMCID: PMC1226046
+PMID: 11389485 [Indexed for MEDLINE]

--- a/references_cache/PMID_21844578.md
+++ b/references_cache/PMID_21844578.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:21844578"
+title: "Two novel PEX1 mutations in a patient with Zellweger syndrome: the first Korean case confirmed by biochemical, and molecular evidence."
+authors:
+- Cho SY
+- Chang YP
+- Park JY
+- Park HD
+- Sohn YB
+- Park SW
+- Kim SH
+- Ji S
+- Kim SJ
+- Choi EW
+- Kim CH
+- Ko AR
+- Paik KH
+- Jin DK
+journal: Ann Clin Lab Sci
+year: '2011'
+keywords:
+- ATPases Associated with Diverse Cellular Activities
+- Female
+- Heterozygote
+- Humans
+- "Infant, Newborn"
+- Male
+- Membrane Proteins/genetics
+- Mutation
+- Republic of Korea
+- "Zellweger Syndrome/etiology, genetics"
+content_type: abstract_only
+---
+
+# Two novel PEX1 mutations in a patient with Zellweger syndrome: the first Korean case confirmed by biochemical, and molecular evidence.
+**Authors:** Cho SY, Chang YP, Park JY, Park HD, Sohn YB, Park SW, Kim SH, Ji S, Kim SJ, Choi EW, Kim CH, Ko AR, Paik KH, Jin DK
+**Journal:** Ann Clin Lab Sci (2011)
+
+## Content
+
+1. Ann Clin Lab Sci. 2011 Spring;41(2):182-7.
+
+Two novel PEX1 mutations in a patient with Zellweger syndrome: the first Korean
+case confirmed by biochemical, and molecular evidence.
+
+Cho SY(1), Chang YP, Park JY, Park HD, Sohn YB, Park SW, Kim SH, Ji S, Kim SJ,
+Choi EW, Kim CH, Ko AR, Paik KH, Jin DK.
+
+Author information:
+(1)Department of Pediatrics, Samsung Medical Center, Sungkyunkwan University
+School of Medicine, 50 Irwon-dong, Gangnam-gu, Seoul, Korea.
+
+Peroxisome biogenesis disorders (PBD) represent a spectrum of genetic disorders
+characterized by impaired peroxisome assembly. Zellweger syndrome (ZS) is the
+most severe form of PBD and is characterized by craniofacial abnormalities,
+severe hypotonia, neonatal seizures, ocular abnormalities, psychomotor
+retardation, hepatomegaly and increased levels of very long chain fatty acids
+(VLCFA). The most common mutation associated with the PBD is PEX1. Here, the
+first Korean patient with ZS confirmed by clinical, biochemical, and molecular
+findings is reported. Two novel mutations of the PEX1 gene were identified in
+the patient with ZS. The patient was a compound heterozygote for
+c.2034_2035delCA and c.2845C>T mutations of the PEX1 gene. Both mutations are
+novel findings and were inherited from the patient's parents. In summary, here
+the first Korean case of ZS is reported that was confirmed by two novel
+mutations of the PEX1 gene.
+
+PMID: 21844578 [Indexed for MEDLINE]

--- a/references_cache/PMID_24503136.md
+++ b/references_cache/PMID_24503136.md
@@ -1,0 +1,125 @@
+---
+reference_id: "PMID:24503136"
+title: "The Pex1-G844D mouse: a model for mild human Zellweger spectrum disorder."
+authors:
+- Hiebler S
+- Masuda T
+- Hacia JG
+- Moser AB
+- Faust PL
+- Liu A
+- Chowdhury N
+- Huang N
+- Lauer A
+- Bennett J
+- Watkins PA
+- Zack DJ
+- Braverman NE
+- Raymond GV
+- Steinberg SJ
+journal: Mol Genet Metab
+year: '2014'
+doi: 10.1016/j.ymgme.2014.01.008
+keywords:
+- ATPases Associated with Diverse Cellular Activities
+- "Adenosine Triphosphatases/genetics, metabolism"
+- Animals
+- "Animals, Newborn"
+- Bile Acids and Salts/metabolism
+- "Disease Models, Animal"
+- Fatty Acids/blood
+- Female
+- Fibroblasts/metabolism
+- Gene Expression Profiling
+- Growth and Development
+- Hearing
+- Heterozygote
+- Humans
+- Male
+- Membrane Proteins/metabolism
+- Mice
+- "Mice, Mutant Strains"
+- Molecular Chaperones/metabolism
+- "Mutation, Missense/genetics"
+- Phenotype
+- "Retina/pathology, physiopathology"
+- "Sexual Behavior, Animal"
+- Skin/pathology
+- Survival Analysis
+- "Vision, Ocular"
+- "Zellweger Syndrome/blood, genetics, pathology, physiopathology"
+content_type: abstract_only
+---
+
+# The Pex1-G844D mouse: a model for mild human Zellweger spectrum disorder.
+**Authors:** Hiebler S, Masuda T, Hacia JG, Moser AB, Faust PL, Liu A, Chowdhury N, Huang N, Lauer A, Bennett J, Watkins PA, Zack DJ, Braverman NE, Raymond GV, Steinberg SJ
+**Journal:** Mol Genet Metab (2014)
+**DOI:** [10.1016/j.ymgme.2014.01.008](https://doi.org/10.1016/j.ymgme.2014.01.008)
+
+## Content
+
+1. Mol Genet Metab. 2014 Apr;111(4):522-532. doi: 10.1016/j.ymgme.2014.01.008.
+Epub  2014 Jan 23.
+
+The Pex1-G844D mouse: a model for mild human Zellweger spectrum disorder.
+
+Hiebler S(#)(1), Masuda T(#)(2), Hacia JG(3), Moser AB(1)(4), Faust PL(5), Liu
+A(1), Chowdhury N(1), Huang N(3), Lauer A(6), Bennett J(7), Watkins PA(1)(4),
+Zack DJ(2)(8)(9)(10), Braverman NE(11)(12), Raymond GV(1)(4), Steinberg
+SJ(1)(4)(8).
+
+Author information:
+(1)Department of Neurogenetics, Hugo W. Moser Research Institute at Kennedy
+Krieger, 707 N. Broadway, Baltimore, MD, USA.
+(2)Wilmer Eye Institute, Johns Hopkins University School of Medicine, Baltimore,
+MD, USA.
+(3)Department of Biochemistry and Molecular Biology, Institute for Genetic
+Medicine, Keck School of Medicine, University of Southern California, Los
+Angeles, CA, USA.
+(4)Department of Neurology, Johns Hopkins University School of Medicine,
+Baltimore, MD, USA.
+(5)Department of Pathology and Cell Biology, College of Physicians and Surgeons,
+Columbia University, New York, NY, USA.
+(6)Otolaryngology-Head and Neck Surgery, Johns Hopkins University School of
+Medicine, Baltimore, MD, USA.
+(7)F.M. Kirby Center for Molecular Ophthalmology, Perelman School of Medicine,
+University of Pennsylvania, Philadelphia, PA, USA.
+(8)McKusick-Nathans Institute of Genetic Medicine, Johns Hopkins University
+School of Medicine, Baltimore, MD, USA.
+(9)Departments of Molecular Biology and Genetics, and Neuroscience, Johns
+Hopkins University School of Medicine, Baltimore, MD, USA.
+(10)Institut de la Vision, Université Pierre et Marie Curie, Paris, France.
+(11)Department of Genetics, McGill University, Montreal, Quebec, Canada.
+(12)Department of Pediatrics, Montreal Children's Hospital, Montreal, Quebec,
+Canada.
+(#)Contributed equally
+
+Zellweger spectrum disorder (ZSD) is a disease continuum that results from
+inherited defects in PEX genes essential for normal peroxisome assembly. These
+autosomal recessive disorders impact brain development and also cause postnatal
+liver, adrenal, and kidney dysfunction, as well as loss of vision and hearing.
+The hypomorphic PEX1-G843D missense allele, observed in approximately 30% of ZSD
+patients, is associated with milder clinical and biochemical phenotypes, with
+some homozygous individuals surviving into early adulthood. Nonetheless,
+affected children with the PEX1-G843D allele have intellectual disability,
+failure to thrive, and significant sensory deficits. To enhance our ability to
+test candidate therapies that improve human PEX1-G843D function, we created the
+novel Pex1-G844D knock-in mouse model that represents the murine equivalent of
+the common human mutation. We show that Pex1-G844D homozygous mice recapitulate
+many classic features of mild ZSD cases, including growth retardation and fatty
+livers with cholestasis. In addition, electrophysiology, histology, and gene
+expression studies provide evidence that these animals develop a retinopathy
+similar to that observed in human patients, with evidence of cone photoreceptor
+cell death. Similar to skin fibroblasts obtained from ZSD patients with a
+PEX1-G843D allele, we demonstrate that murine cells homozygous for the
+Pex1-G844D allele respond to chaperone-like compounds, which normalizes
+peroxisomal β-oxidation. Thus, the Pex1-G844D mouse provides a powerful model
+system for testing candidate therapies that address the most common genetic
+cause of ZSD. In addition, this murine model will enhance studies focused on
+mechanisms of pathogenesis.
+
+Copyright © 2014 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ymgme.2014.01.008
+PMCID: PMC4901203
+PMID: 24503136 [Indexed for MEDLINE]

--- a/references_cache/PMID_26287655.md
+++ b/references_cache/PMID_26287655.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:26287655"
+title: "Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood."
+authors:
+- Berendse K
+- Engelen M
+- Ferdinandusse S
+- Majoie CB
+- Waterham HR
+- Vaz FM
+- Koelman JH
+- Barth PG
+- Wanders RJ
+- Poll-The BT
+journal: J Inherit Metab Dis
+year: '2016'
+doi: 10.1007/s10545-015-9880-2
+keywords:
+- Adolescent
+- Adult
+- Biomarkers/metabolism
+- Disease Progression
+- Female
+- Follow-Up Studies
+- Humans
+- Magnetic Resonance Imaging/methods
+- Male
+- Retrospective Studies
+- "White Matter/metabolism, pathology"
+- Young Adult
+- "Zellweger Syndrome/metabolism, pathology"
+content_type: abstract_only
+---
+
+# Zellweger spectrum disorders: clinical manifestations in patients surviving into adulthood.
+**Authors:** Berendse K, Engelen M, Ferdinandusse S, Majoie CB, Waterham HR, Vaz FM, Koelman JH, Barth PG, Wanders RJ, Poll-The BT
+**Journal:** J Inherit Metab Dis (2016)
+**DOI:** [10.1007/s10545-015-9880-2](https://doi.org/10.1007/s10545-015-9880-2)
+
+## Content
+
+1. J Inherit Metab Dis. 2016 Jan;39(1):93-106. doi: 10.1007/s10545-015-9880-2.
+Epub  2015 Aug 19.
+
+Zellweger spectrum disorders: clinical manifestations in patients surviving into
+adulthood.
+
+Berendse K(1)(2), Engelen M(1), Ferdinandusse S(2), Majoie CB(3), Waterham
+HR(2), Vaz FM(2), Koelman JH(4), Barth PG(1), Wanders RJ(2), Poll-The BT(5).
+
+Author information:
+(1)Department of Paediatric Neurology, Emma Children's Hospital, Academic
+Medical Centre (AMC), University of Amsterdam, Meibergdreef 9, 1105 AZ,
+Amsterdam, The Netherlands.
+(2)Laboratory Genetic Metabolic Diseases, Emma Children's Hospital, AMC,
+University of Amsterdam, Amsterdam, The Netherlands.
+(3)Department of Radiology, AMC, University of Amsterdam, Amsterdam, The
+Netherlands.
+(4)Department of Neurology and Clinical Neurophysiology, AMC, University of
+Amsterdam, Amsterdam, The Netherlands.
+(5)Department of Paediatric Neurology, Emma Children's Hospital, Academic
+Medical Centre (AMC), University of Amsterdam, Meibergdreef 9, 1105 AZ,
+Amsterdam, The Netherlands. B.T.PollThe@amc.uva.nl.
+
+INTRODUCTION: We describe the natural history of patients with a Zellweger
+spectrum disorder (ZSD) surviving into adulthood.
+METHODS: Retrospective cohort study in patients with a genetically confirmed
+ZSD.
+RESULTS: All patients (n = 19; aged 16-35 years) had a follow-up period of
+1-24.4 years (mean 16 years). Seven patients had a progressive disease course,
+while 12 remained clinically stable during follow-up. Disease progression
+usually manifests in adolescence as a gait disorder, caused by central and/or
+peripheral nervous system involvement. Nine were capable of living a partly
+independent life with supported employment. Systematic MRI review revealed T2
+hyperintense white matter abnormalities in the hilus of the dentate nucleus
+and/or peridentate region in nine out of 16 patients. Biochemical analyses in
+blood showed abnormal peroxisomal biomarkers in all patients in infancy and
+childhood, whereas in adolescence/adulthood we observed normalization of some
+metabolites.
+CONCLUSIONS: The patients described here represent a distinct subgroup within
+the ZSDs who survive into adulthood. Most remain stable over many years. Disease
+progression may occur and is mainly due to cerebral and cerebellar white matter
+abnormalities, and peripheral neuropathy.
+
+DOI: 10.1007/s10545-015-9880-2
+PMCID: PMC4710674
+PMID: 26287655 [Indexed for MEDLINE]

--- a/references_cache/PMID_26750748.md
+++ b/references_cache/PMID_26750748.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:26750748"
+title: "Peroxisome biogenesis disorders in the Zellweger spectrum: An overview of current diagnosis, clinical manifestations, and treatment guidelines."
+authors:
+- Braverman NE
+- Raymond GV
+- Rizzo WB
+- Moser AB
+- Wilkinson ME
+- Stone EM
+- Steinberg SJ
+- Wangler MF
+- Rush ET
+- Hacia JG
+- Bose M
+journal: Mol Genet Metab
+year: '2016'
+doi: 10.1016/j.ymgme.2015.12.009
+keywords:
+- Adult
+- Genetic Testing
+- "Hearing Loss, Sensorineural/etiology, physiopathology"
+- Humans
+- Membrane Proteins/genetics
+- Mutation
+- PHEX Phosphate Regulating Neutral Endopeptidase/genetics
+- "Peroxisomal Disorders/diagnosis, therapy"
+- Peroxisomes/genetics
+- Phenotype
+- Practice Guidelines as Topic
+- Precision Medicine
+- "Retinal Dystrophies/etiology, physiopathology"
+- "Zellweger Syndrome/diagnosis, therapy"
+content_type: abstract_only
+---
+
+# Peroxisome biogenesis disorders in the Zellweger spectrum: An overview of current diagnosis, clinical manifestations, and treatment guidelines.
+**Authors:** Braverman NE, Raymond GV, Rizzo WB, Moser AB, Wilkinson ME, Stone EM, Steinberg SJ, Wangler MF, Rush ET, Hacia JG, Bose M
+**Journal:** Mol Genet Metab (2016)
+**DOI:** [10.1016/j.ymgme.2015.12.009](https://doi.org/10.1016/j.ymgme.2015.12.009)
+
+## Content
+
+1. Mol Genet Metab. 2016 Mar;117(3):313-21. doi: 10.1016/j.ymgme.2015.12.009.
+Epub  2015 Dec 23.
+
+Peroxisome biogenesis disorders in the Zellweger spectrum: An overview of
+current diagnosis, clinical manifestations, and treatment guidelines.
+
+Braverman NE(1), Raymond GV(2), Rizzo WB(3), Moser AB(4), Wilkinson ME(5), Stone
+EM(6), Steinberg SJ(7), Wangler MF(8), Rush ET(9), Hacia JG(10), Bose M(11).
+
+Author information:
+(1)McGill University Health Centre, 1001 Décarie Blvd Block E, EM02230,
+Montreal, QC H4A3J1, Canada. Electronic address: nancy.braverman@mcgill.ca.
+(2)Department of Neurology, University of Minnesota, 516 Delaware Street SE,
+Minneapolis, MN 55455, USA,. Electronic address: gvraymon@umn.edu.
+(3)Department of Pediatrics, University of Nebraska Medical Center, 985456
+Nebraska Medical Center - MMI 3062, Omaha, NE 68198-5456, USA. Electronic
+address: wrizzo@umnc.edu.
+(4)Hugo W. Moser Research Institute at Kennedy Krieger, 707 N. Broadway,
+Baltimore, MD 21205, USA. Electronic address: mosera@kennedykrieger.org.
+(5)Carver College of Medicine, Department of Ophthalmology and Visual Sciences,
+University of Iowa, Stephen A. Wynn Institute for Vision Research, 200 Hawkins
+Drive, Iowa City, IA 52242, USA. Electronic address: mark-wilkinson@uiowa.edu.
+(6)Carver College of Medicine, Department of Ophthalmology and Visual Sciences,
+University of Iowa, Stephen A. Wynn Institute for Vision Research, 200 Hawkins
+Drive, Iowa City, IA 52242, USA. Electronic address: edwin-stone@uiowa.edu.
+(7)Institute of Genetic Medicine and Department of Neurology, Johns Hopkins
+University School of Medicine, CMSC1004B, 600 N Wolfe Street, Baltimore, MD
+21287, USA. Electronic address: ssteinb8@jhmi.edu.
+(8)Department of Molecular and Human Genetics, Baylor College of Medicine,
+Duncan Neurological Research Institute, DNRI-1050, Houston, TX 77030, USA.
+Electronic address: michael.wangler@bcm.edu.
+(9)Munroe-Meyer Institute for Genetics and Rehabilitation, University of
+Nebraska Medical Center, 985440 Nebraska Medical Center, Omaha, NE 68198, USA.
+Electronic address: erush@unmc.edu.
+(10)Department of Biochemistry and Molecular Biology, University of Southern
+California, 1975 Zonal Ave, Los Angeles, CA 90033, USA. Electronic address:
+hacia@usc.edu.
+(11)Global Foundation for Peroxisomal Disorders, 5147 S. Harvard Avenue, Suite
+181, Tulsa, OK 74135, USA. Electronic address: mousumi@thegfpd.org.
+
+Peroxisome biogenesis disorders in the Zellweger spectrum (PBD-ZSD) are a
+heterogeneous group of genetic disorders caused by mutations in PEX genes
+responsible for normal peroxisome assembly and functions. As a result of
+impaired peroxisomal activities, individuals with PBD-ZSD can manifest a complex
+spectrum of clinical phenotypes that typically result in shortened life spans.
+The extreme variability in disease manifestation ranging from onset of profound
+neurologic symptoms in newborns to progressive degenerative disease in adults
+presents practical challenges in disease diagnosis and medical management.
+Recent advances in biochemical methods for newborn screening and genetic testing
+have provided unprecedented opportunities for identifying patients at the
+earliest possible time and defining the molecular bases for their diseases.
+Here, we provide an overview of current clinical approaches for the diagnosis of
+PBD-ZSD and provide broad guidelines for the treatment of disease in its wide
+variety of forms. Although we anticipate future progress in the development of
+more effective targeted interventions, the current guidelines are meant to
+provide a starting point for the management of these complex conditions in the
+context of personalized health care.
+
+Copyright © 2015 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ymgme.2015.12.009
+PMCID: PMC5214431
+PMID: 26750748 [Indexed for MEDLINE]

--- a/references_cache/PMID_27493320.md
+++ b/references_cache/PMID_27493320.md
@@ -1,0 +1,39 @@
+---
+reference_id: "PMID:27493320"
+title: "Zellweger syndrome: A cause of neonatal hypotonia and seizures."
+authors:
+- Kheir AE
+journal: Sudan J Paediatr
+year: '2011'
+content_type: abstract_only
+---
+
+# Zellweger syndrome: A cause of neonatal hypotonia and seizures.
+**Authors:** Kheir AE
+**Journal:** Sudan J Paediatr (2011)
+
+## Content
+
+1. Sudan J Paediatr. 2011;11(2):54-8.
+
+Zellweger syndrome: A cause of neonatal hypotonia and seizures.
+
+Kheir AE(1).
+
+Author information:
+(1)Department of Pediatrics , Dallah Hospital, Riyadh , Saudi Arabia.
+
+Zellweger syndrome, a paradigm of human peroxisomal disorders is characterized
+by dysmorphic features, hypotonia, severe neuro-developmental delay,
+hepatomegaly, renal cysts, sensorineural deafness and retinal dysfunction. This
+is a case report of a baby boy born with facial dysmorphism, profound hypotonia,
+seizures, and hepatomegaly. The diagnosis was not evident initially but only
+later when he presented with obstructive jaundiced and renal cysts. He died at
+the age of seven months. Biochemical studies revealed elevation of very long
+chain fatty acids and phytanic acid consistent with a peroxisomal disorder. The
+recognition of this syndrome is important since it is a fatal hereditary
+disease. Zellweger syndrome should be included in the differential diagnosis of
+infantile hypotonia and dysmorphism.
+
+PMCID: PMC4949836
+PMID: 27493320

--- a/references_cache/PMID_28644367.md
+++ b/references_cache/PMID_28644367.md
@@ -1,0 +1,166 @@
+---
+reference_id: "PMID:28644367"
+title: Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid Synthesis and Zellweger Spectrum Disorders.
+authors:
+- Heubi JE
+- Bove KE
+- Setchell KDR
+journal: J Pediatr Gastroenterol Nutr
+year: '2017'
+doi: 10.1097/MPG.0000000000001657
+keywords:
+- "Administration, Oral"
+- Adolescent
+- Bile Acids and Salts/metabolism
+- Child
+- "Child, Preschool"
+- Cholic Acid/therapeutic use
+- Drug Administration Schedule
+- Female
+- Humans
+- Infant
+- "Infant, Newborn"
+- Intention to Treat Analysis
+- Male
+- "Steroid Metabolism, Inborn Errors/drug therapy, metabolism"
+- Treatment Outcome
+- Zellweger Syndrome/drug therapy
+content_type: full_text_xml
+---
+
+# Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid Synthesis and Zellweger Spectrum Disorders.
+**Authors:** Heubi JE, Bove KE, Setchell KDR
+**Journal:** J Pediatr Gastroenterol Nutr (2017)
+**DOI:** [10.1097/MPG.0000000000001657](https://doi.org/10.1097/MPG.0000000000001657)
+
+## Content
+
+1. J Pediatr Gastroenterol Nutr. 2017 Sep;65(3):321-326. doi:
+10.1097/MPG.0000000000001657.
+
+Oral Cholic Acid Is Efficacious and Well Tolerated in Patients With Bile Acid
+Synthesis and Zellweger Spectrum Disorders.
+
+Heubi JE(1), Bove KE, Setchell KDR.
+
+Author information:
+(1)*Division of Pediatric Gastroenterology, Hepatology and Nutrition †Pathology
+and Laboratory Medicine, Cincinnati Children's Hospital Medical Center,
+Cincinnati, OH.
+
+Comment in
+    J Pediatr Gastroenterol Nutr. 2018 Feb;66(2):e57. doi:
+10.1097/MPG.0000000000001763.
+    J Pediatr Gastroenterol Nutr. 2018 Feb;66(2):e57-e59. doi:
+10.1097/MPG.0000000000001764.
+
+OBJECTIVES: Patients with bile acid synthesis disorders (BASDs) due to single
+enzyme defects (SEDs) or Zellweger spectrum disorders (ZSDs) accumulate
+hepatotoxic atypical bile acids resulting in potentially fatal progressive liver
+disease. We evaluated the efficacy and safety of oral cholic acid in patients
+with BASD.
+METHODS: In this phase 3, open-label, single-arm, nonrandomized, noncomparative
+study conducted over 18 years, patients were administered cholic acid orally 10
+to 15 mg · kg · day. The primary efficacy variables were changes from pre- to
+post-treatment in atypical urinary bile acids, liver chemistries (serum
+aspartate aminotransferase, alanine aminotransferase), and height and weight.
+Additional efficacy variables included changes in serum bilirubin and liver
+histology.
+RESULTS: Of the 85 enrolled patients (63 with SED and 22 with ZSD), 79 received
+at least 1 dose of study medication; 70 patients (50 with SED and 20 with ZSD)
+were included in the modified intent-to-treat dataset. Cholic acid significantly
+improved urine bile acid metabolite scores (P < 0.0001) and serum aspartate
+aminotransferase and alanine aminotransferase (P < 0.0001) in patients with SED
+and ZSD. Cholic acid also improved height and weight percentiles in both groups,
+but only the change in weight was significant (P < 0.05). Serum direct bilirubin
+decreased significantly post-treatment (P < 0.001) in the intent-to-treat
+population, and liver biopsies showed either stable findings or histologic
+improvement in all parameters except bridging fibrosis. The overall safety
+profile of cholic acid was favorable, with no study drug-related serious adverse
+events or drug-related deaths reported.
+CONCLUSIONS: Oral cholic acid is a safe, efficacious, and well-tolerated
+treatment for BASD due to SED and ZSD.
+
+DOI: 10.1097/MPG.0000000000001657
+PMCID: PMC5559188
+PMID: 28644367 [Indexed for MEDLINE]
+
+Conflict of interest statement: Drs Heubi and Setchell have an equity interest
+in Asklepion Pharmaceuticals, LLC and are consultants for Retrophin, Inc. The
+remaining author reports no conflicts of interest.
+
+The synthesis of cholic acid and chenodeoxycholic acid from cholesterol involves several steps catalyzed by 15 enzymes located in various subcellular fractions of the hepatocyte (1–4). Rare congenital disorders affecting this biosynthetic pathway are known collectively as bile acid synthesis disorders (BASDs). BASDs are due to a deficiency of or lack of activity in enzymes catalyzing the conversion of cholesterol to bile acids (referred to here as single enzyme defects [SEDs]) or to defects in the oxidation and shortening of the cholesterol side chain (2–5). The most common BASDs involving SEDs are 3β-hydroxy-Δ5-C27-steroid oxidoreductase (HSD3B7, referred to here as 3β-HSD deficiency) and Δ4-3-oxosteroid 5β-reductase (AKR1D1, referred to here as 5β-reductase deficiency), in which primary acid synthesis is absent or negligible (4,6). In the group of diseases known as Zellweger spectrum disorders (ZSDs), side-chain oxidation of bile acid precursors, a process that occurs in the peroxisomes, is impaired and these patients synthesize and accumulate long-chain (C27) bile acids (2,5).
+
+The impairment in bile acid synthesis causes hepatocytes to continuously metabolize bile acids from cholesterol in an attempt to establish a normal bile acid pool. The result is the continued production of high concentrations of atypical bile acids and bile acid intermediates, which may cause progressive cellular injury (4–9). Accumulation of these potentially hepatotoxic metabolites and the reduction in bile acid–dependent bile flow from the lack of primary bile acids may lead to liver injury (4,10). Liver disease associated with these conditions is progressive and if untreated may lead to death from cirrhosis and liver failure. In some cases, extrahepatic injury leads to central nervous system disorders with cholestasis and potential liver injury limited to the newborn period. ZSDs are characterized by progressive liver disease and extrahepatic manifestations such as central nervous system dysfunction (4,11).
+
+It was hypothesized that exogenous administration of bile acids in patients with SED or ZSD would reduce the production of hepatotoxic intermediates and metabolites through downregulation of cholesterol 7α-hydroxylase (CYP7A1), the rate-limiting enzyme in bile acid synthesis; promote bile acid–dependent bile flow, thereby resolving cholestasis; and improve growth by facilitating the absorption of fat and fat-soluble vitamins.
+
+Oral bile acid therapy has been shown to reduce production of atypical bile acids, normalize serum liver transaminases, and improve liver histology in patients with 3β-HSD or 5β-reductase deficiencies (12–17) and to improve liver function in patients with Zellweger syndrome (16,17).
+
+In the present study, we evaluated the efficacy and safety of oral cholic acid in the largest cohort of patients with BASD due to SED or with ZSD. This was initially an investigator-initiated, compassionate use program and then transitioned into a formal clinical trial program. This report focuses on data collected over the 18-year period from January 3, 1992 to December 31, 2009.
+
+This phase 3, open-label, single-arm, nonrandomized, noncomparative, compassionate treatment study began at the Cincinnati Children's Hospital Medical Center (CCHMC) but was later expanded to enroll patients with BASD or ZSD from other sites. Diagnosis of an inborn error of bile acid synthesis was confirmed based on urine fast atom bombardment ionization mass spectrometry (FAB-MS) analysis and the presence of atypical bile acids characteristic of the specific defect in bile acid synthesis (10). No specific exclusion criteria were defined for the study. Patients were permitted to continue their other medications as indicated.
+
+Signed informed consent by the patient and/or parents or legal guardian was solicited and obtained. The present study was approved by the institutional review board of the CCHMC and conducted under an Investigational New Drug application (45,470) approved by the US Food and Drug Administration. All authors of this manuscript had access to the study data and reviewed and approved the final manuscript.
+
+Cholic acid (10 to 15 mg · kg−1 · day−1) was administered once a day or in divided doses twice daily as capsules emptied into food, or as a liquid formulation (15 mg/mL) for patients who could not swallow capsules (see the Supplemental Digital Content, Material, for discussion of use of ursodeoxycholic acid in the original protocol).
+
+Negative ion mass spectra were acquired over 50 to 1000 Da (see the Supplemental Digital Content, Material, for details). In BASD, the FAB-MS negative ion mass spectrum reveals ions that correspond in mass to the accumulated intermediates and/or their metabolites in the biosynthetic pathway proximal to the enzyme block.
+
+Using a scoring system based on signal/noise ratio for the major ions (developed by KDRS) the FAB-MS mass spectra at baseline and post-treatment were assessed as normal (score 0) or as showing slight (score 1), significant (score 2), or marked (score 3) increases in the levels of atypical bile acids. This semiquantitative assessment of the urinary atypical bile acid levels was recently validated for 3β-HSD deficiency and shown to correlate well with quantitative excretion as measured by a targeted tandem MS method (18).
+
+Laboratory assessment of serum aspartate aminotransferase (AST), serum alanine aminotransferase (ALT), and serum bilirubin (total and direct) were performed at baseline and at regular intervals during treatment in Clinical Laboratory Improvement Act or College of American Pathologists certified laboratories. A value of 50 IU/L was selected as the upper limit of normal (ULN) for AST and ALT. Multiples above the ULN (1–<2 and ≥2× ULN) were examined.
+
+Anthropometric measurements (height and weight) were performed at baseline and at intervals determined by the attending physician using standard clinical methods during treatment.
+
+For patients treated at CCHMC, percutaneous liver biopsies were performed at baseline (if no historical sample was available) and between 1 and 10 months after treatment start. In patients with ZSD, a liver biopsy was performed if there was no contraindication to biopsy that increased the risk of the procedure. Liver biopsies were not required for patients evaluated outside the CCHMC site. Liver biopsy processing was done by standard methods, and sections stained with hematoxylin and eosin and trichrome were routinely used.
+
+An experienced pediatric pathologist (K.E.B.) served as a central reader for review of all liver biopsies and narrative text data available. Pre- and post-treatment liver biopsies were analyzed qualitatively for the presence of inflammation, fibrosis, necrosis, giant cells, and cholestasis using the fibrosis staging (0–4) and grading (0–4) system of Ishak et al (19) In a third step, any liver biopsy results were compared with those of the previous biopsy (if available), and the degree of change (improved or worse) was assessed.
+
+The primary efficacy variables were changes from pre- to post-treatment in urinary bile acid metabolites, liver chemistries, and growth measurements (height and weight). Additional efficacy variables evaluated were changes from pre- to post-treatment in serum bilirubin (total and direct) and liver histology (for patients with liver biopsies).
+
+Information on adverse events (AEs) was collected retrospectively and recorded in patient files. The principal investigator (J.E.H.) assessed AE severity (mild, moderate, severe), seriousness, and relationship to study drug based on patient records and memory recall. For analysis, AEs were coded using the Medical Dictionary for Regulatory Activities.
+
+All patients identified as having an inborn error of bile acid synthesis were included in the intent-to-treat (ITT) population. The primary analysis was based on a modified ITT (mITT) dataset, including all patients who received cholic acid and had at least 1 pre- and post-treatment outcome assessment for urine bile acid analysis, liver chemistries, and height and weight. The safety set included all patients who received at least 1 dose of cholic acid. The primary analysis was the worst pretreatment to the best post-treatment response for each efficacy outcome. Sensitivity analyses of the worst pretreatment to the worst post-treatment results and the best pretreatment to the best post-treatment results were also performed (see the Supplemental Digital Content, Material, for details of statistical analysis).
+
+A total of 85 patients (63 with SED and 22 with ZSD) were enrolled; 79 (93%) took at least 1 dose of the study medication and were included in the safety set. Mean duration of treatment for patients in the safety set (patients with available treatment start and stop dates) was 145 weeks (range: 0–545 weeks). Seventy patients (50 with SED and 20 with ZSD) were included in the mITT set.
+
+The majority of patients with SED presented with 3β-HSD deficiency (median age, 37 months) or 5β-reductase deficiency (median age, 3 months). Zellweger syndrome (median age, 6 years) and neonatal adrenoleukodystrophy (median age, 2 years) were the most common ZSD (Table 1).
+
+Treatment with cholic acid significantly improved urine bile acid FAB-MS scores in patients with SED (Fig. 1A) or ZSD (Fig. 1B) in the worst-to-best analysis (see the Supplemental Digital Content, Material, for results of best-to-best and worst-to-worst sensitivity analyses for key efficacy variables). Among patients with SED, the percentage with normal FAB-MS scores (indicating normalized urinary bile acid excretion) increased from 2.3% at baseline to 65.1% post-treatment; the percentage with marked abnormalities decreased from 72.1% to 14.0% post-treatment (P < 0.0001). Among patients with ZSD, the percentage with normal FAB-MS scores increased from 33.3% to 85.2% with cholic acid treatment (P < 0.0001).
+
+Impact of cholic acid treatment on urinary bile acid excretion in (A) patients with single enzyme defects (n = 43) and (B) patients with Zellweger spectrum disorder (ZSD) (n = 27)—worst-to-best analysis, modified intent-to-treat (mITT) population.
+
+In the worst-to-best analysis, treatment with cholic acid significantly improved liver chemistries in the mITT population (P < 0.0001).
+
+For patients with ZSD and those with SED, there was a marked increase in the number of patients with serum ALT and AST values below the ULN and a marked decrease in the number with values ≥2 times the ULN (Fig. 2A and B); changes in serum AST were less pronounced in patients with ZSD.
+
+Impact of cholic acid treatment on liver chemistries in (A) patients with single enzyme defects (n = 43) and (B) patients with ZSD (n = 27)—worst-to-best analysis, mITT population. P values represent pre- versus post-treatment, P-value is from a Cochran-Mantel-Haenszel chi-square test with modified ridit scoring. ALT = alanine aminotransferase; AST = aspartate aminotransferase; mITT = modified intent-to-treat; ULN = upper limit of normal; ZSD = Zellweger spectrum disorders.
+
+Mean serum bilirubin in the ITT population (n = 85) decreased from pretreatment to post-treatment for each bilirubin category (total, direct, indirect, and not otherwise specified), but the decrease (from 3.5 to 0.6 mg/dL) was statistically significant only for direct bilirubin (P < 0.001).
+
+Treatment with cholic acid improved height and weight percentiles in patients with SED and those with ZSD, as determined by the worst-to-best analysis (Fig. 3). Only the changes in weight were, however, statistically significant (P = 0.006 and P = 0.014) for patients with SED and ZSD, respectively. The magnitude of changes in weight and height were comparable for patients with SED and those with ZSD.
+
+Mean height and weight percentiles from pretreatment to post-treatment in the modified intent-to-treat population (N = 70), worst-to-best analysis. Numbers in bars represent absolute percentiles for each group. NS = not significant; SED = single enzyme defect; ZSD = Zellweger spectrum disorders.
+
+A total of 26 patients in the ITT population had at least 1 liver biopsy for qualitative analysis. Pre- and post-treatment liver biopsies were available for analysis in 4 patients (3 with 3β-HSD and 1 with 2-methylacyl-CoA racemase deficiency). In each patient with 3β-HSD, there was either a reduction or no change in inflammatory infiltrates with cholic acid treatment. In a 13-year-old boy with 3β-HSD, inflammation subsided and fibrosis was stable after 10 months of therapy (see the Supplemental Digital Content, Fig. S1A and S1B). Two of 3 patients had no change in fibrosis, whereas 1 had an increase. In a 10-week-old infant with 2-methylacyl-CoA racemase deficiency, giant multinucleated hepatocytes, and mild portal inflammatory infiltrates disappeared and fibrosis remained absent after 10 months of treatment (see the Supplemental Digital Content, Fig. S1C and S1D). With the exception of bridging fibrosis and unspecified fibrosis, all histopathologic features were less prominent in post-treatment biopsies than in pretreatment biopsies. The numbers of young patients with cholestasis, giant cells, and necrosis decreased from pre- to post-treatment.
+
+A higher percentage of patients with ZSD experienced treatment-emergent AEs (TEAEs) and serious AEs (SAEs) compared with patients with SED (see the Supplemental Digital Content, Table S1). TEAEs were predominantly mild or moderate. Only 3 TEAEs in 2 patients were considered treatment related by the investigator. Each AE considered treatment related/unknown occurred in 1 patient only (malaise and jaundice in 1 patient and skin lesion in 1 patient).
+
+A total of 4 patients discontinued the study due to AEs. The AE most frequently leading to study discontinuation was disease progression. All others occurred in single patients only. None of the AEs leading to study discontinuation were considered related to study medication by the investigator.
+
+Ten patients (13%) experienced AEs of severe intensity. These were most frequently related to disease progression (7 patients). The only other severe AE occurring in at least 2 patients was dehydration. Diarrhea is a known adverse effect of excessive dosing with cholic acid. During the 18-year study period, diarrhea was documented in 6 patients. None of the cases of enteritis or diarrhea were assessed as related to study medication and none of the episodes led to discontinuation of treatment.
+
+Of the 28 SAEs, disease progression was the most frequently reported, followed by diarrhea (3%), urinary tract infection (3%), and dehydration (3%). All other SAEs occurred in single patients only. None of the SAEs were considered related to study treatment. One patient had a bleeding gastric ulcer, and for 1 patient with disease progression, the SAE outcome was unknown. A total of 21 patients died during the study period and 1 patient after the study period (see the Supplemental Digital Content, Material, for details). Disease progression, or an event secondary to worsening of the underlying condition (ZSD), was the most frequently noted AE. Death was not considered related to study medication in any case.
+
+Based on the treatment of these 70 patients, oral cholic acid appears to be safe, efficacious, and well tolerated. Our experience in patients with SED is supported by the findings of a case series of 15 patients with SED treated with cholic acid (13). Our experience in 27 patients with ZSD suggests that cholic acid therapy ameliorates liver dysfunction. There is no evidence that treatment with cholic acid has any impact on the extrahepatic disease associated with ZSD; however, there is compelling evidence that it promotes weight gain (16).
+
+Our studies have demonstrated that oral cholic acid treatment of patients with SED leads to reductions in serum bilirubin and serum ALT and AST, suppression of the urinary excretion of bile acid intermediates, and in a limited number of patients, stabilization or improvement in liver histology. The histologic findings in the present study, although limited, are consistent with previous reports, which showed either improved or stabilized inflammation and fibrosis with therapy (5,13,15). It is important to note that the presenting symptoms and signs in patients with SED may be quite variable (20) and may appear from infancy through adulthood (21,22). Patients with 5β-reductase deficiency tended to present at a younger age (median age, 3 months) with marked biochemical abnormalities compared with those presenting with 3β-HSD deficiency, many of whom presented at a later age (median age, 37 months) with evidence of liver fibrosis but less impressive biochemical abnormalities. In a subgroup of patients, particularly those who were identified prospectively due to a previously affected sibling, the biochemical findings were subtle. Patients with a milder phenotype would likely not have the same therapeutic response on their biochemistries, which would explain why not all patients had a biochemical response to therapy. Furthermore, greater awareness of BASD because of a previously affected sibling resulted in a diagnosis being established at an early age and before significant liver dysfunction becomes apparent. Initiating cholic acid therapy would therefore serve to prevent significant advancement in liver disease.
+
+This study was initiated as a compassionate use of cholic acid for the treatment of infants, children, and adolescents with SED and subsequently patients with ZSD. Later, an institutional review board approved study with an Investigational New Drug for use of cholic acid was obtained. The study design therefore was not structured with the rigor now required in contemporary studies. Given the nature of these diseases and understanding of their natural histories, there was never any consideration for performing a placebo-controlled trial because it was considered unethical. Logistically, patients were recruited through an international screening program established at CCHMC. Because patients were identified at sites distant from Cincinnati, we were dependent on local treating physicians to collect laboratory data and submit urine samples for FAB-MS analysis based on our guidelines and their clinical practice; therefore, the collection of laboratory data and urine FAB-MS was not defined at specific and rigid times during the study period.
+
+The overall safety profile of cholic acid was favorable, with no study drug-related SAEs or deaths reported. During the 18-year study period, 48% of patients experienced TEAEs. AEs were considered treatment related by the investigator in only 2 patients. Disease progression was the most common TEAE, followed by diarrhea, urinary tract infection, and dehydration. Diarrhea, recognized as a potential side effect of cholic acid treatment, was reported in only 6 patients over the extended study period. The deaths of patients with SED are concerning and might be misconstrued as cholic acid being ineffective. The 4 patients with 5β-reductase deficiency who died all had end-stage liver disease with ascites and coagulopathy. It is possible that their disease was so advanced that cholic acid was not effective. Alternatively, some of these patients may have had end-stage liver disease from other causes despite their urinary bile acid profile suggesting 5β-reductase deficiency. Because 5β-reductase is the most sensitive of the bile acid biosynthetic enzymes to be affected by advanced liver disease, the atypical urine metabolites observed in this condition may actually be due to terminal liver disease (23,24) rather than due to a primary 5β-reductase deficiency. When this study was conducted, gene sequencing was not available. Indeed, the genes encoding these enzymes had not been cloned when most of these SED were first discovered. A number of Clinical Laboratory Improvement Act/College of American Pathologists certified laboratories now, however, perform gene sequencing for many of these enzymes, including 5β-reductase (AKR1D1), and can determine whether mutations are present in similarly affected patients, permitting either confirmation or clarification of the urine FAB-MS findings in this select population (25).
+
+AEs and deaths were more often reported among patients with ZSD. This was not unexpected, given the additional significant nonhepatic comorbidities typically present in these patients, which would not be expected to be responsive to cholic acid therapy. In addition, some of these patients who died were treated with cholic acid only after advanced liver disease had developed and serious events had occurred and some had been wait-listed for transplantation.
+
+Orally administered cholic acid at a dose of 15 mg · kg−1 · day−1 is a safe, efficacious, and well-tolerated treatment for BASD due to SED and ZSD in patients with liver dysfunction. Cholic acid is effective in improving liver biochemical abnormalities and urine bile acid metabolite excretion in patients with SED and ZSD. In a limited number of patients with SED, it has been shown to stabilize or reduce hepatic inflammation and fibrosis. Future follow-up of treated patients will provide additional comprehensive data demonstrating long-term safety and efficacy.

--- a/references_cache/PMID_28784167.md
+++ b/references_cache/PMID_28784167.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:28784167"
+title: "Identification of a novel mutation in PEX10 in a patient with attenuated Zellweger spectrum disorder: a case report."
+authors:
+- Blomqvist M
+- Ahlberg K
+- Lindgren J
+- Ferdinandusse S
+- Asin-Cayuela J
+journal: J Med Case Rep
+year: '2017'
+doi: 10.1186/s13256-017-1365-5
+keywords:
+- Adolescent
+- Female
+- Genetic Testing
+- High-Throughput Nucleotide Sequencing
+- Humans
+- "Mutation, Missense/genetics"
+- Pedigree
+- Peroxins/genetics
+- "Receptors, Cytoplasmic and Nuclear/genetics"
+- "Zellweger Syndrome/diagnosis, genetics, physiopathology"
+content_type: abstract_only
+---
+
+# Identification of a novel mutation in PEX10 in a patient with attenuated Zellweger spectrum disorder: a case report.
+**Authors:** Blomqvist M, Ahlberg K, Lindgren J, Ferdinandusse S, Asin-Cayuela J
+**Journal:** J Med Case Rep (2017)
+**DOI:** [10.1186/s13256-017-1365-5](https://doi.org/10.1186/s13256-017-1365-5)
+
+## Content
+
+1. J Med Case Rep. 2017 Aug 8;11(1):218. doi: 10.1186/s13256-017-1365-5.
+
+Identification of a novel mutation in PEX10 in a patient with attenuated
+Zellweger spectrum disorder: a case report.
+
+Blomqvist M(1), Ahlberg K(2), Lindgren J(3), Ferdinandusse S(4), Asin-Cayuela
+J(3).
+
+Author information:
+(1)Institute of Biomedicine, Department of Clinical Chemistry and Transfusion
+Medicine, Sahlgrenska Academy, Gothenburg University, Gothenburg, Sweden.
+maria.k.blomqvist@vgregion.se.
+(2)Paediatric Clinic, Central Hospital, S-65185, Karlstad, Sweden.
+(3)Institute of Biomedicine, Department of Clinical Chemistry and Transfusion
+Medicine, Sahlgrenska Academy, Gothenburg University, Gothenburg, Sweden.
+(4)Laboratory Genetic Metabolic Diseases, Department of Clinical Chemistry,
+Academic Medical Center, Amsterdam, The Netherlands.
+
+BACKGROUND: The peroxisome biogenesis disorders, which are caused by mutations
+in any of 13 different PEX genes, include the Zellweger spectrum disorders.
+Severe defects in one of these PEX genes result in the absence of functional
+peroxisomes which is seen in classical Zellweger syndrome. These patients
+present with hypotonia and seizures shortly after birth. Other typical symptoms
+are dysmorphic features, liver disease, retinal degeneration, sensorineural
+deafness, polycystic kidneys, and the patient does not reach any developmental
+milestones.
+CASE PRESENTATION: We report a case of a patient with Zellweger spectrum
+disorder due to a novel mutation in the PEX10 gene, presenting with a mild
+late-onset neurological phenotype. The patient, an Assyrian girl originating
+from Iraq, presented with sensorineural hearing impairment at the age of 5
+followed by sensorimotor polyneuropathy, cognitive delay, impaired gross and
+fine motor skills, and tremor and muscle weakness in her teens. Analyses of
+biochemical markers for peroxisomal disease suggested a mild peroxisomal defect
+and functional studies in fibroblasts confirmed the existence of a peroxisome
+biogenesis disorder. Diagnosis was confirmed by next generation sequencing
+analysis, which showed a novel homozygous mutation (c.530 T > G (p.Leu177Arg)
+(NM_153818.1)) in the PEX10 gene predicted to be pathogenic.
+CONCLUSIONS: This case highlights the importance of performing biochemical,
+functional, and genetic peroxisomal screening in patients with clinical
+presentations milder than those usually observed in Zellweger spectrum
+disorders.
+
+DOI: 10.1186/s13256-017-1365-5
+PMCID: PMC5547663
+PMID: 28784167 [Indexed for MEDLINE]
+
+Conflict of interest statement: ETHICS APPROVAL AND CONSENT TO PARTICIPATE: All
+procedures followed were in accordance with the ethical standards of the
+responsible committee on human experimentation (institutional and national) and
+with Helsinki Declaration of 1975, as revised in 2000. CONSENT FOR PUBLICATION:
+Written informed consent was obtained from the patient’s legal guardians for
+publication of this case report and any accompanying images. A copy of the
+written consent is available for review by the Editor-in-Chief of this journal.
+COMPETING INTERESTS: The authors declare that they have no competing interests.
+PUBLISHER’S NOTE: Springer Nature remains neutral with regard to jurisdictional
+claims in published maps and institutional affiliations.

--- a/references_cache/PMID_30793331.md
+++ b/references_cache/PMID_30793331.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:30793331"
+title: "The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy."
+authors:
+- Klouwer FCC
+- Koot BGP
+- Berendse K
+- Kemper EM
+- Ferdinandusse S
+- Koelfat KVK
+- Lenicek M
+- Vaz FM
+- Engelen M
+- Jansen PLM
+- Wanders RJA
+- Waterham HR
+- Schaap FG
+- Poll-The BT
+journal: J Inherit Metab Dis
+year: '2019'
+doi: 10.1002/jimd.12042
+keywords:
+- "Administration, Oral"
+- Adolescent
+- Adult
+- Bile Acids and Salts/metabolism
+- Biomarkers/blood
+- Child
+- "Child, Preschool"
+- "Cholic Acid/blood, therapeutic use"
+- Female
+- Humans
+- Liver/metabolism
+- "Liver Diseases/drug therapy, metabolism"
+- Male
+- Peroxisomes/metabolism
+- Young Adult
+- "Zellweger Syndrome/blood, drug therapy, metabolism"
+content_type: abstract_only
+---
+
+# The cholic acid extension study in Zellweger spectrum disorders: Results and implications for therapy.
+**Authors:** Klouwer FCC, Koot BGP, Berendse K, Kemper EM, Ferdinandusse S, Koelfat KVK, Lenicek M, Vaz FM, Engelen M, Jansen PLM, Wanders RJA, Waterham HR, Schaap FG, Poll-The BT
+**Journal:** J Inherit Metab Dis (2019)
+**DOI:** [10.1002/jimd.12042](https://doi.org/10.1002/jimd.12042)
+
+## Content
+
+1. J Inherit Metab Dis. 2019 Mar;42(2):303-312. doi: 10.1002/jimd.12042. Epub
+2019  Feb 21.
+
+The cholic acid extension study in Zellweger spectrum disorders: Results and
+implications for therapy.
+
+Klouwer FCC(1)(2), Koot BGP(3), Berendse K(1)(2), Kemper EM(4), Ferdinandusse
+S(2), Koelfat KVK(5), Lenicek M(6), Vaz FM(2), Engelen M(1), Jansen PLM(7),
+Wanders RJA(2), Waterham HR(2), Schaap FG(5)(8), Poll-The BT(1).
+
+Author information:
+(1)Department of Pediatric Neurology, Emma Children's Hospital, Academic Medical
+Center, University of Amsterdam, Meibergdreef 9, 1105 AZ, Amsterdam, The
+Netherlands.
+(2)Laboratory Genetic Metabolic Diseases, Academic Medical Center, University of
+Amsterdam, Amsterdam, The Netherlands.
+(3)Department of Pediatric Gastroenterology, Emma Children's Hospital, Academic
+Medical Center, University of Amsterdam, Amsterdam, The Netherlands.
+(4)Department of Pharmacy, Academic Medical Center, University of Amsterdam,
+Amsterdam, The Netherlands.
+(5)Department of Surgery, Maastricht University, Maastricht, The Netherlands.
+(6)Department of Medical Biochemistry and Laboratory Diagnostics, 1st Faculty of
+Medicine, Charles University, Prague, Czech Republic.
+(7)Department of Gastroenterology and Hepatology, Academic Medical Center,
+University of Amsterdam, Amsterdam, The Netherlands.
+(8)Department of General, Visceral and Transplantation Surgery, RWTH University
+Hospital Aachen, Aachen, Germany.
+
+INTRODUCTION: Currently, no therapies are available for Zellweger spectrum
+disorders (ZSDs), a group of genetic metabolic disorders characterised by a
+deficiency of functional peroxisomes. In a previous study, we showed that oral
+cholic acid (CA) treatment can suppress bile acid synthesis in ZSD patients and,
+thereby, decrease plasma levels of toxic C27 -bile acid intermediates, one of
+the biochemical abnormalities in these patients. However, no effect on
+clinically relevant outcome measures could be observed after 9 months of CA
+treatment. It was noted that, in patients with advanced liver disease, caution
+is needed because of possible hepatotoxicity.
+METHODS: An extension study of the previously conducted pretest-posttest design
+study was conducted including 17 patients with a ZSD. All patients received oral
+CA for an additional period of 12 months, encompassing a total of 21 months of
+treatment. Multiple clinically relevant parameters and markers for bile acid
+synthesis were assessed after 15 and 21 months of treatment.
+RESULTS: Bile acid synthesis was still suppressed after 21 months of CA
+treatment, accompanied with reduced levels of C27 -bile acid intermediates in
+plasma. These levels significantly increased again after discontinuation of CA.
+No significant changes were found in liver tests, liver elasticity, coagulation
+parameters, fat-soluble vitamin levels or body weight.
+CONCLUSIONS: Although CA treatment did lead to reduced levels of toxic C27 -bile
+acid intermediates in ZSD patients without severe liver fibrosis or cirrhosis,
+no improvement of clinically relevant parameters was observed after 21 months of
+treatment. We discuss the implications for CA therapy in ZSD based on these
+results.
+
+© 2018 The Authors. Journal of Inherited Metabolic Disease published by John
+Wiley & Sons Ltd on behalf of SSIEM.
+
+DOI: 10.1002/jimd.12042
+PMID: 30793331 [Indexed for MEDLINE]

--- a/references_cache/PMID_38664000.md
+++ b/references_cache/PMID_38664000.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:38664000"
+title: Systematic study of ophthalmological findings in 10 patients with PEX1-mediated Zellweger spectrum disorder.
+authors:
+- Karuntu JS
+- Klouwer FCC
+- Engelen M
+- Boon CJF
+journal: Ophthalmic Genet
+year: '2024'
+doi: 10.1080/13816810.2024.2330389
+keywords:
+- Humans
+- Male
+- Female
+- Adult
+- Adolescent
+- Visual Acuity/physiology
+- Cross-Sectional Studies
+- "Zellweger Syndrome/genetics, diagnosis, physiopathology"
+- Young Adult
+- "Tomography, Optical Coherence"
+- Phenotype
+- Peroxins/genetics
+- Ophthalmoscopy
+- ATPases Associated with Diverse Cellular Activities/genetics
+- Mutation
+- Visual Fields/physiology
+- Visual Field Tests
+- Electroretinography
+- Pedigree
+- Membrane Proteins
+content_type: abstract_only
+---
+
+# Systematic study of ophthalmological findings in 10 patients with PEX1-mediated Zellweger spectrum disorder.
+**Authors:** Karuntu JS, Klouwer FCC, Engelen M, Boon CJF
+**Journal:** Ophthalmic Genet (2024)
+**DOI:** [10.1080/13816810.2024.2330389](https://doi.org/10.1080/13816810.2024.2330389)
+
+## Content
+
+1. Ophthalmic Genet. 2024 Aug;45(4):351-362. doi: 10.1080/13816810.2024.2330389.
+Epub 2024 Apr 25.
+
+Systematic study of ophthalmological findings in 10 patients with PEX1-mediated
+Zellweger spectrum disorder.
+
+Karuntu JS(1), Klouwer FCC(2), Engelen M(2), Boon CJF(1)(3).
+
+Author information:
+(1)Department of Ophthalmology, Leiden University Medical Center, Leiden, The
+Netherlands.
+(2)Department of Paediatric Neurology/Emma Children's Hospital, Amsterdam
+University Medical Centers, Amsterdam, The Netherlands.
+(3)Department of Ophthalmology, Amsterdam University Medical Centers, Amsterdam,
+The Netherlands.
+
+PURPOSE: This cross-sectional study describes the ophthalmological and general
+phenotype of 10 patients from six different families with a comparatively mild
+form of Zellweger spectrum disorder (ZSD), a rare peroxisomal disorder.
+METHODS: Ophthalmological assessment included best-corrected visual acuity
+(BCVA), perimetry, microperimetry, ophthalmoscopy, fundus photography,
+spectral-domain optical coherence tomography (SD-OCT), and fundus
+autofluorescence (FAF) imaging. Medical records were reviewed for medical
+history and systemic manifestations of ZSD.
+RESULTS: Nine patients were homozygous for c.2528 G > A (p.Gly843Asp) variants
+in PEX1 and one patient was compound heterozygous for c.2528 G>A (p.Gly843Asp)
+and c.2097_2098insT (p.Ile700TyrfsTer42) in PEX1. Median age was 22.6 years
+(interquartile range (IQR): 15.9 - 29.9 years) at the most recent examination,
+with a median symptom duration of 22.1 years. Symptom onset was variable with
+presentations of hearing loss (n = 7) or nyctalopia/reduced visual acuity
+(n = 3) at a median age of 6 months (IQR: 1.9-8.3 months). BCVA (median of 0.8
+logMAR; IQR: 0.6-0.9 logMAR) remained stable over 10.8 years and all patients
+were hyperopic. Fundus examination revealed a variable retinitis pigmentosa
+(RP)-like phenotype with rounded hyperpigmentations as most prominent feature in
+six out of nine patients. Electroretinography, visual field measurements, and
+microperimetry further established the RP-like phenotype. Multimodal imaging
+revealed significant intraretinal fluid cavities on SD-OCT and a remarkable
+pattern of hyperautofluorescent abnormalities on FAF in all patients.
+CONCLUSION: This study highlights the ophthalmological phenotype resembling RP
+with moderate to severe visual impairment in patients with mild ZSD. These
+findings can aid ophthalmologists in diagnosing, counselling, and managing
+patients with mild ZSD.
+
+DOI: 10.1080/13816810.2024.2330389
+PMID: 38664000 [Indexed for MEDLINE]

--- a/references_cache/PMID_40112482.md
+++ b/references_cache/PMID_40112482.md
@@ -1,0 +1,104 @@
+---
+reference_id: "PMID:40112482"
+title: Using multiple modalities to confirm diagnosis in patients with suspected peroxisome biogenesis disorders.
+authors:
+- Cheung ACT
+- Di Pietro E
+- Argyriou C
+- Bareke E
+- "D'Souza Y"
+- Puri RD
+- Muhammed Shabeer P
+- Ganetzky R
+- Goldstein A
+- Vanderver A
+- Mohan S
+- Majewski J
+- Yergeau C
+- Braverman N
+journal: Mol Genet Metab
+year: '2025'
+doi: 10.1016/j.ymgme.2025.109080
+keywords:
+- Humans
+- Exome Sequencing
+- Fibroblasts/metabolism
+- Membrane Proteins/genetics
+- Mutation
+- "Peroxisomal Disorders/diagnosis, genetics"
+- Peroxisome-Targeting Signal 1 Receptor/genetics
+- "Peroxisomes/metabolism, genetics, pathology"
+- "Zellweger Syndrome/diagnosis, genetics"
+- ATPases Associated with Diverse Cellular Activities
+content_type: abstract_only
+---
+
+# Using multiple modalities to confirm diagnosis in patients with suspected peroxisome biogenesis disorders.
+**Authors:** Cheung ACT, Di Pietro E, Argyriou C, Bareke E, D'Souza Y, Puri RD, Muhammed Shabeer P, Ganetzky R, Goldstein A, Vanderver A, Mohan S, Majewski J, Yergeau C, Braverman N
+**Journal:** Mol Genet Metab (2025)
+**DOI:** [10.1016/j.ymgme.2025.109080](https://doi.org/10.1016/j.ymgme.2025.109080)
+
+## Content
+
+1. Mol Genet Metab. 2025 May;145(1):109080. doi: 10.1016/j.ymgme.2025.109080.
+Epub  2025 Mar 11.
+
+Using multiple modalities to confirm diagnosis in patients with suspected
+peroxisome biogenesis disorders.
+
+Cheung ACT(1), Di Pietro E(2), Argyriou C(3), Bareke E(4), D'Souza Y(2), Puri
+RD(5), Muhammed Shabeer P(5), Ganetzky R(6), Goldstein A(6), Vanderver A(7),
+Mohan S(8), Majewski J(4), Yergeau C(2), Braverman N(9).
+
+Author information:
+(1)Division of Medical Genetics, Department of Specialized Medicine, McGill
+University Health Center, Montreal, Quebec, Canada.
+(2)Research Institute of the McGill University Health Centre, Montreal, Quebec,
+Canada.
+(3)Department of Human Genetics, McGill University, Montreal, Quebec, Canada;
+Research Institute of the McGill University Health Centre, Montreal, Quebec,
+Canada.
+(4)Department of Human Genetics, McGill University, Montreal, Quebec, Canada.
+(5)Institute of Medical Genetics and Genomics, Sir Ganga Ram Hospital, Delhi,
+India.
+(6)Mitochondrial Medicine Frontier Program, Division of Human Genetics,
+Department of Pediatrics, Children's Hospital of Philadelphia, Philadelphia, PA,
+USA; Department of Pediatrics, Perelman School of Medicine, University of
+Pennsylvania, Philadelphia, PA, USA.
+(7)Division of Neurology, Children's Hospital of Philadelphia, Philadelphia, PA,
+USA; Department of Neurology, Perlman School of Medicine, University of
+Pennsylvania, Philadelphia, PA, USA.
+(8)Department of Pathology, Duke University School of Medicine, Durham, NC, USA.
+(9)Division of Medical Genetics, Department of Specialized Medicine, McGill
+University Health Center, Montreal, Quebec, Canada; Departments of Human
+Genetics and Pediatrics, McGill University, Montreal, Quebec, Canada; Research
+Institute of the McGill University Health Centre, Montreal, Quebec, Canada.
+Electronic address: nancy.braverman@mcgill.ca.
+
+Zellweger spectrum disorder (ZSD) results from biallelic variants in any one of
+13 PEX genes involved in peroxisome biogenesis and function. The majority of ZSD
+cases result from pathogenic variants in PEX1. Here, we present 3 patients with
+suspected PEX1-related ZSD and non-diagnostic whole exome sequencing and
+describe the use of multiple modalities to ascertain their diagnosis. We
+confirmed peroxisomal dysfunction in the patients by demonstrating abnormal
+peroxisome metabolite levels in blood and peroxisome import dysfunction in
+patient fibroblasts. RNA studies including RNA-seq and RT-PCR, followed by
+Sanger sequencing showed leaky splice variants including an intron 13 variant
+causing exon 14 skipping (Patient 1), an intron 22 variant causing intron 22
+retention (Patient 2), and a synonymous splice-site variant causing exon 16
+skipping (Patient 3). All three patients had very low amounts of canonical PEX1
+transcripts on RNA-seq, as well as residual but reduced PEX1 protein levels on
+immunoblotting, which likely explains their non-severe ZSD phenotype. This study
+suggests that a multi-modality approach combining biochemical testing,
+functional assays in fibroblasts and molecular investigations including
+sequencing of non-coding regions and RNA analysis may aid in diagnosis of
+patients with suspected PBD-ZSD and inconclusive WES.
+
+Copyright © 2024. Published by Elsevier Inc.
+
+DOI: 10.1016/j.ymgme.2025.109080
+PMCID: PMC12301650
+PMID: 40112482 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest The authors
+declare no conflict of interest.

--- a/research/Zellweger_Spectrum_Disorder-deep-research-openai.md
+++ b/research/Zellweger_Spectrum_Disorder-deep-research-openai.md
@@ -1,0 +1,182 @@
+# Zellweger Spectrum Disorder Deep Research Notes
+
+Date: 2026-04-12
+
+## Scope and disease framing
+
+This curation treats Zellweger spectrum disorder (ZSD) as a single disease-level
+continuum rather than splitting classical Zellweger syndrome, neonatal
+adrenoleukodystrophy, infantile Refsum disease, or Heimler syndrome into
+separate dismech entries.
+
+Key framing evidence:
+
+- `PMID:26750748`: "The extreme variability in disease manifestation ranging from onset of profound neurologic symptoms in newborns to progressive degenerative disease in adults presents practical challenges in disease diagnosis and medical management."
+- `PMID:36293220`: "The vast majority of PBDs belong to Zellweger Spectrum Disordes (ZSDs) and represents a continuum of overlapping clinical symptoms, with Zellweger syndrome being the most severe and Heimler syndrome the less severe disease."
+- `PMID:11389485`: "Zellweger syndrome (ZS), neonatal adrenoleukodystrophy (NALD), and infantile Refsum disease (IRD) are clinically overlapping syndromes, collectively called "peroxisome biogenesis disorders" (PBDs), with clinical features being most severe in ZS and least pronounced in IRD."
+
+## Ontology choice
+
+I anchored the YAML to `MONDO:0019234` with preferred term `Zellweger spectrum disorder`.
+
+Reasoning:
+
+- In current MONDO, `MONDO:0019234` is labeled `peroxisome biogenesis disorder`,
+  but its definition corresponds to the Zellweger spectrum / PBD-ZSD continuum.
+- `MONDO:0019609` is labeled `Zellweger spectrum disorders`, but its current
+  definition is narrower and reads more like the classical severe syndrome.
+- Using `MONDO:0019234` avoids over-narrowing the disease anchor while still
+  representing the clinically used ZSD continuum.
+
+This is why the YAML note explicitly documents the MONDO label/preferred-term
+asymmetry instead of silently accepting it.
+
+## Main mechanistic story
+
+The disease story was curated as an atomic chain rather than a bundled
+"peroxisomal dysfunction" block:
+
+1. Biallelic pathogenic variants in 13 `PEX` genes impair peroxisome biogenesis
+   and matrix protein import.
+2. This creates a deficiency of functional peroxisomes.
+3. Distinct downstream consequences then separate into:
+   - reduced peroxisomal beta-oxidation
+   - impaired ether lipid biosynthesis
+   - C27 bile acid intermediate accumulation
+   - abnormal neuronal migration
+4. Those downstream lesions were then mapped to organ/tissue-level pathology:
+   - cerebral/cerebellar white matter disease
+   - retinal degeneration
+   - progressive liver disease
+
+This structure is closer to causal resolution than the previous file, which
+collapsed nearly all disease biology into a few broad nodes.
+
+## Key evidence selections
+
+### Disease-gene set and major gene
+
+- `PMID:40112482`: "Zellweger spectrum disorder (ZSD) results from biallelic variants in any one of 13 PEX genes involved in peroxisome biogenesis and function."
+- `PMID:40112482`: "The majority of ZSD cases result from pathogenic variants in PEX1."
+- `PMID:11389485`: "Approximately 65% of the patients with PBD harbor mutations in PEX1."
+- `PMID:11389485`: "The majority of these latter patients carried at least one copy of the common G843D allele."
+
+Why included:
+
+- This supports one heterogeneous disease definition with `PEX1` highlighted as
+  the dominant disease gene and `PEX1 p.Gly843Asp` captured as a clinically
+  relevant attenuating allele.
+
+### Organelle-level initiating lesion
+
+- `PMID:33417206`: "Impaired peroxisome biogenesis, including defects of membrane assembly, import of peroxisomal matrix proteins, and division of peroxisome, causes peroxisome biogenesis disorders (PBDs)."
+- `PMID:30793331`: "Currently, no therapies are available for Zellweger spectrum disorders (ZSDs), a group of genetic metabolic disorders characterised by a deficiency of functional peroxisomes."
+
+Why included:
+
+- These two quotes cleanly separate the initiating biogenesis/import defect from
+  the next node, loss of functional peroxisomes.
+
+### Lipid metabolic consequences
+
+- `PMID:33417206`: "Peroxisomes are presented in all eukaryotic cells and play essential roles in many of lipid metabolic pathways, including β-oxidation of fatty acids and synthesis of ether-linked glycerophospholipids, such as plasmalogens."
+- `PMID:24503136`: "we demonstrate that murine cells homozygous for the Pex1-G844D allele respond to chaperone-like compounds, which normalizes peroxisomal β-oxidation."
+- `PMID:12473763`: "Multiple peroxisomal functions including de novo plasmalogen synthesis, dihydroxyacetonephosphate acyltransferase (DHAPAT) activity, C26:0/C22:0 ratio, C26:0 and pristanic acid beta-oxidation, and phytanic acid alpha-oxidation were analyzed in fibroblasts from a series of patients with defined clinical phenotypes."
+
+Why included:
+
+- These support keeping beta-oxidation and ether lipid/plasmalogen biology as
+  separate downstream nodes rather than collapsing them into one metabolite node.
+
+### Hepatic mechanism
+
+- `PMID:28644367`: "Accumulation of these potentially hepatotoxic metabolites and the reduction in bile acid-dependent bile flow from the lack of primary bile acids may lead to liver injury"
+- `PMID:28644367`: "ZSDs are characterized by progressive liver disease and extrahepatic manifestations such as central nervous system dysfunction"
+- `PMID:30793331`: "Although CA treatment did lead to reduced levels of toxic C27 -bile acid intermediates in ZSD patients without severe liver fibrosis or cirrhosis, no improvement of clinically relevant parameters was observed after 21 months of treatment."
+
+Why included:
+
+- These support a specific hepatic mechanism node centered on C27 bile acid
+  intermediates rather than a vague "liver involvement" statement, and they
+  justify the nuanced treatment statement for cholic acid.
+
+### Neurodevelopment and later progression
+
+- `PMID:15868469`: "Peroxisome biogenesis disorders, of which Zellweger syndrome is the most severe, result in severe neurological dysfunction associated with abnormal CNS neuronal migrations due to the lack of functional peroxisomes."
+- `PMID:26287655`: "Disease progression may occur and is mainly due to cerebral and cerebellar white matter abnormalities, and peripheral neuropathy."
+- `PMID:26287655`: "Systematic MRI review revealed T2 hyperintense white matter abnormalities in the hilus of the dentate nucleus and/or peridentate region in nine out of 16 patients."
+
+Why included:
+
+- These distinguish an early developmental brain mechanism from later
+  progressive white matter disease in attenuated survivors.
+
+### Sensory phenotypes
+
+- `PMID:38664000`: "Fundus examination revealed a variable retinitis pigmentosa (RP)-like phenotype with rounded hyperpigmentations as most prominent feature in six out of nine patients."
+- `PMID:38664000`: "This study highlights the ophthalmological phenotype resembling RP with moderate to severe visual impairment in patients with mild ZSD."
+- `PMID:34534157`: "The majority of PBD-ZSD patients in this study presented with moderately-severe to severe hearing loss and relatively slow rates of longitudinal changes in hearing sensitivity."
+
+Why included:
+
+- These support retinal degeneration and sensorineural hearing impairment as
+  supported phenotype-level assertions rather than relying on older generic
+  textbook descriptions alone.
+
+### Endocrine modifier with management impact
+
+- `PMID:25179809`: "Primary adrenal insufficiency was found in 7/24 patients examined, with 4/7 being asymptomatic."
+- `PMID:25179809`: "Systematic evaluation of adrenal function, through a Synacthen test, should be included in the clinical management of these patients."
+
+Why included:
+
+- Adrenal insufficiency was included because it changes clinical surveillance and
+  is not just a minor associated finding.
+
+## Treatments included
+
+Included:
+
+- Supportive/surveillance-based care
+- Cholic acid
+
+Why:
+
+- Both have direct disease-specific evidence.
+- Cholic acid was phrased carefully: biochemical benefit is supported, but
+  clinically meaningful disease modification is limited.
+
+Not included:
+
+- Experimental proteostasis/chaperone rescue strategies for `PEX1 p.Gly843Asp`
+- Empiric bile acid statements without disease-specific ZSD evidence
+- Generic supplements without direct support in retrieved evidence
+
+## Histopathology and modifier choices
+
+Included:
+
+- Liver disease as an organ-level pathophysiology node, because liver injury and
+  progressive liver disease are explicitly supported.
+- `PEX1 p.Gly843Asp` as a modifier-like variant note, because residual protein
+  and attenuated phenotype are directly supported.
+
+Not added as standalone sections:
+
+- Separate histopathology block for brain or retina. The strongest retrieved
+  evidence was clinical imaging and phenotype-focused rather than lesion-rich
+  pathology studies with clean disease-level generalizability.
+
+## Curation exclusions and cleanup relative to the old file
+
+The previous `Peroxisome_Biogenesis_Disorder.yaml` entry mixed:
+
+- broad peroxisomal disease language outside the Zellweger spectrum
+- weak or non-specific prevalence claims
+- bundled mechanism nodes
+- partially supported metabolite/treatment statements
+
+Those were removed or tightened. The rewritten file focuses on the ZSD
+continuum, preserves only directly supported mechanisms/phenotypes/treatments,
+and uses ontology-grounded terms where the evidence was strong enough to justify
+them.


### PR DESCRIPTION
## Summary
- recurate `kb/disorders/Peroxisome_Biogenesis_Disorder.yaml` as a disease-level Zellweger spectrum disorder entry with ontology-grounded terms, exact PMID-backed evidence, and atomic pathophysiology nodes
- add `research/Zellweger_Spectrum_Disorder-deep-research-openai.md` documenting the disease-boundary decision, main mechanistic story, and evidence-selection rationale
- add the PMID cache entries needed for deterministic reference validation of the new evidence set

## Why
The prior entry mixed broad peroxisome biogenesis disorder content with bundled mechanisms and weak or non-specific assertions. Issue #1176 asked for a disease-level ZSD curation with deep research, exact quotes, and cleaner mechanistic structure.

## Validation
- `just validate-schema kb/disorders/Peroxisome_Biogenesis_Disorder.yaml`
- `just validate-terms kb/disorders/Peroxisome_Biogenesis_Disorder.yaml`
- `just validate-references kb/disorders/Peroxisome_Biogenesis_Disorder.yaml`
- `uv run pytest tests/test_data.py::test_valid_disorder_files -k 'Peroxisome_Biogenesis_Disorder' -v`
- `uv run pytest tests/test_data.py::test_all_disorders_have_unique_names -v`

Closes #1176