### PR TITLE
[codex] Refine membranous nephropathy second pass

### DIFF
--- a/kb/disorders/Membranous_Nephropathy.yaml
+++ b/kb/disorders/Membranous_Nephropathy.yaml
@@ -1,6 +1,6 @@
 name: Membranous nephropathy
 creation_date: "2026-04-14T00:00:00Z"
-updated_date: "2026-04-14T00:00:00Z"
+updated_date: "2026-04-15T04:45:05Z"
 category: Complex
 parents:
 - Kidney Disease
@@ -24,22 +24,68 @@ notes: >-
   Secondary membranous nephropathy is retained as a subtype because infections,
   autoimmune diseases, malignancy, IgG4-related disease, and drugs can converge
   on the same downstream pattern of subepithelial immune-complex deposition and
-  podocyte injury. Monarch/Monarch API and local MONDO lookup both resolve this
-  disease anchor to MONDO:0005376 with exact synonym "membranous nephropathy".
-  ClinGen gene pages for PLA2R1 and THSD7A were checked on 2026-04-14 and both
-  reported zero published gene-disease validity classifications, so PLA2R1 and
-  THSD7A are represented here as podocyte autoantigen/susceptibility context
-  rather than as definitive monogenic root causes of the whole disease entity.
+  podocyte injury. At the same time, the classic primary-versus-secondary split
+  is no longer sufficient to explain all current MN biology, because target-antigen
+  testing now identifies PLA2R-, THSD7A-, NELL1-, EXT1/EXT2-, PCDH7-, NCAM1-,
+  and other antigen-defined subsets with different clinicopathologic associations.
+  This root page therefore keeps the common autoimmune cascade at center while
+  using subtype and diagnostic fields to capture the more specific antigen landscape.
+  Monarch/Monarch API and local MONDO lookup both resolve this disease anchor to
+  MONDO:0005376 with exact synonym "membranous nephropathy". ClinGen gene pages
+  for PLA2R1 and THSD7A were checked on 2026-04-14 and both reported zero published
+  gene-disease validity classifications, so PLA2R1 and THSD7A are represented
+  here as podocyte autoantigen/susceptibility context rather than as definitive
+  monogenic root causes of the whole disease entity.
 has_subtypes:
 - name: Primary membranous nephropathy
+  classification: clinical_context
   description: >-
     Autoimmune membranous nephropathy driven by circulating autoantibodies
     against podocyte antigens, especially PLA2R1 and less commonly THSD7A.
 - name: Secondary membranous nephropathy
+  classification: clinical_context
   description: >-
     Membranous nephropathy with the same downstream subepithelial immune-deposit
     pattern but triggered by an underlying autoimmune disease, infection,
     malignancy, IgG4-related disease, or drug exposure.
+- name: PLA2R-associated membranous nephropathy
+  classification: molecular
+  description: >-
+    Dominant antigen-defined primary membranous nephropathy subset anchored by
+    circulating anti-PLA2R autoantibodies.
+  evidence:
+  - reference: PMID:33808418
+    reference_title: "Mechanisms of Primary Membranous Nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Approximately 50-80% and 3-5% of primary MN (PMN) cases are associated with either anti-PLA2R or anti-THSD7A antibodies, respectively."
+    explanation: Supports PLA2R-associated disease as the dominant antigen-defined subset of primary membranous nephropathy.
+- name: THSD7A-associated membranous nephropathy
+  classification: molecular
+  description: >-
+    Distinct minority antigen-defined membranous nephropathy subset characterized
+    by anti-THSD7A autoantibodies and podocyte THSD7A targeting.
+  evidence:
+  - reference: PMID:25394321
+    reference_title: "Thrombospondin type-1 domain-containing 7A in idiopathic membranous nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In our cohort, 15 of 154 patients with idiopathic membranous nephropathy had circulating autoantibodies to THSD7A but not to PLA2R1, a finding that suggests a distinct subgroup of patients with this condition."
+    explanation: Supports THSD7A-associated disease as a biologically distinct minority subgroup rather than a nonspecific ancillary biomarker pattern.
+- name: Other antigen-associated membranous nephropathy
+  classification: molecular
+  description: >-
+    PLA2R/THSD7A-negative disease is not a single residual bucket; target-antigen
+    workups can identify NELL1-, EXT1/EXT2-, PCDH7-, NCAM1-, SEMA3B-, and related
+    antigen-defined subsets with different autoimmune, malignancy-associated, or
+    pediatric contexts.
+  evidence:
+  - reference: PMID:33673911
+    reference_title: "A Target Antigen-Based Approach to the Classification of Membranous Nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "OBJECTIVE: To describe the clinical and pathological phenotype of membranous nephropathy (MN) associated with M-type-phospholipase-A2-receptor (PLA2R), thrombospondin-type-1-domain-containing-7A (THSD7A), semaphorin 3B (SEMA3B), neural-epidermal-growth-factor-like-1-protein (NELL-1), protocadherin 7 (PCDH7), exostosin 1/exostosin 2 (EXT1/EXT2) and neural cell adhesion molecule 1 (NCAM-1) as target antigens."
+    explanation: Supports the existence of a broader antigen-defined MN landscape beyond the dominant PLA2R and THSD7A serologic subsets.
 pathophysiology:
 - name: Autoantibody production against podocyte antigens
   subtypes:
@@ -50,7 +96,10 @@ pathophysiology:
     autoantibodies against PLA2R1 in most seropositive cases and THSD7A in a
     smaller minority. These serologic subsets are mechanistically important for
     primary disease classification and monitoring, but they do not imply that
-    the entire membranous nephropathy disease root is monogenic.
+    the entire membranous nephropathy disease root is monogenic. Other target
+    antigens are tracked at the subtype level so the root pathograph stays focused
+    on the shared autoimmune cascade rather than fragmenting into parallel sparse
+    upstream nodes.
   cell_types:
   - preferred_term: B cell
     term:
@@ -399,8 +448,14 @@ biochemical:
     explanation: Supports use of anti-PLA2R antibody level as a disease activity biomarker.
 - name: Anti-THSD7A autoantibodies
   presence: Positive
-  context: Minority serologic subtype of primary membranous nephropathy.
+  context: Minority antigen-defined subgroup of primary membranous nephropathy that can be corroborated by biopsy antigen staining.
   evidence:
+  - reference: PMID:25394321
+    reference_title: "Thrombospondin type-1 domain-containing 7A in idiopathic membranous nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In our cohort, 15 of 154 patients with idiopathic membranous nephropathy had circulating autoantibodies to THSD7A but not to PLA2R1, a finding that suggests a distinct subgroup of patients with this condition."
+    explanation: Supports anti-THSD7A serology as a distinct minority subgroup marker rather than a generic secondary finding.
   - reference: PMID:27777266
     reference_title: "A Proposal for a Serology-Based Approach to Membranous Nephropathy."
     supports: SUPPORT
@@ -454,9 +509,9 @@ diagnosis:
     evidence_source: OTHER
     snippet: "The most characteristic feature of membranous nephropathy (MN) is the presence of subepithelial electron dense deposits and the consequential thickening of the glomerular basement membrane."
     explanation: Supports renal biopsy as the defining diagnostic modality for the characteristic deposit/thickening pattern.
-- name: Anti-PLA2R/anti-THSD7A serology
-  description: Serum antibody testing that complements biopsy and helps subtype disease.
-  results: Positive anti-PLA2R or anti-THSD7A serology supports primary membranous nephropathy and helps distinguish it from secondary disease.
+- name: Serology and target-antigen work-up
+  description: Serum anti-PLA2R/anti-THSD7A testing plus biopsy antigen staining when serology is negative or associated disease is suspected.
+  results: Positive anti-PLA2R or anti-THSD7A serology supports primary membranous nephropathy, and tissue antigen detection helps classify THSD7A-associated or other antigen-defined cases.
   evidence:
   - reference: PMID:27777266
     reference_title: "A Proposal for a Serology-Based Approach to Membranous Nephropathy."
@@ -464,9 +519,31 @@ diagnosis:
     evidence_source: HUMAN_CLINICAL
     snippet: "The presence or absence of anti-PLA2R and anti-THSD7A antibodies adds important information to clinical and immunopathologic data in discriminating between primary and secondary MN."
     explanation: Supports the diagnostic value of serology for primary versus secondary membranous nephropathy.
+  - reference: PMID:25394321
+    reference_title: "Thrombospondin type-1 domain-containing 7A in idiopathic membranous nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This finding not only furthers our understanding of the pathophysiological basis of membranous nephropathy but also allows for the potential identification and monitoring of patients who are positive for anti-THSD7A autoantibodies, by both serologic testing and histologic staining for the antigen."
+    explanation: Supports combining serology with biopsy antigen staining when defining THSD7A-associated membranous nephropathy.
+  - reference: PMID:33673911
+    reference_title: "A Target Antigen-Based Approach to the Classification of Membranous Nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "CONCLUSION: The widely used distinction between primary and secondary MN has limitations. We propose a refined terminology that combines the target antigen and associated disease to better classify MN and guide clinical decision making."
+    explanation: Supports target-antigen classification as a clinically useful refinement of the older primary-versus-secondary diagnostic split.
 treatments:
 - name: Rituximab
-  description: Anti-CD20 B-cell depletion used as first-line immunotherapy for primary membranous nephropathy.
+  description: Anti-CD20 B-cell depletion used in guideline-supported first-line immunotherapy for primary membranous nephropathy.
+  treatment_term:
+    preferred_term: rituximab therapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: rituximab
+      term:
+        id: CHEBI:64357
+        label: rituximab
   target_phenotypes:
   - preferred_term: Nephrotic syndrome
     term:
@@ -481,13 +558,19 @@ treatments:
     treatment_effect: INHIBITS
     description: Anti-CD20 B-cell depletion reduces the autoreactive B-cell compartment that sustains pathogenic anti-podocyte antibodies.
     evidence:
-    - reference: PMID:21595313
-      reference_title: "[Rationale and clinical evidence for the use of rituximab in glomerular diseases]."
-      supports: PARTIAL
+    - reference: PMID:31269364
+      reference_title: "Rituximab or Cyclosporine in the Treatment of Membranous Nephropathy."
+      supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "Because of their central role in the pathogenesis of autoimmunity, B cells have become an attractive therapeutic target. Rituximab is a monoclonal antibody directed against CD20 expressed on the surface of B cells, inducing profound depletion of B cells in the peripheral blood."
-      explanation: Supports the mechanistic treatment edge from rituximab to the upstream B-cell/autoantibody node, although the abstract is not limited to membranous nephropathy.
+      snippet: "Among patients in remission who tested positive for anti-phospholipase A2 receptor (PLA2R) antibodies, the decline in autoantibodies to anti-PLA2R was faster and of greater magnitude and duration in the rituximab group than in the cyclosporine group."
+      explanation: Directly supports rituximab suppressing the pathogenic autoantibody response that sustains primary membranous nephropathy.
   evidence:
+  - reference: PMID:31269364
+    reference_title: "Rituximab or Cyclosporine in the Treatment of Membranous Nephropathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Rituximab was noninferior to cyclosporine in inducing complete or partial remission of proteinuria at 12 months and was superior in maintaining proteinuria remission up to 24 months."
+    explanation: Provides primary randomized-trial evidence that rituximab yields more durable remission than cyclosporine in membranous nephropathy.
   - reference: PMID:41007719
     reference_title: "The Use of Rituximab in Glomerulonephritis: What Is the Evidence?"
     supports: SUPPORT

--- a/references_cache/PMID_25394321.md
+++ b/references_cache/PMID_25394321.md
@@ -1,0 +1,154 @@
+---
+reference_id: "PMID:25394321"
+title: Thrombospondin type-1 domain-containing 7A in idiopathic membranous nephropathy.
+authors:
+- Tomas NM
+- Beck LH Jr
+- Meyer-Schwesinger C
+- Seitz-Polski B
+- Ma H
+- Zahner G
+- Dolla G
+- Hoxha E
+- Helmchen U
+- Dabert-Gay AS
+- Debayle D
+- Merchant M
+- Klein J
+- Salant DJ
+- Stahl RAK
+- Lambeau G
+journal: N Engl J Med
+year: '2014'
+doi: 10.1056/NEJMoa1409354
+keywords:
+- Autoantibodies/blood
+- "Blotting, Western"
+- Case-Control Studies
+- "Glomerulonephritis, Membranous/blood, immunology"
+- Humans
+- Kidney Glomerulus/metabolism
+- "Receptors, Phospholipase A2/blood, immunology, metabolism"
+- "Thrombospondins/blood, immunology, metabolism"
+content_type: full_text_xml
+---
+
+# Thrombospondin type-1 domain-containing 7A in idiopathic membranous nephropathy.
+**Authors:** Tomas NM, Beck LH Jr, Meyer-Schwesinger C, Seitz-Polski B, Ma H, Zahner G, Dolla G, Hoxha E, Helmchen U, Dabert-Gay AS, Debayle D, Merchant M, Klein J, Salant DJ, Stahl RAK, Lambeau G
+**Journal:** N Engl J Med (2014)
+**DOI:** [10.1056/NEJMoa1409354](https://doi.org/10.1056/NEJMoa1409354)
+
+## Content
+
+1. N Engl J Med. 2014 Dec 11;371(24):2277-2287. doi: 10.1056/NEJMoa1409354. Epub 
+2014 Nov 13.
+
+Thrombospondin type-1 domain-containing 7A in idiopathic membranous nephropathy.
+
+Tomas NM(#)(1), Beck LH Jr(#)(1), Meyer-Schwesinger C(1), Seitz-Polski B(1), Ma 
+H(1), Zahner G(1), Dolla G(1), Hoxha E(1), Helmchen U(1), Dabert-Gay AS(1), 
+Debayle D(1), Merchant M(1), Klein J(1), Salant DJ(1), Stahl RAK(1), Lambeau 
+G(1).
+
+Author information:
+(1)Institut de Pharmacologie Moléculaire et Cellulaire, UMR7275, Centre National 
+de la Recherche Scientifique and Université de Nice Sophia Antipolis, Valbonne, 
+France (N.M.T., B.S.-P., G.D., A.-S.D.-G., D.D., G.L.); University Medical 
+Center Hamburg-Eppendorf, Hamburg, Germany (N.M.T., C.M.-S., G.Z., E.H., U.H., 
+R.A.K.S.); Boston University School of Medicine, Boston (L.H.B., H.M., D.J.S.); 
+and the University of Louisville (M.M., J.K.) and Robley Rex Veterans Affairs 
+Medical Center (J.K.) - both in Louisville, KY.
+(#)Contributed equally
+
+Comment in
+    Nat Rev Nephrol. 2015 Feb;11(2):63. doi: 10.1038/nrneph.2014.227.
+    N Engl J Med. 2015 Mar 12;372(11):1074-5. doi: 10.1056/NEJMc1500130.
+    N Engl J Med. 2015 Mar 12;372(11):1073. doi: 10.1056/NEJMc1500130.
+
+BACKGROUND: Idiopathic membranous nephropathy is an autoimmune disease. In 
+approximately 70% of patients, it is associated with autoantibodies against the 
+phospholipase A2 receptor 1 (PLA2R1). Antigenic targets in the remaining 
+patients are unknown.
+METHODS: Using Western blotting, we screened serum samples from patients with 
+idiopathic membranous nephropathy, patients with other glomerular diseases, and 
+healthy controls for antibodies against human native glomerular proteins. We 
+partially purified a putative new antigen, identified this protein by means of 
+mass spectrometry of digested peptides, and validated the results by analysis of 
+recombinant protein expression, immunoprecipitation, and immunohistochemical 
+analysis.
+RESULTS: Serum samples from 6 of 44 patients in a European cohort and 9 of 110 
+patients in a Boston cohort with anti-PLA2R1-negative idiopathic membranous 
+nephropathy recognized a glomerular protein that was 250 kD in size. None of the 
+serum samples from the 74 patients with idiopathic membranous nephropathy who 
+were seropositive for anti-PLA2R1 antibodies, from the 76 patients with other 
+glomerular diseases, and from the 44 healthy controls reacted against this 
+antigen. Although this newly identified antigen is clearly different from 
+PLA2R1, it shares some biochemical features, such as N-glycosylation, membranous 
+location, and reactivity with serum only under nonreducing conditions. Mass 
+spectrometry identified this antigen as thrombospondin type-1 domain-containing 
+7A (THSD7A). All reactive serum samples recognized recombinant THSD7A and 
+immunoprecipitated THSD7A from glomerular lysates. Moreover, immunohistochemical 
+analyses of biopsy samples from patients revealed localization of THSD7A to 
+podocytes, and IgG eluted from one of these samples was specific for THSD7A.
+CONCLUSIONS: In our cohort, 15 of 154 patients with idiopathic membranous 
+nephropathy had circulating autoantibodies to THSD7A but not to PLA2R1, a 
+finding that suggests a distinct subgroup of patients with this condition. 
+(Funded by the French National Center for Scientific Research and others.).
+
+DOI: 10.1056/NEJMoa1409354
+PMCID: PMC4278759
+PMID: 25394321 [Indexed for MEDLINE]
+
+Idiopathic membranous nephropathy is an autoimmune disease and a common cause of the nephrotic syndrome in adults.1 In 2009, the phospholipase A2 receptor 1 (PLA2R1), a protein that is expressed in glomerular podocytes, was discovered as the major antigen involved in the pathogenesis of adult idiopathic membranous nephropathy.2 As confirmed by a number of subsequent studies, about 70% of patients with idiopathic membranous nephropathy have circulating autoantibodies against PLA2R1.2-6 The remaining patients, approximately 30% of those with idiopathic membranous nephropathy, have no obvious secondary cause of the disease, and it is thought that other endogenous glomerular antigens may be involved in these cases.
+
+In the current study, we analyzed serum samples from patients with idiopathic membranous nephropathy as well as samples from patients with other glomerular diseases and healthy controls, to identify circulating antibodies against glomerular antigens other than PLA2R1.
+
+A diagnosis of membranous nephropathy was made by means of a renal biopsy. Serum samples were obtained from patients with membranous nephropathy and from patients with other glomerular diseases and healthy controls and were examined for anti-PLA2R1 antibodies with the use of an enzyme-linked immunosorbent assay (ELISA)7 and Western blot analysis.2 All study participants gave written informed consent, and the study was conducted in accordance with the provisions of the Declaration of Helsinki. A detailed description of the cohorts and the patient characteristics is provided in the Supplementary Appendix, available with the full text of this article at NEJM.org.
+
+Healthy portions of nephrectomized kidneys and kidney cortex from human donor kidneys that had been deemed unsuitable for transplantation were used to prepare a protein extract of glomeruli. Additional details can be found in the Methods section in the Supplementary Appendix.
+
+Gel electrophoresis and protein transfer to polyvinylidene difluoride membranes were performed according to standard protocols. For use as the primary antibody, the serum was diluted at a 1:100 ratio. For specific detection of THSD7A, we used a commercially available rabbit polyclonal antibody at a 1:1000 dilution (Atlas Antibodies).
+
+Human glomerular extracts were incubated overnight with serum samples from patients with membranous nephropathy, from patients with other glomerular diseases, and from healthy controls, and IgG4 affinity matrix (Life Technologies) was added. Immunoprecipitates were collected, electrophoresed, blotted, and examined for the presence of THSD7A protein with the use of anti-THSD7A antibodies (Atlas Antibodies) as described above.
+
+Gel regions corresponding to visible bands on Western blots were excised and subjected to in-gel tryptic digestion. Digested peptides were identified by mass spectrometry as described in the Supplementary Appendix.
+
+Immunofluorescence and immunohistochemical analyses of THSD7A expression in healthy and diseased kidneys and autoantibody elution experiments were performed as described in the Supplementary Appendix.
+
+We screened serum samples from patients with membranous nephropathy and relevant controls against total proteins in human glomerular extracts. Serum reactivity was initially investigated by Western blotting under nonreducing conditions in serum from 65 patients with membranous nephropathy (of whom 30 were negative for anti-PLA2R1 antibodies), 76 patients with other proteinuric or autoimmune kidney diseases, and 44 healthy controls. All samples that were known to be positive for anti-PLA2R1 antibodies, as tested previously by ELISA, reacted with native and recombinant PLA2R1 by means of Western blotting (MN 45 in Fig. 1A). Samples from 4 patients with idiopathic membranous nephropathy, all of whom were seronegative for anti-PLA2R1 antibodies, recognized a glomerular protein approximately 250 kD in size (MN 1 to MN 4 in Fig. 1A). Samples from patients with other glomerular diseases or from healthy controls did not show similar reactivity (Fig. 1A, and Fig. S1 in the Supplementary Appendix). Screening was extended to 152 patients with membranous nephropathy (118 with idiopathic and 34 with secondary membranous nephropathy) (Table S1 in the Supplementary Appendix). A total of 7 serum samples, all of which were negative for anti-PLA2R1 antibodies, showed reactivity in the same 250-kD region (Fig. 1B).
+
+In an independent cohort at Boston University comprising 365 patients with idiopathic membranous nephropathy and 33 with secondary membranous nephropathy (Table S2 in the Supplementary Appendix), 10 additional patients who were seronegative for anti-PLA2R1 antibodies, as determined by Western blot analysis and ELISA, were identified; serum samples from these 10 patients showed similar reactivity to a 250-kD protein present in human glomeruli (Fig. 1C, and Table S3 in the Supplementary Appendix).
+
+The screening thus identified a putative auto-antigen of 250 kD that was present in normal human glomeruli. This protein was found to be N-glycosylated to a lesser extent than PLA2R1 and was expressed almost exclusively in cell membranes, suggesting that it was an as-yet unknown antigen that was different from PLA2R1 (Fig. S2 in the Supplementary Appendix). We also screened the serum from patients with idiopathic membranous nephropathy against the three paralogs of PLA2R1 (MRC1, MRC2, and LY75),8 but we did not observe any reactivity (Fig. S3 and S4 in the Supplementary Appendix).
+
+We used two independent strategies to identify the antigen. In the first, we performed gel electrophoresis and Western blot analysis of glomerular proteins, either untreated or treated with N-glycopeptidase F alone or with both N-glycopeptidase F and neuraminidase; these analyses revealed three different bands — at 250 kD, at 225 kD, and at 200 kD (Fig. S2B in the Supplementary Appendix). In the second strategy, glomerular proteins were partially proteolyzed with trypsin, with and without prior treatment with N-glycopeptidase F. All gel regions corresponding to the Western blot signals were excised and analyzed by mass spectrometry, and a list of candidate protein antigens was generated (Table S4 in the Supplementary Appendix). Candidate proteins were ranked according to the expected characteristics of the newly identified antigen with respect to molecular mass, N-glycosylation, membrane location, and expression in human kidney or glomeruli. We used commercially available antibodies and transiently transfected human embryonic kidney (HEK) 293 cells to specifically test for candidate antigens (data not shown) and finally identified thrombospondin type-1 domain-containing 7A (THSD7A) as the protein of interest.
+
+All 17 serum samples previously shown to be reactive with the 250-kD protein (7 samples from the European cohort and 10 from the Boston cohort) — but none of the samples that were positive for anti-PLA2R1 antibodies or the control samples — also recognized recombinant THSD7A (Fig. 2A). Native and recombinant THSD7A proteins showed the same mass shift after deglycosylation, yet the recombinant protein migrated to a slightly lower position, suggesting a minor difference in post-translational modification (Fig. 2A, and Fig. S5 in the Supplementary Appendix). All reactive serum samples, but not control samples, were able to immunoprecipitate THSD7A from glomerular lysates (Fig. 2B). THSD7A is a 250-kD type I transmembrane protein with a large extracellular region, a single transmembrane domain, and a short intracellular tail. The extracellular part contains 11 thrombospondin type-1 repeats and 1 arginine–glycine–aspartic acid (RGD) motif (Fig. 2C).9
+
+To determine the IgG subtypes of anti-THSD7A autoantibodies, we used secondary antibodies against IgG1 to IgG4. IgG4 was the predominant IgG subclass of anti-THSD7A, although other IgG subtypes were weakly present in most serum samples (Fig. 3A). This finding was in accordance with enhanced staining for IgG4 in all available biopsy samples (data not shown). Moreover, reactivity of all the positive serum samples to both the 250-kD glomerular protein and recombinant THSD7A was lost when gels were run under reducing conditions (Fig. 3B). Thus, the subtype of most anti-THSD7A autoantibodies, like that of most anti-PLA2R1 autoantibodies, is IgG4, and the anti-THSD7A autoantibodies recognize one or more conformation-dependent epitopes in both native and recombinant THSD7A.
+
+Serial serum samples from three patients who were positive for anti-THSD7A antibodies were available for analysis of antibody levels by semi-quantitative Western blot analysis. In one patient, protein levels in the urine were very high at the time of diagnosis; they were decreased with pharmacologic inhibition of the renin–angiotensin system 3 months later but were still in the nephrotic range (Fig. 3C). The protein levels increased 4 months later, and the proteinuria was accompanied by a marked increase in antibody signal. Owing to the development of severe edema, immunosuppressive therapy was started with cyclosporine and low-dose prednisone, which resulted in a decrease in the anti-THSD7A antibody level and in the level of protein in the urine to the subnephrotic range. A second patient had severe proteinuria and was treated with corticotropin analogues, resulting in a decline in the anti-THSD7A antibody level and in the level of protein in the urine (data not shown). In contrast, in a third patient who did not receive immunosuppressive therapy owing to minor clinical problems, the antibody level remained consistently high with sustained proteinuria in the nephrotic range (data not shown). Taken together, these results suggest an association between the antibody level and clinical disease activity.
+
+Immunofluorescence staining of renal-biopsy samples from healthy controls with anti–THSD7A-specific antibodies showed prominent linear glomerular expression of THSD7A (Fig. 4A and 4D). There was no staining when the primary antibody was omitted (data not shown). The staining pattern for nephrin, a transmembrane protein located at the intercellular slit diaphragm of podocyte foot processes, was very similar to that of THSD7A (Fig. 4B and 4E). Moreover, both molecules showed strong colocalization, suggesting that THSD7A is located on or within close proximity of podocyte foot processes (Fig. 4C and 4F, and Fig. S6 in the Supplementary Appendix). On the other hand, THSD7A did not colocalize with markers of the glomerular basement membrane, such as collagen type IV (Fig. 4I, and Fig. S6 in the Supplementary Appendix) and fibronectin (Fig. S7 in the Supplementary Appendix), or with CD34, a marker of endothelial cells (Fig. S8 in the Supplementary Appendix). The abluminal position of THSD7A relative to collagen type IV and fibronectin suggests that THSD7A is expressed on podocyte foot processes rather than on the glomerular basement membrane.
+
+Immunohistochemical staining of THSD7A further revealed a linear positivity in the biopsy samples from healthy controls (Fig. 5A); PLA2R1 is less well expressed than is THSD7A (Fig. 5B). In all 5 available biopsy samples from patients with membranous nephropathy who were positive for anti-THSD7A antibodies, immunohisto-chemical analysis revealed markedly enhanced granular staining for THSD7A (Fig. 5C); PLA2R1 staining was normal in these patients (Fig. 5D). In contrast, all patients with detectable anti-PLA2R1 serum antibodies had normal staining for THSD7A along the capillary walls (Fig. 5E) but enhanced granular staining for PLA2R1 (Fig. 5F), as described previously.10-12 Three of these patients had scant and unspecific positivity for THSD7A within proteinaceous material in the capsular space of a few glomeruli (data not shown). All 50 biopsy samples from patients with membranous nephropathy and no detectable autoantibodies had normal staining for both THSD7A and PLA2R1 (Fig. 5G and 5H).
+
+The PLA2R1 antigen is known to colocalize with IgG4 in subepithelial deposits in patients with PLA2R1-associated idopathic membranous nephropathy.2 Similarly, we found colocalization of IgG4 and THSD7A in biopsy samples from THSD7A-seropositive patients (Fig. S9 in the Supplementary Appendix). Moreover, we found local activation of complement, as shown by strong granular staining for C5b-9 (Fig. S10 in the Supplementary Appendix).
+
+Despite the apparent expression of the target antigen on the basal surface of the podocyte, we also looked for a circulating soluble form of the antigen, as well as THSD7A-containing circulating immune complexes that might be deposited in a similar subepithelial position. We were not able to identify either a circulating soluble form of THSD7A or THSD7A–anti-THSD7A immune complexes (Fig. S11 in the Supplementary Appendix).
+
+IgG eluted from the frozen remnant biopsy core from one patient with anti-THSD7A antibodies specifically recognized recombinant THSD7A on a Western blot, whereas IgG eluted from two PLA2R1-associated cases did not recognize THSD7A but specifically recognized PLA2R1 (Fig. 5I). IgG eluted from a biopsy sample from a patient with class V lupus nephritis recognized neither antigen.
+
+Given the apparent mutual exclusivity of anti-THSD7A and anti-PLA2R1 autoantibodies, we compared the clinical characteristics of the patients with each type of autoantibody. We could not find any significant difference between the two groups with respect to age; levels of urinary protein, serum albumin, and serum creatinine; or status with respect to the receipt of immunosuppressive therapy in the first 6 months after diagnosis (Table S5 and Fig. S12 in the Supplementary Appendix). However, there were significantly more women in the group that was positive for anti-THSD7A autoantibodies (65% vs. 27%), a finding that might also represent a sampling error owing to the small number of patients.
+
+In the current study, we identified THSD7A as a second autoantigen involved in adult idiopathic membranous nephropathy. Approximately 2.5 to 5% of the patients with idiopathic membranous nephropathy whom we evaluated had autoantibodies against THSD7A, which corresponds to 8 to 14% of the patients who are seronegative for anti-PLA2R1 antibodies. The percentage of patients with anti-THSD7A autoantibodies was higher in the European cohort, which comprised patients who had received no treatment for membranous nephropathy and from whom serum samples were obtained close to the time of the biopsy, than in the Boston cohort, which was more cross-sectional in nature and may have included patients who were already in immunologic remission.
+
+We also found anti-THSD7A antibodies in one woman with membranous nephropathy and systemic lupus erythematosus and in one older man with membranous nephropathy and prostate cancer.13 However, the renal-biopsy samples from these patients showed no features typical of lupus nephritis or secondary membranous nephropathy; in addition, their anti-THSD7A serum antibodies were mainly of the IgG4 subclass, and the renal-biopsy samples showed enhanced staining for IgG4, a finding that is similar to that in all other anti-THSD7A–positive patients and that is a feature of idiopathic rather than secondary membranous nephropathy.10,11 It is thus possible that these patients have two independent diseases, idiopathic membranous nephropathy and lupus or cancer. Furthermore, we could not find any reactivity against THSD7A among healthy controls and among patients with other protein-uric or renal autoimmune diseases. However, a number of patients were seronegative for both antigens. Anti-PLA2R1 autoantibodies are known to disappear before the full clinical resolution of disease activity,6,14 and our finding that anti-THSD7A antibody levels also fell with a decrease in disease activity suggests that the same may be true for THSD7A-associated membranous nephropathy. Staining of the biopsy specimen for the presence of the antigen (THSD7A or PLA2R1) may identify a small additional percentage of patients whose serum was sampled after immunologic remission had occurred.12,15 Taken together, THSD7A- and PLA2R1-associated membranous nephropathy may now account for approximately 75 to 85% of cases, which further helps to distinguish idiopathic from secondary membranous nephropathy. The remaining 15 to 25% of cases may involve as-yet unidentified autoantigens that are distinct from THSD7A and PLA2R1 or may have been wrongly classified as idiopathic owing to an undetected secondary cause of the disease.
+
+THSD7A was initially characterized as an endothelial protein that is expressed in the placental vasculature.9 We have shown by immunohistologic analysis that THSD7A is concentrated at the basal aspect of the podocyte, and we did not find any expression in glomerular endothelial cells. This finding is consistent with recent data showing that THSD7A is more highly expressed in podocytes than in glomerular endothelial and mesangial cells.16 On the basis of these experimental data, our current immunohistologic findings, and previous data from patients with other forms of human membranous nephropathy,2,17 we believe that the likely mechanism of THSD7A-associated membranous nephropathy involves in situ immune complex formation with podocyte-associated THSD7A. Our inability to detect circulating soluble THSD7A or THSD7A– anti-THSD7A immune complexes further supports this view. However, we cannot completely rule out the presence of circulating soluble THSD7A or THSD7A–anti-THSD7A immune complexes because of a possible lack of sensitivity of our assays.
+
+THSD7A and PLA2R1 have quite similar structural and biochemical properties. Both proteins are expressed on podocyte membranes and have high molecular masses and a large extra-cellular region consisting of multiple and repeated disulfide-bonded and N-glycosylated domains. In addition, autoantibodies to both THSD7A and PLA2R1 are predominantly of the IgG4 subclass and recognize their target antigen exclusively under nonreducing conditions, suggesting the presence of one or more conformational epitopes in each protein. Furthermore, renal-biopsy samples from patients who were positive for anti-THSD7A antibodies had increased staining for the antigen within immune deposits, a phenomenon also seen in patients who are positive for anti-PLA2R1 antibodies,10-12 and IgG eluted from a biopsy sample from a patient with anti-THSD7A serum autoantibodies recognized recombinant THSD7A but not PLA2R1.
+
+The fact that patients seem to mount an autoimmune response against either THSD7A or PLA2R1, but not both, is of particular interest. A priori, the probability that all patients who were positive for anti-THSD7A autoantibodies would be negative for anti-PLA2R1 autoantibodies owing to chance alone was less than 0.5% among the patients in our European cohort, for whom all samples were assayed against both recombinant molecules. The reasons for this mutual exclusivity of the two antigens remain only speculative at this point. It is known from other autoimmune diseases that a similar histologic and clinical phenotype can arise from disparate antigen–antibody interactions. For example, most patients with myasthenia gravis have auto-antibodies to the acetylcholine receptor, whereas some have IgG4 antibodies to muscle-specific kinase, yet all the patients have the same clinical presentation.18 Whether genetic susceptibility factors such as HLA phenotype, as described for PLA2R1-associated membranous nephropathy,19 also apply to patients with THSD7A-associated membranous nephropathy can be determined only in studies of much larger cohorts. In fact, it is the observed mutual exclusivity of these two antigens that lends credence to our proposal that THSD7A- and PLA2R1-associated membranous nephropathy represent two separate molecular entities and that the respective antigens are primary targets in this disease. It seems unlikely that these antibodies are epiphenomena resulting from podocyte injury and exposure of cryptic antigens, since one would have expected antibodies to both antigens to be found in several cases. At this stage, however, we do not know why antibodies to PLA2R1 develop in some persons with idiopathic membranous nephropathy, antibodies to THSD7A in others, and antibodies to as-yet unidentified antigens in still others.
+
+In conclusion, we have identified a group of patients with idiopathic membranous nephropathy whose circulating autoantibodies are specific for THSD7A and not PLA2R1, suggesting that patients who are positive for anti-THSD7A autoantibodies represent a distinct subgroup with this disease. This finding not only furthers our understanding of the pathophysiological basis of membranous nephropathy but also allows for the potential identification and monitoring of patients who are positive for anti-THSD7A autoantibodies, by both serologic testing and histologic staining for the antigen.

--- a/references_cache/PMID_31269364.md
+++ b/references_cache/PMID_31269364.md
@@ -1,0 +1,169 @@
+---
+reference_id: "PMID:31269364"
+title: Rituximab or Cyclosporine in the Treatment of Membranous Nephropathy.
+authors:
+- Fervenza FC
+- Appel GB
+- Barbour SJ
+- Rovin BH
+- Lafayette RA
+- Aslam N
+- Jefferson JA
+- Gipson PE
+- Rizk DV
+- Sedor JR
+- Simon JF
+- McCarthy ET
+- Brenchley P
+- Sethi S
+- Avila-Casado C
+- Beanlands H
+- Lieske JC
+- Philibert D
+- Li T
+- Thomas LF
+- Green DF
+- Juncos LA
+- Beara-Lasic L
+- Blumenthal SS
+- Sussman AN
+- Erickson SB
+- Hladunewich M
+- Canetta PA
+- Hebert LA
+- Leung N
+- Radhakrishnan J
+- Reich HN
+- Parikh SV
+- Gipson DS
+- Lee DK
+- da Costa BR
+- Jüni P
+- Cattran DC
+- MENTOR Investigators
+journal: N Engl J Med
+year: '2019'
+doi: 10.1056/NEJMoa1814427
+keywords:
+- "Administration, Oral"
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Cyclosporine/adverse effects, therapeutic use"
+- Drug Administration Schedule
+- Female
+- "Glomerulonephritis, Membranous/drug therapy"
+- Humans
+- Immunologic Factors/therapeutic use
+- "Immunosuppressive Agents/adverse effects, therapeutic use"
+- "Infusions, Intravenous"
+- Intention to Treat Analysis
+- Kaplan-Meier Estimate
+- Male
+- Middle Aged
+- Proteinuria/drug therapy
+- Remission Induction
+- "Rituximab/adverse effects, therapeutic use"
+- Treatment Failure
+- Young Adult
+content_type: abstract_only
+---
+
+# Rituximab or Cyclosporine in the Treatment of Membranous Nephropathy.
+**Authors:** Fervenza FC, Appel GB, Barbour SJ, Rovin BH, Lafayette RA, Aslam N, Jefferson JA, Gipson PE, Rizk DV, Sedor JR, Simon JF, McCarthy ET, Brenchley P, Sethi S, Avila-Casado C, Beanlands H, Lieske JC, Philibert D, Li T, Thomas LF, Green DF, Juncos LA, Beara-Lasic L, Blumenthal SS, Sussman AN, Erickson SB, Hladunewich M, Canetta PA, Hebert LA, Leung N, Radhakrishnan J, Reich HN, Parikh SV, Gipson DS, Lee DK, da Costa BR, Jüni P, Cattran DC, MENTOR Investigators
+**Journal:** N Engl J Med (2019)
+**DOI:** [10.1056/NEJMoa1814427](https://doi.org/10.1056/NEJMoa1814427)
+
+## Content
+
+1. N Engl J Med. 2019 Jul 4;381(1):36-46. doi: 10.1056/NEJMoa1814427.
+
+Rituximab or Cyclosporine in the Treatment of Membranous Nephropathy.
+
+Fervenza FC(1), Appel GB(1), Barbour SJ(1), Rovin BH(1), Lafayette RA(1), Aslam 
+N(1), Jefferson JA(1), Gipson PE(1), Rizk DV(1), Sedor JR(1), Simon JF(1), 
+McCarthy ET(1), Brenchley P(1), Sethi S(1), Avila-Casado C(1), Beanlands H(1), 
+Lieske JC(1), Philibert D(1), Li T(1), Thomas LF(1), Green DF(1), Juncos LA(1), 
+Beara-Lasic L(1), Blumenthal SS(1), Sussman AN(1), Erickson SB(1), Hladunewich 
+M(1), Canetta PA(1), Hebert LA(1), Leung N(1), Radhakrishnan J(1), Reich HN(1), 
+Parikh SV(1), Gipson DS(1), Lee DK(1), da Costa BR(1), Jüni P(1), Cattran DC(1); 
+MENTOR Investigators.
+
+Collaborators: Fervenza FC, Lieske JC, Leung N, Erickson SB, Radhakrishnan J, 
+Bomback A, Hogan J, Canetta P, Ahn W, Lafayette R, Arora N, Nargund P, Rovin B, 
+Alvarado A, Parikh S, Aslam N, Porter I, Gipson P, Kretzler M, Plattner B, 
+Gipson D, Mariani L, Garg P, Rao P, Sedor J, O'Toole J, Jefferson JA, Nelson PJ, 
+McCarthy E, Yarlagadda S, Jain N, Rizk D, Simon J, Gebreselassie S, Blumenthal 
+S, Beara-Lasic L, Zhdanova O, Thomas L, Cohen I, Keddis M, Sussman A, Thajudeen 
+B, Juncos L, Fulop T, Craici I, Wagner S, Dreisbach A, Monga D, Green D, 
+Mattiazzi A, Nayer A, Thomas D, Barisoni L, Li T, Vijayan A, Cattran DC, Reich 
+H, Hladunewich M, Barbour S, Levin A, Philibert D, Mac-Way F, Desmeules S.
+
+Author information:
+(1)From the Mayo Clinic, Rochester, MN (F.C.F., S.S., J.C.L., S.B.E., N.L.); 
+Columbia University (G.B.A., P.A.C., J.R.) and the New York University Medical 
+Center (L.B.-L.) - both in New York; the University of British Columbia, 
+Division of Nephrology, Vancouver (S.J.B.), the University Health Network, 
+Toronto General Hospital (C.A.-C., H.N.R., D.C.C.), the Faculty of Community 
+Services, Ryerson University (H.B.), and the Sunnybrook Health Science Centre 
+(M.H.), the Applied Health Research Centre, Li Ka Shing Knowledge Institute of 
+St. Michael's Hospital (D.K.L., B.R.C., P.J.), and the Department of Medicine 
+and Institute of Health Policy, Management, and Evaluation, University of 
+Toronto (B.R.C., P.J.), Toronto, and Centre Hospitalier Universitaire de Québec, 
+Quebec, QC (D.P.) - all in Canada; Ohio State University, Columbus (B.H.R., 
+L.A.H., S.V.P.); Stanford University, Stanford, CA (R.A.L.); the Mayo Clinic, 
+Jacksonville (N.A.), and Florida International University, Miami (D.F.G.) - both 
+in Florida; the University of Washington Medical Center, Seattle (J.A.J.); the 
+University of Michigan Medical Center, Ann Arbor (P.E.G., D.S.G.); the 
+University of Alabama at Birmingham, Birmingham (D.V.R.); Case Western Reserve 
+University (J.R.S.) and the Cleveland Clinic (J.F.S.) - both in Cleveland; 
+Kansas University Medical Center, Kansas City (E.T.M.); Manchester University, 
+Manchester, United Kingdom (P.B.); Washington University School of Medicine, St. 
+Louis (T.L.); the Mayo Clinic, Scottsdale (L.F.T.), and the University of 
+Arizona, Tucson (A.N.S.) - both in Arizona; the University of Mississippi 
+Medical Center, Jackson (L.A.J.); and the Medical College of Wisconsin, 
+Froedtert Hospital, Milwaukee (S.S.B.).
+
+Comment in
+    N Engl J Med. 2019 Jul 4;381(1):86-88. doi: 10.1056/NEJMe1906666.
+    Nat Rev Nephrol. 2019 Nov;15(11):664-666. doi: 10.1038/s41581-019-0200-1.
+    N Engl J Med. 2019 Oct 24;381(17):1688. doi: 10.1056/NEJMc1910393.
+    N Engl J Med. 2019 Oct 24;381(17):1688-1689. doi: 10.1056/NEJMc1910393.
+
+BACKGROUND: B-cell anomalies play a role in the pathogenesis of membranous 
+nephropathy. B-cell depletion with rituximab may therefore be noninferior to 
+treatment with cyclosporine for inducing and maintaining a complete or partial 
+remission of proteinuria in patients with this condition.
+METHODS: We randomly assigned patients who had membranous nephropathy, 
+proteinuria of at least 5 g per 24 hours, and a quantified creatinine clearance 
+of at least 40 ml per minute per 1.73 m2 of body-surface area and had been 
+receiving angiotensin-system blockade for at least 3 months to receive 
+intravenous rituximab (two infusions, 1000 mg each, administered 14 days apart; 
+repeated at 6 months in case of partial response) or oral cyclosporine (starting 
+at a dose of 3.5 mg per kilogram of body weight per day for 12 months). Patients 
+were followed for 24 months. The primary outcome was a composite of complete or 
+partial remission of proteinuria at 24 months. Laboratory variables and safety 
+were also assessed.
+RESULTS: A total of 130 patients underwent randomization. At 12 months, 39 of 65 
+patients (60%) in the rituximab group and 34 of 65 (52%) in the cyclosporine 
+group had a complete or partial remission (risk difference, 8 percentage points; 
+95% confidence interval [CI], -9 to 25; P = 0.004 for noninferiority). At 24 
+months, 39 patients (60%) in the rituximab group and 13 (20%) in the 
+cyclosporine group had a complete or partial remission (risk difference, 40 
+percentage points; 95% CI, 25 to 55; P<0.001 for both noninferiority and 
+superiority). Among patients in remission who tested positive for 
+anti-phospholipase A2 receptor (PLA2R) antibodies, the decline in autoantibodies 
+to anti-PLA2R was faster and of greater magnitude and duration in the rituximab 
+group than in the cyclosporine group. Serious adverse events occurred in 11 
+patients (17%) in the rituximab group and in 20 (31%) in the cyclosporine group 
+(P = 0.06).
+CONCLUSIONS: Rituximab was noninferior to cyclosporine in inducing complete or 
+partial remission of proteinuria at 12 months and was superior in maintaining 
+proteinuria remission up to 24 months. (Funded by Genentech and the Fulk Family 
+Foundation; MENTOR ClinicalTrials.gov number, NCT01180036.).
+
+Copyright © 2019 Massachusetts Medical Society.
+
+DOI: 10.1056/NEJMoa1814427
+PMID: 31269364 [Indexed for MEDLINE]

--- a/references_cache/PMID_33673911.md
+++ b/references_cache/PMID_33673911.md
@@ -1,0 +1,100 @@
+---
+reference_id: "PMID:33673911"
+title: A Target Antigen-Based Approach to the Classification of Membranous Nephropathy.
+authors:
+- Bobart SA
+- Tehranian S
+- Sethi S
+- Alexander MP
+- Nasr SH
+- Casal Moura M
+- Vrana JA
+- Said S
+- Giesen CD
+- Lieske JC
+- Fervenza FC
+- De Vriese AS
+journal: Mayo Clin Proc
+year: '2021'
+doi: 10.1016/j.mayocp.2020.11.028
+keywords:
+- Adult
+- Aged
+- Antigens/metabolism
+- Autoantibodies/metabolism
+- Cadherins/metabolism
+- Female
+- "Glomerulonephritis, Membranous/immunology"
+- Humans
+- Immunohistochemistry
+- Male
+- Middle Aged
+- N-Acetylglucosaminyltransferases/metabolism
+- Neural Cell Adhesion Molecules/metabolism
+- Protocadherins
+- "Receptors, Phospholipase A2/metabolism"
+- Severity of Illness Index
+- Thrombospondins/metabolism
+- Exostosin 2
+- Exostosin 1
+content_type: abstract_only
+---
+
+# A Target Antigen-Based Approach to the Classification of Membranous Nephropathy.
+**Authors:** Bobart SA, Tehranian S, Sethi S, Alexander MP, Nasr SH, Casal Moura M, Vrana JA, Said S, Giesen CD, Lieske JC, Fervenza FC, De Vriese AS
+**Journal:** Mayo Clin Proc (2021)
+**DOI:** [10.1016/j.mayocp.2020.11.028](https://doi.org/10.1016/j.mayocp.2020.11.028)
+
+## Content
+
+1. Mayo Clin Proc. 2021 Mar;96(3):577-591. doi: 10.1016/j.mayocp.2020.11.028.
+
+A Target Antigen-Based Approach to the Classification of Membranous Nephropathy.
+
+Bobart SA(1), Tehranian S(2), Sethi S(3), Alexander MP(3), Nasr SH(3), Casal 
+Moura M(4), Vrana JA(3), Said S(3), Giesen CD(3), Lieske JC(2), Fervenza FC(2), 
+De Vriese AS(5).
+
+Author information:
+(1)Division of Nephrology and Hypertension, Mayo Clinic, Rochester, MN; 
+Cleveland Clinic Florida, Weston.
+(2)Division of Nephrology and Hypertension, Mayo Clinic, Rochester, MN.
+(3)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN.
+(4)Division of Pulmonary and Critical Care, Mayo Clinic, Rochester, MN.
+(5)Division of Nephrology and Infectious Diseases, AZ Sint-Jan Brugge, Brugge, 
+Belgium; Ghent University, Ghent, Belgium. Electronic address: 
+an.devriese@azsintjan.be.
+
+Comment in
+    Mayo Clin Proc. 2021 Mar;96(3):523-525. doi: 10.1016/j.mayocp.2021.01.011.
+
+OBJECTIVE: To describe the clinical and pathological phenotype of membranous 
+nephropathy (MN) associated with M-type-phospholipase-A2-receptor (PLA2R), 
+thrombospondin-type-1-domain-containing-7A (THSD7A), semaphorin 3B (SEMA3B), 
+neural-epidermal-growth-factor-like-1-protein (NELL-1), protocadherin 7 (PCDH7), 
+exostosin 1/exostosin 2 (EXT1/EXT2) and neural cell adhesion molecule 1 (NCAM-1) 
+as target antigens.
+METHODS: A retrospective cohort of 270 adult patients with biopsy-proven MN 
+diagnosed between January 2015 and April 2020 was classified as PLA2R-, THSD7A-, 
+SEMA3B-, NELL-1-, PCDH7-, EXT1/EXT2-, NCAM-1-associated or septuple-negative MN 
+using serologic tests, immunostaining, and/or mass spectrometry. Clinical, 
+biochemical, pathologic, and follow-up data were systematically abstracted from 
+the medical records, including disease activity of conditions traditionally 
+associated with MN and occurring within 5 years of MN diagnosis.
+RESULTS: Patients with PLA2R-associated MN were predominantly middle-aged white 
+men without associated disease. The presence of associated disease did not 
+affect the clinical and pathologic characteristics of PLA2R-associated MN, 
+suggesting that they were coincidental rather than causally linked. THSD7A-, 
+NELL-1-, PCDH7-, and NCAM-1-associated MN were rare and SEMA3B-associated MN was 
+not discovered in our cohort. EXT1/EXT2-associated MN was primarily diagnosed in 
+younger women with active systemic autoimmunity. A significant proportion of 
+septuple-negative patients had associated malignancy or systemic autoimmunity.
+CONCLUSION: The widely used distinction between primary and secondary MN has 
+limitations. We propose a refined terminology that combines the target antigen 
+and associated disease to better classify MN and guide clinical decision making.
+
+Copyright © 2020 Mayo Foundation for Medical Education and Research. Published 
+by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.mayocp.2020.11.028
+PMID: 33673911 [Indexed for MEDLINE]


### PR DESCRIPTION
Follow-up to #1328.

## Summary
- add explicit antigen-based framing to the disorder root while keeping the pathograph centered on the shared primary-MN autoimmune cascade
- add molecular subtypes for PLA2R-associated, THSD7A-associated, and broader other antigen-associated MN so the root page better reflects current MN biology without overclaiming the disease anchor
- strengthen diagnostics by expanding the serology section into a serology plus target-antigen work-up concept, including biopsy antigen staining
- upgrade key evidence quality with primary human studies for THSD7A-associated MN and rituximab efficacy/mechanism (`PMID:25394321`, `PMID:31269364`, `PMID:33673911`)

## Why
- the merged page was strong, but the primary-versus-secondary framing still read as more complete than current antigen-defined cohort data supports
- THSD7A subgroup claims and rituximab treatment claims were worth grounding in direct human studies rather than leaning as heavily on review-level support

## Validation
```bash
just validate-schema kb/disorders/Membranous_Nephropathy.yaml
just validate-terms kb/disorders/Membranous_Nephropathy.yaml
just validate-references kb/disorders/Membranous_Nephropathy.yaml
uv run python -m dismech.graph --show kb/disorders/Membranous_Nephropathy.yaml
```
