### PR TITLE
[codex] Enhance Kniest dysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Kniest_Dysplasia.yaml
+++ b/kb/disorders/Kniest_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Kniest Dysplasia
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-03T00:00:00Z'
+updated_date: '2026-04-19T00:10:48Z'
 category: Mendelian
 description: >
   Kniest dysplasia is a moderately severe type II collagenopathy caused by
@@ -377,14 +377,25 @@ phenotypes:
 - name: Disproportionate Short-Trunk Short Stature
   category: Skeletal
   description: >
-    Severe short stature with disproportionately short trunk, typically
-    apparent at birth. Expected adult height is 100-140 cm.
+    Disproportionate short stature with a short trunk is a core skeletal
+    manifestation of Kniest dysplasia.
   phenotype_term:
     preferred_term: Disproportionate short-trunk short stature
     term:
       id: HP:0003521
       label: Disproportionate short-trunk short stature
   evidence:
+  - reference: PMID:10406661
+    reference_title: Small deletions in the type II collagen triple helix produce kniest dysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Kniest dysplasia is a moderately severe type II collagenopathy, characterized by
+      short trunk and limbs, kyphoscoliosis, midface hypoplasia, severe myopia, and
+      hearing loss.
+    explanation: >-
+      Supports disproportionate short-trunk short stature as part of the defining
+      Kniest dysplasia skeletal phenotype.
   - reference: PMID:41378240
     reference_title: >-
       Out-of-Frame Transcript and in-Frame Deletion owing to a Novel Splice
@@ -401,9 +412,8 @@ phenotypes:
 - name: Enlarged Joints
   category: Skeletal
   description: >
-    Prominent, enlarged-appearing joints especially at knees and wrists,
-    with restricted mobility. Enlargement is due to epiphyseal expansion
-    from abnormal cartilage.
+    Prominent enlarged joints with restricted mobility are a characteristic
+    clinical feature.
   phenotype_term:
     preferred_term: Enlarged joints
     term:
@@ -424,8 +434,7 @@ phenotypes:
 - name: Joint Stiffness
   category: Skeletal
   description: >
-    Progressive joint stiffness and contractures develop, limiting mobility.
-    Early-onset arthropathy is common and may require orthopedic intervention.
+    Joint stiffness contributes to reduced mobility in affected individuals.
   phenotype_term:
     preferred_term: Joint stiffness
     term:
@@ -443,12 +452,32 @@ phenotypes:
       patients.
     explanation: >-
       Describes joint stiffness as a defining feature of Kniest syndrome.
+- name: Hand Arthropathy
+  category: Skeletal
+  description: >
+    Arthropathy can be particularly prominent in the hands.
+  phenotype_term:
+    preferred_term: Hand arthropathy
+    term:
+      id: HP:0003040
+      label: Arthropathy
+  evidence:
+  - reference: PMID:25592122
+    reference_title: Ophthalmic and molecular genetic findings in Kniest dysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other features include marked hand arthropathy, cleft palate, hearing
+      loss, and ocular abnormalities (myopia, abnormal vitreous, and high risk
+      of developing retinal detachment).
+    explanation: >-
+      Directly supports hand arthropathy as part of the Kniest dysplasia
+      clinical phenotype.
 - name: Enlarged Epiphyses
   category: Skeletal
   description: >
-    Splayed and enlarged epiphyses of long bones, visible on radiography.
-    Capital femoral epiphyses may be radiographically absent in infancy
-    due to delayed ossification of large cartilaginous megaepiphyses.
+    Splayed and enlarged epiphyses of the long bones are a characteristic
+    radiographic feature.
   phenotype_term:
     preferred_term: Enlarged epiphyses
     term:
@@ -500,11 +529,53 @@ phenotypes:
     explanation: >-
       Confirms dumbbell-shaped long bones as a typical radiological finding
       in Kniest dysplasia.
+- name: Clubfoot
+  category: Skeletal
+  description: >
+    Clubfeet have been reported in a small radiographic series and may expand
+    the recognized skeletal phenotype.
+  phenotype_term:
+    preferred_term: Clubfoot
+    term:
+      id: HP:0001762
+      label: Talipes equinovarus
+  evidence:
+  - reference: PMID:27303468
+    reference_title: "Kniest Dysplasia: New Radiographic Features in the Skeleton."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Bilateral radial head dislocations and bilateral clubfeet were seen in
+      our series.
+    explanation: >-
+      Supports clubfoot as a reported skeletal manifestation in a four-patient
+      Kniest dysplasia radiographic series.
+- name: Radial Head Dislocation
+  category: Skeletal
+  description: >
+    Bilateral radial head dislocation has been reported in a small radiographic
+    series.
+  phenotype_term:
+    preferred_term: Radial head dislocation
+    term:
+      id: HP:0003083
+      label: Dislocated radial head
+  evidence:
+  - reference: PMID:27303468
+    reference_title: "Kniest Dysplasia: New Radiographic Features in the Skeleton."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Bilateral radial head dislocations and bilateral clubfeet were seen in
+      our series.
+    explanation: >-
+      Supports radial head dislocation as a reported skeletal manifestation in
+      a four-patient Kniest dysplasia radiographic series.
 - name: Platyspondyly
   category: Skeletal
   description: >
-    Flattened vertebral bodies contributing to short trunk. Vertebral
-    flattening is visible on lateral spine radiographs from infancy.
+    Flattened vertebral bodies contribute to the short-trunk skeletal
+    phenotype.
   phenotype_term:
     preferred_term: Platyspondyly
     term:
@@ -528,8 +599,8 @@ phenotypes:
 - name: Coronal Cleft Vertebrae
   category: Skeletal
   description: >
-    Coronal clefts of the vertebral bodies, seen as superior-inferior defects
-    in the midportion of vertebrae during infancy and early childhood.
+    Coronal clefts of the vertebral bodies are a characteristic spinal
+    radiographic finding.
   phenotype_term:
     preferred_term: Coronal cleft vertebrae
     term:
@@ -555,12 +626,33 @@ phenotypes:
     explanation: >-
       Documents vertebral clefts as a radiological feature in severe neonatal
       Kniest dysplasia.
+- name: Narrow Thorax
+  category: Skeletal
+  description: >
+    Thoracic narrowing has been reported in affected infants.
+  phenotype_term:
+    preferred_term: Narrow thorax
+    term:
+      id: HP:0000774
+      label: Narrow chest
+  evidence:
+  - reference: PMID:40475174
+    reference_title: Kniest Dysplasia without Ocular and Auditory Abnormalities in a Boy of 12 Months.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Herein, we report on an 8-month-old boy who was referred to the
+      pediatric genetic department due to narrow thorax and short extremities.
+      He had mild dysmorphic features, cleft palate, narrow thorax, short
+      extremities, and short stature.
+    explanation: >-
+      Directly documents narrow thorax in an infant with molecularly confirmed
+      Kniest dysplasia.
 - name: Kyphoscoliosis
   category: Skeletal
   description: >
-    Combined kyphosis and scoliosis of the spine, developing in infancy and
-    tending to progress with age. Contributes to respiratory restriction
-    through reduced thoracic volume.
+    Combined kyphosis and scoliosis of the spine is a characteristic
+    vertebral deformity.
   phenotype_term:
     preferred_term: Kyphoscoliosis
     term:
@@ -591,76 +683,59 @@ phenotypes:
     explanation: >-
       Radiographic confirmation of kyphoscoliosis in an adult patient with
       Kniest dysplasia.
-- name: Coxa Vara
-  category: Skeletal
-  description: >
-    Varus deformity of the hip due to abnormal development of the proximal
-    femur and hip joint dysplasia. Over 50% of type II collagenopathy
-    patients require orthopedic surgery, including femoral osteotomy or hip
-    replacement.
-  phenotype_term:
-    preferred_term: Coxa vara
-    term:
-      id: HP:0002812
-      label: Coxa vara
-  evidence:
-  - reference: PMID:25604898
-    reference_title: >-
-      A study of the clinical and radiological features in a cohort of 93
-      patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia
-      congenita or a related phenotype.
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Over 50% of the patients had undergone orthopedic surgery, usually for
-      scoliosis, femoral osteotomy or hip replacement.
-    explanation: >-
-      Documents high rate of hip-related orthopedic surgery in a mixed
-      SEDC/Kniest/related COL2A1 cohort (7/93 had Kniest dysplasia).
 - name: Hypoplasia of the Odontoid Process
   category: Skeletal
   description: >
-    Underdevelopment of the odontoid process of the axis (C2), predisposing
-    to atlanto-axial instability. In a large COL2A1 cohort, odontoid
-    hypoplasia was present in 56% and correlated with short stature.
-    Atlanto-axial instability was observed in 28% of those imaged.
+    Abnormal odontoid morphology, including a short odontoid process, has
+    been documented in Kniest dysplasia.
   phenotype_term:
     preferred_term: Hypoplasia of the odontoid process
     term:
       id: HP:0003311
       label: Hypoplasia of the odontoid process
   evidence:
-  - reference: PMID:25604898
-    reference_title: >-
-      A study of the clinical and radiological features in a cohort of 93
-      patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia
-      congenita or a related phenotype.
+  - reference: PMID:2931448
+    reference_title: Craniofacial and mucopolysaccharide abnormalities in Kniest dysplasia.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Odontoid hypoplasia was present in 56% (95% CI 38-74) and a correlation
-      between odontoid hypoplasia and short stature was observed.
-      Atlanto-axial instability, was observed in 5 of the 18 patients (28%,
-      95% CI 10-54) in whom flexion-extension films of the cervical spine were
-      available
+      The odontoid process was short and wide.
     explanation: >-
-      Quantifies the frequency of odontoid hypoplasia and atlanto-axial
-      instability in a large COL2A1 skeletal dysplasia cohort.
-- name: Malar Flattening
+      Directly documents abnormal odontoid morphology in a patient with
+      Kniest dysplasia.
+- name: Midface Hypoplasia
   category: Craniofacial
   description: >
-    Midface hypoplasia with malar flattening and flat facial profile.
-    A well-recognized craniofacial feature of Kniest dysplasia attributed
-    to abnormal endochondral ossification of midfacial structures.
-  notes: >-
-    Flat face and midface hypoplasia are consistently described in clinical
-    reviews of Kniest dysplasia but no cached abstract contains an exact
-    quotable snippet specifically naming malar flattening.
+    Midface retrusion contributes to the characteristic flattened facial
+    appearance.
   phenotype_term:
-    preferred_term: Malar flattening
+    preferred_term: Midface retrusion
     term:
-      id: HP:0000272
-      label: Malar flattening
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:10406661
+    reference_title: Small deletions in the type II collagen triple helix produce kniest dysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Kniest dysplasia is a moderately severe type II collagenopathy, characterized by
+      short trunk and limbs, kyphoscoliosis, midface hypoplasia, severe myopia, and
+      hearing loss.
+    explanation: >-
+      Identifies midface hypoplasia as part of the defining Kniest dysplasia
+      phenotype.
+  - reference: PMID:2931448
+    reference_title: Craniofacial and mucopolysaccharide abnormalities in Kniest dysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The facial skeleton, including the nasal bones, infra-orbital rims,
+      maxilla and mandible, was retropositioned relative to the anterior
+      cranial base.
+    explanation: >-
+      Provides direct cephalometric evidence of midfacial retrusion in Kniest
+      dysplasia.
 - name: Cleft Palate
   category: Craniofacial
   description: >
@@ -697,15 +772,23 @@ phenotypes:
 - name: Myopia
   category: Ophthalmologic
   description: >
-    High myopia develops due to abnormal type II collagen in the vitreous and
-    ocular connective tissues. Six of seven patients in one series were high
-    myopes.
+    High myopia is a frequent ocular manifestation.
   phenotype_term:
     preferred_term: High myopia
     term:
       id: HP:0011003
       label: High myopia
   evidence:
+  - reference: PMID:10406661
+    reference_title: Small deletions in the type II collagen triple helix produce kniest dysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Kniest dysplasia is a moderately severe type II collagenopathy, characterized by
+      short trunk and limbs, kyphoscoliosis, midface hypoplasia, severe myopia, and
+      hearing loss.
+    explanation: >-
+      Supports severe myopia as part of the core Kniest dysplasia phenotype.
   - reference: PMID:25592122
     reference_title: Ophthalmic and molecular genetic findings in Kniest dysplasia.
     supports: SUPPORT
@@ -716,21 +799,38 @@ phenotypes:
     explanation: >-
       Documents that 6/7 patients with molecularly confirmed Kniest dysplasia
       had high myopia.
-  - reference: PMID:25604898
-    reference_title: >-
-      A study of the clinical and radiological features in a cohort of 93
-      patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia
-      congenita or a related phenotype.
+- name: Cataract
+  category: Ophthalmologic
+  description: >
+    Cataract has been reported in some affected individuals.
+  phenotype_term:
+    preferred_term: Cataract
+    term:
+      id: HP:0000518
+      label: Cataract
+  evidence:
+  - reference: PMID:25592122
+    reference_title: Ophthalmic and molecular genetic findings in Kniest dysplasia.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Myopia was found in 45% (95% CI 35-56), and retinal detachment had
-      occurred in 12% (95% CI 6-21; median age 14 years; youngest age 3.5
-      years).
+      Bilateral quandratic cataracts and subluxed lenses were noted in one
+      subject.
     explanation: >-
-      Quantifies myopia frequency at 45% in a mixed SEDC/Kniest/related
-      COL2A1 cohort (7/93 Kniest); ophthalmological features more frequent
-      and severe in splicing-mutation patients.
+      Documents cataract in a molecularly confirmed Kniest dysplasia patient.
+  - reference: PMID:41378240
+    reference_title: >-
+      Out-of-Frame Transcript and in-Frame Deletion owing to a Novel Splice
+      Mutation of COL2A1 (c.1266+2T>A) in an Adult with Kniest Dysplasia: A
+      Case Report.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      She also showed markedly short stature (-4.37 SD), cleft palate,
+      cataract, retinal detachment, and serous otitis media.
+    explanation: >-
+      Independent adult case report confirming cataract as part of the Kniest
+      dysplasia phenotype.
 - name: Vitreoretinopathy
   category: Ophthalmologic
   description: >
@@ -755,9 +855,7 @@ phenotypes:
 - name: Retinal Detachment
   category: Ophthalmologic
   description: >
-    Increased risk of retinal detachment due to vitreous abnormalities from
-    defective type II collagen. Can occur as early as the first decade of life
-    and may lead to permanent vision loss.
+    Retinal detachment is a major vision-threatening complication.
   phenotype_term:
     preferred_term: Retinal detachment
     term:
@@ -775,27 +873,21 @@ phenotypes:
     explanation: >-
       Lists high risk of retinal detachment as a recognized ocular
       complication.
-  - reference: PMID:25604898
-    reference_title: >-
-      A study of the clinical and radiological features in a cohort of 93
-      patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia
-      congenita or a related phenotype.
+  - reference: PMID:14644246
+    reference_title: A case of Kniest dysplasia with retinal detachment and the mutation analysis.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      retinal detachment had occurred in 12% (95% CI 6-21; median age 14
-      years; youngest age 3.5 years).
+      A 14-year-old Japanese boy was diagnosed with Kniest dysplasia, and
+      ophthalmic examination revealed a retinal detachment in the right eye.
     explanation: >-
-      Quantifies retinal detachment rate at 12% in a mixed SEDC/Kniest/related
-      COL2A1 cohort (7/93 Kniest), with earliest occurrence at age 3.5 years.
+      Provides direct case evidence of retinal detachment in adolescent Kniest
+      dysplasia.
 - name: Hearing Loss
   category: Otologic
   description: >
-    Hearing loss is common, affecting both conductive and sensorineural
-    components. Conductive hearing loss relates to abnormal ossicular
-    development from defective cartilage; sensorineural involvement may be
-    underrecognized initially. Six of seven patients in one series had
-    significant hearing impairment.
+    Hearing loss is common and may include both conductive and sensorineural
+    components.
   phenotype_term:
     preferred_term: Mixed conductive and sensorineural hearing impairment
     term:
@@ -820,19 +912,6 @@ phenotypes:
     explanation: >-
       Documents mixed conductive and sensorineural hearing loss in Kniest
       syndrome, occurring in approximately 50% of patients.
-  - reference: PMID:25604898
-    reference_title: >-
-      A study of the clinical and radiological features in a cohort of 93
-      patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia
-      congenita or a related phenotype.
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Thirty-two patients complained of hearing loss (37%, 95% CI 27-48) of
-      whom 17 required hearing aids.
-    explanation: >-
-      Quantifies hearing loss at 37% in a mixed SEDC/Kniest/related COL2A1
-      cohort (7/93 Kniest), with over half requiring hearing aids.
 treatments:
 - name: Orthopedic Management
   description: >

--- a/references_cache/PMID_10406661.md
+++ b/references_cache/PMID_10406661.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:10406661"
+title: Small deletions in the type II collagen triple helix produce kniest dysplasia.
+authors:
+- Wilkin DJ
+- Artz AS
+- South S
+- Lachman RS
+- Rimoin DL
+- Wilcox WR
+- McKusick VA
+- Stratakis CA
+- Francomano CA
+- Cohn DH
+journal: Am J Med Genet
+year: '1999'
+keywords:
+- Base Sequence
+- Bone and Bones/diagnostic imaging
+- Child
+- "Child, Preschool"
+- Collagen/genetics
+- Female
+- Gene Deletion
+- Humans
+- Infant
+- Male
+- "Models, Genetic"
+- Molecular Sequence Data
+- "Osteochondrodysplasias/diagnostic imaging, genetics"
+- Radiography
+content_type: abstract_only
+---
+
+# Small deletions in the type II collagen triple helix produce kniest dysplasia.
+**Authors:** Wilkin DJ, Artz AS, South S, Lachman RS, Rimoin DL, Wilcox WR, McKusick VA, Stratakis CA, Francomano CA, Cohn DH
+**Journal:** Am J Med Genet (1999)
+
+## Content
+
+1. Am J Med Genet. 1999 Jul 16;85(2):105-12.
+
+Small deletions in the type II collagen triple helix produce kniest dysplasia.
+
+Wilkin DJ(1), Artz AS, South S, Lachman RS, Rimoin DL, Wilcox WR, McKusick VA, 
+Stratakis CA, Francomano CA, Cohn DH.
+
+Author information:
+(1)Medical Genetics Branch, National Human Genome Research Institute, National 
+Institutes of Health, Bethesda, Maryland 20892-1267, USA.
+
+Kniest dysplasia is a moderately severe type II collagenopathy, characterized by 
+short trunk and limbs, kyphoscoliosis, midface hypoplasia, severe myopia, and 
+hearing loss. Mutations in the gene that encodes type II collagen (COL2A1), the 
+predominant protein of cartilage, have been identified in a number of 
+individuals with Kniest dysplasia. All but two of these previously described 
+mutations cause in-frame deletions in type II collagen, either by small 
+deletions in the gene or splice site alterations. Furthermore, all but one of 
+these mutations is located between exons 12 and 24 in the COL2A1 gene. We used 
+heteroduplex analysis to identify sequence anomalies in five individuals with 
+Kniest dysplasia. Sequencing of the index patients' genomic DNA identified four 
+new dominant mutations in COL2A1 that result in Kniest dysplasia: a 21-bp 
+deletion in exon 16, an 18-bp deletion in exon 19, and 4-bp deletions in the 
+splice donor sites of introns 14 and 20. A previously described 28-bp deletion 
+at the COL2A1 exon 12-intron 12 junction, deleting the splice donor site, was 
+identified in the fifth case. The latter three mutations are predicted to result 
+in exon skipping in the mRNA encoded from the mutant allele. These data suggest 
+that Kniest dysplasia results from shorter type II collagen monomers, and 
+support the hypothesis that alteration of a specific COL2A1 domain, which may 
+span from exons 12 to 24, leads to the Kniest dysplasia phenotype.
+
+PMID: 10406661 [Indexed for MEDLINE]

--- a/references_cache/PMID_14644246.md
+++ b/references_cache/PMID_14644246.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:14644246"
+title: A case of Kniest dysplasia with retinal detachment and the mutation analysis.
+authors:
+- Yokoyama T
+- Nakatani S
+- Murakami A
+journal: Am J Ophthalmol
+year: '2003'
+doi: 10.1016/s0002-9394(03)00713-x
+keywords:
+- Adolescent
+- Collagen Type II/genetics
+- DNA Mutational Analysis
+- Humans
+- Male
+- Osteochondrodysplasias/genetics
+- Point Mutation
+- Polymerase Chain Reaction
+- "Retinal Detachment/genetics, surgery"
+- Silicone Oils/therapeutic use
+- Visual Acuity
+- Vitrectomy
+content_type: abstract_only
+---
+
+# A case of Kniest dysplasia with retinal detachment and the mutation analysis.
+**Authors:** Yokoyama T, Nakatani S, Murakami A
+**Journal:** Am J Ophthalmol (2003)
+**DOI:** [10.1016/s0002-9394(03)00713-x](https://doi.org/10.1016/s0002-9394(03)00713-x)
+
+## Content
+
+1. Am J Ophthalmol. 2003 Dec;136(6):1186-8. doi: 10.1016/s0002-9394(03)00713-x.
+
+A case of Kniest dysplasia with retinal detachment and the mutation analysis.
+
+Yokoyama T(1), Nakatani S, Murakami A.
+
+Author information:
+(1)Department of Ophthalmology, Juntendo University, School of Medicine, Tokyo, 
+Japan. yokoyama@med.juntendo.ac.jp
+
+PURPOSE: To report a case of Kniest dysplasia with retinal detachment associated 
+with a novel type II collagen gene (COL2A1) mutation.
+DESIGN: Interventional case report.
+METHODS: DNA was isolated from peripheral lymphocytes, and mutational analysis 
+was carried out using polymerase chain reaction and direct sequencing.
+RESULTS: A 14-year-old Japanese boy was diagnosed with Kniest dysplasia, and 
+ophthalmic examination revealed a retinal detachment in the right eye. He was 
+successfully treated by vitrectomy and silicon oil injection, and his visual 
+acuity improved from 0.01 to 0.22. DNA analysis of COL2A1 revealed a single 
+base-pair substitution at position +5 of intron 20.
+CONCLUSION: Vitrectomy and silicon oil injection were effective in reattaching 
+the retinal detachment in a Kniest dysplasia patient. The genetic alteration 
+found in this patient suggested that this prevented the normal splicing of 
+COL2A1, resulting in an abnormal type II collagen product.
+
+DOI: 10.1016/s0002-9394(03)00713-x
+PMID: 14644246 [Indexed for MEDLINE]

--- a/references_cache/PMID_27303468.md
+++ b/references_cache/PMID_27303468.md
@@ -1,0 +1,48 @@
+---
+reference_id: "PMID:27303468"
+title: "Kniest Dysplasia: New Radiographic Features in the Skeleton."
+authors:
+- Maldjian C
+- Chew FS
+- Klein R
+- Bonakdarpour A
+- McCarthy J
+- Kelly J
+journal: Radiol Case Rep
+year: '2007'
+doi: 10.2484/rcr.v2i2.89
+content_type: abstract_only
+---
+
+# Kniest Dysplasia: New Radiographic Features in the Skeleton.
+**Authors:** Maldjian C, Chew FS, Klein R, Bonakdarpour A, McCarthy J, Kelly J
+**Journal:** Radiol Case Rep (2007)
+**DOI:** [10.2484/rcr.v2i2.89](https://doi.org/10.2484/rcr.v2i2.89)
+
+## Content
+
+1. Radiol Case Rep. 2015 Dec 7;2(2):72-7. doi: 10.2484/rcr.v2i2.89. eCollection 
+2007.
+
+Kniest Dysplasia: New Radiographic Features in the Skeleton.
+
+Maldjian C, Chew FS, Klein R, Bonakdarpour A, McCarthy J, Kelly J.
+
+OBJECTIVE: To describe skeletal findings in patients with Kniest dysplasia, 
+focusing on osseous abnormalities that have not been characteristically 
+associated with this disorder.
+MATERIALS AND METHODS: This was a retrospective study. The radiographs of four 
+patients with known Kniest Dysplasia were evaluated by three musculoskeletal 
+radiologists.
+RESULTS: Bilateral radial head dislocations and bilateral clubfeet were seen in 
+our series. Other characteristic findings for this dysplasia were seen in all 
+four patients.
+CONCLUSIONS: Clubfeet and radial head dislocations may be associated with Kniest 
+dysplasia. The presence of these osseous findings in the context of multiple 
+skeletal abnormalities suggestive of a skeletal dysplasia should indicate the 
+possibility of Kniest dysplasia and pathognomonic features for this entity 
+should be sought.
+
+DOI: 10.2484/rcr.v2i2.89
+PMCID: PMC4891633
+PMID: 27303468

--- a/references_cache/PMID_2931448.md
+++ b/references_cache/PMID_2931448.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:2931448"
+title: Craniofacial and mucopolysaccharide abnormalities in Kniest dysplasia.
+authors:
+- Friede H
+- Matalon R
+- Harris V
+- Rosenthal IM
+journal: J Craniofac Genet Dev Biol
+year: '1985'
+keywords:
+- Cephalometry
+- Child
+- "Facial Bones/abnormalities, diagnostic imaging"
+- Glycosaminoglycans/urine
+- Humans
+- Keratan Sulfate/urine
+- Male
+- "Mucopolysaccharidoses/complications, diagnostic imaging"
+- Radiography
+- "Skull/abnormalities, diagnostic imaging"
+content_type: abstract_only
+---
+
+# Craniofacial and mucopolysaccharide abnormalities in Kniest dysplasia.
+**Authors:** Friede H, Matalon R, Harris V, Rosenthal IM
+**Journal:** J Craniofac Genet Dev Biol (1985)
+
+## Content
+
+1. J Craniofac Genet Dev Biol. 1985;5(3):267-76.
+
+Craniofacial and mucopolysaccharide abnormalities in Kniest dysplasia.
+
+Friede H, Matalon R, Harris V, Rosenthal IM.
+
+Serial roentgencephalograms of a male patient with Kniest dysplasia were 
+obtained between 1 7/12 and 11 3/12 years of age and were analyzed and compared 
+to cephalometric normative data. The patient displayed macrocephaly with 
+increased size of the neurocranium in all three dimensions. The cranial base 
+angle was significantly flattened, partly as a result of anterior displacement 
+of the sella turcica. The odontoid process was short and wide. At 11 years of 
+age there was bony fusion between the anterior arch of the atlas and the 
+odontoid process as well as between the posterior arch of the atlas and the 
+cranial base. The facial skeleton, including the nasal bones, infra-orbital 
+rims, maxilla and mandible, was retropositioned relative to the anterior cranial 
+base. The mandibular retrognathia was pronounced at an early age but improved 
+with growth. At age 11 years the patient had a straight facial skeletal profile. 
+Examination of the patient's 24-hour urinary excretion of keratan sulfate 
+revealed values markedly elevated for his age. Three additional patients with 
+Kniest dysplasia demonstrated similarly increased excretion of this 
+glycosaminoglycan. The diagnosis of Kniest dysplasia can usually be made from 
+roentgenograms of the extremities, the spine, and the pelvis. However, the 
+morphologic characteristics of the head, as shown by cephalometric analysis, and 
+the increased urinary excretion of keratan sulfate add confirmatory evidence 
+useful in differential diagnosis.
+
+PMID: 2931448 [Indexed for MEDLINE]

--- a/research/Kniest_Dysplasia-phenotype-curation-2026-04-18.md
+++ b/research/Kniest_Dysplasia-phenotype-curation-2026-04-18.md
@@ -1,0 +1,24 @@
+# Kniest Dysplasia Phenotype Curation Notes
+
+Date: 2026-04-18
+
+Scope: targeted phenotype-section cleanup for `kb/disorders/Kniest_Dysplasia.yaml`.
+
+## Main phenotype sources used
+
+- `PMID:10406661` supports the core overview phenotype: short trunk and limbs, kyphoscoliosis, midface hypoplasia, severe myopia, and hearing loss.
+- `PMID:25592122` provides the strongest disease-specific ophthalmic series and also supports enlarged joints with restricted mobility, marked hand arthropathy, clefting abnormalities, hearing impairment, abnormal vitreous architecture, high myopia, and retinal detachment risk.
+- `PMID:40475174` supports narrow thorax, short extremities, short stature, cleft palate, platyspondyly, coronal clefts, and dumbbell-shaped long bones in an infant with molecularly confirmed disease.
+- `PMID:41378240` supports adult short stature, cataract, retinal detachment, kyphoscoliosis, and epiphyseal enlargement.
+- `PMID:2931448` supports abnormal odontoid morphology and craniofacial retrusion.
+- `PMID:27303468` supports clubfoot and radial head dislocation as reported radiographic associations in a 4-patient Kniest series.
+- `PMID:14644246` supports retinal detachment in an adolescent patient.
+- `PMID:7700721` supports cleft palate and progressive arthropathy as classic Kniest manifestations.
+
+## Curatorial decisions
+
+- Added missing clinically important phenotypes: hand arthropathy, narrow thorax, cataract, clubfoot, and radial head dislocation.
+- Replaced the unsupported `Malar Flattening` entry with PMID-backed `Midface Hypoplasia`.
+- Kept odontoid involvement but rewrote it to direct Kniest evidence instead of mixed-COL2A1 cohort frequencies.
+- Removed the weak `Coxa Vara` phenotype because the cited evidence did not actually support a Kniest-specific coxa vara claim.
+- Removed or softened mixed-cohort frequency/onset statements for myopia, retinal detachment, hearing loss, and odontoid hypoplasia unless directly supported by Kniest-specific abstracts.


### PR DESCRIPTION
## Summary
- tighten the `Kniest_Dysplasia.yaml` phenotype section to exact PMID-backed claims
- add missing clinically important phenotypes including hand arthropathy, narrow thorax, cataract, midface hypoplasia, clubfoot, and radial head dislocation
- remove or soften weak phenotype assertions that relied on mixed COL2A1 cohorts or unsupported wording, including the unsupported `Coxa Vara` entry

## Validation
- `just validate kb/disorders/Kniest_Dysplasia.yaml`
- `just validate-references kb/disorders/Kniest_Dysplasia.yaml`
- `just validate-terms kb/disorders/Kniest_Dysplasia.yaml`

Related: #1453