### PR TITLE
[codex] Enhance phenotype section for Achondroplasia

### DIFF
--- a/kb/disorders/Achondroplasia.yaml
+++ b/kb/disorders/Achondroplasia.yaml
@@ -1,6 +1,6 @@
 name: Achondroplasia
 creation_date: '2026-02-02T00:16:36Z'
-updated_date: '2026-04-03T12:00:00Z'
+updated_date: '2026-04-19T00:07:00Z'
 category: Mendelian
 description: >
   Achondroplasia is the most common form of short-limbed dwarfism, affecting approximately
@@ -285,195 +285,373 @@ pathophysiology:
 phenotypes:
 - name: Disproportionate short stature
   description: >
-    Adults with achondroplasia have an average height of approximately 131 cm (males)
-    and 124 cm (females). The short stature is disproportionate with rhizomelic
-    (proximal) limb shortening.
-  frequency: HP_0040281
+    Disproportionate short-limb short stature is a defining skeletal manifestation
+    of achondroplasia.
   phenotype_term:
     preferred_term: Disproportionate short-limb short stature
     term:
       id: HP:0008873
       label: Disproportionate short-limb short stature
-- name: Rhizomelic limb shortening
-  description: Proximal segments of the limbs (humerus and femur) are disproportionately shortened compared to middle and distal segments.
-  frequency: HP_0040281
+  evidence:
+  - reference: PMID:32803853
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Achondroplasia is a genetic disorder that results in disproportionate short stature."
+    explanation: Supports disproportionate short stature as a core phenotype of achondroplasia.
+- name: Rhizomelia
+  description: >
+    Shortening is most pronounced in the proximal long bones.
   phenotype_term:
-    preferred_term: Rhizomelic arm shortening
+    preferred_term: Rhizomelia
     term:
-      id: HP:0004991
-      label: Rhizomelic arm shortening
+      id: HP:0008905
+      label: Rhizomelia
+  evidence:
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most prevalent radiographic findings were rhizomelic shortening of the long bones and narrowing of the interpediculate distance of the caudal spine."
+    explanation: Supports rhizomelic long-bone shortening as a characteristic skeletal manifestation.
 - name: Macrocephaly
   description: >
-    Enlarged head circumference with frontal bossing is characteristic. The skull base
-    (chondrocranium) is affected by impaired endochondral ossification while the cranial
-    vault (membranous bone) grows normally.
-  frequency: HP_0040281
+    Macrocephaly is part of the characteristic cranial phenotype.
   phenotype_term:
     preferred_term: Macrocephaly
     term:
       id: HP:0000256
       label: Macrocephaly
-- name: Frontal bossing
-  description: Prominent forehead due to relative overgrowth of the frontal bones.
-  frequency: HP_0040281
+  evidence:
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most prevalent clinical findings were short stature, high forehead, trident hands, genu varum and macrocephaly."
+    explanation: Clinical cohort data identify macrocephaly as one of the most prevalent physical findings.
+- name: Prominent forehead
+  description: >
+    Prominent forehead is a characteristic craniofacial feature.
   phenotype_term:
-    preferred_term: Frontal bossing
+    preferred_term: Prominent forehead
     term:
-      id: HP:0002007
-      label: Frontal bossing
+      id: HP:0011220
+      label: Prominent forehead
+  evidence:
+  - reference: PMID:37072824
+    reference_title: "Craniofacial growth and function in achondroplasia: a multimodal 3D study on 15 patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Craniofacial phenotype was characterized by maxillo-zygomatic retrusion, deep nasal root, and prominent forehead."
+    explanation: Multimodal craniofacial study directly documents prominent forehead in pediatric achondroplasia.
 - name: Midface retrusion
-  description: Hypoplasia of the midface structures due to impaired growth of the skull base, contributing to the characteristic facial appearance.
-  frequency: HP_0040281
+  description: >
+    Midface retrusion contributes to the characteristic craniofacial appearance.
   phenotype_term:
     preferred_term: Midface retrusion
     term:
       id: HP:0011800
       label: Midface retrusion
+  evidence:
+  - reference: PMID:37072824
+    reference_title: "Craniofacial growth and function in achondroplasia: a multimodal 3D study on 15 patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Craniofacial phenotype was characterized by maxillo-zygomatic retrusion, deep nasal root, and prominent forehead."
+    explanation: Maxillo-zygomatic retrusion directly supports midface retrusion as a core craniofacial phenotype.
 - name: Trident hand
-  description: Characteristic hand configuration with short fingers and increased space between the middle and ring fingers, creating a trident appearance.
-  frequency: HP_0040281
+  description: >
+    Trident hand is a characteristic hand configuration in achondroplasia.
   phenotype_term:
     preferred_term: Trident hand
     term:
       id: HP:0004060
       label: Trident hand
-- name: Brachydactyly
-  description: Shortening of the fingers and toes due to impaired growth of the phalangeal bones.
-  frequency: HP_0040281
-  phenotype_term:
-    preferred_term: Brachydactyly
-    term:
-      id: HP:0001156
-      label: Brachydactyly
+  evidence:
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most prevalent clinical findings were short stature, high forehead, trident hands, genu varum and macrocephaly."
+    explanation: Clinical cohort data identify trident hands as one of the most prevalent physical findings.
 - name: Genu varum
-  description: Bowing of the legs (bowlegs) is common and may worsen with weight-bearing, sometimes requiring surgical correction.
-  frequency: HP_0040282
+  description: >
+    Genu varum is a common lower-limb deformity and is typically recognized during childhood.
   phenotype_term:
     preferred_term: Genu varum
     term:
       id: HP:0002970
       label: Genu varum
-- name: Lumbar hyperlordosis
-  description: Exaggerated lumbar lordosis develops as children begin to walk, contributing to the characteristic posture.
-  frequency: HP_0040282
-  phenotype_term:
-    preferred_term: Lumbar hyperlordosis
-    term:
-      id: HP:0002938
-      label: Lumbar hyperlordosis
+  evidence:
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most prevalent clinical findings were short stature, high forehead, trident hands, genu varum and macrocephaly."
+    explanation: Clinical cohort data identify genu varum as one of the most prevalent physical findings.
 - name: Thoracolumbar kyphosis
-  description: Thoracolumbar kyphosis is present in infancy and typically resolves or transitions to lumbar hyperlordosis as the child begins walking.
-  frequency: HP_0040282
+  description: >
+    Thoracolumbar kyphosis is common in young children and often improves over time.
   phenotype_term:
     preferred_term: Thoracolumbar kyphosis
     term:
       id: HP:0005619
       label: Thoracolumbar kyphosis
+  evidence:
+  - reference: PMID:37493935
+    reference_title: "Walking status and spinopelvic parameters in young children with achondroplasia: 10-year follow-up."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Thoracolumbar kyphosis (TLK) is common in children with achondroplasia and resolves in 90% by 10 years of age."
+    explanation: Supports both childhood onset and the usual tendency toward spontaneous improvement by age 10.
+  - reference: PMID:27927547
+    reference_title: "Prevalence of Scoliosis and Thoracolumbar Kyphosis in Patients With Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Thoracolumbar kyphosis was observed in 79%, with 52% exhibiting moderate to severe curvature."
+    explanation: Large orthopedic cohort documents thoracolumbar kyphosis as a common spinal phenotype.
+- name: Scoliosis
+  description: >
+    Scoliosis is a common spinal deformity in achondroplasia.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  evidence:
+  - reference: PMID:27927547
+    reference_title: "Prevalence of Scoliosis and Thoracolumbar Kyphosis in Patients With Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Scoliosis was observed in 60%."
+    explanation: Large orthopedic cohort documents scoliosis in 60% of patients with achondroplasia.
 - name: Foramen magnum stenosis
   description: >
-    Narrowing of the foramen magnum due to premature closure of cranial base
-    synchondroses, leading to risk of cervicomedullary compression, central apnea,
-    and sudden death in infancy. Requires monitoring with neuroimaging and polysomnography.
-  frequency: HP_0040282
+    Foramen magnum stenosis is a major infant complication that can cause cervical cord compression.
   phenotype_term:
     preferred_term: Small foramen magnum
     term:
       id: HP:0002677
       label: Small foramen magnum
   evidence:
-  - reference: PMID:29959505
-    reference_title: "Polysomnography as an indicator for cervicomedullary decompression to treat foramen magnum stenosis in achondroplasia."
+  - reference: PMID:32883660
+    reference_title: "Achondroplasia Foramen Magnum Score: screening infants for stenosis."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "MRI revealed four severe, four moderate, and one mild case of cervicomedullary compression, and PSG demonstrated severe sleep apnea in four cases and moderate sleep apnea in five cases."
-    explanation: Clinical study showing high prevalence of cervicomedullary compression and sleep apnea secondary to foramen magnum stenosis in achondroplasia, even in patients asymptomatic during daytime.
+    snippet: "Of 36 infants (M:F, 18:18), 2 (5.6%) did not have FMS (AFMS0); 13 (36.1%) had FMS with preservation of the cerebrospinal fluid (CSF) spaces (AFMS1); 3 (8.3%) had FMS with loss of the CSF space but no spinal cord distortion (AFMS2); 13 (36.1%) had FMS with flattening of the cervical cord without signal change (AFMS3); and 5 (13.9%) had FMS resulting in cervical cord signal change (AFMS4)."
+    explanation: Infant MRI cohort shows that most screened infants had foramen magnum stenosis, including many with cord flattening or signal change.
+  - reference: PMID:38554024
+    reference_title: "Clinical outcomes and medical management of achondroplasia in Japanese children: A retrospective medical record review of clinical data."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All patients were monitored by magnetic resonance imaging; 73.0% had foramen magnum stenosis, while 54.1% had Achondroplasia Foramen Magnum Score 3 or 4."
+    explanation: Independent pediatric cohort confirms that foramen magnum stenosis is a frequent early complication.
 - name: Spinal canal stenosis
   description: >
-    Progressive narrowing of the spinal canal due to shortened pedicles and vertebral
-    body abnormalities. Symptomatic lumbar spinal stenosis with neurogenic claudication
-    is a major complication in adults.
-  frequency: HP_0040282
+    Cervical and lumbar spinal canal stenosis occur across the lifespan and symptomatic lumbar disease is especially important in adults.
   phenotype_term:
     preferred_term: Spinal canal stenosis
     term:
       id: HP:0003416
       label: Spinal canal stenosis
   evidence:
-  - reference: PMID:35698202
-    reference_title: "Literature review and expert opinion on the impact of achondroplasia on medical complications and health-related quality of life and expectations for long-term impact of vosoritide: a modified Delphi study."
+  - reference: PMID:32864841
+    reference_title: "Natural history of achondroplasia: A retrospective review of longitudinal clinical data."
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "the greater the probability of a positive effect on the lifetime incidence of symptomatic spinal stenosis, kyphosis, obstructive sleep apnea, and foramen magnum stenosis. These are among the most clinically important complications of achondroplasia because of their high impact on comorbidity, mortality, and/or HRQoL."
-    explanation: Expert consensus identifies spinal stenosis as one of the most clinically significant complications of achondroplasia due to high impact on morbidity and quality of life.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cervical and lumbar stenosis were diagnosed in children and adults while, genu varum, elbow contractures, and radial head dislocations were identified during childhood."
+    explanation: Longitudinal chart review supports spinal stenosis as a cross-lifespan complication affecting both cervical and lumbar regions.
+  - reference: PMID:32170149
+    reference_title: "Lumbar spinal stenosis and disc alterations affect the upper lumbar spine in adults with achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Unlike the general population, spinal stenosis and disc degeneration involve the upper part of the lumbar spine in adults with achondroplasia, associated with thoraco-lumbar kyphosis and loss of lumbar lordosis."
+    explanation: Adult imaging study refines the adult lumbar phenotype by showing upper-lumbar predominance with associated degenerative change.
 - name: Obstructive sleep apnea
   description: >
-    Obstructive sleep apnea results from midface hypoplasia with upper airway narrowing
-    and may also be compounded by foramen magnum stenosis causing central apnea.
-    Requires polysomnography for evaluation.
-  frequency: HP_0040282
+    Obstructive sleep apnea is a major respiratory complication in children and can recur later in life.
   phenotype_term:
     preferred_term: Obstructive sleep apnea
     term:
       id: HP:0002870
       label: Obstructive sleep apnea
   evidence:
-  - reference: PMID:35028714
-    reference_title: "Disease-specific complications and multidisciplinary interventions in achondroplasia."
+  - reference: PMID:40675782
+    reference_title: "Sleep-disordered breathing in children with achondroplasia assessed by polysomnography: a retrospective chart review."
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "patients with ACH have a high prevalence of medical complications, including upper airway obstructive apnea, increased mortality, foramen magnum stenosis, hydrocephalus, developmental delay, recurrent ear infections, genu varum, obesity, and spinal canal stenosis, throughout their whole life."
-    explanation: Comprehensive review establishing obstructive sleep apnea as a high-prevalence complication in achondroplasia.
-- name: Recurrent otitis media
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sleep-disordered breathing subtypes included obstructive sleep apnoea in 81% (55/68), central sleep apnoea in 3% (2/68), mixed sleep apnoea in 7% (5/68) and primary snoring in 9% (6/68)."
+    explanation: In a pediatric polysomnography cohort, 55 of 80 children had obstructive sleep apnoea and 5 additional children had mixed apnoea with an obstructive component.
+  - reference: PMID:32864841
+    reference_title: "Natural history of achondroplasia: A retrospective review of longitudinal clinical data."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Central sleep apnea and obstructive sleep apnea were present in children, while the diagnosis of obstructive sleep apnea was shown to recur in adulthood."
+    explanation: Longitudinal review supports both childhood occurrence and adult recurrence of obstructive sleep apnea.
+- name: Central sleep apnea
   description: >
-    Recurrent middle ear infections due to Eustachian tube dysfunction secondary to
-    midface hypoplasia and skull base abnormalities, which can lead to conductive
-    hearing loss if inadequately managed.
-  frequency: HP_0040282
+    Central sleep apnea occurs in some affected children and is part of the sleep-disordered breathing spectrum in achondroplasia.
   phenotype_term:
-    preferred_term: Recurrent otitis media
+    preferred_term: Central sleep apnea
     term:
-      id: HP:0000403
-      label: Recurrent otitis media
+      id: HP:0010536
+      label: Central sleep apnea
   evidence:
-  - reference: PMID:35028714
-    reference_title: "Disease-specific complications and multidisciplinary interventions in achondroplasia."
+  - reference: PMID:32864841
+    reference_title: "Natural history of achondroplasia: A retrospective review of longitudinal clinical data."
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "patients with ACH have a high prevalence of medical complications, including upper airway obstructive apnea, increased mortality, foramen magnum stenosis, hydrocephalus, developmental delay, recurrent ear infections, genu varum, obesity, and spinal canal stenosis, throughout their whole life."
-    explanation: Recurrent ear infections are listed among the high-prevalence complications of achondroplasia.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Central sleep apnea and obstructive sleep apnea were present in children, while the diagnosis of obstructive sleep apnea was shown to recur in adulthood."
+    explanation: Longitudinal natural-history data explicitly document central sleep apnea in children with achondroplasia.
+  - reference: PMID:40675782
+    reference_title: "Sleep-disordered breathing in children with achondroplasia assessed by polysomnography: a retrospective chart review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sleep-disordered breathing subtypes included obstructive sleep apnoea in 81% (55/68), central sleep apnoea in 3% (2/68), mixed sleep apnoea in 7% (5/68) and primary snoring in 9% (6/68)."
+    explanation: Polysomnography cohort confirms central sleep apnoea as a measured pediatric sleep phenotype, although much less common than obstructive disease.
+- name: Otitis media with effusion
+  description: >
+    Otitis media with effusion is a common otologic complication and often leads to repeated ventilation-tube placement.
+  phenotype_term:
+    preferred_term: Otitis media with effusion
+    term:
+      id: HP:0031353
+      label: Otitis media with effusion
+  evidence:
+  - reference: PMID:39660705
+    reference_title: "Otologic Manifestations in Patients with Achondroplasia: A Multicenter Study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fifty-one patients (72.9%) had middle ear effusion at least once."
+    explanation: Multicenter otology cohort shows otitis media with effusion in most evaluated patients.
+- name: Conductive hearing impairment
+  description: >
+    Hearing loss is common and is usually conductive or mixed rather than purely sensorineural.
+  phenotype_term:
+    preferred_term: Conductive hearing impairment
+    term:
+      id: HP:0000405
+      label: Conductive hearing impairment
+  evidence:
+  - reference: PMID:39660705
+    reference_title: "Otologic Manifestations in Patients with Achondroplasia: A Multicenter Study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Among 53 patients who underwent audiometry, 26 showed conductive hearing loss, 2 had mixed-type hearing loss, and 4 had sensorineural hearing loss."
+    explanation: Pediatric multicenter cohort shows that hearing loss in achondroplasia is usually conductive or mixed.
+  - reference: PMID:34736503
+    reference_title: "Hearing loss in Norwegian adults with achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The majority (15/24) had conductive hearing loss, or a combination of conductive and sensorineural hearing loss (8/24)."
+    explanation: Adult population-based cohort shows conductive or mixed hearing loss remains common beyond childhood.
 - name: Obesity
-  description: Obesity is a common complication in both children and adults with achondroplasia, worsening orthopedic and cardiovascular outcomes.
-  frequency: HP_0040282
+  description: >
+    Obesity begins in early childhood and remains prevalent across the lifespan.
   phenotype_term:
     preferred_term: Obesity
     term:
       id: HP:0001513
       label: Obesity
   evidence:
-  - reference: PMID:35028714
-    reference_title: "Disease-specific complications and multidisciplinary interventions in achondroplasia."
+  - reference: PMID:3228140
+    reference_title: "Obesity in achondroplasia."
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "patients with ACH have a high prevalence of medical complications, including upper airway obstructive apnea, increased mortality, foramen magnum stenosis, hydrocephalus, developmental delay, recurrent ear infections, genu varum, obesity, and spinal canal stenosis, throughout their whole life."
-    explanation: Obesity is documented as a prevalent complication in achondroplasia across the lifespan.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Obesity is a significant and potentially serious health problem in achondroplasia. Body mass indices, weight-to-square of the height ratio (W/H2), and triceps skinfold measurements show that obesity is common. It begins in early childhood and is prevalent at all ages."
+    explanation: Classic cohort study directly supports obesity as an early and persistent complication.
 - name: Hydrocephalus
   description: >
-    Communicating hydrocephalus can develop due to impaired venous drainage at the
-    narrowed foramen magnum and jugular foramina. Most cases stabilize without shunting,
-    but monitoring of head circumference and fontanelle is required.
-  frequency: HP_0040283
+    Hydrocephalus is an occasional but clinically important neurosurgical complication in childhood.
   phenotype_term:
     preferred_term: Hydrocephalus
     term:
       id: HP:0000238
       label: Hydrocephalus
   evidence:
-  - reference: PMID:35028714
-    reference_title: "Disease-specific complications and multidisciplinary interventions in achondroplasia."
+  - reference: PMID:33579320
+    reference_title: "Predictors of cervical myelopathy and hydrocephalus in young children with achondroplasia."
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "patients with ACH have a high prevalence of medical complications, including upper airway obstructive apnea, increased mortality, foramen magnum stenosis, hydrocephalus, developmental delay, recurrent ear infections, genu varum, obesity, and spinal canal stenosis, throughout their whole life."
-    explanation: Hydrocephalus is recognized as a complication of achondroplasia, secondary to skull base abnormalities.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cervical myelopathy and hydrocephalus occasionally occur in young children with achondroplasia."
+    explanation: Supports hydrocephalus as a recognized pediatric complication without overstating its frequency.
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One patient developed hydrocephalus at 10 years old."
+    explanation: Natural-history cohort provides direct longitudinal evidence that hydrocephalus can occur during follow-up.
+- name: Delayed gross motor development
+  description: >
+    Children with achondroplasia show delayed acquisition of gross motor and ambulatory skills.
+  phenotype_term:
+    preferred_term: Delayed gross motor development
+    term:
+      id: HP:0002194
+      label: Delayed gross motor development
+  evidence:
+  - reference: PMID:22409389
+    reference_title: "Development in children with achondroplasia: a prospective clinical cohort study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "children with achondroplasia are delayed in development of gross motor and ambulatory skills."
+    explanation: Prospective developmental cohort directly supports delayed gross motor development.
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "There was motor developmental delay in 18 patients and speech delay in 16 patients."
+    explanation: Independent natural-history cohort corroborates developmental delay affecting motor milestones.
+- name: Delayed speech and language development
+  description: >
+    Speech and language delay is reported in pediatric achondroplasia cohorts.
+  phenotype_term:
+    preferred_term: Delayed speech and language development
+    term:
+      id: HP:0000750
+      label: Delayed speech and language development
+  evidence:
+  - reference: PMID:29972438
+    reference_title: "Natural history of 39 patients with Achondroplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "There was motor developmental delay in 18 patients and speech delay in 16 patients."
+    explanation: Natural-history cohort directly reports speech delay in a substantial subset of patients.
+  - reference: PMID:22409389
+    reference_title: "Development in children with achondroplasia: a prospective clinical cohort study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "While delays were seen in development of later communication items, there were fewer delays seen across development of early communication, fine motor, and feeding skills."
+    explanation: Prospective developmental study supports delayed later communication skill acquisition.
+- name: Elbow contracture
+  description: >
+    Elbow contractures are recognized childhood orthopedic manifestations.
+  phenotype_term:
+    preferred_term: Elbow contracture
+    term:
+      id: HP:0034391
+      label: Elbow contracture
+  evidence:
+  - reference: PMID:32864841
+    reference_title: "Natural history of achondroplasia: A retrospective review of longitudinal clinical data."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cervical and lumbar stenosis were diagnosed in children and adults while, genu varum, elbow contractures, and radial head dislocations were identified during childhood."
+    explanation: Longitudinal chart review identifies elbow contractures as a childhood orthopedic phenotype.
+- name: Radial head dislocation
+  description: >
+    Radial head dislocation is an orthopedic manifestation recognized during childhood.
+  phenotype_term:
+    preferred_term: Radial head dislocation
+    term:
+      id: HP:0005070
+      label: Proximal radial head dislocation
+  evidence:
+  - reference: PMID:32864841
+    reference_title: "Natural history of achondroplasia: A retrospective review of longitudinal clinical data."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cervical and lumbar stenosis were diagnosed in children and adults while, genu varum, elbow contractures, and radial head dislocations were identified during childhood."
+    explanation: Longitudinal chart review identifies radial head dislocation as a childhood orthopedic phenotype.
 genetic:
 - name: FGFR3 G380R mutation
   association: Causative

--- a/references_cache/PMID_22409389.md
+++ b/references_cache/PMID_22409389.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:22409389"
+title: "Development in children with achondroplasia: a prospective clinical cohort study."
+authors:
+- Ireland PJ
+- Donaghey S
+- McGill J
+- Zankl A
+- Ware RS
+- Pacey V
+- Ault J
+- Savarirayan R
+- Sillence D
+- Thompson E
+- Townshend S
+- Johnston LM
+journal: Dev Med Child Neurol
+year: '2012'
+doi: 10.1111/j.1469-8749.2012.04234.x
+keywords:
+- "Achondroplasia/complications, epidemiology"
+- Australia
+- "Child, Preschool"
+- Cohort Studies
+- Community Health Planning
+- "Developmental Disabilities/complications, epidemiology"
+- Disability Evaluation
+- Family Health
+- Female
+- Humans
+- Male
+- Movement/physiology
+- New Zealand
+- Retrospective Studies
+- Severity of Illness Index
+- Surveys and Questionnaires
+content_type: abstract_only
+---
+
+# Development in children with achondroplasia: a prospective clinical cohort study.
+**Authors:** Ireland PJ, Donaghey S, McGill J, Zankl A, Ware RS, Pacey V, Ault J, Savarirayan R, Sillence D, Thompson E, Townshend S, Johnston LM
+**Journal:** Dev Med Child Neurol (2012)
+**DOI:** [10.1111/j.1469-8749.2012.04234.x](https://doi.org/10.1111/j.1469-8749.2012.04234.x)
+
+## Content
+
+1. Dev Med Child Neurol. 2012 Jun;54(6):532-7. doi: 
+10.1111/j.1469-8749.2012.04234.x. Epub 2012 Mar 12.
+
+Development in children with achondroplasia: a prospective clinical cohort 
+study.
+
+Ireland PJ(1), Donaghey S, McGill J, Zankl A, Ware RS, Pacey V, Ault J, 
+Savarirayan R, Sillence D, Thompson E, Townshend S, Johnston LM.
+
+Author information:
+(1)Queensland Paediatric Rehabilitation Service, Royal Children's Hospital, 
+Brisbane, Qld., Australia. penny_ireland@health.qld.gov.au
+
+Comment in
+    Dev Med Child Neurol. 2012 Jun;54(6):488-9. doi: 
+10.1111/j.1469-8749.2012.04267.x.
+
+AIM: Achondroplasia is characterized by delays in the development of 
+communication and motor skills. While previously reported developmental profiles 
+exist across gross motor, fine motor, feeding, and communication skills, there 
+has been no prospective study of development across multiple areas 
+simultaneously.
+METHOD: This Australasian population-based study utilized a prospective 
+questionnaire to quantify developmental data for skills in children born from 
+2000 to 2009. Forty-eight families from Australia and New Zealand were asked to 
+report every 3 months on their child's attainment of 41 milestones. Results 
+include reference to previously available prospective information.
+RESULTS: Information from questionnaires was used to develop an 
+achondroplasia-specific developmental recording form. The 25th, 50th, 75th, and 
+90th centiles were plotted to offer clear guidelines for development across 
+gross motor, fine motor, feeding, and communication skills in children with 
+achondroplasia.
+INTERPRETATIONS: Consistent with results from previous research, children with 
+achondroplasia are delayed in development of gross motor and ambulatory skills. 
+Young children with achondroplasia demonstrate a number of unique movement 
+strategies that appear compensatory for the biomechanical changes. While delays 
+were seen in development of later communication items, there were fewer delays 
+seen across development of early communication, fine motor, and feeding skills.
+
+© The Authors. Developmental Medicine & Child Neurology © 2012 Mac Keith Press.
+
+DOI: 10.1111/j.1469-8749.2012.04234.x
+PMID: 22409389 [Indexed for MEDLINE]

--- a/references_cache/PMID_27927547.md
+++ b/references_cache/PMID_27927547.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:27927547"
+title: Prevalence of Scoliosis and Thoracolumbar Kyphosis in Patients With Achondroplasia.
+authors:
+- Khan BI
+- Yost MT
+- Badkoobehi H
+- Ain MC
+journal: Spine Deform
+year: '2016'
+doi: 10.1016/j.jspd.2015.08.003
+keywords:
+- Achondroplasia/complications
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- "Infant, Newborn"
+- "Kyphosis/complications, epidemiology"
+- Lumbar Vertebrae
+- Male
+- Prevalence
+- Retrospective Studies
+- "Scoliosis/complications, epidemiology"
+- Spinal Fusion
+- Thoracic Vertebrae
+- Young Adult
+content_type: abstract_only
+---
+
+# Prevalence of Scoliosis and Thoracolumbar Kyphosis in Patients With Achondroplasia.
+**Authors:** Khan BI, Yost MT, Badkoobehi H, Ain MC
+**Journal:** Spine Deform (2016)
+**DOI:** [10.1016/j.jspd.2015.08.003](https://doi.org/10.1016/j.jspd.2015.08.003)
+
+## Content
+
+1. Spine Deform. 2016 Mar;4(2):145-148. doi: 10.1016/j.jspd.2015.08.003. Epub
+2016  Feb 2.
+
+Prevalence of Scoliosis and Thoracolumbar Kyphosis in Patients With 
+Achondroplasia.
+
+Khan BI(1), Yost MT(1), Badkoobehi H(1), Ain MC(2).
+
+Author information:
+(1)Department of Orthopaedic Surgery, The Johns Hopkins School of Medicine, 4940 
+Eastern Ave., Baltimore, MD 21224, USA.
+(2)Department of Orthopaedic Surgery, The Johns Hopkins School of Medicine, 4940 
+Eastern Ave., Baltimore, MD 21224, USA. Electronic address: 
+editorialservices@jhmi.edu.
+
+STUDY DESIGN: Retrospective chart review, case series.
+OBJECTIVES: To determine the prevalence of scoliosis and kyphosis in patients 
+with achondroplasia.
+SUMMARY OF BACKGROUND DATA: There is little published research on the prevalence 
+of scoliosis and thoracolumbar kyphosis in patients with achondroplasia.
+METHODS: The authors retrospectively reviewed charts of 459 patients with 
+achondroplasia who were seen by the senior author, an orthopedic surgeon, from 
+1999 through 2013, at a tertiary referral center. After excluding patients who 
+presented after spinal surgery and those who were referred for specific 
+non-spinal issues, 326 patients were included (71%). Cobb angles were measured 
+on lateral and posteroanterior radiographs. Scoliosis was defined as curvature 
+on posteroanterior radiographs greater than 10°; thoracolumbar kyphosis was 
+defined as any kyphotic curvature with an apex between T11 and L2. These data 
+were then stratified by sex, age group (0-2, 3-12, 13-19, 20-40, and >40 years), 
+and severity: within normal limits (≤10°), mild (>10°-25°), moderate (26°-50°), 
+and severe (>50°).
+RESULTS: The study population consisted of 176 males and 150 females with a mean 
+age of 18 years. Scoliosis was observed in 60%. Thoracolumbar kyphosis was 
+observed in 79%, with 52% exhibiting moderate to severe curvature.
+CONCLUSIONS: In these patients, the rates of scoliosis and kyphosis were 60% and 
+79%, respectively, which are much higher than the rates reported in the 
+literature for the general population of children.
+LEVEL OF EVIDENCE: Level 3 or 4.
+
+Copyright © 2016 Scoliosis Research Society. Published by Elsevier Inc. All 
+rights reserved.
+
+DOI: 10.1016/j.jspd.2015.08.003
+PMID: 27927547 [Indexed for MEDLINE]

--- a/references_cache/PMID_29972438.md
+++ b/references_cache/PMID_29972438.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:29972438"
+title: Natural history of 39 patients with Achondroplasia.
+authors:
+- Ceroni JRM
+- Soares DCQ
+- Testai LC
+- Kawahira RSH
+- Yamamoto GL
+- Sugayama SMM
+- Oliveira LAN
+- Bertola DR
+- Kim CA
+journal: Clinics (Sao Paulo)
+year: '2018'
+doi: 10.6061/clinics/2018/e324
+keywords:
+- "Achondroplasia/diagnosis, genetics, pathology"
+- Adult
+- Age Factors
+- Aged
+- Female
+- Follow-Up Studies
+- Humans
+- "Infant, Newborn"
+- Male
+- Middle Aged
+- Molecular Diagnostic Techniques
+- Mutation
+- Radiography
+- "Receptor, Fibroblast Growth Factor, Type 3/genetics"
+- Retrospective Studies
+- Young Adult
+content_type: abstract_only
+---
+
+# Natural history of 39 patients with Achondroplasia.
+**Authors:** Ceroni JRM, Soares DCQ, Testai LC, Kawahira RSH, Yamamoto GL, Sugayama SMM, Oliveira LAN, Bertola DR, Kim CA
+**Journal:** Clinics (Sao Paulo) (2018)
+**DOI:** [10.6061/clinics/2018/e324](https://doi.org/10.6061/clinics/2018/e324)
+
+## Content
+
+1. Clinics (Sao Paulo). 2018 Jul 2;73:e324. doi: 10.6061/clinics/2018/e324.
+
+Natural history of 39 patients with Achondroplasia.
+
+Ceroni JRM(1), Soares DCQ(1), Testai LC(2), Kawahira RSH(1), Yamamoto GL(1), 
+Sugayama SMM(1), Oliveira LAN(3), Bertola DR(1), Kim CA(1).
+
+Author information:
+(1)Unidade de Genetica, Instituto da Crianca (ICR), Hospital das Clinicas 
+HCFMUSP, Faculdade de Medicina, Universidade de Sao Paulo, Sao Paulo, SP, BR.
+(2)Centro de Pesquisas sobre o Genoma Humano e Celulas-Tronco (CEGH-CEL), 
+Instituto de Biociencias (IB), Universidade de Sao Paulo, Sao Paulo, SP, BR.
+(3)Unidade de Radiologia, Instituto da Crianca (ICR), Hospital das Clinicas 
+HCFMUSP, Faculdade de Medicina, Universidade de Sao Paulo, Sao Paulo, SP, BR.
+
+OBJECTIVES: To characterize the natural history of 39 achondroplastic patients 
+diagnosed by clinical, radiological and molecular assessments.
+METHODS: Observational and retrospective study of 39 patients who were attended 
+at a public tertiary level hospital between 1995 and 2016.
+RESULTS: Diagnosis was made prenatally in 11 patients, at birth in 9 patients 
+and within the first year of life in 13 patients. The most prevalent clinical 
+findings were short stature, high forehead, trident hands, genu varum and 
+macrocephaly. The most prevalent radiographic findings were rhizomelic 
+shortening of the long bones and narrowing of the interpediculate distance of 
+the caudal spine. There was motor developmental delay in 18 patients and speech 
+delay in 16 patients. The most common clinical intercurrences were middle ear 
+dysfunction, sleep apnea, limb pain and obesity from 2 to 9 years of age. One 
+patient was large for the gestational age but did not develop obesity. One 
+patient developed hydrocephalus at 10 years old. The current age of the patients 
+varies from 15 months to 36 years. The molecular study performed by Sanger 
+sequencing of the common heterozygous mutation 1138G>A in FGFR3 was positive in 
+all patients. Four cases were inherited, and 35 were sporadic (paternal age from 
+19 to 66 years).
+CONCLUSIONS: The diagnoses were made early based on clinical and radiographic 
+findings. All cases were confirmed molecularly. Despite presenting a benign 
+course, it is necessary to establish a systematic protocol for the surveillance 
+of these patients due to the common clinical intercurrences.
+
+DOI: 10.6061/clinics/2018/e324
+PMCID: PMC6005962
+PMID: 29972438 [Indexed for MEDLINE]
+
+Conflict of interest statement: No potential conflict of interest was reported.

--- a/references_cache/PMID_32170149.md
+++ b/references_cache/PMID_32170149.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:32170149"
+title: Lumbar spinal stenosis and disc alterations affect the upper lumbar spine in adults with achondroplasia.
+authors:
+- Huet T
+- Cohen-Solal M
+- Laredo JD
+- Collet C
+- Baujat G
+- Cormier-Daire V
+- Yelnik A
+- Orcel P
+- Beaudreuil J
+journal: Sci Rep
+year: '2020'
+doi: 10.1038/s41598-020-61704-w
+keywords:
+- "Achondroplasia/diagnostic imaging, pathology"
+- Adult
+- Female
+- Humans
+- "Intervertebral Disc Degeneration/diagnostic imaging, pathology"
+- "Lumbar Vertebrae/diagnostic imaging, pathology"
+- Magnetic Resonance Imaging
+- Male
+- Middle Aged
+- Radiography
+- "Spinal Stenosis/diagnostic imaging, pathology"
+content_type: abstract_only
+---
+
+# Lumbar spinal stenosis and disc alterations affect the upper lumbar spine in adults with achondroplasia.
+**Authors:** Huet T, Cohen-Solal M, Laredo JD, Collet C, Baujat G, Cormier-Daire V, Yelnik A, Orcel P, Beaudreuil J
+**Journal:** Sci Rep (2020)
+**DOI:** [10.1038/s41598-020-61704-w](https://doi.org/10.1038/s41598-020-61704-w)
+
+## Content
+
+1. Sci Rep. 2020 Mar 13;10(1):4699. doi: 10.1038/s41598-020-61704-w.
+
+Lumbar spinal stenosis and disc alterations affect the upper lumbar spine in 
+adults with achondroplasia.
+
+Huet T(1), Cohen-Solal M(1), Laredo JD(2), Collet C(3), Baujat G(4), 
+Cormier-Daire V(4), Yelnik A(5), Orcel P(1), Beaudreuil J(6)(7).
+
+Author information:
+(1)Université de Paris, BIOSCAR Inserm U1132 and Department of Rheumatology and 
+Reference Center for Constitutional Bone Diseases, AP-HP Hospital Lariboisière, 
+F-75010, Paris, France.
+(2)Université de Paris, Department of Bone and Joint Imaging, AP-HP Hospital 
+Lariboisière, F-75010, Paris, France.
+(3)Université de Paris, Department of Biochemistry and Genetics, AP-HP Hospital 
+Lariboisière, F-75010, Paris, France.
+(4)Université de Paris, Department of Genetics, Reference Center for 
+Constitutional Bone Diseases, AP-HP Hospital Necker, Paris, France.
+(5)Université de Paris, Department of Physical Medicine and Rehabilitation, 
+AP-HP Hospital Fernand Widal, Paris, France.
+(6)Université de Paris, BIOSCAR Inserm U1132 and Department of Rheumatology and 
+Reference Center for Constitutional Bone Diseases, AP-HP Hospital Lariboisière, 
+F-75010, Paris, France. johann.beaudreuil@aphp.fr.
+(7)Université de Paris, Department of Physical Medicine and Rehabilitation, 
+AP-HP Hospital Fernand Widal, Paris, France. johann.beaudreuil@aphp.fr.
+
+In achondroplasia, lumbar spinal stenosis arises from congenital dysplasia and 
+acquired degenerative changes. We here aimed to describe the changes of the 
+lumbar spinal canal and intervertebral disc in adults. We included 18 adults 
+(age ≥ 18 years) with achondroplasia and lumbar spinal stenosis. Radiographs 
+were used to analyze spinal-pelvic angles. Antero-posterior diameter of the 
+spinal canal and the grade of disc degeneration were measured by MRI. 
+Antero-posterior diameters of the spinal canal differed by spinal level 
+(P < 0.05), with lower values observed at T12-L1, L1-2 and L2-3. Degrees of disc 
+degeneration differed by intervertebral level, with higher degrees observed at 
+L1-2, L2-3 and L3-4. A significant correlation was found between disc 
+degeneration and thoraco-lumbar kyphosis at L2-3, between antero-posterior 
+diameter of the spinal canal and lumbar lordosis at T12-L1 and L2-3, and between 
+antero-posterior diameter of the spinal canal and thoraco-lumbar kyphosis at 
+L1-2. Unlike the general population, spinal stenosis and disc degeneration 
+involve the upper part of the lumbar spine in adults with achondroplasia, 
+associated with thoraco-lumbar kyphosis and loss of lumbar lordosis.
+
+DOI: 10.1038/s41598-020-61704-w
+PMCID: PMC7070089
+PMID: 32170149 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_3228140.md
+++ b/references_cache/PMID_3228140.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:3228140"
+title: Obesity in achondroplasia.
+authors:
+- Hecht JT
+- Hood OJ
+- Schwartz RJ
+- Hennessey JC
+- Bernhardt BA
+- Horton WA
+journal: Am J Med Genet
+year: '1988'
+doi: 10.1002/ajmg.1320310314
+keywords:
+- Achondroplasia/complications
+- Adolescent
+- Adult
+- Aged
+- Body Constitution
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- "Infant, Newborn"
+- Male
+- Middle Aged
+- "Obesity/etiology, prevention & control"
+- Skinfold Thickness
+content_type: abstract_only
+---
+
+# Obesity in achondroplasia.
+**Authors:** Hecht JT, Hood OJ, Schwartz RJ, Hennessey JC, Bernhardt BA, Horton WA
+**Journal:** Am J Med Genet (1988)
+**DOI:** [10.1002/ajmg.1320310314](https://doi.org/10.1002/ajmg.1320310314)
+
+## Content
+
+1. Am J Med Genet. 1988 Nov;31(3):597-602. doi: 10.1002/ajmg.1320310314.
+
+Obesity in achondroplasia.
+
+Hecht JT(1), Hood OJ, Schwartz RJ, Hennessey JC, Bernhardt BA, Horton WA.
+
+Author information:
+(1)University of Texas Health Science Center at Houston.
+
+Obesity is a significant and potentially serious health problem in 
+achondroplasia. Body mass indices, weight-to-square of the height ratio (W/H2), 
+and triceps skinfold measurements show that obesity is common. It begins in 
+early childhood and is prevalent at all ages. We recommend that weight be 
+monitored closely in all persons with achondroplasia and that dietary 
+intervention be instituted whenever the body mass indices, W/H2, and triceps 
+skinfold measurements exceed the 95th centile for the general population.
+
+DOI: 10.1002/ajmg.1320310314
+PMID: 3228140 [Indexed for MEDLINE]

--- a/references_cache/PMID_32864841.md
+++ b/references_cache/PMID_32864841.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:32864841"
+title: "Natural history of achondroplasia: A retrospective review of longitudinal clinical data."
+authors:
+- Okenfuss E
+- Moghaddam B
+- Avins AL
+journal: Am J Med Genet A
+year: '2020'
+doi: 10.1002/ajmg.a.61825
+keywords:
+- "Achondroplasia/complications, genetics"
+- Adolescent
+- Adult
+- Brain/abnormalities
+- Cervical Vertebrae/surgery
+- Child
+- "Child, Preschool"
+- "Constriction, Pathologic"
+- "Databases, Factual"
+- Female
+- Foramen Magnum/surgery
+- Humans
+- Infant
+- "Infant, Newborn"
+- "Kyphosis/complications, genetics, surgery"
+- Longitudinal Studies
+- Male
+- Middle Aged
+- "Nervous System Diseases/complications, genetics"
+- Orthopedics
+- Retrospective Studies
+- "Sleep Apnea, Obstructive/complications, genetics"
+- Young Adult
+content_type: abstract_only
+---
+
+# Natural history of achondroplasia: A retrospective review of longitudinal clinical data.
+**Authors:** Okenfuss E, Moghaddam B, Avins AL
+**Journal:** Am J Med Genet A (2020)
+**DOI:** [10.1002/ajmg.a.61825](https://doi.org/10.1002/ajmg.a.61825)
+
+## Content
+
+1. Am J Med Genet A. 2020 Nov;182(11):2540-2551. doi: 10.1002/ajmg.a.61825. Epub 
+2020 Aug 31.
+
+Natural history of achondroplasia: A retrospective review of longitudinal 
+clinical data.
+
+Okenfuss E(1), Moghaddam B(1), Avins AL(2).
+
+Author information:
+(1)Department of Genetics, Kaiser Permanente, Sacramento, California, USA.
+(2)Division of Research, Kaiser Permanente, Oakland, California, USA.
+
+There are limited data on the longitudinal frequency and severity of the 
+symptoms and complications of achondroplasia. We undertook a retrospective 
+electronic chart review of 114 patients to develop a more thorough understanding 
+of the lifetime impact of achondroplasia. Craniocervical stenosis (involving the 
+foramen magnum with or without cervical vertebrae C1 and/or C2) was noted in 
+nearly 50% of patients with craniovertebral junction imaging; however, 
+corrective decompression surgery was only needed in 6% of patients. No children 
+in our cohort died at 4 years of age or under. Kyphosis was present in most 
+patients but usually resolved in early childhood. Cervical and lumbar stenosis 
+were diagnosed in children and adults while, genu varum, elbow contractures, and 
+radial head dislocations were identified during childhood. Central sleep apnea 
+and obstructive sleep apnea were present in children, while the diagnosis of 
+obstructive sleep apnea was shown to recur in adulthood. Cardiovascular risk 
+factors were present in only 7% of patients. A range of mental health disorders 
+were identified, with most diagnoses being made before 18 years of age. Our data 
+show that achondroplasia has a significant impact on patients' physical health, 
+and complications continue to be reported and require intervention throughout 
+patients' lifetimes. This highlights the need for continuous support beyond 
+pediatric care, by adult care clinicians experienced with managing the long-term 
+complications of achondroplasia.
+
+© 2020 Wiley Periodicals LLC.
+
+DOI: 10.1002/ajmg.a.61825
+PMID: 32864841 [Indexed for MEDLINE]

--- a/references_cache/PMID_32883660.md
+++ b/references_cache/PMID_32883660.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:32883660"
+title: "Achondroplasia Foramen Magnum Score: screening infants for stenosis."
+authors:
+- Cheung MS
+- Irving M
+- Cocca A
+- Santos R
+- Shaunak M
+- Dougherty H
+- Siddiqui A
+- Gringras P
+- Thompson D
+journal: Arch Dis Child
+year: '2021'
+doi: 10.1136/archdischild-2020-319625
+keywords:
+- "Achondroplasia/diagnosis, diagnostic imaging, surgery"
+- Algorithms
+- "Child, Preschool"
+- "Constriction, Pathologic/diagnosis, diagnostic imaging, surgery"
+- Decision Trees
+- "Decompression, Surgical"
+- Female
+- Foramen Magnum/pathology
+- Humans
+- Infant
+- "Infant, Newborn"
+- Magnetic Resonance Imaging
+- Male
+- Neonatal Screening
+- Predictive Value of Tests
+- Severity of Illness Index
+content_type: abstract_only
+---
+
+# Achondroplasia Foramen Magnum Score: screening infants for stenosis.
+**Authors:** Cheung MS, Irving M, Cocca A, Santos R, Shaunak M, Dougherty H, Siddiqui A, Gringras P, Thompson D
+**Journal:** Arch Dis Child (2021)
+**DOI:** [10.1136/archdischild-2020-319625](https://doi.org/10.1136/archdischild-2020-319625)
+
+## Content
+
+1. Arch Dis Child. 2021 Feb;106(2):180-184. doi:
+10.1136/archdischild-2020-319625.  Epub 2020 Sep 3.
+
+Achondroplasia Foramen Magnum Score: screening infants for stenosis.
+
+Cheung MS(1), Irving M(2), Cocca A(3), Santos R(4), Shaunak M(3), Dougherty 
+H(3), Siddiqui A(5), Gringras P(6), Thompson D(7).
+
+Author information:
+(1)Department of Paediatric Endocrinology, Evelina London Children's Hospital, 
+London, UK Moira.Cheung@gstt.nhs.uk.
+(2)Department of Clinical Genetics, Guy's and St Thomas' NHS Foundation Trust, 
+London, UK.
+(3)Department of Paediatric Endocrinology, Evelina London Children's Hospital, 
+London, UK.
+(4)Department of Paediatric Radiology, Guy's and St Thomas' NHS Foundation 
+Trust, London, UK.
+(5)Department of Neuroradiology, Guy's and St Thomas' NHS Foundation Trust, 
+London, UK.
+(6)Department of Sleep and Neurodisability, Evelina London Children's Hospital, 
+London, UK.
+(7)Department of Paediatric Neurosurgery, Great Ormond Street Hospital, London, 
+UK.
+
+BACKGROUND: Achondroplasia is associated with foramen magnum stenosis (FMS) and 
+significant risk of morbidity and sudden death in infants. A sensitive and 
+reliable method of detecting infants who require decompressive surgery is 
+required. This study aims to describe the incidence and severity of FMS in an 
+unselected, sequential series of infants using a novel MRI score and 
+retrospectively correlate severity with clinical examination and 
+cardiorespiratory sleep (CRS) studies.
+METHODS: The Achondroplasia Foramen Magnum Score (AFMS) was developed and scores 
+were retrospectively correlated with clinical and CRS data over a 3-year period.
+RESULTS: Of 36 infants (M:F, 18:18), 2 (5.6%) did not have FMS (AFMS0); 13 
+(36.1%) had FMS with preservation of the cerebrospinal fluid (CSF) spaces 
+(AFMS1); 3 (8.3%) had FMS with loss of the CSF space but no spinal cord 
+distortion (AFMS2); 13 (36.1%) had FMS with flattening of the cervical cord 
+without signal change (AFMS3); and 5 (13.9%) had FMS resulting in cervical cord 
+signal change (AFMS4). Mean Total Apnea and Hypopnea Index (TAHI) for AFMS0-4 
+was 3.4, 6.41, 2.97, 10.5 and 25.8, respectively. Severe TAHI had a specificity 
+of 89% but only a 59% sensitivity for AFMS3-4. Neurological examination was 
+normal in 34/36 (94%) patients. Overall, 9/36 (25%) infants required 
+neurosurgery with minimal surgical complications.
+CONCLUSIONS: Clinical examination and CRS have a low sensitivity for predicting 
+the effects of foramen stenosis on the spinal cord. Routine screening with MRI 
+using AFMS can aid in detecting early spinal cord changes and has the potential 
+to reduce infant morbidity and mortality.
+
+© Author(s) (or their employer(s)) 2021. No commercial re-use. See rights and 
+permissions. Published by BMJ.
+
+DOI: 10.1136/archdischild-2020-319625
+PMID: 32883660 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None declared.

--- a/references_cache/PMID_33579320.md
+++ b/references_cache/PMID_33579320.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:33579320"
+title: Predictors of cervical myelopathy and hydrocephalus in young children with achondroplasia.
+authors:
+- Shim Y
+- Ko JM
+- Cho TJ
+- Kim SK
+- Phi JH
+journal: Orphanet J Rare Dis
+year: '2021'
+doi: 10.1186/s13023-021-01725-4
+keywords:
+- Achondroplasia/complications
+- Child
+- "Child, Preschool"
+- Foramen Magnum
+- Humans
+- Hydrocephalus
+- Magnetic Resonance Imaging
+- Retrospective Studies
+- Spinal Cord Diseases
+content_type: abstract_only
+---
+
+# Predictors of cervical myelopathy and hydrocephalus in young children with achondroplasia.
+**Authors:** Shim Y, Ko JM, Cho TJ, Kim SK, Phi JH
+**Journal:** Orphanet J Rare Dis (2021)
+**DOI:** [10.1186/s13023-021-01725-4](https://doi.org/10.1186/s13023-021-01725-4)
+
+## Content
+
+1. Orphanet J Rare Dis. 2021 Feb 12;16(1):81. doi: 10.1186/s13023-021-01725-4.
+
+Predictors of cervical myelopathy and hydrocephalus in young children with 
+achondroplasia.
+
+Shim Y(#)(1), Ko JM(#)(2), Cho TJ(3)(4), Kim SK(1), Phi JH(5).
+
+Author information:
+(1)Division of Pediatric Neurosurgery, Seoul National University Children's 
+Hospital, Seoul National University College of Medicine, 101 Daehak-ro, 
+Jongno-gu, 03080, Seoul, Republic of Korea.
+(2)Department of Pediatrics, Seoul National University Children's Hospital, 
+Seoul National University College of Medicine, Seoul, Republic of Korea.
+(3)Division of Pediatric Orthopaedics, Seoul National University Children's 
+Hospital, Seoul, Republic of Korea.
+(4)Department of Orthopaedic Surgery, Seoul National University College of 
+Medicine, Seoul, Republic of Korea.
+(5)Division of Pediatric Neurosurgery, Seoul National University Children's 
+Hospital, Seoul National University College of Medicine, 101 Daehak-ro, 
+Jongno-gu, 03080, Seoul, Republic of Korea. phijh@snu.ac.kr.
+(#)Contributed equally
+
+BACKGROUND: Cervical myelopathy and hydrocephalus occasionally occur in young 
+children with achondroplasia. However, these conditions are not evaluated in a 
+timely manner in many cases. The current study presents significant predictors 
+for cervical myelopathy and hydrocephalus in young children with achondroplasia.
+METHODS: A retrospective analysis of 65 patients with achondroplasia who visited 
+Seoul National University Children's Hospital since 2012 was performed. The 
+patients were divided into groups according to the presence of cervical 
+myelopathy and hydrocephalus, and differences in foramen magnum parameters and 
+ventricular parameters by magnetic resonance imaging between groups were 
+analyzed. Predictors for cervical myelopathy and hydrocephalus were analyzed, 
+and the cut-off points for significant ones were calculated.
+RESULTS: The group with cervical myelopathy showed foramen magnum parameters 
+that indicated significantly lower cord thickness than in the group without 
+cervical myelopathy, and the group with hydrocephalus showed significantly 
+higher ventricular parameters and 'Posterior indentation' grade than the group 
+without hydrocephalus. 'Cord constriction ratio' (OR 5199.90, p = 0.001) for 
+cervical myelopathy and 'Frontal horn width' (OR 1.14, p = 0.001) and 'Posterior 
+indentation' grade (grade 1: OR 9.25, p = 0.06; grade 2: OR 18.50, p = 0.01) for 
+hydrocephalus were significant predictors. The cut-off points for cervical 
+myelopathy were 'Cord constriction ratio' of 0.25 and 'FM AP' of 8 mm (AUC 0.821 
+and 0.862, respectively) and 'Frontal horn width' of 50 mm and 'Posterior 
+indentation' grade of 0 (AUC 0.788 and 0.758, respectively) for hydrocephalus.
+CONCLUSION: 'Cord constriction ratio' for cervical myelopathy and 'Frontal horn 
+width' and 'Posterior indentation' grade for hydrocephalus were significant 
+predictors and may be used as useful parameters for management. 'Posterior 
+indentation' grade may also be used to determine the treatment method for 
+hydrocephalus.
+
+DOI: 10.1186/s13023-021-01725-4
+PMCID: PMC7881633
+PMID: 33579320 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare they have no competing 
+interests.

--- a/references_cache/PMID_34736503.md
+++ b/references_cache/PMID_34736503.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:34736503"
+title: Hearing loss in Norwegian adults with achondroplasia.
+authors:
+- Fredwall SO
+- Åberg B
+- Berdal H
+- Savarirayan R
+- Solheim J
+journal: Orphanet J Rare Dis
+year: '2021'
+doi: 10.1186/s13023-021-02095-7
+keywords:
+- "Achondroplasia/complications, genetics"
+- Acoustic Impedance Tests
+- Adolescent
+- Adult
+- Aged
+- "Audiometry, Pure-Tone"
+- Cross-Sectional Studies
+- Deafness
+- Female
+- Hearing Loss/etiology
+- "Hearing Loss, Sensorineural"
+- Humans
+- Male
+- Middle Aged
+- Norway
+- Young Adult
+content_type: abstract_only
+---
+
+# Hearing loss in Norwegian adults with achondroplasia.
+**Authors:** Fredwall SO, Åberg B, Berdal H, Savarirayan R, Solheim J
+**Journal:** Orphanet J Rare Dis (2021)
+**DOI:** [10.1186/s13023-021-02095-7](https://doi.org/10.1186/s13023-021-02095-7)
+
+## Content
+
+1. Orphanet J Rare Dis. 2021 Nov 4;16(1):468. doi: 10.1186/s13023-021-02095-7.
+
+Hearing loss in Norwegian adults with achondroplasia.
+
+Fredwall SO(1)(2), Åberg B(3), Berdal H(3), Savarirayan R(4), Solheim J(3).
+
+Author information:
+(1)TRS National Resource Centre for Rare Disorders, Sunnaas Rehabilitation 
+Hospital, 1450, Nesodden, Norway. svfred@sunnaas.no.
+(2)Faculty of Medicine, Institute of Clinical Medicine, University of Oslo, 
+Oslo, Norway. svfred@sunnaas.no.
+(3)Department of Hearing, Lovisenberg Diaconal Hospital, Oslo, Norway.
+(4)Victorian Clinical Genetics Services, Murdoch Children's Research Institute, 
+University of Melbourne, Parkville, Australia.
+
+BACKGROUND: Achondroplasia is the most common form of disproportionate skeletal 
+dysplasia. The condition is caused by a mutation in the FGFR3 gene, affecting 
+endochondral bone growth, including the craniofacial anatomy. Recurrent otitis 
+media infections, chronic middle ear effusion, and hearing loss are common in 
+children with achondroplasia, but few studies have investigated hearing loss in 
+adults with this condition.
+OBJECTIVES: This population-based study investigated the prevalence, severity, 
+and type of hearing loss in Norwegian adults with achondroplasia.
+METHODS: We collected data on 45 adults with genetically confirmed 
+achondroplasia: 23 men and 22 women, aged 16-70 years. All participants 
+underwent a comprehensive audiologic assessment, including medical history, 
+pure-tone audiometry, speech audiometry, and impedance audiometry. According to 
+the Global Burden of Disease classification, pure-tone average ≥ 20 decibel 
+hearing level (dB HL) was considered clinically significant hearing loss.
+RESULTS: Insertion of ventilation tubes had been performed in 44% (20/45) of the 
+participants, 49% (22/45) had a history of adenoidectomy, while 20% (9/45) used 
+hearing aids. Hearing loss in at least one ear was found in 53% (24/45) of the 
+participants; in 57% (13/23) of the men and 50% (11/22) of the women. In the 
+youngest age group (age 16-44 years), 50% (14/28) had hearing loss, although 
+predominantly mild (20-34 dB HL). An abnormal tympanometry (Type B or C) was 
+found in 71% (32/45) of the participants. The majority (15/24) had conductive 
+hearing loss, or a combination of conductive and sensorineural hearing loss 
+(8/24).
+CONCLUSIONS: Adults with achondroplasia are at increased risk of early hearing 
+loss. Our findings underline the importance of a regular hearing assessment 
+being part of standard care in achondroplasia, including adolescents and young 
+adults. In adult patients diagnosed with hearing loss, an evaluation by an 
+otolaryngologist should be considered, and the need for hearing aids, assistive 
+listening devices, and workplace and educational accommodations should be 
+discussed. Clinical trial registration ClinicalTrials.gov identifier 
+NCT03780153.
+
+© 2021. The Author(s).
+
+DOI: 10.1186/s13023-021-02095-7
+PMCID: PMC8570016
+PMID: 34736503 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have completed the ICMJE form and 
+declare that they have no competing interests.

--- a/references_cache/PMID_37072824.md
+++ b/references_cache/PMID_37072824.md
@@ -1,0 +1,113 @@
+---
+reference_id: "PMID:37072824"
+title: "Craniofacial growth and function in achondroplasia: a multimodal 3D study on 15 patients."
+authors:
+- Morice A
+- Taverne M
+- Eché S
+- Griffon L
+- Fauroux B
+- Leboulanger N
+- Couloigner V
+- Baujat G
+- Cormier-Daire V
+- Picard A
+- Legeai-Mallet L
+- Kadlub N
+- Khonsari RH
+journal: Orphanet J Rare Dis
+year: '2023'
+doi: 10.1186/s13023-023-02664-y
+keywords:
+- Humans
+- Retrognathia
+- Cephalometry
+- Sleep Apnea Syndromes
+- "Sleep Apnea, Obstructive"
+- Achondroplasia/genetics
+content_type: abstract_only
+---
+
+# Craniofacial growth and function in achondroplasia: a multimodal 3D study on 15 patients.
+**Authors:** Morice A, Taverne M, Eché S, Griffon L, Fauroux B, Leboulanger N, Couloigner V, Baujat G, Cormier-Daire V, Picard A, Legeai-Mallet L, Kadlub N, Khonsari RH
+**Journal:** Orphanet J Rare Dis (2023)
+**DOI:** [10.1186/s13023-023-02664-y](https://doi.org/10.1186/s13023-023-02664-y)
+
+## Content
+
+1. Orphanet J Rare Dis. 2023 Apr 18;18(1):88. doi: 10.1186/s13023-023-02664-y.
+
+Craniofacial growth and function in achondroplasia: a multimodal 3D study on 15 
+patients.
+
+Morice A(1)(2)(3), Taverne M(4), Eché S(5), Griffon L(6), Fauroux B(6), 
+Leboulanger N(7), Couloigner V(7), Baujat G(8)(9), Cormier-Daire V(8)(9), Picard 
+A(5), Legeai-Mallet L(8), Kadlub N(5), Khonsari RH(5)(4)(8).
+
+Author information:
+(1)Service de chirurgie maxillofaciale et chirurgie plastique, Centre de 
+Référence Maladies Rares MAFACE, Faculté de Médecine, Hôpital Necker-Enfants 
+Malades, Assistance Publique-Hôpitaux de Paris, Université Paris Cité, Paris, 
+France. anne.morice2@aphp.fr.
+(2)Laboratoire 'Forme et Croissance du Crâne', Faculté de Médecine, Hôpital 
+Necker-Enfants Malades, Assistance Publique-Hôpitaux de Paris, Université Paris 
+Cité, Paris, France. anne.morice2@aphp.fr.
+(3)Molecular and Physiopathological Bases of Osteochondrodysplasia. INSERM UMR 
+1163, Imagine Institute, Paris, France. anne.morice2@aphp.fr.
+(4)Laboratoire 'Forme et Croissance du Crâne', Faculté de Médecine, Hôpital 
+Necker-Enfants Malades, Assistance Publique-Hôpitaux de Paris, Université Paris 
+Cité, Paris, France.
+(5)Service de chirurgie maxillofaciale et chirurgie plastique, Centre de 
+Référence Maladies Rares MAFACE, Faculté de Médecine, Hôpital Necker-Enfants 
+Malades, Assistance Publique-Hôpitaux de Paris, Université Paris Cité, Paris, 
+France.
+(6)Unité de ventilation non invasive et du sommeil de l'enfant, Faculté de 
+Médecine, Hôpital Necker-Enfants Malades, Assistance Publique-Hôpitaux de Paris, 
+Université Paris Cité, VIFASOM, Paris, EA, France.
+(7)Service d'oto-rhino-laryngologie et chirurgie cervico-faciale, Faculté de 
+Médecine, Hôpital Necker-Enfants Malades, Assistance Publique-Hôpitaux de Paris, 
+Université Paris Cité, Paris, France.
+(8)Molecular and Physiopathological Bases of Osteochondrodysplasia. INSERM UMR 
+1163, Imagine Institute, Paris, France.
+(9)Centre de Référence des Maladies Osseuses Constitutionnelles, Service de 
+Médecine Génomique des Maladies Rares, Hôpital Universitaire Necker-Enfants 
+Malades, Paris, France.
+
+BACKGROUND: Achondroplasia is the most frequent FGFR3-related chondrodysplasia, 
+leading to rhizomelic dwarfism, craniofacial anomalies, stenosis of the foramen 
+magnum, and sleep apnea. Craniofacial growth and its correlation with 
+obstructive sleep apnea syndrome has not been assessed in achondroplasia. In 
+this study, we provide a multimodal analysis of craniofacial growth and 
+anatomo-functional correlations between craniofacial features and the severity 
+of obstructive sleep apnea syndrome.
+METHODS: A multimodal study was performed based on a paediatric cohort of 15 
+achondroplasia patients (mean age, 7.8 ± 3.3 years), including clinical and 
+sleep study data, 2D cephalometrics, and 3D geometric morphometry analyses, 
+based on CT-scans (mean age at CT-scan: patients, 4.9 ± 4.9 years; controls, 
+3.7 ± 4.2 years).
+RESULTS: Craniofacial phenotype was characterized by maxillo-zygomatic 
+retrusion, deep nasal root, and prominent forehead. 2D cephalometric studies 
+showed constant maxillo-mandibular retrusion, with excessive vertical dimensions 
+of the lower third of the face, and modifications of cranial base angles. All 
+patients with available CT-scan had premature fusion of skull base 
+synchondroses. 3D morphometric analyses showed more severe craniofacial 
+phenotypes associated with increasing patient age, predominantly regarding the 
+midface-with increased maxillary retrusion in older patients-and the skull 
+base-with closure of the spheno-occipital angle. At the mandibular level, both 
+the corpus and ramus showed shape modifications with age, with shortened 
+anteroposterior mandibular length, as well as ramus and condylar region lengths. 
+We report a significant correlation between the severity of maxillo-mandibular 
+retrusion and obstructive sleep apnea syndrome (p < 0.01).
+CONCLUSIONS: Our study shows more severe craniofacial phenotypes at older ages, 
+with increased maxillomandibular retrusion, and demonstrates a significant 
+anatomo-functional correlation between the severity of midface and mandible 
+craniofacial features and obstructive sleep apnea syndrome.
+
+© 2023. The Author(s).
+
+DOI: 10.1186/s13023-023-02664-y
+PMCID: PMC10114380
+PMID: 37072824 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_37493935.md
+++ b/references_cache/PMID_37493935.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:37493935"
+title: "Walking status and spinopelvic parameters in young children with achondroplasia: 10-year follow-up."
+authors:
+- da Silva LCA
+- Asma A
+- Ulusaloglu AC
+- Margetts M
+- Ditro CP
+- Rogers KJ
+- Bowen JR
+- Mackenzie WG
+- Mackenzie WGS
+journal: Spine Deform
+year: '2023'
+doi: 10.1007/s43390-023-00733-7
+keywords:
+- Humans
+- "Achondroplasia/physiopathology, complications, diagnostic imaging"
+- Male
+- Female
+- Retrospective Studies
+- Child
+- "Child, Preschool"
+- Follow-Up Studies
+- Walking/physiology
+- "Kyphosis/etiology, physiopathology, diagnostic imaging"
+- Lumbar Vertebrae/diagnostic imaging
+- Thoracic Vertebrae/diagnostic imaging
+- Pelvis
+- Disease Progression
+- Pelvic Bones/diagnostic imaging
+- Lordosis
+content_type: abstract_only
+---
+
+# Walking status and spinopelvic parameters in young children with achondroplasia: 10-year follow-up.
+**Authors:** da Silva LCA, Asma A, Ulusaloglu AC, Margetts M, Ditro CP, Rogers KJ, Bowen JR, Mackenzie WG, Mackenzie WGS
+**Journal:** Spine Deform (2023)
+**DOI:** [10.1007/s43390-023-00733-7](https://doi.org/10.1007/s43390-023-00733-7)
+
+## Content
+
+1. Spine Deform. 2023 Nov;11(6):1477-1483. doi: 10.1007/s43390-023-00733-7. Epub 
+2023 Jul 26.
+
+Walking status and spinopelvic parameters in young children with achondroplasia: 
+10-year follow-up.
+
+da Silva LCA(1), Asma A(1), Ulusaloglu AC(1), Margetts M(2), Ditro CP(1), Rogers 
+KJ(1), Bowen JR(1), Mackenzie WG(1), Mackenzie WGS(3).
+
+Author information:
+(1)Department of Orthopaedic Surgery, Nemours Children's Health, 1600 Rockland 
+Road, Wilmington, DE, 19803, USA.
+(2)Cambridge University, Cambridge, UK.
+(3)Department of Orthopaedic Surgery, Nemours Children's Health, 1600 Rockland 
+Road, Wilmington, DE, 19803, USA. stuart.mackenzie@nemours.org.
+
+PURPOSE: Thoracolumbar kyphosis (TLK) is common in children with achondroplasia 
+and resolves in 90% by 10 years of age. Our purpose was to describe the natural 
+progression of TLK in a cohort of pre-walking children with achondroplasia.
+METHODS: A single-center, retrospective review identified 62 children (32 male, 
+30 female) with achondroplasia. Clinical information and sagittal spinopelvic 
+parameters were collected. The children were divided into positive pelvic tilt 
+(PT) and negative PT. All parents were routinely counseled about unsupported 
+sitting.
+RESULTS: Spontaneous resolution rate was 64.5% at 1-year post-walking, 74.2% at 
+5 years of age, and 88.7% at 10 years of age. None of the children required 
+posterior spinal decompression and fusion for progressive deformity or 
+symptomatic spinal stenosis. At 1-year post-walking, the negative PT group had a 
+higher sacral slope (p = 0.006), higher lumbar lordosis (p < 0.001), and lower 
+pelvic incidence (p < 0.001). This relationship remained constant up to 10 years 
+of age, and there was no association with TLK.
+CONCLUSION: In this largest series to date, spontaneous resolution of TLK in 
+children with achondroplasia was 64.5% at 1-year post-walking, 74.2% at 5 years 
+of age, and 88.7% in children followed to 10 years of age. With early 
+identification and regular follow-up with patient education, no patient in this 
+series required treatment or developed symptomatic spinal stenosis. While not 
+predictive of resolution of TLK, the dichotomous presentation of PT in young 
+children with achondroplasia persists at 5 and 10 years of age and reliably 
+predicts the spinopelvic parameters.
+LEVEL OF EVIDENCE: III-retrospective comparative study.
+
+© 2023. The Author(s), under exclusive licence to Scoliosis Research Society.
+
+DOI: 10.1007/s43390-023-00733-7
+PMID: 37493935 [Indexed for MEDLINE]

--- a/references_cache/PMID_38554024.md
+++ b/references_cache/PMID_38554024.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:38554024"
+title: "Clinical outcomes and medical management of achondroplasia in Japanese children: A retrospective medical record review of clinical data."
+authors:
+- Saitou H
+- Kitaoka T
+- Kubota T
+- Kanno J
+- Mochizuki H
+- Michigami T
+- Hasegawa K
+- Fujiwara I
+- Hamajima T
+- Harada D
+- Seki Y
+- Nagasaki K
+- Dateki S
+- Namba N
+- Tokuoka H
+- Pimenta JM
+- Cohen S
+- Ozono K
+journal: Am J Med Genet A
+year: '2024'
+doi: 10.1002/ajmg.a.63612
+keywords:
+- Humans
+- "Achondroplasia/drug therapy, genetics, pathology"
+- Male
+- Female
+- Retrospective Studies
+- "Child, Preschool"
+- Japan/epidemiology
+- Infant
+- Human Growth Hormone/therapeutic use
+- Treatment Outcome
+- Child
+- Body Height/drug effects
+- Disease Management
+- Medical Records
+- Magnetic Resonance Imaging
+- East Asian People
+content_type: abstract_only
+---
+
+# Clinical outcomes and medical management of achondroplasia in Japanese children: A retrospective medical record review of clinical data.
+**Authors:** Saitou H, Kitaoka T, Kubota T, Kanno J, Mochizuki H, Michigami T, Hasegawa K, Fujiwara I, Hamajima T, Harada D, Seki Y, Nagasaki K, Dateki S, Namba N, Tokuoka H, Pimenta JM, Cohen S, Ozono K
+**Journal:** Am J Med Genet A (2024)
+**DOI:** [10.1002/ajmg.a.63612](https://doi.org/10.1002/ajmg.a.63612)
+
+## Content
+
+1. Am J Med Genet A. 2024 Aug;194(8):e63612. doi: 10.1002/ajmg.a.63612. Epub 2024
+ Mar 30.
+
+Clinical outcomes and medical management of achondroplasia in Japanese children: 
+A retrospective medical record review of clinical data.
+
+Saitou H(1), Kitaoka T(1), Kubota T(1), Kanno J(2), Mochizuki H(3), Michigami 
+T(4), Hasegawa K(5), Fujiwara I(6), Hamajima T(7), Harada D(8), Seki Y(9), 
+Nagasaki K(10), Dateki S(11), Namba N(12), Tokuoka H(13), Pimenta JM(14), Cohen 
+S(14), Ozono K(1).
+
+Author information:
+(1)Department of Pediatrics, Osaka University Graduate School of Medicine, 
+Suita, Japan.
+(2)Department of Pediatrics, Tohoku University Graduate School of Medicine, 
+Sendai, Japan.
+(3)Division of Endocrinology and Metabolism, Saitama Children's Medical Center, 
+Saitama, Japan.
+(4)Department of Bone and Mineral Research, Research Institute, Osaka Women's 
+and Children's Hospital, Izumi, Japan.
+(5)Department of Pediatrics, Okayama University Hospital, Okayama, Japan.
+(6)Department of Pediatrics, Sendai City Hospital, Sendai, Japan.
+(7)Department of Endocrinology and Metabolism, Aichi Children's Health and 
+Medical Center, Aichi, Japan.
+(8)Department of Pediatrics, Osaka Hospital, Japan Community of Health Care 
+Organization (JCHO), Osaka, Japan.
+(9)Department of Pediatrics, Kagoshima University School of Medicine, Kagoshima, 
+Japan.
+(10)Department of Pediatrics, Niigata University Medical & Dental Hospital, 
+Niigata, Japan.
+(11)Department of Pediatrics, Nagasaki University Graduate School of Biomedical 
+Sciences, Nagasaki, Japan.
+(12)Division of Pediatrics and Perinatology, Faculty of Medicine, Tottori 
+University, Tottori, Japan.
+(13)BioMarin Pharmaceutical Japan K.K., Tokyo, Japan.
+(14)BioMarin (U.K.) Limited, London, UK.
+
+Achondroplasia (ACH) is a rare, autosomal dominant skeletal dysplasia 
+characterized by short stature, characteristic facial configuration, and trident 
+hands. Before vosoritide approval in Japan, patients with ACH could start growth 
+hormone (GH) treatment at age 3 years. However, ACH and its treatment in young 
+Japanese children have not been studied. This retrospective, longitudinal, 
+medical records-based cohort study (before vosoritide approval) summarized 
+symptoms, complications, monitoring, surgery/interventions, and height 
+with/without GH in Japanese patients with ACH <5 years. Complications were 
+observed in 89.2% of all 37 patients; 75.7% required surgery or intervention. 
+All patients were monitored by magnetic resonance imaging; 73.0% had foramen 
+magnum stenosis, while 54.1% had Achondroplasia Foramen Magnum Score 3 or 4. Of 
+28 GH-treated patients, 22 initiating at age 3 years were generally taller after 
+12 months versus 9 non-GH-treated patients. Mean annual growth velocity 
+significantly increased from age 2 to 3 versus 3 to 4 years in GH-treated 
+patients (4.37 vs. 7.23 cm/year; p = 0.0014), but not in non-GH-treated patients 
+(4.94 vs. 4.20 cm/year). The mean height at age 4 years with/without GH was 
+83.6/79.8 cm. These results improve our understanding of young patients with ACH 
+in Japan and confirm that early diagnosis of ACH and monitoring of complications 
+help facilitate appropriate interventions.
+
+© 2024 The Authors. American Journal of Medical Genetics Part A published by 
+Wiley Periodicals LLC.
+
+DOI: 10.1002/ajmg.a.63612
+PMID: 38554024 [Indexed for MEDLINE]

--- a/references_cache/PMID_39660705.md
+++ b/references_cache/PMID_39660705.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:39660705"
+title: "Otologic Manifestations in Patients with Achondroplasia: A Multicenter Study."
+authors:
+- Kim D
+- Yoon J
+- Suh MW
+- Ho Lee J
+- Kyun Park M
+journal: J Int Adv Otol
+year: '2024'
+doi: 10.5152/iao.2024.241523
+keywords:
+- Humans
+- Achondroplasia/complications
+- Male
+- Retrospective Studies
+- Female
+- Child
+- Adolescent
+- Republic of Korea/epidemiology
+- "Child, Preschool"
+- "Hearing Loss, Conductive/etiology, diagnosis"
+- Adult
+- "Hearing Loss, Sensorineural/etiology, epidemiology, diagnosis"
+- Middle Ear Ventilation/methods
+- Young Adult
+- "Tomography, X-Ray Computed"
+- "Otitis Media with Effusion/etiology, epidemiology, complications, surgery"
+- Adenoidectomy/methods
+- Audiometry/methods
+- Treatment Outcome
+- Prevalence
+- "Temporal Bone/diagnostic imaging, pathology"
+content_type: abstract_only
+---
+
+# Otologic Manifestations in Patients with Achondroplasia: A Multicenter Study.
+**Authors:** Kim D, Yoon J, Suh MW, Ho Lee J, Kyun Park M
+**Journal:** J Int Adv Otol (2024)
+**DOI:** [10.5152/iao.2024.241523](https://doi.org/10.5152/iao.2024.241523)
+
+## Content
+
+1. J Int Adv Otol. 2024 Nov 25;20(6):517-522. doi: 10.5152/iao.2024.241523.
+
+Otologic Manifestations in Patients with Achondroplasia: A Multicenter Study.
+
+Kim D(1), Yoon J(1), Suh MW(1)(2), Ho Lee J(1)(2), Kyun Park M(1)(2).
+
+Author information:
+(1)Department of Otorhinolaryngology-Head and Neck Surgery, Seoul National 
+University College of Medicine, Seoul, Republic of Korea.
+(2)Sensory Organ Research Institute, Seoul National University Medical Research 
+Center, Seoul, Republic of Korea.
+
+BACKGROUND: Achondroplasia, the most prevalent form of skeletal dysplasia 
+involving short stature, necessitates a multidisciplinary approach that includes 
+otology and auditory rehabilitation. Despite this, the clinical characteristics 
+of hearing loss and otologic manifestations in achondroplasia patients remain 
+poorly defined. This study aimed to explore the prevalence and treatment 
+outcomes of otologic disease in individuals with achondroplasia.
+METHODS: A retrospective review of medical records was conducted for 70 patients 
+who visited the otolaryngology clinic at 3 institutions in South Korea from 1999 
+to 2023. Demographic and clinical characteristics, including audiometric 
+findings, imaging studies, treatment modalities, and outcomes, were analyzed.
+RESULTS: Among 53 patients who underwent audiometry, 26 showed conductive 
+hearing loss, 2 had mixed-type hearing loss, and 4 had sensorineural hearing 
+loss. Fifty-one patients (72.9%) had middle ear effusion at least once. 
+Myringotomy or ventilation tube insertion was performed on 33 patients (47.1%), 
+and 16 patients (22.9%) required multiple insertions. Eighteen patients (25.7%) 
+had adenoid hypertrophy, and 16 (22.9%) underwent adenoidectomy. Temporal bone 
+computed tomography (TBCT) scans were taken in 9 patients (12.9%) for middle ear 
+evaluation. Computed tomography (CT) scans showed a high jugular bulb and 
+rotated inner ear structures. Chronic otitis media with cholesteatoma was 
+diagnosed in 2 patients (2.9%), in whom tympanomastoidectomy was performed.
+CONCLUSION: Half of the children with achondroplasia experienced hearing loss, 
+most commonly due to conductive hearing loss. Threequarters of these children 
+exhibited otitis media with effusions, often necessitating the insertion of a 
+ventilation tube and adenoidectomy. Given the anatomical variations present in 
+these children, such as a high jugular bulb and rotated structures of the inner 
+ear and facial nerve, a cautious approach is essential when performing middle 
+ear surgery.
+
+DOI: 10.5152/iao.2024.241523
+PMCID: PMC11639576
+PMID: 39660705 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of Interests: The authors have no 
+conflicts of interest to declare.

--- a/references_cache/PMID_40675782.md
+++ b/references_cache/PMID_40675782.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:40675782"
+title: "Sleep-disordered breathing in children with achondroplasia assessed by polysomnography: a retrospective chart review."
+authors:
+- Buciek LH
+- Jacobsen JR
+- Raj S
+- Adams AM
+- Vandeleur M
+- Hove HB
+- Buchwald CV
+- Kiaer EK
+- Griffiths A
+- Savarirayan R
+journal: Arch Dis Child
+year: '2025'
+doi: 10.1136/archdischild-2025-328595
+keywords:
+- Humans
+- Achondroplasia/complications
+- Polysomnography/methods
+- Female
+- Retrospective Studies
+- Child
+- Male
+- "Child, Preschool"
+- Infant
+- "Sleep Apnea Syndromes/epidemiology, etiology, diagnosis"
+- Adolescent
+- Prevalence
+- Australia/epidemiology
+- "Sleep Apnea, Obstructive/epidemiology, etiology"
+- "Infant, Newborn"
+content_type: abstract_only
+---
+
+# Sleep-disordered breathing in children with achondroplasia assessed by polysomnography: a retrospective chart review.
+**Authors:** Buciek LH, Jacobsen JR, Raj S, Adams AM, Vandeleur M, Hove HB, Buchwald CV, Kiaer EK, Griffiths A, Savarirayan R
+**Journal:** Arch Dis Child (2025)
+**DOI:** [10.1136/archdischild-2025-328595](https://doi.org/10.1136/archdischild-2025-328595)
+
+## Content
+
+1. Arch Dis Child. 2025 Dec 15;111(1):43-48. doi:
+10.1136/archdischild-2025-328595.
+
+Sleep-disordered breathing in children with achondroplasia assessed by 
+polysomnography: a retrospective chart review.
+
+Buciek LH(#)(1)(2), Jacobsen JR(#)(1)(2), Raj S(1), Adams AM(3), Vandeleur M(3), 
+Hove HB(2), Buchwald CV(4), Kiaer EK(4), Griffiths A(#)(3), Savarirayan R(#)(5).
+
+Author information:
+(1)Murdoch Children's Research Institute, Parkville, Victoria, Australia.
+(2)Department of Pediatrics, Center for Rare Diseases, Rigshospitalet, 
+Copenhagen, Denmark.
+(3)Respiratory and Sleep Medicine, The Royal Children's Hospital Melbourne, 
+Melbourne, Victoria, Australia.
+(4)Department of Otorhinolaryngology, Head and Neck Surgery, and Audiology, 
+Rigshospitalet, Copenhagen, Denmark.
+(5)Molecular Therapies, Murdoch Children's Research Institute, Parkville, 
+Victoria, Australia ravi.savarirayan@mcri.edu.au.
+(#)Contributed equally
+
+OBJECTIVES: Sleep-disordered breathing is a key childhood complication in 
+children with achondroplasia. This retrospective study aimed to document the 
+prevalence of sleep-disordered breathing in children with achondroplasia 
+assessed by polysomnography.
+DESIGN: The prevalence of sleep-disordered breathing assessed by polysomnography 
+among children aged 0-18 years with achondroplasia from 2013 to 2024 at The 
+Royal Children's Hospital, Australia, was retrospectively reviewed.
+RESULTS: The cohort included 80 children with achondroplasia (54% females, 95% 
+confirmed molecular diagnosis) with an average number of 3.6 polysomnographies 
+collected per child (n=288). A total of 85% (68/80) had sleep-disordered 
+breathing and 21% reported no prior symptoms. Sleep-disordered breathing 
+subtypes included obstructive sleep apnoea in 81% (55/68), central sleep apnoea 
+in 3% (2/68), mixed sleep apnoea in 7% (5/68) and primary snoring in 9% (6/68). 
+Among those with obstructive and mixed sleep apnoea, 58% (35/60) had moderate or 
+severe obstructive sleep apnoea. In 44 children, a corresponding MRI was 
+evaluated for foramen magnum stenosis using the Achondroplasia Foramen Magnum 
+Score. No correlation was found with sleep-disordered breathing severity 
+(Spearman's coefficient (ρ)=0.03). Among 27 children who received a precision 
+therapy for achondroplasia (vosoritide, n=18, infigratinib, n=8 and recifercept, 
+n=1), the median respiratory disturbance index/hour improved from 2.7 (25th-75th 
+percentile, (0.9-4.8)) to 1.1 (0.3-2.6) after 1 year of treatment compared with 
+baseline.
+CONCLUSIONS: Sleep-disordered breathing was present in 85% of 80 children with 
+achondroplasia, with 21% being asymptomatic. Respiratory parameters did not 
+correlate with foramen magnum stenosis severity and improved after 1 year of 
+treatment in those treated with a precision therapy.
+
+© Author(s) (or their employer(s)) 2026. No commercial re-use. See rights and 
+permissions. Published by BMJ Group.
+
+DOI: 10.1136/archdischild-2025-328595
+PMID: 40675782 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None declared.

--- a/research/Achondroplasia-deep-research-codex.md
+++ b/research/Achondroplasia-deep-research-codex.md
@@ -1,0 +1,72 @@
+# Achondroplasia phenotype curation notes
+
+Date: 2026-04-18
+Curator: Codex
+Issue: monarch-initiative/dismech#1449
+
+## Scope
+
+Focused only on strengthening `kb/disorders/Achondroplasia.yaml` phenotype coverage.
+Priority was given to cohort, natural-history, and complication-specific PubMed
+abstracts that could support exact quoted snippets for phenotype assertions.
+
+## Key sources used
+
+- PMID:32803853
+  Supports disproportionate short stature as a defining phenotype.
+- PMID:29972438
+  Natural-history cohort supporting macrocephaly, high/prominent forehead,
+  trident hands, genu varum, rhizomelic long-bone shortening, motor delay,
+  speech delay, obesity, sleep apnea, middle-ear dysfunction, and occasional
+  hydrocephalus.
+- PMID:37072824
+  Supports prominent forehead and midface/maxillary retrusion in a dedicated
+  craniofacial cohort.
+- PMID:37493935
+  Supports childhood thoracolumbar kyphosis with frequent spontaneous
+  resolution by age 10.
+- PMID:27927547
+  Supports scoliosis and thoracolumbar kyphosis prevalence in a large
+  orthopedic cohort.
+- PMID:32883660
+  Supports infant foramen magnum stenosis severity spectrum on MRI.
+- PMID:38554024
+  Confirms frequent foramen magnum stenosis in a young-child cohort.
+- PMID:32864841
+  Supports lifespan complications including cervical/lumbar stenosis,
+  childhood elbow contractures and radial head dislocations, and central/obstructive
+  sleep apnea.
+- PMID:32170149
+  Refines adult lumbar spinal stenosis phenotype.
+- PMID:40675782
+  Supports pediatric obstructive and central sleep apnea by polysomnography.
+- PMID:39660705
+  Supports otitis media with effusion and predominantly conductive hearing loss.
+- PMID:34736503
+  Confirms persistent conductive/mixed hearing loss burden in adults.
+- PMID:3228140
+  Supports obesity beginning in early childhood and remaining prevalent at all ages.
+- PMID:22409389
+  Supports delayed gross motor and later communication development.
+- PMID:33579320
+  Supports cautious retention of hydrocephalus as an occasional pediatric complication.
+
+## Curation decisions
+
+- Removed unsupported phenotype frequency qualifiers instead of preserving
+  broad `VERY_FREQUENT`/`FREQUENT` claims without explicit evidence.
+- Removed unsupported or weakly grounded phenotype entries rather than keeping
+  them on general clinical familiarity alone.
+- Replaced imprecise mappings with more grounded HPO terms, including:
+  - `HP:0008905` Rhizomelia
+  - `HP:0011220` Prominent forehead
+  - `HP:0031353` Otitis media with effusion
+  - `HP:0000405` Conductive hearing impairment
+  - `HP:0002194` Delayed gross motor development
+  - `HP:0000750` Delayed speech and language development
+
+## Open caution
+
+Lumbar hyperlordosis and brachydactyly were not retained as standalone
+phenotypes because the current source set did not provide sufficiently direct
+abstract-level support for a clean, evidence-backed entry.


### PR DESCRIPTION
## Summary
- replace the Achondroplasia phenotype block with PMID-backed skeletal, craniofacial, neurologic, respiratory, ENT, developmental, and orthopedic manifestations
- remove unsupported phenotype frequency assertions and mechanistic overreach from phenotype descriptions
- add the supporting PubMed cache files plus a focused Achondroplasia research note

## Validation
- `just validate kb/disorders/Achondroplasia.yaml`
- `just validate-references kb/disorders/Achondroplasia.yaml`
- `just validate-terms kb/disorders/Achondroplasia.yaml`

## Notes
- scope was kept to `kb/disorders/Achondroplasia.yaml`, relevant `references_cache/` entries, and `research/Achondroplasia-deep-research-codex.md`
- unrelated dirty worktree files were intentionally left untouched