### PR TITLE
[codex] bump workflow model selectors to claude-opus-4-7

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,8 +66,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4.6, uncomment for Claude Opus 4.6)
-          # model: "claude-opus-4-6"
+          # Optional: Specify model (defaults to Claude Sonnet 4.6, uncomment for Claude Opus 4.7)
+          # model: "claude-opus-4-7"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/post-review-agent.yml
+++ b/.github/workflows/post-review-agent.yml
@@ -30,13 +30,13 @@ on:
         type: string
       model:
         description: "Claude model to use"
-        default: claude-opus-4-6
+        default: claude-opus-4-7
         type: choice
         options:
           # Current models
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
-          - claude-opus-4-6
+          - claude-opus-4-7
 
 jobs:
   editorial-review:

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -21,13 +21,13 @@ on:
 
       model:
         description: "Claude model to use"
-        default: claude-opus-4-6
+        default: claude-opus-4-7
         type: choice
         options:
           # Current models
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
-          - claude-opus-4-6
+          - claude-opus-4-7
 
 jobs:
   compliance-fixes:
@@ -65,7 +65,7 @@ jobs:
           claude_args: |
             --dangerously-skip-permissions
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
-            --model ${{ inputs.model || 'claude-opus-4-6' }}
+            --model ${{ inputs.model || 'claude-opus-4-7' }}
 
           prompt: |
             You are running as part of an automated CI workflow to improve the dismech knowledge base.


### PR DESCRIPTION
## Summary
- replace `claude-opus-4-6` with `claude-opus-4-7` in the `.github` workflow model selectors
- update the commented example in `claude.yml` to match the new Opus version

## Why
These workflows still referenced the older Opus model string in manual inputs and workflow arguments.

## Validation
- `grep -R -n --color=never 'opus-4-6' .github/`
- `git diff --check -- .github/workflows/post-review-agent.yml .github/workflows/claude.yml .github/workflows/weekly-compliance.yaml`
- `pre-commit run --files .github/workflows/post-review-agent.yml .github/workflows/claude.yml .github/workflows/weekly-compliance.yaml`

## Scope Notes
- only `.github` workflow files were changed
- existing unrelated local edits outside `.github/` were left untouched