### PR TITLE
[codex] move references and deep research to page end

### DIFF
--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -583,6 +583,25 @@
             font-style: italic;
         }
 
+        .grouped-section + .grouped-section {
+            margin-top: 28px;
+            padding-top: 24px;
+            border-top: 1px solid #e2e8f0;
+        }
+
+        .grouped-section-header {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .grouped-section-title {
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--text);
+        }
+
         /* Item containers with evidence */
         .item-box {
             padding: 16px;
@@ -2495,6 +2514,7 @@
         {% set experimental_models_count = experimental_models | length %}
         {% set computational_models_count = computational_models | length %}
         {% set models_count = experimental_models_count + computational_models_count %}
+        {% set references_count = (disorder.references or []) | length %}
         {% set literature_count = (literature_sections or []) | length %}
         {% set reports_count = (report_sections or []) | length %}
         {% set ns = namespace(mappings_count=0) %}
@@ -2686,19 +2706,27 @@
                 <div class="stat-label">Models</div>
             </div>
             {% endif %}
-            {% if literature_count %}
-            <a class="stat-link" href="#literature-summaries">
-            <div class="stat-item">
-                <div class="stat-value">{{ literature_count }}</div>
-                <div class="stat-label">Literature</div>
-            </div>
-            </a>
-            {% endif %}
             {% if reports_count %}
             <a class="stat-link" href="#reports">
             <div class="stat-item">
                 <div class="stat-value">{{ reports_count }}</div>
                 <div class="stat-label">Reports</div>
+            </div>
+            </a>
+            {% endif %}
+            {% if references_count %}
+            <a class="stat-link" href="#references">
+            <div class="stat-item">
+                <div class="stat-value">{{ references_count }}</div>
+                <div class="stat-label">References</div>
+            </div>
+            </a>
+            {% endif %}
+            {% if literature_count %}
+            <a class="stat-link" href="#literature-summaries">
+            <div class="stat-item">
+                <div class="stat-value">{{ literature_count }}</div>
+                <div class="stat-label">Deep Research</div>
             </div>
             </a>
             {% endif %}
@@ -3206,39 +3234,6 @@
                 </div>
                 {% endfor %}
             </div>
-        </div>
-        {% endif %}
-
-        <!-- References -->
-        {% if disorder.references %}
-        <div class="card reference-card" id="references">
-            <div class="card-header">
-                <div class="card-icon" style="background: #eef2ff; color: #4f46e5;">📚</div>
-                <h2 class="card-title">References</h2>
-                <span class="card-count">{{ disorder.references | length }}</span>
-            </div>
-            {% for publication in disorder.references %}
-            <div class="reference-entry">
-                <div class="reference-entry-header">
-                    <div>
-                        <div class="reference-curie">
-                            <a href="{{ publication.reference | curie_to_url }}" target="_blank">{{ publication.reference }}</a>
-                        </div>
-                        {% if publication.title %}
-                        <div class="reference-title">{{ publication.title }}</div>
-                        {% endif %}
-                    </div>
-                    {% if publication.findings %}
-                    <span class="reference-summary">{{ publication.findings | length }} finding{{ 's' if publication.findings | length != 1 else '' }}</span>
-                    {% endif %}
-                </div>
-                {% if publication.findings %}
-                {{ render_reference_findings(publication.findings) }}
-                {% else %}
-                <div class="reference-empty">No top-level findings curated for this source.</div>
-                {% endif %}
-            </div>
-            {% endfor %}
         </div>
         {% endif %}
 
@@ -4275,46 +4270,6 @@
         </div>
         {% endif %}
 
-        <!-- Literature Summaries -->
-        {% if literature_sections %}
-        <div class="card" id="literature-summaries">
-            <div class="card-header">
-                <div class="card-icon" style="background: #ecfeff; color: #0f766e;">📚</div>
-                <h2 class="card-title">Literature Summaries</h2>
-                <span class="card-count">{{ literature_sections | length }}</span>
-            </div>
-            {% for report in literature_sections %}
-            <div style="margin-bottom: 4px;">
-                <div class="report-toggle" onclick="this.nextElementSibling.classList.toggle('show'); this.querySelector('.toggle-indicator').textContent = this.nextElementSibling.classList.contains('show') ? '▾' : '▸'">
-                    <span>{{ report.title }}</span>
-                    <span class="toggle-indicator" style="font-size: 0.9rem;">▸</span>
-                </div>
-                <div class="report-body">
-                    {% if report.subtitle or report.model or report.end_time or report.citation_count %}
-                    <div class="report-meta">
-                        {% if report.subtitle %}
-                        <div class="report-subtitle">{{ report.subtitle }}</div>
-                        {% endif %}
-                        {% if report.model %}
-                        <span class="report-badge">{{ report.model }}</span>
-                        {% endif %}
-                        {% if report.citation_count is not none %}
-                        <span class="report-badge">{{ report.citation_count }} citations</span>
-                        {% endif %}
-                        {% if report.end_time %}
-                        <span class="report-meta-text">{{ report.end_time }}</span>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-                    <div class="report-content">
-                        {{ report.html | safe }}
-                    </div>
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-        {% endif %}
-
         <!-- Reports -->
         {% if report_sections %}
         <div class="card" id="reports">
@@ -4350,6 +4305,83 @@
                 <pre class="yaml-preview">{{ yaml_content }}</pre>
             </div>
         </div>
+
+        <!-- References & Deep Research -->
+        {% if disorder.references or literature_sections %}
+        <div class="card reference-card" id="references-deep-research">
+            <div class="card-header">
+                <div class="card-icon" style="background: #eef2ff; color: #4f46e5;">📚</div>
+                <h2 class="card-title">References &amp; Deep Research</h2>
+            </div>
+            {% if disorder.references %}
+            <div class="grouped-section anchor-target" id="references">
+                <div class="grouped-section-header">
+                    <h3 class="grouped-section-title">References</h3>
+                    <span class="card-count">{{ disorder.references | length }}</span>
+                </div>
+                {% for publication in disorder.references %}
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="{{ publication.reference | curie_to_url }}" target="_blank">{{ publication.reference }}</a>
+                            </div>
+                            {% if publication.title %}
+                            <div class="reference-title">{{ publication.title }}</div>
+                            {% endif %}
+                        </div>
+                        {% if publication.findings %}
+                        <span class="reference-summary">{{ publication.findings | length }} finding{{ 's' if publication.findings | length != 1 else '' }}</span>
+                        {% endif %}
+                    </div>
+                    {% if publication.findings %}
+                    {{ render_reference_findings(publication.findings) }}
+                    {% else %}
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% if literature_sections %}
+            <div class="grouped-section anchor-target" id="literature-summaries">
+                <div class="grouped-section-header">
+                    <h3 class="grouped-section-title">Deep Research</h3>
+                    <span class="card-count">{{ literature_sections | length }}</span>
+                </div>
+                {% for report in literature_sections %}
+                <div style="margin-bottom: 4px;">
+                    <div class="report-toggle" onclick="this.nextElementSibling.classList.toggle('show'); this.querySelector('.toggle-indicator').textContent = this.nextElementSibling.classList.contains('show') ? '▾' : '▸'">
+                        <span>{{ report.title }}</span>
+                        <span class="toggle-indicator" style="font-size: 0.9rem;">▸</span>
+                    </div>
+                    <div class="report-body">
+                        {% if report.subtitle or report.model or report.end_time or report.citation_count %}
+                        <div class="report-meta">
+                            {% if report.subtitle %}
+                            <div class="report-subtitle">{{ report.subtitle }}</div>
+                            {% endif %}
+                            {% if report.model %}
+                            <span class="report-badge">{{ report.model }}</span>
+                            {% endif %}
+                            {% if report.citation_count is not none %}
+                            <span class="report-badge">{{ report.citation_count }} citations</span>
+                            {% endif %}
+                            {% if report.end_time %}
+                            <span class="report-meta-text">{{ report.end_time }}</span>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+                        <div class="report-content">
+                            {{ report.html | safe }}
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
 
         <footer class="page-footer">
             <p>

--- a/tests/test_render_literature_summaries.py
+++ b/tests/test_render_literature_summaries.py
@@ -93,9 +93,60 @@ citation_count: 7
     render_disorder(disorder_path, output_path=output_path)
     html = output_path.read_text()
 
+    assert 'id="references-deep-research"' in html
     assert 'id="literature-summaries"' in html
-    assert "Literature Summaries" in html
+    assert "References &amp; Deep Research" in html
+    assert "Deep Research" in html
     assert "Cyberian Codex" in html
     assert "codex-local-synthesis" in html
     assert "Calcium signaling" in html
     assert "Codex secondary synthesis." not in html
+
+
+def test_render_disorder_places_references_and_deep_research_last(
+    tmp_path: Path,
+) -> None:
+    disorder_path = tmp_path / "Test_Disorder.yaml"
+    output_path = tmp_path / "pages" / "disorders" / "Test_Disorder.html"
+    research_dir = tmp_path / "research"
+    reports_dir = tmp_path / "reports" / "Test_Disorder"
+    research_dir.mkdir()
+    reports_dir.mkdir(parents=True)
+    _write_disorder(
+        disorder_path,
+        {
+            "name": "Test Disorder",
+            "references": [
+                {
+                    "reference": "PMID:12345678",
+                    "title": "Reference title",
+                    "findings": [],
+                }
+            ],
+        },
+    )
+    (research_dir / "Test_Disorder-deep-research-openai.md").write_text(
+        """---
+provider: openai
+---
+## Output
+
+## Pathophysiology description
+Deep research body.
+"""
+    )
+    (reports_dir / "01-report.md").write_text("# Report\n\nReport body.\n")
+
+    render_disorder(disorder_path, output_path=output_path)
+    html = output_path.read_text()
+
+    assert html.index('stat-label">Reports') < html.index('stat-label">References')
+    assert html.index('stat-label">References') < html.index(
+        'stat-label">Deep Research'
+    )
+    assert html.index('id="reports"') < html.index('id="yamlContent"')
+    assert html.index('id="yamlContent"') < html.index('id="references-deep-research"')
+    assert html.index('id="references"') < html.index('id="literature-summaries"')
+    assert html.index('id="references-deep-research"') < html.index(
+        '<footer class="page-footer">'
+    )

--- a/tests/test_render_references.py
+++ b/tests/test_render_references.py
@@ -48,7 +48,9 @@ def test_render_disorder_shows_top_level_references_with_findings(
     render_disorder(disorder_path, output_path=output_path)
     html = output_path.read_text()
 
-    assert '<div class="card reference-card" id="references">' in html
+    assert 'id="references-deep-research"' in html
+    assert 'id="references"' in html
+    assert "References &amp; Deep Research" in html
     assert f'href="{curie_to_url("PMID:3159974")}"' in html
     assert "Molecular basis of Down syndrome phenotypes." in html
     assert "Chromosome 21 triplication produces broad developmental effects." in html
@@ -83,5 +85,6 @@ def test_render_disorder_references_without_findings_show_empty_state(
     render_disorder(disorder_path, output_path=output_path)
     html = output_path.read_text()
 
+    assert 'id="references-deep-research"' in html
     assert "Down syndrome developmental review." in html
     assert "No top-level findings curated for this source." in html


### PR DESCRIPTION
## Summary
- move the disorder-page `References` block to the end of the page and pair it with deep-research content under a shared `References & Deep Research` section
- reorder the header stats so `References` and `Deep Research` appear last, matching the new page layout
- update render tests to cover the new grouping and ordering

## Why
The rendered disorder pages previously surfaced top-level references mid-page and deep-research content later under a separate heading. This made the page order and header summary order drift apart. Grouping them at the end keeps the evidence/provenance material together and aligns the top summary with the rendered layout.

## Impact
- disorder pages now end with a shared provenance block just before the footer
- deep-research content keeps its existing render source (`literature_sections`) but is labeled `Deep Research` in the UI
- no derived HTML pages are included in this PR

## Validation
- `uv run pytest tests/test_render_references.py tests/test_render_literature_summaries.py -q`
- regenerated and spot-checked: `Achoo_Syndrome`, `Achondroplasia`, `Ainhum`

## Notes
- `render.py` data collection was reviewed, but the behavior change was satisfied in the Jinja template and tests; no Python changes were required
- unrelated local modifications in `kb/disorders/Choroid_Plexus_Carcinoma.yaml` and two generated `pages/disorders/*.html` files were intentionally left untouched and are not part of this branch's commit
