### PR TITLE
[codex] Enhance Diastrophic Dysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Diastrophic_Dysplasia.yaml
+++ b/kb/disorders/Diastrophic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Diastrophic Dysplasia
 creation_date: '2026-03-04T07:00:00Z'
-updated_date: '2026-04-06T23:35:31Z'
+updated_date: '2026-04-19T00:08:54Z'
 category: Mendelian
 classifications:
   harrisons_chapter:
@@ -537,14 +537,27 @@ phenotypes:
   name: Disproportionate Short-Limbed Short Stature
   frequency: OBLIGATE
   description: >
-    Marked limb shortening with a relatively preserved trunk length, resulting
-    in rhizomelic dwarfism. Growth failure is progressive, with median adult
-    height of 136 cm in males and 129 cm in females.
+    Marked short-limbed short stature is present from birth and growth failure
+    is progressive through childhood.
   phenotype_term:
     preferred_term: Disproportionate short-limb short stature
     term:
       id: HP:0008873
       label: Disproportionate short-limb short stature
+  phenotype_contexts:
+  - onset:
+      onset_category: CONGENITAL
+      notes: Significant growth deficit was usually already present at birth.
+    evidence:
+    - reference: PMID:34064542
+      reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The children had usually a significant growth deficit already at birth.
+      explanation: >-
+        The Finnish pediatric cohort documents congenital onset of growth
+        deficiency in DTD.
   evidence:
   - reference: PMID:9108864
     reference_title: "Growth in diastrophic dysplasia."
@@ -557,21 +570,20 @@ phenotypes:
     explanation: >-
       Largest growth study in DTD (121 Finnish patients) with disease-specific
       growth curves.
-  - reference: PMID:24598000
-    reference_title: "SLC26A2 disease spectrum in Sweden - high frequency of recessive multiple epiphyseal dysplasia (rMED)."
+  - reference: PMID:34064542
+    reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Clinical features include short stature, joint contractures, spinal
-      deformities, and cleft palate.
+      In our cohort, all children with DTD phenotype had a short stature.
     explanation: >-
-      Short stature listed as core DTD manifestation in the Swedish cohort.
+      The contemporary Finnish cohort confirms that short stature is an
+      obligate phenotype in clinically typical DTD.
 - category: Skeletal
   name: Clubfoot
   frequency: FREQUENT
   description: >
-    Bilateral talipes equinovarus is present in most affected neonates and
-    frequently requires early casting or surgical correction.
+    Congenital talipes equinovarus is common and often bilateral.
   phenotype_term:
     preferred_term: Clubfoot
     term:
@@ -595,13 +607,14 @@ phenotypes:
       club feet, ulnar diviation of hands, shortened phalanges, and, in
       particular, abduction of thumbs ('hitchhiker thumbs') and big toes.
     explanation: >-
-      Clubfoot documented as part of the characteristic DTD deformity pattern.
+      Prenatal ultrasound shows that clubfoot can already be present before
+      birth in DTD.
 - category: Skeletal
   name: Hitchhiker Thumb
   frequency: FREQUENT
   description: >
-    Abducted "hitchhiker" thumbs are a hallmark hand deformity arising from
-    dysplasia of the first metacarpal and metacarpophalangeal joint.
+    Abduction of the thumb is a characteristic hand finding that can be
+    recognized prenatally.
   phenotype_term:
     preferred_term: Hitchhiker thumb
     term:
@@ -622,10 +635,37 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      the most common findings were symphalangism of the fingers (n = 7),
-      hitchhiker's thumb/abduction of the thumb (n = 7)
+      Hand abnormalities were present in all subjects; the most common
+      findings were symphalangism of the fingers (n = 7), hitchhiker’s
+      thumb/abduction of the thumb (n = 7), flexion tendency of the fingers
+      (n = 6) and lack of proximal interphalangeal joints (n = 1).
     explanation: >-
-      Hitchhiker thumb present in half the Finnish pediatric cohort subjects.
+      Hitchhiker thumb was one of the commonest hand abnormalities in the
+      Finnish pediatric cohort.
+- category: Skeletal
+  name: Finger Symphalangism
+  frequency: FREQUENT
+  description: >
+    Finger symphalangism is a common component of the characteristic hand
+    phenotype in DTD.
+  phenotype_term:
+    preferred_term: Finger symphalangism
+    term:
+      id: HP:0009700
+      label: Finger symphalangism
+  evidence:
+  - reference: PMID:34064542
+    reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hand abnormalities were present in all subjects; the most common
+      findings were symphalangism of the fingers (n = 7), hitchhiker’s
+      thumb/abduction of the thumb (n = 7), flexion tendency of the fingers
+      (n = 6) and lack of proximal interphalangeal joints (n = 1).
+    explanation: >-
+      Symphalangism was reported in half of the Finnish pediatric cohort and is
+      a specific, recurrent hand manifestation of DTD.
 - category: Skeletal
   name: Joint Contractures
   frequency: VERY_FREQUENT
@@ -660,30 +700,105 @@ phenotypes:
       Hip flexion contractures documented in 93% of 50 DTD patients, with
       progressive course.
 - category: Skeletal
+  name: Genu Valgum
+  frequency: VERY_FREQUENT
+  description: >
+    Valgus knee deformity is a prominent lower-limb manifestation in DTD.
+  phenotype_term:
+    preferred_term: Genu valgum
+    term:
+      id: HP:0002857
+      label: Genu valgum
+  evidence:
+  - reference: PMID:34064542
+    reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The prevalence of knee problems was high; valgus deformity (86%), lateral
+      position of patella (79%) and absence/laxity of the anterior cruciate
+      ligament (ACL) (71%) were the main features.
+    explanation: >-
+      The Finnish pediatric cohort documents genu valgum in 86% of affected
+      children.
+  - reference: PMID:14630837
+    reference_title: "Total knee arthroplasty in patients with diastrophic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The knee joint often has an abnormal valgus position and is unstable, and
+      degeneration of all joint compartments occurs, even during growth.
+    explanation: >-
+      Adult surgical series independently confirms valgus knee deformity as a
+      typical DTD knee phenotype.
+- category: Skeletal
+  name: Patellar Dislocation
+  frequency: FREQUENT
+  description: >
+    Patellar instability and luxation are common components of the DTD knee
+    phenotype.
+  phenotype_term:
+    preferred_term: Patellar dislocation
+    term:
+      id: HP:0002999
+      label: Patellar dislocation
+  evidence:
+  - reference: PMID:34064542
+    reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patellar luxation was seen in over half of the cohort.
+    explanation: >-
+      The Finnish pediatric cohort shows that patellar luxation is a common
+      manifestation in childhood DTD.
+  - reference: PMID:14630837
+    reference_title: "Total knee arthroplasty in patients with diastrophic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Preoperatively, ten knees had chronic dislocation of the patella.
+    explanation: >-
+      Adult surgical series confirms clinically significant patellar
+      dislocation in advanced DTD knee disease.
+- category: Skeletal
   name: Cervical Kyphosis
   frequency: FREQUENT
   description: >
-    Cervical kyphosis is present in the majority of DTD patients during
-    childhood. It may resolve spontaneously but can progress to severe degrees
-    with risk of spinal cord compression.
+    Cervical kyphosis is usually apparent at birth or in early infancy. It
+    often resolves during growth, but severe cases may require surgery or cause
+    neurologic compromise.
   phenotype_term:
     preferred_term: Cervical kyphosis
     term:
       id: HP:0002947
       label: Cervical kyphosis
+  phenotype_contexts:
+  - onset:
+      onset_category: CONGENITAL
+      notes: Usually shown at the time of birth or on the first cervical images.
+    evidence:
+    - reference: PMID:10528373
+      reference_title: "Cervical kyphosis in diastrophic dysplasia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Cervical kyphosis in diastrophic dysplasia usually is shown at the
+        time of birth.
+      explanation: >-
+        Longitudinal cervical spine study establishes congenital onset for this
+        phenotype in most affected patients.
   evidence:
   - reference: PMID:10528373
     reference_title: "Cervical kyphosis in diastrophic dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Typical findings in this rare skeletal dysplasia are sport-limbed short
-      stature, multiple joint contractures, early degeneration of joints, and
-      spinal deformities such as cervical kyphosis, scoliosis, and exaggerated
-      lumbar lordosis.
+      In the 24 patients, the kyphosis resolved spontaneously at an average age
+      of 7.1 years.
     explanation: >-
-      Longitudinal radiographic series identifying cervical kyphosis as a
-      typical DTD spinal finding.
+      Natural-history study shows that cervical kyphosis commonly improves
+      spontaneously during childhood.
   - reference: PMID:34064542
     reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
     supports: SUPPORT
@@ -697,32 +812,30 @@ phenotypes:
   name: Scoliosis
   frequency: FREQUENT
   description: >
-    Scoliosis occurs in 37-90% of DTD patients and has variable natural
-    history. It can be classified as early-progressive, idiopathic-like, or
-    mild non-progressive.
+    Scoliosis affects a substantial subset of patients and may appear in
+    infancy or later childhood.
   phenotype_term:
     preferred_term: Scoliosis
     term:
       id: HP:0002650
       label: Scoliosis
   evidence:
-  - reference: PMID:10528373
-    reference_title: "Cervical kyphosis in diastrophic dysplasia."
+  - reference: PMID:34064542
+    reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Typical findings in this rare skeletal dysplasia are sport-limbed short
-      stature, multiple joint contractures, early degeneration of joints, and
-      spinal deformities such as cervical kyphosis, scoliosis, and exaggerated
-      lumbar lordosis.
+      Five children (36%) had scoliosis. The children obtained their diagnosis
+      of scoliosis at 0-14 years of age. One child had a rapidly progressing
+      scoliosis at age 1 year.
     explanation: >-
-      Scoliosis identified as part of the canonical DTD spinal phenotype.
+      The Finnish pediatric cohort documents both the frequency of scoliosis and
+      the wide variation in age at onset and severity.
 - category: Skeletal
   name: Lumbar Hyperlordosis
   frequency: FREQUENT
   description: >
-    Exaggerated lumbar lordosis is present in over half of DTD patients and
-    contributes to spinal imbalance and gait difficulty.
+    Pronounced lumbar lordosis is a common spinal deformity in DTD.
   phenotype_term:
     preferred_term: Lumbar hyperlordosis
     term:
@@ -750,8 +863,7 @@ phenotypes:
   name: Cleft Palate
   frequency: FREQUENT
   description: >
-    Cleft palate occurs in approximately 30-64% of DTD patients, reflecting
-    disrupted proteoglycan-dependent craniofacial mesenchyme development.
+    Cleft palate is a common craniofacial manifestation of DTD.
   phenotype_term:
     preferred_term: Cleft palate
     term:
@@ -776,16 +888,16 @@ phenotypes:
     explanation: >-
       High prevalence (64%) of cleft palate in the Finnish pediatric cohort.
 - category: Craniofacial
-  name: Micrognathia
+  name: Short Chin
   frequency: FREQUENT
   description: >
-    Small mandible is a common craniofacial finding in DTD, reflecting
-    disrupted cartilaginous development of the mandibular condyle.
+    A small or short chin is common in DTD; prenatal reports may describe this
+    craniofacial finding as micrognathia.
   phenotype_term:
-    preferred_term: Micrognathia
+    preferred_term: Short chin
     term:
-      id: HP:0000347
-      label: Micrognathia
+      id: HP:0000331
+      label: Short chin
   evidence:
   - reference: PMID:3065771
     reference_title: "Diastrophic dysplasia: a specific prenatal diagnosis by ultrasound."
@@ -795,8 +907,8 @@ phenotypes:
       micrognathia, cervical kyphosis, persistent extension limitation in elbow
       and knee joints, club feet
     explanation: >-
-      Micrognathia documented among characteristic DTD deformities on prenatal
-      ultrasound.
+      Prenatal ultrasound supports mandibular/chin hypoplasia as part of the
+      DTD craniofacial phenotype.
   - reference: PMID:34064542
     reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
     supports: SUPPORT
@@ -804,23 +916,45 @@ phenotypes:
     snippet: >-
       ten had small chin
     explanation: >-
-      Small chin (micrognathia) present in 10 of 14 subjects in the Finnish
-      pediatric cohort.
+      Small chin was present in 10 of 14 children in the Finnish pediatric
+      cohort.
 - category: Ear
-  name: Cystic Ear Swelling
+  name: Cystic Lesions of the Pinnae
   frequency: FREQUENT
-  diagnostic: true
   description: >
-    Cystic swelling of the pinnae in the neonatal period, present in
-    approximately two-thirds of neonates with DTD. If the swelling scars,
-    it produces a cauliflower ear deformity. This finding is considered
-    pathognomonic for diastrophic dysplasia.
+    Auricular swelling is a characteristic cartilage manifestation in DTD. It
+    commonly appears in early infancy and may heal with permanent deformity.
   phenotype_term:
-    preferred_term: Cystic ear swelling (cauliflower ear deformity)
+    preferred_term: Cystic lesions of the pinnae
     term:
-      id: HP:0000377
-      label: Abnormal pinna morphology
+      id: HP:0010723
+      label: Cystic lesions of the pinnae
+  phenotype_contexts:
+  - onset:
+      onset_category: INFANTILE
+      notes: Auricular swelling commonly occurs in early infancy.
+    evidence:
+    - reference: PMID:21414669
+      reference_title: "Prevention of auricular deformity in children with diastrophic dysplasia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In diastrophic dysplasia, auricular swelling commonly occurs in early
+        infancy, inevitably leading to deformity.
+      explanation: >-
+        Phenotype-specific otolaryngology case report establishes early infancy
+        as the typical onset window.
   evidence:
+  - reference: PMID:21414669
+    reference_title: "Prevention of auricular deformity in children with diastrophic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In diastrophic dysplasia, auricular swelling commonly occurs in early
+      infancy, inevitably leading to deformity.
+    explanation: >-
+      Auricular swelling with later deformity is a recognized DTD-specific ear
+      manifestation.
   - reference: PMID:34064542
     reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
     supports: SUPPORT
@@ -829,18 +963,54 @@ phenotypes:
       five had auricular abnormalities (swelling/deformities).
     explanation: >-
       Auricular swelling and deformities documented in the Finnish cohort.
-- category: Skeletal
-  name: Premature Osteoarthritis
+- category: Respiratory
+  name: Respiratory Insufficiency
   frequency: FREQUENT
   description: >
-    Early-onset degenerative joint disease affecting weight-bearing joints,
-    especially hips and knees. Undersulfated articular cartilage cannot
-    withstand normal mechanical stress, leading to osteoarthritis often
-    requiring joint replacement in young adulthood.
+    Respiratory insufficiency can complicate the neonatal period in DTD and may
+    require intensive care.
+  phenotype_term:
+    preferred_term: Respiratory insufficiency
+    term:
+      id: HP:0002093
+      label: Respiratory insufficiency
+  phenotype_contexts:
+  - onset:
+      onset_category: NEONATAL
+      notes: Respiratory insufficiency was reported after birth in the Finnish cohort.
+    evidence:
+    - reference: PMID:34064542
+      reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Five subjects (36%) had respiratory insufficiency after birth; three of
+        them were treated at the intensive care unit and one had severe
+        pulmonary hypertension.
+      explanation: >-
+        The Finnish pediatric cohort directly documents neonatal respiratory
+        insufficiency in DTD.
+  evidence:
+  - reference: PMID:34064542
+    reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Five subjects (36%) had respiratory insufficiency after birth; three of
+      them were treated at the intensive care unit and one had severe pulmonary
+      hypertension.
+    explanation: >-
+      Respiratory insufficiency after birth occurred in over one third of the
+      Finnish pediatric cohort.
+- category: Skeletal
+  name: Premature Osteoarthritis
+  description: >
+    Degenerative joint disease affects weight-bearing joints early, especially
+    the hips and knees.
   notes: >-
-    Only 2/14 pediatric subjects had early-onset osteoarthritis in the
-    Finnish cohort, but prevalence increases substantially with age; most
-    adults develop degenerative changes in weight-bearing joints.
+    In the Finnish pediatric cohort, arthrosis was already documented at ages 10
+    and 17 years, and adult hip and knee series show progression to secondary
+    osteoarthritis and arthroplasty.
   phenotype_term:
     preferred_term: Premature osteoarthritis
     term:
@@ -868,16 +1038,15 @@ phenotypes:
       Progressive hip deformity leading to secondary osteoarthritis
       documented radiographically.
 - category: Skeletal
-  name: Short Phalanges
-  frequency: VERY_FREQUENT
+  name: Brachydactyly
   description: >
-    Shortened phalanges of the fingers are common, contributing to
-    brachydactyly and limited hand function.
+    Shortened digits are part of the characteristic hand phenotype in DTD and
+    can be recognized prenatally.
   phenotype_term:
-    preferred_term: Short phalanx of finger
+    preferred_term: Brachydactyly
     term:
-      id: HP:0009803
-      label: Short phalanx of finger
+      id: HP:0001156
+      label: Brachydactyly
   evidence:
   - reference: PMID:3065771
     reference_title: "Diastrophic dysplasia: a specific prenatal diagnosis by ultrasound."
@@ -886,20 +1055,20 @@ phenotypes:
     snippet: >-
       shortened phalanges
     explanation: >-
-      Shortened phalanges noted among characteristic skeletal deformities on
-      prenatal imaging.
+      Prenatal ultrasound documented shortened phalanges in fetal DTD.
   - reference: PMID:34064542
     reference_title: "SLC26A2-Associated Diastrophic Dysplasia and rMED-Clinical Features in Affected Finnish Children and Review of the Literature."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Hand abnormalities were present in all subjects; the most common
-      findings were symphalangism of the fingers (n = 7), hitchhiker's
-      thumb/abduction of the thumb (n = 7), flexion tendency of the fingers
-      (n = 6) and lack of proximal interphalangeal joints (n = 1).
+      Radiological findings in DTD include shortened long bones with
+      metaphyseal flaring, flat epiphyses, kyphoscoliosis, cervical kyphosis,
+      bowed radius and tibia, proximally situated "hitchhiker" thumb with
+      shortness of the first metacarpal, brachydactyly and ulnar deviation of
+      fingers.
     explanation: >-
-      Hand abnormalities including shortened/absent phalanges present in
-      100% of the Finnish DTD cohort, supporting VERY_FREQUENT frequency.
+      Review of radiographic findings identifies brachydactyly as part of the
+      canonical DTD hand phenotype.
 biochemical:
 - name: Reduced Proteoglycan Sulfation
   presence: Decreased

--- a/references_cache/PMID_21414669.md
+++ b/references_cache/PMID_21414669.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:21414669"
+title: Prevention of auricular deformity in children with diastrophic dysplasia.
+authors:
+- Cushing SL
+- Swanson RL
+- Sie KC
+journal: Int J Pediatr Otorhinolaryngol
+year: '2011'
+doi: 10.1016/j.ijporl.2011.02.003
+keywords:
+- Combined Modality Therapy
+- Drainage/methods
+- "Dwarfism/complications, diagnosis, therapy"
+- Ear Auricle/abnormalities
+- "Ear Deformities, Acquired/etiology, prevention & control"
+- "Edema/diagnosis, therapy"
+- Follow-Up Studies
+- Humans
+- "Infant, Newborn"
+- Prostheses and Implants
+- Risk Assessment
+- Siblings
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Prevention of auricular deformity in children with diastrophic dysplasia.
+**Authors:** Cushing SL, Swanson RL, Sie KC
+**Journal:** Int J Pediatr Otorhinolaryngol (2011)
+**DOI:** [10.1016/j.ijporl.2011.02.003](https://doi.org/10.1016/j.ijporl.2011.02.003)
+
+## Content
+
+1. Int J Pediatr Otorhinolaryngol. 2011 May;75(5):713-5. doi: 
+10.1016/j.ijporl.2011.02.003. Epub 2011 Mar 17.
+
+Prevention of auricular deformity in children with diastrophic dysplasia.
+
+Cushing SL(1), Swanson RL, Sie KC.
+
+Author information:
+(1)Division of Pediatric Otolaryngology, Head and Neck Surgery, Seattle 
+Children's Hospital, Seattle, WA, United States; Department of Otolaryngology, 
+Head and Neck Surgery, Hospital for Sick Children, Toronto, ON, Canada.
+
+In diastrophic dysplasia, auricular swelling commonly occurs in early infancy, 
+inevitably leading to deformity. Till date, no description exists in the 
+literature for the initial treatment of auricular swelling in this population. 
+We present two siblings with diastrophic dysplasia on whom auricular swelling 
+was treated with incision and drainage or conforming auricular molds. The ear 
+treated with incision and drainage had worse outcome than those treated with 
+pressure alone. This paper presents a novel but simple approach to the 
+compression of auricular swelling in the setting of diastrophic dysplasia, using 
+conforming molds with the goal of preventing permanent deformity.
+
+Copyright © 2011. Published by Elsevier Ireland Ltd.
+
+DOI: 10.1016/j.ijporl.2011.02.003
+PMID: 21414669 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
This PR deepens the phenotype curation for `kb/disorders/Diastrophic_Dysplasia.yaml` with a narrow focus on issue #1452.

Changes in scope:
- tightened existing phenotype descriptions so frequency and onset claims are only used where directly supported
- replaced the broad ear mapping with a specific HPO term backed by a phenotype-specific PMID
- added missing clinically important phenotypes with PMID-backed evidence, including finger symphalangism, genu valgum, patellar dislocation, and neonatal respiratory insufficiency
- softened unsupported diagnostic/pathognomonic language in the ear phenotype entry

## Why
The existing phenotype block captured the core DTD picture, but several manifestations were either missing, mapped too broadly, or described more strongly than the cited evidence justified. This update makes the phenotype section more complete and better aligned to exact source text.

## Validation
Ran locally:
- `just validate kb/disorders/Diastrophic_Dysplasia.yaml`
- `just validate-references kb/disorders/Diastrophic_Dysplasia.yaml`
- `just validate-terms kb/disorders/Diastrophic_Dysplasia.yaml`

All three commands passed.

Refs: #1452