### PR TITLE
[codex] Curate anaplastic large cell lymphoma

### DIFF
--- a/kb/disorders/Anaplastic_Large_Cell_Lymphoma.yaml
+++ b/kb/disorders/Anaplastic_Large_Cell_Lymphoma.yaml
@@ -1,0 +1,877 @@
+name: Anaplastic Large Cell Lymphoma
+creation_date: "2026-04-13T05:41:42Z"
+updated_date: "2026-04-13T05:41:42Z"
+category: Cancer
+categories:
+- Hematologic Malignancy
+- T-cell Neoplasm
+- Non-Hodgkin Lymphoma
+synonyms:
+- ALCL
+- anaplastic large-cell lymphoma
+description: >-
+  Anaplastic large cell lymphoma (ALCL) is a CD30-positive mature T-cell lymphoma
+  family that includes systemic ALK-positive disease, systemic ALK-negative
+  disease, primary cutaneous disease, and breast implant-associated disease.
+  This entry models ALCL as a single disease-level mechanism graph with
+  subtype-scoped mechanisms, phenotypes, biomarkers, and treatments rather than
+  splitting every ontology subclass into a separate dismech page.
+definitions:
+- name: Pathologic definition of anaplastic large cell lymphoma
+  definition_type: CASE_DEFINITION
+  description: >-
+    ALCL is a mature T-cell lymphoma family unified by strong CD30 expression
+    and subdivided into systemic ALK-positive, systemic ALK-negative, primary
+    cutaneous, and breast implant-associated entities.
+  scope: General pathologic and molecular definition of anaplastic large cell lymphoma
+  evidence:
+  - reference: PMID:40565334
+    reference_title: "Molecular Insights into the Diagnosis of Anaplastic Large Cell Lymphoma: Beyond Morphology and Immunophenotype."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Anaplastic Large Cell Lymphoma (ALCL) represents a diverse group of mature
+      T-Cell Lymphomas unified by strong CD30 expression but with different molecular
+      and clinical subtypes.
+    explanation: >-
+      This review provides a concise disease-level definition that fits the
+      dismech page as the shared ALCL mechanism unit.
+disease_term:
+  preferred_term: anaplastic large cell lymphoma
+  term:
+    id: MONDO:0020325
+    label: anaplastic large cell lymphoma
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0020325
+      label: anaplastic large cell lymphoma
+    mapping_predicate: skos:exactMatch
+    mapping_source: MONDO
+    mapping_justification: Primary MONDO disease identifier for this ALCL entry.
+parents:
+- Lymphoma
+has_subtypes:
+- name: Systemic ALK-Positive
+  display_name: Systemic ALK-Positive Anaplastic Large Cell Lymphoma
+  description: >-
+    Systemic ALCL subtype driven by ALK rearrangement or fusion, usually
+    affecting younger patients and often presenting with advanced-stage disease.
+    It is the most treatment-responsive systemic ALCL subtype.
+  classification: molecular
+  subtype_term:
+    preferred_term: ALK-positive anaplastic large cell lymphoma
+    term:
+      id: MONDO:0017602
+      label: ALK-positive anaplastic large cell lymphoma
+  evidence:
+  - reference: PMID:37655119
+    reference_title: "ALK-positive anaplastic large cell lymphoma in adults."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      This subtype contains a translocation between the ALK gene on chromosome 2
+      and one of several other genes that together form an oncogene.
+    explanation: >-
+      This review defines systemic ALK-positive ALCL by its ALK translocation-driven
+      oncogene.
+  - reference: PMID:37655119
+    reference_title: "ALK-positive anaplastic large cell lymphoma in adults."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      This lymphoma has a median age of 34 years, is more common in males, and is
+      in advanced stage at the time of diagnosis in most patients.
+    explanation: >-
+      This supports the typical younger age distribution and advanced-stage
+      presentation of systemic ALK-positive ALCL.
+- name: Systemic ALK-Negative
+  display_name: Systemic ALK-Negative Anaplastic Large Cell Lymphoma
+  description: >-
+    Systemic ALCL subtype lacking ALK rearrangement and showing marked genetic
+    heterogeneity, including DUSP22-rearranged, TP63-rearranged, and triple-negative
+    cases with different outcomes.
+  classification: molecular
+  subtype_term:
+    preferred_term: ALK-negative anaplastic large cell lymphoma
+    term:
+      id: MONDO:0017603
+      label: ALK-negative anaplastic large cell lymphoma
+  evidence:
+  - reference: PMID:24894770
+    reference_title: "ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous disease with widely disparate clinical outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thus, ALK-negative ALCL is a genetically heterogeneous disease with widely
+      disparate outcomes following standard therapy.
+    explanation: >-
+      This multicenter study supports modeling systemic ALK-negative ALCL as one
+      subtype with clinically important internal genetic heterogeneity.
+  - reference: PMID:24894770
+    reference_title: "ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous disease with widely disparate clinical outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Chromosomal rearrangements of DUSP22 and TP63 were identified in 30% and 8%
+      of ALK-negative ALCLs, respectively.
+    explanation: >-
+      This provides the core genomic subgrouping used inside the systemic
+      ALK-negative ALCL facet.
+- name: Primary Cutaneous
+  display_name: Primary Cutaneous Anaplastic Large Cell Lymphoma
+  description: >-
+    CD30-positive cutaneous ALCL caused by skin-homing malignant T cells. It
+    typically presents with solitary or multifocal ulcerative nodules and has a
+    more localized clinical program than systemic ALCL.
+  classification: anatomical_site
+  subtype_term:
+    preferred_term: primary cutaneous anaplastic large cell lymphoma
+    term:
+      id: MONDO:0017598
+      label: primary cutaneous anaplastic large cell lymphoma
+  evidence:
+  - reference: PMID:34382383
+    reference_title: "Whole-genome profiling of primary cutaneous anaplastic large cell lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Primary cutaneous anaplastic large cell lymphoma (pcALCL), a hematological
+      neoplasm caused by skin-homing CD30+ malignant T cells, is part of the spectrum
+      of primary cutaneous CD30+ lymphoproliferative disorders.
+    explanation: >-
+      This genomic study directly supports primary cutaneous ALCL as a skin-homing
+      CD30-positive malignant T-cell process.
+  - reference: PMID:24346900
+    reference_title: "Primary cutaneous anaplastic large-cell lymphoma--case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Primary cutaneous anaplastic large-cell lymphoma is part of the spectrum of
+      CD30+ lymphoproliferative cutaneous processes, characterized by single or
+      multifocal nodules that ulcerate, are autoregressive and recurrent.
+    explanation: >-
+      This case-based abstract supports the characteristic cutaneous clinical
+      presentation used for this subtype facet.
+- name: Breast Implant-Associated
+  display_name: Breast Implant-Associated Anaplastic Large Cell Lymphoma
+  description: >-
+    Exposure-associated ALCL subtype that arises in the capsule around textured
+    breast implants, usually as a delayed seroma and less commonly as a capsular
+    mass. Limited-stage seroma-confined disease is managed primarily with complete
+    surgery.
+  classification: exposure_associated
+  subtype_term:
+    preferred_term: breast implant-associated anaplastic large cell lymphoma
+    term:
+      id: MONDO:0850112
+      label: breast implant-associated anaplastic large cell lymphoma
+  evidence:
+  - reference: PMID:38102324
+    reference_title: "Surgical Management and Long-Term Outcomes of BIA-ALCL: A Multidisciplinary Approach."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Breast implant-associated anaplastic large cell lymphoma (BIA-ALCL) is a
+      subtype of ALCL that arises as a seroma or a mass in the capsule surrounding
+      textured breast implants.
+    explanation: >-
+      This cohort abstract directly defines breast implant-associated ALCL as a
+      capsule-based seroma or mass around textured implants.
+pathophysiology:
+- name: ALK Fusion Oncogene Formation
+  description: >-
+    Systemic ALK-positive ALCL is initiated by chromosomal rearrangements that
+    generate ALK fusion oncogenes, most commonly NPM1::ALK.
+  genes:
+  - preferred_term: ALK
+    term:
+      id: hgnc:427
+      label: ALK
+  - preferred_term: NPM1
+    term:
+      id: hgnc:7910
+      label: NPM1
+  subtypes:
+  - Systemic ALK-Positive
+  evidence:
+  - reference: PMID:29617304
+    reference_title: "The Pathological Spectrum of Systemic Anaplastic Large Cell Lymphoma (ALCL)."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      ALK is rearranged in approximately 80% of systemic ALCL cases with one of
+      its partner genes, most commonly NPM1
+    explanation: >-
+      This review supports ALK rearrangement, most often with NPM1, as the core
+      initiating lesion in systemic ALK-positive ALCL.
+  downstream:
+  - target: ALK-Driven STAT3 Activation
+    description: ALK fusion proteins signal constitutively to STAT3.
+- name: ALK-Driven STAT3 Activation
+  description: >-
+    Activated ALK constitutively phosphorylates and activates STAT3 in systemic
+    ALK-positive ALCL, establishing a central survival and growth program.
+  genes:
+  - preferred_term: ALK
+    term:
+      id: hgnc:427
+      label: ALK
+  - preferred_term: STAT3
+    term:
+      id: hgnc:11364
+      label: STAT3
+  biological_processes:
+  - preferred_term: cell surface receptor signaling pathway via JAK-STAT
+    modifier: INCREASED
+    term:
+      id: GO:0007259
+      label: cell surface receptor signaling pathway via JAK-STAT
+  - preferred_term: cell surface receptor protein tyrosine kinase signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0007169
+      label: cell surface receptor protein tyrosine kinase signaling pathway
+  subtypes:
+  - Systemic ALK-Positive
+  evidence:
+  - reference: PMID:11850821
+    reference_title: "Anaplastic lymphoma kinase (ALK) activates Stat3 and protects hematopoietic cells from cell death."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      We show here that expression of activated ALK induces the constitutive
+      phosphorylation of Stat3 in transfected cells as well as in primary human ALCLs.
+    explanation: >-
+      This mechanistic study directly supports constitutive STAT3 activation as
+      a consequence of activated ALK in ALCL.
+  - reference: PMID:40565334
+    reference_title: "Molecular Insights into the Diagnosis of Anaplastic Large Cell Lymphoma: Beyond Morphology and Immunophenotype."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      In ALK-positive ALCL, ALK fusion proteins drive oncogenesis via constitutive
+      activation of STAT3 and other signaling pathways.
+    explanation: >-
+      This review independently supports STAT3 as a central ALK-driven oncogenic
+      signaling hub in ALK-positive ALCL.
+  downstream:
+  - target: BCL2L1-Mediated Apoptosis Resistance
+    description: STAT3 activity sustains anti-apoptotic transcriptional output.
+  - target: PD-L1-Mediated Immune Evasion
+    description: STAT3 activity promotes checkpoint-ligand upregulation.
+- name: BCL2L1-Mediated Apoptosis Resistance
+  description: >-
+    ALK-positive ALCL uses STAT3-dependent BCL2L1 transcription to resist cell
+    death and support clonal outgrowth.
+  genes:
+  - preferred_term: BCL2L1
+    term:
+      id: hgnc:992
+      label: BCL2L1
+  biological_processes:
+  - preferred_term: apoptotic process
+    modifier: DECREASED
+    term:
+      id: GO:0006915
+      label: apoptotic process
+  subtypes:
+  - Systemic ALK-Positive
+  evidence:
+  - reference: PMID:11850821
+    reference_title: "Anaplastic lymphoma kinase (ALK) activates Stat3 and protects hematopoietic cells from cell death."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      These studies support a pathogenic mechanism whereby stimulation of
+      anti-apoptotic signals through activation of Stat3 contributes to the successful
+      outgrowth of ALK positive tumor cells.
+    explanation: >-
+      This directly supports a discrete apoptosis-resistance node downstream of
+      ALK-driven STAT3 activation.
+- name: PD-L1-Mediated Immune Evasion
+  description: >-
+    ALK-positive ALCL can upregulate PD-L1/CD274 through STAT3, adding an
+    immune-suppressive phenotype to the malignant T-cell program.
+  genes:
+  - preferred_term: CD274
+    term:
+      id: hgnc:17635
+      label: CD274
+  biological_processes:
+  - preferred_term: negative regulation of T cell mediated immunity
+    modifier: INCREASED
+    term:
+      id: GO:0002710
+      label: negative regulation of T cell mediated immunity
+  subtypes:
+  - Systemic ALK-Positive
+  evidence:
+  - reference: PMID:19088198
+    reference_title: "Oncogenic kinase NPM/ALK induces through STAT3 expression of immunosuppressive protein CD274 (PD-L1, B7-H1)."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      NPM/ALK induces CD274 expression by activating its key signal transmitter,
+      transcription factor STAT3.
+    explanation: >-
+      This directly supports PD-L1 upregulation as a STAT3-dependent immune-evasion
+      mechanism in ALK-positive ALCL cells.
+  - reference: PMID:24404580
+    reference_title: "The potent oncogene NPM-ALK mediates malignant transformation of normal human CD4(+) T lymphocytes."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      These unique features, which are strictly dependent on NPM-ALK activity and
+      expression, include perpetual cell growth, proliferation, and survival;
+      activation of the key signal transduction pathways STAT3 and mTORC1; and
+      expression of CD30 (the hallmark of anaplastic large-cell lymphoma) and of
+      immunosuppressive cytokine IL-10 and cell-surface protein PD-L1/CD274.
+    explanation: >-
+      This transformation model independently links NPM-ALK to PD-L1 expression
+      in a malignant ALCL-like T-cell state.
+- name: JAK/STAT3 Pathway Alteration in ALK-Negative ALCL
+  description: >-
+    Many ALK-negative ALCLs activate JAK/STAT signaling through JAK1 and/or
+    STAT3 mutations instead of ALK fusion signaling. Similar lesions are also
+    seen in breast implant-associated ALCL.
+  genes:
+  - preferred_term: JAK1
+    term:
+      id: hgnc:6190
+      label: JAK1
+  - preferred_term: STAT3
+    term:
+      id: hgnc:11364
+      label: STAT3
+  biological_processes:
+  - preferred_term: cell surface receptor signaling pathway via JAK-STAT
+    modifier: INCREASED
+    term:
+      id: GO:0007259
+      label: cell surface receptor signaling pathway via JAK-STAT
+  subtypes:
+  - Systemic ALK-Negative
+  - Breast Implant-Associated
+  evidence:
+  - reference: PMID:34572893
+    reference_title: "ALK-Negative Anaplastic Large Cell Lymphoma: Current Concepts and Molecular Pathogenesis of a Heterogeneous Group of Large T-Cell Lymphomas."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Additionally, systemic ALK- ALCL-apart from DUSP22-rearranged cases-harbors
+      JAK1 and/or STAT3 mutations that result in the activation of the JAK/STAT
+      signaling pathway. The JAK1/3 and STAT3 mutations have also been identified in
+      BIA-ALCL but not in pc-ALCL.
+    explanation: >-
+      This review directly supports subtype-scoped JAK/STAT pathway activation in
+      systemic ALK-negative and breast implant-associated ALCL.
+  - reference: PMID:40565334
+    reference_title: "Molecular Insights into the Diagnosis of Anaplastic Large Cell Lymphoma: Beyond Morphology and Immunophenotype."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      ALK-negative ALCL comprises heterogeneous genetic subtypes, in which JAK/STAT3
+      pathway alterations and novel gene fusions are gaining recognition as potential
+      therapeutic targets.
+    explanation: >-
+      This disease-level review supports JAK/STAT3 alteration as a mechanistically
+      important branch of ALK-negative ALCL biology.
+- name: PI3K-AKT and MAPK Signaling Upregulation in Primary Cutaneous ALCL
+  description: >-
+    Primary cutaneous ALCL shows recurrent genomic and transcriptomic changes
+    affecting PI3K/AKT, MAPK, and related signaling routes that can support
+    proliferation in skin-homing malignant T cells.
+  genes:
+  - preferred_term: PIK3R1
+    term:
+      id: hgnc:8979
+      label: PIK3R1
+  subtypes:
+  - Primary Cutaneous
+  evidence:
+  - reference: PMID:34382383
+    reference_title: "Whole-genome profiling of primary cutaneous anaplastic large cell lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Consistent with the genomic data, transcriptome analysis uncovered
+      upregulation of signal transduction routes associated with the PI-3-K, MAPK
+      and G-protein pathways (e.g., ERK, phospholipase C, AKT).
+    explanation: >-
+      This genomic and transcriptomic study supports a distinct signaling program
+      in primary cutaneous ALCL centered on PI3K/AKT and MAPK pathways.
+histopathology:
+- name: Hallmark Cell Morphology
+  finding_term:
+    preferred_term: Abnormal cell morphology
+    term:
+      id: HP:0025461
+      label: Abnormal cell morphology
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    Across ALCL subtypes, pleomorphic tumor cells with hallmark-cell morphology
+    are a key tissue-level feature used to recognize the disease family.
+  evidence:
+  - reference: PMID:28975123
+    reference_title: "Systemic and primary cutaneous anaplastic large cell lymphoma: Clinical features, morphological spectrum, and immunohistochemical profile."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histologically, all the subtypes showed pleomorphic and "hallmark" cells
+      with strong CD30 expression and variable loss of T-cell antigens.
+    explanation: >-
+      This abstract directly supports hallmark-cell morphology as a shared
+      histopathologic feature across ALCL subtypes.
+phenotypes:
+- category: Cutaneous
+  name: Ulcerating Skin Nodules
+  subtype: Primary Cutaneous
+  frequency: VERY_FREQUENT
+  description: >-
+    Primary cutaneous ALCL typically presents with solitary or multifocal skin
+    nodules that may ulcerate and recur.
+  phenotype_term:
+    preferred_term: Skin nodule
+    term:
+      id: HP:0200036
+      label: Skin nodule
+  evidence:
+  - reference: PMID:24346900
+    reference_title: "Primary cutaneous anaplastic large-cell lymphoma--case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Primary cutaneous anaplastic large-cell lymphoma is part of the spectrum of
+      CD30+ lymphoproliferative cutaneous processes, characterized by single or
+      multifocal nodules that ulcerate, are autoregressive and recurrent.
+    explanation: >-
+      This abstract directly supports ulcerating cutaneous nodules as the
+      defining clinical presentation of primary cutaneous ALCL.
+- category: Lymphatic
+  name: Regional Lymph Node Involvement
+  subtype: Primary Cutaneous
+  frequency: OCCASIONAL
+  description: >-
+    Primary cutaneous ALCL can disseminate to regional lymph nodes.
+  phenotype_term:
+    preferred_term: Lymphadenopathy
+    term:
+      id: HP:0002716
+      label: Lymphadenopathy
+  evidence:
+  - reference: PMID:24346900
+    reference_title: "Primary cutaneous anaplastic large-cell lymphoma--case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Extracutaneous dissemination may occur, especially to regional lymph nodes.
+    explanation: >-
+      This abstract supports regional lymph-node involvement as an occasional
+      extracutaneous phenotype of primary cutaneous ALCL.
+- category: Device-associated mass
+  name: Capsular Mass
+  subtype: Breast Implant-Associated
+  frequency: OCCASIONAL
+  description: >-
+    A minority of breast implant-associated ALCL cases present as a capsule-based
+    mass rather than isolated seroma.
+  phenotype_term:
+    preferred_term: Breast mass
+    term:
+      id: HP:0032408
+      label: Breast mass
+  evidence:
+  - reference: PMID:38102324
+    reference_title: "Surgical Management and Long-Term Outcomes of BIA-ALCL: A Multidisciplinary Approach."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients presented with clinically evident effusion in 78% of cases and a
+      mass in 17% of cases, and 83% of patients presented with stage 1 BIA-ALCL.
+    explanation: >-
+      This cohort quantifies the less-common mass-presenting phenotype in
+      breast implant-associated ALCL.
+biochemical:
+- name: CD30/TNFRSF8 Expression
+  biomarker_term:
+    preferred_term: Tumor Necrosis Factor Receptor Superfamily Member 8
+    term:
+      id: NCIT:C38906
+      label: Tumor Necrosis Factor Receptor Superfamily Member 8
+  presence: strong diffuse tumor-cell expression
+  frequency: VERY_FREQUENT
+  notes: >-
+    Strong CD30 expression is the shared biomarker that unifies ALCL as a disease
+    family and enables CD30-directed therapy.
+  evidence:
+  - reference: PMID:29617304
+    reference_title: "The Pathological Spectrum of Systemic Anaplastic Large Cell Lymphoma (ALCL)."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Anaplastic large cell lymphoma (ALCL) represents a group of malignant T-cell
+      lymphoproliferations that share morphological and immunophenotypical features,
+      namely strong CD30 expression and variable loss of T-cell markers
+    explanation: >-
+      This review supports strong CD30 expression as the defining biomarker of
+      the ALCL disease family.
+- name: ALK Fusion Protein Expression
+  subtype: Systemic ALK-Positive
+  biomarker_term:
+    preferred_term: ALK Fusion Protein Expression
+    term:
+      id: NCIT:C81946
+      label: ALK Fusion Protein Expression
+  presence: immunohistochemically detectable surrogate for ALK rearrangement
+  notes: >-
+    ALK immunohistochemistry is a practical surrogate for ALK rearrangement in
+    systemic ALK-positive ALCL.
+  evidence:
+  - reference: PMID:35941721
+    reference_title: "Immunohistochemical Approach to Genetic Subtyping of Anaplastic Large Cell Lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ALK immunohistochemistry is an excellent surrogate for ALK- R
+    explanation: >-
+      This pathology study directly supports ALK protein expression by
+      immunohistochemistry as the biomarker surrogate for ALK-rearranged ALCL.
+genetic:
+- name: ALK Rearrangement
+  subtype: Systemic ALK-Positive
+  association: Defining Rearrangement
+  gene_term:
+    preferred_term: ALK
+    term:
+      id: hgnc:427
+      label: ALK
+  notes: >-
+    ALK rearrangement defines systemic ALK-positive ALCL and creates an oncogenic
+    tyrosine kinase program.
+  evidence:
+  - reference: PMID:29617304
+    reference_title: "The Pathological Spectrum of Systemic Anaplastic Large Cell Lymphoma (ALCL)."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      ALK is rearranged in approximately 80% of systemic ALCL cases with one of
+      its partner genes, most commonly NPM1
+    explanation: >-
+      This review directly supports ALK rearrangement as the defining genetic
+      event of systemic ALK-positive ALCL.
+- name: DUSP22 Rearrangement
+  subtype: Systemic ALK-Negative
+  association: Molecular Subgroup
+  gene_term:
+    preferred_term: DUSP22
+    term:
+      id: hgnc:16077
+      label: DUSP22
+  notes: >-
+    DUSP22 rearrangement identifies a major molecular subgroup within systemic
+    ALK-negative ALCL.
+  evidence:
+  - reference: PMID:24894770
+    reference_title: "ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous disease with widely disparate clinical outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Chromosomal rearrangements of DUSP22 and TP63 were identified in 30% and 8%
+      of ALK-negative ALCLs, respectively.
+    explanation: >-
+      This study directly supports DUSP22 rearrangement as a recurrent molecular
+      subgroup within systemic ALK-negative ALCL.
+- name: TP63 Rearrangement
+  subtype: Systemic ALK-Negative
+  association: Molecular Subgroup
+  gene_term:
+    preferred_term: TP63
+    term:
+      id: hgnc:15979
+      label: TP63
+  notes: >-
+    TP63 rearrangement defines a smaller systemic ALK-negative ALCL subgroup
+    with poor outcomes under standard therapy.
+  evidence:
+  - reference: PMID:24894770
+    reference_title: "ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous disease with widely disparate clinical outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Chromosomal rearrangements of DUSP22 and TP63 were identified in 30% and 8%
+      of ALK-negative ALCLs, respectively.
+    explanation: >-
+      This study directly supports TP63 rearrangement as a recurrent molecular
+      subgroup within systemic ALK-negative ALCL.
+- name: JAK1 Mutation
+  subtype: Systemic ALK-Negative
+  association: JAK/STAT Pathway Activation
+  gene_term:
+    preferred_term: JAK1
+    term:
+      id: hgnc:6190
+      label: JAK1
+  notes: >-
+    JAK1 mutation is one route to constitutive JAK/STAT signaling in systemic
+    ALK-negative ALCL.
+  evidence:
+  - reference: PMID:34572893
+    reference_title: "ALK-Negative Anaplastic Large Cell Lymphoma: Current Concepts and Molecular Pathogenesis of a Heterogeneous Group of Large T-Cell Lymphomas."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Additionally, systemic ALK- ALCL-apart from DUSP22-rearranged cases-harbors
+      JAK1 and/or STAT3 mutations that result in the activation of the JAK/STAT
+      signaling pathway.
+    explanation: >-
+      This review supports JAK1 mutation as a recurrent route to JAK/STAT pathway
+      activation in systemic ALK-negative ALCL.
+- name: STAT3 Mutation
+  subtype: Systemic ALK-Negative
+  association: JAK/STAT Pathway Activation
+  gene_term:
+    preferred_term: STAT3
+    term:
+      id: hgnc:11364
+      label: STAT3
+  notes: >-
+    STAT3 mutation is another recurrent route to constitutive JAK/STAT signaling
+    in systemic ALK-negative ALCL.
+  evidence:
+  - reference: PMID:34572893
+    reference_title: "ALK-Negative Anaplastic Large Cell Lymphoma: Current Concepts and Molecular Pathogenesis of a Heterogeneous Group of Large T-Cell Lymphomas."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Additionally, systemic ALK- ALCL-apart from DUSP22-rearranged cases-harbors
+      JAK1 and/or STAT3 mutations that result in the activation of the JAK/STAT
+      signaling pathway.
+    explanation: >-
+      This review supports STAT3 mutation as a recurrent route to JAK/STAT pathway
+      activation in systemic ALK-negative ALCL.
+diagnosis:
+- name: Tissue diagnosis with morphology and immunohistochemistry
+  description: >-
+    Diagnosis relies on recognizing hallmark-cell morphology and confirming the
+    ALCL immunophenotype with immunohistochemistry, including CD30 in the initial
+    panel.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  markers: CD30, ALK, CD2, CD3, CD5, CD20, PAX5, CD15
+  evidence:
+  - reference: PMID:28975123
+    reference_title: "Systemic and primary cutaneous anaplastic large cell lymphoma: Clinical features, morphological spectrum, and immunohistochemical profile."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Diagnosis of ALCL is based on recognizing the key morphological features,
+      especially the presence of "hallmark" cells. IHC is essential for confirmation
+      of diagnosis and excluding other malignancies with anaplastic morphology. The
+      inclusion of CD30 in the initial IHC panel will help identify LCA negative cases
+      and avoid misdiagnosis.
+    explanation: >-
+      This abstract directly supports morphology-plus-IHC as the core diagnostic
+      workflow for ALCL.
+- name: Molecular genetic subtyping
+  description: >-
+    Genetic subtyping uses ALK immunohistochemistry plus targeted ancillary
+    testing to sort ALCL into ALK-rearranged, TP63-rearranged, DUSP22-rearranged,
+    and related groups.
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+  markers: ALK, DUSP22, TP63, LEF1, TIA1, phospho-STAT3 Y705, p63
+  evidence:
+  - reference: PMID:35941721
+    reference_title: "Immunohistochemical Approach to Genetic Subtyping of Anaplastic Large Cell Lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Together with previous data, these findings support a 4-marker
+      immunohistochemistry algorithm using ALK, LEF1, TIA1, and p63 for genetic
+      subtyping of ALCL.
+    explanation: >-
+      This study directly supports ancillary testing for molecular subgrouping
+      within the unified ALCL disease page.
+treatments:
+- name: Anthracycline-Based Combination Chemotherapy
+  description: >-
+    Anthracycline-containing multiagent chemotherapy remains a core systemic
+    treatment backbone for ALK-positive systemic ALCL.
+  context: Systemic ALK-Positive disease
+  treatment_term:
+    preferred_term: cancer chemotherapy
+    term:
+      id: MAXO:0000646
+      label: cancer chemotherapy
+    therapeutic_agent:
+    - preferred_term: cyclophosphamide
+      term:
+        id: CHEBI:4027
+        label: cyclophosphamide
+    - preferred_term: doxorubicin
+      term:
+        id: CHEBI:28748
+        label: doxorubicin
+    - preferred_term: vincristine
+      term:
+        id: CHEBI:28445
+        label: vincristine
+    - preferred_term: prednisone
+      term:
+        id: CHEBI:8382
+        label: prednisone
+  evidence:
+  - reference: PMID:29279550
+    reference_title: "Anaplastic large cell lymphoma: pathology, genetics, and clinical aspects."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Patients with ALK-positive ALCL are usually treated with anthracycline-based
+      regimens, such as combination cyclophosphamide, doxorubicin, vincristine, and
+      prednisolone (CHOP) or CHOEP (CHOP plus etoposide)
+    explanation: >-
+      This review supports anthracycline-based multiagent chemotherapy as a core
+      systemic treatment backbone in ALK-positive ALCL.
+- name: Brentuximab Vedotin Plus CHP
+  description: >-
+    Frontline brentuximab vedotin plus CHP improved progression-free and overall
+    survival over CHOP in previously untreated systemic ALCL and other CD30-positive
+    PTCL.
+  context: Previously untreated systemic ALCL
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: brentuximab vedotin
+      term:
+        id: NCIT:C66944
+        label: Brentuximab Vedotin
+  evidence:
+  - reference: PMID:30914464
+    reference_title: "FDA Approval Summary: Brentuximab Vedotin in First-Line Treatment of Peripheral T-Cell Lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In November 2018, the U.S. Food and Drug Administration (FDA) approved
+      brentuximab vedotin (BV) for the treatment of adult patients with previously
+      untreated systemic anaplastic large cell lymphoma
+    explanation: >-
+      This FDA summary directly supports brentuximab vedotin plus CHP as a
+      frontline systemic ALCL regimen.
+  - reference: PMID:30914464
+    reference_title: "FDA Approval Summary: Brentuximab Vedotin in First-Line Treatment of Peripheral T-Cell Lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median PFS was 48.2 months with BV+CHP versus 20.8 months with CHOP,
+      resulting in a hazard ratio (HR) of 0.71
+    explanation: >-
+      This directly supports superior frontline disease control with BV+CHP over
+      CHOP in the ECHELON-2 approval-setting trial.
+- name: Single-Agent Brentuximab Vedotin
+  description: >-
+    In relapsed or refractory systemic ALCL, single-agent brentuximab vedotin
+    can produce durable complete remissions in a subset of patients.
+  context: Relapsed or refractory systemic ALCL
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: brentuximab vedotin
+      term:
+        id: NCIT:C66944
+        label: Brentuximab Vedotin
+  evidence:
+  - reference: PMID:28974506
+    reference_title: "Five-year results of brentuximab vedotin in patients with relapsed or refractory systemic anaplastic large cell lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These final results, which demonstrated a high rate of peripheral neuropathy
+      resolution, and durable remissions in a subset of patients with relapsed or
+      refractory systemic ALCL, provide evidence that single-agent brentuximab
+      vedotin may be a potentially curative treatment option.
+    explanation: >-
+      This phase 2 follow-up study directly supports durable disease control with
+      single-agent brentuximab vedotin in relapsed or refractory systemic ALCL.
+- name: Crizotinib
+  description: >-
+    ALK inhibition with crizotinib has meaningful activity in relapsed or
+    refractory systemic ALK-positive ALCL.
+  context: Relapsed or refractory systemic ALK-Positive disease
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: crizotinib
+      term:
+        id: CHEBI:64310
+        label: crizotinib
+  evidence:
+  - reference: PMID:37549532
+    reference_title: "Efficacy and safety of crizotinib in ALK-positive systemic anaplastic large-cell lymphoma in children, adolescents, and adult patients: results of the French AcSé-crizotinib trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSION: Crizotinib shows efficacy and an acceptable safety profile in
+      ALK+ ALCL relapsed/refractory patients.
+    explanation: >-
+      This phase 2 study directly supports crizotinib as an active targeted agent
+      in relapsed or refractory ALK-positive systemic ALCL.
+- name: Radiation Therapy
+  description: >-
+    Localized primary cutaneous ALCL can be treated with skin-directed radiation
+    therapy.
+  context: Localized primary cutaneous disease
+  treatment_term:
+    preferred_term: radiation therapy
+    term:
+      id: MAXO:0000014
+      label: radiation therapy
+  evidence:
+  - reference: PMID:24346900
+    reference_title: "Primary cutaneous anaplastic large-cell lymphoma--case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiotherapy, removal of the lesion and/or low-dose methotrexate are the
+      treatments of choice.
+    explanation: >-
+      This abstract directly supports radiation therapy as a standard local
+      treatment option in primary cutaneous ALCL.
+- name: Complete Surgical Excision with Implant Removal
+  description: >-
+    Breast implant-associated ALCL is primarily managed with complete surgical
+    excision, including total capsulectomy and implant removal.
+  context: Breast Implant-Associated disease
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  evidence:
+  - reference: PMID:26628470
+    reference_title: "Complete Surgical Excision Is Essential for the Management of Patients With Breast Implant-Associated Anaplastic Large-Cell Lymphoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients who underwent a complete surgical excision that consisted of total
+      capsulectomy with breast implant removal had better OS (P = .022) and EFS
+      (P = .014)
+    explanation: >-
+      This multi-institutional cohort directly supports complete capsulectomy
+      with implant removal as the key treatment for breast implant-associated ALCL.

--- a/references_cache/PMID_11850821.md
+++ b/references_cache/PMID_11850821.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:11850821"
+title: Anaplastic lymphoma kinase (ALK) activates Stat3 and protects hematopoietic cells from cell death.
+authors:
+- Zamo A
+- Chiarle R
+- Piva R
+- Howes J
+- Fan Y
+- Chilosi M
+- Levy DE
+- Inghirami G
+journal: Oncogene
+year: '2002'
+doi: 10.1038/sj.onc.1205152
+keywords:
+- Anaplastic Lymphoma Kinase
+- Animals
+- Apoptosis
+- Cell Line
+- "DNA-Binding Proteins/immunology, metabolism"
+- "Hematopoietic Stem Cells/enzymology, metabolism"
+- Humans
+- Immunohistochemistry
+- Janus Kinase 3
+- "Lymphoma, Large-Cell, Anaplastic/enzymology, metabolism, pathology"
+- Phosphorylation
+- "Protein-Tyrosine Kinases/analysis, immunology, metabolism, physiology"
+- Proto-Oncogene Proteins c-bcl-2/biosynthesis
+- Proto-Oncogene Proteins pp60(c-src)/physiology
+- Receptor Protein-Tyrosine Kinases
+- STAT3 Transcription Factor
+- "Trans-Activators/immunology, metabolism"
+- "Tumor Cells, Cultured"
+- Up-Regulation
+- bcl-X Protein
+content_type: abstract_only
+---
+
+# Anaplastic lymphoma kinase (ALK) activates Stat3 and protects hematopoietic cells from cell death.
+**Authors:** Zamo A, Chiarle R, Piva R, Howes J, Fan Y, Chilosi M, Levy DE, Inghirami G
+**Journal:** Oncogene (2002)
+**DOI:** [10.1038/sj.onc.1205152](https://doi.org/10.1038/sj.onc.1205152)
+
+## Content
+
+1. Oncogene. 2002 Feb 7;21(7):1038-47. doi: 10.1038/sj.onc.1205152.
+
+Anaplastic lymphoma kinase (ALK) activates Stat3 and protects hematopoietic
+cells from cell death.
+
+Zamo A(1), Chiarle R, Piva R, Howes J, Fan Y, Chilosi M, Levy DE, Inghirami G.
+
+Author information:
+(1)Department of Pathology and Kaplan Comprehensive Cancer Center, New York
+University School of Medicine, 550 First Avenue, New York, NY 10016, USA.
+
+The anaplastic lymphoma kinase (ALK) gene is characteristically translocated in
+Anaplastic Large Cell Lymphomas (ALCL) and the juxtaposition of the ALK gene to
+multiple partners results in its constitutive protein tyrosine kinase activity.
+We show here that expression of activated ALK induces the constitutive
+phosphorylation of Stat3 in transfected cells as well as in primary human ALCLs.
+Furthermore, immunohistochemical studies demonstrate that among distinct human B
+and T cell lymphomas, activation of Stat3 nuclear translocation is uniquely
+associated with ALK expression. NPM-ALK also binds and activates Jak3; however,
+Jak3 is not required for Stat3 activation or for cell transformation in vitro.
+Moreover, src family kinases are not necessary for NPM-ALK-mediated Stat3
+activation or transformation, suggesting that Stat3 may be phosphorylated
+directly by ALK. To evaluate relevant targets of ALK-activated Stat3, we
+investigated the regulation of the anti-apoptotic protein Bcl-x(L) and its role
+in cell survival in NPM-ALK positive cells. NPM-ALK expression caused enhanced
+Bcl-x(L) transcription, largely mediated by Stat3. Increased expression of
+Bcl-x(L) provided sufficient anti-apoptotic signals to protect cells from
+treatment with specific inhibitors of the Jaks/Stat pathway or the Brc-Abl
+kinase. These studies support a pathogenic mechanism whereby stimulation of
+anti-apoptotic signals through activation of Stat3 contributes to the successful
+outgrowth of ALK positive tumor cells.
+
+DOI: 10.1038/sj.onc.1205152
+PMID: 11850821 [Indexed for MEDLINE]

--- a/references_cache/PMID_19088198.md
+++ b/references_cache/PMID_19088198.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:19088198"
+title: "Oncogenic kinase NPM/ALK induces through STAT3 expression of immunosuppressive protein CD274 (PD-L1, B7-H1)."
+authors:
+- Marzec M
+- Zhang Q
+- Goradia A
+- Raghunath PN
+- Liu X
+- Paessler M
+- Wang HY
+- Wysocka M
+- Cheng M
+- Ruggeri BA
+- Wasik MA
+journal: Proc Natl Acad Sci U S A
+year: '2008'
+doi: 10.1073/pnas.0810958105
+keywords:
+- "Antigens, CD/biosynthesis, genetics"
+- B7-H1 Antigen
+- "Cell Line, Tumor"
+- Cell Proliferation/drug effects
+- "Cell Survival/drug effects, genetics"
+- Enzyme Inhibitors/pharmacology
+- "Gene Expression Regulation, Leukemic/drug effects, genetics"
+- Humans
+- "Lymphoma, T-Cell/genetics, metabolism"
+- "Oncogene Proteins, Fusion/antagonists & inhibitors, genetics, metabolism"
+- "Protein-Tyrosine Kinases/antagonists & inhibitors, genetics, metabolism"
+- "RNA, Small Interfering/genetics"
+- "STAT3 Transcription Factor/biosynthesis, genetics"
+content_type: abstract_only
+---
+
+# Oncogenic kinase NPM/ALK induces through STAT3 expression of immunosuppressive protein CD274 (PD-L1, B7-H1).
+**Authors:** Marzec M, Zhang Q, Goradia A, Raghunath PN, Liu X, Paessler M, Wang HY, Wysocka M, Cheng M, Ruggeri BA, Wasik MA
+**Journal:** Proc Natl Acad Sci U S A (2008)
+**DOI:** [10.1073/pnas.0810958105](https://doi.org/10.1073/pnas.0810958105)
+
+## Content
+
+1. Proc Natl Acad Sci U S A. 2008 Dec 30;105(52):20852-7. doi:
+10.1073/pnas.0810958105. Epub 2008 Dec 16.
+
+Oncogenic kinase NPM/ALK induces through STAT3 expression of immunosuppressive
+protein CD274 (PD-L1, B7-H1).
+
+Marzec M(1), Zhang Q, Goradia A, Raghunath PN, Liu X, Paessler M, Wang HY,
+Wysocka M, Cheng M, Ruggeri BA, Wasik MA.
+
+Author information:
+(1)Department of Pathology and Laboratory Medicine, University of Pennsylvania,
+Philadelphia, PA 19104, USA.
+
+The mechanisms of malignant cell transformation caused by the oncogenic,
+chimeric nucleophosmin (NPM)/anaplastic lymphoma kinase (ALK) remain only
+partially understood, with most of the previous studies focusing mainly on the
+impact of NPM/ALK on cell survival and proliferation. Here we report that the
+NPM/ALK-carrying T cell lymphoma (ALK+TCL) cells strongly express the
+immunosuppressive cell-surface protein CD274 (PD-L1, B7-H1), as determined on
+the mRNA and protein level. The CD274 expression is strictly dependent on the
+expression and enzymatic activity of NPM/ALK, as demonstrated by inhibition of
+the NPM/ALK function in ALK+TCL cells by the small molecule ALK inhibitor
+CEP-14083 and by documenting CD274 expression in IL-3-depleted BaF3 cells
+transfected with the wild-type NPM/ALK, but not the kinase-inactive NPM/ALK
+K210R mutant or empty vector alone. NPM/ALK induces CD274 expression by
+activating its key signal transmitter, transcription factor STAT3. STAT3 binds
+to the CD274 gene promoter in vitro and in vivo, as shown in the gel
+electromobility shift and chromatin immunoprecipitation assays, and is required
+for the PD-L1 gene expression, as demonstrated by siRNA-mediated STAT3
+depletion. These findings identify an additional cell-transforming property of
+NPM/ALK and describe a direct link between an oncoprotein and an
+immunosuppressive cell-surface protein. These results also provide an additional
+rationale to therapeutically target NPM/ALK and STAT3 in ALK+TCL. Finally, they
+suggest that future immunotherapeutic protocols for this type of lymphoma may
+need to include the inhibition of NPM/ALK and STAT3 to achieve optimal clinical
+efficacy.
+
+DOI: 10.1073/pnas.0810958105
+PMCID: PMC2634900
+PMID: 19088198 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_24346900.md
+++ b/references_cache/PMID_24346900.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:24346900"
+title: Primary cutaneous anaplastic large-cell lymphoma--case report.
+authors:
+- Oliveira LS
+- Nobrega MP
+- Monteiro MG
+- Almeida WL
+journal: An Bras Dermatol
+year: '2013'
+doi: 10.1590/abd1806-4841.20131731
+keywords:
+- Biopsy
+- Dermatologic Agents/therapeutic use
+- Female
+- Humans
+- Immunohistochemistry
+- Lung Neoplasms/diagnostic imaging
+- "Lymphoma, Primary Cutaneous Anaplastic Large Cell/drug therapy, pathology"
+- Methotrexate/therapeutic use
+- Middle Aged
+- Radiography
+- Skin/pathology
+- "Skin Neoplasms/drug therapy, pathology"
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Primary cutaneous anaplastic large-cell lymphoma--case report.
+**Authors:** Oliveira LS, Nobrega MP, Monteiro MG, Almeida WL
+**Journal:** An Bras Dermatol (2013)
+**DOI:** [10.1590/abd1806-4841.20131731](https://doi.org/10.1590/abd1806-4841.20131731)
+
+## Content
+
+1. An Bras Dermatol. 2013 Nov-Dec;88(6 Suppl 1):132-5. doi:
+10.1590/abd1806-4841.20131731.
+
+Primary cutaneous anaplastic large-cell lymphoma--case report.
+
+Oliveira LS(1), Nobrega MP(2), Monteiro MG(3), Almeida WL(4).
+
+Author information:
+(1)Federal University of Campina Grande, Campina GrandePB, Brazil.
+(2)Center for Endocrinology and Metabolism, Campina GrandePB, Brazil.
+(3)Federal University of Campina Grande, University Hospital Alcides Carneiro,
+Campina GrandePB, Brazil.
+(4)Campinense Unit of Diagnosis, Campina GrandePB, Brazil.
+
+Primary cutaneous anaplastic large-cell lymphoma is part of the spectrum of
+CD30+ lymphoproliferative cutaneous processes, characterized by single or
+multifocal nodules that ulcerate, are autoregressive and recurrent.
+Extracutaneous dissemination may occur, especially to regional lymph nodes.
+Histology shows a diffuse, non-epidermotropic infiltrate , anaplastic large
+lymphoid cells of immunohistochemistry CD30+, CD4+, EMA-/+, ALK-, CD15- and
+TIA1-/+. Prognosis is good and does not depend on lymphatic invasion.
+Radiotherapy, removal of the lesion and/or low-dose methotrexate are the
+treatments of choice. The present study reports the case of a 57-year-old-woman
+presenting Primary cutaneous anaplastic large-cell lymphoma with multifocal
+lesions. The patient evolved with pulmonary involvement 7 years later. She
+showed a good response to the treatment with low-dose methotrexate prescribed
+weekly.
+
+Linfoma cutâneo primário de grandes células T anaplásicas faz parte do espectro
+de processos linfoproliferativos cutâneos CD30+ e caracteriza-se por nódulos
+únicos ou multifocais, ulcerados, autorregressivos e recidivantes. Pode haver
+disseminação extracutânea, principalmente para linfonodos regionais. O
+histológico mostra infiltrado difuso, não-epidermotrópico, grandes células
+linfóides anaplásicas de imunohistoquímica CD30+, CD4+, EMA-/+, ALK-, CD15- e
+TIA1-/+. O prognóstico é bom e independe da invasão ganglionar. Radioterapia,
+retirada da lesão e/ou metotrexato em baixas doses são os tratamentos de
+escolha. Este estudo relata o caso de uma mulher, 57 anos, com Linfoma cutâneo
+primário de grandes células T com lesões multifocais e que, após 7 anos, evoluiu
+com acometimento pulmonar. Apresentou boa resposta ao tratamento com metotrexato
+em baixas doses semanais.
+
+DOI: 10.1590/abd1806-4841.20131731
+PMCID: PMC3875977
+PMID: 24346900 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of interest: None

--- a/references_cache/PMID_24404580.md
+++ b/references_cache/PMID_24404580.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:24404580"
+title: The potent oncogene NPM-ALK mediates malignant transformation of normal human CD4(+) T lymphocytes.
+authors:
+- Zhang Q
+- Wei F
+- Wang HY
+- Liu X
+- Roy D
+- Xiong QB
+- Jiang S
+- Medvec A
+- Danet-Desnoyers G
+- Watt C
+- Tomczak E
+- Kalos M
+- Riley JL
+- Wasik MA
+journal: Am J Pathol
+year: '2013'
+doi: 10.1016/j.ajpath.2013.08.030
+keywords:
+- Animals
+- "CD4-Positive T-Lymphocytes/metabolism, pathology"
+- "Cell Transformation, Neoplastic/genetics, metabolism, pathology"
+- Female
+- "Gene Expression Regulation, Neoplastic/genetics"
+- Humans
+- "Lymphoma, Large B-Cell, Diffuse/genetics, metabolism, pathology"
+- Male
+- Mice
+- "Oncogene Proteins, Fusion/biosynthesis, genetics"
+- "Protein-Tyrosine Kinases/biosynthesis, genetics"
+- Signal Transduction/genetics
+content_type: abstract_only
+---
+
+# The potent oncogene NPM-ALK mediates malignant transformation of normal human CD4(+) T lymphocytes.
+**Authors:** Zhang Q, Wei F, Wang HY, Liu X, Roy D, Xiong QB, Jiang S, Medvec A, Danet-Desnoyers G, Watt C, Tomczak E, Kalos M, Riley JL, Wasik MA
+**Journal:** Am J Pathol (2013)
+**DOI:** [10.1016/j.ajpath.2013.08.030](https://doi.org/10.1016/j.ajpath.2013.08.030)
+
+## Content
+
+1. Am J Pathol. 2013 Dec;183(6):1971-80. doi: 10.1016/j.ajpath.2013.08.030.
+
+The potent oncogene NPM-ALK mediates malignant transformation of normal human
+CD4(+) T lymphocytes.
+
+Zhang Q, Wei F, Wang HY, Liu X, Roy D, Xiong QB, Jiang S, Medvec A,
+Danet-Desnoyers G, Watt C, Tomczak E, Kalos M, Riley JL, Wasik MA.
+
+With this study we have demonstrated that in vitro transduction of normal human
+CD4(+) T lymphocytes with NPM-ALK results in their malignant transformation. The
+transformed cells become immortalized and display morphology and immunophenotype
+characteristic of patient-derived anaplastic large-cell lymphomas. These unique
+features, which are strictly dependent on NPM-ALK activity and expression,
+include perpetual cell growth, proliferation, and survival; activation of the
+key signal transduction pathways STAT3 and mTORC1; and expression of CD30 (the
+hallmark of anaplastic large-cell lymphoma) and of immunosuppressive cytokine
+IL-10 and cell-surface protein PD-L1/CD274. Implantation of NPM-ALK-transformed
+CD4(+) T lymphocytes into immunodeficient mice resulted in formation of tumors
+indistinguishable from patients' anaplastic large-cell lymphomas. Our findings
+demonstrate that the key aspects of human carcinogenesis closely recapitulating
+the features of the native tumors can be faithfully reproduced in vitro when an
+appropriate oncogene is used to transform its natural target cells; this in turn
+points to the fundamental role in malignant cell transformation of potent
+oncogenes expressed in the relevant target cells. Such transformed cells should
+permit study of the early stages of carcinogenesis, and in particular the
+initial oncogene-host cell interactions. This experimental design could also be
+useful for studies of the effects of early therapeutic intervention and likely
+also the mechanisms of malignant progression.
+
+DOI: 10.1016/j.ajpath.2013.08.030
+PMCID: PMC5745542
+PMID: 24404580 [Indexed for MEDLINE]

--- a/references_cache/PMID_24894770.md
+++ b/references_cache/PMID_24894770.md
@@ -1,0 +1,129 @@
+---
+reference_id: "PMID:24894770"
+title: ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous disease with widely disparate clinical outcomes.
+authors:
+- Parrilla Castellar ER
+- Jaffe ES
+- Said JW
+- Swerdlow SH
+- Ketterling RP
+- Knudson RA
+- Sidhu JS
+- Hsi ED
+- Karikehalli S
+- Jiang L
+- Vasmatzis G
+- Gibson SE
+- Ondrejka S
+- Nicolae A
+- Grogg KL
+- Allmer C
+- Ristow KM
+- Wilson WH
+- Macon WR
+- Law ME
+- Cerhan JR
+- Habermann TM
+- Ansell SM
+- Dogan A
+- Maurer MJ
+- Feldman AL
+journal: Blood
+year: '2014'
+doi: 10.1182/blood-2014-04-571091
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Anaplastic Lymphoma Kinase
+- "Biomarkers, Tumor/genetics, metabolism"
+- Child
+- Dual-Specificity Phosphatases/genetics
+- Female
+- Gene Rearrangement
+- Humans
+- Immunohistochemistry
+- "In Situ Hybridization, Fluorescence"
+- Interferon Regulatory Factors/genetics
+- Kaplan-Meier Estimate
+- "Lymphoma, Large-Cell, Anaplastic/genetics, metabolism, pathology"
+- Male
+- Middle Aged
+- Mitogen-Activated Protein Kinase Phosphatases/genetics
+- Prognosis
+- "Receptor Protein-Tyrosine Kinases/genetics, metabolism"
+- Transcription Factors/genetics
+- Tumor Suppressor Proteins/genetics
+- Young Adult
+- Interferon Regulatory Factor-4
+content_type: abstract_only
+---
+
+# ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous disease with widely disparate clinical outcomes.
+**Authors:** Parrilla Castellar ER, Jaffe ES, Said JW, Swerdlow SH, Ketterling RP, Knudson RA, Sidhu JS, Hsi ED, Karikehalli S, Jiang L, Vasmatzis G, Gibson SE, Ondrejka S, Nicolae A, Grogg KL, Allmer C, Ristow KM, Wilson WH, Macon WR, Law ME, Cerhan JR, Habermann TM, Ansell SM, Dogan A, Maurer MJ, Feldman AL
+**Journal:** Blood (2014)
+**DOI:** [10.1182/blood-2014-04-571091](https://doi.org/10.1182/blood-2014-04-571091)
+
+## Content
+
+1. Blood. 2014 Aug 28;124(9):1473-80. doi: 10.1182/blood-2014-04-571091. Epub
+2014  Jun 3.
+
+ALK-negative anaplastic large cell lymphoma is a genetically heterogeneous
+disease with widely disparate clinical outcomes.
+
+Parrilla Castellar ER(1), Jaffe ES(2), Said JW(3), Swerdlow SH(4), Ketterling
+RP(1), Knudson RA(1), Sidhu JS(5), Hsi ED(6), Karikehalli S(7), Jiang L(8),
+Vasmatzis G(9), Gibson SE(4), Ondrejka S(6), Nicolae A(2), Grogg KL(1), Allmer
+C(10), Ristow KM(11), Wilson WH(12), Macon WR(1), Law ME(1), Cerhan JR(10),
+Habermann TM(11), Ansell SM(11), Dogan A(1), Maurer MJ(10), Feldman AL(1).
+
+Author information:
+(1)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN;
+(2)Hematopathology Section, Laboratory of Pathology, National Cancer Institute,
+Bethesda, MD;
+(3)Department of Pathology, David Geffen School of Medicine, University of
+California, Los Angeles, CA;
+(4)Division of Hematopathology, University of Pittsburgh Medical Center,
+Pittsburgh, PA;
+(5)Department of Pathology and Laboratory Medicine, United Health Services
+Hospitals, Johnson City/Binghamton, NY;
+(6)Department of Clinical Pathology, Cleveland Clinic, Cleveland, OH;
+(7)Department of Pathology and Laboratory Medicine, Centrex Clinical
+Laboratories, Utica, NY;
+(8)Department of Laboratory Medicine and Pathology, Mayo Clinic, Jacksonville,
+FL;
+(9)Center for Individualized Medicine.
+(10)Department of Health Sciences Research, and.
+(11)Division of Hematology, Mayo Clinic, Rochester, MN; and.
+(12)Lymphoid Malignancies Branch, Center for Cancer Research, National Cancer
+Institute, Bethesda, MD.
+
+Comment in
+    Blood. 2014 Aug 28;124(9):1385-6. doi: 10.1182/blood-2014-06-581694.
+
+Anaplastic lymphoma kinase (ALK)-negative anaplastic large cell lymphoma (ALCL)
+is a CD30-positive T-cell non-Hodgkin lymphoma that morphologically resembles
+ALK-positive ALCL but lacks chromosomal rearrangements of the ALK gene. The
+genetic and clinical heterogeneity of ALK-negative ALCL has not been delineated.
+We performed immunohistochemistry and fluorescence in situ hybridization on 73
+ALK-negative ALCLs and 32 ALK-positive ALCLs and evaluated the associations
+among pathology, genetics, and clinical outcome. Chromosomal rearrangements of
+DUSP22 and TP63 were identified in 30% and 8% of ALK-negative ALCLs,
+respectively. These rearrangements were mutually exclusive and were absent in
+ALK-positive ALCLs. Five-year overall survival rates were 85% for ALK-positive
+ALCLs, 90% for DUSP22-rearranged ALCLs, 17% for TP63-rearranged ALCLs, and 42%
+for cases lacking all 3 genetic markers (P < .0001). Hazard ratios for death in
+these 4 groups after adjusting for International Prognostic Index and age were
+1.0 (reference group), 0.58, 8.63, and 4.16, respectively (P = 7.10 × 10(-5)).
+These results were similar when restricted to patients receiving
+anthracycline-based chemotherapy, as well as to patients not receiving stem cell
+transplantation. Thus, ALK-negative ALCL is a genetically heterogeneous disease
+with widely disparate outcomes following standard therapy. DUSP22 and TP63
+rearrangements may serve as predictive biomarkers to help guide patient
+management.
+
+DOI: 10.1182/blood-2014-04-571091
+PMCID: PMC4148769
+PMID: 24894770 [Indexed for MEDLINE]

--- a/references_cache/PMID_26628470.md
+++ b/references_cache/PMID_26628470.md
@@ -1,0 +1,150 @@
+---
+reference_id: "PMID:26628470"
+title: Complete Surgical Excision Is Essential for the Management of Patients With Breast Implant-Associated Anaplastic Large-Cell Lymphoma.
+authors:
+- Clemens MW
+- Medeiros LJ
+- Butler CE
+- Hunt KK
+- Fanale MA
+- Horwitz S
+- Weisenburger DD
+- Liu J
+- Morgan EA
+- Kanagal-Shamanna R
+- Parkash V
+- Ning J
+- Sohani AR
+- Ferry JA
+- Mehta-Shah N
+- Dogan A
+- Liu H
+- Thormann N
+- Di Napoli A
+- Lade S
+- Piccolini J
+- Reyes R
+- Williams T
+- McCarthy CM
+- Hanson SE
+- Nastoupil LJ
+- Gaur R
+- Oki Y
+- Young KH
+- Miranda RN
+journal: J Clin Oncol
+year: '2016'
+doi: 10.1200/JCO.2015.63.3412
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Breast Implants/adverse effects
+- "Breast Neoplasms/etiology, pathology, surgery, therapy"
+- "Chemotherapy, Adjuvant"
+- Disease Management
+- Disease-Free Survival
+- Female
+- Follow-Up Studies
+- Humans
+- Kaplan-Meier Estimate
+- "Lymphoma, Large-Cell, Anaplastic/etiology, pathology, surgery, therapy"
+- Middle Aged
+- "Radiotherapy, Adjuvant"
+- Retrospective Studies
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Complete Surgical Excision Is Essential for the Management of Patients With Breast Implant-Associated Anaplastic Large-Cell Lymphoma.
+**Authors:** Clemens MW, Medeiros LJ, Butler CE, Hunt KK, Fanale MA, Horwitz S, Weisenburger DD, Liu J, Morgan EA, Kanagal-Shamanna R, Parkash V, Ning J, Sohani AR, Ferry JA, Mehta-Shah N, Dogan A, Liu H, Thormann N, Di Napoli A, Lade S, Piccolini J, Reyes R, Williams T, McCarthy CM, Hanson SE, Nastoupil LJ, Gaur R, Oki Y, Young KH, Miranda RN
+**Journal:** J Clin Oncol (2016)
+**DOI:** [10.1200/JCO.2015.63.3412](https://doi.org/10.1200/JCO.2015.63.3412)
+
+## Content
+
+1. J Clin Oncol. 2016 Jan 10;34(2):160-8. doi: 10.1200/JCO.2015.63.3412. Epub
+2015  Nov 30.
+
+Complete Surgical Excision Is Essential for the Management of Patients With
+Breast Implant-Associated Anaplastic Large-Cell Lymphoma.
+
+Clemens MW(1), Medeiros LJ(1), Butler CE(1), Hunt KK(1), Fanale MA(1), Horwitz
+S(1), Weisenburger DD(1), Liu J(1), Morgan EA(1), Kanagal-Shamanna R(1), Parkash
+V(1), Ning J(1), Sohani AR(1), Ferry JA(1), Mehta-Shah N(1), Dogan A(1), Liu
+H(1), Thormann N(1), Di Napoli A, Lade S(1), Piccolini J(1), Reyes R(1),
+Williams T(1), McCarthy CM(1), Hanson SE(1), Nastoupil LJ(1), Gaur R(1), Oki
+Y(1), Young KH(1), Miranda RN(2).
+
+Author information:
+(1)Mark W. Clemens, L. Jeffrey Medeiros, Charles E. Butler, Kelly K. Hunt,
+Michelle A. Fanale, Jun Liu, Rashmi Kanagal-Shamanna, Jing Ning, Summer E.
+Hanson, Loretta J. Nastoupil, Yasuhiro Oki, Ken H. Young, and Roberto N.
+Miranda, The University of Texas MD Anderson Cancer Center, Houston, TX; Steven
+Horwitz, Neha Mehta-Shah, Ahmed Dogan, and Colleen M. McCarthy, Memorial Sloan
+Kettering Cancer Center, New York, NY; Dennis D. Weisenburger, City of Hope
+National Medical Center, Duarte, CA; Elizabeth A. Morgan, Brigham and Women's
+Hospital and Harvard Medical School; Aliyah R. Sohani and Judith A. Ferry,
+Massachusetts General Hospital and Harvard Medical School, Boston, MA; Vinita
+Parkash, Yale School of Medicine, New Haven, CT; Hui Liu, Xuzhou Medical
+College, Xuzhou, People's Republic of China; Nora Thormann, Fundacao
+Universitaria Mario Martins, Porto Alegre, Brazil; Arianna DiNapoli, Sant'Andrea
+Hospital, Sapienza University, Rome, Italy; Stephen Lade, University of
+Melbourne, Melbourne, Victoria, Australia; Jorge Piccolini, Hospital Italiano de
+Buenos Aires, Buenos Aires, Argentina; Ruben Reyes, Kansas University Medical
+Center, Kansas City, KS; Travis Williams, St Luke's Mountain States Tumor
+Institute, Meridian, ID; and Rakesh Gaur, St Luke's Hospital, Kansas City, MO.
+(2)Mark W. Clemens, L. Jeffrey Medeiros, Charles E. Butler, Kelly K. Hunt,
+Michelle A. Fanale, Jun Liu, Rashmi Kanagal-Shamanna, Jing Ning, Summer E.
+Hanson, Loretta J. Nastoupil, Yasuhiro Oki, Ken H. Young, and Roberto N.
+Miranda, The University of Texas MD Anderson Cancer Center, Houston, TX; Steven
+Horwitz, Neha Mehta-Shah, Ahmed Dogan, and Colleen M. McCarthy, Memorial Sloan
+Kettering Cancer Center, New York, NY; Dennis D. Weisenburger, City of Hope
+National Medical Center, Duarte, CA; Elizabeth A. Morgan, Brigham and Women's
+Hospital and Harvard Medical School; Aliyah R. Sohani and Judith A. Ferry,
+Massachusetts General Hospital and Harvard Medical School, Boston, MA; Vinita
+Parkash, Yale School of Medicine, New Haven, CT; Hui Liu, Xuzhou Medical
+College, Xuzhou, People's Republic of China; Nora Thormann, Fundacao
+Universitaria Mario Martins, Porto Alegre, Brazil; Arianna DiNapoli, Sant'Andrea
+Hospital, Sapienza University, Rome, Italy; Stephen Lade, University of
+Melbourne, Melbourne, Victoria, Australia; Jorge Piccolini, Hospital Italiano de
+Buenos Aires, Buenos Aires, Argentina; Ruben Reyes, Kansas University Medical
+Center, Kansas City, KS; Travis Williams, St Luke's Mountain States Tumor
+Institute, Meridian, ID; and Rakesh Gaur, St Luke's Hospital, Kansas City, MO.
+roberto.miranda@mdanderson.org.
+
+Erratum in
+    J Clin Oncol. 2016 Mar 10;34(8):888. doi: 10.1200/JCO.2016.66.7659..
+DiNapoli, Arianna [corrected to Di Napoli, Arianna].
+
+PURPOSE: Breast implant-associated anaplastic large-cell lymphoma (BI-ALCL) is a
+rare type of T-cell lymphoma that arises around breast implants. The optimal
+management of this disease has not been established. The goal of this study is
+to evaluate the efficacy of different therapies used in patients with BI-ALCL to
+determine an optimal treatment approach.
+PATIENTS AND METHODS: In this study, we applied strict criteria to pathologic
+findings, assessed therapies used, and conducted a clinical follow-up of 87
+patients with BI-ALCL, including 50 previously reported in the literature and 37
+unreported. A Prentice, Williams, and Peterson model was used to assess the rate
+of events for each therapeutic intervention.
+RESULTS: The median and mean follow-up times were 45 and 30 months, respectively
+(range, 3 to 217 months). The median overall survival (OS) time after diagnosis
+of BI-ALCL was 13 years, and the OS rate was 93% and 89% at 3 and 5 years,
+respectively. Patients with lymphoma confined by the fibrous capsule surrounding
+the implant had better event-free survival (EFS) and OS than did patients with
+lymphoma that had spread beyond the capsule (P = .03). Patients who underwent a
+complete surgical excision that consisted of total capsulectomy with breast
+implant removal had better OS (P = .022) and EFS (P = .014) than did patients
+who received partial capsulectomy, systemic chemotherapy, or radiation therapy.
+CONCLUSION: Surgical management with complete surgical excision is essential to
+achieve optimal EFS in patients with BI-ALCL.
+
+© 2015 by American Society of Clinical Oncology.
+
+DOI: 10.1200/JCO.2015.63.3412
+PMCID: PMC4872006
+PMID: 26628470 [Indexed for MEDLINE]
+
+Conflict of interest statement: Authors' disclosures of potential conflicts of
+interest are found in the article online at www.jco.org. Author contributions
+are found at the end of this article.

--- a/references_cache/PMID_28974506.md
+++ b/references_cache/PMID_28974506.md
@@ -1,0 +1,141 @@
+---
+reference_id: "PMID:28974506"
+title: Five-year results of brentuximab vedotin in patients with relapsed or refractory systemic anaplastic large cell lymphoma.
+authors:
+- Pro B
+- Advani R
+- Brice P
+- Bartlett NL
+- Rosenblatt JD
+- Illidge T
+- Matous J
+- Ramchandren R
+- Fanale M
+- Connors JM
+- Fenton K
+- Huebner D
+- Pinelli JM
+- Kennedy DA
+- Shustov A
+journal: Blood
+year: '2017'
+doi: 10.1182/blood-2017-05-780049
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Brentuximab Vedotin
+- Disease Progression
+- Disease-Free Survival
+- Female
+- Humans
+- "Immunoconjugates/adverse effects, therapeutic use"
+- Longitudinal Studies
+- "Lymphoma, Large-Cell, Anaplastic/complications, drug therapy, pathology"
+- Male
+- Middle Aged
+- Peripheral Nervous System Diseases/etiology
+- Remission Induction
+- Salvage Therapy/methods
+- Stem Cell Transplantation
+- Survival Analysis
+- Treatment Outcome
+- Young Adult
+content_type: abstract_only
+---
+
+# Five-year results of brentuximab vedotin in patients with relapsed or refractory systemic anaplastic large cell lymphoma.
+**Authors:** Pro B, Advani R, Brice P, Bartlett NL, Rosenblatt JD, Illidge T, Matous J, Ramchandren R, Fanale M, Connors JM, Fenton K, Huebner D, Pinelli JM, Kennedy DA, Shustov A
+**Journal:** Blood (2017)
+**DOI:** [10.1182/blood-2017-05-780049](https://doi.org/10.1182/blood-2017-05-780049)
+
+## Content
+
+1. Blood. 2017 Dec 21;130(25):2709-2717. doi: 10.1182/blood-2017-05-780049. Epub
+2017 Oct 3.
+
+Five-year results of brentuximab vedotin in patients with relapsed or refractory
+systemic anaplastic large cell lymphoma.
+
+Pro B(1), Advani R(2), Brice P(3), Bartlett NL(4), Rosenblatt JD(5), Illidge
+T(6), Matous J(7), Ramchandren R(8), Fanale M(9), Connors JM(10), Fenton K(11),
+Huebner D(12), Pinelli JM(11), Kennedy DA(11), Shustov A(13).
+
+Author information:
+(1)Robert H. Lurie Comprehensive Cancer Center, Chicago, IL.
+(2)Division of Oncology, Stanford University Medical Center, Palo Alto, CA.
+(3)Hemato-oncology Department, Hospital Saint-Louis, Paris, France.
+(4)Siteman Cancer Center, Washington University School of Medicine, St. Louis,
+MO.
+(5)Division of Hematology-Oncology, Department of Medicine, Sylvester
+Comprehensive Cancer Center, University of Miami, Miami, FL.
+(6)Christie Hospital National Health Service, Manchester, United Kingdom.
+(7)Colorado Blood and Cancer Institute, Denver, CO.
+(8)Karmanos Cancer Institute, Detroit, MI.
+(9)Department of Lymphoma and Myeloma, The University of Texas MD Anderson
+Cancer Center, Houston, TX.
+(10)British Columbia Cancer Agency Centre for Lymphoid Cancer, Vancouver, BC,
+Canada.
+(11)Seattle Genetics, Inc, Bothell, WA.
+(12)Millennium Pharmaceuticals, Inc, Cambridge, MA, a wholly owned subsidiary of
+Takeda Pharmaceuticals Limited; and.
+(13)Division of Hematology, University of Washington School of Medicine,
+Seattle, WA.
+
+Erratum in
+    Blood. 2018 Jul 26;132(4):458-459. doi: 10.1182/blood-2018-05-853192.
+
+Comment in
+    Blood. 2017 Dec 21;130(25):2691-2692. doi: 10.1182/blood-2017-10-811083.
+
+This pivotal phase 2 study evaluated the safety and efficacy of brentuximab
+vedotin in patients with relapsed or refractory (R/R) systemic anaplastic large
+cell lymphoma (ALCL). After a median observation period of approximately 6 years
+from first treatment, we examined the durability of remission, progression-free
+survival (PFS), overall survival (OS), and safety outcomes of patients treated
+on this trial. Among all enrolled patients (n = 58), no progressions were
+observed beyond 40 months, and median OS was not reached. Patients with a
+complete response (CR), as assessed by the investigator (38 of 58, 66%),
+continued to demonstrate improved outcomes with neither median OS nor PFS
+reached. Of the 38 CR patients, 16 received a consolidative stem cell transplant
+(SCT) with median PFS not reached. Among patients who were on-study and in
+remission at study closure, 16 patients had not received any new treatment after
+single-agent brentuximab vedotin other than consolidative SCT. Among this subset
+of 16 patients, 8 received SCT, and the remaining 8 patients (14% of all
+enrolled patients) remained in sustained remission without consolidative SCT or
+any new anticancer therapy. Thirty-three patients experienced peripheral
+neuropathy, among whom, the majority (30 of 33, 91%) had experienced resolution
+or improvement at their last assessment. These final results, which demonstrated
+a high rate of peripheral neuropathy resolution, and durable remissions in a
+subset of patients with relapsed or refractory systemic ALCL, provide evidence
+that single-agent brentuximab vedotin may be a potentially curative treatment
+option. This trial was registered at www.clinicaltrials.gov as #NCT00866047.
+
+© 2017 by The American Society of Hematology.
+
+DOI: 10.1182/blood-2017-05-780049
+PMCID: PMC5746164
+PMID: 28974506 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict-of-interest disclosure: J.M.P., K.F.,
+and D.A.K. are employees of and have equity ownership of Seattle Genetics. D.H.
+is an employee of and has equity ownership of Takeda. P.B. received funding from
+Seattle Genetics and Takeda. J.M.C. received funding from Seattle Genetics,
+Takeda, Roche, and Bristol-Myers Squibb. B.P., M.F., T.I., J.M., J.D.R., A.S.,
+and R.R. received funding from Seattle Genetics; R.A. received funding from
+Kura, Celgene, Genentech, Infinity, Seattle Genetics, Agensys, Bristol-Myers
+Squibb, Merck, Millennium, Regeneron, Janssen, and Pharmacyclics. N.L.B.
+received funding from Celgene, Seattle Genetics, Genentech, Pfizer, KITE, Merck,
+Bristol-Myers Squibb, Immune Design, Forty Seven, Affimed, Janssen,
+Pharmacyclics, Millennium, AstraZeneca, ImaginAb, and Novartis. B.P. and T.I.
+received honoraria from Takeda. P.B. received honoraria from Takeda, Roche,
+Gilead, and Bristol-Myers Squibb. M.F. received honoraria from Seattle Genetics.
+M.F. and R.R. has received consultant fees from Seattle Genetics. T.I. has
+received consultant fees from Seattle Genetics and Takeda. J.M. has received
+consultant fees from Celgene. B.P. has received consultant fees from Seattle
+Genetics. N.L.B. has received consultant fees from Seattle Genetics, KITE, and
+Gilead. R.A. has received consultant fees from NanoString Technologies,
+Pharmacyclics, Spectrum, Bristol-Myers Squibb, Forty Seven, Sutro Biopharma,
+Juno Therapeutics, and Gilead. J.M. is a member of the speakers bureau for
+Seattle Genetics and Celgene. M.F., B.P., and R.R. have received travel expenses
+from Seattle Genetics.

--- a/references_cache/PMID_28975123.md
+++ b/references_cache/PMID_28975123.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:28975123"
+title: "Systemic and primary cutaneous anaplastic large cell lymphoma: Clinical features, morphological spectrum, and immunohistochemical profile."
+authors:
+- Kwatra KS
+- Paul PAM
+- Calton N
+- John JM
+- Cotelingam JD
+journal: South Asian J Cancer
+year: '2017'
+doi: 10.4103/2278-330X.214575
+content_type: full_text_xml
+---
+
+# Systemic and primary cutaneous anaplastic large cell lymphoma: Clinical features, morphological spectrum, and immunohistochemical profile.
+**Authors:** Kwatra KS, Paul PAM, Calton N, John JM, Cotelingam JD
+**Journal:** South Asian J Cancer (2017)
+**DOI:** [10.4103/2278-330X.214575](https://doi.org/10.4103/2278-330X.214575)
+
+## Content
+
+1. South Asian J Cancer. 2017 Jul-Sep;6(3):129-131. doi:
+10.4103/2278-330X.214575.
+
+Systemic and primary cutaneous anaplastic large cell lymphoma: Clinical
+features, morphological spectrum, and immunohistochemical profile.
+
+Kwatra KS(1), Paul PAM(1), Calton N(1), John JM(2), Cotelingam JD(3).
+
+Author information:
+(1)Department of Pathology, Christian Medical College and Hospital, Ludhiana,
+Punjab, India.
+(2)Department of Clinical Hematology, Hemato-Oncology and Bone Marrow (Stem
+Cell) Transplant Unit, Christian Medical College and Hospital, Ludhiana, Punjab,
+India.
+(3)Department of Pathology, Louisiana State University Health Sciences Center,
+Shreveport, LA 71103, USA.
+
+BACKGROUND: T-cell lymphomas with anaplastic morphology typically comprise of
+anaplastic lymphoma kinase positive, anaplastic large cell lymphoma (ALK+ ALCL),
+ALK-negative ALCL (ALK- ALCL), and primary cutaneous ALCL (PC-ALCL). However,
+other entities such as diffuse large B-cell lymphoma, peripheral T-cell
+lymphoma, Hodgkin lymphoma, and undifferentiated carcinoma can also show similar
+anaplastic features.
+AIMS: To study the clinical features and histological spectrum of ALCL and
+emphasize the role of immunohistochemistry (IHC) in their diagnosis and
+categorization.
+SETTING AND DESIGN: Eight cases of ALCL diagnosed over a period of 4 years were
+selected for the study.
+MATERIALS AND METHODS: Histopathological review and IHC was performed on all
+cases. Two ALK+ ALCL cases were tested by fluorescent in situ hybridization
+(FISH) for t(2;5)(p23;q35).
+RESULTS: There were four cases of ALK+ ALCL and two each of ALK- ALCL and
+PC-ALCL. Histologically, all the subtypes showed pleomorphic and "hallmark"
+cells with strong CD30 expression and variable loss of T-cell antigens. One case
+of PC-ALCL was leukocyte common antigen (LCA) negative. Epithelial membrane
+antigen was positive in all the six systemic ALCL cases. Two cases tested for
+t(2;5)(p23;q35) by FISH were positive.
+CONCLUSIONS: Diagnosis of ALCL is based on recognizing the key morphological
+features, especially the presence of "hallmark" cells. IHC is essential for
+confirmation of diagnosis and excluding other malignancies with anaplastic
+morphology. The inclusion of CD30 in the initial IHC panel will help identify
+LCA negative cases and avoid misdiagnosis.
+
+DOI: 10.4103/2278-330X.214575
+PMCID: PMC5615884
+PMID: 28975123
+
+Conflict of interest statement: There are no conflicts of interest.
+
+Anaplastic large cell lymphomas (ALCLs) are a group of T-cell lymphomas composed of anaplastic large lymphoid cells which show diffuse CD30 positivity. It includes three entities, namely anaplastic lymphoma kinase positive, ALCL (ALK+ ALCL), ALK-negative ALCL (ALK− ALCL), and primary cutaneous ALCL (PC-ALCL).[123] ALCL should be distinguished from other lymphomas with anaplastic features which may also show CD30 expression, like diffuse large B-cell lymphoma (DLBCL), classical Hodgkin lymphoma, and peripheral T-cell lymphoma not otherwise specified (PTCL-NOS). In this single institutional study of eight cases, we analyze the clinicopathological features and immunohistochemical (IHC) profile of ALCL with emphasis on diagnostic pitfalls.
+
+All cases diagnosed as ALCL over a period of 4 years in our institution (2011–2014), were included in the study. Hematoxylin and eosin sections and IHC sections were reviewed. All cases were stained with CD45, CD30, ALK-1, CD20, PAX5, CD15, epithelial membrane antigen (EMA), Epstein–Barr virus (latent membrane protein-1) and Ki-67 using standard IHC protocols. Fluorescent in situ hybridization (FISH) for ALK translocation t(2;5)(p23;q35) was carried out using Vysis ALK dual color LSI break apart FISH probe.
+
+Of a total of 246 cases of non-Hodgkin lymphoma (NHL) diagnosed over a period of 4 years, eight cases (3.3%) were categorized as ALCL. Of these, four were ALK+ ALCL, and there were two cases each of ALK− ALCL and PC-ALCL.
+
+The clinical features and histopathological findings are summarized in Table 1. The age range was 15–72 years with an equal sex distribution in all the subtypes. B-symptoms were present in four cases, three of which were ALK+ ALCL. Extranodal involvement of the intestine was present in one case of ALK− ALCL. One case of PC-ALCL had multiple lesions on the thigh and gluteal region while the other had a solitary lesion on the face. Hepatomegaly was present in three cases, one ALK+ ALCL and two ALK− ALCL cases, while none had splenomegaly. Bone marrow (BM) involvement was present in one case of ALK+ ALCL. Serum lactate dehydrogenase levels were increased with a mean value of 407 U/L.
+
+Clinical profile and histopathological findings of patients with anaplastic large cell lymphoma
+
+All the cases showed diffuse sheets of large anaplastic lymphoid cells with interspersed scattered “hallmark” cells. The latter showed large kidney-shaped vesicular nuclei, conspicuous nucleoli, and abundant cytoplasm [Figure 1]. One case of ALK+ ALCL resembled syncytial variant of nodular sclerosis Hodgkin lymphoma. Mitotic activity was uniformly high. A polymorphous inflammatory background was present in one case of ALK− ALCL and one case of PC-ALCL, which was ulcerated.
+
+Anaplastic lymphoid cells and “hallmark” cells (arrows) (H and E, ×800)
+
+IHC findings are shown in Table 2. All cases were strongly and uniformly positive for CD30. The pattern of staining of ALK-1 in all the four ALK+ ALCL cases was nuclear and cytoplasmic [Figure 2]. One case of PC-ALCL was leukocyte common antigen (LCA) negative. Aberrant loss of CD3 was present in 5/8 cases, CD5 loss in 3/8, and both CD3 and CD5 loss in 2/8 cases. Both the cases of PC-ALCL were EMA negative while all the six cases of systemic ALCL were positive. The mean Ki-67 proliferative index was 74%. Two cases of ALK+, ALCL tested for t(2;5)(p23;q35) by FISH were positive.
+
+Immunohistochemical profile of anaplastic large cell lymphoma cases
+
+Anaplastic lymphoma kinase-1 positivity, both nuclear and cytoplasmic (IHC, ×400)
+
+Complete staging and work up were possible in five of eight cases. Of these five cases, treatment was possible in three; 2 ALK+ ALCL (Case numbers 1 and 2) and 1 PC-ALCL (Case number 7). All were given six cycles of cyclophosphamide, adriamycin, vincristine, and prednisolone (CHOP) and were in clinical remission at their last follow-up of 3 years, 1 year, and 2 years 9 months, respectively. Two patients; one ALK+ ALCL (Case number 4) and one ALK− ALCL (Case number 5), expired at diagnosis, and the remaining three were lost to follow-up.
+
+The rarity of ALCL was highlighted in our study which showed it to comprise 3.3% (8/246) of all NHL. A clinical evaluation of 1378 cases of NHL by International NHL Classification Project found ALCL to be comprising 2.4%.[4]
+
+The clinical profile of our patients was similar to that described in literature. ALK+ ALCL mostly occurs in the first three decades of life with the male:female ratio ranging from 1.5 and 6.5.[1] This lymphoma is aggressive and frequently presents as Stage III–IV disease with systemic symptoms and extranodal involvement.[1] The frequency of BM involvement is 11%. Only one case of ALK+ ALCL in our series had BM involvement. ALK− ALCL occurs in older patients, peak age of incidence being in the sixth decade of life, with a lower male predominance when compared to ALK+ ALCL. Advanced-stage disease and B-symptoms are relatively less common.[25] Primary cutaneous CD30-positive T-cell lymphoproliferative disorders include PC-ALCL and lymphomatoid papulosis (LyP). The median age at diagnosis for PC-ALCL is 60 years with a male:female ratio of 2–3:1.[36] Common sites of involvement are the face, trunk, extremities, and buttocks. They commonly present with solitary nodules that may ulcerate. In 20% of cases, the lesions are multiple while in 10% cases there may be regional lymph node involvement.[36]
+
+Histologically, all types of ALCL are characterized by sheets of large pleomorphic cells with a variable proportion of “hallmark” cells showing typical horseshoe-shaped nuclei. In ALK+ ALCL, morphological patterns that have been recognized are: (1) Common pattern (60%); (2) lymphohistiocytic pattern (10%); (3) small cell pattern (5–10%); (4) Hodgkin-like pattern (3%); and (5) composite pattern (15%).[14] One case of ALK+ ALCL in our series showed nodular sclerosis Hodgkin-like pattern. The rest showed “common pattern.” The histology of ALK− ALCL shows a similar morphologic spectrum.[24] PC-ALCL shows nonepidermotropic infiltrates of anaplastic cells with a variable number of inflammatory cells in the background which are especially prominent in ulcerated lesions. To differentiate such cases from LyP features like lesions limited to an anatomical region and infiltration into subcutaneous tissue favor a diagnosis of PC-ALCL.[7]
+
+The defining feature of all types of ALCL is strong and diffuses CD30 staining in more than 75% of tumor cells. All eight cases in our series had a uniform and intense CD30 staining. Positivity for CD30 is not specific for ALCL and can be expressed by HRS cells and a subset of B- and T-cell lymphomas.[4] However, the CD30 immunostain is generally less intense in CD30+ PTCL-NOS and DLBCL and is often seen only in a fraction of tumor cells. ALCL usually demonstrate an aberrant T phenotype, with frequent loss of T-cell markers. Null cell ALCL by IHC can usually be proven to be lymphoma of T-cell origin with clonal T-cell receptor rearrangements.[4] In our series, aberrant T-cell antigen loss was a frequent finding. A diagnostic pitfall is negative or weak staining for LCA in some cases of ALCL.[8] One case of PC-ALCL was LCA negative with loss of T-cell antigens and initially misdiagnosed as melanoma at another institute. Hence in suspected cases, CD30 should always be included in the initial IHC panel. In certain situations, like Case number 4 in our study, which was a treated case of carcinoma esophagus, metastatic carcinoma may enter the histological differential diagnosis. It is preferable to use cytokeratin immunostain than EMA for this purpose as ALCL can be EMA positive.[4] EMA expression is more frequent in ALK+ than ALK− ALCL (83% vs. 43%).[5]
+
+In histologically suspected cases which are a CD30 positive, further evaluation with markers for T-cells (CD2, CD3, CD5), B-cells (CD20, PAX5), Hodgkin lymphoma (CD15, PAX5) and ALCL (ALK-1) is required. To distinguish PC-ALCL from systemic ALCL with secondary skin involvement, EMA can be helpful, which is usually negative in the former.[7] Feature which differentiates ALK− ALCL from PTCL-NOS is weak and heterogeneous staining of CD30, consistent expression of T-cell markers and EMA negativity in the latter.[5]
+
+Systemic ALK+ ALCL show t(2;5)(p23;q35) in 84% cases. Variant translocations also occur, albeit with a much lower frequency.[9] Translocation t(2;5) results in a nuclear and diffuse cytoplasmic staining for ALK-1 on IHC. All the four ALK+ ALCL cases in our series showed nuclear and diffuse cytoplasmic staining and two of these who were tested for t(2;5) by FISH were positive. Variant translocations can produce cytoplasmic, membranous or nuclear staining patterns.[1]
+
+CHOP chemotherapy regimen remains the standard of care in primary systemic ALCL. The addition of etoposide to the standard CHOP regimen is an important consideration for young patients with ALK+ ALCL.[10] Immunologic strategies with anti-CD30 agent brentuximab vedotin and ALK inhibitor crizotinib have also been used. Solitary or localized PC-ALCL is best treated with radiation therapy or surgical excision.
+
+Five year overall survival (OS) rates for ALK+ ALCL have ranged from 70% to 93% and that of ALK− ALCL from 15% to 49%.[5] PC-ALCL has a very high OS of 90% at 10 years.[3] Two patients of ALK+ ALCL and one of PC-ALCL who were given CHOP therapy showed good response to treatment and were in clinical remission at their last follow-up.
+
+The clinical and histopathological findings of our study are commensurate with that recorded in literature. LCA negativity and aberrant T-cell antigen loss are potential diagnostic pitfalls. However, a diligent search for hallmark cells with the inclusion of CD30 and at least two T-cell markers in the initial IHC panel will clinch the diagnosis in most cases.
+
+Nil.
+
+There are no conflicts of interest.

--- a/references_cache/PMID_29279550.md
+++ b/references_cache/PMID_29279550.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:29279550"
+title: "Anaplastic large cell lymphoma: pathology, genetics, and clinical aspects."
+authors:
+- Tsuyama N
+- Sakamoto K
+- Sakata S
+- Dobashi A
+- Takeuchi K
+journal: J Clin Exp Hematop
+year: '2017'
+doi: 10.3960/jslrt.17023
+keywords:
+- Anaplastic Lymphoma Kinase
+- Animals
+- Antineoplastic Combined Chemotherapy Protocols/therapeutic use
+- Cyclophosphamide/therapeutic use
+- Doxorubicin/therapeutic use
+- Humans
+- "Ki-1 Antigen/analysis, genetics"
+- "Lymphoma, Large-Cell, Anaplastic/genetics, pathology, therapy"
+- Mutation
+- Prednisolone/therapeutic use
+- Protein Kinase Inhibitors/therapeutic use
+- "Receptor Protein-Tyrosine Kinases/analysis, genetics"
+- Vincristine/therapeutic use
+content_type: abstract_only
+---
+
+# Anaplastic large cell lymphoma: pathology, genetics, and clinical aspects.
+**Authors:** Tsuyama N, Sakamoto K, Sakata S, Dobashi A, Takeuchi K
+**Journal:** J Clin Exp Hematop (2017)
+**DOI:** [10.3960/jslrt.17023](https://doi.org/10.3960/jslrt.17023)
+
+## Content
+
+1. J Clin Exp Hematop. 2017;57(3):120-142. doi: 10.3960/jslrt.17023.
+
+Anaplastic large cell lymphoma: pathology, genetics, and clinical aspects.
+
+Tsuyama N(1), Sakamoto K(2), Sakata S(2), Dobashi A(2), Takeuchi K(1)(2).
+
+Author information:
+(1)Division of Pathology, Cancer Institute, Japanese Foundation for Cancer
+Research.
+(2)Pathology Project for Molecular Targets, Cancer Institute, Japanese
+Foundation for Cancer Research.
+
+Anaplastic large cell lymphoma (ALCL) was first described in 1985 as a
+large-cell neoplasm with anaplastic morphology immunostained by the Ki-1
+antibody, which recognizes CD30. In 1994, the nucleophosmin (NPM)-anaplastic
+lymphoma kinase (ALK) fusion receptor tyrosine kinase was identified in a subset
+of patients, leading to subdivision of this disease into ALK-positive and
+-negative ALCL in the present World Health Organization classification. Due to
+variations in morphology and immunophenotype, which may sometimes be atypical
+for lymphoma, many differential diagnoses should be considered, including solid
+cancers, lymphomas, and reactive processes. CD30 and ALK are key molecules
+involved in the pathogenesis, diagnosis, and treatment of ALCL. In addition,
+signal transducer and activator of transcription 3 (STAT3)-mediated mechanisms
+are relevant in both types of ALCL, and fusion/mutated receptor tyrosine kinases
+other than ALK have been reported in ALK-negative ALCL. ALK-positive ALCL has a
+better prognosis than ALK-negative ALCL or other peripheral T-cell lymphomas.
+Patients with ALK-positive ALCL are usually treated with anthracycline-based
+regimens, such as combination cyclophosphamide, doxorubicin, vincristine, and
+prednisolone (CHOP) or CHOEP (CHOP plus etoposide), which provide a favorable
+prognosis, except in patients with multiple International Prognostic Index
+factors. For targeted therapies, an anti-CD30 monoclonal antibody linked to a
+synthetic antimitotic agent (brentuximab vedotin) and ALK inhibitors
+(crizotinib, alectinib, and ceritinib) are being used in clinical settings.
+
+DOI: 10.3960/jslrt.17023
+PMCID: PMC6144189
+PMID: 29279550 [Indexed for MEDLINE]
+
+Conflict of interest statement: CONFLICT OF INTEREST: The authors do not have
+any conflicts of interest to declare.

--- a/references_cache/PMID_29617304.md
+++ b/references_cache/PMID_29617304.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:29617304"
+title: The Pathological Spectrum of Systemic Anaplastic Large Cell Lymphoma (ALCL).
+authors:
+- Montes-Mojarro IA
+- Steinhilber J
+- Bonzheim I
+- Quintanilla-Martinez L
+- Fend F
+journal: Cancers (Basel)
+year: '2018'
+doi: 10.3390/cancers10040107
+content_type: abstract_only
+---
+
+# The Pathological Spectrum of Systemic Anaplastic Large Cell Lymphoma (ALCL).
+**Authors:** Montes-Mojarro IA, Steinhilber J, Bonzheim I, Quintanilla-Martinez L, Fend F
+**Journal:** Cancers (Basel) (2018)
+**DOI:** [10.3390/cancers10040107](https://doi.org/10.3390/cancers10040107)
+
+## Content
+
+1. Cancers (Basel). 2018 Apr 4;10(4):107. doi: 10.3390/cancers10040107.
+
+The Pathological Spectrum of Systemic Anaplastic Large Cell Lymphoma (ALCL).
+
+Montes-Mojarro IA(1), Steinhilber J(2), Bonzheim I(3), Quintanilla-Martinez
+L(4), Fend F(5).
+
+Author information:
+(1)Institute of Pathology and Neuropathology and Comprehensive Cancer Center
+Tübingen, Eberhard-Karls-University, Liebermeisterstraße 8, 72076 Tübingen,
+Germany. Ivonne.Montes@med.uni-tuebingen.de.
+(2)Institute of Pathology and Neuropathology and Comprehensive Cancer Center
+Tübingen, Eberhard-Karls-University, Liebermeisterstraße 8, 72076 Tübingen,
+Germany. Julia.Steinhilber@med.uni-tuebingen.de.
+(3)Institute of Pathology and Neuropathology and Comprehensive Cancer Center
+Tübingen, Eberhard-Karls-University, Liebermeisterstraße 8, 72076 Tübingen,
+Germany. Irina.Bonzheim@med.uni-tuebingen.de.
+(4)Institute of Pathology and Neuropathology and Comprehensive Cancer Center
+Tübingen, Eberhard-Karls-University, Liebermeisterstraße 8, 72076 Tübingen,
+Germany. Leticia.Quintanilla-Fend@med.uni-tuebingen.de.
+(5)Institute of Pathology and Neuropathology and Comprehensive Cancer Center
+Tübingen, Eberhard-Karls-University, Liebermeisterstraße 8, 72076 Tübingen,
+Germany. Falko.Fend@med.uni-tuebingen.de.
+
+Anaplastic large cell lymphoma (ALCL) represents a group of malignant T-cell
+lymphoproliferations that share morphological and immunophenotypical features,
+namely strong CD30 expression and variable loss of T-cell markers, but differ in
+clinical presentation and prognosis. The recognition of anaplastic lymphoma
+kinase (ALK) fusion proteins as a result of chromosomal translocations or
+inversions was the starting point for the distinction of different subgroups of
+ALCL. According to their distinct clinical settings and molecular findings, the
+2016 revised World Health Organization (WHO) classification recognizes four
+different entities: systemic ALK-positive ALCL (ALK+ ALCL), systemic
+ALK-negative ALCL (ALK&minus; ALCL), primary cutaneous ALCL (pC-ALCL), and
+breast implant-associated ALCL (BI-ALCL), the latter included as a provisional
+entity. ALK is rearranged in approximately 80% of systemic ALCL cases with one
+of its partner genes, most commonly NPM1, and is associated with favorable
+prognosis, whereas systemic ALK&minus; ALCL shows heterogeneous clinical,
+phenotypical, and genetic features, underlining the different oncogenesis
+between these two entities. Recognition of the pathological spectrum of ALCL is
+crucial to understand its pathogenesis and its boundaries with other entities.
+In this review, we will focus on the morphological, immunophenotypical, and
+molecular features of systemic ALK+ and ALK&minus; ALCL. In addition, BI-ALCL
+will be discussed.
+
+DOI: 10.3390/cancers10040107
+PMCID: PMC5923362
+PMID: 29617304
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_30914464.md
+++ b/references_cache/PMID_30914464.md
@@ -1,0 +1,193 @@
+---
+reference_id: "PMID:30914464"
+title: "FDA Approval Summary: Brentuximab Vedotin in First-Line Treatment of Peripheral T-Cell Lymphoma."
+authors:
+- Richardson NC
+- Kasamon YL
+- Chen H
+- de Claro RA
+- Ye J
+- Blumenthal GM
+- Farrell AT
+- Pazdur R
+journal: Oncologist
+year: '2019'
+doi: 10.1634/theoncologist.2019-0098
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Antineoplastic Agents, Immunological/pharmacology, therapeutic use"
+- "Brentuximab Vedotin/pharmacology, therapeutic use"
+- Female
+- Humans
+- "Lymphoma, T-Cell, Peripheral/drug therapy"
+- Male
+- Middle Aged
+- United States
+- United States Food and Drug Administration
+- Young Adult
+content_type: full_text_xml
+---
+
+# FDA Approval Summary: Brentuximab Vedotin in First-Line Treatment of Peripheral T-Cell Lymphoma.
+**Authors:** Richardson NC, Kasamon YL, Chen H, de Claro RA, Ye J, Blumenthal GM, Farrell AT, Pazdur R
+**Journal:** Oncologist (2019)
+**DOI:** [10.1634/theoncologist.2019-0098](https://doi.org/10.1634/theoncologist.2019-0098)
+
+## Content
+
+1. Oncologist. 2019 May;24(5):e180-e187. doi: 10.1634/theoncologist.2019-0098.
+Epub  2019 Mar 26.
+
+FDA Approval Summary: Brentuximab Vedotin in First-Line Treatment of Peripheral
+T-Cell Lymphoma.
+
+Richardson NC(1), Kasamon YL(2), Chen H(3), de Claro RA(2), Ye J(3), Blumenthal
+GM(2)(4), Farrell AT(2), Pazdur R(2)(4).
+
+Author information:
+(1)Office of Hematology and Oncology Products, Center for Drug Evaluation and
+Research, Silver Spring, Maryland, USA nicholas.richardson@fda.hhs.gov.
+(2)Office of Hematology and Oncology Products, Center for Drug Evaluation and
+Research, Silver Spring, Maryland, USA.
+(3)Office of Biostatistics, Center for Drug Evaluation and Research, Silver
+Spring, Maryland, USA.
+(4)Oncology Center of Excellence, U.S. Food and Drug Administration, Silver
+Spring, Maryland, USA.
+
+In November 2018, the U.S. Food and Drug Administration (FDA) approved
+brentuximab vedotin (BV) for the treatment of adult patients with previously
+untreated systemic anaplastic large cell lymphoma or other CD30-expressing
+peripheral T-cell lymphomas (PTCL), including angioimmunoblastic T-cell lymphoma
+and PTCL not otherwise specified, in combination with cyclophosphamide,
+doxorubicin, and prednisone (CHP). Approval was based on ECHELON-2, a
+randomized, double-blind, actively controlled trial that compared BV+CHP with
+cyclophosphamide, doxorubicin, vincristine, and prednisone (CHOP) in 452
+patients with newly diagnosed, CD30-expressing PTCL. Efficacy was based on
+independent review facility-assessed progression-free survival (PFS). The median
+PFS was 48.2 months with BV+CHP versus 20.8 months with CHOP, resulting in a
+hazard ratio (HR) of 0.71 (95% confidence interval [CI]: 0.54-0.93). The trial
+also demonstrated improvement in overall survival (HR 0.66; 95% CI: 0.46-0.95),
+complete response rate (68% vs. 56%), and overall response rate (83% vs. 72%)
+with BV+CHP. The most common adverse reactions (incidence ≥20%) observed ≥2%
+more with BV+CHP were nausea, diarrhea, fatigue or asthenia, mucositis, pyrexia,
+vomiting, and anemia. Peripheral neuropathy rates were similar (52% with BV+CHP,
+55% with CHOP). Through the Real-Time Oncology Review pilot program, which
+allows FDA early access to key data, FDA granted this approval less than 2 weeks
+after official submission of the application. IMPLICATIONS FOR PRACTICE: This is
+the first U.S. Food and Drug Administration approval for treatment of patients
+with newly diagnosed peripheral T-cell lymphomas (PTCL). Improvement in
+progression-free and overall survival over cyclophosphamide, doxorubicin,
+vincristine, and prednisone chemotherapy, which has been the standard of care
+for decades, is unprecedented. The new regimen represents a major advance for
+the frontline treatment of patients with CD30-expressing PTCL.
+
+Published 2019. This article is a U.S. Government work and is in the public
+domain in the USA.
+
+DOI: 10.1634/theoncologist.2019-0098
+PMCID: PMC6516120
+PMID: 30914464 [Indexed for MEDLINE]
+
+Conflict of interest statement: Disclosures of potential conflicts of interest
+may be found at the end of this article.
+
+Peripheral T‐cell lymphoma (PTCL), which makes up approximately 10% of non‐Hodgkin lymphomas in the U.S., is a heterogeneous group of lymphomas with an aggressive clinical course [1], [2]. The most common types have a predominantly nodal presentation and include anaplastic large cell lymphoma (ALCL), angioimmunoblastic T‐cell lymphoma (AITL), and PTCL not otherwise specified. Although first‐line therapy for PTCL has curative potential, the majority of patients relapse or progress. PTCLs are challenging to treat, with clinical courses often marked by advanced‐stage disease at presentation and chemoresistance or relapse [1], [2].
+
+An anthracycline‐containing regimen, with or without consolidative autologous hematopoietic stem cell transplantation [3], is the usual frontline approach for most types of PTCL. Cyclophosphamide, doxorubicin, vincristine, and prednisone (CHOP) remains the historical standard and the most widely used frontline regimen for most types of PTCL [2], [4]. Anaplastic lymphoma kinase (ALK)‐positive ALCL is the only type of PTCL wherein the majority of patients achieve durable remissions with CHOP (5‐year failure‐free survival 60% vs. 36% with ALK‐negative ALCL) [2], [5]. Anthracycline‐containing regimens have otherwise had disappointing results. In a 340‐patient case series of PTCL not otherwise specified, the estimated 5‐year overall survival (OS) was 32%, and the estimated 5‐year failure‐free survival was only 20% [1]. Only approximately 20% of patients with AITL have prolonged disease‐free survival [2], and the median OS for patients with enteropathy‐associated or hepatosplenic lymphoma is less than 1 year [6].
+
+Attempts to improve upon CHOP with nontargeted agents have been largely unsuccessful [7], [8]. The low rates of complete remission (CR) and 5‐year OS rates (generally <50%) associated with CHOP underscore the high unmet need. On November 16, 2018, after an expedited review, the U.S. Food and Drug Administration (FDA) approved a new regimen for the first‐line treatment of selected PTCLs. Brentuximab vedotin (BV) received regular approval for the treatment of adult patients with previously untreated systemic ALCL or other CD30‐expressing PTCLs, including AITL and PTCL not otherwise specified, in combination with cyclophosphamide, doxorubicin, and prednisone (CHP). BV is a CD30‐directed antibody‐drug conjugate with prior approvals in Hodgkin lymphoma, previously treated ALCL (systemic and primary cutaneous), and previously treated CD30‐expressing mycosis fungoides (Table 1). Herein, we summarize the FDA clinical review and basis of approval of BV+CHP as a first‐line regimen for CD30‐expressing PTCL.
+
+Abbreviations: ADC, antibody‐drug conjugate; ALCL, anaplastic large cell lymphoma; auto‐HSCT, autologous hematopoietic stem cell transplantation; cHL, classical Hodgkin lymphoma; IgG1, immunoglobulin G1; MMAE, monomethyl auristatin E.
+
+The ECHELON‐2 trial (SGN35‐014, NCT01777152) is a phase III, randomized, double‐blind, double‐dummy, actively controlled trial of BV+CHP versus CHOP in adult patients with newly diagnosed, CD30‐expressing PTCL [9]. The trial required CD30 expression ≥10% per immunohistochemistry (IHC) per local assessment. The trial excluded patients with primary cutaneous lymphoproliferative disorders and lymphomas, central nervous system involvement by lymphoma, or grade 2 or higher peripheral neuropathy. Requirements included an Eastern Cooperative Oncology Group performance status <2, hepatic transaminases ≤3 times the upper limit of normal (ULN), total bilirubin ≤1.5 times ULN, and serum creatinine ≤2 times ULN.
+
+Patients were randomized 1:1 to receive BV+CHP or CHOP for six to eight cycles, as shown in Table 2. Randomization was stratified by International Prognostic Index (IPI) score and histology (ALK‐positive ALCL vs. other).
+
+Administered within 1 hour of completing treatment with other agents administered via IV. Maximum dose of BV was 180 mg.
+
+Prepared by the site pharmacist; pharmacy blind maintained.
+
+May be administered over up to 48 hours according to institutional standards.
+
+Vincristine dose capped at 2 mg.
+
+For patients who stopped treatment early for reasons other than progressive disease, such as toxicity, the denominator for the RDI calculation was the intended number of cycles. For patients who stopped because of progressive disease, the denominator was the actual number of cycles.
+
+Abbreviations: AR, adverse reaction; BV, brentuximab vedotin; GCSF, granulocyte‐colony stimulating factor; HSCT, hematopoietic stem cell transplantation; IV, intravenous; RDI, relative dose intensity; SD, standard deviation.
+
+The primary efficacy endpoint was progression‐free survival (PFS), defined as the time from randomization to progression, death, or receipt of subsequent therapy for residual or progressive disease. The trial was designed to detect an improvement in PFS, assuming a median PFS of 24 months for BV+CHP versus 17 months for CHOP (corresponding hazard ratio [HR] = 0.69), with 80% power and a two‐sided type I error rate of 0.05. The key secondary endpoints, which were tested hierarchically, were PFS in patients with systemic ALCL and, in all randomized patients, CR rate, OS, and overall response rate (ORR). PFS and response were based on independent review facility assessment.
+
+Of 452 patients randomized, 449 were treated (223 with BV+CHP, 226 with CHOP). The demographics and disease characteristics were balanced between treatment arms (Table 3). Of all randomized patients, the disease subtypes included systemic ALCL (70%, 22% of which were ALK positive), PTCL not otherwise specified (16%), angioimmunoblastic T‐cell lymphoma (12%), adult T‐cell leukemia/lymphoma (2%), and enteropathy‐associated T‐cell lymphoma (<1%). Most patients had stage III or IV disease (81%) and an intermediate‐risk IPI (63%). Most patients (81%) had six cycles planned, with 30% receiving primary prophylaxis with granulocyte‐colony stimulating factor (GCSF; Table 3).
+
+Percentage of cells with CD30 expression, per central review of immunohistochemistry.
+
+Three patients with ALCL had 60%–100% CD30 expression per local IHC but 0% per central review.
+
+Abbreviations: ALCL, anaplastic large cell lymphoma; ALK, anaplastic lymphoma kinase; BV, brentuximab vedotin; CHOP, cyclophosphamide, doxorubicin, vincristine, and prednisone; CHP, cyclophosphamide, doxorubicin, and prednisone; IPI, international prognostic index; PTCL, peripheral T‐cell lymphoma.
+
+Efficacy results are presented in Table 4. ECHELON‐2 demonstrated a statistically significant improvement in PFS with BV+CHP compared with CHOP, with an HR of 0.71 (95% confidence interval [CI]: 0.54–0.93; p = .011; Fig. 1). On intention‐to‐treat analysis, patients in the BV+CHP arm had an estimated median PFS of 48.2 months (95% CI: 35.2 to not estimable [NE]), whereas patients in the CHOP arm had an estimated median PFS of 20.8 months (95% CI: 12.7–47.6). The difference in event rate was driven by more treatment failures on the CHOP arm. The improvement in PFS with BV+CHP translated into a statistically significant improvement in OS (HR 0.66; 95% CI: 0.46–0.95; p = .024; Fig. 1). The median OS was not reached in either treatment arm, with an estimated median follow‐up of 42 months. Sensitivity analyses of PFS and OS supported the results of the primary analyses.
+
+Progression‐free and overall survival. (A): PFS in all patients. (B): Overall survival. (C): PFS in patients with systemic anaplastic large cell lymphoma.
+
+Abbreviations: BV, brentuximab vedotin; CHOP, cyclophosphamide, doxorubicin, vincristine, and prednisone; CHP, cyclophosphamide, doxorubicin, and prednisone; CI, confidence interval; NE, not estimable; OS, overall survival; PFS, progression‐free survival.
+
+PFS and response are based on independent review facility assessment. Efficacy endpoints were tested at a two‐sided alpha level 0.05 in the following order: PFS overall (intention‐to‐treat population), PFS in systemic ALCL subgroup, then in all patients, CR rate, OS, and ORR.
+
+Kaplan‐Meier estimate. Median PFS follow‐up was 36 months in the BV+CHP arm and 42 months in the CHOP arm; median OS follow‐up was 24 months in each arm.
+
+Hazard ratio (BV+CHP/CHOP) and 95% CI based on Cox's proportional hazards regression model stratified by histology and international prognostic index score.
+
+Stratified log‐rank test.
+
+Best response per 2007 International Working Group Criteria at end of treatment.
+
+Stratified Cochrane‐Mantel‐Haenszel test.
+
+Abbreviations: ALCL, anaplastic large cell lymphoma; BV, brentuximab vedotin; CHOP, cyclophosphamide, doxorubicin, vincristine, and prednisone; CHP, cyclophosphamide, doxorubicin, and prednisone; CI, confidence interval; CR, complete remission; NE, not estimable; ORR, overall response rate; OS, overall survival; PFS, progression‐free survival.
+
+The CR rate and ORR at the end of treatment were likewise statistically significantly higher with BV+CHP than CHOP: 68% versus 56% (p = .007) and 83% versus 72% (p = .003), respectively (Table 4).
+
+In the subset of patients with systemic ALCL, PFS was also statistically significantly improved on the BV+CHP arm (HR 0.59; 95% CI: 0.42–0.84; p = .003; Fig. 1). On the BV+CHP arm, 34% of patients experienced a PFS event with an estimated median PFS of 55.7 months (95% CI: 48.2 to NE). In contrast, 48% of patients on the CHOP arm experienced a PFS event with an estimated median PFS of 54.2 months (95% CI: 13.4 to NE).
+
+CD30 expression is variable in PTCL subtypes other than ALCL [10], [11], [12]. Table 3 summarizes the CD30 expression profiles in ECHELON‐2. Nine patients on the BV+CHP arm had CD30 expression ≤10% per central IHC, of whom seven (78%) achieved an objective response, including five (56%) CRs. Additional data from two supportive studies, SGN35‐012 (NCT01421667) and 35‐IST‐30 (NCT02588651), included 18 patients with relapsed or refractory PTCL with CD30 expression <10% per local IHC, including 8 patients with undetectable CD30 per IHC [13]. Of the 18 patients, 8 (44%) achieved an objective response, including 4 (22%) CRs, to BV monotherapy. Of the eight patients with undetectable CD30, two achieved CR and one achieved PR.
+
+The safety analysis considered all‐cause events reported within 30 days of treatment. The arms had similar incidences of grade ≥3 and serious adverse reactions (ARs). Fatal ARs within 30 days of treatment occurred in 3% of the BV+CHP arm and 4% of the CHOP arm. The leading cause in both arms was infection, followed by acute cardiac events. The reported incidence of serious ARs was 38% with BV+CHP and 35% with CHOP. Serious ARs reported in >2% of the BV+CHP arm included febrile neutropenia (14%), pneumonia (5%), pyrexia (4%), neutropenia (4%), and sepsis (3%).
+
+Table 5 summarizes ARs reported in ≥15% of either arm. With BV+CHP, the most common (≥20%) ARs, in order of decreasing incidence, were peripheral neuropathy, nausea, diarrhea, neutropenia, fatigue or asthenia, mucositis, constipation, alopecia, pyrexia, vomiting, and anemia. Other common ARs with BV+CHP, with incidences of 11% to 13%, included dizziness, cough, weight decrease, hypokalemia, myalgia, and insomnia. The most common ARs reported ≥2% more with BV+CHP were nausea, diarrhea, fatigue or asthenia, mucositis, pyrexia, vomiting, and anemia. The largest difference was the 18% higher incidence of diarrhea with BV+CHP (38%, vs. 20% with CHOP).
+
+Includes events occurring up to 30 days after therapy completion. Toxicities were graded using National Cancer Institute Common Terminology Criteria for Adverse Events version 4.
+
+Derived from adverse reaction and laboratory data. Labs were reported at the start of each cycle and end of treatment.
+
+17% in recipients of primary granulocyte‐colony stimulating factor prophylaxis, 20% in the remainder.
+
+With BV+CHP, 49% of patients had sensory neuropathy, 9% motor; with CHOP, 51% had sensory neuropathy, 12% motor.
+
+By maximum grade, 34% of patients had grade 1 peripheral neuropathy, 15% grade 2, 3% grade 3, <1% grade 4.
+
+Abbreviations: BV, brentuximab vedotin; CHOP, cyclophosphamide, doxorubicin, vincristine, and prednisone; CHP, cyclophosphamide, doxorubicin, and prednisone.
+
+The incidences and patterns of peripheral neuropathy were similar with BV+CHP and CHOP (Table 5). With BV+CHP, 52% of patients had new or worsening peripheral neuropathy, with a median time to onset of 2 months. The neuropathy was predominantly sensory (94% sensory, 16% motor) and predominantly grade 1–2. At last evaluation, 50% had complete resolution and 12% had partial improvement, with a median time to resolution or improvement of 4 months (range, 0–45).
+
+The arms had similar incidences of treatment changes due to ARs (Table 2). In recipients of BV+CHP, ARs led to dose delays in 25% of patients, dose reduction in 9% (most often for peripheral neuropathy), and discontinuation of BV with or without the other components in 7%. The arms had similar mean exposure (relative dose intensities) for BV/vincristine, cyclophosphamide, and doxorubicin, although a numerically higher percentage of CHOP recipients had a relative dose intensity of ≥90% for cyclophosphamide and doxorubicin (Table 2).
+
+The prescribing information for BV [13] includes warnings and precautions on progressive multifocal leukoencephalopathy (boxed warning), peripheral neuropathy, anaphylaxis and infusion reactions, hematologic toxicities, infection, tumor lysis syndrome, hepatotoxicity, pulmonary toxicity, dermatologic reactions, gastrointestinal toxicity, and embryo‐fetal toxicity. The prescribing information provides dose modification guidelines for toxicity.
+
+BV+CHP is the first FDA‐approved regimen for newly diagnosed PTCL. In patients with previously untreated, CD30‐expressing PTCL, the efficacy of BV+CHP was established by progression‐free and overall survival outcomes, as well as the magnitude and depth of response relative to CHOP. The recommended dose schedule of BV is 1.8 mg/kg (maximum dose, 180 mg) as an intravenous infusion over 30 minutes on day 1 of a 21‐day treatment cycle, in combination with cyclophosphamide, doxorubicin, and prednisone for six to eight cycles. GCSF primary prophylaxis is advised for all recipients of BV+CHP starting with cycle 1.
+
+The ECHELON‐2 trial demonstrated a robust improvement in PFS and OS over CHOP chemotherapy, the decades‐old standard of care for most types of PTCL. Based on these results, BV+CHP received Breakthrough Therapy Designation for its approved indication. Table 6 summarizes the FDA benefit‐risk analysis. Because BV+CHP demonstrated substantial improvement in a randomized trial using established clinical endpoints, the application was selected for the Real‐Time Oncology Review pilot program [14], [15]. This new program explores a more efficient review process that gives FDA access to key efficacy and safety data before official submission of the marketing application. Through this initiative, FDA was able to grant approval within 2 weeks of receipt of the complete application.
+
+Abbreviations: ALCL, anaplastic large cell lymphoma; ALK, anaplastic lymphoma kinase; ARs, adverse reactions; BV, brentuximab vedotin; CHOP, cyclophosphamide, doxorubicin, vincristine, and prednisone; CHP, cyclophosphamide, doxorubicin, and prednisone; CI, confidence interval; CR, complete remission; GCSF, granulocyte‐colony stimulating factor; ORR, overall response rate; OS, overall survival; PFS, progression‐free survival; PTCL, peripheral T‐cell lymphoma.
+
+The safety profile of BV+CHP was consistent with the known safety profile of BV across multiple clinical trials. The arms had similar incidences of all‐grade and grade ≥3 peripheral neuropathy (52% and 4%, respectively, with BV+CHP) and serious adverse reactions (BV+CHP 38%, CHOP 35%) with infection being the leading cause. Neutropenia rates in ECHELON‐2 are underestimated because laboratory data were captured only at the start of each cycle (after the nadir in counts). Evaluation of the impact of GCSF was limited by the incomplete data on cytopenias and by the small number of patients who received primary prophylaxis (Table 2). Nevertheless, the review team felt that primary prophylaxis is justified with BV+CHP because (a) recipients of primary prophylaxis had a substantial reduction in grade ≥3 and grade ≥4 neutropenia events (absolute reduction 32% and 17%, respectively), (b) the febrile neutropenia rate approached or met the 20% threshold for which practice guidelines recommend prophylaxis [16], and (c) more infectious complications are expected in the general population than in a study population.
+
+Important questions remain about the optimal patient population who might benefit from BV+CHP, including the relationship between the degree of CD30 expression and tumor response. Based on the available clinical data with BV, an optimal CD30 expression threshold remains uncertain [9], [17], [18], [19], [20]. Because ECHELON‐2 required ≥10% CD30 expression per IHC, there are no phase III data with BV+CHP in patients with CD30 expression levels of 1% to 9%. Two single‐arm trials provided supportive data in patients with relapsed or refractory PTCL treated with BV monotherapy, wherein objective responses were seen in cases having <10% CD30 expression. Interestingly, three patients with 0% CD30 expression per IHC achieved objective responses to BV monotherapy, raising questions about the mechanism of action. Because the minimum CD30 expression level necessary for BV activity is not determined, the indication statements for BV do not specify a minimum CD30 expression level. Data in low‐CD30‐expressing PTCL remain limited, and whether the single‐agent activity of BV in such cases translates into superiority of BV+CHP over CHOP is not established.
+
+Another important limitation is the paucity of data with BV+CHP in PTCL subtypes other than ALCL. Enrollment in ECHELON‐2 study was enriched for ALCL, with a prespecified target of 75%. Thus, by study design, patients with ALCL are the primary drivers of the study's outcomes. Although outcomes in the other PTCL populations were consistent with the overall study results, the data are limited, and some rare subtypes were not represented. Nevertheless, FDA granted approval of BV+CHP for CD30‐expressing PTCL independent of subtype, in an effort to be as inclusive as possible because of the poor prognosis in most subtypes with frontline therapy. The broad indication statement also matches the ECHELON‐2 eligibility criteria. Additional prospective trials would be helpful to characterize the activity of BV+CHP in patients with rare CD30‐expressing subtypes of PTCL.
+
+The applicability of BV regimens is limited by variability in CD30 expression. Although systemic ALCL universally expresses CD30, its expression in other types of PTCL is heterogeneous. Reported estimates of CD30 expression per IHC range from 58% to 64% in PTCL not otherwise specified, 63% to 75% in AITL, 0% to 55% in adult T‐cell leukemia/lymphoma, 0% to 100% in enteropathy‐associated T‐cell lymphoma, and 0% to 25% in hepatosplenic T‐cell lymphoma [10], [11], [12]. As a postmarketing commitment, FDA requested that the Sponsor develop a clinically validated in vitro diagnostic for CD30 expression, in order to inform patient selection for BV+CHP.
+
+Based on improvement in progression‐free as well as overall survival and a favorable benefit/risk balance, BV+CHP is a significant advance in the frontline therapy of CD30‐expressing PTCL.

--- a/references_cache/PMID_34382383.md
+++ b/references_cache/PMID_34382383.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:34382383"
+title: Whole-genome profiling of primary cutaneous anaplastic large cell lymphoma.
+authors:
+- Bastidas Torres AN
+- Melchers RC
+- Van Grieken L
+- Out-Luiting JJ
+- Mei H
+- Agaser C
+- Kuipers TB
+- Quint KD
+- Willemze R
+- Vermeer MH
+- Tensen CP
+journal: Haematologica
+year: '2022'
+doi: 10.3324/haematol.2020.263251
+keywords:
+- 3-Phosphoinositide-Dependent Protein Kinases
+- Fetal Proteins
+- Humans
+- Ki-1 Antigen
+- "Lymphoma, Large-Cell, Anaplastic/genetics, pathology"
+- "Lymphoma, Primary Cutaneous Anaplastic Large Cell"
+- Lymphoproliferative Disorders/pathology
+- Protein-Tyrosine Kinases
+- Proto-Oncogene Proteins c-akt
+- Skin Neoplasms/metabolism
+content_type: abstract_only
+---
+
+# Whole-genome profiling of primary cutaneous anaplastic large cell lymphoma.
+**Authors:** Bastidas Torres AN, Melchers RC, Van Grieken L, Out-Luiting JJ, Mei H, Agaser C, Kuipers TB, Quint KD, Willemze R, Vermeer MH, Tensen CP
+**Journal:** Haematologica (2022)
+**DOI:** [10.3324/haematol.2020.263251](https://doi.org/10.3324/haematol.2020.263251)
+
+## Content
+
+1. Haematologica. 2022 Jul 1;107(7):1619-1632. doi: 10.3324/haematol.2020.263251.
+
+Whole-genome profiling of primary cutaneous anaplastic large cell lymphoma.
+
+Bastidas Torres AN(1), Melchers RC(1), Van Grieken L(1), Out-Luiting JJ(1), Mei
+H(2), Agaser C(2), Kuipers TB(2), Quint KD(1), Willemze R(1), Vermeer MH(1),
+Tensen CP(3).
+
+Author information:
+(1)Department of Dermatology, Leiden University Medical Center, Leiden.
+(2)Sequencing Analysis Support Core, Leiden University Medical Center, Leiden.
+(3)Department of Dermatology, Leiden University Medical Center, Leiden.
+c.p.tensen@lumc.nl.
+
+Primary cutaneous anaplastic large cell lymphoma (pcALCL), a hematological
+neoplasm caused by skin-homing CD30+ malignant T cells, is part of the spectrum
+of primary cutaneous CD30+ lymphoproliferative disorders. To date, only a small
+number of molecular alterations have been described in pcALCL and, so far, no
+clear unifying theme that could explain the pathogenetic origin of the disease
+has emerged among patients. In order to clarify the pathogenetic basis of
+pcALCL, we performed high-resolution genetic profiling (genome/transcriptome) of
+this lymphoma (n=12) by using whole-genome sequencing, whole-exome sequencing
+and RNA sequencing. Our study, which uncovered novel genomic rearrangements,
+copy number alterations and small-scale mutations underlying this malignancy,
+revealed that the cell cycle, T-cell physiology regulation, transcription and
+signaling via the PI-3-K, MAPK and G-protein pathways are cellular processes
+commonly impacted by molecular alterations in patients with pcALCL. Recurrent
+events affecting cancer-associated genes included deletion of PRDM1 and
+TNFRSF14, gain of EZH2 and TNFRSF8, small-scale mutations in LRP1B, PDPK1 and
+PIK3R1 and rearrangements involving GPS2, LINC-PINT and TNK1. Consistent with
+the genomic data, transcriptome analysis uncovered upregulation of signal
+transduction routes associated with the PI-3-K, MAPK and G-protein pathways
+(e.g., ERK, phospholipase C, AKT). Our molecular findings suggest that
+inhibition of proliferation-promoting pathways altered in pcALCL (particularly
+PI-3-K/AKT signaling) should be explored as potential alternative therapy for
+patients with this lymphoma, especially, for cases that do not respond to
+first-line skin-directed therapies or with extracutaneous disease.
+
+DOI: 10.3324/haematol.2020.263251
+PMCID: PMC9244823
+PMID: 34382383 [Indexed for MEDLINE]

--- a/references_cache/PMID_34572893.md
+++ b/references_cache/PMID_34572893.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:34572893"
+title: "ALK-Negative Anaplastic Large Cell Lymphoma: Current Concepts and Molecular Pathogenesis of a Heterogeneous Group of Large T-Cell Lymphomas."
+authors:
+- Pina-Oviedo S
+- Ortiz-Hidalgo C
+- Carballo-Zarate AA
+- Zarate-Osorno A
+journal: Cancers (Basel)
+year: '2021'
+doi: 10.3390/cancers13184667
+content_type: abstract_only
+---
+
+# ALK-Negative Anaplastic Large Cell Lymphoma: Current Concepts and Molecular Pathogenesis of a Heterogeneous Group of Large T-Cell Lymphomas.
+**Authors:** Pina-Oviedo S, Ortiz-Hidalgo C, Carballo-Zarate AA, Zarate-Osorno A
+**Journal:** Cancers (Basel) (2021)
+**DOI:** [10.3390/cancers13184667](https://doi.org/10.3390/cancers13184667)
+
+## Content
+
+1. Cancers (Basel). 2021 Sep 17;13(18):4667. doi: 10.3390/cancers13184667.
+
+ALK-Negative Anaplastic Large Cell Lymphoma: Current Concepts and Molecular
+Pathogenesis of a Heterogeneous Group of Large T-Cell Lymphomas.
+
+Pina-Oviedo S(1), Ortiz-Hidalgo C(2), Carballo-Zarate AA(3), Zarate-Osorno A(3).
+
+Author information:
+(1)Department of Pathology, University of Arkansas for Medical Sciences, Little
+Rock, AR 72205, USA.
+(2)Department of Pathology, Hospital Médica Sur, Mexico City 14050, Mexico.
+(3)Department of Pathology, Hospital Español, Mexico City 11520, Mexico.
+
+Anaplastic large cell lymphoma (ALCL) is a subtype of CD30+ large T-cell
+lymphoma (TCL) that comprises ~2% of all adult non-Hodgkin lymphomas. Based on
+the presence/absence of the rearrangement and expression of anaplastic lymphoma
+kinase (ALK), ALCL is divided into ALK+ and ALK-, and both differ clinically and
+prognostically. This review focuses on the historical points, clinical features,
+histopathology, differential diagnosis, and relevant cytogenetic and molecular
+alterations of ALK- ALCL and its subtypes: systemic, primary cutaneous
+(pc-ALCL), and breast implant-associated (BIA-ALCL). Recent studies have
+identified recurrent genetic alterations in this TCL. In systemic ALK- ALCL,
+rearrangements in DUSP22 and TP63 are detected in 30% and 8% of cases,
+respectively, while the remaining cases are negative for these rearrangements. A
+similar distribution of these rearrangements is seen in pc-ALCL, whereas none
+have been detected in BIA-ALCL. Additionally, systemic ALK- ALCL-apart from
+DUSP22-rearranged cases-harbors JAK1 and/or STAT3 mutations that result in the
+activation of the JAK/STAT signaling pathway. The JAK1/3 and STAT3 mutations
+have also been identified in BIA-ALCL but not in pc-ALCL. Although the
+pathogenesis of these alterations is not fully understood, most of them have
+prognostic value and open the door to the use of potential targeted therapies
+for this subtype of TCL.
+
+DOI: 10.3390/cancers13184667
+PMCID: PMC8472588
+PMID: 34572893
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_35941721.md
+++ b/references_cache/PMID_35941721.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:35941721"
+title: Immunohistochemical Approach to Genetic Subtyping of Anaplastic Large Cell Lymphoma.
+authors:
+- Feldman AL
+- Oishi N
+- Ketterling RP
+- Ansell SM
+- Shi M
+- Dasari S
+journal: Am J Surg Pathol
+year: '2022'
+doi: 10.1097/PAS.0000000000001941
+keywords:
+- Gene Rearrangement
+- Humans
+- "In Situ Hybridization, Fluorescence"
+- "Lymphoma, Large-Cell, Anaplastic/genetics, pathology"
+- Receptor Protein-Tyrosine Kinases/genetics
+- Transcription Factors/genetics
+content_type: abstract_only
+---
+
+# Immunohistochemical Approach to Genetic Subtyping of Anaplastic Large Cell Lymphoma.
+**Authors:** Feldman AL, Oishi N, Ketterling RP, Ansell SM, Shi M, Dasari S
+**Journal:** Am J Surg Pathol (2022)
+**DOI:** [10.1097/PAS.0000000000001941](https://doi.org/10.1097/PAS.0000000000001941)
+
+## Content
+
+1. Am J Surg Pathol. 2022 Nov 1;46(11):1490-1499. doi:
+10.1097/PAS.0000000000001941. Epub 2022 Aug 8.
+
+Immunohistochemical Approach to Genetic Subtyping of Anaplastic Large Cell
+Lymphoma.
+
+Feldman AL(1), Oishi N(1)(2), Ketterling RP(1), Ansell SM(3), Shi M(1), Dasari
+S(4).
+
+Author information:
+(1)Departments of Laboratory Medicine and Pathology.
+(2)Department of Pathology, University of Yamanashi, Chuo, Yamanashi Prefecture,
+Japan.
+(3)Division of Hematology, Mayo Clinic, Rochester, MN.
+(4)Quantitative Health Sciences.
+
+Anaplastic large cell lymphoma (ALCL) can be classified genetically based on
+rearrangements (R) of the ALK , TP63 , and/or DUSP22 genes. ALK- R defines a
+specific entity, ALK-positive ALCL, while DUSP22- R and TP63- R define subgroups
+of ALK-negative ALCLs with distinct clinicopathologic features. ALK -R and TP63
+-R produce oncogenic fusion proteins that can be detected by
+immunohistochemistry. ALK immunohistochemistry is an excellent surrogate for
+ALK- R and screening with p63 immunohistochemistry excludes TP63- R in two third
+of ALCLs. In contrast, DUSP22 -R does not produce a fusion protein and its
+identification requires fluorescence in situ hybridization. However, DUSP22- R
+ALCL has a characteristic phenotype including negativity for cytotoxic markers
+and phospho-STAT3 Y705 . Recently, we also identified overexpression of the LEF1
+transcription factor in DUSP22- R ALCL. Here, we sought to validate this finding
+and examine models for predicting DUSP22- R using immunohistochemistry for LEF1
+and TIA1 or phospho-STAT3 Y705 . We evaluated these 3 markers in our original
+discovery cohort (n=45) and in an independent validation cohort (n=46) of ALCLs.
+The correlation between DUSP22- R and LEF1 expression replicated strongly in the
+validation cohort ( P <0.0001). In addition, we identified and validated a
+strategy using LEF1 and TIA1 immunohistochemistry that predicted DUSP22- R with
+positive and negative predictive values of 100% after exclusion of indeterminate
+cases and would eliminate the need for fluorescence in situ hybridization in 65%
+of ALK-negative ALCLs. This approach had similar results in identifying DUSP22-
+R in the related condition, lymphomatoid papulosis. Together with previous data,
+these findings support a 4-marker immunohistochemistry algorithm using ALK,
+LEF1, TIA1, and p63 for genetic subtyping of ALCL.
+
+Copyright © 2022 Wolters Kluwer Health, Inc. All rights reserved.
+
+DOI: 10.1097/PAS.0000000000001941
+PMCID: PMC9588576
+PMID: 35941721 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflicts of Interest and Source of Funding:
+Supported by P01 CA229100, P30 CA15083, P50 CA97274, and UL1 TR002377 from the
+National Institutes of Health; and by TRP 6574-19 from the Leukemia & Lymphoma
+Society. A.L.F. receives research funding from Seattle Genetics, is an inventor
+of technology discussed in this manuscript for which Mayo Clinic holds an
+unlicensed patent, and has intellectual property licensed to Zeno
+Pharmaceuticals. R.P.K. is an inventor of technology discussed in this
+manuscript for which Mayo Clinic holds an unlicensed patent. For the remaining
+authors none were declared.

--- a/references_cache/PMID_37549532.md
+++ b/references_cache/PMID_37549532.md
@@ -1,0 +1,154 @@
+---
+reference_id: "PMID:37549532"
+title: "Efficacy and safety of crizotinib in ALK-positive systemic anaplastic large-cell lymphoma in children, adolescents, and adult patients: results of the French AcSé-crizotinib trial."
+authors:
+- Brugières L
+- Cozic N
+- Houot R
+- Rigaud C
+- Sibon D
+- Arfi-Rouche J
+- Bories P
+- Cottereau AS
+- Delmer A
+- Ducassou S
+- Garnier N
+- Lamant L
+- Leruste A
+- Millot F
+- Moalla S
+- Morschhauser F
+- Nolla M
+- Pagnier A
+- Reguerre Y
+- Renaud L
+- Schmitt A
+- Simonin M
+- Verschuur A
+- Hoog Labouret N
+- Mahier Ait Oukhatar C
+- Vassal G
+journal: Eur J Cancer
+year: '2023'
+doi: 10.1016/j.ejca.2023.112984
+keywords:
+- Humans
+- Adult
+- Child
+- Adolescent
+- Young Adult
+- Crizotinib/therapeutic use
+- "Lymphoma, Large-Cell, Anaplastic/drug therapy"
+- Protein-Tyrosine Kinases/therapeutic use
+- Anaplastic Lymphoma Kinase
+- "Neoplasm Recurrence, Local/drug therapy"
+- Proto-Oncogene Proteins
+- Receptor Protein-Tyrosine Kinases/therapeutic use
+- Protein Kinase Inhibitors/adverse effects
+- Lung Neoplasms/drug therapy
+content_type: abstract_only
+---
+
+# Efficacy and safety of crizotinib in ALK-positive systemic anaplastic large-cell lymphoma in children, adolescents, and adult patients: results of the French AcSé-crizotinib trial.
+**Authors:** Brugières L, Cozic N, Houot R, Rigaud C, Sibon D, Arfi-Rouche J, Bories P, Cottereau AS, Delmer A, Ducassou S, Garnier N, Lamant L, Leruste A, Millot F, Moalla S, Morschhauser F, Nolla M, Pagnier A, Reguerre Y, Renaud L, Schmitt A, Simonin M, Verschuur A, Hoog Labouret N, Mahier Ait Oukhatar C, Vassal G
+**Journal:** Eur J Cancer (2023)
+**DOI:** [10.1016/j.ejca.2023.112984](https://doi.org/10.1016/j.ejca.2023.112984)
+
+## Content
+
+1. Eur J Cancer. 2023 Sep;191:112984. doi: 10.1016/j.ejca.2023.112984. Epub 2023
+Jul 17.
+
+Efficacy and safety of crizotinib in ALK-positive systemic anaplastic large-cell
+lymphoma in children, adolescents, and adult patients: results of the French
+AcSé-crizotinib trial.
+
+Brugières L(1), Cozic N(2), Houot R(3), Rigaud C(4), Sibon D(5), Arfi-Rouche
+J(6), Bories P(7), Cottereau AS(8), Delmer A(9), Ducassou S(10), Garnier N(11),
+Lamant L(12), Leruste A(13), Millot F(14), Moalla S(7), Morschhauser F(15),
+Nolla M(16), Pagnier A(17), Reguerre Y(18), Renaud L(19), Schmitt A(20), Simonin
+M(21), Verschuur A(22), Hoog Labouret N(23), Mahier Ait Oukhatar C(24), Vassal
+G(4).
+
+Author information:
+(1)Department of Children and Adolescent Oncology, Gustave Roussy Cancer Campus,
+Paris-Saclay University, Villejuif, France. Electronic address:
+laurence.brugieres@gustaveroussy.fr.
+(2)Service de Biostatistique et d'Epidémiologie, Gustave Roussy, Oncostat U1018
+INSERM, Labeled Ligue Contre le Cancer, Université Paris-Saclay, Villejuif,
+France.
+(3)Department of Hematology, CHU de Rennes, Université de Rennes, Rennes,
+France.
+(4)Department of Children and Adolescent Oncology, Gustave Roussy Cancer Campus,
+Paris-Saclay University, Villejuif, France.
+(5)Lymphoid Malignancies Department, Henri Mondor University Hospital, AP-HP,
+Creteil, France.
+(6)Department of Radiology, Gustave Roussy Cancer Campus, Paris-Saclay
+University, Villejuif, France.
+(7)Institut Universitaire du Cancer - Oncopole, Toulouse, France.
+(8)Department of Nuclear Medicine, Cochin Hospital, AP-HP, University of Paris,
+Paris, France.
+(9)Department of Hematology, University Hospital of Reims and UFR Médecine,
+Reims, France.
+(10)Department of Pediatric Hemato-Oncology, Bordeaux, France.
+(11)Institut d'Hematologie et d'Oncologie Pediatrique, Hospices Civils de Lyon,
+Lyon, France.
+(12)Department of Pathology, Institut Universitaire du Cancer de Toulouse
+Oncopole, Toulouse, France Université Toulouse III-Paul Sabatier; UMR1037
+CRCT, Toulouse, France.
+(13)SIREDO Oncology Center (Care, Innovation and Research for Children and AYA
+with Cancer), Institut Curie, PSL Research University, Paris, France.
+(14)Inserm CIC 1402, University Hospital, Poitiers, France.
+(15)ULR 7365 - GRITA - Groupe de Recherche sur les formes Injectables et les
+Technologies Associées, Univ. Lille, CHU Lille, Lille, France.
+(16)Pediatric Hematology-Immunology, CHU Toulouse Purpan, France.
+(17)Pediatric Immunology Hematology and Oncology, CHU Grenoble Alpes, France.
+(18)CHU de Saint Denis de La Réunion Service d'Oncologie et d'Hématologie
+Pédiatrique, Saint Denis, France.
+(19)Assistance Publique-Hôpitaux de Paris, Hôpital Saint-Louis,
+Hemato-Oncologie, DMU DHI; Université de Paris, Paris, France.
+(20)Hématologie, Institut Bergonié, Bordeaux, France.
+(21)Department of Pediatric Hematology and Oncology, Assistance
+Publique-Hôpitaux de Paris Armand Trousseau Hospital, Sorbonne Université,
+Paris, France.
+(22)Department of Pediatric Hematology-Oncology, La Timone University Hospital,
+APHM, Marseille, France.
+(23)Institut National du Cancer, Boulogne Billancourt, Paris, France.
+(24)UNICANCER, Paris, France.
+
+BACKGROUND: The French phase II AcSé-crizotinib trial aimed to evaluate the
+safety and efficacy of crizotinib in patients with ALK, ROS1, and MET-driven
+malignancies, including ALK-positive anaplastic large-cell lymphoma (ALK+ ALCL).
+METHODS: ALK+ ALCL patients 12 months or older with measurable disease and no
+standard care options available received crizotinib twice daily at 165 mg/m2 in
+children and adolescents and 250 mg in adults. The primary end-point was the
+response rate at 8 weeks.
+RESULTS: Twenty-eight patients were enroled between February 2014 and March
+2018. Three patients who were not treated were excluded from the analysis. The
+median age was 19 years. The median previous line of chemotherapy was two. In
+the 24 patients with an evaluable response, the response rate at 8 weeks was 67%
+(95% CI: 47-82%). All patients discontinued crizotinib after a median treatment
+duration of 3.7 months: eight for progression, two for adverse events
+(AEs) related to prior treatments, and 15 by choice, including six for
+allogeneic stem-cell transplantation. The median follow-up was 45 months. Nine
+patients experienced an event: eight relapses (seven after crizotinib
+discontinuation and one after dose reduction), and one died in complete
+remission. The median duration of response was 43.3 months (95% CI: 8.3-not
+reached). The 3-year progression-free and overall survival rates were 40% (95%
+CI: 23-59%) and 63% (95% CI: 43-79%). Grade 3 or 4 treatment-related AEs
+occurred in 32% of patients.
+CONCLUSION: Crizotinib shows efficacy and an acceptable safety profile in ALK+
+ALCL relapsed/refractory patients. However, a large proportion of patients
+experience a relapse after crizotinib discontinuation. Future studies will
+assess if prolonged ALK inhibitor exposure has curative potential without
+consolidation.
+
+Copyright © 2023 The Authors. Published by Elsevier Ltd.. All rights reserved.
+
+DOI: 10.1016/j.ejca.2023.112984
+PMID: 37549532 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of Competing Interest The authors
+declare that they have no known competing financial interests or personal
+relationships that could have appeared to influence the work reported in this
+paper.

--- a/references_cache/PMID_37655119.md
+++ b/references_cache/PMID_37655119.md
@@ -1,0 +1,53 @@
+---
+reference_id: "PMID:37655119"
+title: ALK-positive anaplastic large cell lymphoma in adults.
+authors:
+- Gromowsky MJ
+- "D'Angelo CR"
+- Lunning MA
+- Armitage JO
+journal: Fac Rev
+year: '2023'
+doi: 10.12703/r/12-21
+content_type: abstract_only
+---
+
+# ALK-positive anaplastic large cell lymphoma in adults.
+**Authors:** Gromowsky MJ, D'Angelo CR, Lunning MA, Armitage JO
+**Journal:** Fac Rev (2023)
+**DOI:** [10.12703/r/12-21](https://doi.org/10.12703/r/12-21)
+
+## Content
+
+1. Fac Rev. 2023 Aug 25;12:21. doi: 10.12703/r/12-21. eCollection 2023.
+
+ALK-positive anaplastic large cell lymphoma in adults.
+
+Gromowsky MJ(1), D'Angelo CR(1), Lunning MA(1), Armitage JO(1).
+
+Author information:
+(1)University of Nebraska Medical Center, Omaha, Nebraska, USA.
+
+ALK-positive anaplastic large cell lymphoma (ALCL) represents approximately 6-7%
+of the mature T-cell lymphomas. This subtype contains a translocation between
+the ALK gene on chromosome 2 and one of several other genes that together form
+an oncogene. The most frequent translocation is t(2;5) which combines ALK with
+NPM1. This lymphoma has a median age of 34 years, is more common in males, and
+is in advanced stage at the time of diagnosis in most patients. ALK-positive
+ALCL is the most curable of the peripheral T-cell lymphomas. The CHOP regimen
+has been most frequently used, but results are improved with the substitution of
+brentuximab vedotin for vincristine (BV-CHP) and the addition of etoposide
+(CHOEP), with BV-CHP being favored. Salvage therapies include allogeneic or
+autologous bone marrow transplantation, BV, if not used as part of the primary
+therapy, and ALK inhibitors. The latter are very active and likely to be
+incorporated into the primary therapy.
+
+Copyright: © 2023 Armitage JO et al.
+
+DOI: 10.12703/r/12-21
+PMCID: PMC10467138
+PMID: 37655119
+
+Conflict of interest statement: JA is a Cardiff Oncology-Member, Board of
+Directors. The other authors declare that they have no competing interests.No
+competing interests were disclosed.No competing interests were disclosed.

--- a/references_cache/PMID_38102324.md
+++ b/references_cache/PMID_38102324.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:38102324"
+title: "Surgical Management and Long-Term Outcomes of BIA-ALCL: A Multidisciplinary Approach."
+authors:
+- Vorstenbosch J
+- Ghione P
+- Plitas G
+- Horwitz S
+- Kim M
+- Cordeiro P
+- Nelson J
+- McCarthy C
+journal: Ann Surg Oncol
+year: '2024'
+doi: 10.1245/s10434-023-14636-4
+keywords:
+- Humans
+- Female
+- Adult
+- Middle Aged
+- Aged
+- Breast Implants/adverse effects
+- Retrospective Studies
+- "Lymphoma, Large-Cell, Anaplastic/etiology"
+- Seroma/etiology
+- Breast Implantation/adverse effects
+- Breast Neoplasms/surgery
+content_type: abstract_only
+---
+
+# Surgical Management and Long-Term Outcomes of BIA-ALCL: A Multidisciplinary Approach.
+**Authors:** Vorstenbosch J, Ghione P, Plitas G, Horwitz S, Kim M, Cordeiro P, Nelson J, McCarthy C
+**Journal:** Ann Surg Oncol (2024)
+**DOI:** [10.1245/s10434-023-14636-4](https://doi.org/10.1245/s10434-023-14636-4)
+
+## Content
+
+1. Ann Surg Oncol. 2024 Mar;31(3):2032-2040. doi: 10.1245/s10434-023-14636-4.
+Epub  2023 Dec 15.
+
+Surgical Management and Long-Term Outcomes of BIA-ALCL: A Multidisciplinary
+Approach.
+
+Vorstenbosch J(#)(1), Ghione P(#)(2), Plitas G(3), Horwitz S(4), Kim M(5),
+Cordeiro P(5), Nelson J(5), McCarthy C(6).
+
+Author information:
+(1)Division of Plastic Surgery, McGill University, Montreal, QC, Canada.
+(2)Lymphoma Section, Department of Medicine, Roswell Park Comprehensive Cancer
+Centre, Buffalo, NY, USA.
+(3)Breast Surgical Service, Department of Surgery, Memorial Sloan Kettering
+Cancer Center, New York, NY, USA.
+(4)Hematology and Oncology Service, Department of Medicine, Memorial Sloan
+Kettering Cancer Center, New York, USA.
+(5)Plastic and Reconstructive Surgery Service, Department of Surgery, Memorial
+Sloan Kettering Cancer Center, New York, NY, USA.
+(6)Plastic and Reconstructive Surgery Service, Department of Surgery, Memorial
+Sloan Kettering Cancer Center, New York, NY, USA. McCarthc@mskcc.org.
+(#)Contributed equally
+
+BACKGROUND: Breast implant-associated anaplastic large cell lymphoma (BIA-ALCL)
+is a subtype of ALCL that arises as a seroma or a mass in the capsule
+surrounding textured breast implants. However, collections of cases usually come
+from large groups of institutions or countries, with different approaches
+regarding surgery and treatment. Here we describe a cohort of 18 cases
+undergoing implant removal and capsulectomy followed at Memorial Sloan Kettering
+Cancer Center (MSKCC).
+PATIENTS AND METHODS: We retrospectively analyzed all the cases of women with
+breast implants undergoing implant removal and capsulectomy for BIA-ALCL at
+MSKCC from January 2011 to June 2020.
+RESULTS: Median age at diagnosis was 57 (range 35-77) years following a median
+implant exposure of 11 (range 7-33) years. All known implants were macrotextured
+with the proprietary Biocell macrotexturing pattern from salt-loss technique. A
+total of 16 patients (89%) had implants placed for breast cancer reconstruction.
+Patients presented with clinically evident effusion in 78% of cases and a mass
+in 17% of cases, and 83% of patients presented with stage 1 BIA-ALCL. Patients
+were followed for a median of 43.4 months (SD 45 months) after diagnosis. There
+were no cases of recurrent ALCL. All patients remain disease free and no
+patients died of ALCL.
+CONCLUSIONS: In this cohort of patients with BIA-ALCL surgically treated and
+followed at a single institution, we confirm the importance of adequate surgery
+(bilateral implant removal and complete capsulectomy) in patients presenting
+with seroma-confined disease. This dataset reinforces high rates of
+progression-free and overall survival when diagnosis is identified and treatment
+performed in those with limited-stage disease.
+
+© 2023. Society of Surgical Oncology.
+
+DOI: 10.1245/s10434-023-14636-4
+PMID: 38102324 [Indexed for MEDLINE]

--- a/references_cache/PMID_40565334.md
+++ b/references_cache/PMID_40565334.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:40565334"
+title: "Molecular Insights into the Diagnosis of Anaplastic Large Cell Lymphoma: Beyond Morphology and Immunophenotype."
+authors:
+- Frutos Díaz-Alejo J
+- Prieto-Potín I
+- Manso R
+- Rodríguez M
+- Rebollo-González M
+- Díaz de la Pinta FJ
+- Morales-Gallego M
+- Rodríguez-Pinilla SM
+- Onaindia A
+journal: Int J Mol Sci
+year: '2025'
+doi: 10.3390/ijms26125871
+keywords:
+- Humans
+- "Lymphoma, Large-Cell, Anaplastic/diagnosis, genetics, metabolism, pathology"
+- Immunophenotyping
+- "Anaplastic Lymphoma Kinase/genetics, metabolism"
+- "STAT3 Transcription Factor/metabolism, genetics"
+- Signal Transduction
+- "Biomarkers, Tumor"
+content_type: abstract_only
+---
+
+# Molecular Insights into the Diagnosis of Anaplastic Large Cell Lymphoma: Beyond Morphology and Immunophenotype.
+**Authors:** Frutos Díaz-Alejo J, Prieto-Potín I, Manso R, Rodríguez M, Rebollo-González M, Díaz de la Pinta FJ, Morales-Gallego M, Rodríguez-Pinilla SM, Onaindia A
+**Journal:** Int J Mol Sci (2025)
+**DOI:** [10.3390/ijms26125871](https://doi.org/10.3390/ijms26125871)
+
+## Content
+
+1. Int J Mol Sci. 2025 Jun 19;26(12):5871. doi: 10.3390/ijms26125871.
+
+Molecular Insights into the Diagnosis of Anaplastic Large Cell Lymphoma: Beyond
+Morphology and Immunophenotype.
+
+Frutos Díaz-Alejo J(1), Prieto-Potín I(1), Manso R(1), Rodríguez M(1),
+Rebollo-González M(1), Díaz de la Pinta FJ(1), Morales-Gallego M(1),
+Rodríguez-Pinilla SM(1), Onaindia A(2)(3).
+
+Author information:
+(1)Pathology Department, Instituto de Investigación Sanitaria-Fundación Jiménez
+Díaz University Hospital, Universidad Autónoma de Madrid (IIS-FJD, UAM), 28040
+Madrid, Spain.
+(2)Pathology Department, Osakidetza Basque Health Service, Araba University
+Hospital, 01070 Vitoria-Gasteiz, Spain.
+(3)Oncohaematology Research Group, Bioaraba Health Research Institute, 01070
+Vitoria-Gasteiz, Spain.
+
+Anaplastic Large Cell Lymphoma (ALCL) represents a diverse group of mature
+T-Cell Lymphomas unified by strong CD30 expression but with different molecular
+and clinical subtypes. This review summarizes recent molecular advances in ALCL,
+highlighting key discoveries that have refined its classification, diagnosis,
+and therapeutic strategies. ALCL comprises four major entities: systemic
+ALK-positive ALCL, systemic ALK-negative ALCL, Breast Implant-Associated ALCL
+(BIA-ALCL), and primary cutaneous ALCL. Each subtype exhibits unique phenotypes,
+along with cytogenetic and molecular alterations that affect clinical outcomes.
+Nevertheless, different oncogenic mechanisms mediate STAT3 activation. In
+ALK-positive ALCL, ALK fusion proteins drive oncogenesis via constitutive
+activation of STAT3 and other signaling pathways. ALK-negative ALCL comprises
+heterogeneous genetic subtypes, in which JAK/STAT3 pathway alterations and novel
+gene fusions are gaining recognition as potential therapeutic targets. This
+review emphasizes the need for integrative molecular diagnostics to improve
+stratification of ALCL subtypes and targeted treatment approaches. Future
+research should focus on elucidating the biological mechanisms underlying these
+alterations and on translating molecular insights into clinical practice.
+
+DOI: 10.3390/ijms26125871
+PMCID: PMC12192600
+PMID: 40565334 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/research/Anaplastic_Large_Cell_Lymphoma-deep-research-openai.md
+++ b/research/Anaplastic_Large_Cell_Lymphoma-deep-research-openai.md
@@ -1,0 +1,168 @@
+---
+provider: openai
+model: gpt-5
+curation_date: "2026-04-13"
+disease_name: Anaplastic Large Cell Lymphoma
+issue: 1209
+---
+
+# Anaplastic Large Cell Lymphoma Curation Notes
+
+## Modeling Decision
+
+This curation follows the cancer modeling guidance from dismech issue `#1198` and
+the Wilms tumor pattern:
+
+- The dismech page is the disease-level mechanism graph for ALCL, not a one-page-per-ontology-subclass expansion.
+- `disease_term` stays MONDO-first at `MONDO:0020325` (`anaplastic large cell lymphoma`).
+- Major ALCL entities are represented as flat subtype facets under one page:
+  - Systemic ALK-positive
+  - Systemic ALK-negative
+  - Primary cutaneous
+  - Breast implant-associated
+- Genetic subgroups such as `DUSP22`-rearranged and `TP63`-rearranged ALK-negative
+  ALCL are modeled as mechanism/genetic facts inside the unified disease page,
+  not as separate dismech pages.
+- Current schema only provides `Subtype.subtype_term` as a MONDO-grounded slot
+  and does not expose a disease-level `ncit_mappings` slot. Because of that,
+  NCIT grounding was carried through histopathology findings, biomarkers, and
+  treatment regimens/agents rather than by inventing non-schema subtype mapping
+  structures.
+
+## Ontology Anchors
+
+### Disease
+
+- MONDO disease anchor: `MONDO:0020325` `anaplastic large cell lymphoma`
+- NCIT companion cancer concept: `NCIT:C3720` `Anaplastic Large Cell Lymphoma`
+
+### MONDO subtype anchors used in YAML
+
+- `MONDO:0017602` `ALK-positive anaplastic large cell lymphoma`
+- `MONDO:0017603` `ALK-negative anaplastic large cell lymphoma`
+- `MONDO:0017598` `primary cutaneous anaplastic large cell lymphoma`
+- `MONDO:0850112` `breast implant-associated anaplastic large cell lymphoma`
+
+### NCIT companion subtype concepts used in interpretation
+
+- `NCIT:C37195` `Systemic Anaplastic Large Cell Lymphoma, ALK-Positive`
+- `NCIT:C37196` `Systemic Anaplastic Large Cell Lymphoma, ALK-Negative`
+- `NCIT:C6860` `Primary Cutaneous Anaplastic Large Cell Lymphoma`
+- `NCIT:C139012` `Breast Implant-Associated Anaplastic Large Cell Lymphoma`
+
+### Histopathology / biomarker / treatment grounding
+
+- `NCIT:C39679` `Hallmark Cell`
+- `NCIT:C193484` `CD30 Antigen [Presence] in Tissue by Immune Stain`
+- `NCIT:C38906` `Tumor Necrosis Factor Receptor Superfamily Member 8`
+- `NCIT:C81946` `ALK Fusion Protein Expression`
+- `NCIT:C66944` `Brentuximab Vedotin`
+- `NCIT:C159558` `CHP-Brentuximab Vedotin Regimen`
+- `NCIT:C160013` `Crizotinib Regimen`
+
+## PMID-Backed Evidence Used
+
+### Disease framing and subtype axes
+
+- `PMID:40565334`
+  - Quote: `Anaplastic Large Cell Lymphoma (ALCL) represents a diverse group of mature T-Cell Lymphomas unified by strong CD30 expression but with different molecular and clinical subtypes.`
+  - Use: disease-level definition and justification for one unified ALCL page.
+- `PMID:40565334`
+  - Quote: `ALCL comprises four major entities: systemic ALK-positive ALCL, systemic ALK-negative ALCL, Breast Implant-Associated ALCL (BIA-ALCL), and primary cutaneous ALCL.`
+  - Use: flat subtype facet structure.
+- `PMID:24894770`
+  - Quote: `Thus, ALK-negative ALCL is a genetically heterogeneous disease with widely disparate outcomes following standard therapy.`
+  - Use: ALK-negative modeled as one subtype with internal genetic heterogeneity, not split into multiple pages.
+
+### Histopathology and diagnosis
+
+- `PMID:28975123`
+  - Quote: `Histologically, all the subtypes showed pleomorphic and "hallmark" cells with strong CD30 expression and variable loss of T-cell antigens.`
+  - Use: hallmark-cell histopathology and diffuse CD30-positive tissue phenotype.
+- `PMID:28975123`
+  - Quote: `Diagnosis of ALCL is based on recognizing the key morphological features, especially the presence of "hallmark" cells.`
+  - Use: diagnostic emphasis on morphology.
+- `PMID:28975123`
+  - Quote: `The inclusion of CD30 in the initial IHC panel will help identify LCA negative cases and avoid misdiagnosis.`
+  - Use: diagnostic workflow and IHC panel design.
+- `PMID:35941721`
+  - Quote: `Together with previous data, these findings support a 4-marker immunohistochemistry algorithm using ALK, LEF1, TIA1, and p63 for genetic subtyping of ALCL.`
+  - Use: ancillary subtype-specific diagnostic testing.
+
+### Mechanism notes kept atomic in YAML
+
+- `PMID:29617304`
+  - Quote: `ALK is rearranged in approximately 80% of systemic ALCL cases with one of its partner genes, most commonly NPM1`
+  - Use: discrete `ALK Fusion Oncogene Formation` node.
+- `PMID:11850821`
+  - Quote: `We show here that expression of activated ALK induces the constitutive phosphorylation of Stat3 in transfected cells as well as in primary human ALCLs.`
+  - Use: separate `ALK-Driven STAT3 Activation` node.
+- `PMID:11850821`
+  - Quote: `These studies support a pathogenic mechanism whereby stimulation of anti-apoptotic signals through activation of Stat3 contributes to the successful outgrowth of ALK positive tumor cells.`
+  - Use: separate `BCL2L1-Mediated Apoptosis Resistance` node.
+- `PMID:19088198`
+  - Quote: `NPM/ALK induces CD274 expression by activating its key signal transmitter, transcription factor STAT3.`
+  - Use: separate `PD-L1-Mediated Immune Evasion` node.
+- `PMID:34572893`
+  - Quote: `Additionally, systemic ALK- ALCL-apart from DUSP22-rearranged cases-harbors JAK1 and/or STAT3 mutations that result in the activation of the JAK/STAT signaling pathway.`
+  - Use: subtype-scoped `JAK/STAT3 Pathway Alteration in ALK-Negative ALCL`.
+- `PMID:34382383`
+  - Quote: `Consistent with the genomic data, transcriptome analysis uncovered upregulation of signal transduction routes associated with the PI-3-K, MAPK and G-protein pathways (e.g., ERK, phospholipase C, AKT).`
+  - Use: distinct primary-cutaneous signaling node rather than collapsing all non-ALK biology together.
+
+### Phenotypes and treatment
+
+- `PMID:37655119`
+  - Quote: `This lymphoma has a median age of 34 years, is more common in males, and is in advanced stage at the time of diagnosis in most patients.`
+  - Use: advanced-stage presentation phenotype for systemic ALK-positive disease.
+- `PMID:24346900`
+  - Quote: `Primary cutaneous anaplastic large-cell lymphoma is part of the spectrum of CD30+ lymphoproliferative cutaneous processes, characterized by single or multifocal nodules that ulcerate, are autoregressive and recurrent.`
+  - Use: skin-nodule phenotype for primary cutaneous ALCL.
+- `PMID:38102324`
+  - Quote: `Breast implant-associated anaplastic large cell lymphoma (BIA-ALCL) is a subtype of ALCL that arises as a seroma or a mass in the capsule surrounding textured breast implants.`
+  - Use: seroma and capsule-mass phenotypes for BIA-ALCL.
+- `PMID:30914464`
+  - Quote: `In November 2018, the U.S. Food and Drug Administration (FDA) approved brentuximab vedotin (BV) for the treatment of adult patients with previously untreated systemic anaplastic large cell lymphoma`
+  - Use: frontline brentuximab vedotin plus CHP.
+- `PMID:28974506`
+  - Quote: `These final results, which demonstrated ... durable remissions in a subset of patients with relapsed or refractory systemic ALCL, provide evidence that single-agent brentuximab vedotin may be a potentially curative treatment option.`
+  - Use: relapsed/refractory brentuximab vedotin.
+- `PMID:37549532`
+  - Quote: `CONCLUSION: Crizotinib shows efficacy and an acceptable safety profile in ALK+ ALCL relapsed/refractory patients.`
+  - Use: targeted ALK inhibition.
+- `PMID:26628470`
+  - Quote: `Patients who underwent a complete surgical excision that consisted of total capsulectomy with breast implant removal had better OS (P = .022) and EFS (P = .014)`
+  - Use: surgery-first management for BIA-ALCL.
+
+## Why Separate Pages Were Not Created
+
+Separate disease files were not created for ALK-positive ALCL, ALK-negative
+ALCL, primary cutaneous ALCL, or BIA-ALCL because:
+
+- the user explicitly requested application of the `#1198` cancer-guideline pattern;
+- ALCL is represented in current disease ontology usage as one disease family with
+  major subtype entities;
+- the important modeling burden here is subtype-scoped mechanism and treatment
+  separation inside one page, not proliferating disease pages; and
+- only some branches, especially ALK-positive systemic disease and cutaneous/BIA
+  disease, show clearly different mechanistic programs, which are captured by
+  atomic nodes and subtype-scoped evidence inside the single page.
+
+## Cached References Added for This Slice
+
+- `PMID:40565334`
+- `PMID:29617304`
+- `PMID:37655119`
+- `PMID:24894770`
+- `PMID:35941721`
+- `PMID:34382383`
+- `PMID:34572893`
+- `PMID:24404580`
+- `PMID:19088198`
+- `PMID:11850821`
+- `PMID:30914464`
+- `PMID:28974506`
+- `PMID:37549532`
+- `PMID:24346900`
+- `PMID:26628470`
+- `PMID:38102324`


### PR DESCRIPTION
## Summary
- add a disease-level ALCL curation anchored on `MONDO:0020325` with flat subtype facets for systemic ALK-positive, systemic ALK-negative, primary cutaneous, and breast implant-associated disease
- add atomic subtype-scoped pathophysiology, histopathology, phenotype, biomarker, diagnosis, genetic, and treatment curation with exact PMID-backed evidence
- add a paired deep-research note plus the PMID cache files used for this disease slice

## Modeling
- applies the `#1198` cancer-guideline pattern: one dismech page for ALCL rather than separate pages for every ontology subclass
- keeps the disease anchor MONDO-first and uses cancer-specific NCIT grounding in histopathology, biomarkers, and therapeutics
- keeps genetic subgroup facts such as `DUSP22` and `TP63` inside the ALK-negative subtype rather than promoting them to separate disease pages

## Validation
- `just validate kb/disorders/Anaplastic_Large_Cell_Lymphoma.yaml`
- `just validate-terms kb/disorders/Anaplastic_Large_Cell_Lymphoma.yaml`
- `just validate-references kb/disorders/Anaplastic_Large_Cell_Lymphoma.yaml`

Closes #1209