### PR TITLE
[codex] backfill MED13 research notes branch

### DIFF
--- a/research/MED13-related_Neurodevelopmental_Disorder-curation-notes.md
+++ b/research/MED13-related_Neurodevelopmental_Disorder-curation-notes.md
@@ -1,0 +1,42 @@
+# MED13-related neurodevelopmental disorder curation notes
+
+Date: 2026-04-12
+Issue: https://github.com/monarch-initiative/dismech/issues/1140
+
+## Bottom line
+
+`MED13-related neurodevelopmental disorder` should become both a disorder entry and a project note.
+
+The disorder entry is justified now because the local repo triage already flags `MED13` as a `CRITICAL` missing anchor, the 2018 cohort defines a recognizable syndrome, later cases expand but do not dissolve that syndrome, and the 2026 cortical-neuron study gives a credible mechanism trunk for a first pathophysiology model.
+
+The project note is still worth keeping because there is a real modeling decision to preserve: G2P points to the MED13-specific term `MONDO:0032485`, while the local ClinGen validity cache is attached to the broader umbrella `MONDO:0100038` `complex neurodevelopmental disorder`. That split should be documented explicitly rather than rediscovered later from raw spreadsheets.
+
+## Why a disorder entry is warranted
+
+- The local G2P triage row says `ADD_FIRST_GENE_DISEASE_ANCHOR` for `MED13`.
+- The disease signal is not based on one isolated patient; it has a syndrome-defining cohort plus later phenotype-expansion reports.
+- The mechanistic center is coherent enough for dismech: Mediator kinase-module dysfunction leading to developmental transcriptional dysregulation in cortical neurons.
+- A conservative first entry can stay focused on developmental delay, intellectual disability, speech impairment, hypotonia, and behavioral or autism-spectrum features without overcommitting to rare severe presentations.
+
+## Why a project note is also warranted
+
+- The anchor choice needs explanation: specific MED13 disorder term versus broader ClinGen umbrella term.
+- The first entry should state clearly that cardiac, hearing, and mitochondrial findings are spectrum extensions, not the primary mechanistic trunk.
+- Missense-versus-truncating mechanism questions remain open enough that future curators will benefit from a preserved decision memo.
+
+## Recommended first-entry scope
+
+- Root the disorder at `MONDO:0032485` and gene `MED13` (`hgnc:22474`).
+- Use a mechanism chain centered on:
+  - Mediator kinase-module dysfunction
+  - transcriptional dysregulation
+  - impaired cortical neuron migration and projection
+  - neurodevelopmental phenotypes
+- Keep secondary multisystem findings conservative unless directly evidenced at the disease level.
+
+## References to carry forward
+
+- `research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md`
+- `docs/research/g2p_all_genes_row_triage_2026_03_28.tsv`
+- `docs/research/g2p_all_genes_gene_summary_2026_03_28.tsv`
+- `cache/clingen/gene_validity.csv`

--- a/research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md
+++ b/research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md
@@ -1,0 +1,153 @@
+# MED13-related neurodevelopmental disorder
+
+Date: 2026-04-12
+Issue: https://github.com/monarch-initiative/dismech/issues/1140
+Primary proposed disease anchor: `MONDO:0032485` `intellectual developmental disorder 61`
+Related broader disease context: `MONDO:0100038` `complex neurodevelopmental disorder`
+Category: Mendelian
+Aliases used in the literature: intellectual developmental disorder, autosomal dominant 61; MRD61; MED13-associated syndrome
+
+## Repo state
+
+- The repo currently has no `kb/disorders/` entry for this disease.
+- The current G2P release triage marks `MED13` as `CRITICAL`, `NO_DISMECH_MATCH`, `strong`, and `loss of function`, with the suggested action `ADD_FIRST_GENE_DISEASE_ANCHOR`.
+- The local ClinGen cache records a definitive `MED13` gene-disease validity assertion, but it is attached to the broader label `complex neurodevelopmental disorder` rather than the more specific MED13 disease term used in the G2P row.
+
+## Mechanism-centered assessment
+
+MED13-related neurodevelopmental disorder is best framed as a dosage-sensitive transcriptional dysregulation disorder within the Mediator kinase module, not as a primary mitochondrial disease, channelopathy, or isolated malformation syndrome. The strongest disease trunk is:
+
+1. heterozygous pathogenic `MED13` variation
+2. altered MED13 dosage or function within the `MED12`-`MED13`-`CDK8`-`CCNC` kinase module
+3. dysregulated RNA polymerase II-associated developmental transcription
+4. impaired cortical neuronal migration, projection, and maturation programs
+5. neurodevelopmental phenotypes dominated by developmental delay, intellectual disability, speech impairment, hypotonia, and behavioral or autism-spectrum features
+
+That trunk is stronger than any alternative because it is supported at three separate levels:
+
+- official gene-function annotation placing MED13 in the Mediator kinase module
+- a syndrome-defining human cohort
+- a direct cortical-development model connecting Med13 loss to neuronal migration and projection defects
+
+## Why this mechanism is credible
+
+NCBI Gene describes MED13 as a Mediator complex subunit that forms a sub-complex with MED12, cyclin C, and CDK8 and can negatively regulate Mediator-driven transactivation. That makes MED13 a plausible dosage-sensitive upstream controller of developmental transcription rather than a gene whose effects should be modeled through one narrow terminal pathway.
+
+The strongest new mechanistic bridge is the 2026 Communications Biology study showing that Med13 knockdown in developing cortical neurons impaired radial migration, contralateral projection, and dendritic complexity, with partial rescue of migration and projection phenotypes by `PLXNA4` overexpression. This is the first localizable mechanistic link from MED13 dysfunction to a disease-relevant neurodevelopmental process and argues that cortical circuit formation should sit near the center of any first dismech pathophysiology model.
+
+## Human disease evidence
+
+### Syndrome-defining evidence
+
+The anchoring paper is Snijders Blok et al. (Human Genetics, 2018; PMID: `29740699`), which established de novo `MED13` variants as the basis of a recognizable neurodevelopmental syndrome. This remains the single best paper for a first disease anchor because it defines the shared phenotype rather than a single outlier presentation.
+
+### Phenotype expansion without changing the core mechanism
+
+- Trivisano et al. (Seizure, 2022; PMID: `36087421`) shows that developmental and epileptic encephalopathy with infantile spasms can occur in the MED13 spectrum.
+- Tolmacheva et al. (BMC Medical Genomics, 2024; PMID: `38745205`) extends the multisystem congenital-anomaly end of the phenotype.
+- The 2025 hearing-loss case report (PMID: `41561257`) is useful because a truncating allele supports a loss-of-function or haploinsufficiency-skewed interpretation and expands the sensory phenotype.
+- Harada et al. (Human Genome Variation, 2025; PMID: `41130977`) reports infantile spasms, cardiomyopathy, hepatomegaly, and mitochondrial abnormalities, but this should currently be treated as a severe or allele-specific presentation rather than the default mechanistic center of the disorder.
+
+The implication is that epilepsy, heart disease, hearing loss, and possible metabolic stress are real spectrum extensions, but they should branch off the main transcriptional/cortical-development mechanism rather than define it.
+
+## Anchor choice in this repo
+
+The local data split in two directions:
+
+- G2P points to the MED13-specific disease concept `MONDO:0032485` (`intellectual developmental disorder 61`).
+- ClinGen validity is cached against the broader umbrella `MONDO:0100038` (`complex neurodevelopmental disorder`).
+
+For dismech, the better first anchor is still the MED13-specific term. The human literature now supports a recognizable MED13-centered syndrome, and the G2P row explicitly asks for a first gene-disease anchor. The broader ClinGen label is still useful as supporting evidence that the gene-disease relationship is definitive, but it should not force the entry to collapse into an umbrella disorder that loses the MED13-specific mechanism and phenotype framing.
+
+## Curation-ready entities
+
+### Primary disease gene
+
+- `MED13` (`hgnc:22474`)
+
+### Mechanistically relevant partner genes
+
+- `MED12`
+- `CDK8`
+- `CCNC`
+- `PLXNA4`
+
+These are useful for pathophysiology narrative and downstream edges, but they do not change the fact that the disorder should be rooted as a MED13 disease.
+
+### Candidate cell types
+
+- neural progenitor cell
+- neuron
+- cerebral cortex neuron
+
+If a later YAML needs a narrower model, callosal or contralaterally projecting cortical neurons are attractive, but the current literature supports a broader cortical-neuron framing more safely.
+
+### Candidate anatomical locations
+
+- brain
+- cerebral cortex
+- corpus callosum
+
+Secondary or variable sites:
+
+- heart
+- inner ear or auditory pathway
+- eye or optic pathway
+
+### Candidate biological processes
+
+- regulation of transcription by RNA polymerase II
+- cerebral cortex development
+- neuron migration
+- neuron projection development
+- dendrite development
+
+## Phenotypes that are safe for a first entry
+
+### Core phenotypes
+
+- developmental delay or global developmental delay
+- intellectual disability
+- speech and language impairment
+- hypotonia
+- autism-spectrum or behavioral abnormalities
+
+### Secondary or spectrum-expanding phenotypes
+
+- seizures, including infantile spasms
+- congenital heart disease or cardiomyopathy
+- hearing impairment
+- ocular abnormalities
+- corpus callosum abnormalities
+- growth restriction or feeding difficulty
+- mild dysmorphic facial features
+
+The core list is strong enough for a first conservative YAML. The secondary list should be added only where there is direct disease-level evidence rather than extrapolation from isolated severe reports.
+
+## What looks settled versus unsettled
+
+### Settled enough
+
+- `MED13` is a credible Mendelian neurodevelopmental disease gene.
+- Autosomal-dominant, usually de novo disease is the default human pattern.
+- Loss-of-function or haploinsufficiency is the best current default model, especially for truncating alleles.
+- The most coherent mechanism framing is Mediator kinase-module dysfunction causing transcriptional dysregulation during cortical development.
+
+### Still unsettled
+
+- Whether all missense alleles operate through the same mechanism as truncating alleles
+- Whether cardiomyopathy, hepatomegaly, and mitochondrial abnormalities are core-spectrum versus allele-specific
+- The exact disease-level frequency of congenital heart disease, hearing loss, epilepsy, and corpus callosum anomalies
+
+## Recommendation
+
+This should become both:
+
+- a conservative disorder entry rooted at `MONDO:0032485`
+- a short project or curation note that records the anchor choice, the ClinGen versus G2P label split, and the decision to keep the first mechanism centered on Mediator/cortical-development biology rather than severe outlier phenotypes
+
+The disorder entry is justified because the gene-disease relationship and core syndrome are already strong enough. The project note is still useful because the worktree currently needs a durable record of why the first entry should stay narrow and how to treat the more severe cardiac, auditory, and mitochondrial reports.
+
+## Bottom line
+
+`MED13` is no longer just a backlog candidate. In this repo it is a critical missing disease anchor, and the current local evidence supports a coherent first mechanism model: MED13 loss-of-function-skewed disruption of the Mediator kinase module leads to transcriptional dysregulation during cortical development, which then produces a recognizable neurodevelopmental syndrome. The right next step is not to wait for a perfect mechanism map, but to create a conservative MED13 disorder entry while preserving the unresolved anchor and phenotype-boundary decisions in a companion curation note linked to issue `#1140`.

--- a/research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md.citations.md
+++ b/research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md.citations.md
@@ -1,0 +1,77 @@
+# Citations for MED13-related neurodevelopmental disorder
+
+Date: 2026-04-12
+Issue: https://github.com/monarch-initiative/dismech/issues/1140
+
+## Repo context
+
+1. G2P row triage in this repo:
+   - [docs/research/g2p_all_genes_row_triage_2026_03_28.tsv](../docs/research/g2p_all_genes_row_triage_2026_03_28.tsv)
+   - `MED13	G2P02649	MED13-related neurodevelopmental disorder	MONDO:0032485	strong	loss of function	...	NO_DISMECH_MATCH	CRITICAL`
+
+2. G2P gene summary in this repo:
+   - [docs/research/g2p_all_genes_gene_summary_2026_03_28.tsv](../docs/research/g2p_all_genes_gene_summary_2026_03_28.tsv)
+   - marks `MED13` as `CRITICAL` and recommends `ADD_FIRST_GENE_DISEASE_ANCHOR`
+
+3. Local ClinGen cache in this repo:
+   - [cache/clingen/gene_validity.csv](../cache/clingen/gene_validity.csv)
+   - MED13 -> "complex neurodevelopmental disorder" -> `Definitive`
+
+4. Issue requesting this reassessment:
+   - https://github.com/monarch-initiative/dismech/issues/1140
+   - "Research MED13-related neurodevelopmental disorder"
+
+## Official / authoritative sources
+
+5. NCBI Gene: MED13 mediator complex subunit 13
+   - https://www.ncbi.nlm.nih.gov/gene/9969
+   - Useful for official symbol, synonyms, gene function, associated condition `Intellectual developmental disorder 61`, and the key publication list.
+
+6. ClinGen gene validity assertion URL from the local cache
+   - https://search.clinicalgenome.org/kb/gene-validity/CGGV:assertion_e82f63b1-ed0f-4dd0-8168-3aa4e0a4c2a9-2022-05-17T180000.000Z
+   - Local cache records this as MED13 -> complex neurodevelopmental disorder -> `Definitive`, AD, dated 2022-05-17.
+
+## Primary literature
+
+7. Snijders Blok L, et al. De novo mutations in MED13, a component of the Mediator complex, are associated with a novel neurodevelopmental disorder.
+   - PubMed: https://pubmed.ncbi.nlm.nih.gov/29740699/
+   - PMID: 29740699
+   - Why it matters: syndrome-defining cohort and best single paper for a first disease anchor.
+
+8. Trivisano M, et al. MED13 mutation: A novel cause of developmental and epileptic encephalopathy with infantile spasms.
+   - PubMed: https://pubmed.ncbi.nlm.nih.gov/36087421/
+   - PMID: 36087421
+   - Why it matters: establishes that severe epilepsy / infantile spasms can occur in the MED13 spectrum.
+
+9. Tolmacheva E, et al. Expanding phenotype of MED13-associated syndrome presenting novel de novo missense variant in a patient with multiple congenital anomalies.
+   - PubMed: https://pubmed.ncbi.nlm.nih.gov/38745205/
+   - Full text: https://bmcmedgenomics.biomedcentral.com/articles/10.1186/s12920-024-01857-z
+   - PMID: 38745205
+   - DOI: 10.1186/s12920-024-01857-z
+   - Why it matters: expands the severe congenital-anomaly end of the phenotype.
+
+10. Intellectual Developmental Disorder of Autosomal Dominant 61 Caused by a MED13 Variant Presenting With Congenital Unilateral Sensorineural Hearing Loss: A Case Report.
+   - PubMed: https://pubmed.ncbi.nlm.nih.gov/41561257/
+   - PMID: 41561257
+   - Why it matters: supports haploinsufficiency for truncating variants and expands the sensory phenotype to congenital unilateral SNHL.
+
+11. Harada M, et al. Mitochondrial dysfunction in MED13 variant-associated disease: a case of infantile spasms, cardiomyopathy and hepatomegaly.
+    - PubMed: https://pubmed.ncbi.nlm.nih.gov/41130977/
+    - PMC: https://pmc.ncbi.nlm.nih.gov/articles/PMC12549833/
+    - PMID: 41130977
+    - PMCID: PMC12549833
+    - DOI: 10.1038/s41439-025-00327-x
+    - Why it matters: important severe case report, but likely not yet sufficient to define the core mechanism of the disorder.
+
+12. Li Z-X, et al. Med13 is involved in the radial migration and contralateral projection of cortical neurons via PlxnA4.
+    - Nature / Communications Biology: https://www.nature.com/articles/s42003-026-09704-w
+    - DOI: 10.1038/s42003-026-09704-w
+    - Published: 2026-02-09
+    - Why it matters: first direct mechanistic study tying Med13 loss to cortical neuron migration / callosal projection defects and implicating `PLXNA4`.
+
+## Notes on use
+
+- For a first dismech disease anchor, prioritize citations 5 through 9 plus the local repo-context items above.
+- Citation 11 is best treated as phenotype-expanding rather than syndrome-defining.
+- Citation 12 is currently the strongest mechanistic bridge from MED13 to cortical developmental defects and is particularly useful for pathophysiology nodes.
+- The main terminology decision to preserve is that the first entry should use the MED13-specific disease concept from G2P (`MONDO:0032485`) while still acknowledging that ClinGen validity was curated against the broader umbrella `MONDO:0100038`.


### PR DESCRIPTION
## What changed

Opens the pre-existing `research/med13` branch as a draft PR for transparency.

This branch contains three MED13 research documents created on April 12, 2026:

- `research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md`
- `research/MED13-related_Neurodevelopmental_Disorder-deep-research-codex.md.citations.md`
- `research/MED13-related_Neurodevelopmental_Disorder-curation-notes.md`

## Why

These docs existed on a pushed branch but were not visible through a PR. Opening a draft PR makes that historical work auditable while we compare it against:

- PR #1304 (`MED13_Syndrome.yaml`)
- the already merged `kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml` entry on `main`

## Important context

This branch is historical research context, not a ready-to-merge content PR.

Some statements in the docs reflect repo state as of April 12, 2026 and are now stale relative to `main`.
In particular, the docs predate the merged Mediator-complex grouping entry that now carries a MED13 subtype and MED13-linked pathophysiology.

## Validation

- inspected branch diff against `main`
- confirmed branch contains only the three MED13 research docs above
- no additional local changes from the worktree were included in this PR