### PR TITLE
feat: Add Focal Segmental Glomerulosclerosis with validated evidence

### DIFF
--- a/kb/disorders/Focal_Segmental_Glomerulosclerosis.yaml
+++ b/kb/disorders/Focal_Segmental_Glomerulosclerosis.yaml
@@ -1,0 +1,627 @@
+name: Focal Segmental Glomerulosclerosis
+creation_date: "2026-04-13T17:56:50Z"
+updated_date: "2026-04-13T17:56:50Z"
+category: Complex
+disease_term:
+  preferred_term: Focal Segmental Glomerulosclerosis
+  term:
+    id: MONDO:0100313
+    label: focal segmental glomerulosclerosis
+parents:
+  - glomerulosclerosis
+  - nephrotic syndrome
+
+has_subtypes:
+  - name: Primary FSGS
+    description: >
+      Idiopathic FSGS with no identifiable secondary cause; immune-mediated with
+      circulating permeability factors (including soluble urokinase plasminogen
+      activator receptor, anti-nephrin antibodies, and others) targeting podocytes.
+      Associated with high rates of post-transplant recurrence (30-40%).
+  - name: Secondary FSGS
+    description: >
+      FSGS arising from an identifiable cause such as obesity, reflux nephropathy,
+      viral infection (HIV, parvovirus B19), heroin use, or as a maladaptive
+      response to reduced nephron mass (e.g., solitary kidney, prior nephrectomy).
+  - name: Genetic FSGS
+    description: >
+      Hereditary FSGS caused by mutations in podocyte-expressed genes including
+      NPHS1, NPHS2, ACTN4, TRPC6, and INF2. Generally does not recur after
+      kidney transplantation, unlike primary FSGS.
+  - name: Collapsing FSGS
+    description: >
+      A severe morphological variant with segmental or global collapse of the
+      glomerular tuft and marked podocyte hyperplasia/hypertrophy. Associated with
+      HIV nephropathy (HIVAN), COVID-19-associated nephropathy (COVAN), and
+      interferon therapy.
+
+pathophysiology:
+  - name: Podocyte Injury and Loss
+    description: >
+      The central initiating event in FSGS is injury to podocytes — terminally
+      differentiated glomerular visceral epithelial cells forming the outer layer
+      of the glomerular filtration barrier. Podocyte stress leads to foot process
+      effacement, detachment, and apoptosis. Because podocytes have very limited
+      regenerative capacity, cumulative loss beyond a threshold triggers segmental
+      sclerosis. The pathophysiology is multifactorial: direct podocyte injury
+      from genetic defects, immune-mediated mechanisms via circulating permeability
+      factors, and metabolic disturbances including intracellular cholesterol
+      accumulation all contribute.
+    cell_types:
+      - preferred_term: podocyte
+        term:
+          id: CL:0000653
+          label: podocyte
+    biological_processes:
+      - preferred_term: podocyte apoptosis
+        term:
+          id: GO:0097194
+          label: execution phase of apoptosis
+        modifier: INCREASED
+      - preferred_term: actin cytoskeleton reorganization
+        term:
+          id: GO:0030036
+          label: actin cytoskeleton organization
+        modifier: ABNORMAL
+    evidence:
+      - reference: PMID:41009330
+        reference_title: "Focal Segmental Glomerulosclerosis: Comprehensive Review and Exploration of the Dual Potential of Cyclodextrins in Therapeutic Optimization."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "The pathophysiology is multifactorial and includes direct podocyte injury (e.g., genetic defects, mechanical or toxic injury), immune-mediated processes (e.g., circulating permeability factors, inflammatory mediators), and metabolic disturbances."
+        explanation: >
+          This comprehensive review establishes that podocyte injury arises from multiple
+          converging mechanisms, including genetic, immune, and metabolic factors.
+
+  - name: Circulating Permeability Factor-Mediated Podocyte Injury
+    description: >
+      Primary (idiopathic) FSGS is driven by one or more circulating factors in
+      the serum that injure podocytes. Candidate factors include soluble urokinase
+      plasminogen activator receptor (suPAR), cardiotrophin-like cytokine 1, and
+      angiopoietin-like 4. More recently, anti-nephrin antibodies have been
+      identified in a significant proportion of primary FSGS cases and predict
+      recurrence after transplantation. The immune basis is supported by
+      responsiveness to corticosteroids, calcineurin inhibitors targeting T-cells,
+      and rituximab targeting B-cells.
+    cell_types:
+      - preferred_term: podocyte
+        term:
+          id: CL:0000653
+          label: podocyte
+      - preferred_term: T cell
+        term:
+          id: CL:0000084
+          label: T cell
+      - preferred_term: B cell
+        term:
+          id: CL:0000236
+          label: B cell
+    biological_processes:
+      - preferred_term: immune response
+        term:
+          id: GO:0006955
+          label: immune response
+        modifier: ABNORMAL
+      - preferred_term: glomerular filtration
+        term:
+          id: GO:0003094
+          label: glomerular filtration
+        modifier: DECREASED
+    evidence:
+      - reference: PMID:41133676
+        reference_title: "Serum Factors in Primary Podocytopathies."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Primary podocytopathies, including minimal change disease (MCD) and focal segmental glomerulosclerosis (FSGS), are caused by a circulating factor or factors injurious to the podocyte."
+        explanation: >
+          Establishes circulating factors as the primary pathogenic mechanism in
+          primary FSGS, with immune-mediated mechanisms supported by treatment
+          responsiveness to immunosuppressants.
+      - reference: PMID:41133676
+        reference_title: "Serum Factors in Primary Podocytopathies."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Potential non-antibody-mediated circulating factors have been identified, including cardiotrophin-like cytokine 1, soluble urokinase plasminogen activator receptor, and angiopoietin-like 4, among others."
+        explanation: >
+          Identifies specific candidate circulating permeability factors implicated in
+          primary FSGS pathogenesis beyond classical autoantibodies.
+
+  - name: Glomerular Filtration Barrier Dysfunction
+    description: >
+      Loss of podocyte structural integrity — particularly foot process effacement
+      and disruption of the slit diaphragm complex (nephrin, podocin) — increases
+      glomerular permeability to albumin and other plasma proteins, producing
+      massive proteinuria. Slit diaphragm proteins nephrin and podocin are essential
+      structural and signaling components of the filtration barrier; loss-of-function
+      mutations in their encoding genes (NPHS1, NPHS2) cause hereditary nephrotic
+      syndrome and FSGS.
+    cell_types:
+      - preferred_term: podocyte
+        term:
+          id: CL:0000653
+          label: podocyte
+    biological_processes:
+      - preferred_term: glomerular filtration
+        term:
+          id: GO:0003094
+          label: glomerular filtration
+        modifier: DECREASED
+      - preferred_term: protein transport
+        term:
+          id: GO:0015031
+          label: protein transport
+        modifier: INCREASED
+    evidence:
+      - reference: PMID:41009330
+        reference_title: "Focal Segmental Glomerulosclerosis: Comprehensive Review and Exploration of the Dual Potential of Cyclodextrins in Therapeutic Optimization."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "This pattern of injury can lead to progressive renal dysfunction and, in some cases, end-stage kidney disease."
+        explanation: >
+          Documents the clinical consequence of glomerular filtration barrier
+          disruption: progressive loss of kidney function leading to end-stage
+          kidney disease.
+
+  - name: Mesangial Expansion and Glomerulosclerosis
+    description: >
+      Secondary to podocyte loss, mesangial cells proliferate and deposit excessive
+      extracellular matrix components (fibronectin, collagen IV), leading to segmental
+      obliteration of glomerular capillary loops — the defining histological lesion
+      of FSGS. Glomerulosclerosis is irreversible and accumulates progressively as
+      nephron loss continues.
+    cell_types:
+      - preferred_term: glomerular mesangial cell
+        term:
+          id: CL:0000650
+          label: mesangial cell
+    biological_processes:
+      - preferred_term: extracellular matrix organization
+        term:
+          id: GO:0030198
+          label: extracellular matrix organization
+        modifier: INCREASED
+      - preferred_term: mesangial cell proliferation
+        term:
+          id: GO:0072126
+          label: positive regulation of glomerular mesangial cell proliferation
+        modifier: INCREASED
+    evidence: []
+
+  - name: Tubulointerstitial Inflammation and Fibrosis
+    description: >
+      Filtered proteins that escape into the tubular lumen trigger tubular
+      epithelial cell injury and NF-κB–driven inflammatory signaling. Proteinuria-
+      driven complement activation promotes interstitial macrophage infiltration
+      and cytokine release, eventually leading to tubulointerstitial fibrosis.
+      The degree of interstitial fibrosis correlates more strongly with long-term
+      GFR decline than the degree of glomerulosclerosis itself.
+    cell_types:
+      - preferred_term: proximal tubule epithelial cell
+        term:
+          id: CL:0002518
+          label: kidney epithelial cell
+      - preferred_term: macrophage
+        term:
+          id: CL:0000235
+          label: macrophage
+    biological_processes:
+      - preferred_term: inflammatory response
+        term:
+          id: GO:0006954
+          label: inflammatory response
+        modifier: INCREASED
+      - preferred_term: fibroblast proliferation
+        term:
+          id: GO:0048144
+          label: fibroblast proliferation
+        modifier: INCREASED
+    evidence: []
+
+phenotypes:
+  - name: Proteinuria
+    description: >
+      Massive urinary protein loss (typically >3.5 g/day in adults) is the hallmark
+      of FSGS, resulting from disruption of the glomerular filtration barrier and
+      podocyte injury. Proteinuria severity is a key predictor of renal outcomes and
+      economic burden.
+    frequency: VERY_FREQUENT
+    phenotype_term:
+      preferred_term: Proteinuria
+      term:
+        id: HP:0000093
+        label: Proteinuria
+    evidence:
+      - reference: PMID:41222995
+        reference_title: "Prevalence, resource utilization, and economic impact of kidney function and proteinuria in patients with focal segmental glomerulosclerosis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "More advanced chronic kidney disease and higher levels of proteinuria were both associated with greater health care resource utilization and costs."
+        explanation: >
+          Large US real-world study (9,899 FSGS patients) demonstrating that proteinuria
+          is the central clinical driver of disease burden in FSGS.
+
+  - name: Nephrotic Syndrome
+    description: >
+      Full nephrotic syndrome (nephrotic-range proteinuria, hypoalbuminemia, edema,
+      hyperlipidemia) is present in many primary FSGS cases at diagnosis, particularly
+      in children and young adults. FSGS is one of the major causes of nephrotic
+      syndrome globally.
+    frequency: FREQUENT
+    phenotype_term:
+      preferred_term: Nephrotic syndrome
+      term:
+        id: HP:0000100
+        label: Nephrotic syndrome
+    evidence:
+      - reference: PMID:41906863
+        reference_title: "Recurrence of focal segmental glomerulosclerosis: An updated review of pathophysiology, biomarkers, and therapeutic strategies."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Focal segmental glomerulosclerosis (FSGS) is one of the major causes of nephrotic syndrome, which can progress to end-stage renal disease, leading to kidney transplantation."
+        explanation: >
+          Establishes FSGS as a major cause of nephrotic syndrome and documents
+          the natural history of progression to end-stage renal disease.
+
+  - name: Hypertension
+    description: >
+      Hypertension is common in FSGS, arising from sodium retention, RAAS activation,
+      and reduced nephron mass. It accelerates GFR decline and contributes to
+      cardiovascular risk.
+    frequency: FREQUENT
+    phenotype_term:
+      preferred_term: Hypertension
+      term:
+        id: HP:0000822
+        label: Hypertension
+    evidence: []
+
+  - name: Progressive Renal Insufficiency
+    description: >
+      FSGS is the most common primary glomerular disease leading to end-stage
+      kidney disease (ESKD) in adults. Progression is driven by ongoing podocyte
+      loss and tubulointerstitial fibrosis.
+    frequency: FREQUENT
+    phenotype_term:
+      preferred_term: Renal insufficiency
+      term:
+        id: HP:0000083
+        label: Renal insufficiency
+    evidence:
+      - reference: PMID:41009330
+        reference_title: "Focal Segmental Glomerulosclerosis: Comprehensive Review and Exploration of the Dual Potential of Cyclodextrins in Therapeutic Optimization."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "This pattern of injury can lead to progressive renal dysfunction and, in some cases, end-stage kidney disease."
+        explanation: >
+          Review confirms that glomerular injury in FSGS leads to progressive
+          renal insufficiency, with a subset reaching end-stage kidney disease.
+
+  - name: Edema
+    description: >
+      Peripheral and periorbital edema result from hypoalbuminemia-driven reduction
+      in plasma oncotic pressure combined with renal sodium retention.
+    frequency: FREQUENT
+    phenotype_term:
+      preferred_term: Edema
+      term:
+        id: HP:0000969
+        label: Edema
+    evidence: []
+
+  - name: Hypoalbuminemia
+    description: >
+      Serum albumin is markedly reduced due to massive urinary protein losses
+      exceeding hepatic albumin synthesis capacity.
+    frequency: FREQUENT
+    phenotype_term:
+      preferred_term: Hypoalbuminemia
+      term:
+        id: HP:0003073
+        label: Hypoalbuminemia
+    evidence: []
+
+  - name: Hyperlipidemia
+    description: >
+      Compensatory hepatic lipoprotein overproduction in response to low oncotic
+      pressure drives dyslipidemia. Elevated LDL and total cholesterol increase
+      cardiovascular risk in FSGS patients.
+    frequency: FREQUENT
+    phenotype_term:
+      preferred_term: Hyperlipidemia
+      term:
+        id: HP:0003077
+        label: Hyperlipidemia
+    evidence: []
+
+  - name: Hematuria
+    description: >
+      Microscopic hematuria may occur in FSGS, reflecting glomerular inflammation
+      and disruption of the filtration barrier. Macroscopic hematuria is uncommon.
+    frequency: OCCASIONAL
+    phenotype_term:
+      preferred_term: Hematuria
+      term:
+        id: HP:0000790
+        label: Hematuria
+    evidence: []
+
+treatments:
+  - name: Corticosteroids
+    description: >
+      High-dose prednisone is first-line therapy for primary FSGS (typically 1 mg/kg/day
+      for 4–6 months). Approximately 30–40% of patients achieve complete or partial
+      remission. Corticosteroids remain the recommended initial treatment for primary
+      FSGS based on network meta-analysis evidence.
+    treatment_term:
+      preferred_term: corticosteroid therapy
+      term:
+        id: MAXO:0000058
+        label: pharmacotherapy
+      therapeutic_agent:
+        - preferred_term: prednisone
+          term:
+            id: CHEBI:8382
+            label: prednisone
+    evidence:
+      - reference: PMID:39663153
+        reference_title: "Efficacy and safety of nine immunosuppressive agents for primary focal segmental glomerulosclerosis in adults: a pairwise and network meta-analysis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Steroids remain the recommended initial treatment for pFSGS."
+        explanation: >
+          Network meta-analysis of 20 RCTs confirms corticosteroids as the
+          recommended first-line treatment for primary FSGS.
+
+  - name: Calcineurin Inhibitors
+    description: >
+      Cyclosporine (with or without steroids) is the preferred option for steroid-resistant
+      FSGS based on network meta-analysis. Calcineurin inhibitors reduce proteinuria
+      partly through direct podocyte cytoskeletal stabilization in addition to
+      immunosuppression of T-cells.
+    treatment_term:
+      preferred_term: calcineurin inhibitor therapy
+      term:
+        id: MAXO:0000058
+        label: pharmacotherapy
+      therapeutic_agent:
+        - preferred_term: cyclosporine
+          term:
+            id: CHEBI:4031
+            label: cyclosporin A
+        - preferred_term: tacrolimus
+          term:
+            id: CHEBI:61049
+            label: tacrolimus (anhydrous)
+    evidence:
+      - reference: PMID:39663153
+        reference_title: "Efficacy and safety of nine immunosuppressive agents for primary focal segmental glomerulosclerosis in adults: a pairwise and network meta-analysis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "For those patients with SRNS, CSA + STE might be the best choice for improving the rate of TR. LEF + STE and MMF + STE also appear to offer a steroid-saving alternative to high-dose glucocorticoids for patients."
+        explanation: >
+          Network meta-analysis of 20 RCTs identifies cyclosporine plus steroids
+          (CSA + STE) as the best option for steroid-resistant FSGS patients.
+
+  - name: Sparsentan
+    description: >
+      Dual endothelin-angiotensin receptor antagonist (DARA) FDA-approved (2023)
+      for adults with primary FSGS. Reduces proteinuria through combined blockade
+      of endothelin type A and angiotensin II type 1 receptors. Superior to
+      irbesartan in reducing proteinuria in FSGS clinical trials.
+    treatment_term:
+      preferred_term: sparsentan therapy
+      term:
+        id: MAXO:0000058
+        label: pharmacotherapy
+    evidence:
+      - reference: PMID:39333921
+        reference_title: "Safety and efficacy of sparsentan versus irbesartan in focal segmental glomerulosclerosis and IgA nephropathy: a systematic review and meta-analysis of randomized controlled trials."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Sparsentan is effective and has a good safety profile for treating FSGS and patients with IgA nephropathy."
+        explanation: >
+          Meta-analysis of RCTs confirms sparsentan's efficacy and safety as a
+          treatment for FSGS, supporting its FDA approval for primary FSGS.
+
+  - name: Renin-Angiotensin System Blockade
+    description: >
+      ACE inhibitors or angiotensin receptor blockers reduce intraglomerular pressure
+      and proteinuria in all FSGS subtypes. Cornerstone of non-immunosuppressive
+      management; often used as baseline therapy alongside immunosuppression.
+    treatment_term:
+      preferred_term: renin-angiotensin system blockade
+      term:
+        id: MAXO:0000058
+        label: pharmacotherapy
+    evidence: []
+
+  - name: Mycophenolate Mofetil
+    description: >
+      Used as steroid-sparing agent or in combination with calcineurin inhibitors
+      for steroid-resistant or frequently relapsing FSGS. MMF plus steroids
+      demonstrates significant superiority over non-immunosuppressive therapy
+      in reducing 24-hour urine protein.
+    treatment_term:
+      preferred_term: mycophenolate mofetil therapy
+      term:
+        id: MAXO:0000058
+        label: pharmacotherapy
+      therapeutic_agent:
+        - preferred_term: mycophenolate mofetil
+          term:
+            id: CHEBI:8764
+            label: mycophenolate mofetil
+    evidence:
+      - reference: PMID:39663153
+        reference_title: "Efficacy and safety of nine immunosuppressive agents for primary focal segmental glomerulosclerosis in adults: a pairwise and network meta-analysis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Only mycophenolate mofetil-combined steroids (SMD -11, 95% CI -21 to -0.64) showed significant superiority in reducing 24-h UTP when compared with NIT."
+        explanation: >
+          Network meta-analysis shows MMF combined with steroids is the only regimen
+          demonstrating statistically significant reduction in 24-hour urine protein
+          vs non-immunosuppressive therapy.
+
+  - name: Kidney Transplantation
+    description: >
+      End-stage FSGS is treated with kidney transplantation. However, primary FSGS
+      recurs post-transplant in approximately 30–40% of patients due to persistence
+      of circulating permeability factors. Genetic FSGS (e.g., NPHS2 mutations) has
+      substantially lower recurrence risk.
+    treatment_term:
+      preferred_term: kidney transplantation
+      term:
+        id: MAXO:0010039
+        label: organ transplantation
+    evidence:
+      - reference: PMID:41906863
+        reference_title: "Recurrence of focal segmental glomerulosclerosis: An updated review of pathophysiology, biomarkers, and therapeutic strategies."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Following renal transplantation, recurrence of FSGS (rFSGS) occurs in 30%-40% of patients with a high risk of graft loss."
+        explanation: >
+          Establishes the quantitative recurrence rate of primary FSGS after
+          kidney transplantation, the key complication of this treatment.
+
+genetic:
+  - name: NPHS2
+    association: Causative
+    gene_term:
+      preferred_term: NPHS2
+      term:
+        id: hgnc:13394
+        label: NPHS2
+    inheritance:
+      - name: Autosomal recessive
+    notes: >
+      Autosomal recessive mutations in NPHS2 (podocin) are the most common cause
+      of genetic FSGS, particularly in childhood-onset steroid-resistant nephrotic
+      syndrome. Podocin is an essential integral membrane protein of the slit
+      diaphragm complex, belonging to the stomatin protein family.
+    evidence:
+      - reference: PMID:10742096
+        reference_title: "NPHS2, encoding the glomerular protein podocin, is mutated in autosomal recessive steroid-resistant nephrotic syndrome."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "We found ten different NPHS2 mutations, comprising nonsense, frameshift and missense mutations, to segregate with the disease, demonstrating a crucial role for podocin in the function of the glomerular filtration barrier."
+        explanation: >
+          Original discovery paper identifying NPHS2 mutations as the cause of
+          autosomal recessive steroid-resistant nephrotic syndrome and FSGS,
+          establishing podocin's essential role in glomerular filtration.
+
+  - name: NPHS1
+    association: Causative
+    gene_term:
+      preferred_term: NPHS1
+      term:
+        id: hgnc:7908
+        label: NPHS1
+    inheritance:
+      - name: Autosomal recessive
+    notes: >
+      Mutations in NPHS1 (nephrin), the major structural component of the slit
+      diaphragm, cause congenital nephrotic syndrome of the Finnish type and FSGS.
+      Nephrin is also the target of autoantibodies implicated in primary FSGS.
+    evidence: []
+
+  - name: ACTN4
+    association: Causative
+    gene_term:
+      preferred_term: ACTN4
+      term:
+        id: hgnc:166
+        label: ACTN4
+    inheritance:
+      - name: Autosomal dominant
+    notes: >
+      Autosomal dominant mutations in ACTN4 (alpha-actinin-4), an actin-filament
+      crosslinking protein expressed in podocytes, disrupt cytoskeletal architecture
+      and cause familial FSGS. Mutant alpha-actinin-4 binds F-actin more strongly
+      than wild-type, altering podocyte actin cytoskeleton dynamics.
+    evidence:
+      - reference: PMID:10700177
+        reference_title: "Mutations in ACTN4, encoding alpha-actinin-4, cause familial focal segmental glomerulosclerosis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Here we present evidence implicating mutations in the gene encoding alpha-actinin-4 (ACTN4; ref. 2), an actin-filament crosslinking protein, as the cause of disease in three families with an autosomal dominant form of FSGS."
+        explanation: >
+          Original discovery paper establishing ACTN4 mutations as the cause of
+          autosomal dominant familial FSGS, identifying podocyte cytoskeletal
+          disruption as a pathogenic mechanism.
+      - reference: PMID:10700177
+        reference_title: "Mutations in ACTN4, encoding alpha-actinin-4, cause familial focal segmental glomerulosclerosis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "In vitro, mutant alpha-actinin-4 binds filamentous actin (F-actin) more strongly than does wild-type alpha-actinin-4."
+        explanation: >
+          Mechanistic evidence showing that ACTN4 mutations cause aberrant
+          actin binding, explaining how cytoskeletal disruption leads to
+          podocyte dysfunction.
+
+  - name: TRPC6
+    association: Causative
+    gene_term:
+      preferred_term: TRPC6
+      term:
+        id: hgnc:12338
+        label: TRPC6
+    inheritance:
+      - name: Autosomal dominant
+    notes: >
+      Gain-of-function mutations in TRPC6 (transient receptor potential cation
+      channel, subfamily C, member 6) cause autosomal dominant FSGS by enhancing
+      calcium influx in podocytes, leading to podocyte injury and apoptosis.
+      TRPC6 is highly expressed in podocytes.
+    evidence:
+      - reference: PMID:15879175
+        reference_title: "A mutation in the TRPC6 cation channel causes familial focal segmental glomerulosclerosis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "Here we show that a large family with hereditary FSGS carries a missense mutation in the TRPC6 gene on chromosome 11q, encoding the ion-channel protein transient receptor potential cation channel 6 (TRPC6)."
+        explanation: >
+          Original discovery paper identifying TRPC6 missense mutations as the cause
+          of familial FSGS, establishing a calcium channel mechanism distinct from
+          previously known cytoskeletal FSGS genes.
+      - reference: PMID:38814201
+        reference_title: "A novel gain-of-function mutation in transient receptor potential C6 that causes podocytes injury."
+        supports: SUPPORT
+        evidence_source: MODEL_ORGANISM
+        snippet: "Our results suggest that this new mutation causes podocyte injury probably by enhancing calcium influx and podocyte apoptosis, accompanied by increased proteinuria and decreased expression of nephrin and podocin."
+        explanation: >
+          Mouse knock-in and cell culture experiments confirming that TRPC6
+          gain-of-function mutations cause podocyte injury through enhanced
+          calcium influx, validating the disease mechanism.
+
+  - name: INF2
+    association: Causative
+    gene_term:
+      preferred_term: INF2
+      term:
+        id: hgnc:23791
+        label: INF2
+    inheritance:
+      - name: Autosomal dominant
+    notes: >
+      Autosomal dominant mutations in INF2 (inverted formin 2), a formin family
+      actin-regulating protein expressed in podocytes, cause FSGS sometimes
+      accompanied by Charcot-Marie-Tooth neuropathy. Mutations act through a
+      gain-of-function mechanism affecting actin cytoskeleton dynamics in podocytes.
+    evidence:
+      - reference: PMID:20023659
+        reference_title: "Mutations in the formin gene INF2 cause focal segmental glomerulosclerosis."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "we detected nine independent nonconservative missense mutations in INF2, which encodes a member of the formin family of actin-regulating proteins. These mutations, all within the diaphanous inhibitory domain of INF2, segregate with FSGS in 11 unrelated families and alter highly conserved amino acid residues."
+        explanation: >
+          Original discovery paper identifying INF2 mutations as the cause of
+          autosomal dominant FSGS, establishing actin polymerization regulation
+          as critical to podocyte function.
+      - reference: PMID:39536114
+        reference_title: "INF2 mutations cause kidney disease through a gain-of-function mechanism."
+        supports: SUPPORT
+        evidence_source: MODEL_ORGANISM
+        snippet: "gain-of-function mechanisms drive INF2-related FSGS and explain this disease's autosomal dominant inheritance."
+        explanation: >
+          Functional studies in mice and human kidney organoids demonstrating
+          that INF2 disease mutations act through gain-of-function effects on
+          the actin cytoskeleton, explaining the dominant inheritance pattern.

--- a/references_cache/PMID_10700177.md
+++ b/references_cache/PMID_10700177.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:10700177"
+title: "Mutations in ACTN4, encoding alpha-actinin-4, cause familial focal segmental glomerulosclerosis."
+authors:
+- Kaplan JM
+- Kim SH
+- North KN
+- Rennke H
+- Correia LA
+- Tong HQ
+- Mathis BJ
+- Rodríguez-Pérez JC
+- Allen PG
+- Beggs AH
+- Pollak MR
+journal: Nat Genet
+year: '2000'
+doi: 10.1038/73456
+keywords:
+- "Actinin/deficiency, genetics, physiology"
+- Actins/metabolism
+- Amino Acid Sequence
+- "Chromosomes, Human, Pair 19/genetics"
+- "Cytoskeleton/metabolism, ultrastructure"
+- DNA Mutational Analysis
+- Female
+- "Fluorescent Antibody Technique, Indirect"
+- Genetic Predisposition to Disease
+- "Glomerulosclerosis, Focal Segmental/genetics"
+- Humans
+- "Kidney Failure, Chronic/etiology, genetics"
+- Male
+- Microfilament Proteins
+- Molecular Sequence Data
+- Mutation
+- Pedigree
+- Sequence Alignment
+- "Sequence Homology, Amino Acid"
+content_type: abstract_only
+---
+
+# Mutations in ACTN4, encoding alpha-actinin-4, cause familial focal segmental glomerulosclerosis.
+**Authors:** Kaplan JM, Kim SH, North KN, Rennke H, Correia LA, Tong HQ, Mathis BJ, Rodríguez-Pérez JC, Allen PG, Beggs AH, Pollak MR
+**Journal:** Nat Genet (2000)
+**DOI:** [10.1038/73456](https://doi.org/10.1038/73456)
+
+## Content
+
+1. Nat Genet. 2000 Mar;24(3):251-6. doi: 10.1038/73456.
+
+Mutations in ACTN4, encoding alpha-actinin-4, cause familial focal segmental 
+glomerulosclerosis.
+
+Kaplan JM(1), Kim SH, North KN, Rennke H, Correia LA, Tong HQ, Mathis BJ, 
+Rodríguez-Pérez JC, Allen PG, Beggs AH, Pollak MR.
+
+Author information:
+(1)Renal and Brigham and Women's Hospital, Harvard Medical School, Boston, 
+Massachusetts, USA.
+
+Focal and segmental glomerulosclerosis (FSGS) is a common, non-specific renal 
+lesion. Although it is often secondary to other disorders, including HIV 
+infection, obesity, hypertension and diabetes, FSGS also appears as an isolated, 
+idiopathic condition. FSGS is characterized by increased urinary protein 
+excretion and decreasing kidney function. Often, renal insufficiency in affected 
+patients progresses to end-stage renal failure, a highly morbid state requiring 
+either dialysis therapy or kidney transplantation. Here we present evidence 
+implicating mutations in the gene encoding alpha-actinin-4 (ACTN4; ref. 2), an 
+actin-filament crosslinking protein, as the cause of disease in three families 
+with an autosomal dominant form of FSGS. In vitro, mutant alpha-actinin-4 binds 
+filamentous actin (F-actin) more strongly than does wild-type alpha-actinin-4. 
+Regulation of the actin cytoskeleton of glomerular podocytes may be altered in 
+this group of patients. Our results have implications for understanding the role 
+of the cytoskeleton in the pathophysiology of kidney disease and may lead to a 
+better understanding of the genetic basis of susceptibility to kidney damage.
+
+DOI: 10.1038/73456
+PMID: 10700177 [Indexed for MEDLINE]

--- a/references_cache/PMID_10742096.md
+++ b/references_cache/PMID_10742096.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:10742096"
+title: "NPHS2, encoding the glomerular protein podocin, is mutated in autosomal recessive steroid-resistant nephrotic syndrome."
+authors:
+- Boute N
+- Gribouval O
+- Roselli S
+- Benessy F
+- Lee H
+- Fuchshuber A
+- Dahan K
+- Gubler MC
+- Niaudet P
+- Antignac C
+journal: Nat Genet
+year: '2000'
+doi: 10.1038/74166
+keywords:
+- Animals
+- Blood Proteins/genetics
+- Caenorhabditis elegans
+- Caenorhabditis elegans Proteins
+- "Cloning, Molecular"
+- DNA Mutational Analysis
+- Expressed Sequence Tags
+- Fetus
+- "Genes, Recessive"
+- Genetic Linkage
+- Helminth Proteins/genetics
+- Humans
+- In Situ Hybridization
+- Intracellular Signaling Peptides and Proteins
+- "Kidney Glomerulus/embryology, metabolism"
+- Membrane Proteins/genetics
+- Molecular Sequence Data
+- Multigene Family
+- Mutation/genetics
+- "Nephrotic Syndrome/genetics, metabolism"
+- Organ Specificity
+- Pedigree
+- Physical Chromosome Mapping
+- Reverse Transcriptase Polymerase Chain Reaction
+- "Sequence Homology, Amino Acid"
+content_type: abstract_only
+---
+
+# NPHS2, encoding the glomerular protein podocin, is mutated in autosomal recessive steroid-resistant nephrotic syndrome.
+**Authors:** Boute N, Gribouval O, Roselli S, Benessy F, Lee H, Fuchshuber A, Dahan K, Gubler MC, Niaudet P, Antignac C
+**Journal:** Nat Genet (2000)
+**DOI:** [10.1038/74166](https://doi.org/10.1038/74166)
+
+## Content
+
+1. Nat Genet. 2000 Apr;24(4):349-54. doi: 10.1038/74166.
+
+NPHS2, encoding the glomerular protein podocin, is mutated in autosomal 
+recessive steroid-resistant nephrotic syndrome.
+
+Boute N(1), Gribouval O, Roselli S, Benessy F, Lee H, Fuchshuber A, Dahan K, 
+Gubler MC, Niaudet P, Antignac C.
+
+Author information:
+(1)Inserm U423, Tour Lavoisier, Université René Descartes, Paris, France.
+
+Erratum in
+    Nat Genet 2000 May;25(1):125.
+
+Familial idiopathic nephrotic syndromes represent a heterogeneous group of 
+kidney disorders, and include autosomal recessive steroid-resistant nephrotic 
+syndrome, which is characterized by early childhood onset of proteinuria, rapid 
+progression to end-stage renal disease and focal segmental glomerulosclerosis. A 
+causative gene for this disease, NPHS2, was mapped to 1q25-31 and we report here 
+its identification by positional cloning. NPHS2 is almost exclusively expressed 
+in the podocytes of fetal and mature kidney glomeruli, and encodes a new 
+integral membrane protein, podocin, belonging to the stomatin protein family. We 
+found ten different NPHS2 mutations, comprising nonsense, frameshift and 
+missense mutations, to segregate with the disease, demonstrating a crucial role 
+for podocin in the function of the glomerular filtration barrier.
+
+DOI: 10.1038/74166
+PMID: 10742096 [Indexed for MEDLINE]

--- a/references_cache/PMID_15879175.md
+++ b/references_cache/PMID_15879175.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:15879175"
+title: A mutation in the TRPC6 cation channel causes familial focal segmental glomerulosclerosis.
+authors:
+- Winn MP
+- Conlon PJ
+- Lynn KL
+- Farrington MK
+- Creazzo T
+- Hawkins AF
+- Daskalakis N
+- Kwan SY
+- Ebersviller S
+- Burchette JL
+- Pericak-Vance MA
+- Howell DN
+- Vance JM
+- Rosenberg PB
+journal: Science
+year: '2005'
+doi: 10.1126/science.1106215
+keywords:
+- Amino Acid Substitution
+- "Angiotensin II/metabolism, pharmacology"
+- Calcium/metabolism
+- "Calcium Channels/chemistry, genetics, metabolism"
+- Calcium Signaling
+- Carbachol/pharmacology
+- Cell Line
+- Cell Membrane/metabolism
+- "Chromosomes, Human, Pair 11/genetics"
+- Exons
+- Female
+- "GTP-Binding Protein alpha Subunits, Gq-G11/metabolism"
+- "Glomerulosclerosis, Focal Segmental/genetics"
+- Haplotypes
+- Humans
+- Kidney/metabolism
+- Kidney Glomerulus/metabolism
+- Kidney Tubules/metabolism
+- Male
+- "Mutation, Missense"
+- Patch-Clamp Techniques
+- Pedigree
+- "Receptor, Angiotensin, Type 1/genetics, metabolism"
+- "Sequence Analysis, DNA"
+- Sodium/metabolism
+- TRPC Cation Channels
+- TRPC6 Cation Channel
+- Transfection
+- "Uridine Triphosphate/metabolism, pharmacology"
+content_type: abstract_only
+---
+
+# A mutation in the TRPC6 cation channel causes familial focal segmental glomerulosclerosis.
+**Authors:** Winn MP, Conlon PJ, Lynn KL, Farrington MK, Creazzo T, Hawkins AF, Daskalakis N, Kwan SY, Ebersviller S, Burchette JL, Pericak-Vance MA, Howell DN, Vance JM, Rosenberg PB
+**Journal:** Science (2005)
+**DOI:** [10.1126/science.1106215](https://doi.org/10.1126/science.1106215)
+
+## Content
+
+1. Science. 2005 Jun 17;308(5729):1801-4. doi: 10.1126/science.1106215. Epub 2005
+ May 5.
+
+A mutation in the TRPC6 cation channel causes familial focal segmental 
+glomerulosclerosis.
+
+Winn MP(1), Conlon PJ, Lynn KL, Farrington MK, Creazzo T, Hawkins AF, Daskalakis 
+N, Kwan SY, Ebersviller S, Burchette JL, Pericak-Vance MA, Howell DN, Vance JM, 
+Rosenberg PB.
+
+Author information:
+(1)Department of Medicine, Duke University Medical Center, Durham, NC 27710, 
+USA. michelle.winn@duke.edu
+
+Focal and segmental glomerulosclerosis (FSGS) is a kidney disorder of unknown 
+etiology, and up to 20% of patients on dialysis have been diagnosed with it. 
+Here we show that a large family with hereditary FSGS carries a missense 
+mutation in the TRPC6 gene on chromosome 11q, encoding the ion-channel protein 
+transient receptor potential cation channel 6 (TRPC6). The proline-to-glutamine 
+substitution at position 112, which occurs in a highly conserved region of the 
+protein, enhances TRPC6-mediated calcium signals in response to agonists such as 
+angiotensin II and appears to alter the intracellular distribution of TRPC6 
+protein. Previous work has emphasized the importance of cytoskeletal and 
+structural proteins in proteinuric kidney diseases. Our findings suggest an 
+alternative mechanism for the pathogenesis of glomerular disease.
+
+DOI: 10.1126/science.1106215
+PMID: 15879175 [Indexed for MEDLINE]

--- a/references_cache/PMID_20023659.md
+++ b/references_cache/PMID_20023659.md
@@ -1,0 +1,128 @@
+---
+reference_id: "PMID:20023659"
+title: Mutations in the formin gene INF2 cause focal segmental glomerulosclerosis.
+authors:
+- Brown EJ
+- Schlöndorff JS
+- Becker DJ
+- Tsukaguchi H
+- Tonna SJ
+- Uscinski AL
+- Higgs HN
+- Henderson JM
+- Pollak MR
+journal: Nat Genet
+year: '2010'
+doi: 10.1038/ng.505
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Amino Acid Sequence
+- Base Sequence
+- "Cells, Cultured"
+- Child
+- DNA Mutational Analysis
+- Female
+- Formins
+- "Glomerulosclerosis, Focal Segmental/genetics"
+- Humans
+- In Situ Hybridization
+- "Kidney/metabolism, pathology, ultrastructure"
+- Male
+- "Microfilament Proteins/chemistry, genetics"
+- "Microscopy, Electron"
+- Middle Aged
+- "Models, Molecular"
+- Molecular Sequence Data
+- "Mutation, Missense"
+- Pedigree
+- "Podocytes/metabolism, pathology"
+- "Protein Structure, Tertiary"
+- "Sequence Homology, Amino Acid"
+- Young Adult
+content_type: full_text_xml
+---
+
+# Mutations in the formin gene INF2 cause focal segmental glomerulosclerosis.
+**Authors:** Brown EJ, Schlöndorff JS, Becker DJ, Tsukaguchi H, Tonna SJ, Uscinski AL, Higgs HN, Henderson JM, Pollak MR
+**Journal:** Nat Genet (2010)
+**DOI:** [10.1038/ng.505](https://doi.org/10.1038/ng.505)
+
+## Content
+
+1. Nat Genet. 2010 Jan;42(1):72-6. doi: 10.1038/ng.505. Epub 2009 Dec 20.
+
+Mutations in the formin gene INF2 cause focal segmental glomerulosclerosis.
+
+Brown EJ(1), Schlöndorff JS, Becker DJ, Tsukaguchi H, Tonna SJ, Uscinski AL, 
+Higgs HN, Henderson JM, Pollak MR.
+
+Author information:
+(1)Renal Division, Children's Hospital, Boston, Massachusetts, USA.
+
+Erratum in
+    Nat Genet. 2010 Apr;42(4):361. Tonna, Stephen J [added].
+
+Focal segmental glomerulosclerosis (FSGS) is a pattern of kidney injury observed 
+either as an idiopathic finding or as a consequence of underlying systemic 
+conditions. Several genes have been identified that, when mutated, lead to 
+inherited FSGS and/or the related nephrotic syndrome. These findings have 
+accelerated the understanding of glomerular podocyte function and disease, 
+motivating our search for additional FSGS genes. Using linkage analysis, we 
+identified a locus for autosomal-dominant FSGS susceptibility on a region of 
+chromosome 14q. By sequencing multiple genes in this region, we detected nine 
+independent nonconservative missense mutations in INF2, which encodes a member 
+of the formin family of actin-regulating proteins. These mutations, all within 
+the diaphanous inhibitory domain of INF2, segregate with FSGS in 11 unrelated 
+families and alter highly conserved amino acid residues. The observation that 
+alterations in this podocyte-expressed formin cause FSGS emphasizes the 
+importance of fine regulation of actin polymerization in podocyte function.
+
+DOI: 10.1038/ng.505
+PMCID: PMC2980844
+PMID: 20023659 [Indexed for MEDLINE]
+
+We genotyped members of a large family with apparent autosomal dominant FSGS using a dense set of SNP markers (Affymetrix 250K SNPChip array) followed by focused microsatellite genotyping. We identified a locus for FSGS in this family on 14q32 (family FGJN, Figure 1 and Supplementary Figure 2). This region overlapped with a larger locus that we previously identified by linkage analysis in another large family with a similar clinical course (family FGBR, Figure 1 and Supplementary Figure 2). We suspected that FSGS in both families was caused by a defect in the same gene. Under this assumption, the critical region was defined by flanking SNPs rs3783397 (at approximately 103 Mb on the Marshfield map) and rs6576201 (at approximately 106 Mb).
+
+We used public databases to identify genes in this region. We sequenced 15 genes in affected members of the FGBR and FGJN families. We found a sequence variant in each family within the same exon of INF2 that segregated with disease and predicted a non-conservative amino-acid change (R218Q in FGJN and S186P in FGBR). We observed no significant sequence variants in the other genes analyzed. The R218Q variant found in family FGJN was a de novo mutation, as the first individual in the family carrying this R218Q variant shared the disease associated haplotype, but not this variant, with several unaffected siblings (not shown).
+
+We then sequenced INF2 in 91 unrelated individuals with familial FSGS. In probands from nine additional families, we identified point mutations leading to non-conservative amino acid changes (Table 1, Figure 2a, and Supplementary Figure 3). We typed these variants in available family members. We considered a family member to be affected if he/she had biopsy-proven FSGS, ESRD without other apparent cause, or significant albuminuria without other apparent cause (> 250 mg albumin per gram creatinine). We found that these mutations segregated with disease in their respective families (Figure 1 and Supplementary Figure 2). In five families, some younger individuals carrying these point mutations had no increase in urine protein, consistent with reduced, age-related penetrance, similar to the phenotypes associated with TRPC6 and ACTN4 mutations1–3. We found nucleotide variants in exons 8, 18, and 20, but these did not segregate with disease and were found in control individuals. All of the disease segregating mutations are located within the region of INF2 known as the diaphanous-inhibitory domain, or DID (Figure 2b), and most reside within exon 44.
+
+To be certain that these variants were not polymorphisms, and to be certain that the INF2 gene is not a site of frequent but biologically insignificant variation, we resequenced exon 4, the location of all but two of the putative mutations, in 282 control individuals. None of these individuals carried any of these putative disease-causing INF2 variants, nor any other missense or splicing variation. We genotyped the two putative disease-causing mutations found in exon 2 (A13T, L42P) as well as the E184K and R218Q mutations in an additional 341 control individuals using Sequenom assays. Neither variant was present in any of the 682 chromosomes assayed.
+
+The phenotype in families with INF2 mutations shares certain features. Unlike the early onset, nephrotic presentation seen with mutations in the slit-diaphragm proteins nephrin and podocin, these individuals presented in early adolescence or adulthood, typically with moderate proteinuria. While we documented nephrotic range proteinuria in members of several of these families, none of the affected individuals displayed the spectrum of clinical findings that constitutes the so-called nephrotic syndrome. Microscopic hematuria and hypertension were noted in some affected individuals. Similar to patients with mutations in ACTN4, disease and proteinuria were progressive, often leading to end-stage renal disease (ESRD).
+
+We reviewed available renal biopsy tissue samples from individuals with INF2 mutations. Light microscopy typically showed FSGS (Figure 3a). In these biopsies, electron microscopy showed focal areas of podocyte foot process effacement, typical of secondary and some genetic forms of FSGS, as well as areas where foot processes and slit-diaphragms were well preserved. We also noted unusually prominent actin bundles within the foot processes (Figure 3b). Glomerular hypertrophy was not a prominent feature of the biopsies. Neither we nor the original pathology reports noted perihilar, collapsing, or cellular lesions that characterize some subtypes of FSGS. Thus, these biopsies would be categorized as “FSGS, not-otherwise-specified” following one widely adopted classification scheme5.
+
+We examined the expression of INF2 in the kidney by in situ hybridization and by antibody staining (Figure 4a,b). Both showed INF2 expression in the podocyte. We examined expression of INF2 and the slit-diaphragm protein nephrin together (Figure 4b). INF2 expression showed areas of colocalization with nephrin in podocytes. Some INF2 staining was also noted in a pericapillary pattern, suggesting expression in cells other than podocytes. Within the podocyte, antibody staining showed what appeared to be a predominantly perinuclear pattern of INF2. Northern blot analysis showed INF2 expression in all tissues tested and identified INF2 transcripts of approximately 1.5 and 4.5 kb in length (Figure 4c). This was consistent with previous reports describing INF2 as well as the major transcripts predicted from ESTs and genomic sequence analysis as collated in the UCSC Genome Browser (http://genome.ucsc.edu/)4,6,7.
+
+INF2 is a member of the formin family of actin-regulating proteins that accelerate actin polymerization8. All of the FSGS-associated mutations we identified lie within the DID. The DID is an autoinhibitory domain found in the diaphanous formins. In the best studied diaphanous formin, mDia1, the interaction of the N-terminal DID with the C-terminal diaphanous activating domain (DAD) inhibits mDia1 function; this inhibition is relieved by binding to Rho 9. We used structural data available for the N-terminal region of mDia1 to map the mutated INF2 residues and make functional predictions. Our INF2 model derived from the mDia1-RhoC structure (Figure 2 c,d,e) was in agreement with models derived from the other available mDia1 structures (not shown)10. Two mutated residues, R214 and R218, lie close to the DAD-binding region of the DID. R214 is on the surface of the DID in proximity to this site (Figure 2c). R218 is predominately buried but has a small region of surface exposure in this region (Figure 2d). Three other mutated residues (L42, S186, E220) are surface-exposed but on the opposite side of the DID structure from the DAD-binding region (Figure 2e). The A13 position is surface-exposed and lies at the N-terminus of the DID, in the region corresponding to the GTPase binding domain of mDia1. Two of the mutated residues are buried in the core DID structure (E184, L198).
+
+Based on these models, we can postulate potential functions for the mutated INF2 residues. R214 and R218 likely form part of the DAD binding site, given their spatial proximity to key DAD-binding residues A149 and I152. The prominent exposure of L42, S186, and E220 on the DID surface raises the possibility that they interact with other molecules. Since the N-terminus of mDia1 plays a major role in its cellular localization11, the N-terminus of INF2 could also mediate localization. We postulate that E184, L198, and R218 are likely to be important for maintaining the overall fold of the DID. These residues are buried in the interior in all of our models and the identified mutations (E184K and L198R, R218Q) could have effects on the integrity of the DID.
+
+We inserted two mutations (E184K and R218Q) predicted to have large effects on the structural integrity of the DID into the INF2 cDNA. We also inserted a third mutation located away from the DAD binding site (S186P) into the cDNA. These three mutations included the two (E186P and R218Q) found in the large families used in the initial genetic linkage analysis. We examined cultured podocytes transfected with wild-type or mutant INF2 (E184K, S186P, and R218Q, Figure 5). Wild-type transfected podocytes showed perinuclear INF2 staining, while INF2 harboring E184K and R218Q mutations showed a different localization pattern, with a finer, more diffuse distribution. The cellular localization of the S186P mutant INF2 was closer to the pattern observed in the wild-type cells but with a more vermiform appearance. Both the wild-type and mutant forms of INF2 showed significant costaining with phalloidin, consistent with the notion that these proteins induced actin polymerization at their localization, with the overall staining of phalloidin mimicking that of INF2. In the mutant transfected cells, stress fibers and cortical actin were less prominent. The similar and more dramatic changes seen with the E184K and R218Q mutants are consistent with the predicted effect on the overall INF2 DID structure. Furthermore, these data suggest that the DID domain is critical for the subcellular localization of INF2, and is consistent with data demonstrating that it is not required for the ability of INF2 to mediate actin polymerization7. While these mutant forms of INF2 clearly behave differently than the wild-type, the relationship between this altered behavior and the disease mechanism remains to be clarified.
+
+The cumulative evidence we have presented demonstrates that mutations in the INF2 gene cause an autosomal dominant form of FSGS. In two large families, we found evidence of genetic linkage to a region on chromosome 14 containing INF2. We identified missense mutations in INF2 in 11 of 93 families examined. These mutations cause non-conservative substitutions in amino acids that are highly conserved through evolution. Within the individual families harboring these mutations, inheritance of the mutation segregates with disease. Seven of the nine distinct mutations occur in close proximity within exon 4, and all nine lie within the diaphanous inhibitory domain. By resequencing, we verified that neither these mutations, nor other non-synonymous DID variants, are present in control groups. INF2 is highly expressed in the kidney including in glomerular podocytes, the cell type thought to initiate most forms of FSGS. Electron microscopy of kidney biopsy material from an INF2-mutant FSGS patient showed irregular podocyte foot process morphology and prominent actin bundles. In addition, transfection studies of overexpressed wild-type and FSGS-associated mutant forms of INF2 indicate differences in the subcellular localization of mutant and wild-type protein, as well as differences in the pattern of distribution of the associated F-actin. In the electron micrographs, prominent actin filament bundles are noted, whereas actin filaments appear somewhat less prominent than normal in the INF2-mutant expressing cells. The precise mechanism by which actin behavior is disrupted in the presence of INF2 mutations in vivo remains to be defined.
+
+Formins are a family of proteins that accelerate actin filament assembly12. INF2 has the unique ability to accelerate both polymerization as well as depolymerization of actin in vitro, and localizes to the endoplasmic reticulum in fibroblasts. All of the disease-causing INF2 mutations we identified are located within the N-terminal regulatory portion containing the DID7. The DID binds the DAD region of INF2 and autoinhibits INF2-mediated actin depolymerization but not actin polymerization7. Previously published work shows that expression of an INF2 mutant in which the DID/DAD interaction is blocked causes actin filament accumulation around the ER and collapse of the ER onto the nuclear membrane7. Here, we find that mutations in the DID predicted to severely affect the domain structure (E184K, R218Q) do not appear to prevent INF2 mediated actin filament accumulation, but do alter INF2 and F-actin localization.
+
+Podocytes are complex, actin-rich, interdigitating structures that must be able to react to a unique set of physical and chemical stresses. Dysregulation of the podocyte cytoskeleton is a common feature of glomerular disease states13. The proximal trigger leading to altered actin behavior in podocytes can derive from external signals (e.g. from the slit-diaphragm14) or internally (as seen in α-actinin-4 mutations1). Similar to what has been observed with α-actinin-4, INF2 is a widely expressed actin-binding protein which when mutated causes a podocyte-limited phenotype. Our results support a model of podocytes as dynamic structures that are extremely sensitive to alterations in the spatial or temporal regulation of the actin cytoskeleton. We hypothesize that individuals harboring disease-associated INF2 mutations have a defect in actin-mediated podocyte structural maintenance and repair. Future studies aimed at defining how INF2 mutations lead to disease will contribute to our understanding of podocyte biology and FSGS as well as our understanding of the common forms of kidney disease characterized by podocyte dysfunction.
+
+Subjects were enrolled in these studies after obtaining informed consent in accordance with a human subjects protocol approved by the Brigham and Women’s Hospital. We extracted DNA from peripheral blood, measured urine microalbumin and creatinine concentrations, and obtained clinical and family history information. We reviewed medical records, kidney biopsies, and biopsy reports when available.
+
+In family FGBR, we performed a genome-wide analysis using DNA samples from 31 informative family members and approximately 300 microsatellite markers from the Marshfield map using standard methodology. We computed parametric 2-point and multipoint lod scores using the FASTLINK and VITESSE programs15,16. In family FGJN, we performed genome-wide linkage analysis using 250K Affymetrix SNPChips, follow-up genotyping using 14q microsatellite markers, and performed parametric multipoint linkage analysis using both LINKAGE and GENEHUNTER17. Additional genotyping of the identified variants was performed using MALDI-TOF mass spectrometry (Sequenom) at the Harvard-Partners Core Genotyping Facility.
+
+Using standard Sanger sequencing methodology on an ABI 3730 machine, we sequenced PCR-amplified segments containing coding sequence and flanking splice sites of 15 genes (INF2, ADSSL1, SIVA1, AKT1, PLD4, AHNAK2, CDCA4, GPR132, JAG2, NUDT14, BRF1, PACS2, MTA1, CRIP2, CRIP1) from the 14q critical region in 12 individuals, 3 affected and 3 unaffected members from family FGBR and from family FGJN, followed by additional sequencing of INF2 in family members and control individuals. (Sequencing primers are available on request.)
+
+We designed structural models of INF2 using the Phyre resource from Imperial College, London 18. We submitted amino acids 1–424 of mouse INF2, and recovered INF2 models based on the structural coordinates of three mDia1 N-terminal structures10,19,20. (The fourth mDia1 N-terminal structure 21 was not represented in this search.) We manipulated the models using the program PyMOL. In the model, the identified FSGS mutations correspond to residues in mDia1 in the structural alignment (see Supplementary Table).
+
+We obtained a clone containing full-length INF2 in the pCMV6-XL5 vector (Origene). Mutagenesis was carried out using the Stratagene QuikChange II kit and mutagenesis primers designed to create the E184K, S186P, and R218Q variants. All mutagenesis reactions were verified by sequencing.
+
+A human multiple tissue Northern blot was purchased from Ambion. 5´ sense and antisense probes consisting of the first 590 basepairs of INF2 were made using α32P-dCTP labeling of a PCR generated fragment using Klenow (New England Biolabs NEBlot kit).
+
+Non-radioactive in situ hybridization was performed as described22, using a digoxigenin (DIG)-labeled cRNA probe that contained the first 590 bases of the INF2 sequence. Frozen sections (10µm) of human kidney tissue were cut in a cryostat and captured onto Superfrost plus microscope slides (Fisher Scientific, Pittsburgh, PA). Sections were then fixed and acetylated, and hybridized to the probe at 70°C for approximately 72 hrs (approximate concentration 100 ng/ml). Hybridized probe was visualized using alkaline phosphatase-conjugated anti-DIG Fab fragments (Roche, Indianapolis, IN) and 5-Bromo-4-chloro-3-indolyl-phosphate/Nitroblue tetrazolium (BCIP/NBT) substrate (Kierkegard and Perry Laboratories, Gaithersburg, MD). Sections were rinsed several times in 100 mM Tris, 150 mM NaCl, 20 mM EDTA pH 9.5, and coverslipped with glycerol gelatin (Sigma, St. Louis, MO). Control sections were incubated in an identical concentration of the sense probe transcript.
+
+Undifferentiated human podocytes in culture (gift of Moin Saleem) were transfected with wild-type or mutant INF2 constructs using FuGENE (Roche). We used antibody to the C-terminus of INF2 directly conjugated to Cy3 for visualizing wild-type and mutant INF2 protein at 1:200 dilution 7. We used FITC Phalloidin and DAPI to visualize actin filaments and nuclei.
+
+We made 5 micron sections of acetone fixed kidneys from healthy 6 week old mice. After washing with phosphate-buffered saline, we incubated sections with primary antibodies: rabbit anti-INF2 (C-terminal 300 amino acids)7, guinea pig anti-nephrin (Progen Biotechnik). We used anti-rabbit Cy2 coupled and anti-guinea pig Cy3 coupled secondary antibodies to visualize INF2 and nephrin and DAPI to visualize nuclei. We analyzed specimens using a Nikon TE-200E inverted microscope and AutoDeblur deconvolution software (Media Cybernetics).

--- a/references_cache/PMID_21368758.md
+++ b/references_cache/PMID_21368758.md
@@ -1,5 +1,5 @@
 ---
-reference_id: PMID:21368758
+reference_id: "PMID:21368758"
 title: MHC class II transactivator CIITA is a recurrent gene fusion partner in lymphoid cancers.
 authors:
 - Steidl C

--- a/references_cache/PMID_27221964.md
+++ b/references_cache/PMID_27221964.md
@@ -1,5 +1,5 @@
 ---
-reference_id: PMID:27221964
+reference_id: "PMID:27221964"
 title: NF-κB deregulation in Hodgkin lymphoma.
 authors:
 - Weniger MA

--- a/references_cache/PMID_38814201.md
+++ b/references_cache/PMID_38814201.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:38814201"
+title: A novel gain-of-function mutation in transient receptor potential C6 that causes podocytes injury.
+authors:
+- Yu M
+- Hu J
+- Ju T
+- Wang R
+- Wang M
+- Gao C
+- Xia Z
+journal: Cell Mol Biol (Noisy-le-grand)
+year: '2024'
+doi: 10.14715/cmb/2024.70.5.42
+keywords:
+- "Podocytes/metabolism, pathology"
+- Animals
+- "TRPC6 Cation Channel/genetics, metabolism"
+- Apoptosis/genetics
+- Mice
+- Gain of Function Mutation/genetics
+- Calcium/metabolism
+- "Glomerulosclerosis, Focal Segmental/genetics, metabolism, pathology"
+- "Membrane Proteins/genetics, metabolism"
+- "Desmin/genetics, metabolism"
+- Cell Proliferation/genetics
+- "Intracellular Signaling Peptides and Proteins/genetics, metabolism"
+- "TRPC Cation Channels/genetics, metabolism"
+- Male
+- "Mice, Inbred C57BL"
+content_type: abstract_only
+---
+
+# A novel gain-of-function mutation in transient receptor potential C6 that causes podocytes injury.
+**Authors:** Yu M, Hu J, Ju T, Wang R, Wang M, Gao C, Xia Z
+**Journal:** Cell Mol Biol (Noisy-le-grand) (2024)
+**DOI:** [10.14715/cmb/2024.70.5.42](https://doi.org/10.14715/cmb/2024.70.5.42)
+
+## Content
+
+1. Cell Mol Biol (Noisy-le-grand). 2024 May 27;70(5):284-288. doi: 
+10.14715/cmb/2024.70.5.42.
+
+A novel gain-of-function mutation in transient receptor potential C6 that causes 
+podocytes injury.
+
+Yu M(1), Hu J(2), Ju T(3), Wang R(4), Wang M(5), Gao C(6), Xia Z(6).
+
+Author information:
+(1)Department of Neonatology, Taizhou People's Hospital, Nanjing Medical 
+University, Taizhou, Jiangsu 225300, China. 569646022@qq.com.
+(2)Department of Pediatrics, The Affiliated Huai'an No.1 People's Hospital of 
+Nanjing Medical University, Huai'an, Jiangsu 223300, China. 13852398989@163.com.
+(3)Department of Neonatology, Taizhou People's Hospital, Nanjing Medical 
+University, Taizhou, Jiangsu 225300, China. 1285259522@qq.com.
+(4)Department of Pediatrics, Jinling Hospital, Nanjing, Jiangsu 210002, China. 
+1547132442@qq.com.
+(5)Department of Pediatrics, Affiliated Jinling Hospital, Medical School of 
+Nanjing University, Nanjing, Jiangsu 210002, China. 1481700382@qq.com.
+(6)Department of Pediatrics, Jinling Hospital, Nanjing, Jiangsu 210002, China. 
+njxzk@126.com.
+
+Podocyte injury plays a vital role in focal segmental glomerulosclerosis (FSGS), 
+and apoptosis is one of its mechanisms. The transient receptor potential channel 
+6 (TRPC6) is highly expressed in podocytes and mutations mediate podocyte 
+injury. We found TRPC6 gene mutation (N110S) was a new mutation and pathogenic 
+in the preliminary clinical work. The purpose of this study was to investigate 
+the potential mechanism of mutation in TRPC6 (TRPC6-N110S) in the knock-in gene 
+mouse model and in immortalized mouse podocytes (MPC5). Transmission electron 
+microscopy was used to evaluate renal injury morphology. We measured 24-hour 
+urinary albumin-to-creatinine ratios and major biochemical parameters such as 
+serum albumin, urea nitrogen, and total cholesterol. The results of CCK-8 assay 
+and apoptosis experiments showed that the TRPC6-N110S overexpression group had 
+slower proliferative activity and increased apoptosis than the control group. 
+FluO-3 assay revealed increased calcium influx in the TRPC6-N110S overexpression 
+group. Podocin level was decreased in TRPC6-N110S group, while TRPC6 and desmin 
+levels were increased in TRPC6-N110S group. The 24 h uACR at 6 weeks was 
+significantly higher in the pure-zygotes group than in the WT and heterozygotes 
+groups, and this difference was found at 8 and 10 weeks.TRPC6 levels showed no 
+significant difference between homozygote and WT mice. Compared to homozygote 
+group, expression of podocin and nephrin were increased in WT, but levels of 
+desmin was decreased in WT. Our results suggest that this new mutation causes 
+podocyte injury probably by enhancing calcium influx and podocyte apoptosis, 
+accompanied by increased proteinuria and decreased expression of nephrin and 
+podocin.
+
+DOI: 10.14715/cmb/2024.70.5.42
+PMID: 38814201 [Indexed for MEDLINE]

--- a/references_cache/PMID_39039881.md
+++ b/references_cache/PMID_39039881.md
@@ -1,5 +1,5 @@
 ---
-reference_id: PMID:39039881
+reference_id: "PMID:39039881"
 title: "[Analysis of 10 cases of brentuximab vedotin combined with chemotherapy in the treatment of children with refractory and or relapsed classic Hodgkin lymphoma]."
 authors:
 - Li N

--- a/references_cache/PMID_39333921.md
+++ b/references_cache/PMID_39333921.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:39333921"
+title: "Safety and efficacy of sparsentan versus irbesartan in focal segmental glomerulosclerosis and IgA nephropathy: a systematic review and meta-analysis of randomized controlled trials."
+authors:
+- Elnaga AAA
+- Alsaied MA
+- Elettreby AM
+- Ramadan A
+- Abouzid M
+- Shetta R
+- Al-Ajlouni YA
+journal: BMC Nephrol
+year: '2024'
+doi: 10.1186/s12882-024-03713-9
+keywords:
+- Humans
+- "Angiotensin II Type 1 Receptor Blockers/administration & dosage, adverse effects"
+- "Glomerulonephritis, IGA/complications, drug therapy, urine"
+- "Glomerulosclerosis, Focal Segmental/complications, drug therapy, urine"
+- "Irbesartan/administration & dosage, adverse effects"
+- "Proteinuria/drug therapy, etiology"
+- Randomized Controlled Trials as Topic
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Safety and efficacy of sparsentan versus irbesartan in focal segmental glomerulosclerosis and IgA nephropathy: a systematic review and meta-analysis of randomized controlled trials.
+**Authors:** Elnaga AAA, Alsaied MA, Elettreby AM, Ramadan A, Abouzid M, Shetta R, Al-Ajlouni YA
+**Journal:** BMC Nephrol (2024)
+**DOI:** [10.1186/s12882-024-03713-9](https://doi.org/10.1186/s12882-024-03713-9)
+
+## Content
+
+1. BMC Nephrol. 2024 Sep 27;25(1):316. doi: 10.1186/s12882-024-03713-9.
+
+Safety and efficacy of sparsentan versus irbesartan in focal segmental 
+glomerulosclerosis and IgA nephropathy: a systematic review and meta-analysis of 
+randomized controlled trials.
+
+Elnaga AAA(1), Alsaied MA(1), Elettreby AM(1), Ramadan A(2), Abouzid M(3)(4), 
+Shetta R(5), Al-Ajlouni YA(6).
+
+Author information:
+(1)Faculty of Medicine, Mansoura University, Mansoura, AAA, Egypt.
+(2)Faculty of Medicine, South Valley University, Qena, Egypt.
+(3)Department of Physical Pharmacy and Pharmacokinetics, Faculty of Pharmacy, 
+Poznan University of Medical Sciences, Rokietnicka 3 St, Poznan, 60-806, Poland.
+(4)Doctoral School, Poznan University of Medical Sciences, Poznan, 60-812, 
+Poland.
+(5)Department of Internal Medicine, UCF College of Medicine, HCA Florida Ocala, 
+Ocala, USA.
+(6)Department of Physical Medicine and Rehabilitation, Montefiore Medical 
+Center, Wakefield Campus, NY, Montefiore, USA. alajlouni.yazan@gmail.com.
+
+BACKGROUND: Sparsentan has shown positive effects on managing different subtypes 
+of glomerulonephritis. The recent results of trials require a pooled analysis to 
+validate these results.
+AIM: We aim to assess the safety and efficacy of sparsentan versus irbesartan 
+for patients with IgA nephropathy and focal glomerulosclerosis (FSGS).
+METHODS: We conducted a systematic review and meta-analysis of randomized 
+controlled trials retrieved by systematically searching PubMed, Web of Science, 
+Scopus, and Cochrane through March 2024. We used Review Manager v.5.4 to pool 
+dichotomous data using risk ratio (RR) and continuous data using mean difference 
+(MD) with a 95% confidence interval (CI).
+RESULTS: Three studies with a total of 884 patients were included. Sparsentan 
+was superior to irbesartan in improving urine protein to creatinine ratio (UP/C) 
+(ratio of percentage reduction 0.66, 95% CI [0.58 to 0.74], P < 0.001); as well 
+as the proportion of patients achieved complete and partial remission of 
+proteinuria (RR = 2.57, 95% CI [1.73 to 3.81], P < 0.001) and (RR = 1.63, 95% CI 
+[1.4 to 1.91], P < 0.001) respectively. Regarding the effect on the glomerular 
+filtration rate, the results estimate did not favor either sparsentan or 
+irbesartan (MD = 1.98 ml/min per 1.73mm2, 95% CI [-1.05 to 5.01], P = 0.2). 
+There were no significant differences in adverse events except for hypotension, 
+which showed higher rates in the sparsentan group (RR = 2.02, 95% CI [1.3 to 
+3.16], P = 0.002).
+CONCLUSION: Sparsentan is effective and has a good safety profile for treating 
+FSGS and patients with IgA nephropathy. However, more well-designed RCTs against 
+ARBs, ACE inhibitors, and steroids with larger sample sizes are needed to get 
+conclusive evidence.
+
+© 2024. The Author(s).
+
+DOI: 10.1186/s12882-024-03713-9
+PMCID: PMC11429118
+PMID: 39333921 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest. The 
+authors declare no competing interests.

--- a/references_cache/PMID_39536114.md
+++ b/references_cache/PMID_39536114.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:39536114"
+title: INF2 mutations cause kidney disease through a gain-of-function mechanism.
+authors:
+- Subramanian B
+- Williams S
+- Karp S
+- Hennino MF
+- Jacas S
+- Lee M
+- Riella CV
+- Alper SL
+- Higgs HN
+- Pollak MR
+journal: Sci Adv
+year: '2024'
+doi: 10.1126/sciadv.adr1017
+keywords:
+- Animals
+- "Formins/genetics, metabolism"
+- Humans
+- Mice
+- Gain of Function Mutation
+- "Podocytes/metabolism, pathology"
+- "Glomerulosclerosis, Focal Segmental/genetics, pathology, metabolism"
+- "Mice, Knockout"
+- "Kidney Diseases/genetics, pathology, metabolism"
+- Mutation
+- "Mitochondria/metabolism, genetics"
+- "Disease Models, Animal"
+- Actin Cytoskeleton/metabolism
+- "Charcot-Marie-Tooth Disease/genetics, pathology, metabolism"
+- "Organoids/metabolism, pathology"
+- Phenotype
+content_type: abstract_only
+---
+
+# INF2 mutations cause kidney disease through a gain-of-function mechanism.
+**Authors:** Subramanian B, Williams S, Karp S, Hennino MF, Jacas S, Lee M, Riella CV, Alper SL, Higgs HN, Pollak MR
+**Journal:** Sci Adv (2024)
+**DOI:** [10.1126/sciadv.adr1017](https://doi.org/10.1126/sciadv.adr1017)
+
+## Content
+
+1. Sci Adv. 2024 Nov 15;10(46):eadr1017. doi: 10.1126/sciadv.adr1017. Epub 2024
+Nov  13.
+
+INF2 mutations cause kidney disease through a gain-of-function mechanism.
+
+Subramanian B(1)(2), Williams S(1), Karp S(1), Hennino MF(1), Jacas S(1), Lee 
+M(3), Riella CV(1), Alper SL(1)(4), Higgs HN(3), Pollak MR(1)(2)(4).
+
+Author information:
+(1)Division of Nephrology, Department of Medicine, Beth Israel Deaconess Medical 
+Center, Harvard Medical School, Boston, MA, USA.
+(2)Kidney Bioengineering Resource Center, Beth Israel Deaconess Medical Center, 
+Harvard Medical School, Boston, MA, USA.
+(3)Department of Biochemistry, Geisel School of Medicine, Dartmouth College, 
+Hanover, NH, USA.
+(4)Broad Institute of Harvard and Massachusetts Institute of Technology, 
+Cambridge, MA, USA.
+
+Heterozygosity for inverted formin-2 (INF2) mutations causes focal segmental 
+glomerulosclerosis (FSGS) with or without Charcot-Marie-Tooth disease. A key 
+question is whether the disease is caused by gain-of-function effects on INF2 or 
+loss of function (haploinsufficiency). Despite established roles in multiple 
+cellular processes, neither INF2 knockout mice nor mice with a 
+disease-associated point mutation display an evident kidney or neurologic 
+phenotype. Here, we compared responses to puromycin aminonucleoside 
+(PAN)-induced kidney injury between INF2 R218Q and INF2 knockout mice. R218Q 
+INF2 mice are susceptible to glomerular disease, in contrast to INF2 knockout 
+mice. Colocalization, coimmunoprecipitation analyses, and cellular actin 
+measurements showed that INF2 R218Q confers a gain-of-function effect on the 
+actin cytoskeleton. RNA expression analysis showed that adhesion and 
+mitochondria-related pathways were enriched in the PAN-treated R218Q mice. Both 
+podocytes from INF2 R218Q mice and human kidney organoids with an INF2 mutation 
+(S186P) recapitulate adhesion and mitochondrial phenotypes. Thus, 
+gain-of-function mechanisms drive INF2-related FSGS and explain this disease's 
+autosomal dominant inheritance.
+
+DOI: 10.1126/sciadv.adr1017
+PMCID: PMC11559609
+PMID: 39536114 [Indexed for MEDLINE]

--- a/references_cache/PMID_39663153.md
+++ b/references_cache/PMID_39663153.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:39663153"
+title: "Efficacy and safety of nine immunosuppressive agents for primary focal segmental glomerulosclerosis in adults: a pairwise and network meta-analysis."
+authors:
+- Zhu Y
+- Chen B
+- Xu G
+journal: Ren Fail
+year: '2024'
+doi: 10.1080/0886022X.2024.2438861
+keywords:
+- Adult
+- Humans
+- "Cyclosporine/administration & dosage, adverse effects"
+- "Drug Therapy, Combination/adverse effects, methods"
+- "Glomerulosclerosis, Focal Segmental/drug therapy"
+- "Immunosuppressive Agents/administration & dosage, adverse effects"
+- Randomized Controlled Trials as Topic
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Efficacy and safety of nine immunosuppressive agents for primary focal segmental glomerulosclerosis in adults: a pairwise and network meta-analysis.
+**Authors:** Zhu Y, Chen B, Xu G
+**Journal:** Ren Fail (2024)
+**DOI:** [10.1080/0886022X.2024.2438861](https://doi.org/10.1080/0886022X.2024.2438861)
+
+## Content
+
+1. Ren Fail. 2024 Dec;46(2):2438861. doi: 10.1080/0886022X.2024.2438861. Epub
+2024  Dec 11.
+
+Efficacy and safety of nine immunosuppressive agents for primary focal segmental 
+glomerulosclerosis in adults: a pairwise and network meta-analysis.
+
+Zhu Y(1), Chen B(1), Xu G(1).
+
+Author information:
+(1)Department of Nephrology, The Second Affiliated Hospital, Jiangxi Medical 
+College, Nanchang University, Nanchang, P. R. China.
+
+BACKGROUND: Immunosuppressants are widely used as the preferred treatment for 
+primary focal segmental glomerulosclerosis (pFSGS). Nevertheless, controversies 
+persist regarding the effectiveness and side effects of different 
+immunosuppressive medications.
+METHODS: From July 2023 until June 2024, we systematically searched PubMed, 
+Cochrane Library, Web of Science, clinicalrials.gov, SinoMed, Chinese 
+Biomedical, Chinese National Knowledge Infrastructure, Wanfang, and VIP 
+information. Randomized controlled trials comparing different immunosuppressants 
+were included in adult patients with pFSGS, with total remission (TR) and 24-h 
+urine total protein (24-h UTP) as the main outcome measures.
+RESULTS: We identified 20 RCTs comparing nine different immunosuppressants for 
+the final analysis. Most immunosuppressants showed better therapeutic effects in 
+TR compared to non-immunosuppressive therapies (NIT), with risk ratios (RRs) of 
+2.22 (95% CI 1.41-3.50) for cyclosporin, 2.10 (1.57-2.80) for 
+leflunomide-combined steroids, 2.01 (1.24-3.27) for chlorambucil-combined 
+steroids, 1.98 (1.17-3.33) for tacrolimus-combined steroids, 1.89 (1.36-2.63) 
+for cyclosporin-combined steroids, 1.67 (1.28-2.18) for mycophenolate 
+mofetil-combined steroids, and 1.47 (1.21-1.80) for steroids. Only mycophenolate 
+mofetil-combined steroids (SMD -11, 95% CI -21 to -0.64) showed significant 
+superiority in reducing 24-h UTP when compared with NIT. The subgroup analyses 
+of steroids-resistant nephrotic syndrome (SRNS) patients showed that CSA + STE 
+was significantly superior than the NIT group, with RR of 10.5 (95% CI 
+2.28-44.35).
+CONCLUSION: Steroids remain the recommended initial treatment for pFSGS. For 
+those patients with SRNS, CSA + STE might be the best choice for improving the 
+rate of TR. LEF + STE and MMF + STE also appear to offer a steroid-saving 
+alternative to high-dose glucocorticoids for patients.
+
+DOI: 10.1080/0886022X.2024.2438861
+PMCID: PMC11636141
+PMID: 39663153 [Indexed for MEDLINE]
+
+Conflict of interest statement: No potential conflict of interest was reported 
+by the author(s).

--- a/references_cache/PMID_41009330.md
+++ b/references_cache/PMID_41009330.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:41009330"
+title: "Focal Segmental Glomerulosclerosis: Comprehensive Review and Exploration of the Dual Potential of Cyclodextrins in Therapeutic Optimization."
+authors:
+- Mascarenhas-Melo F
+- Martins B
+- Monteiro I
+- Lohani A
+- Krambeck K
+journal: Int J Mol Sci
+year: '2025'
+doi: 10.3390/ijms26188760
+keywords:
+- Humans
+- "Glomerulosclerosis, Focal Segmental/drug therapy, metabolism, pathology, etiology"
+- "Cyclodextrins/therapeutic use, pharmacology"
+- Animals
+- "Podocytes/metabolism, drug effects, pathology"
+content_type: abstract_only
+---
+
+# Focal Segmental Glomerulosclerosis: Comprehensive Review and Exploration of the Dual Potential of Cyclodextrins in Therapeutic Optimization.
+**Authors:** Mascarenhas-Melo F, Martins B, Monteiro I, Lohani A, Krambeck K
+**Journal:** Int J Mol Sci (2025)
+**DOI:** [10.3390/ijms26188760](https://doi.org/10.3390/ijms26188760)
+
+## Content
+
+1. Int J Mol Sci. 2025 Sep 9;26(18):8760. doi: 10.3390/ijms26188760.
+
+Focal Segmental Glomerulosclerosis: Comprehensive Review and Exploration of the 
+Dual Potential of Cyclodextrins in Therapeutic Optimization.
+
+Mascarenhas-Melo F(1)(2), Martins B(1), Monteiro I(1), Lohani A(3), Krambeck 
+K(1)(2).
+
+Author information:
+(1)Higher School of Health, Polytechnic Institute of Guarda, Rua da Cadeia, 
+6300-307 Guarda, Portugal.
+(2)BRIDGES-Biotechnology Research, Innovation and Design for Health Products, 
+Polytechnic University of Guarda, Avenida Dr. Francisco Sá Carneiro, No. 50, 
+6300-559 Guarda, Portugal.
+(3)Amity Institute of Pharmacy, Amity University Uttar Pradesh, Noida 201313, 
+India.
+
+Focal segmental glomerulosclerosis (FSGS) is a histopathological pattern of 
+segmental glomerulosclerosis that arises from diverse primary and secondary 
+causes. Primary (idiopathic) FSGS is rare and is often linked to intrinsic 
+podocyte injury, while secondary forms are more prevalent and may reflect 
+adaptative, toxic, genetic, or viral etiologies. This pattern of injury can lead 
+to progressive renal dysfunction and, in some cases, end-stage kidney disease. 
+The pathophysiology is multifactorial and includes direct podocyte injury (e.g., 
+genetic defects, mechanical or toxic injury), immune-mediated processes (e.g., 
+circulating permeability factors, inflammatory mediators), and metabolic 
+disturbances. In particular, disturbance of lipid metabolism, including 
+intracellular cholesterol accumulation in podocytes, have been implicated as a 
+contributory mechanism in podocyte dysfunction and progression of disease in 
+proteinuric/nephrotic presentations and in specific disease subtypes. Diagnosis 
+relies on clinical assessment, laboratory testing, and histological examination, 
+with kidney biopsy remaining the gold standard. Conventional treatments include 
+corticosteroids, and other immunosuppressants when indicated, and measures to 
+reduce proteinuria and control blood pressure, but the therapeutic response is 
+variable and many patients show progression, highlighting the need for more 
+effective and novel therapeutic approaches. Cyclodextrins (CDs), widely used as 
+drug carriers to enhance solubility, can also mobilize and promote efflux of 
+cholesterol from cells. Preclinical studies show that CDs reduce renal lipid 
+accumulation and ameliorate podocyte injury in experimental models, supporting 
+the idea that CDs could have a dual role as drug carriers and as direct 
+modulators of lipid-related podocyte injury in lipid-associated forms of FSGS. 
+Given the limited direct clinical data in FSGS, in this article we discuss the 
+biological rationale, preclinical evidence, and remaining knowledge gaps for 
+exploring CDs as an innovative therapeutic strategy.
+
+DOI: 10.3390/ijms26188760
+PMCID: PMC12470019
+PMID: 41009330 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests for 
+this work.

--- a/references_cache/PMID_41133676.md
+++ b/references_cache/PMID_41133676.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:41133676"
+title: Serum Factors in Primary Podocytopathies.
+authors:
+- Filippone EJ
+- Farber JL
+journal: Antibodies (Basel)
+year: '2025'
+doi: 10.3390/antib14040082
+content_type: abstract_only
+---
+
+# Serum Factors in Primary Podocytopathies.
+**Authors:** Filippone EJ, Farber JL
+**Journal:** Antibodies (Basel) (2025)
+**DOI:** [10.3390/antib14040082](https://doi.org/10.3390/antib14040082)
+
+## Content
+
+1. Antibodies (Basel). 2025 Sep 28;14(4):82. doi: 10.3390/antib14040082.
+
+Serum Factors in Primary Podocytopathies.
+
+Filippone EJ(1), Farber JL(2).
+
+Author information:
+(1)Division of Nephrology, Department of Medicine, Sidney Kimmel Medical 
+College, Thomas Jefferson University, 2228 south Broad St, Philadelphia, PA 
+19145, USA.
+(2)Department of Pathology, Sidney Kimmel Medical College, Thomas Jefferson 
+University, Philadelphia, PA 19145, USA.
+
+Primary podocytopathies, including minimal change disease (MCD) and focal 
+segmental glomerulosclerosis (FSGS), are caused by a circulating factor or 
+factors injurious to the podocyte. An immunologic origin seems likely based on 
+responsiveness to corticosteroids or other immunosuppressive agents, including 
+calcineurin inhibitors targeting T-cells and rituximab targeting B-cells. 
+Potential non-antibody-mediated circulating factors have been identified, 
+including cardiotrophin-like cytokine 1, soluble urokinase plasminogen activator 
+receptor, and angiopoietin-like 4, among others. More recent research supports a 
+primary antibody pathogenesis, with anti-nephrin antibodies found in a 
+significant percentage of cases. Such antibodies also predict recurrence after 
+transplantation. Other potential antigenic targets besides nephrin include 
+annexin, the proteosome, podocin, and CD40. Additionally, high-resolution 
+confocal microscopy has identified punctate immunoglobulin deposits along the 
+slit diaphragm and podocyte cell body that may or may not colocalize with 
+abnormal punctate nephrin staining and may correlate with detectable circulating 
+antibodies. The success of rituximab in observational studies in both native 
+kidneys and transplants supports a primary role for autoantibodies. We discuss 
+in detail the data supporting putative non-antibody circulating factors, as well 
+as the recent data supporting antibody pathogenesis, which may provide some 
+clues on treating the individual patient.
+
+DOI: 10.3390/antib14040082
+PMCID: PMC12550970
+PMID: 41133676
+
+Conflict of interest statement: EJF: speakers bureau for Boehringer-Ingelheim 
+and Lilly Pharmaceuticals, Advisory board for Otsuka pharmaceutical. JLF: none.

--- a/references_cache/PMID_41222995.md
+++ b/references_cache/PMID_41222995.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:41222995"
+title: "Prevalence, resource utilization, and economic impact of kidney function and proteinuria in patients with focal segmental glomerulosclerosis."
+authors:
+- Bensink ME
+- Thakker KM
+- Lerma EV
+- Lieblich RM
+- Bunke CM
+- Wang K
+- Gong W
+- Rava A
+- Murphy MV
+- Oliveri D
+- Amari DT
+- Cork D
+- Velez JCQ
+journal: Am J Manag Care
+year: '2025'
+doi: 10.37765/ajmc.2025.89831
+content_type: abstract_only
+---
+
+# Prevalence, resource utilization, and economic impact of kidney function and proteinuria in patients with focal segmental glomerulosclerosis.
+**Authors:** Bensink ME, Thakker KM, Lerma EV, Lieblich RM, Bunke CM, Wang K, Gong W, Rava A, Murphy MV, Oliveri D, Amari DT, Cork D, Velez JCQ
+**Journal:** Am J Manag Care (2025)
+**DOI:** [10.37765/ajmc.2025.89831](https://doi.org/10.37765/ajmc.2025.89831)
+
+## Content
+
+1. Am J Manag Care. 2025 Nov 12. doi: 10.37765/ajmc.2025.89831. Online ahead of 
+print.
+
+Prevalence, resource utilization, and economic impact of kidney function and 
+proteinuria in patients with focal segmental glomerulosclerosis.
+
+Bensink ME(1), Thakker KM, Lerma EV, Lieblich RM, Bunke CM, Wang K, Gong W, Rava 
+A, Murphy MV, Oliveri D, Amari DT, Cork D, Velez JCQ.
+
+Author information:
+(1)HEOR Lead for Sparsentan, Travere Therapeutics, Inc, 3611 Valley Centre Dr, 
+Ste 300, San Diego, CA 92130. Email: Mark.Bensink@travere.com.
+
+BACKGROUND: Among patients with focal segmental glomerulosclerosis (FSGS), 
+proteinuria and kidney function decline may be associated with increased 
+economic burden. This study aimed to provide current information on the 
+epidemiology and economic burden of FSGS in the United States.
+METHODS: In this descriptive, noninterventional, retrospective cohort study, 
+9899 patients were identified between January 2016 and December 2020 in Optum 
+de-identified Market Clarity Data based on International Classification of 
+Diseases code or Optum proprietary natural language processing data. Descriptive 
+statistics were reported for categorical and continuous variables. Prevalence 
+estimates were standardized to the age, gender, and race/ethnicity distribution 
+of the general US population using direct methods and data from the 2021 United 
+States Census Bureau. Per-patient-per-month health care resource utilization and 
+associated costs (2024 US $) were reported by proteinuria (≤ 1.5 g/g vs > 1.5 
+g/g or < 3.5 g/g vs ≥ 3.5 g/g) and chronic kidney disease stage (stage 
+1-5/kidney failure). The Fisher exact test was used for categorical health care 
+resource utilization outcomes, and linear regression (mean) and the 
+Jonckheere-Terpstra test (medians) were used for continuous health care resource 
+utilization and cost outcomes.
+RESULTS: Estimated annual US prevalence (average for 2016-2020) of FSGS was 
+212.6 per 1 million. There was a consistent trend toward higher health care 
+resource utilization and total costs with both chronic kidney disease 
+progression (stage 1-5/kidney failure) and higher levels of proteinuria (≤ 1.5 
+g/g vs > 1.5 g/g or < 3 .5 g/g vs ≥ 3.5 g/g).
+CONCLUSIONS: The observed prevalence of FSGS increased in the US and was highest 
+among Black individuals. More advanced chronic kidney disease and higher levels 
+of proteinuria were both associated with greater health care resource 
+utilization and costs. Treatments that reduce proteinuria and slow kidney 
+function decline have the potential to delay disease progression and to reduce 
+the economic burden associated with FSGS.
+
+DOI: 10.37765/ajmc.2025.89831
+PMID: 41222995

--- a/references_cache/PMID_41906863.md
+++ b/references_cache/PMID_41906863.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:41906863"
+title: "Recurrence of focal segmental glomerulosclerosis: An updated review of pathophysiology, biomarkers, and therapeutic strategies."
+authors:
+- Oatley Z
+- Jaber D
+- Rayarakula N
+- Guirguis T
+- Khawaja L
+- Bhindwallam S
+- Aguirre M
+- Restrepo JM
+- Raina R
+journal: Cell Transplant
+year: '2026'
+doi: 10.1177/09636897261417049
+keywords:
+- Humans
+- "Glomerulosclerosis, Focal Segmental/therapy, physiopathology, pathology"
+- Biomarkers/metabolism
+- Recurrence
+- Kidney Transplantation
+content_type: abstract_only
+---
+
+# Recurrence of focal segmental glomerulosclerosis: An updated review of pathophysiology, biomarkers, and therapeutic strategies.
+**Authors:** Oatley Z, Jaber D, Rayarakula N, Guirguis T, Khawaja L, Bhindwallam S, Aguirre M, Restrepo JM, Raina R
+**Journal:** Cell Transplant (2026)
+**DOI:** [10.1177/09636897261417049](https://doi.org/10.1177/09636897261417049)
+
+## Content
+
+1. Cell Transplant. 2026 Jan-Dec;35:9636897261417049. doi: 
+10.1177/09636897261417049. Epub 2026 Mar 30.
+
+Recurrence of focal segmental glomerulosclerosis: An updated review of 
+pathophysiology, biomarkers, and therapeutic strategies.
+
+Oatley Z(1), Jaber D(1), Rayarakula N(2), Guirguis T(1), Khawaja L(1), 
+Bhindwallam S(1), Aguirre M(3), Restrepo JM(4)(5), Raina R(1)(6)(7).
+
+Author information:
+(1)College of Medicine, Northeast Ohio Medical University, Rootstown, OH, USA.
+(2)College of Public Health, Kent State University, Kent, OH, USA.
+(3)Medical Oncology Department, Gregorio Marañón Hospital, Madrid, Spain.
+(4)Pediatric Nephrology Department, Fundación Valle del Lili, Cali, Colombia.
+(5)Universidad ICESI, Cali, Colombia.
+(6)Department of Nephrology, Akron Nephrology Associates/Cleveland Clinic Akron 
+General, Akron, OH, USA.
+(7)Department of Nephrology, Akron Children's Hospital, Akron, OH, USA.
+
+Focal segmental glomerulosclerosis (FSGS) is one of the major causes of 
+nephrotic syndrome, which can progress to end-stage renal disease, leading to 
+kidney transplantation. Following renal transplantation, recurrence of FSGS 
+(rFSGS) occurs in 30%-40% of patients with a high risk of graft loss. rFSGS 
+typically presents with nephrotic-range proteinuria within days after 
+post-transplantation. This review summarizes pathophysiology, biomarkers, and 
+therapeutic strategies for rFSGS. Monogenic causes of FSGS, such as those caused 
+by APOL1 mutation, show variable recurrence, while NPHS2 and ACTN4 show low 
+recurrence of FSGS. Evidence suggests that idiopathic or primary FSGS is 
+strongly associated with rFSGS, owing to podocyte structural damage caused by 
+circulating permeability factors or immune dysfunction. Recent advances have 
+identified biomarkers such as anti-nephrin antibodies, anti-CD40 antibodies, 
+soluble tumor necrosis factor receptor 2 (sTNFR2), and soluble urokinase-type 
+plasminogen activator receptor (suPAR) that help in early detection of recurrent 
+FSGS. Post-transplant monitoring includes measuring urine protein-to-creatinine 
+ratio (UPCR) and 24-h urine protein excretion, and a kidney biopsy. Preventive 
+strategies, although including plasmapheresis and rituximab, show limited 
+benefit and are not recommended for routine prophylaxis. Treatment options 
+include plasmapheresis, immunoadsorption, and immunosuppressive drugs such as 
+cyclophosphamide, rituximab, or calcineurin inhibitors. Recurrent FSGS is a 
+clinical challenge with its multifactorial pathogenesis. Incorporating 
+strategies such as genetic testing, risk stratification, and early detection 
+with the help of biomarkers and early treatment can induce remission and 
+preserve graft survival. Despite these advances, large prospective studies are 
+still required for standardizing prevention and management strategies for rFSGS.
+
+DOI: 10.1177/09636897261417049
+PMCID: PMC13039636
+PMID: 41906863 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of Conflicting InterestsThe authors 
+declared no potential conflicts of interest with respect to the research, 
+authorship, and/or publication of this article.


### PR DESCRIPTION
New disorder entry for FSGS (MONDO:0100313), a leading cause of nephrotic syndrome and end-stage kidney disease.

Coverage:
- 5 pathophysiology nodes: podocyte injury, circulating permeability factors, glomerular filtration barrier dysfunction, mesangial expansion, and tubulointerstitial fibrosis
- 4 subtypes: Primary, Secondary, Genetic, Collapsing
- 8 phenotypes with HPO terms (proteinuria, nephrotic syndrome, renal insufficiency, hypertension, edema, hypoalbuminemia, hyperlipidemia, hematuria)
- 6 treatments with MAXO/CHEBI terms (corticosteroids, calcineurin inhibitors, sparsentan, RAS blockade, mycophenolate mofetil, kidney transplantation)
- 5 causative genes with HGNC bindings (NPHS2, NPHS1, ACTN4, TRPC6, INF2)
- 12 PMIDs fetched and cached; all evidence items have reference_title
- 80.4% compliance; schema, terms, and reference validations all pass

Key references: PMID:10742096 (NPHS2), PMID:10700177 (ACTN4), PMID:15879175 (TRPC6), PMID:20023659 (INF2), PMID:39536114 (INF2 GOF), PMID:41133676 (circulating factors), PMID:39663153 (treatment meta-analysis), PMID:39333921 (sparsentan), PMID:41906863 (recurrence/transplant)