### PR TITLE
[codex] Enhance phenotype evidence for Schmid metaphyseal chondrodysplasia

### DIFF
--- a/kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml
+++ b/kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml
@@ -1,6 +1,6 @@
 name: Metaphyseal Chondrodysplasia, Schmid Type
 creation_date: '2026-03-04T18:10:30Z'
-updated_date: '2026-04-07T02:36:25Z'
+updated_date: '2026-04-19T00:06:00Z'
 category: Mendelian
 description: >
   Metaphyseal Chondrodysplasia, Schmid Type (MCDS) is an autosomal dominant skeletal
@@ -540,11 +540,38 @@ phenotypes:
       The Schmid type of metaphyseal chondrodyplasia (MCDS) is characterized by short stature, widened growth plates, and bowing of the long bones.
     explanation: >-
       Confirms short stature in a clinical cohort with molecularly confirmed MCDS.
+- name: Short Lower Limbs
+  category: Clinical
+  description: >
+    Short lower limbs are part of the early phenotype and are often evident when
+    the disorder first becomes clinically apparent in early childhood.
+  phenotype_term:
+    preferred_term: Short lower limbs
+    term:
+      id: HP:0006385
+      label: Short lower limbs
+  evidence:
+  - reference: PMID:31633898
+    reference_title: "Schmid Metaphyseal Chondrodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The clinical and radiographic features are usually not present at birth, but manifest in early childhood with short limbs, genu varum, and waddling gait.
+    explanation: >-
+      GeneReviews identifies short limbs as part of the characteristic early phenotype.
+  - reference: PMID:25542771
+    reference_title: "Case of mild Schmid-type metaphyseal chondrodysplasia with novel sequence variation involving an unusual mutational site of the COL10A1 gene."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Schmid-type metaphyseal chondrodysplasia (MCDS) is characterized by short stature with short legs, bowing of the long bones, coxa vara, and waddling gait.
+    explanation: >-
+      Independent clinical series confirms lower-limb shortening as a defining feature.
 - name: Genu Varum
   category: Clinical
   description: >
-    Bow legs (genu varum) are a prominent and often progressive lower limb deformity.
-    Recurrence with growth is not uncommon and may require repeated surgical correction.
+    Bow legs are a prominent lower-limb deformity that typically emerges in early
+    childhood and can progress to angular deformity.
   phenotype_term:
     preferred_term: Genu varum
     term:
@@ -570,8 +597,8 @@ phenotypes:
 - name: Coxa Vara
   category: Clinical
   description: >
-    Coxa vara is a characteristic hip deformity in MCDS, contributing to waddling gait
-    and limb length discrepancy. Significant coxa vara may require valgus osteotomy.
+    Coxa vara is a characteristic hip deformity that contributes to waddling gait
+    and proximal femoral deformity.
   phenotype_term:
     preferred_term: Coxa vara
     term:
@@ -597,8 +624,8 @@ phenotypes:
 - name: Waddling Gait
   category: Clinical
   description: >
-    A waddling gait is a common clinical presentation, typically resulting from
-    coxa vara and lower limb deformities.
+    Waddling gait is a common early manifestation and in one cohort was a
+    consequence of coxa vara in eight of 12 children.
   phenotype_term:
     preferred_term: Waddling gait
     term:
@@ -624,8 +651,7 @@ phenotypes:
 - name: Metaphyseal Widening
   category: Radiographic
   description: >
-    Growth plate and metaphyseal widening is a characteristic radiographic feature,
-    reflecting the expanded hypertrophic zone of the growth plate.
+    Widened growth plates and physes are characteristic radiographic abnormalities.
   phenotype_term:
     preferred_term: Metaphyseal widening
     term:
@@ -640,6 +666,14 @@ phenotypes:
       The Schmid type of metaphyseal chondrodyplasia (MCDS) is characterized by short stature, widened growth plates, and bowing of the long bones.
     explanation: >-
       Widened growth plates confirmed in molecularly characterized cohort.
+  - reference: PMID:30027601
+    reference_title: "Schmid's Type of Metaphyseal Chondrodysplasia: Diagnosis and Management."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Diffuse metaphyseal flaring, irregularity, and growth plate widening, which are most severe in the knees, are the most striking radiological features of this disease.
+    explanation: >-
+      Independent cohort confirms growth plate widening as a major radiographic feature.
 - name: Metaphyseal Irregularity
   category: Radiographic
   description: >
@@ -670,9 +704,8 @@ phenotypes:
 - name: Flared Metaphyses
   category: Radiographic
   description: >
-    Metaphyseal flaring, particularly around the knees, is a hallmark radiographic
-    finding reflecting failure of normal mineralization of the zone of provisional
-    calcification.
+    Diffuse metaphyseal flaring, especially around the knees, is a hallmark
+    radiographic finding.
   phenotype_term:
     preferred_term: Flared metaphysis
     term:
@@ -690,8 +723,8 @@ phenotypes:
 - name: Bowing of the Long Bones
   category: Radiographic
   description: >
-    Bowing of the long bones, particularly in the lower extremities, contributes
-    to limb deformity and gait disturbance.
+    Bowing of the long bones is a defining skeletal deformity; femoral bowing is
+    specifically reported in radiographic series.
   phenotype_term:
     preferred_term: Bowing of the long bones
     term:
@@ -706,17 +739,33 @@ phenotypes:
       The Schmid type of metaphyseal chondrodyplasia (MCDS) is characterized by short stature, widened growth plates, and bowing of the long bones.
     explanation: >-
       Bowing of the long bones confirmed as a defining feature.
+  - reference: PMID:15578582
+    reference_title: "Hand involvement in Schmid metaphyseal chondrodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiographic findings include anterior cupping, sclerosis and splaying of the ribs, diffuse metaphyseal flaring, and irregularity that is most pronounced at the knees, coxa vara, and femoral bowing.
+    explanation: >-
+      Registry radiographs specifically document femoral bowing as part of the skeletal phenotype.
 - name: Anterior Rib Cupping
   category: Radiographic
   description: >
-    Anterior cupping, sclerosis, and splaying of the ribs are recognized
-    radiographic features.
+    Anterior cupping with sclerosis and splaying of the ribs is a recurrent
+    radiographic feature.
   phenotype_term:
     preferred_term: Anterior rib cupping
     term:
       id: HP:0000907
       label: Anterior rib cupping
   evidence:
+  - reference: PMID:15578582
+    reference_title: "Hand involvement in Schmid metaphyseal chondrodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiographic findings include anterior cupping, sclerosis and splaying of the ribs, diffuse metaphyseal flaring, and irregularity that is most pronounced at the knees, coxa vara, and femoral bowing.
+    explanation: >-
+      Registry radiographs identify anterior rib cupping with associated rib sclerosis and splaying.
   - reference: PMID:31633898
     reference_title: "Schmid Metaphyseal Chondrodysplasia."
     supports: SUPPORT
@@ -724,27 +773,18 @@ phenotypes:
     snippet: >-
       Radiographs show metaphyseal irregularities of the long bones (e.g., splaying, flaring, cupping); shortening of the tubular bones; widened growth plates; coxa vara; and anterior cupping, sclerosis, and splaying of the ribs.
     explanation: >-
-      GeneReviews lists anterior rib cupping as a radiographic finding.
+      GeneReviews independently lists anterior rib cupping among the characteristic radiographic findings.
 - name: Platyspondyly
   category: Radiographic
   description: >
-    Platyspondyly and vertebral end plate irregularities are less common features
-    that may be present in a subset of patients. These findings support reclassification
-    of MCDS as a spondylometaphyseal dysplasia in some cases.
+    Spinal involvement is uncommon; one registry review found mild platyspondyly,
+    vertebral body abnormalities, and end-plate irregularity in 9.1% (3/33) of cases.
   phenotype_term:
     preferred_term: Platyspondyly
     term:
       id: HP:0000926
       label: Platyspondyly
   evidence:
-  - reference: PMID:31633898
-    reference_title: "Schmid Metaphyseal Chondrodysplasia."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Platyspondyly and vertebral end plate irregularities are less common.
-    explanation: >-
-      GeneReviews notes platyspondyly as a less common but recognized feature.
   - reference: PMID:10929364
     reference_title: "Schmid type metaphyseal chondrodysplasia: a spondylometaphyseal dysplasia identical to the \"Japanese\" type."
     supports: SUPPORT
@@ -752,7 +792,15 @@ phenotypes:
     snippet: >-
       We found that in 9.1% (3/33) of cases reviewed there was definite radiographic evidence of spinal involvement comprising mild platyspondyly, vertebral body abnormalities, and end-plate irregularity.
     explanation: >-
-      Documents spinal involvement in 9.1% of a registry cohort, supporting platyspondyly as an uncommon but real component.
+      Registry review quantifies platyspondyly as an uncommon but real component of MCDS.
+  - reference: PMID:41454937
+    reference_title: "Clinical, Molecular Characteristics, and Genotype-Phenotype Relationships of Metaphyseal Chondrodysplasia Type Schmid."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The four patients presented with short stature or waddling gait, flattened vertebrae, and irregular femoral epiphyses.
+    explanation: >-
+      Recent series also reported flattened vertebrae, providing contemporary support for vertebral flattening in MCDS.
 - name: Arthralgia
   category: Clinical
   description: >
@@ -775,8 +823,7 @@ phenotypes:
 - name: Delayed Gross Motor Development
   category: Clinical
   description: >
-    Early motor milestones may be delayed due to orthopedic complications
-    including lower limb deformities. Intelligence is normal.
+    Early motor milestones may be delayed because of orthopedic complications.
   phenotype_term:
     preferred_term: Delayed gross motor development
     term:
@@ -790,7 +837,35 @@ phenotypes:
     snippet: >-
       Early motor milestones may be delayed due to orthopedic complications. Intelligence is normal.
     explanation: >-
-      Motor delay is attributed to orthopedic complications, not neurological involvement.
+      GeneReviews documents delayed gross motor milestones as a secondary consequence of orthopedic burden.
+- name: Short Tubular Bones of the Hand
+  category: Radiographic
+  description: >
+    Mild hand involvement is not universal but was found in 47% (7/15) of one
+    registry series, with shortening of the tubular bones and metaphyseal cupping
+    of the metacarpals and proximal phalanges.
+  phenotype_term:
+    preferred_term: Short tubular bones of the hand
+    term:
+      id: HP:0001248
+      label: Short tubular bones of the hand
+  evidence:
+  - reference: PMID:15578582
+    reference_title: "Hand involvement in Schmid metaphyseal chondrodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We found hand involvement in 47% (7/15) of cases included in our analysis. These changes were subtle and consisted of shortening of the tubular bones and metaphyseal cupping of the proximal phalanges and metacarpals.
+    explanation: >-
+      Provides explicit frequency data and defines the hand radiographic pattern in MCDS.
+  - reference: PMID:31633898
+    reference_title: "Schmid Metaphyseal Chondrodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Mild hand involvement often includes shortening of the tubular bones and metaphyseal cupping of the metacarpals and proximal phalanges.
+    explanation: >-
+      GeneReviews corroborates the characteristic hand involvement pattern described in registry studies.
 diagnosis:
 - name: Clinical-Radiographic and Molecular Diagnosis
   description: >

--- a/references_cache/PMID_15578582.md
+++ b/references_cache/PMID_15578582.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:15578582"
+title: Hand involvement in Schmid metaphyseal chondrodysplasia.
+authors:
+- Elliott AM
+- Field FM
+- Rimoin DL
+- Lachman RS
+journal: Am J Med Genet A
+year: '2005'
+doi: 10.1002/ajmg.a.30433
+keywords:
+- Collagen Type X/genetics
+- Female
+- "Fingers/abnormalities, diagnostic imaging"
+- Hand/diagnostic imaging
+- "Hand Deformities, Congenital/diagnostic imaging"
+- Humans
+- Los Angeles
+- Male
+- "Mutation, Missense"
+- "Osteochondrodysplasias/genetics, pathology"
+- Radiography
+- "Registries/statistics & numerical data"
+content_type: abstract_only
+---
+
+# Hand involvement in Schmid metaphyseal chondrodysplasia.
+**Authors:** Elliott AM, Field FM, Rimoin DL, Lachman RS
+**Journal:** Am J Med Genet A (2005)
+**DOI:** [10.1002/ajmg.a.30433](https://doi.org/10.1002/ajmg.a.30433)
+
+## Content
+
+1. Am J Med Genet A. 2005 Jan 15;132A(2):191-3. doi: 10.1002/ajmg.a.30433.
+
+Hand involvement in Schmid metaphyseal chondrodysplasia.
+
+Elliott AM(1), Field FM, Rimoin DL, Lachman RS.
+
+Author information:
+(1)International Skeletal Dysplasia Registry, Cedars-Sinai Medical Center, Los
+Angeles, CA, USA. amelliot@mts.net
+
+Schmid metaphyseal chondrodysplasia (Schmid MCD, MIM 156500) is caused by
+mutations in the COL10A1 gene and is clinically characterized by short stature,
+bowed legs, and a waddling gait. Radiographic findings include anterior cupping,
+sclerosis and splaying of the ribs, diffuse metaphyseal flaring, and
+irregularity that is most pronounced at the knees, coxa vara, and femoral
+bowing. We reviewed the radiographs of Schmid MCD patients at the International
+Skeletal Dysplasia Registry in Los Angeles for evidence of hand involvement. We
+found hand involvement in 47% (7/15) of cases included in our analysis. These
+changes were subtle and consisted of shortening of the tubular bones and
+metaphyseal cupping of the proximal phalanges and metacarpals. Mild hand
+involvement is a common feature of Schmid MCD.
+
+DOI: 10.1002/ajmg.a.30433
+PMID: 15578582 [Indexed for MEDLINE]

--- a/references_cache/PMID_25542771.md
+++ b/references_cache/PMID_25542771.md
@@ -1,0 +1,95 @@
+---
+reference_id: "PMID:25542771"
+title: Case of mild Schmid-type metaphyseal chondrodysplasia with novel sequence variation involving an unusual mutational site of the COL10A1 gene.
+authors:
+- Park H
+- Hong S
+- Cho SI
+- Cho TJ
+- Choi IH
+- Jin DK
+- Sohn YB
+- Park SW
+- Cho HH
+- Cheon JE
+- Kim SY
+- Kim JY
+- Park SS
+- Seong MW
+journal: Eur J Med Genet
+year: '2015'
+doi: 10.1016/j.ejmg.2014.12.011
+keywords:
+- Amino Acid Sequence
+- Asian People/genetics
+- Child
+- "Child, Preschool"
+- Collagen Type XI/genetics
+- DNA Mutational Analysis
+- Female
+- Frameshift Mutation
+- Genetic Variation
+- Growth Disorders/genetics
+- Humans
+- Male
+- Molecular Sequence Data
+- "Mutation, Missense"
+- "Osteochondrodysplasias/diagnosis, genetics"
+content_type: abstract_only
+---
+
+# Case of mild Schmid-type metaphyseal chondrodysplasia with novel sequence variation involving an unusual mutational site of the COL10A1 gene.
+**Authors:** Park H, Hong S, Cho SI, Cho TJ, Choi IH, Jin DK, Sohn YB, Park SW, Cho HH, Cheon JE, Kim SY, Kim JY, Park SS, Seong MW
+**Journal:** Eur J Med Genet (2015)
+**DOI:** [10.1016/j.ejmg.2014.12.011](https://doi.org/10.1016/j.ejmg.2014.12.011)
+
+## Content
+
+1. Eur J Med Genet. 2015 Mar;58(3):175-9. doi: 10.1016/j.ejmg.2014.12.011. Epub
+2014 Dec 24.
+
+Case of mild Schmid-type metaphyseal chondrodysplasia with novel sequence
+variation involving an unusual mutational site of the COL10A1 gene.
+
+Park H(1), Hong S(1), Cho SI(1), Cho TJ(2), Choi IH(2), Jin DK(3), Sohn YB(4),
+Park SW(3), Cho HH(5), Cheon JE(5), Kim SY(6), Kim JY(7), Park SS(8), Seong
+MW(9).
+
+Author information:
+(1)Department of Laboratory Medicine, Seoul National University Hospital, Seoul,
+South Korea.
+(2)Department of Orthopedic Surgery, Seoul National University Hospital, Seoul,
+South Korea.
+(3)Department of Pediatrics, Samsung Medical Center, Sungkyunkwan University
+School of Medicine, Seoul, South Korea.
+(4)Department of Medical Genetics, Ajou University School of Medicine, Suwon,
+South Korea.
+(5)Department of Radiology, Seoul National University Hospital, Seoul, South
+Korea.
+(6)Department of Laboratory Medicine, National Medical Center, Seoul, South
+Korea.
+(7)Biomedical Research Institute, Seoul National University Hospital, Seoul,
+South Korea.
+(8)Department of Laboratory Medicine, Seoul National University Hospital, Seoul,
+South Korea; Biomedical Research Institute, Seoul National University Hospital,
+Seoul, South Korea.
+(9)Department of Laboratory Medicine, Seoul National University Hospital, Seoul,
+South Korea. Electronic address: mwseong@snu.ac.kr.
+
+Schmid-type metaphyseal chondrodysplasia (MCDS) is characterized by short
+stature with short legs, bowing of the long bones, coxa vara, and waddling gait.
+MCDS is a relatively common form of MCD. Most mutations that cause MCDS occur
+within the carboxyl-terminal non-collagenous domain (NC1) of the COL10A1 gene.
+We performed mutational analysis of the COL10A1 genes in 4 unrelated Korean
+patients with diagnosed MCDS. Mutational analysis of COL10A1 identified
+c.1904_1915delinsT (p.Gln635LeufsX10) and c.1969dupG (p.Ala657GlyfsX10), 2 novel
+frameshift mutations, and c.2030T>A (p.Val677Glu) and c.862G>C (p.Gly288Arg) at
+unusual mutational sites, which could be pathogenic. We present the first report
+of the molecular characteristics of MCDS in 4 Korean patients. Our findings
+suggest that a novel sequence variation involving an unusual mutational site of
+the COL10A1 gene can cause mild MCDS.
+
+Copyright © 2014 Elsevier Masson SAS. All rights reserved.
+
+DOI: 10.1016/j.ejmg.2014.12.011
+PMID: 25542771 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
Enhance the phenotype section for `kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml` with tighter PMID-backed evidence and more specific phenotype grounding.

## What changed
- added missing phenotype coverage for short lower limbs
- added hand phenotype coverage with PMID-backed frequency for short tubular bones of the hand
- strengthened radiographic phenotype evidence for rib cupping, femoral bowing, and platyspondyly
- tightened phenotype descriptions to remove management-heavy or weakly supported wording
- fetched and committed the new reference cache entries used by the phenotype additions

## Why
Issue #1455 asks for a phenotype-only enrichment pass that is as complete and evidence-backed as possible without broadening into an unrelated rewrite.

## Validation
- `just validate kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
  - passed
- `just validate-references kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
  - passed
- `just validate-terms kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
  - passed

Closes #1455