### PR TITLE
[codex] Curate Waldenstrom macroglobulinemia

### DIFF
--- a/kb/disorders/Waldenstrom_Macroglobulinemia.yaml
+++ b/kb/disorders/Waldenstrom_Macroglobulinemia.yaml
@@ -1,0 +1,625 @@
+name: Waldenstrom Macroglobulinemia
+creation_date: '2026-04-13T05:35:14Z'
+updated_date: '2026-04-13T05:47:42Z'
+category: Cancer
+categories:
+- Hematologic Malignancy
+- B-cell Neoplasm
+- Non-Hodgkin Lymphoma
+synonyms:
+- Waldenström macroglobulinemia
+- Waldenstrom's macroglobulinemia
+- WM
+description: >-
+  Waldenstrom macroglobulinemia is an indolent B-cell neoplasm defined by bone
+  marrow infiltration with lymphoplasmacytic lymphoma and secretion of a
+  monoclonal IgM paraprotein. The disease is driven in most cases by MYD88
+  L265P and further shaped in a substantial subset by subclonal CXCR4
+  WHIM-like mutations. Morbidity reflects both marrow infiltration by the
+  lymphoplasmacytic clone and the downstream effects of the IgM paraprotein,
+  including hyperviscosity and peripheral neuropathy. Current disease-level
+  management centers on observation for asymptomatic disease, fixed-duration
+  chemoimmunotherapy, covalent BTK inhibition, and plasmapheresis for urgent
+  paraprotein reduction.
+disease_term:
+  preferred_term: Waldenstrom macroglobulinemia
+  term:
+    id: MONDO:0100280
+    label: Waldenstrom macroglobulinemia
+parents:
+- lymphoplasmacytic lymphoma
+has_subtypes:
+- name: Asymptomatic Waldenstrom Macroglobulinemia
+  classification: clinical_course
+  description: >-
+    Asymptomatic WM is managed with observation rather than immediate therapy
+    unless there is critically elevated IgM or compromised hematopoietic
+    function.
+  evidence:
+  - reference: PMID:37099027
+    reference_title: "Report of consensus panel 1 from the 11(th) International Workshop on Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve patients."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The panel reiterated that watchful waiting remains the gold standard for
+      asymptomatic patients without critically elevated IgM or compromised
+      hematopoietic function.
+    explanation: >-
+      This consensus update supports asymptomatic WM as a clinically meaningful
+      disease-course subtype defined by deferred treatment.
+- name: Symptomatic Waldenstrom Macroglobulinemia
+  classification: clinical_course
+  description: >-
+    Symptomatic WM is the treatment-requiring clinical subset distinguished from
+    asymptomatic WM and precursor IgM-related states.
+  evidence:
+  - reference: PMID:12720118
+    reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Simple criteria to distinguish patients with symptomatic WM who require
+      therapy from those with asymptomatic WM and MGUS were also proposed.
+    explanation: >-
+      This consensus definition supports symptomatic WM as a clinically distinct
+      treatment-triggering subtype axis within the same disease entry.
+- name: MYD88-mutant Waldenstrom Macroglobulinemia
+  classification: molecular
+  description: >-
+    The dominant molecular subset of WM carries MYD88 L265P, an early oncogenic
+    lesion that organizes the baseline disease program.
+  genes:
+  - preferred_term: MYD88
+    term:
+      id: hgnc:7562
+      label: MYD88
+  evidence:
+  - reference: PMID:24224040
+    reference_title: "L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia and its absence in myeloma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These results suggest that the L265P mutation is involved in the majority
+      of Waldenström's macroglobulinemia.
+    explanation: >-
+      This supports a MYD88-mutant molecular subset that belongs inside the same
+      disease page rather than as a separate dismech entry.
+- name: CXCR4-mutated Waldenstrom Macroglobulinemia
+  classification: molecular
+  description: >-
+    A treatment-relevant molecular subset of WM acquires subclonal WHIM-like
+    CXCR4 mutations layered onto the core disease program.
+  genes:
+  - preferred_term: CXCR4
+    term:
+      id: hgnc:2561
+      label: CXCR4
+  evidence:
+  - reference: PMID:26659815
+    reference_title: "Clonal architecture of CXCR4 WHIM-like mutations in Waldenström Macroglobulinaemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The findings show that CXCR4(WHIM) mutations are more common in WM than
+      previously revealed, and are primarily subclonal, supporting their
+      acquisition after MYD88(L265P) in WM oncogenesis.
+    explanation: >-
+      This supports CXCR4-mutated WM as a molecular facet subtype nested within
+      the broader Waldenstrom disease graph.
+definitions:
+- name: Pathologic definition of Waldenstrom macroglobulinemia
+  definition_type: CASE_DEFINITION
+  description: >-
+    Waldenstrom macroglobulinemia is a distinct clinicopathologic entity defined
+    by bone marrow infiltration by lymphoplasmacytic lymphoma together with an
+    IgM monoclonal gammopathy.
+  scope: General clinicopathologic definition for disease-level curation
+  evidence:
+  - reference: PMID:12720118
+    reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      WM is an uncommon lymphoproliferative disorder characterized primarily by
+      bone marrow infiltration and IgM monoclonal gammopathy.
+    explanation: >-
+      This consensus definition anchors WM as a disease entity defined by marrow
+      lymphoplasmacytic infiltration together with IgM paraproteinemia.
+pathophysiology:
+- name: Bone Marrow Lymphoplasmacytic Infiltration
+  description: >-
+    The disease-defining tissue state is infiltration of the bone marrow by a
+    clonal lymphoplasmacytic population spanning mature B-cell, plasmacytoid,
+    and plasma-cell differentiation states.
+  evidence:
+  - reference: PMID:12720118
+    reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      WM is an uncommon lymphoproliferative disorder characterized primarily by
+      bone marrow infiltration and IgM monoclonal gammopathy.
+    explanation: >-
+      The consensus definition identifies marrow infiltration as a primary
+      clinicopathologic feature of WM.
+  - reference: PMID:11718214
+    reference_title: "Lymphoplasmacytic lymphoma/immunocytoma: towards a disease-targeted treatment?"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Lymphoplasmacytic-lymphoplasmacytoid lymphoma (LPL)/Waldenstrom's
+      macroglobulinemia (WM) or immunocytoma (IMC) consists of diffuse
+      proliferation of small mature B lymphocytes, plasmacytoid lymphocytes, and
+      plasma-cells.
+    explanation: >-
+      This abstract specifies the marrow-infiltrating tumor-cell composition
+      that underlies the lymphoplasmacytic clone in WM.
+  cell_types:
+  - preferred_term: B cell
+    term:
+      id: CL:0000236
+      label: B cell
+  - preferred_term: plasma cell
+    term:
+      id: CL:0000786
+      label: plasma cell
+  biological_processes:
+  - preferred_term: cell population proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  locations:
+  - preferred_term: bone marrow
+    term:
+      id: UBERON:0002371
+      label: bone marrow
+  downstream:
+  - target: Monoclonal IgM Secretion
+    description: The marrow lymphoplasmacytic clone gives rise to the circulating IgM paraprotein.
+    evidence:
+    - reference: PMID:12720118
+      reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        WM is an uncommon lymphoproliferative disorder characterized primarily by
+        bone marrow infiltration and IgM monoclonal gammopathy.
+      explanation: >-
+        This consensus definition supports the causal pairing of marrow
+        lymphoplasmacytic disease with its defining IgM paraprotein output.
+- name: Monoclonal IgM Secretion
+  description: >-
+    The clonal lymphoplasmacytic population produces a monoclonal IgM
+    paraprotein that accumulates in the circulation and mediates important
+    downstream complications.
+  evidence:
+  - reference: PMID:12720118
+    reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      WM is an uncommon lymphoproliferative disorder characterized primarily by
+      bone marrow infiltration and IgM monoclonal gammopathy.
+    explanation: >-
+      The consensus definition supports monoclonal IgM production as a core
+      downstream output of the malignant lymphoplasmacytic clone.
+  cell_types:
+  - preferred_term: IgM plasma cell
+    term:
+      id: CL:0000986
+      label: IgM plasma cell
+  biological_processes:
+  - preferred_term: immunoglobulin production
+    modifier: INCREASED
+    term:
+      id: GO:0002377
+      label: immunoglobulin production
+  locations:
+  - preferred_term: blood serum
+    term:
+      id: UBERON:0001977
+      label: blood serum
+  downstream:
+  - target: Serum Hyperviscosity
+    description: Heavy circulating IgM burden increases serum viscosity and contributes to neurologic complications.
+    evidence:
+    - reference: PMID:18813229
+      reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >-
+        Peripheral neuropathy occurs in nearly half of patients with this
+        condition, and hyperviscosity-related nervous system disorders are
+        encountered in up to a third.
+      explanation: >-
+        This clinical review directly documents hyperviscosity-related neurologic
+        complications in WM; coupled with the disease-defining IgM paraprotein,
+        it supports serum hyperviscosity as a downstream pathogenic process.
+- name: Serum Hyperviscosity
+  description: >-
+    High circulating IgM burden increases serum viscosity and contributes to
+    neurologic morbidity in a substantial subset of patients.
+  evidence:
+  - reference: PMID:18813229
+    reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Peripheral neuropathy occurs in nearly half of patients with this
+      condition, and hyperviscosity-related nervous system disorders are
+      encountered in up to a third.
+    explanation: >-
+      This review supports serum hyperviscosity as a common intermediate
+      pathogenic process contributing to WM neurologic morbidity.
+  locations:
+  - preferred_term: blood
+    term:
+      id: UBERON:0000178
+      label: blood
+- name: MYD88 L265P Founder Mutation
+  description: >-
+    MYD88 L265P is the dominant recurrent somatic lesion in WM and functions as
+    an early oncogenic event in disease pathogenesis.
+  evidence:
+  - reference: PMID:24224040
+    reference_title: "L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia and its absence in myeloma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These results suggest that the L265P mutation is involved in the majority
+      of Waldenström's macroglobulinemia.
+    explanation: >-
+      This patient-series abstract supports MYD88 L265P as a major recurrent
+      driver lesion in WM.
+  downstream:
+  - target: Bone Marrow Lymphoplasmacytic Infiltration
+    description: MYD88-mutant clones participate in the core lymphoplasmacytic marrow disease state.
+    evidence:
+    - reference: PMID:24224040
+      reference_title: "L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia and its absence in myeloma."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        These results suggest that the L265P mutation is involved in the majority
+        of Waldenström's macroglobulinemia.
+      explanation: >-
+        This supports MYD88 L265P as a founding lesion contributing to the core
+        marrow lymphoplasmacytic disease state.
+  - target: CXCR4 WHIM-like Subclonal Mutation
+    description: Secondary CXCR4 mutations are commonly acquired after the MYD88 founder event.
+    evidence:
+    - reference: PMID:26659815
+      reference_title: "Clonal architecture of CXCR4 WHIM-like mutations in Waldenström Macroglobulinaemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The findings show that CXCR4(WHIM) mutations are more common in WM than
+        previously revealed, and are primarily subclonal, supporting their
+        acquisition after MYD88(L265P) in WM oncogenesis.
+      explanation: >-
+        This directly supports CXCR4 mutation acquisition as a later subclonal
+        branch layered onto the MYD88-mutant WM clone.
+- name: CXCR4 WHIM-like Subclonal Mutation
+  description: >-
+    A substantial subset of WM cases acquire subclonal WHIM-like CXCR4
+    mutations, adding heterogeneity to the MYD88-mutant clone and influencing
+    treatment response.
+  evidence:
+  - reference: PMID:26659815
+    reference_title: "Clonal architecture of CXCR4 WHIM-like mutations in Waldenström Macroglobulinaemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      By combined AS-PCR and Sanger sequencing, CXCR4(WHIM) mutations were
+      identified in 44/102 (43%), 21/62 (34%), 2/12 (17%) and 1/20 (5%) untreated
+      WM, previously treated WM, IgM MGUS and marginal zone lymphoma patients,
+      respectively, but no chronic lymphocytic leukaemia, multiple myeloma,
+      non-IgM MGUS patients or healthy donors.
+    explanation: >-
+      This supports CXCR4 WHIM-like mutation as a recurrent, disease-enriched
+      secondary genomic event in WM.
+- name: Mast Cell Supportive Signaling
+  description: >-
+    Excess marrow mast cells provide trophic and survival signals to the
+    lymphoplasmacytic clone, making the marrow microenvironment an active
+    participant in WM pathogenesis.
+  evidence:
+  - reference: PMID:18216294
+    reference_title: "CD27-CD70 interactions in the pathogenesis of Waldenstrom macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Importantly, sCD27 stimulated expression of CD40L on 10 of 10 BM MC
+      samples and APRIL on 4 of 10 BM MC samples obtained from patients with WM
+      as well as on LAD2 MCs.
+    explanation: >-
+      This experiment supports a mechanistic microenvironment program in which
+      WM-associated mast cells are induced to express trophic ligands.
+  - reference: PMID:18216294
+    reference_title: "CD27-CD70 interactions in the pathogenesis of Waldenstrom macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Last, treatment of severe combined immunodeficiency-human (SCID-hu) mice
+      with established WM using the SGN-70 antibody blocked disease progression
+      in 12 of 12 mice, whereas disease progressed in all 5 untreated mice.
+    explanation: >-
+      This xenograft result supports the biologic importance of the CD27-CD70
+      microenvironment axis in sustaining WM disease progression.
+  cell_types:
+  - preferred_term: mast cell
+    term:
+      id: CL:0000097
+      label: mast cell
+  - preferred_term: B cell
+    term:
+      id: CL:0000236
+      label: B cell
+  biological_processes:
+  - preferred_term: cell-cell signaling
+    term:
+      id: GO:0007267
+      label: cell-cell signaling
+  locations:
+  - preferred_term: bone marrow
+    term:
+      id: UBERON:0002371
+      label: bone marrow
+  downstream:
+  - target: Bone Marrow Lymphoplasmacytic Infiltration
+    description: Microenvironmental mast-cell signals support persistence of the malignant lymphoplasmacytic clone.
+    evidence:
+    - reference: PMID:18216294
+      reference_title: "CD27-CD70 interactions in the pathogenesis of Waldenstrom macroglobulinemia."
+      supports: PARTIAL
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        Last, treatment of severe combined immunodeficiency-human (SCID-hu) mice
+        with established WM using the SGN-70 antibody blocked disease progression
+        in 12 of 12 mice, whereas disease progressed in all 5 untreated mice.
+      explanation: >-
+        Interrupting the mast-cell linked CD27-CD70 signaling axis reduced WM
+        progression in vivo, partially supporting this pathway as an upstream
+        contributor to persistence of the lymphoplasmacytic clone.
+histopathology:
+- name: Lymphoplasmacytic Lymphoma
+  finding_term:
+    preferred_term: Lymphoplasmacytic Lymphoma
+    term:
+      id: NCIT:C3212
+      label: Lymphoplasmacytic Lymphoma
+  frequency: OBLIGATE
+  diagnostic: true
+  description: >-
+    The defining pathologic diagnosis in WM is lymphoplasmacytic lymphoma in the
+    bone marrow, typically with an intertrabecular infiltrative pattern.
+  evidence:
+  - reference: PMID:12720118
+    reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The underlying pathological diagnosis in WM is lymphoplasmacytic lymphoma
+      as defined by the World Health Organization (WHO) and Revised
+      European-American Lymphoma (REAL) classification criteria.
+    explanation: >-
+      Because the consensus definition states that the underlying pathologic
+      diagnosis in WM is lymphoplasmacytic lymphoma, this histopathologic finding
+      is OBLIGATE for the disease concept curated here.
+phenotypes:
+- category: Hematologic
+  name: IgM Paraproteinemia
+  frequency: OBLIGATE
+  diagnostic: true
+  description: >-
+    A monoclonal IgM paraprotein is required for the disease concept curated
+    here and reflects secretion by the lymphoplasmacytic clone.
+  phenotype_term:
+    preferred_term: IgM heavy chain paraproteinemia
+    term:
+      id: HP:0020196
+      label: IgM heavy chain paraproteinemia
+  evidence:
+  - reference: PMID:12720118
+    reference_title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      WM is an uncommon lymphoproliferative disorder characterized primarily by
+      bone marrow infiltration and IgM monoclonal gammopathy.
+    explanation: >-
+      The consensus definition makes IgM monoclonal gammopathy part of the
+      defining disease concept, supporting an OBLIGATE IgM paraproteinemia
+      phenotype.
+- category: Lymphatic
+  name: Lymphadenopathy
+  description: >-
+    Diffuse lymphadenopathy is a common manifestation of tissue involvement by
+    the lymphoplasmacytic clone.
+  phenotype_term:
+    preferred_term: Lymphadenopathy
+    term:
+      id: HP:0002716
+      label: Lymphadenopathy
+  evidence:
+  - reference: PMID:18813229
+    reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Waldenström macroglobulinemia, a condition that most commonly occurs in
+      lymphoplasmacytic lymphoma, typically manifests with diffuse
+      lymphadenopathies, cytopenias, and a markedly elevated erythrocyte
+      sedimentation rate.
+    explanation: >-
+      This review directly lists diffuse lymphadenopathy among the typical WM
+      clinical manifestations.
+- category: Neurologic
+  name: Peripheral Neuropathy
+  frequency: FREQUENT
+  description: >-
+    Peripheral neuropathy is a major symptomatic complication of WM and often
+    reflects the downstream consequences of the circulating IgM paraprotein.
+  phenotype_term:
+    preferred_term: Peripheral neuropathy
+    term:
+      id: HP:0009830
+      label: Peripheral neuropathy
+  evidence:
+  - reference: PMID:18813229
+    reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Peripheral neuropathy occurs in nearly half of patients with this
+      condition, and hyperviscosity-related nervous system disorders are
+      encountered in up to a third.
+    explanation: >-
+      Nearly half of patients corresponds to about 50%, which falls in the
+      FREQUENT band (30-79%).
+genetic:
+- name: MYD88
+  association: Somatic Mutation
+  notes: >-
+    MYD88 L265P is the dominant recurrent somatic lesion in WM and is treated
+    here as an upstream founder event in disease oncogenesis.
+  evidence:
+  - reference: PMID:24224040
+    reference_title: "L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia and its absence in myeloma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These results suggest that the L265P mutation is involved in the majority
+      of Waldenström's macroglobulinemia.
+    explanation: >-
+      This supports MYD88 L265P as the dominant recurrent somatic alteration in WM.
+- name: CXCR4
+  association: Somatic Mutation
+  notes: >-
+    WHIM-like CXCR4 mutations occur in a substantial subset of WM cases and are
+    primarily subclonal, consistent with later acquisition after MYD88.
+  evidence:
+  - reference: PMID:26659815
+    reference_title: "Clonal architecture of CXCR4 WHIM-like mutations in Waldenström Macroglobulinaemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The findings show that CXCR4(WHIM) mutations are more common in WM than
+      previously revealed, and are primarily subclonal, supporting their
+      acquisition after MYD88(L265P) in WM oncogenesis.
+    explanation: >-
+      This supports CXCR4 mutation as a recurrent secondary somatic event in WM.
+treatments:
+- name: Watchful Waiting
+  description: >-
+    Observation without immediate therapy is the standard disease-management
+    strategy for asymptomatic WM without critically elevated IgM or compromised
+    hematopoietic function.
+  treatment_term:
+    preferred_term: watchful waiting
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: PMID:37099027
+    reference_title: "Report of consensus panel 1 from the 11(th) International Workshop on Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve patients."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The panel reiterated that watchful waiting remains the gold standard for
+      asymptomatic patients without critically elevated IgM or compromised
+      hematopoietic function.
+    explanation: >-
+      This consensus update supports watchful waiting as the standard management
+      approach for asymptomatic WM.
+- name: Bendamustine-Rituximab
+  description: >-
+    Fixed-duration bendamustine-rituximab chemoimmunotherapy remains a central
+    first-line option for symptomatic treatment-naive WM.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: bendamustine
+      term:
+        id: CHEBI:135515
+        label: bendamustine
+    - preferred_term: rituximab
+      term:
+        id: NCIT:C1702
+        label: Rituximab
+  evidence:
+  - reference: PMID:37099027
+    reference_title: "Report of consensus panel 1 from the 11(th) International Workshop on Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve patients."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      For first-line treatment, chemoimmunotherapy (CIT) regimens such as
+      dexamethasone, cyclophosphamide, rituximab (DRC), or bendamustine,
+      rituximab (Benda-R) continue to play a central role in managing WM, as
+      they are effective, of fixed duration, generally well-tolerated, and
+      affordable.
+    explanation: >-
+      The 2023 IWWM consensus panel identifies bendamustine-rituximab as a
+      central fixed-duration first-line treatment option for symptomatic WM.
+- name: Zanubrutinib
+  description: >-
+    Zanubrutinib is a covalent BTK inhibitor option for symptomatic WM and shows
+    lower toxicity and deeper remissions than ibrutinib in the cited randomized
+    trial update.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: zanubrutinib
+      term:
+        id: NCIT:C141428
+        label: Zanubrutinib
+  evidence:
+  - reference: PMID:37099027
+    reference_title: "Report of consensus panel 1 from the 11(th) International Workshop on Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve patients."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      In a Phase III randomized trial updated at IWWM-11, the second-generation
+      cBTKi, zanubrutinib, was less toxic than ibrutinib and induced deeper
+      remissions, thus categorizing zanubrutinib as a suitable treatment option
+      in WM.
+    explanation: >-
+      This consensus update supports zanubrutinib as an evidence-based BTK
+      inhibitor option for WM, with favorable efficacy and tolerability.
+- name: Plasmapheresis
+  description: >-
+    Plasmapheresis is used for rapid paraprotein reduction in hyperviscosity and
+    related neurologic complications while systemic therapy addresses the
+    underlying clone.
+  treatment_term:
+    preferred_term: plasmapheresis
+    term:
+      id: NCIT:C15304
+      label: Plasmapheresis
+  evidence:
+  - reference: PMID:18813229
+    reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Treatment options, which should address both the paraprotein burden and
+      the lymphoplasmacytic clone, include plasmapheresis and chemotherapy with
+      alkylating agents, nucleoside analogs, and rituximab.
+    explanation: >-
+      This review supports plasmapheresis as a disease-relevant intervention for
+      rapid reduction of pathogenic paraprotein burden in WM.
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0100280
+      label: Waldenstrom macroglobulinemia
+    mapping_predicate: skos:exactMatch
+    mapping_source: MONDO
+    mapping_justification: Primary MONDO disease identifier for this Waldenstrom macroglobulinemia entry.

--- a/kb/disorders/Waldenstrom_Macroglobulinemia.yaml
+++ b/kb/disorders/Waldenstrom_Macroglobulinemia.yaml
@@ -227,7 +227,7 @@ pathophysiology:
     - reference: PMID:18813229
       reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >-
         Peripheral neuropathy occurs in nearly half of patients with this
         condition, and hyperviscosity-related nervous system disorders are
@@ -244,7 +244,7 @@ pathophysiology:
   - reference: PMID:18813229
     reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Peripheral neuropathy occurs in nearly half of patients with this
       condition, and hyperviscosity-related nervous system disorders are
@@ -446,7 +446,7 @@ phenotypes:
   - reference: PMID:18813229
     reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Waldenström macroglobulinemia, a condition that most commonly occurs in
       lymphoplasmacytic lymphoma, typically manifests with diffuse
@@ -470,7 +470,7 @@ phenotypes:
   - reference: PMID:18813229
     reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Peripheral neuropathy occurs in nearly half of patients with this
       condition, and hyperviscosity-related nervous system disorders are
@@ -607,7 +607,7 @@ treatments:
   - reference: PMID:18813229
     reference_title: "Neurological manifestations of Waldenström macroglobulinemia."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Treatment options, which should address both the paraprotein burden and
       the lymphoplasmacytic clone, include plasmapheresis and chemotherapy with

--- a/references_cache/PMID_11718214.md
+++ b/references_cache/PMID_11718214.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:11718214"
+title: "Lymphoplasmacytic lymphoma/immunocytoma: towards a disease-targeted treatment?"
+authors:
+- Clavio M
+- Quintino S
+- Venturino C
+- Ballerini F
+- Varaldo R
+- Gatto S
+- Galbusera V
+- Garrone A
+- Grasso R
+- Canepa L
+- Miglino M
+- Pierri I
+- Gobbi M
+journal: J Exp Clin Cancer Res
+year: '2001'
+keywords:
+- "Antibodies, Monoclonal/therapeutic use"
+- "Antibodies, Monoclonal, Murine-Derived"
+- Antineoplastic Agents/therapeutic use
+- B-Lymphocytes/pathology
+- "Diagnosis, Differential"
+- Humans
+- Immunophenotyping
+- Immunotherapy
+- "Lymphoma, B-Cell/genetics, immunology, pathology, therapy"
+- Lymphoproliferative Disorders/immunology
+- Rituximab
+content_type: abstract_only
+---
+
+# Lymphoplasmacytic lymphoma/immunocytoma: towards a disease-targeted treatment?
+**Authors:** Clavio M, Quintino S, Venturino C, Ballerini F, Varaldo R, Gatto S, Galbusera V, Garrone A, Grasso R, Canepa L, Miglino M, Pierri I, Gobbi M
+**Journal:** J Exp Clin Cancer Res (2001)
+
+## Content
+
+1. J Exp Clin Cancer Res. 2001 Sep;20(3):351-8.
+
+Lymphoplasmacytic lymphoma/immunocytoma: towards a disease-targeted treatment?
+
+Clavio M(1), Quintino S, Venturino C, Ballerini F, Varaldo R, Gatto S, Galbusera
+V, Garrone A, Grasso R, Canepa L, Miglino M, Pierri I, Gobbi M.
+
+Author information:
+(1)Dept. of Internal Medicine, University of Genoa, Genova, Italy.
+
+Lymphoplasmacytic-lymphoplasmacytoid lymphoma (LPL)/Waldenstrom's
+macroglobulinemia (WM) or immunocytoma (IMC) consists of diffuse proliferation
+of small mature B lymphocytes, plasmacytoid lymphocytes, and plasma-cells. The
+nosographic definition includes the lack of histological, immunophenotypic,
+cytogenetic, and molecular markers considered specific of other types of
+lymphoma. The cells show surface Ig (usually IgM), B-cell-associated antigens
+and display the CD5-, CD23- and CD10- phenotype, which allows for differential
+diagnosis from B-CLL and mantle cell lymphoma. t(9;14)(p13;q32) chromosomal
+translocation has been found in 50% of all LPL cases. The cytogenetic
+rearrangement juxtaposes the PAX-5 gene, which encodes for an essential
+transcription factor for B-cell proliferation and differention, to the Ig heavy
+chain gene. The combination of chlorambucil and prednisone holds as the standard
+treatment and seems to guarantee good control of the disease in most patients.
+Similar therapeutic results have been described with the combination of
+cyclophosphamide, vincristine, prednisone with (CHOP) or without doxorubicin
+(CVP), or with a combination of other alkylating agents and prednisone.
+Nucleoside analogues, alone or in combination with alkylating agents and
+anthracyclines, provide good salvage therapy for IMC and being increasingly
+employed as first line therapy. In a multicentric European trial Foran et al.
+administered the chimeric anti-CD20-monoclonal antibody (Rituximab) to 28
+patients with previously treated IMC. Seven out of 25 evaluable patients (28%)
+achieved a partial response. Byrd et al. examined the outcome of 7 previously
+treated WM patients who received weekly infusions of rituximab (375 mg/m2).
+Therapy was well tolerated by all patients, and there was no decrease in
+cellular immune function, or significant infectious morbidity. Partial responses
+were noted in three of these patients, including two with fludarabine-refractory
+disease. These data suggest that rituximab exerts clinical activity on heavily
+pre-treated patients with WM. Furthermore, Weide et al. first reported that
+WM-associated polyneuropathy can be treated effectively with a combination of
+chemotherapy and the anti-CD20 monoclonal antibody rituximab. Most published
+trials exploring the efficacy of high dose treatment as salvage therapy for
+relapsed or refractory low grade non Hodgkin's lymphoma have included
+prevalently follicular or lymphocytic lymphomas. In selected high risk patients
+radioimmunotherapy with autologous stem-cell rescue, and myeloablative therapy
+followed either by autologous stem cell transplantation (SCT) or allogeneic SCT
+might represent an alternative strategy.
+
+PMID: 11718214 [Indexed for MEDLINE]

--- a/references_cache/PMID_12720118.md
+++ b/references_cache/PMID_12720118.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:12720118"
+title: "Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia."
+authors:
+- Owen RG
+- Treon SP
+- Al-Katib A
+- Fonseca R
+- Greipp PR
+- McMaster ML
+- Morra E
+- Pangalis GA
+- San Miguel JF
+- Branagan AR
+- Dimopoulos MA
+journal: Semin Oncol
+year: '2003'
+doi: 10.1053/sonc.2003.50082
+keywords:
+- CD5 Antigens
+- Chromosome Aberrations
+- Humans
+- Immunoglobulin A/immunology
+- Immunoglobulin G/immunology
+- Immunoglobulin M/immunology
+- Immunophenotyping
+- Lymphoma/immunology
+- "Waldenstrom Macroglobulinemia/classification, diagnosis, immunology, pathology"
+content_type: abstract_only
+---
+
+# Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus panel recommendations from the Second International Workshop on Waldenstrom's Macroglobulinemia.
+**Authors:** Owen RG, Treon SP, Al-Katib A, Fonseca R, Greipp PR, McMaster ML, Morra E, Pangalis GA, San Miguel JF, Branagan AR, Dimopoulos MA
+**Journal:** Semin Oncol (2003)
+**DOI:** [10.1053/sonc.2003.50082](https://doi.org/10.1053/sonc.2003.50082)
+
+## Content
+
+1. Semin Oncol. 2003 Apr;30(2):110-5. doi: 10.1053/sonc.2003.50082.
+
+Clinicopathological definition of Waldenstrom's macroglobulinemia: consensus
+panel recommendations from the Second International Workshop on Waldenstrom's
+Macroglobulinemia.
+
+Owen RG(1), Treon SP, Al-Katib A, Fonseca R, Greipp PR, McMaster ML, Morra E,
+Pangalis GA, San Miguel JF, Branagan AR, Dimopoulos MA.
+
+Author information:
+(1)Leeds General Infirmary, Leeds, UK.
+
+This presentation represents consensus recommendations for the
+clinicopathological definition of Waldenstrom's macroglobulinemia (WM), which
+were prepared in conjunction with the Second International Workshop held in
+Athens, Greece during September 2002. WM is an uncommon lymphoproliferative
+disorder characterized primarily by bone marrow infiltration and IgM monoclonal
+gammopathy. It should be considered a distinct clinicopathological entity rather
+than a clinical syndrome secondary to IgM secretion. The underlying pathological
+diagnosis in WM is lymphoplasmacytic lymphoma as defined by the World Health
+Organization (WHO) and Revised European-American Lymphoma (REAL) classification
+criteria. The concentration of monoclonal IgM can vary widely in WM and it is
+not possible to define a concentration that reliably distinguishes WM from
+monoclonal gammopathy of undetermined significance (MGUS) and other
+lymphoproliferative disorders. A diagnosis of WM can therefore be made
+irrespective of IgM concentration if there is evidence on a bone marrow trephine
+biopsy of bone marrow infiltration by lymphoplasmacytic lymphoma with
+predominantly an intertrabecular pattern, supported by appropriate
+immunophenotypic studies. Simple criteria to distinguish patients with
+symptomatic WM who require therapy from those with asymptomatic WM and MGUS were
+also proposed. Patients with clinical features attributable to IgM monoclonal
+gammopathy but no overt evidence of lymphoma are considered to constitute a
+distinct clinical group and the term "IgM-related disorders" is proposed.
+
+Copyright 2003 Elsevier Inc. All rights reserved.
+
+DOI: 10.1053/sonc.2003.50082
+PMID: 12720118 [Indexed for MEDLINE]

--- a/references_cache/PMID_18216294.md
+++ b/references_cache/PMID_18216294.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:18216294"
+title: CD27-CD70 interactions in the pathogenesis of Waldenstrom macroglobulinemia.
+authors:
+- Ho AW
+- Hatjiharissi E
+- Ciccarelli BT
+- Branagan AR
+- Hunter ZR
+- Leleu X
+- Tournilhac O
+- Xu L
+- "O'Connor K"
+- Manning RJ
+- Santos DD
+- Chemaly M
+- Patterson CJ
+- Soumerai JD
+- Munshi NC
+- McEarchern JA
+- Law CL
+- Grewal IS
+- Treon SP
+journal: Blood
+year: '2008'
+doi: 10.1182/blood-2007-04-084525
+keywords:
+- Animals
+- "Antibodies, Monoclonal/pharmacology, therapeutic use"
+- "Biomarkers, Tumor/metabolism"
+- "CD27 Ligand/immunology, metabolism, physiology"
+- Case-Control Studies
+- "Cells, Cultured"
+- Humans
+- "Mast Cells/metabolism, pathology"
+- Mice
+- "Mice, SCID"
+- "Plasma Cells/metabolism, pathology"
+- Protein Binding
+- Tumor Burden
+- "Tumor Necrosis Factor Receptor Superfamily, Member 7/metabolism, physiology"
+- "Waldenstrom Macroglobulinemia/etiology, metabolism, pathology, therapy"
+- Xenograft Model Antitumor Assays
+content_type: abstract_only
+---
+
+# CD27-CD70 interactions in the pathogenesis of Waldenstrom macroglobulinemia.
+**Authors:** Ho AW, Hatjiharissi E, Ciccarelli BT, Branagan AR, Hunter ZR, Leleu X, Tournilhac O, Xu L, O'Connor K, Manning RJ, Santos DD, Chemaly M, Patterson CJ, Soumerai JD, Munshi NC, McEarchern JA, Law CL, Grewal IS, Treon SP
+**Journal:** Blood (2008)
+**DOI:** [10.1182/blood-2007-04-084525](https://doi.org/10.1182/blood-2007-04-084525)
+
+## Content
+
+1. Blood. 2008 Dec 1;112(12):4683-9. doi: 10.1182/blood-2007-04-084525. Epub 2008
+ Jan 23.
+
+CD27-CD70 interactions in the pathogenesis of Waldenstrom macroglobulinemia.
+
+Ho AW(1), Hatjiharissi E, Ciccarelli BT, Branagan AR, Hunter ZR, Leleu X,
+Tournilhac O, Xu L, O'Connor K, Manning RJ, Santos DD, Chemaly M, Patterson CJ,
+Soumerai JD, Munshi NC, McEarchern JA, Law CL, Grewal IS, Treon SP.
+
+Author information:
+(1)Bing Center for Waldenström's Macroglobulinemia, Dana-Farber Cancer
+Institute, Harvard Medical School, Boston, MA 02115, USA.
+
+Waldenström macroglobulinemia (WM) is a B-cell malignancy characterized by an
+IgM monoclonal gammopathy and bone marrow (BM) infiltration with
+lymphoplasmacytic cells (LPCs). Excess mast cells (MCs) are commonly present in
+WM, and provide growth and survival signals to LPCs through several TNF family
+ligands (CD40L, a proliferation-inducing ligand [APRIL], and B-lymphocyte
+stimulator factor [BLYS]). As part of these studies, we demonstrated that WM
+LPCs secrete soluble CD27 (sCD27), which is elevated in patients with WM (P <
+.001 vs healthy donors), and serves as a faithful marker of disease.
+Importantly, sCD27 stimulated expression of CD40L on 10 of 10 BM MC samples and
+APRIL on 4 of 10 BM MC samples obtained from patients with WM as well as on LAD2
+MCs. Moreover, the SGN-70 humanized monoclonal antibody, which binds to CD70
+(the receptor-ligand partner of CD27), abrogated sCD27 mediated up-regulation of
+CD40L and APRIL on WM MCs. Last, treatment of severe combined
+immunodeficiency-human (SCID-hu) mice with established WM using the SGN-70
+antibody blocked disease progression in 12 of 12 mice, whereas disease
+progressed in all 5 untreated mice. The results of these studies demonstrate a
+functional role for sCD27 in WM pathogenesis, along with its utility as a
+surrogate marker of disease and a target in the treatment of WM.
+
+DOI: 10.1182/blood-2007-04-084525
+PMCID: PMC2597134
+PMID: 18216294 [Indexed for MEDLINE]

--- a/references_cache/PMID_18813229.md
+++ b/references_cache/PMID_18813229.md
@@ -1,0 +1,55 @@
+---
+reference_id: "PMID:18813229"
+title: Neurological manifestations of Waldenström macroglobulinemia.
+authors:
+- Baehring JM
+- Hochberg EP
+- Raje N
+- Ulrickson M
+- Hochberg FH
+journal: Nat Clin Pract Neurol
+year: '2008'
+doi: 10.1038/ncpneuro0917
+keywords:
+- Humans
+- "Nervous System Diseases/etiology, physiopathology"
+- "Waldenstrom Macroglobulinemia/complications, therapy"
+content_type: abstract_only
+---
+
+# Neurological manifestations of Waldenström macroglobulinemia.
+**Authors:** Baehring JM, Hochberg EP, Raje N, Ulrickson M, Hochberg FH
+**Journal:** Nat Clin Pract Neurol (2008)
+**DOI:** [10.1038/ncpneuro0917](https://doi.org/10.1038/ncpneuro0917)
+
+## Content
+
+1. Nat Clin Pract Neurol. 2008 Oct;4(10):547-56. doi: 10.1038/ncpneuro0917. Epub
+2008 Sep 23.
+
+Neurological manifestations of Waldenström macroglobulinemia.
+
+Baehring JM(1), Hochberg EP, Raje N, Ulrickson M, Hochberg FH.
+
+Author information:
+(1)Yale University School of Medicine, Yale Brain Tumor Center, New Haven, CT,
+USA.
+
+Waldenström macroglobulinemia, a condition that most commonly occurs in
+lymphoplasmacytic lymphoma, typically manifests with diffuse lymphadenopathies,
+cytopenias, and a markedly elevated erythrocyte sedimentation rate. Peripheral
+neuropathy occurs in nearly half of patients with this condition, and
+hyperviscosity-related nervous system disorders are encountered in up to a
+third. Other neurological complications, such as encephalopathy or myelopathy
+caused by direct tumor infiltration, paraprotein deposition or autoimmune
+phenomena, are rare. Diagnosis of Waldenström macroglobulinemia requires
+identification of monoclonal IgM protein in the serum, bone marrow biopsy, and
+appropriate neurological testing (e.g. imaging studies of affected areas of the
+central neuraxis, electrophysiological studies). Treatment options, which should
+address both the paraprotein burden and the lymphoplasmacytic clone, include
+plasmapheresis and chemotherapy with alkylating agents, nucleoside analogs, and
+rituximab. As the disease is incurable and its course indolent, these treatments
+are only provided to symptomatic patients.
+
+DOI: 10.1038/ncpneuro0917
+PMID: 18813229 [Indexed for MEDLINE]

--- a/references_cache/PMID_24224040.md
+++ b/references_cache/PMID_24224040.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:24224040"
+title: "L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia and its absence in myeloma."
+authors:
+- Mori N
+- Ohwashi M
+- Yoshinaga K
+- Mitsuhashi K
+- Tanaka N
+- Teramura M
+- Okada M
+- Shiseki M
+- Tanaka J
+- Motoji T
+journal: PLoS One
+year: '2013'
+doi: 10.1371/journal.pone.0080088
+keywords:
+- Adult
+- Aged
+- Female
+- Genotype
+- Humans
+- Lymphoma/genetics
+- Male
+- Middle Aged
+- Multiple Myeloma/genetics
+- Mutation
+- Myeloid Differentiation Factor 88/genetics
+- Polymerase Chain Reaction
+- Waldenstrom Macroglobulinemia/genetics
+content_type: abstract_only
+---
+
+# L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia and its absence in myeloma.
+**Authors:** Mori N, Ohwashi M, Yoshinaga K, Mitsuhashi K, Tanaka N, Teramura M, Okada M, Shiseki M, Tanaka J, Motoji T
+**Journal:** PLoS One (2013)
+**DOI:** [10.1371/journal.pone.0080088](https://doi.org/10.1371/journal.pone.0080088)
+
+## Content
+
+1. PLoS One. 2013 Nov 5;8(11):e80088. doi: 10.1371/journal.pone.0080088.
+eCollection 2013.
+
+L265P mutation of the MYD88 gene is frequent in Waldenström's macroglobulinemia
+and its absence in myeloma.
+
+Mori N(1), Ohwashi M, Yoshinaga K, Mitsuhashi K, Tanaka N, Teramura M, Okada M,
+Shiseki M, Tanaka J, Motoji T.
+
+Author information:
+(1)Department of Hematology, Tokyo Women's Medical University, Tokyo, Japan.
+
+L265P mutation in the MYD88 gene has recently been reported in Waldenström's
+macroglobulinemia; however the incidence has been different according to the
+methods used. To determine the relevance and compare the incidence by different
+methods, we analyzed the L265P mutation in bone marrow mononuclear cells from
+lymphoid neoplasms. We first performed cloning and sequencing in 10 patients: 8
+Waldenström's macroglobulinemia; 1 non-IgM-secreting lymphoplasmacytic lymphoma;
+and 1 low grade B-cell lymphoma with monoclonal IgG protein. The L265P mutation
+was detected in only 1/8 Waldenström's macroglobulinemia patients (2 of 9
+clones). To confirm these results, direct sequencing was performed in the 10
+patients and an additional 17 Waldenström's macroglobulinemia patients and 1
+lymphoplasmacytic lymphoma patient. Nine of 28 patients (7/25 Waldenström's
+macroglobulinemia, 1/2 lymphoplasmacytic lymphoma, and B-cell lymphoma) harbored
+the mutation. We next tested for the mutation with BSiE1 digestion and
+allele-specific polymerase chain reaction in the 28 patients and 38 patients
+with myeloma. Aberrant bands corresponding to the mutation were detected by
+BSiE1 digestion in 19/25 patients with Waldenström's macroglobulinemia (76%),
+1/2 lymphoplasmacytic lymphoma and B-cell lymphoma, but not in the 38 myeloma
+patients. The L265P mutation was more frequent in patients with Waldenström's
+macroglobulinemia than in those with myeloma (p=1.3x10(-10)). The mutation was
+detected by allele-specific polymerase chain reaction in 18/25 Waldenström's
+macroglobulinemia patients (72%). In the 25 Waldenström's macroglobulinemia
+patients, the L265P was more frequently detected by BSiE1 digestion than by
+direct sequencing (p=5.3x10(-4)), and in males (15/16, 94%) than in females
+(4/9, 44%) (p=1.2x10(-2)). No siginificant difference was observed in the
+incidence of the L265P mutation between BSiE1 digestion and allele-specific
+polymerase chain reaction (p=0.32). These results suggest that the L265P
+mutation is involved in the majority of Waldenström's macroglobulinemia. BSiE1
+digestion and allele-specific polymerase chain reaction may detect a small
+fraction of mutated cells in some cases.
+
+DOI: 10.1371/journal.pone.0080088
+PMCID: PMC3818242
+PMID: 24224040 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing Interests: The authors have declared
+that no competing interests exist.

--- a/references_cache/PMID_26659815.md
+++ b/references_cache/PMID_26659815.md
@@ -1,0 +1,123 @@
+---
+reference_id: "PMID:26659815"
+title: Clonal architecture of CXCR4 WHIM-like mutations in Waldenström Macroglobulinaemia.
+authors:
+- Xu L
+- Hunter ZR
+- Tsakmaklis N
+- Cao Y
+- Yang G
+- Chen J
+- Liu X
+- Kanan S
+- Castillo JJ
+- Tai YT
+- Zehnder JL
+- Brown JR
+- Carrasco RD
+- Advani R
+- Sabile JM
+- Argyropoulos K
+- Lia Palomba M
+- Morra E
+- Trojani A
+- Greco A
+- Tedeschi A
+- Varettoni M
+- Arcaini L
+- Munshi NM
+- Anderson KC
+- Treon SP
+journal: Br J Haematol
+year: '2016'
+doi: 10.1111/bjh.13897
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Amino Acid Substitution
+- Female
+- Genomic Instability
+- Humans
+- Immunoglobulin M/blood
+- "Lymphoma, B-Cell, Marginal Zone/genetics"
+- Male
+- Middle Aged
+- Monoclonal Gammopathy of Undetermined Significance/genetics
+- Mutation
+- Myeloid Differentiation Factor 88/genetics
+- Polymerase Chain Reaction/methods
+- "Receptors, CXCR4/genetics"
+- "Sequence Analysis, DNA/methods"
+- Waldenstrom Macroglobulinemia/genetics
+content_type: abstract_only
+---
+
+# Clonal architecture of CXCR4 WHIM-like mutations in Waldenström Macroglobulinaemia.
+**Authors:** Xu L, Hunter ZR, Tsakmaklis N, Cao Y, Yang G, Chen J, Liu X, Kanan S, Castillo JJ, Tai YT, Zehnder JL, Brown JR, Carrasco RD, Advani R, Sabile JM, Argyropoulos K, Lia Palomba M, Morra E, Trojani A, Greco A, Tedeschi A, Varettoni M, Arcaini L, Munshi NM, Anderson KC, Treon SP
+**Journal:** Br J Haematol (2016)
+**DOI:** [10.1111/bjh.13897](https://doi.org/10.1111/bjh.13897)
+
+## Content
+
+1. Br J Haematol. 2016 Mar;172(5):735-44. doi: 10.1111/bjh.13897. Epub 2015 Dec
+13.
+
+Clonal architecture of CXCR4 WHIM-like mutations in Waldenström
+Macroglobulinaemia.
+
+Xu L(1), Hunter ZR(1)(2), Tsakmaklis N(1), Cao Y(1)(2), Yang G(1)(2), Chen J(1),
+Liu X(1)(2), Kanan S(1), Castillo JJ(1)(2), Tai YT(2)(3), Zehnder JL(4), Brown
+JR(2)(5), Carrasco RD(2)(5), Advani R(6), Sabile JM(6), Argyropoulos K(7), Lia
+Palomba M(7), Morra E(8), Trojani A(8), Greco A(8), Tedeschi A(8), Varettoni
+M(9)(10), Arcaini L(9)(10), Munshi NM(2)(3), Anderson KC(2)(3), Treon SP(1)(2).
+
+Author information:
+(1)Bing Center for Waldenström's Macroglobulinemia, Dana Farber Cancer
+Institute, Boston, MA, USA.
+(2)Department of Medicine, Harvard Medical School, Boston, MA, USA.
+(3)Lipper Center for Multiple Myeloma, Dana Farber Cancer Institute, Boston, MA,
+USA.
+(4)Department of Pathology, Stanford University Medical Center, Stanford, CA,
+USA.
+(5)Department of Medical Oncology, Dana Farber Cancer Institute, Boston, MA,
+USA.
+(6)Department of Medical Oncology, Stanford University Medical Center, Stanford,
+CA, USA.
+(7)Department of Medical Oncology, Memorial Sloane Kettering Cancer Center, New
+York, NY, USA.
+(8)Haematology Unit, Niguarda Hospital, Milan, Italy.
+(9)Department of Molecular Medicine, University of Pavia, Pavia, Italy.
+(10)Department of Haematology Oncology, Fondazione IRCCS Policlinico San Matteo,
+Pavia, Italy.
+
+CXCR4(WHIM) somatic mutations are distinctive to Waldenström Macroglobulinaemia
+(WM), and impact disease presentation and treatment outcome. The clonal
+architecture of CXCR4(WHIM) mutations remains to be delineated. We developed
+highly sensitive allele-specific polymerase chain reaction (AS-PCR) assays for
+detecting the most common CXCR4(WHIM) mutations (CXCR4(S338X C>A and C>G) ) in
+WM. The AS-PCR assays detected CXCR4(S338X) mutations in WM and IgM monoclonal
+gammopathy of unknown significance (MGUS) patients not revealed by Sanger
+sequencing. By combined AS-PCR and Sanger sequencing, CXCR4(WHIM) mutations were
+identified in 44/102 (43%), 21/62 (34%), 2/12 (17%) and 1/20 (5%) untreated WM,
+previously treated WM, IgM MGUS and marginal zone lymphoma patients,
+respectively, but no chronic lymphocytic leukaemia, multiple myeloma, non-IgM
+MGUS patients or healthy donors. Cancer cell fraction analysis in WM and IgM
+MGUS patients showed CXCR4(S338X) mutations were primarily subclonal, with
+highly variable clonal distribution (median 35·1%, range 1·2-97·5%). Combined
+AS-PCR and Sanger sequencing revealed multiple CXCR4(WHIM) mutations in many
+individual WM patients, including homozygous and compound heterozygous mutations
+validated by deep RNA sequencing. The findings show that CXCR4(WHIM) mutations
+are more common in WM than previously revealed, and are primarily subclonal,
+supporting their acquisition after MYD88(L265P) in WM oncogenesis. The presence
+of multiple CXCR4(WHIM) mutations within individual WM patients may be
+indicative of targeted CXCR4 genomic instability.
+
+© 2015 John Wiley & Sons Ltd.
+
+DOI: 10.1111/bjh.13897
+PMCID: PMC5409813
+PMID: 26659815 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflicts of interest: No conflicts of interest
+are identified by the investigators for this work.

--- a/references_cache/PMID_37099027.md
+++ b/references_cache/PMID_37099027.md
@@ -1,0 +1,139 @@
+---
+reference_id: "PMID:37099027"
+title: "Report of consensus panel 1 from the 11(th) International Workshop on Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve patients."
+authors:
+- Buske C
+- Castillo JJ
+- Abeykoon JP
+- Advani R
+- Arulogun SO
+- Branagan AR
+- Cao X
+- "D'Sa S"
+- Hou J
+- Kapoor P
+- Kastritis E
+- Kersten MJ
+- LeBlond V
+- Leiba M
+- Matous JV
+- Paludo J
+- Qiu L
+- Tam CS
+- Tedeschi A
+- Thomas SK
+- Tohidi-Esfahani I
+- Varettoni M
+- Vos JM
+- Garcia-Sanz R
+- San-Miguel J
+- Dimopoulos MA
+- Treon SP
+- Trotman J
+journal: Semin Hematol
+year: '2023'
+doi: 10.1053/j.seminhematol.2023.03.005
+keywords:
+- Humans
+- Rituximab/therapeutic use
+- "Waldenstrom Macroglobulinemia/drug therapy, genetics, diagnosis"
+- Immunoglobulin Light-chain Amyloidosis
+- Prospective Studies
+- Bendamustine Hydrochloride/therapeutic use
+content_type: abstract_only
+---
+
+# Report of consensus panel 1 from the 11(th) International Workshop on Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve patients.
+**Authors:** Buske C, Castillo JJ, Abeykoon JP, Advani R, Arulogun SO, Branagan AR, Cao X, D'Sa S, Hou J, Kapoor P, Kastritis E, Kersten MJ, LeBlond V, Leiba M, Matous JV, Paludo J, Qiu L, Tam CS, Tedeschi A, Thomas SK, Tohidi-Esfahani I, Varettoni M, Vos JM, Garcia-Sanz R, San-Miguel J, Dimopoulos MA, Treon SP, Trotman J
+**Journal:** Semin Hematol (2023)
+**DOI:** [10.1053/j.seminhematol.2023.03.005](https://doi.org/10.1053/j.seminhematol.2023.03.005)
+
+## Content
+
+1. Semin Hematol. 2023 Mar;60(2):73-79. doi: 10.1053/j.seminhematol.2023.03.005.
+Epub 2023 Mar 29.
+
+Report of consensus panel 1 from the 11(th) International Workshop on
+Waldenstrom's Macroglobulinemia on management of symptomatic, treatment-naïve
+patients.
+
+Buske C(1), Castillo JJ(2), Abeykoon JP(3), Advani R(4), Arulogun SO(5),
+Branagan AR(6), Cao X(7), D'Sa S(5), Hou J(8), Kapoor P(3), Kastritis E(9),
+Kersten MJ(10), LeBlond V(11), Leiba M(12), Matous JV(13), Paludo J(3), Qiu
+L(14), Tam CS(15), Tedeschi A(16), Thomas SK(17), Tohidi-Esfahani I(18),
+Varettoni M(19), Vos JM(10), Garcia-Sanz R(20), San-Miguel J(21), Dimopoulos
+MA(9), Treon SP(2), Trotman J(18).
+
+Author information:
+(1)University Hospital Ulm, Institute of Experimental Cancer Research, Ulm,
+Germany. Electronic address: christian.buske@uni-ulm.de.
+(2)Dana Farber Cancer Institute, Harvard Medical School, Boston MA.
+(3)Mayo Clinic, Rochester MN.
+(4)Stanford University Medical Center, Stanford CA.
+(5)University College London Hospitals, London UK.
+(6)Massachusetts General Hospital, Boston MA.
+(7)Peking Union Medical College Hospital, Chinese Academy of Medical Sciences
+and Peking Union Medical College, Beijing, China.
+(8)Renji Hospital, Shanghai China.
+(9)Department of Clinical Therapeutics, National and Kapodistrian University of
+Athens, Athens, Greece.
+(10)Department of Hematology, Amsterdam UMC, University of Amsterdam, Cancer
+Center Amsterdam/LYMMCARE, Amsterdam, Netherlands.
+(11)Groupe Hospitalier Pitié-Salpêtrière, Sorbonne University, Paris France.
+(12)Faculty of Health Science, Ben- Gurion University of the Negev, Israel
+Assuta Ashdod University Hospital; Faculty of Health Science, Ben-Gurion
+University of the Negev, Negev, Israel Memorial Sloan Kettering Cancer Center,
+New York, NY.
+(13)Colorado Blood Cancer Institute, Sarah Cannon Research Institute, Denver,
+CO.
+(14)National Clinical Medical Research Center for Blood Diseases, Institute of
+Hematology and Blood Diseases Hospital, Chinese Academy of Medical Sciences and
+Peking Union Medical College, Tianjin, China.
+(15)Alfred Health, Monash University, Melbourne, Australia.
+(16)A.O. Ospedale Niguarda Ca' Granda, Milan, Italy.
+(17)University of Texas, MD Anderson Cancer Center, Houston, TX.
+(18)Concord Repatriation General Hospital, University of Sydney, Sydney,
+Australia.
+(19)Division of Hematology, Fondazione IRCCS Policlinico San Matteo, Pavia,
+Italy.
+(20)Hematology Department, University Hospital of Salamanca, Research Biomedical
+Institute of Salamanca, CIBERONC and Center for Cancer Research-IBMCC
+(University of Salamanca-CSIC), Salamanca, Spain.
+(21)Clínica Universidad de Navarra, Centro de Investigación Médica Aplicada,
+Instituto de Investigación Sanitaria de Navarra, Centro de Investigación
+Biomédica en Red Cáncer, Pamplona, Spain.
+
+Consensus Panel 1 (CP1) of the 11th International Workshop on Waldenstrom's
+Macroglobulinemia (IWWM-11) was tasked with updating guidelines for the
+management of symptomatic, treatment-naïve patients with WM. The panel
+reiterated that watchful waiting remains the gold standard for asymptomatic
+patients without critically elevated IgM or compromised hematopoietic function.
+For first-line treatment, chemoimmunotherapy (CIT) regimens such as
+dexamethasone, cyclophosphamide, rituximab (DRC), or bendamustine, rituximab
+(Benda-R) continue to play a central role in managing WM, as they are effective,
+of fixed duration, generally well-tolerated, and affordable. Covalent BTK
+inhibitors (cBTKi) offer a continuous, generally well-tolerated alternative for
+the primary treatment of WM patients, particularly those unsuitable for CIT. In
+a Phase III randomized trial updated at IWWM-11, the second-generation cBTKi,
+zanubrutinib, was less toxic than ibrutinib and induced deeper remissions, thus
+categorizing zanubrutinib as a suitable treatment option in WM. While the
+overall findings of a prospective, randomized trial updated at IWWM-11 did not
+show superiority of fixed duration rituximab maintenance over observation
+following attainment of a major response to Benda-R induction, a subset analysis
+showed benefit in patients >65 years and those with a high IPPSWM score.
+Whenever possible, the mutational status of MYD88 and CXCR4 should be determined
+before treatment initiation, as alterations in these 2 genes predict sensitivity
+towards cBTKi activity. Treatment approaches for WM-associated cryoglobulins,
+cold agglutinins, AL amyloidosis, Bing-Neel syndrome (BNS), peripheral
+neuropathy, and hyperviscosity syndrome follow the common principle of reducing
+tumor and abnormal protein burden rapidly and deeply to improve symptoms. In
+BNS, ibrutinib can be highly active and produce durable responses. In contrast,
+cBTKi are not recommended for treating AL amyloidosis. The panel emphasized that
+continuous improvement of treatment options for symptomatic, treatment-naïve WM
+patients critically depends on the participation of patients in clinical trials,
+whenever possible.
+
+Copyright © 2023. Published by Elsevier Inc.
+
+DOI: 10.1053/j.seminhematol.2023.03.005
+PMID: 37099027 [Indexed for MEDLINE]

--- a/research/Waldenstrom_Macroglobulinemia-deep-research-manual.md
+++ b/research/Waldenstrom_Macroglobulinemia-deep-research-manual.md
@@ -1,0 +1,202 @@
+---
+provider: manual_pubmed_review
+model: n/a
+cached: false
+start_time: '2026-04-13T04:20:00Z'
+end_time: '2026-04-13T05:35:00Z'
+duration_seconds: 4500.0
+citation_count: 7
+notes: >
+  Manual PubMed and ontology-browser review completed for Waldenstrom
+  macroglobulinemia curation. Cancer curation guidance from issue #1198 /
+  Wilms tumor was applied explicitly: the curation unit remains one coherent
+  Waldenstrom mechanism graph anchored to MONDO:0100280, lymphoplasmacytic
+  lymphoma is treated as the parent histopathologic backbone rather than a
+  separate dismech page, and smoldering/familial/recurrent/refractory/
+  transformed states were not split into standalone disease pages because they
+  do not define separate core causal programs for this entry. Instead, the YAML
+  uses flat `has_subtypes` facet axes for clinical course and molecular context
+  within one page. NCIT was used where the current schema and validator support
+  oncology-specific grounding directly (histopathology, drug, and procedure
+  terms). The current schema still lacks disease-level or subtype-level
+  `ncit_mappings`, and the current `RegimenTerm` expansion did not admit the
+  candidate BR and zanubrutinib regimen codes, so those #1198 recommendations
+  were applied conservatively rather than approximated with ad hoc slots.
+---
+
+## Question
+
+Produce a disease-level mechanistic research summary for Waldenstrom
+macroglobulinemia suitable for a dismech cancer curation, with explicit notes
+on MONDO/NCIT modeling choices.
+
+## Output
+
+# Waldenstrom Macroglobulinemia: Mechanistic Summary
+
+## Disease anchor and modeling choice
+
+Waldenstrom macroglobulinemia (WM) is best modeled here as a single disease-level
+mechanism graph rooted to **MONDO:0100280 Waldenstrom macroglobulinemia**, not as
+a lattice of every oncology subclass. The key defining combination is:
+
+- lymphoplasmacytic lymphoma involving the bone marrow
+- secretion of a monoclonal IgM paraprotein
+- recurrent MYD88-driven B-cell oncogenesis with CXCR4-mutant subclonal evolution
+
+Following issue #1198, I treated **lymphoplasmacytic lymphoma** as the disease
+parent / diagnostic histopathology concept rather than opening a separate dismech
+page for every related ontology refinement. Likewise, I did **not** split
+smoldering WM, familial WM, refractory WM, recurrent WM, or transformed WM into
+separate disorder files, because those are disease-state, predisposition, or
+transformation facets rather than distinct causal programs for the baseline WM
+mechanism graph. In the YAML, this was reflected by keeping one disease page and
+encoding subtype structure only as flat `has_subtypes` facets for clinical
+course and molecular context.
+
+Relevant ontology anchors:
+
+- MONDO:0100280 Waldenstrom macroglobulinemia
+- MONDO:0000432 lymphoplasmacytic lymphoma
+- NCIT:C80307 Waldenstrom Macroglobulinemia
+- NCIT:C3212 Lymphoplasmacytic Lymphoma
+
+## Foundational disease definition
+
+PMID:12720118 remains the key disease-definition paper for this curation. It
+defines WM as an uncommon lymphoproliferative disorder characterized by bone
+marrow lymphoplasmacytic infiltration and IgM monoclonal gammopathy, and it
+explicitly argues that WM is a distinct clinicopathologic entity rather than
+just an IgM secretion syndrome.
+
+PMID:11718214 complements this by describing the underlying cell composition:
+small mature B lymphocytes, plasmacytoid lymphocytes, and plasma cells. For the
+dismech entry, that supports treating the bone-marrow lymphoplasmacytic clone as
+the core disease unit and the IgM paraprotein as a downstream biochemical output
+of that clone.
+
+## Core mechanisms selected for the YAML graph
+
+### 1. Bone marrow lymphoplasmacytic infiltration
+
+This is the disease-defining tissue state. The mechanistic unit is the marrow
+infiltrating clone composed of B-cell/plasma-cell lineage lymphoplasmacytic
+cells. This node should sit near the top of the graph because it links the
+founding genomic lesions to the clinical consequences of marrow occupation and
+paraprotein secretion.
+
+Key support:
+
+- PMID:12720118
+- PMID:11718214
+
+### 2. Monoclonal IgM secretion
+
+The IgM paraprotein is the key biochemical output of the malignant clone and is
+best modeled as a separate downstream node rather than bundled into the marrow
+infiltration node. This helps keep the graph atomic and allows direct edges to
+paraprotein-driven complications.
+
+Key support:
+
+- PMID:12720118
+
+### 3. Serum hyperviscosity
+
+Hyperviscosity is a downstream biophysical consequence of heavy circulating IgM
+burden. I modeled this as a separate pathophysiology node rather than collapsing
+it into the phenotype list, because it is an intermediate pathogenic process
+that explains neurologic and visual symptoms.
+
+Key support:
+
+- PMID:18813229
+
+### 4. MYD88 L265P founder mutation
+
+MYD88 L265P is the dominant recurrent somatic lesion in WM and should be treated
+as an upstream genomic driver node. The cached abstract set supports two
+important, conservative claims:
+
+- MYD88 L265P is present in the majority of WM cases (PMID:24224040)
+- CXCR4 WHIM-like mutations are usually acquired after MYD88 L265P in WM
+  oncogenesis (PMID:26659815)
+
+Because the cached abstract set was used conservatively, I did not overstate the
+full MYD88 -> BTK -> IRAK -> NF-kB signaling chain in the YAML evidence block
+without a validated PMID cache line for that exact claim. That mechanistic detail
+is real and well-supported in the broader WM literature, but the YAML entry is
+restricted to what could be quoted exactly and validated in this branch.
+
+### 5. CXCR4 WHIM-like subclonal evolution
+
+CXCR4 mutations are not the founding lesion; they are modeled as a later,
+subclonal branch layered onto the MYD88-mutant clone. This is a good example of
+an oncology refinement that belongs inside the same disease graph rather than in
+a separate disease page.
+
+Key support:
+
+- PMID:26659815
+- PMID:37099027 (clinical relevance for BTK-inhibitor sensitivity)
+
+### 6. Mast-cell supportive signaling in the marrow microenvironment
+
+PMID:18216294 shows that excess marrow mast cells are common in WM and provide
+growth/survival signals to lymphoplasmacytic cells. This is worth a separate
+node because it captures a bona fide microenvironmental mechanism rather than a
+mere descriptive pathology feature.
+
+Key support:
+
+- PMID:18216294
+
+## Clinical phenotype and complication summary
+
+The best abstract-backed phenotype set from the cached reference slice is:
+
+- IgM paraproteinemia / monoclonal gammopathy (PMID:12720118)
+- lymphadenopathy (PMID:18813229)
+- peripheral neuropathy, occurring in nearly half of patients (PMID:18813229)
+
+Hyperviscosity-related neurologic disorders are common enough to matter
+mechanistically but were better represented as a downstream pathophysiology node
+than as an HP-grounded phenotype because the available ontology grounding in this
+schema is much cleaner for the manifestations than for the syndrome label itself.
+
+## Treatment conclusions for the entry
+
+The current disease-level treatment section should emphasize:
+
+- **watchful waiting** for asymptomatic patients, per the 2023 IWWM consensus
+  (PMID:37099027)
+- fixed-duration **chemoimmunotherapy** as an important first-line option,
+  especially bendamustine-rituximab (PMID:37099027)
+- **zanubrutinib** as a current covalent BTK inhibitor option with lower toxicity
+  and deeper remissions than ibrutinib in the referenced randomized-trial update
+  (PMID:37099027)
+- **plasmapheresis** for rapid paraprotein reduction in hyperviscosity and related
+  neurologic complications (PMID:18813229)
+
+Following #1198, NCIT should be preferred where it gives materially better
+oncology specificity. In the YAML this means:
+
+- NCIT:C3212 for the histopathology finding
+- NCIT:C1702 for rituximab
+- NCIT:C141428 for zanubrutinib
+- NCIT:C15304 for plasmapheresis
+
+I initially attempted to ground BR and zanubrutinib with NCIT regimen terms as
+well, but the current `RegimenTerm` validator expansion in this branch did not
+accept those codes, so I retained the validated disease-level treatment
+representation using treatment actions plus ontology-grounded agents/procedures.
+
+## References
+
+- PMID:11718214
+- PMID:12720118
+- PMID:18216294
+- PMID:18813229
+- PMID:24224040
+- PMID:26659815
+- PMID:37099027


### PR DESCRIPTION
## Summary
- add a disease-level Waldenstrom macroglobulinemia dismech entry with MONDO-first disease anchoring, NCIT-grounded histopathology/treatment concepts, PMID-backed evidence, and atomic pathophysiology nodes
- add a manual deep-research note documenting the literature slice, ontology choices, and the cancer-modeling decisions applied from issue #1198 / the Wilms pattern
- cache the PubMed references used by the new curation

## Modeling Notes
- keep one coherent Waldenstrom mechanism graph rather than splitting asymptomatic, symptomatic, MYD88-mutant, or CXCR4-mutated disease facets into separate disorder pages
- treat lymphoplasmacytic lymphoma as the parent histopathologic backbone rather than as a separate dismech page for this slice
- use flat subtype facets for clinical course and molecular context inside the same entry
- use NCIT where the current schema/validator supports oncology-specific grounding directly; do not force unsupported regimen bindings

## Validation
- `just validate kb/disorders/Waldenstrom_Macroglobulinemia.yaml`
- `just validate-references kb/disorders/Waldenstrom_Macroglobulinemia.yaml`
- `just check-research Waldenstrom_Macroglobulinemia`

Closes #1213