### PR TITLE
Third-pass IgA nephropathy audit: tighten therapy evidence, keep IgAV split

### DIFF
--- a/kb/disorders/IgA_Nephropathy.yaml
+++ b/kb/disorders/IgA_Nephropathy.yaml
@@ -1,6 +1,6 @@
 name: IgA Nephropathy
 creation_date: '2025-12-19T01:12:52Z'
-updated_date: '2026-04-14T21:20:49Z'
+updated_date: '2026-04-15T04:43:47Z'
 category: Autoimmune
 parents:
 - Autoimmune Disease
@@ -31,10 +31,14 @@ description: >-
   complement activation, mesangial proliferation, podocyte injury, and
   progressive chronic kidney damage.
 notes: >-
-  This entry models kidney-limited / primary IgA nephropathy. IgA vasculitis is
-  retained as a separate systemic small-vessel vasculitis differential rather
-  than a subtype of IgAN, despite shared four-hit biology and overlapping renal
-  histology.
+  This entry models kidney-limited / primary IgA nephropathy. The core page
+  deliberately includes only the shared kidney-relevant four-hit biology
+  (mucosal dysregulation, galactose-deficient IgA1, anti-glycan
+  autoantibodies, and mesangial immune-complex/complement injury) that also
+  underlies IgA vasculitis nephritis. The systemic small-vessel vasculitis
+  manifestations of IgA vasculitis, such as palpable purpura, arthritis, and
+  gastrointestinal vasculitis, are kept in separate disease framing rather than
+  collapsed into this kidney-limited IgAN page.
 pathophysiology:
 - name: Mucosal B-cell hyper-responsiveness
   description: >-
@@ -647,7 +651,7 @@ genetic:
   notes: Glycosylation locus consistent with dysregulated IgA1 O-glycosylation and Gd-IgA1 production rather than monogenic disease causation.
 treatments:
 - name: ACE inhibitors / ARBs
-  description: First-line supportive therapy for proteinuria reduction and renoprotection.
+  description: First-line supportive renin-angiotensin system blockade for proteinuric and/or hypertensive IgAN.
   target_phenotypes:
   - preferred_term: Proteinuria
     term:
@@ -657,15 +661,39 @@ treatments:
     term:
       id: HP:0000822
       label: Hypertension
+  evidence:
+  - reference: PMID:39188719
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The mainstay of therapy is supportive, consisting of lifestyle
+      modifications, renin-angiotensin inhibition (if hypertensive or
+      proteinuric), sodium-glucose-transporter 2 inhibition (if GFR reduced or
+      proteinuric), and endothelin-receptor antagonism (if proteinuric).
+    explanation: >-
+      Contemporary review supports that renin-angiotensin inhibition remains
+      first-line supportive therapy in proteinuric and/or hypertensive IgAN.
 - name: SGLT2 inhibitors
-  description: Kidney-protective therapy for proteinuric chronic kidney disease including IgAN.
+  description: Adjunct kidney-protective therapy that lowers CKD progression risk in proteinuric IgAN.
   target_phenotypes:
   - preferred_term: Proteinuria
     term:
       id: HP:0000093
       label: Proteinuria
+  evidence:
+  - reference: PMID:33878338
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thus, in participants with IgA nephropathy, dapagliflozin reduced the
+      risk of chronic kidney disease progression with a favorable safety
+      profile.
+    explanation: >-
+      Prespecified DAPA-CKD IgAN subgroup analysis provides direct human trial
+      evidence supporting SGLT2 inhibition as kidney-protective adjunct
+      therapy.
 - name: Corticosteroids
-  description: Considered in selected high-risk patients after maximal supportive care.
+  description: Considered in selected high-risk patients after maximal supportive care, with attention to infection and other toxicity risks.
   target_mechanisms:
   - target: Mesangial proliferation and inflammatory amplification
     treatment_effect: MODULATES
@@ -675,15 +703,40 @@ treatments:
     term:
       id: HP:0000093
       label: Proteinuria
+  evidence:
+  - reference: PMID:35579642
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Among patients with IgA nephropathy at high risk of progression,
+      treatment with oral methylprednisolone for 6 to 9 months, compared with
+      placebo, significantly reduced the risk of the composite outcome of kidney
+      function decline, kidney failure, or death due to kidney disease.
+      However, the incidence of serious adverse events was increased with oral
+      methylprednisolone, mainly with high-dose therapy.
+    explanation: >-
+      TESTING provides direct randomized evidence for corticosteroid efficacy in
+      high-risk IgAN while also justifying cautious, selective use because
+      serious adverse events increased.
 - name: Sparsentan
-  description: Dual endothelin and angiotensin receptor antagonist used for persistent proteinuric disease.
+  description: Dual endothelin and angiotensin receptor antagonist used to lower persistent proteinuria in IgAN.
   target_phenotypes:
   - preferred_term: Proteinuria
     term:
       id: HP:0000093
       label: Proteinuria
+  evidence:
+  - reference: PMID:37015244
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Once-daily treatment with sparsentan produced meaningful reduction in
+      proteinuria compared with irbesartan in adults with IgA nephropathy.
+    explanation: >-
+      PROTECT interim analysis directly supports sparsentan as a proteinuria-
+      lowering therapy in biopsy-proven IgAN.
 - name: Targeted-release budesonide
-  description: Mucosal-targeted corticosteroid strategy to reduce proteinuria and slow progression.
+  description: Gut-targeted corticosteroid strategy that reduces proteinuria and slows eGFR decline in high-risk primary IgAN.
   target_mechanisms:
   - target: Mucosal B-cell hyper-responsiveness
     treatment_effect: MODULATES
@@ -693,6 +746,19 @@ treatments:
     term:
       id: HP:0000093
       label: Proteinuria
+  evidence:
+  - reference: PMID:37591292
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A 9-month treatment period with Nefecon provided a clinically relevant
+      reduction in eGFR decline and a durable reduction in proteinuria versus
+      placebo, providing support for a disease-modifying effect in patients with
+      IgA nephropathy.
+    explanation: >-
+      Phase 3 NefIgArd trial directly supports targeted-release budesonide as a
+      mucosal-directed therapy that improves proteinuria and kidney-function
+      trajectory in primary IgAN.
 differential_diagnoses:
 - name: IgA vasculitis
   disease_term:
@@ -765,6 +831,18 @@ references:
   findings: []
 - reference: DOI:10.1038/ng.787
   title: Genome-wide association study identifies susceptibility loci for IgA nephropathy
+  findings: []
+- reference: DOI:10.1016/S0140-6736(23)00569-X
+  title: 'Sparsentan in patients with IgA nephropathy: a prespecified interim analysis from a randomised, double-blind, active-controlled clinical trial'
+  findings: []
+- reference: DOI:10.1016/S0140-6736(23)01554-4
+  title: 'Efficacy and safety of a targeted-release formulation of budesonide in patients with primary IgA nephropathy (NefIgArd): 2-year results from a randomised phase 3 trial'
+  findings: []
+- reference: DOI:10.1016/j.kint.2021.03.033
+  title: A pre-specified analysis of the DAPA-CKD trial demonstrates the effects of dapagliflozin on major adverse kidney events in patients with IgA nephropathy
+  findings: []
+- reference: DOI:10.1001/jama.2022.5368
+  title: 'Effect of Oral Methylprednisolone on Decline in Kidney Function or Kidney Failure in Patients With IgA Nephropathy: The TESTING Randomized Clinical Trial'
   findings: []
 - reference: DOI:10.1016/j.semnephrol.2025.151571
   title: 'IgA Vasculitis and IgA Nephropathy: Two Sides of the Same Coin?'

--- a/references_cache/PMID_33878338.md
+++ b/references_cache/PMID_33878338.md
@@ -1,0 +1,118 @@
+---
+reference_id: "PMID:33878338"
+title: A pre-specified analysis of the DAPA-CKD trial demonstrates the effects of dapagliflozin on major adverse kidney events in patients with IgA nephropathy.
+authors:
+- Wheeler DC
+- Toto RD
+- Stefánsson BV
+- Jongs N
+- Chertow GM
+- Greene T
+- Hou FF
+- McMurray JJV
+- Pecoits-Filho R
+- Correa-Rotter R
+- Rossing P
+- Sjöström CD
+- Umanath K
+- Langkilde AM
+- Heerspink HJL
+- DAPA-CKD Trial Committees and Investigators
+journal: Kidney Int
+year: '2021'
+doi: 10.1016/j.kint.2021.03.033
+keywords:
+- Benzhydryl Compounds
+- "Diabetes Mellitus, Type 2"
+- Glomerular Filtration Rate
+- "Glomerulonephritis, IGA/drug therapy"
+- Glucosides
+- Humans
+- Kidney
+- Middle Aged
+- "Renal Insufficiency, Chronic/complications, diagnosis, drug therapy"
+- Sodium-Glucose Transporter 2 Inhibitors
+content_type: abstract_only
+---
+
+# A pre-specified analysis of the DAPA-CKD trial demonstrates the effects of dapagliflozin on major adverse kidney events in patients with IgA nephropathy.
+**Authors:** Wheeler DC, Toto RD, Stefánsson BV, Jongs N, Chertow GM, Greene T, Hou FF, McMurray JJV, Pecoits-Filho R, Correa-Rotter R, Rossing P, Sjöström CD, Umanath K, Langkilde AM, Heerspink HJL, DAPA-CKD Trial Committees and Investigators
+**Journal:** Kidney Int (2021)
+**DOI:** [10.1016/j.kint.2021.03.033](https://doi.org/10.1016/j.kint.2021.03.033)
+
+## Content
+
+1. Kidney Int. 2021 Jul;100(1):215-224. doi: 10.1016/j.kint.2021.03.033. Epub
+2021  Apr 18.
+
+A pre-specified analysis of the DAPA-CKD trial demonstrates the effects of 
+dapagliflozin on major adverse kidney events in patients with IgA nephropathy.
+
+Wheeler DC(1), Toto RD(2), Stefánsson BV(3), Jongs N(4), Chertow GM(5), Greene 
+T(6), Hou FF(7), McMurray JJV(8), Pecoits-Filho R(9), Correa-Rotter R(10), 
+Rossing P(11), Sjöström CD(3), Umanath K(12), Langkilde AM(3), Heerspink HJL(4); 
+DAPA-CKD Trial Committees and Investigators.
+
+Author information:
+(1)Department of Renal Medicine, University College London, London, UK; The 
+George Institute for Global Health, Sydney, Australia. Electronic address: 
+d.wheeler@ucl.ac.uk.
+(2)Department of Internal Medicine, UT Southwestern Medical Center, Dallas, 
+Texas, USA.
+(3)Late-Stage Development, Cardiovascular, Renal and Metabolism, 
+Biopharmaceuticals R&D, AstraZeneca, Gothenburg, Sweden.
+(4)Department Clinical Pharmacy and Pharmacology, University of Groningen, 
+University Medical Center Groningen, Groningen, the Netherlands.
+(5)Department of Medicine, Stanford University School of Medicine, Stanford, 
+California, USA; Department of Epidemiology and Population Health, Stanford 
+University School of Medicine, Stanford, California, USA.
+(6)Study Design and Biostatistics Center, University of Utah Health Sciences, 
+Salt Lake City, Utah, USA.
+(7)Division of Nephrology, Nanfang Hospital, Southern Medical University, 
+National Clinical Research Center for Kidney Disease, Guangzhou, China.
+(8)Institute of Cardiovascular and Medical Sciences, University of Glasgow, 
+Glasgow, UK.
+(9)Arbor Research Collaborative for Health, Ann Arbor, Michigan, USA; School of 
+Medicine, Pontifical Catholic University of Paraná, Curitiba, Paraná, Brazil.
+(10)National Medical Science and Nutrition Institute Salvador Zubirán, Mexico 
+City, Mexico.
+(11)Steno Diabetes Center Copenhagen, Gentofte, Denmark; Department of Clinical 
+Medicine, University of Copenhagen, Copenhagen, Denmark.
+(12)Division of Nephrology and Hypertension, Henry Ford Hospital, Detroit, 
+Michigan, USA; Division of Nephrology and Hypertension, Wayne State University, 
+Detroit, Michigan, USA.
+
+Comment in
+    Kidney Int. 2021 Jul;100(1):24-26. doi: 10.1016/j.kint.2021.04.002.
+
+Immunoglobulin A (IgA) nephropathy is a common form of glomerulonephritis, which 
+despite use of renin-angiotensin-aldosterone-system blockers and 
+immunosuppressants, often progresses to kidney failure. In the Dapagliflozin and 
+Prevention of Adverse Outcomes in Chronic Kidney Disease trial, dapagliflozin 
+reduced the risk of kidney failure and prolonged survival in participants with 
+chronic kidney disease with and without type 2 diabetes, including those with 
+IgA nephropathy. Participants with estimated glomerular filtration rate (eGFR) 
+25-75 mL/min/1.73m2 and urinary albumin-to-creatinine ratio 200-5000 mg/g 
+(22.6-565 mg/mol) were randomized to dapagliflozin 10mg or placebo, as adjunct 
+to standard care. The primary composite endpoint was a sustained decline in eGFR 
+of 50% or more, end-stage kidney disease, or death from a kidney disease-related 
+or cardiovascular cause. Of 270 participants with IgA nephropathy (254 [94%] 
+confirmed by previous biopsy), 137 were randomized to dapagliflozin and 133 to 
+placebo, and followed for median 2.1 years. Overall, mean age was 51.2 years; 
+mean eGFR, 43.8 mL/min/1.73m2; and median urinary albumin-to-creatinine ratio, 
+900 mg/g. The primary outcome occurred in six (4%) participants on dapagliflozin 
+and 20 (15%) on placebo (hazard ratio, 0.29; 95% confidence interval, 0.12, 
+0.73). Mean rates of eGFR decline with dapagliflozin and placebo were -3.5 
+and -4.7 mL/min/1.73m2/year, respectively. Dapagliflozin reduced the urinary 
+albumin-to-creatinine ratio by 26% relative to placebo. Adverse events leading 
+to study drug discontinuation were similar with dapagliflozin and placebo. There 
+were fewer serious adverse events with dapagliflozin, and no new safety findings 
+in this population. Thus, in participants with IgA nephropathy, dapagliflozin 
+reduced the risk of chronic kidney disease progression with a favorable safety 
+profile.
+
+Copyright © 2021 International Society of Nephrology. Published by Elsevier Inc. 
+All rights reserved.
+
+DOI: 10.1016/j.kint.2021.03.033
+PMID: 33878338 [Indexed for MEDLINE]

--- a/references_cache/PMID_35579642.md
+++ b/references_cache/PMID_35579642.md
@@ -1,0 +1,281 @@
+---
+reference_id: "PMID:35579642"
+title: "Effect of Oral Methylprednisolone on Decline in Kidney Function or Kidney Failure in Patients With IgA Nephropathy: The TESTING Randomized Clinical Trial."
+authors:
+- Lv J
+- Wong MG
+- Hladunewich MA
+- Jha V
+- Hooi LS
+- Monaghan H
+- Zhao M
+- Barbour S
+- Jardine MJ
+- Reich HN
+- Cattran D
+- Glassock R
+- Levin A
+- Wheeler DC
+- Woodward M
+- Billot L
+- Stepien S
+- Rogers K
+- Chan TM
+- Liu ZH
+- Johnson DW
+- Cass A
+- Feehally J
+- Floege J
+- Remuzzi G
+- Wu Y
+- Agarwal R
+- Zhang H
+- Perkovic V
+- TESTING Study Group
+journal: JAMA
+year: '2022'
+doi: 10.1001/jama.2022.5368
+keywords:
+- "Administration, Oral"
+- Adult
+- Disease Progression
+- Double-Blind Method
+- Female
+- "Glomerulonephritis, IGA/etiology, therapy"
+- Humans
+- Kidney
+- Male
+- "Methylprednisolone/administration & dosage, adverse effects"
+- Proteinuria/etiology
+- Renal Dialysis
+- "Renal Insufficiency/chemically induced, therapy"
+content_type: abstract_only
+---
+
+# Effect of Oral Methylprednisolone on Decline in Kidney Function or Kidney Failure in Patients With IgA Nephropathy: The TESTING Randomized Clinical Trial.
+**Authors:** Lv J, Wong MG, Hladunewich MA, Jha V, Hooi LS, Monaghan H, Zhao M, Barbour S, Jardine MJ, Reich HN, Cattran D, Glassock R, Levin A, Wheeler DC, Woodward M, Billot L, Stepien S, Rogers K, Chan TM, Liu ZH, Johnson DW, Cass A, Feehally J, Floege J, Remuzzi G, Wu Y, Agarwal R, Zhang H, Perkovic V, TESTING Study Group
+**Journal:** JAMA (2022)
+**DOI:** [10.1001/jama.2022.5368](https://doi.org/10.1001/jama.2022.5368)
+
+## Content
+
+1. JAMA. 2022 May 17;327(19):1888-1898. doi: 10.1001/jama.2022.5368.
+
+Effect of Oral Methylprednisolone on Decline in Kidney Function or Kidney 
+Failure in Patients With IgA Nephropathy: The TESTING Randomized Clinical Trial.
+
+Lv J(1)(2), Wong MG(2)(3), Hladunewich MA(4), Jha V(5)(6)(7), Hooi LS(8), 
+Monaghan H(2), Zhao M(1), Barbour S(9), Jardine MJ(10), Reich HN(11), Cattran 
+D(11), Glassock R(12), Levin A(9), Wheeler DC(13), Woodward M(7), Billot L(2), 
+Stepien S(2), Rogers K(2), Chan TM(14), Liu ZH(15), Johnson DW(16), Cass 
+A(2)(17), Feehally J(18), Floege J(19), Remuzzi G(20), Wu Y(21), Agarwal R(22), 
+Zhang H(1), Perkovic V(2); TESTING Study Group.
+
+Collaborators: Razavian M, Gallagher M, Daley F, Hand S, Knight H, Gallagher S, 
+Bose B, Lawlor C, McCourt J, Peh CA, Scott E, Carroll R, Coates T, Hockley B, 
+Hockley M, Latte J, Nicholls K, Cai M, Champion de Crespigny P, Cronin T, 
+Farrell M, Hughes P, Masterson R, Sepe G, Tan SJ, Toussaint N, Wollstencroft R, 
+Cooper B, Chang M, Clayton H, Tan S, Tsang H, Sudak J, Laurin LP, Pichette V, 
+Chausse K, Comeau M, Lepine L, Soliel M, Beauchemin S, René E, Quach M, Daoust 
+K, Lessard A, Bachand-Fournier M, Bétournay M, Paradis MS, Mikye Castor M, Huang 
+S, Moist L, Gallo K, VanWesenbeeck R, Longfield T, Norris F, Moyer A, Bailey 
+Lozon Z, Miller M, Clase C, Rabbat C, Salisbury M, Mazzetti Vieira A, Lalji F, 
+Moreau C, Pannu N, Hildebrand A, Ruholl N, Ahmad N, Muneer M, Girard L, Mann MC, 
+Hemmelgarn B, Manns B, Ravani P, Li S, Mackay J, Gulewich S, Sheriff Z, Ferera 
+J, Vela K, Gonzalez A, Bhasin A, Lam P, Haji F, Shi S, Liu L, Bao Y, Sui G, Wang 
+C, Li Z, Lv L, Yang L, Li H, Liu Z, Zhang J, Huang B, Yang Y, Fu S, Li S, Pei H, 
+Zhang L, Lu N, Xu J, Xu L, Yang Q, Jin J, Chen N, Wang W, Xu L, Xia Z, Xu H, 
+Huang W, Mo Y, Chen W, Wang L, Li R, Yao S, Li X, Ni Z, Wang L, Gu L, Pang H, 
+Zhou Y, Jin Y, Zhang H, Wang X, Le W, Hou J, Song X, Zhu L, Zhao J, Hou W, Wu J, 
+Shi Y, Liu J, Zhang C, Wan C, Chen S, Zhu H, Tang F, Li H, Jiang X, Wang M, Zuo 
+L, Yan Y, Dong B, Wang Y, Zhang X, Bai L, Li P, Qi D, Cai Z, Li G, Wang L, Peng 
+K, Hong D, Yao D, Jiang A, Luo Q, Hou S, Zhang F, Zheng L, Luo Y, Cai G, Duan S, 
+Zhang Y, Liang S, Shao X, Wang R, Liu X, Xu Y, Zhang J, Chen J, Cheng J, Zhao L, 
+Du X, Chen H, Zhu B, Pan W, Ma Y, Cui C, Zhang Q, Zhang J, Fu P, Tang X, Qin W, 
+Liang Y, Li D, Sun G, Su X, Zhao B, He Q, Shen X, Zheng D, Sun Y, Zheng H, Zheng 
+W, Lu F, Lai L, Zhang M, Xu N, Shi H, Chen W, Liang X, Ye Z, Xu L, Zhang R, Tao 
+Y, Xu D, Tang L, Lian X, Ding G, Wang H, Yang L, Li Z, Hu Z, Jiang B, Guo Z, 
+Chang J, Wang Q, Li N, Zhang A, Shi S, Li Z, Xu H, Bao B, Zhao Y, Nie Z, Liu T, 
+Wang Y, Cui Z, Su C, Gong L, Liu G, Yu L, Wang B, Xu D, Li Y, Lin Q, Yu K, Shen 
+Y, Cheng H, Xu X, Wang Y, Liu R, Xu G, Han M, Wang L, Xing C, Zhang C, Huang Z, 
+Yang G, Xu X, Lv X, Hong H, Liu B, Tao L, Zhang X, Yang H, Yang X, Zhang X, Yang 
+H, Mao Y, Wu H, Li T, Wang H, Zhao B, Lin H, Yang N, Fung KS, Chan R, Law R, 
+Melemadathil S, Pt H, Razak R, Sinta KC, Natarajan G, Mohammed J, Thanigachalam 
+DK, Devaraju SR, Alavala SR, Golla A, Nagalla V, Nallagasu R, Sahay M, Borra S, 
+Sahay R, Dasyam LKS, Kumbagiri M, Msln P, Nazneen A, Prathyusha K, Ramachandran 
+R, Gupta KL, Sain T, Prasad N, Bhaduria DS, Pandy AK, Singh P, Abdul Wahab MZ, 
+Che Rohani Z, Mohd Yassim H, Razali SNO, Saaidi N, Wan Hazlina WM, Yahya R, Yee 
+SY, Zaynah N, Azahar NH, Tan HF, Loh CL, Hashim S, Lee YY, Lim XJ, Mohd Khairi 
+N, Ramanaidu S, Thong KM, Liu WJ, Ee LW, Mohd Yusoff Y, Ngu LLS, Chai NS, Hii 
+LWS, Tan CHH, Wan Japar SH, Mushahar L, Md Yusuff SH, Noor M, Ng KP, Lim SK, 
+Razali WAFA, Wan Md Adnan WAH, Jayne D, Greene T, Walsh M, Wang AY, Mather A, 
+Wang AY.
+
+Author information:
+(1)Renal Division, Department of Medicine, Peking University First Hospital, 
+Beijing, China.
+(2)The George Institute for Global Health, University of New South Wales, 
+Sydney, Australia.
+(3)Department of Renal Medicine, Royal North Shore Hospital, Australia.
+(4)Sunnybrook Health Sciences Centre, University of Toronto, Toronto, Ontario, 
+Canada.
+(5)The George Institute for Global Health India, UNSW, New Delhi, India.
+(6)Prasanna School of Public Health, Manipal Academy of Higher Education, 
+Manipal, India.
+(7)The George Institute for Global Health, School of Public Health, Imperial 
+College London, United Kingdom.
+(8)Sultanah Aminah Hospital, Johor Bahru, Malaysia.
+(9)The University of British Columbia, Vancouver, British Columbia, Canada.
+(10)NHMRC Clinical Trials Centre, University of Sydney, Australia.
+(11)University Health Network, Toronto, Ontario, Canada.
+(12)David Geffen School of Medicine, University of California, Los Angeles.
+(13)Department of Renal Medicine, University College London, United Kingdom.
+(14)Department of Medicine, The University of Hong Kong, Hong Kong, SAR of 
+China.
+(15)Research Institute of Nephrology, Jinling Hospital, Nanjing, China.
+(16)Australasian Kidney Trials Network, University of Queensland, Brisbane, 
+Australia.
+(17)Menzies School of Health Research, Charles Darwin University, Darwin, 
+Australia.
+(18)University of Leicester, Leicester, United Kingdom.
+(19)Division of Nephrology and Clinical Immunology, RWTH Aachen University, 
+Aachen, Germany.
+(20)Istituto di Ricerche Farmacologiche Mario Negri IRCCS, Bergamo, Italy.
+(21)Peking University Clinical Research Institute, Beijing, China.
+(22)Indiana University School of Medicine, Indianapolis.
+
+Comment in
+    JAMA. 2022 May 17;327(19):1872-1874. doi: 10.1001/jama.2022.4638.
+    Ann Intern Med. 2022 Sep;175(9):JC105. doi: 10.7326/J22-0067.
+    JAMA. 2022 Sep 20;328(11):1107-1108. doi: 10.1001/jama.2022.12709.
+    Nephrology (Carlton). 2022 Dec;27(12):1003-1004. doi: 10.1111/nep.14114.
+
+IMPORTANCE: The effect of glucocorticoids on major kidney outcomes and adverse 
+events in IgA nephropathy has been uncertain.
+OBJECTIVE: To evaluate the efficacy and adverse effects of methylprednisolone in 
+patients with IgA nephropathy at high risk of kidney function decline.
+DESIGN, SETTING, AND PARTICIPANTS: An international, multicenter, double-blind, 
+randomized clinical trial that enrolled 503 participants with IgA nephropathy, 
+proteinuria greater than or equal to 1 g per day, and estimated glomerular 
+filtration rate (eGFR) of 20 to 120 mL/min/1.73 m2 after at least 3 months of 
+optimized background care from 67 centers in Australia, Canada, China, India, 
+and Malaysia between May 2012 and November 2019, with follow-up until June 2021.
+INTERVENTIONS: Participants were randomized in a 1:1 ratio to receive oral 
+methylprednisolone (initially 0.6-0.8 mg/kg/d, maximum 48 mg/d, weaning by 8 
+mg/d/mo; n = 136) or placebo (n = 126). After 262 participants were randomized, 
+an excess of serious infections was identified, leading to dose reduction (0.4 
+mg/kg/d, maximum 32 mg/d, weaning by 4 mg/d/mo) and addition of antibiotic 
+prophylaxis for pneumocystis pneumonia for subsequent participants (121 in the 
+oral methylprednisolone group and 120 in the placebo group).
+MAIN OUTCOMES AND MEASURES: The primary end point was a composite of 40% decline 
+in eGFR, kidney failure (dialysis, transplant), or death due to kidney disease. 
+There were 11 secondary outcomes, including kidney failure.
+RESULTS: Among 503 randomized patients (mean age, 38 years; 198 [39%] women; 
+mean eGFR, 61.5 mL/min/1.73 m2; mean proteinuria, 2.46 g/d), 493 (98%) completed 
+the trial. Over a mean of 4.2 years of follow-up, the primary outcome occurred 
+in 74 participants (28.8%) in the methylprednisolone group compared with 106 
+(43.1%) in the placebo group (hazard ratio [HR], 0.53 [95% CI, 0.39-0.72]; 
+P < .001; absolute annual event rate difference, -4.8% per year [95% CI, -8.0% 
+to -1.6%]). The effect on the primary outcome was seen across each dose compared 
+with the relevant participants in the placebo group recruited to each regimen (P 
+for heterogeneity = .11): full-dose HR, 0.58 (95% CI, 0.41-0.81); reduced-dose 
+HR, 0.27 (95% CI, 0.11-0.65). Of the 11 prespecified secondary end points, 9 
+showed significant differences in favor of the intervention, including kidney 
+failure (50 [19.5%] vs 67 [27.2%]; HR, 0.59 [95% CI, 0.40-0.87]; P = .008; 
+annual event rate difference, -2.9% per year [95% CI, -5.4% to -0.3%]). Serious 
+adverse events were more frequent with methylprednisolone vs placebo (28 [10.9%] 
+vs 7 [2.8%] patients with serious adverse events), primarily with full-dose 
+therapy compared with its matching placebo (22 [16.2%] vs 4 [3.2%]).
+CONCLUSIONS AND RELEVANCE: Among patients with IgA nephropathy at high risk of 
+progression, treatment with oral methylprednisolone for 6 to 9 months, compared 
+with placebo, significantly reduced the risk of the composite outcome of kidney 
+function decline, kidney failure, or death due to kidney disease. However, the 
+incidence of serious adverse events was increased with oral methylprednisolone, 
+mainly with high-dose therapy.
+TRIAL REGISTRATION: ClinicalTrials.gov Identifier: NCT01560052.
+
+DOI: 10.1001/jama.2022.5368
+PMCID: PMC9115617
+PMID: 35579642 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of Interest Disclosures: Dr Lv reported 
+receiving grants from the China National Funds for Distinguished Young 
+Scientists and the National Key Research and Development Program of China during 
+the conduct of the study and personal fees from Chinook Therapeutics and KBP 
+Bioscience outside the submitted work. Dr Wong reported receiving fees for 
+advisory boards, steering committee roles, or scientific presentations from 
+Travere, Baxter, Amgen, AbbVie, Chinook, Dimerix, Otsuka, GlaxoSmithKline, and 
+CSL Behring. Dr Hladunewich reported receiving grants from the Canadian 
+Institute for Health Research and study drugs from Pfizer during the conduct of 
+the study and grants from Calliditas for a study in IgA, Ionis for a study in 
+IgA, Pfizer for a study in focal segmental glomerulosclerolsis, and Roche for a 
+study in preeclampsia outside the submitted work and being the medical lead for 
+glomerulonephritis for the Ontario Renal Network. Dr Jha reported receiving 
+grants paid to the institution from Baxter Healthcare and NephroPlus and 
+personal fees paid to the institution from GlaxoSmithKline, AstraZeneca, Bayer, 
+Zydus Cadilla, and Panacea outside the submitted work. Dr Jardine reported 
+receiving grants from the National Health and Medical Research Council during 
+the conduct of the study and other competitively awarded grants from the 
+National Health and Medical Research Council, the Australian government 
+research-funding body, outside the submitted work. Dr Reich reported receiving 
+personal fees from Calliditas, being a clinical trial investigator for Omeros, 
+receiving personal fees from Novartis for providing advisory to and being a 
+speaker at an internal conference, providing advisory to Chinook and being a 
+national coordinating investigator for the ALIGN study, receiving personal fees 
+from Travere for providing advisory, being a site trial co-investigator for 
+Alnylam, being a site trial investigator for Pfizer, and being director of the 
+Glomerulonephritis Fellowship funded by the Louise Fast Foundation outside the 
+submitted work. Dr Cattran reported receiving grants from the Canadian Institute 
+of Health Research for salary support of coordinator during the conduct of the 
+study and personal fees from Calliditis for being on a pharmaceutical scientific 
+advisory board, Alnylam Pharmaceutical Scientific for being on a steering 
+committee, Novartis for being a pharmaceutical data and safety monitoring 
+committee member, Chemocentryx for being a data and safety monitoring committee 
+member, Alexion Pharmaceutical for being an advisory board member, and UpToDate 
+for being an author and being a member of a steering committee for the 
+international IgA nephropathy network outside the submitted work. Dr Glassock 
+reported receiving personal fees from Omeros, Biocryst, Novartis, Calliditas, 
+Chemocentryx, Ionis, Travere, Arrowhead, and Horizon outside the submitted work, 
+being editor of the Nephrology section of UpToDate, and being a contributor to 
+KDIGO 2021 Clinical Practice Guideline for the Management of Glomerular 
+Diseases. Dr Wheeler reported receiving personal fees from Amgen, Astellas, 
+Mundipharma/Napp, Merck Sharp and Dohme, Boehringer Ingelheim, and Vifor for 
+speaker fees, personal fees from AstraZeneca for a consultancy contract, and 
+personal fees from Bayer GlaxoSmithKline, Gilead, Janssen, Tricida, and Zydus 
+for consultancy outside the submitted work. Dr Woodward reported receiving 
+personal fees as a consultant from Amgen, Freeline, and Kyowa Kirin outside the 
+submitted work. Dr Billot reported receiving grants from the Australian National 
+Health and Medical Research Council during the conduct of the study. Dr Johnson 
+reported receiving personal fees from Baxter Healthcare, AstraZeneca, Bayer, 
+AWAK Technologies, and Boehringer Ingelheim and Lilly; grants from Fresenius 
+Medical Care; and travel sponsorship from Ono and Amgen outside the submitted 
+work. Dr Cass reported receiving grants from Australian National Health and 
+Medical Research Council during the conduct of the study. Dr Floege reported 
+receiving personal fees from Calliditas, Idorsia, Omeros, Travere, and Visterra 
+during the conduct of the study and personal fees from Bayer, Boehringer, and 
+AstraZeneca outside the submitted work. Dr Remuzzi reported receiving personal 
+fees from Akebia Pharmaceuticals, Alexion Pharmaceuticals, AstraZeneca, BioCryst 
+Pharmaceuticals, Boehringer Ingelheim, Janssen Research & Development, Menarini 
+Ricerche Spa, Otsuka, and Silence Therapeutics outside the submitted work. Dr 
+Agarwal reported receiving personal fees from Bayer Healthcare Pharmaceuticals, 
+AstraZeneca, Boehringer, Relypsa, Vifor Pharma, Merck, Sanofi, Eli Lilly, 
+Lexicon, Reata, Chinook, Vertex Pharma, Akebia, and Diamedica outside the 
+submitted work and reported being an author for UpToDate. Dr Zhang reported 
+receiving personal fees related to steering committee roles from Novartis, 
+Omeros, Calliditas, and Chinook and grants and funding from Pfizer during the 
+conduct of the study. Dr Perkovic reported receiving grants from Pfizer, which 
+provided study drug and initial seed funding, during the conduct of the study 
+and grants from AbbVie for a clinical trial steering committee; personal fees 
+from Amgen for serving on an advisory board; serving on a clinical trial 
+steering committee for Astellas; receiving personal fees from AstraZeneca 
+Boehringer Ingelheim, Janssen, Novo Nordisk, and Novartis for serving on a 
+steering committee, advisory committee, and scientific presentations; serving on 
+a trial steering committee and advisory committee for Bayer; receiving personal 
+fees from Chinook Therapeutics for serving on an advisory committee; serving on 
+a data and safety monitoring committee for Dimerix; serving on the board of 
+directors for George Clinical; serving on a steering committee and advisory 
+committee for Gilead, GlaxoSmithKline, and Travere; serving on an advisory 
+committee for Medimmune; receiving personal fees from Mitsubishi Tanabe for 
+scientific presentations; receiving personal fees from Mundipharma for advisory 
+committee and scientific presentations; and serving on an advisory committee for 
+Vifor Pharma. No other disclosures were reported.

--- a/references_cache/PMID_37015244.md
+++ b/references_cache/PMID_37015244.md
@@ -1,0 +1,292 @@
+---
+reference_id: "PMID:37015244"
+title: "Sparsentan in patients with IgA nephropathy: a prespecified interim analysis from a randomised, double-blind, active-controlled clinical trial."
+authors:
+- Heerspink HJL
+- Radhakrishnan J
+- Alpers CE
+- Barratt J
+- Bieler S
+- Diva U
+- Inrig J
+- Komers R
+- Mercer A
+- Noronha IL
+- Rheault MN
+- Rote W
+- Rovin B
+- Trachtman H
+- Trimarchi H
+- Wong MG
+- Perkovic V
+- PROTECT Investigators
+journal: Lancet
+year: '2023'
+doi: 10.1016/S0140-6736(23)00569-X
+keywords:
+- Adult
+- Humans
+- Adolescent
+- Irbesartan/therapeutic use
+- "Glomerulonephritis, IGA/drug therapy"
+- Creatinine/urine
+- Proteinuria/drug therapy
+- Double-Blind Method
+- Treatment Outcome
+- Spiro Compounds
+- Sulfonamides
+content_type: abstract_only
+---
+
+# Sparsentan in patients with IgA nephropathy: a prespecified interim analysis from a randomised, double-blind, active-controlled clinical trial.
+**Authors:** Heerspink HJL, Radhakrishnan J, Alpers CE, Barratt J, Bieler S, Diva U, Inrig J, Komers R, Mercer A, Noronha IL, Rheault MN, Rote W, Rovin B, Trachtman H, Trimarchi H, Wong MG, Perkovic V, PROTECT Investigators
+**Journal:** Lancet (2023)
+**DOI:** [10.1016/S0140-6736(23)00569-X](https://doi.org/10.1016/S0140-6736(23)00569-X)
+
+## Content
+
+1. Lancet. 2023 May 13;401(10388):1584-1594. doi: 10.1016/S0140-6736(23)00569-X. 
+Epub 2023 Apr 1.
+
+Sparsentan in patients with IgA nephropathy: a prespecified interim analysis 
+from a randomised, double-blind, active-controlled clinical trial.
+
+Heerspink HJL(1), Radhakrishnan J(2), Alpers CE(3), Barratt J(4), Bieler S(5), 
+Diva U(6), Inrig J(6), Komers R(6), Mercer A(7), Noronha IL(8), Rheault MN(9), 
+Rote W(6), Rovin B(10), Trachtman H(11), Trimarchi H(12), Wong MG(13), Perkovic 
+V(14); PROTECT Investigators.
+
+Collaborators: Alarmartine E, Barratt J, Chae DW, Del Vecchio L, Floege J, Hwang 
+SJ, Jelakovic B, Maes B, Malecki R, Miglinas M, Nolasco FEB, Praga M, 
+Rabindranath K, Rosenberg M, Rovin B, Tang SCW, Tesar V, Wong MG, Bose B, 
+Gangadharan M, McDonald S, Peh C, Jahan S, Yeap C, Clayton P, Irish G, 
+Thyagarajan N, Hollett P, Krishnasamy R, Carroll R, Jesudason S, Crail S, Coates 
+T, Waugh J, Noble E, Mahadevan K, Campbell V, Salehi T, Lim W, Boudville N, 
+Chakera A, Chan D, Krishnan A, Eqbal Y, Gillies A, Vilayur E, Maung Myint TM, 
+Gray N, Waugh J, Noble E, Cheetham M, Eqbal Y, Hollett P, Krishnasamy R, 
+Mahadevan K, Campbell V, Pollock C, Cooper B, Mather A, Roxburgh S, Shen Y, 
+Stangenberg S, Siriwardana A, O'Lone E, Wan S, Neuen B, Tsun Kit Ha J, Kim D, 
+Heath L, Jain A, Phua E, Li Y, Gallagher M, Jardine M, Ritchie A, Razavian M, 
+Foote C, Wyndham R, Sen S, Endre Z, Erlich J, Fernando M, Yong K, Luxton G, 
+Kotwal S, Roger S, Wijeratne V, Packham D, Fraser I, Vandewiele B, Laute M, 
+Lemahieu W, Jamar S, Ombelet S, Meeus G, Decupere M, Schockaert O, Doubel P, 
+Viaene L, Radermacher L, Masset C, Moonen M, Firre E, Milicevic M, Warling X, 
+Vanacker A, Malfait T, Durlen I, Horvatic I, Savuk A, Gellineo L, Karanovic S, 
+Dika Z, Plavljanic D, Mikacic I, Trajbar Kentric D, Barisic D, Stankovic M, 
+Majstorovic Barac K, Kruljac I, Pavlovic D, Drinkovic M, Prkacin I, Barbic J, 
+Sitas Z, Vujcic D, Rychlik I, Benesova A, Drinovska K, Kratka K, Maixnerova D, 
+Ilmoja M, Unt K, Lilienthal K, Auerbach A, Leis L, Piel J, Adoberg A, Kolvald K, 
+Veermae K, Telling K, Seppet E, Uhlinova J, Zaoui P, Carron PL, Masson I, Dinic 
+M, Thibaudin D, Broyet C, Maillard N, Mohey H, Mariat C, Claisse G, Alamartine 
+E, Dussol B, Burtey S, Chiche-Jourde N, Serre JE, Jeantet G, Chenine L, 
+Blanchard A, Roueff S, Thervet E, Fouassier D, Buffet A, Livrozet M, Gaisset R, 
+Karras A, Heng AE, Garrouste C, Philipponnet C, Nicolo C, Atenza A, Lanaret C, 
+Greze C, Mayet V, Dumond C, Delmas Y, Combe C, Rigothier C, Burguet L, Labat A, 
+Mucha S, de Précigout V, Weinreich T, Reichel H, Draganova D, Wolf L, Hohenstein 
+B, Heinrichs S, Kulka S, Sat S, Weiland L, Krueger T, Wolf G, Kettner C, 
+Schlosser M, Herfurth JK, Koch A, Busch M, Werth SC, Nitschke M, Cakiroglu F, 
+Sarnow F, Schulz L, Weiner S, Wirtz N, Koester E, Moeller M, Stamellou E, Sanden 
+S, Schmidt-Guertler H, Bernhardt W, Patecki M, Schlieper G, Schulte K, Girardet 
+A, Kunzendorf U, Kwan LPY, Mok MMY, Chan GCW, Ma M, Lie DNW, Chan ATP, Szeto CC, 
+Ng KCJ, Cheung SF, Yue TTA, Fung KSS, Tang H, Yim KF, Law WP, Wong YH, Lam CKD, 
+Wong SHS, Marcantoni C, Aliotta R, Deodato F, Patella G, Comi N, Vita C, Carullo 
+N, Bolignano D, Musolino M, Trillini M, Perico N, Remuzzi G, Daina E, Biancone 
+L, Colla L, Burdese M, Cogno C, Boaglio E, Abbasciano I, Zizzi CF, Randone P, 
+Napodano P, Ricchiuto A, Cassia M, Accarino S, Cozzolino M, Baccaro R, Costanzi 
+S, Di Maio F, Arena M, Urciuolo F, Vigano S, Cavalli A, Limardo M, Bordoli M, 
+Ponti S, Longhi S, Solazzo A, Giaroni F, Donati G, Torreggiani M, Catucci D, 
+Colucci M, Esposito V, Esposito C, Gesualdo L, Capaccio F, Diletta Stea E, Sivo 
+C, Annese F, Papadia F, Messa P, Belingheri M, Passerini P, Malvica S, Vickiene 
+A, Zakauskiene U, Asakiene E, Bumblyte' IA, Stankuviene A, Santockiene L, Hayat 
+A, Williams A, Sizeland P, Tan E, Waters G, Chan LW, Henderson A, Turnbull A, 
+McNally A, Reynolds A, Pilmore H, Dittmer I, Manley P, Stallworthy E, Goh T, 
+Semple D, Collins M, Curry E, Ahmed J, Nguyen T, Winiarska A, Zbrzezniak J, 
+Stompor T, Krajewska M, Augustyniak-Bartosik H, Zielinska D, Jander A, Stanczyk 
+M, Tkaczyk M, Miarka P, Aksamit D, Jaskowski P, Sulowicz W, Cieniawski D, 
+Gontarek-Kacprzak J, Felicjanczuk E, Kwella N, Kwella B, Satora E, Fernandes JC, 
+Gomes AM, Reis M, Lopes D, Almeida C, Sá H, Figueiredo AC, Pardinhas C, Almeida 
+E, Raimundo M, Cortesão Costa A, Falcao Goncalves LP, Fernandes S, Silva S, 
+Teixeira C, Fernandes A, Nolasco F, Alves P, Gois M, Fonseca N, Messias A, 
+Menezes M, Cardoso F, Sousa H, Marques J, Barata R, Lopes JA, Jorge S, Gameiro 
+J, de Almeida Agapito Fonseca JN, Goncalves S, Farinha A, Valerio Santos P, 
+Natario A, de Jesus Barreto JC, Abrantes C, Quadrado Soares ES, Soares 
+Felgueiras JS, Cunha L, Parreira L, Furtado T, Vaz A, Oh KH, Lee H, Joong Kim S, 
+Jeong JC, Hoon Kim Y, Kim Y, Park HC, Choi HY, Wook Kim H, Lee MH, Yoon S, Lee 
+KB, Hyun Y, Yoo TH, Han SH, Park JT, Kim S, Song YR, Kim JK, Lee HS, Joo N, Lee 
+J, Ryoun Jang H, Jeon J, Chung W, Lee H, Chang JH, Chun KY, Jung JY, Ro H, Kim 
+A, Jo SK, Yang J, Kim MG, Oh S, Martinez Villanueva C, Gimeno AV, Andres Useche 
+Bonilla G, Tamarit E, Galan Serrano A, Verde Moreno E, Fernandez JL, Goicoechea 
+Diezhandino MA, Verdalles Guzman U, de Jose AP, Ortiz Arduan A, Pérez Gómez MV, 
+Martín Cleary C, Prado RF, Goma E, Ballarin J, Encarnacion MD, Da Silva Santos 
+I, Marco Rusinol H, Furlano M, Arias C, Barrios C, Garcia ER, Sierra Ochoa A, 
+Vizcaino Castillo B, Pantoja Perez J, Gonzalez Moya M, Sargsyan M, Calatayud 
+Aristoy E, Bernabeu AA, Perez Lluna L, Malek Marin T, Antonia Munar Vila M, 
+Bobadilla Rico IM, Allende Burgos N, Gutierrez Martinez E, Gutierrez Solis E, 
+Sevillano A, Merida Herrero E, Miquel Blasco Pelicano J, Rodas Marin LM, 
+Quintana LF, Antonieta Azancot Rivero M, Ramos Terrades N, Garcia Carro C, Agraz 
+Pamplona I, Salgueira Lazo M, de la Prada Alvarez F, Alonso Garcia F, Adrian 
+Aguilera Morales W, Virxinia Pol Heres S, Forcen A, Parra Moncasi E, Medrano 
+Villarroya C, Soria Villen A, Gracia Garcia O, Velo Plaza M, Sánchez de la Nieta 
+MD, Calvo Arevalo M, Moreno A, Cigarran Guldris S, de Vicente MP, Munar Vila MA, 
+Bobadilla Rico IM, Allende Burgos N, Hsu BG, Wang CH, Chen CH, Yu TM, Wu MJ, 
+Tsai SF, Hsu CT, Chiu HF, Chou KJ, Fang HC, Lee PT, Chen HY, Chen CL, Huang CW, 
+Ou SH, Ho TY, Hsu CY, Chang MS, Chiu YL, Peng YS, Shu KH, Pan SY, Hsu SP, Yang 
+JY, Pai MF, Tseng PY, Wu HY, Tsai WC, Tung KT, Chen HY, Chen HC, Kuo MC, Hwang 
+DY, Chiu YW, Hung CC, Kuo HT, Tsai JC, McCafferty K, Forbes S, Dasgupta I, 
+Thomas M, Mahdi A, Ajayi B, Chowdhury P, Kasimatis T, Moutzouris D, Dudreuilh C, 
+Pruthi R, Mansfield N, Doctor G, Shah S, Kon S, Smith P, Hamilton P, 
+Kanigicherla D, Ibrahim Ragy OS, Alchi B, Flossmann O, Ghalli F, Lawman S, Sinha 
+S, Chrysochou C, Chukwu C, Maire De Bhailis A, Al Chalabi S, Hudson A, Gopu A, 
+Wickens O, Storrar J, Wahba M, Lorde N, Rony M, Griffin S, Latif F, Ali M, 
+DaSilva L, Ayling-Smith J, Mahdi E, Willcocks L, Jones R, Cheung CK, 
+Selvaskandan H, Pugh D, Sayer M, Dhaun N, Chapman F, Mark P, Geddes C, McQuarrie 
+E, Patel R, Solomon L, Ponnusamy A, Morris A, Okoh P, Floyd L, Dhaygude A, Leung 
+J, Goldsmith C, Pandya B, Tez D, Mikhail A, Brown K, Bucknall T, Lambie M, 
+Comunale R, Brandon D, Martinez S, Hall A, Henderson A, Fearday A, Douthit N, 
+Snow B, Silva A, Sly C, Keller C, Davidson R, Meng J, Haws R, Kattamanchi S, 
+Mojarrab J, Pillai U, Lafayette R, O'Shaughnessy M, Kamal F, Mehta K, Baker B, 
+Ruiz M, Jyothinagaram P, Peri U, Paxton W, Tumlin J, McGreal K, McCarthy E, 
+Kimber C, Gautam A, Khalil K, Nguyen V, Nguyen V, Minasian R, Arfaania D, 
+Daneshvari S, Zakari M, Patrikyan A, Afsari R, Ayvazyan C, Fakih F, Lagatta M, 
+Fakih F, Rodriguez A, Avella JEM, Patak R, Kadakia J, Radhakrishnan J, Appel G, 
+Ahn W, Nelson B, Medina A, Ahmad S, Peleg Y, Clement N, Chiu I, Hendren E, 
+Bomback A, Canetta P, Spinowitz B, Charytan C, Parikh N, Kuo S, Raichoudhury R, 
+Dobre M, Negrea L, Padiyar A, Jittirat A, Pradhan N, Dhelaria R, Balamuthusamy 
+S, Madhrira M, Powell T, Lifland H, Bailey A, Ford Sightler SA, Suthar MP, Green 
+H, Parikh S, Ayoub I, Almaani S, Contreras G, Fornoni A, Drexler Y, Geara A, 
+Sheridan B, Coppock G, Hogan J, Gonzalez C, Bhadra S, Chowdhury P, Kyaw K, Tan 
+M, Raakesh L, Mendoza E, Viramontes V, Chaudhry A, Carbonell J, Gadh R, 
+Fernandez V, Kassem M, Jacob R, Wilder K, Newsome B, Klamm K, Suyumova I, 
+Kooienga LA, Janko C, Rizk D, Julian B, Caster D, Perez E, Garg G, Gowda N, 
+Udani S, Mandayam S, Workeneh B, Comunale R, Brandon D, Pillai U, Assefi A, 
+Greco B, Germain M, Patel J, Quinn S, Sullivan J, Glaze J, Madonia P, McMahon K, 
+Giles H, Adler S, Dai T.
+
+Author information:
+(1)Department of Clinical Pharmacy and Pharmacology, University of Groningen, 
+Groningen, Netherlands; The George Institute for Global Health, University of 
+New South Wales, Sydney, NSW, Australia. Electronic address: 
+h.j.lambers.heerspink@umcg.nl.
+(2)Division of Nephrology, Columbia University, New York, NY, USA.
+(3)Department of Laboratory Medicine and Pathology, University of Washington, 
+Seattle, WA, USA.
+(4)Department of Cardiovascular Sciences, University of Leicester General 
+Hospital, Leicester, UK.
+(5)Department of Clinical Pharmacy and Pharmacology, University of Groningen, 
+Groningen, Netherlands.
+(6)Travere Therapeutics, San Diego, CA, USA.
+(7)JAMCO Pharma Consulting, Stockholm, Sweden.
+(8)Laboratory of Cellular, Genetic, and Molecular Nephrology, Division of 
+Nephrology, University of São Paulo School of Medicine, São Paulo, Brazil.
+(9)Division of Pediatric Nephrology, University of Minnesota Medical School, 
+Minneapolis, MN, USA.
+(10)Division of Nephrology, Ohio State University Wexner Medical Center, 
+Columbus, OH, USA.
+(11)Division of Nephrology, Department of Pediatrics, University of Michigan, 
+Ann Arbor, MI, USA.
+(12)The George Institute for Global Health, University of New South Wales, 
+Sydney, NSW, Australia; Nephrology Service, Hospital Británico de Buenos Aires, 
+Buenos Aires, Argentina.
+(13)Department of Renal Medicine, Concord Repatriation General Hospital, 
+Concord, NSW, Australia; Concord Clinical School, University of Sydney, Concord, 
+NSW, Australia.
+(14)The George Institute for Global Health, University of New South Wales, 
+Sydney, NSW, Australia; Faculty of Medicine & Health, University of New South 
+Wales Sydney, Sydney, NSW, Australia.
+
+Comment in
+    Lancet. 2023 May 13;401(10388):1548-1550. doi: 
+10.1016/S0140-6736(23)00630-X.
+    Nat Rev Nephrol. 2023 Jun;19(6):359. doi: 10.1038/s41581-023-00719-8.
+
+BACKGROUND: Sparsentan is a novel, non-immunosuppressive, single-molecule, dual 
+endothelin and angiotensin receptor antagonist being examined in an ongoing 
+phase 3 trial in adults with IgA nephropathy. We report the prespecified interim 
+analysis of the primary proteinuria efficacy endpoint, and safety.
+METHODS: PROTECT is an international, randomised, double-blind, 
+active-controlled study, being conducted in 134 clinical practice sites in 18 
+countries. The study examines sparsentan versus irbesartan in adults (aged ≥18 
+years) with biopsy-proven IgA nephropathy and proteinuria of 1·0 g/day or higher 
+despite maximised renin-angiotensin system inhibitor treatment for at least 12 
+weeks. Participants were randomly assigned in a 1:1 ratio to receive sparsentan 
+400 mg once daily or irbesartan 300 mg once daily, stratified by estimated 
+glomerular filtration rate at screening (30 to <60 mL/min per 1·73 m2 and ≥60 
+mL/min per 1·73 m2) and urine protein excretion at screening (≤1·75 g/day and 
+>1·75 g/day). The primary efficacy endpoint was change from baseline to week 36 
+in urine protein-creatinine ratio based on a 24-h urine sample, assessed using 
+mixed model repeated measures. Treatment-emergent adverse events (TEAEs) were 
+safety endpoints. All endpoints were examined in all participants who received 
+at least one dose of randomised treatment. The study is ongoing and is 
+registered with ClinicalTrials.gov, NCT03762850.
+FINDINGS: Between Dec 20, 2018, and May 26, 2021, 404 participants were randomly 
+assigned to sparsentan (n=202) or irbesartan (n=202) and received treatment. At 
+week 36, the geometric least squares mean percent change from baseline in urine 
+protein-creatinine ratio was statistically significantly greater in the 
+sparsentan group (-49·8%) than the irbesartan group (-15·1%), resulting in a 
+between-group relative reduction of 41% (least squares mean ratio=0·59; 95% CI 
+0·51-0·69; p<0·0001). TEAEs with sparsentan were similar to irbesartan. There 
+were no cases of severe oedema, heart failure, hepatotoxicity, or oedema-related 
+discontinuations. Bodyweight changes from baseline were not different between 
+the sparsentan and irbesartan groups.
+INTERPRETATION: Once-daily treatment with sparsentan produced meaningful 
+reduction in proteinuria compared with irbesartan in adults with IgA 
+nephropathy. Safety of sparsentan was similar to irbesartan. Future analyses 
+after completion of the 2-year double-blind period will show whether these 
+beneficial effects translate into a long-term nephroprotective potential of 
+sparsentan.
+FUNDING: Travere Therapeutics.
+
+Copyright © 2023 Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/S0140-6736(23)00569-X
+PMID: 37015244 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests HJLH reports consulting 
+fees from AbbVie, AstraZeneca, Bayer, Boehringer Ingelheim, Chinook, CSL 
+Behring, Dimerix, Eli Lilly, Gilead, Janssen, Merck, Novartis, Novo Nordisk, and 
+Travere Therapeutics; research support for clinical trials from AstraZeneca, 
+Boehringer Ingelheim, Janssen, and Novo Nordisk; honoraria from AstraZeneca and 
+Novo Nordisk; travel expenses from Eli Lilly; and reports that The George 
+Institute for Global Health and George Clinical hold research contracts for 
+trials in kidney disease. CEA reports consulting fees from AstraZeneca and 
+Mantra Bio; and grant support from Sana. JB reports research grants from Argenx, 
+Calliditas Therapeutics, Chinook Therapeutics, Galapagos, GlaxoSmithKline, 
+Novartis, and Travere Therapeutics; and is medical and/or scientific advisor to 
+Alnylam Pharmaceuticals, Argenx, Astellas Pharma, BioCryst Pharmaceuticals, 
+Calliditas Therapeutics, Chinook Therapeutics, Dimerix, Galapagos, Novartis, 
+Omeros, Travere Therapeutics, UCB, Vera Therapeutics, and Visterra. SB, UD, JI, 
+RK, and WR are employees and stockholders of Travere Therapeutics. AM reports 
+consulting fees from Travere Therapeutics through a contract with JAMCO Pharma 
+Consulting and consulting fees from Vera Therapeutics. ILN reports receiving 
+honoraria for scientific presentations from AstraZeneca, Bayer, Novartis, and 
+Roche; travel expenses from AstraZeneca; and reports that The George Institute 
+for Global Health holds research contracts for trials in kidney disease. JR 
+reports consulting fees from Calliditas, Chinook, and Travere Therapeutics; and 
+grant support from Travere Therapeutics. MNR reports acting as clinical trial 
+site principal investigator for Chinook, Kaneka, Reata, River 3 Renal Corp, 
+Sanofi, and Travere Therapeutics; consulting fees from Visterra; is a member of 
+the Data and Safety Monitoring Board for Advicenne; and is in a leadership or 
+fiduciary role for Pediatric Nephrology Research Consortium, Women in 
+Nephrology, and #NephJC. BR reports consulting fees from Calliditas, Novartis, 
+Omeros, Travere Therapeutics, and Vera; and clinical trial funding to his 
+institution from Travere Therapeutics. HTra reports consulting fees and 
+membership on data monitoring committees for Akebia, ChemoCentryx, Goldfinch 
+Bio, Natera, Otsuka, Travere Therapeutics, and Walden; and serves on a data 
+safety monitoring board or advisory board for DUPRO. HTri reports receiving 
+honoraria for scientific work from AstraZeneca, Bayer, Calliditas, Chinook, 
+Dimerix, GSK, Novartis, Omeros, Roche, Travere Therapeutics, and Visterra 
+Otsuka; and reports that The George Institute for Global Health holds research 
+contracts for trials in kidney disease. MGW reports receiving honoraria for 
+scientific presentations from Alpine, Amgen, AstraZeneca, Baxter, Chinook, CSL 
+Behring, Dimerix, Eledon, George Clinical, Horizon, Otuska, and Travere 
+Therapeutics. VP is an employee of UNSW Sydney and serves as a Board Director 
+for St. Vincent's Health Australia, George Clinical, and several Medical 
+Research Institutes; has received consulting fees from AbbVie, Amgen, Astellas, 
+AstraZeneca, Baxter, Bayer, Boehringer Ingelheim, Chinook, Durect, Eli Lilly, 
+Gilead, GSK, Janssen, Medimmune, Merck, Mitsubishi Tanabe, Mundipharma, 
+Novartis, Novo Nordisk, Otsuka, Pfizer, Pharmalink, Reata, Relypsa, Roche, 
+Sanofi, Servier, Travere Therapeutics, Tricida, and Vifor Pharma; honoraria from 
+Janssen; serves on a data safety monitoring board or advisory board for Dimerix; 
+has stock or stock options in George Clinical; and reports that The George 
+Institute for Global Health and George Clinical hold research contracts for 
+trials in kidney disease.

--- a/references_cache/PMID_37591292.md
+++ b/references_cache/PMID_37591292.md
@@ -1,0 +1,171 @@
+---
+reference_id: "PMID:37591292"
+title: "Efficacy and safety of a targeted-release formulation of budesonide in patients with primary IgA nephropathy (NefIgArd): 2-year results from a randomised phase 3 trial."
+authors:
+- Lafayette R
+- Kristensen J
+- Stone A
+- Floege J
+- Tesař V
+- Trimarchi H
+- Zhang H
+- Eren N
+- Paliege A
+- Reich HN
+- Rovin BH
+- Barratt J
+- NefIgArd trial investigators
+journal: Lancet
+year: '2023'
+doi: 10.1016/S0140-6736(23)01554-4
+keywords:
+- Adult
+- Male
+- Humans
+- Female
+- Adolescent
+- "Glomerulonephritis, IGA/drug therapy"
+- Asia
+- Budesonide/adverse effects
+- Europe
+- "Proteinuria/drug therapy, etiology"
+content_type: abstract_only
+---
+
+# Efficacy and safety of a targeted-release formulation of budesonide in patients with primary IgA nephropathy (NefIgArd): 2-year results from a randomised phase 3 trial.
+**Authors:** Lafayette R, Kristensen J, Stone A, Floege J, Tesař V, Trimarchi H, Zhang H, Eren N, Paliege A, Reich HN, Rovin BH, Barratt J, NefIgArd trial investigators
+**Journal:** Lancet (2023)
+**DOI:** [10.1016/S0140-6736(23)01554-4](https://doi.org/10.1016/S0140-6736(23)01554-4)
+
+## Content
+
+1. Lancet. 2023 Sep 9;402(10405):859-870. doi: 10.1016/S0140-6736(23)01554-4.
+Epub  2023 Aug 14.
+
+Efficacy and safety of a targeted-release formulation of budesonide in patients 
+with primary IgA nephropathy (NefIgArd): 2-year results from a randomised phase 
+3 trial.
+
+Lafayette R(1), Kristensen J(2), Stone A(3), Floege J(4), Tesař V(5), Trimarchi 
+H(6), Zhang H(7), Eren N(8), Paliege A(9), Reich HN(10), Rovin BH(11), Barratt 
+J(12); NefIgArd trial investigators.
+
+Author information:
+(1)Division of Nephrology, Department of Medicine, Stanford University, 
+Stanford, CA, USA. Electronic address: czar@stanford.edu.
+(2)Calliditas Therapeutics, Stockholm, Sweden.
+(3)Stone Biostatistics, Crewe, UK.
+(4)Department of Nephrology and Clinical Immunology, Rheinisch-Westfälische 
+Technische Hochschule Aachen University Hospital, Aachen, Germany.
+(5)Department of Nephrology, First Faculty of Medicine and General University 
+Hospital, Charles University, Prague, Czech Republic.
+(6)Nephrology Service, Hospital Británico de Buenos Aires, Buenos Aires, 
+Argentina.
+(7)Renal Division, Peking University First Hospital, Peking University Institute 
+of Nephrology, Beijing, China.
+(8)Department of Nephrology, Kocaeli University, Kocaeli, Turkey.
+(9)Division of Nephrology, Department of Internal Medicine III, University 
+Hospital Carl Gustav Carus, Technische Universität Dresden, Dresden, Germany.
+(10)Division of Nephrology, University Health Network, Department of Medicine, 
+University of Toronto, Toronto, ON, Canada.
+(11)Division of Nephrology, The Ohio State University Wexner Medical Center, 
+Columbus, OH, USA.
+(12)College of Medicine Biological Sciences and Psychology, University of 
+Leicester, Leicester, UK.
+
+Erratum in
+    Lancet. 2023 Sep 9;402(10405):850. doi: 10.1016/S0140-6736(23)01851-2.
+
+Comment in
+    Lancet. 2023 Sep 9;402(10405):827-829. doi: 10.1016/S0140-6736(23)01633-1.
+    Lancet. 2024 Jun 29;403(10446):2785. doi: 10.1016/S0140-6736(24)00794-3.
+    Lancet. 2024 Jun 29;403(10446):2785-2786. doi: 
+10.1016/S0140-6736(24)00795-5.
+
+BACKGROUND: IgA nephropathy is a chronic immune-mediated kidney disease and a 
+major cause of kidney failure worldwide. The gut mucosal immune system is 
+implicated in its pathogenesis, and Nefecon is a novel, oral, targeted-release 
+formulation of budesonide designed to act at the gut mucosal level. We present 
+findings from the 2-year, phase 3 NefIgArd trial of Nefecon in patients with IgA 
+nephropathy.
+METHODS: In this phase 3, multicentre, randomised, double-blind, 
+placebo-controlled trial, adult patients (aged ≥18 years) with primary IgA 
+nephropathy, estimated glomerular filtration rate (eGFR) 35-90 mL/min per 1·73 
+m2, and persistent proteinuria (urine protein-creatinine ratio ≥0·8 g/g or 
+proteinuria ≥1 g/24 h) despite optimised renin-angiotensin system blockade were 
+enrolled at 132 hospital-based clinical sites in 20 countries worldwide. 
+Patients were randomly assigned (1:1) to receive 16 mg/day oral capsules of 
+Nefecon or matching placebo for 9 months, followed by a 15-month observational 
+follow-up period off study drug. Randomisation via an interactive response 
+technology system was stratified according to baseline proteinuria (<2 or ≥2 
+g/24 h), baseline eGFR (<60 or ≥60 mL/min per 1·73 m2), and region 
+(Asia-Pacific, Europe, North America, or South America). Patients, 
+investigators, and site staff were masked to treatment assignment throughout the 
+2-year trial. Optimised supportive care was also continued throughout the trial. 
+The primary efficacy endpoint was time-weighted average of eGFR over 2 years. 
+Efficacy and safety analyses were done in the full analysis set (ie, all 
+randomly assigned patients). The trial was registered on ClinicalTrials.gov, 
+NCT03643965, and is completed.
+FINDINGS: Patients were recruited to the NefIgArd trial between Sept 5, 2018, 
+and Jan 20, 2021, with 364 patients (182 per treatment group) randomly assigned 
+in the full analysis set. 240 (66%) patients were men and 124 (34%) were women, 
+and 275 (76%) identified as White. The time-weighted average of eGFR over 2 
+years showed a statistically significant treatment benefit with Nefecon versus 
+placebo (difference 5·05 mL/min per 1·73 m2 [95% CI 3·24 to 7·38], p<0·0001), 
+with a time-weighted average change of -2·47 mL/min per 1·73 m2 (95% CI -3·88 to 
+-1·02) reported with Nefecon and -7·52 mL/min per 1·73 m2 (-8·83 to -6·18) 
+reported with placebo. The most commonly reported treatment-emergent adverse 
+events during treatment with Nefecon were peripheral oedema (31 [17%] patients, 
+vs placebo, seven [4%] patients), hypertension (22 [12%] vs six [3%]), muscle 
+spasms (22 [12%] vs seven [4%]), acne (20 [11%] vs two [1%]), and headache (19 
+[10%] vs 14 [8%]). No treatment-related deaths were reported.
+INTERPRETATION: A 9-month treatment period with Nefecon provided a clinically 
+relevant reduction in eGFR decline and a durable reduction in proteinuria versus 
+placebo, providing support for a disease-modifying effect in patients with IgA 
+nephropathy. Nefecon was also well tolerated, with a safety profile as expected 
+for a locally acting oral budesonide product.
+FUNDING: Calliditas Therapeutics.
+
+Copyright © 2023 Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/S0140-6736(23)01554-4
+PMID: 37591292 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests RL received support for 
+the present manuscript from Calliditas Therapeutics; reports institutional 
+grants from Calliditas Therapeutics, ChemoCentryx, Omeros, Otsuka, Pfizer, 
+Roche, Travere Therapeutics, Vera Therapeutics, and Visterra; and has served on 
+advisory boards for Cara Therapeutics. JK is a consultant for Calliditas 
+Therapeutics. AS received support for the present manuscript from Calliditas 
+Therapeutics and reports consulting fees from AstraZeneca and Calliditas 
+Therapeutics outside the submitted work. JF has received consultancy fees or 
+honoraria from AstraZeneca, Bayer, Boehringer Ingelheim, Calliditas 
+Therapeutics, Chinook, GlaxoSmithKline, Novartis, Omeros, Otsuka, and Travere 
+Therapeutics; and serves on data safety monitoring boards for Novo Nordisk and 
+Visterra. VT reports consultancy fees or honoraria from Calliditas Therapeutics, 
+Novartis, Omeros, Otsuka, and Travere Therapeutics. HT has served on advisory 
+boards for Calliditas Therapeutics; and has received grants, honoraria, 
+consultancy fees, or travel support from AstraZeneca, Calliditas Therapeutics, 
+Chinook, George Clinical, Novartis, Omeros, Otsuka, and Travere Therapeutics. HZ 
+has received consulting fees or honoraria from Calliditas Therapeutics, Chinook, 
+Novartis, Omeros, and Otsuka. AP has received honoraria and travel grants from 
+Alexion, AstraZeneca, Bayer, Boehringer Ingelheim, GlaxoSmithKline, Otsuka, 
+STADA Arzneimittel, and Vifor Pharma. HNR received support to serve as a member 
+of the steering committee of the present study and funding for the execution of 
+the present study from Calliditas Therapeutics; has received grant support from 
+the Canadian Institutes of Health Research, and the Kidney Foundation of Canada 
+via John and Leslie Pearson; has received fellowship support from the Louise 
+Fast Foundation; reports consulting fees, honoraria, or travel support from 
+Calliditas Therapeutics, Chinook, Novartis, Omeros, Pfizer, and Travere 
+Therapeutics; has served on advisory boards and steering committees for Chinook, 
+Novartis, Omeros, Pfizer, and Travere Therapeutics; has been an investigator for 
+Alnylam Pharmaceuticals, Calliditas Therapeutics, ChemoCentryx, Chinook, Omeros, 
+and Pfizer; and is director of the Glomerulonephritis Fellowship, funded by the 
+Louise Fast Foundation. BHR received support for the present manuscript from 
+Calliditas Therapeutics; reports consulting fees from Alpine Immune Sciences, 
+Alexion, Calliditas Therapeutics, Novartis, Omeros, Visterra (owned by Otsuka), 
+Q32 Bio, Travere Therapeutics, and Vera Therapeutics; and is currently co-chair 
+of the Glomerular Diseases Guidelines for the Kidney Disease: Improving Global 
+Outcomes organisation. JB is a consultant to Calliditas Therapeutics and reports 
+grants and consultancy and personal fees from STADA Arzneimittel, Everest 
+Medicines, and Calliditas Therapeutics. NE declares no competing interests.


### PR DESCRIPTION
## Summary
- keep the current IgA nephropathy / IgA vasculitis split intact and clarify the core-page boundary so the IgAN page explicitly includes the shared kidney-relevant four-hit biology while leaving systemic small-vessel vasculitis manifestations to separate IgAV framing
- tighten the IgAN therapy section with direct human evidence for SGLT2 inhibition, corticosteroids, sparsentan, and targeted-release budesonide, and anchor ACEi/ARB supportive care to current review language
- add only the four related reference-cache files needed for those treatment-evidence upgrades

## Lump / split decision
Kept **IgA nephropathy and IgA vasculitis related-but-separate**.

`IgA_Nephropathy.yaml` remains the kidney-limited / primary IgAN page. What belongs here is the shared renal four-hit axis and kidney biopsy/progression framing. What does **not** belong here is the systemic IgA vasculitis phenotype frame (purpura, arthritis, gastrointestinal vasculitis), even though IgAV nephritis shares the same Gd-IgA1-centered biology and can be histologically indistinguishable on kidney biopsy.

I did not create a new IgA vasculitis page in this pass because the merged mainline split already survives scrutiny and the substantive gap I found was therapy-evidence support, not disease-boundary modeling.

## Validation
```bash
just validate-schema kb/disorders/IgA_Nephropathy.yaml
just validate-terms kb/disorders/IgA_Nephropathy.yaml
just validate-references kb/disorders/IgA_Nephropathy.yaml
uv run python - <<'PY'
from pathlib import Path
import yaml
from src.dismech.graph import build_causal_graph
path = Path('kb/disorders/IgA_Nephropathy.yaml')
with path.open() as f:
    disorder = yaml.safe_load(f)
graph = build_causal_graph(disorder)
if graph.integrity_issues:
    print('\n'.join(graph.integrity_issues))
    raise SystemExit(1)
print('Graph integrity OK for', path)
PY
python3 - <<'PY'
from pathlib import Path
import re, yaml
pmids = {'PMID:33878338','PMID:35579642','PMID:37015244','PMID:37591292'}
obj = yaml.safe_load(Path('kb/disorders/IgA_Nephropathy.yaml').read_text())
def norm(s):
    return re.sub(r'\s+', ' ', s).strip()
checks=[]
for treatment in obj.get('treatments', []):
    for ev in treatment.get('evidence', []) or []:
        ref = ev.get('reference')
        if ref in pmids:
            cache = Path('references_cache') / f"{ref.replace(':','_')}.md"
            content = norm(cache.read_text())
            snippet = norm(ev['snippet'])
            if snippet not in content:
                raise SystemExit(f'missing snippet for {treatment["name"]}: {ref}')
            checks.append((treatment['name'], ref))
for name, ref in checks:
    print(f'{name}: {ref}: OK')
print(f'Checked {len(checks)} new treatment evidence snippets with whitespace normalization')
PY
```