### PR TITLE
[codex] Enhance TD2 phenotype evidence

### DIFF
--- a/kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
+++ b/kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
@@ -1,6 +1,6 @@
 name: Thanatophoric Dysplasia Type 2
 creation_date: '2026-02-02T00:16:36Z'
-updated_date: '2026-04-07T16:11:01Z'
+updated_date: '2026-04-19T00:07:48Z'
 category: Mendelian
 description: >
   Thanatophoric dysplasia type 2 (TD2) is a severe, usually lethal skeletal dysplasia
@@ -490,9 +490,8 @@ pathophysiology:
 phenotypes:
 - name: Lethal short-limbed short stature
   description: >
-    Extreme micromelia with severely shortened limbs appearing flipper-like,
-    predominantly rhizomelic in distribution.
-  frequency: HP_0040281
+    Severe micromelia with marked shortening of the limbs, especially
+    proximally.
   phenotype_term:
     preferred_term: Lethal short-limbed short stature
     term:
@@ -515,7 +514,6 @@ phenotypes:
     Unlike TD1, the femurs in TD2 are straight rather than bowed. This is the
     key distinguishing radiographic feature between the two types, with TD2
     femurs described as having a proximal medial spike.
-  frequency: HP_0040281
   notes: >-
     No specific HPO term currently captures the TD2-defining straight
     (non-bowed) femur morphology with proximal medial spike. Broader parent
@@ -545,9 +543,9 @@ phenotypes:
       Adds the proximal medial spike detail for TD2 femur morphology.
 - name: Cloverleaf skull
   description: >
-    Kleeblattschadel (cloverleaf skull) deformity with trilobed skull shape due
-    to premature craniosynostosis. This is highly characteristic of TD2 and
-    helps distinguish it from TD1, where it is less common.
+    Severe kleeblattschadel with a trilobed skull contour. This is one of the
+    most characteristic cranial manifestations of TD2 and helps distinguish it
+    from TD1.
   frequency: HP_0040281
   phenotype_term:
     preferred_term: Cloverleaf skull
@@ -555,6 +553,15 @@ phenotypes:
       id: HP:0002676
       label: Cloverleaf skull
   evidence:
+  - reference: PMID:3130852
+    reference_title: "Thanatophoric dysplasia and cloverleaf skull."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Almost all type 2 cases have severe CS.
+    explanation: >-
+      Direct qualitative frequency evidence supporting a VERY_FREQUENT
+      cloverleaf skull phenotype in TD2.
   - reference: PMID:8845844
     reference_title: "Missense FGFR3 mutations create cysteine residues in thanatophoric dwarfism type I (TD1)."
     supports: SUPPORT
@@ -563,17 +570,47 @@ phenotypes:
       in TD2, straight femurs are associated with cloverleaf skull.
     explanation: >-
       Establishes the association of cloverleaf skull with TD2 specifically.
+- name: Short ribs
+  description: >
+    Short ribs contribute to the narrow thorax and secondary pulmonary
+    hypoplasia.
+  phenotype_term:
+    preferred_term: Short ribs
+    term:
+      id: HP:0000773
+      label: Short ribs
+  evidence:
+  - reference: PMID:23573386
+    reference_title: "Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo FGFR3 Missense Mutations located in cis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      It is primarily an autosomal dominant disorder and is characterised by
+      macrocephaly, a narrow thorax, short ribs, brachydactyly, and hypotonia.
+    explanation: >-
+      The abstract lists short ribs among the core clinical features of
+      thanatophoric dysplasia shared across subtypes, supporting inclusion in
+      TD2.
 - name: Narrow thorax
   description: >
-    Severely narrow, bell-shaped thorax with short ribs leading to pulmonary
-    hypoplasia and respiratory failure.
-  frequency: HP_0040281
+    Severely narrow thorax present prenatally and persisting postnatally.
   phenotype_term:
     preferred_term: Narrow chest
     term:
       id: HP:0000774
       label: Narrow chest
   evidence:
+  - reference: PMID:11241532
+    reference_title: "Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The TD2 fetus was characterized by polyhydramnios, short limbs, a narrow
+      thoracic cage, straight short femora, hydrocephalus and a cloverleaf skull
+      at 24 weeks' gestation.
+    explanation: >-
+      Prenatal case report documenting a narrow thoracic cage in molecularly
+      confirmed TD2.
   - reference: PMID:8845844
     reference_title: "Missense FGFR3 mutations create cysteine residues in thanatophoric dwarfism type I (TD1)."
     supports: SUPPORT
@@ -582,10 +619,41 @@ phenotypes:
       Thanatophoric dwarfism (TD) is a sporadic lethal skeletal dysplasia with
       micromelic shortening of the limbs, macrocephaly, platyspondyly and reduced
       thoracic cavity.
-    explanation: Confirms reduced thoracic cavity as a core TD feature.
+    explanation: Confirms reduced thoracic cavity as a core thanatophoric dysplasia feature.
+- name: Pulmonary hypoplasia
+  description: >
+    Underdevelopment of the lungs secondary to thoracic restriction, contributing
+    directly to perinatal lethality.
+  phenotype_term:
+    preferred_term: Pulmonary hypoplasia
+    term:
+      id: HP:0002089
+      label: Pulmonary hypoplasia
+  evidence:
+  - reference: PMID:23323754
+    reference_title: "Thanatophoric dysplasia: autopsy findings over a 25-year period."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Lung/body, brain/body, and brain/lung weight ratios confirm macrocephaly
+      and lung hypoplasia, which are constant findings in cases involving
+      thanatophoric dysplasia.
+    explanation: >-
+      Large autopsy series identifies lung hypoplasia as a constant morphologic
+      finding in thanatophoric dysplasia.
+  - reference: PMID:33520059
+    reference_title: "Thanatophoric dysplasia: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The fetal death is usually due to severe respiratory insufficiency from a
+      reduced thoracic capacity and hypoplastic lungs and/or respiratory failure
+      due to brainstem compression.
+    explanation: >-
+      Independent case report links pulmonary hypoplasia to the lethal
+      respiratory phenotype.
 - name: Platyspondyly
   description: Severe flattening of the vertebral bodies.
-  frequency: HP_0040281
   phenotype_term:
     preferred_term: Platyspondyly
     term:
@@ -602,14 +670,26 @@ phenotypes:
       thoracic cavity.
     explanation: Confirms platyspondyly as a core feature.
 - name: Macrocephaly
-  description: Large head circumference, often associated with cloverleaf deformity.
-  frequency: HP_0040281
+  description: Large head circumference relative to body size.
   phenotype_term:
     preferred_term: Macrocephaly
     term:
       id: HP:0000256
       label: Macrocephaly
   evidence:
+  - reference: PMID:24075385
+    reference_title: "Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The pregnancy was subsequently terminated, and a 480-g malformed fetus was
+      delivered with macrocephaly, depressed nasal bridge, short upturned nasal
+      tip, hypoplastic midface, frontal bossing, short digits, trident-shaped
+      hands, short limbs, cloverleaf skull, narrow chest, brachydactyly, nuchal
+      edema, and bulging occipital bone.
+    explanation: >-
+      Molecularly confirmed TD2 case documents macrocephaly among the craniofacial
+      findings.
   - reference: PMID:8845844
     reference_title: "Missense FGFR3 mutations create cysteine residues in thanatophoric dwarfism type I (TD1)."
     supports: SUPPORT
@@ -621,23 +701,64 @@ phenotypes:
     explanation: Confirms macrocephaly as a core TD feature.
 - name: Frontal bossing
   description: Prominent forehead.
-  frequency: HP_0040281
   phenotype_term:
     preferred_term: Frontal bossing
     term:
       id: HP:0002007
       label: Frontal bossing
+  evidence:
+  - reference: PMID:24075385
+    reference_title: "Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The prenatal ultrasound showed short straight femurs, prominent forehead,
+      narrow chest, skin edema, short limbs, and cloverleaf skull consistent
+      with the diagnosis of TD2.
+    explanation: >-
+      Molecularly confirmed prenatal TD2 case supports frontal bossing/prominent
+      forehead as a craniofacial manifestation.
+- name: Brachydactyly
+  description: Short digits of the hands and feet.
+  phenotype_term:
+    preferred_term: Brachydactyly
+    term:
+      id: HP:0001156
+      label: Brachydactyly
+  evidence:
+  - reference: PMID:24075385
+    reference_title: "Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The pregnancy was subsequently terminated, and a 480-g malformed fetus was
+      delivered with macrocephaly, depressed nasal bridge, short upturned nasal
+      tip, hypoplastic midface, frontal bossing, short digits, trident-shaped
+      hands, short limbs, cloverleaf skull, narrow chest, brachydactyly, nuchal
+      edema, and bulging occipital bone.
+    explanation: >-
+      Molecularly confirmed TD2 case documents short digits and brachydactyly.
 - name: Respiratory insufficiency
   description: >
-    Severe respiratory failure due to pulmonary hypoplasia is the primary cause
-    of perinatal death. All long-term survivors require assisted ventilation.
-  frequency: HP_0040281
+    Severe respiratory failure is typical in the perinatal period, and long-term
+    survivors require ongoing ventilatory support.
   phenotype_term:
     preferred_term: Respiratory insufficiency
     term:
       id: HP:0002093
       label: Respiratory insufficiency
   evidence:
+  - reference: PMID:33520059
+    reference_title: "Thanatophoric dysplasia: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The fetal death is usually due to severe respiratory insufficiency from a
+      reduced thoracic capacity and hypoplastic lungs and/or respiratory failure
+      due to brainstem compression.
+    explanation: >-
+      Supports respiratory insufficiency as the dominant lethal clinical
+      consequence of the thoracic and pulmonary phenotype.
   - reference: PMID:34597445
     reference_title: "Development of individuals with thanatophoric dysplasia surviving beyond infancy."
     supports: SUPPORT
@@ -648,17 +769,25 @@ phenotypes:
       ventilatory support.
 - name: Hydrocephalus
   description: >
-    Ventricular enlargement is common and can present as early onset
-    hydrocephalus detectable prenatally. In severe cases, hydrancephaly may
-    develop. The hydrocephalus is associated with intracranial pressure from
-    craniosynostosis.
-  frequency: HP_0040282
+    Prenatal ventricular enlargement and hydrocephalus are reported in some
+    TD2 fetuses, and severe fluid-space abnormalities such as hydrancephaly have
+    also been described.
   phenotype_term:
     preferred_term: Hydrocephalus
     term:
       id: HP:0000238
       label: Hydrocephalus
   evidence:
+  - reference: PMID:11241532
+    reference_title: "Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The TD2 fetus was characterized by polyhydramnios, short limbs, a narrow
+      thoracic cage, straight short femora, hydrocephalus and a cloverleaf skull
+      at 24 weeks' gestation.
+    explanation: >-
+      Molecularly confirmed prenatal TD2 case documents hydrocephalus.
   - reference: PMID:29458880
     reference_title: "Prenatal diagnosis of hydrancephaly and enlarged cerebellum and cisterna magna in a fetus with thanatophoric dysplasia type II and a review of prenatal diagnosis of brain anomalies associated with thanatophoric dysplasia."
     supports: SUPPORT
@@ -672,9 +801,9 @@ phenotypes:
       early onset hydrocephalus and hydrancephaly.
 - name: Small foramen magnum
   description: >
-    Foramen magnum stenosis resulting from premature closure of cranial base
-    synchondroses driven by FGFR3-MAPK signaling. This can cause neurological
-    complications from cervicomedullary compression.
+    Foramen magnum narrowing is a recognized complication of FGFR3-related
+    chondrodysplasias and may contribute to cervicomedullary compression in
+    surviving individuals.
   phenotype_term:
     preferred_term: Small foramen magnum
     term:
@@ -691,13 +820,83 @@ phenotypes:
     explanation: >-
       Establishes foramen magnum stenosis as a clinically significant
       feature of FGFR3 chondrodysplasias including TD.
+- name: Temporal lobe dysplasia
+  description: >
+    Intrinsic cerebral malformation involving the temporal lobes, often with
+    associated polymicrogyria and hippocampal abnormalities on neuropathologic
+    examination.
+  phenotype_term:
+    preferred_term: Temporal lobe dysplasia
+    term:
+      id: HP:0034222
+      label: Temporal lobe dysplasia
+  evidence:
+  - reference: PMID:23323754
+    reference_title: "Thanatophoric dysplasia: autopsy findings over a 25-year period."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Temporal lobe dysplasia was recognized in 52% of the cases, and after
+      1998 temporal lobe dysplasia was described in all cases.
+    explanation: >-
+      Large autopsy series shows temporal lobe dysplasia is a recurring
+      neuropathologic manifestation of thanatophoric dysplasia.
+  - reference: PMID:11965423
+    reference_title: "[Thanatophoric dysplasia: report of 2 cases with neuropathological study]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Microscopic examination of both cases revealed temporal lobe
+      polymicrogyria, abnormalities of the hippocampus and heterotopic
+      neuroglial tissue within the meninges. There were no noticeable
+      differences in CNS abnormalities between TD type I and II.
+    explanation: >-
+      Neuropathologic study including one TD2 case supports that the temporal
+      lobe malformation phenotype also occurs in TD2.
+- name: Polyhydramnios
+  description: >
+    Excess amniotic fluid can be part of the prenatal presentation of TD2.
+  phenotype_term:
+    preferred_term: Polyhydramnios
+    term:
+      id: HP:0001561
+      label: Polyhydramnios
+  evidence:
+  - reference: PMID:11241532
+    reference_title: "Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The TD2 fetus was characterized by polyhydramnios, short limbs, a narrow
+      thoracic cage, straight short femora, hydrocephalus and a cloverleaf skull
+      at 24 weeks' gestation.
+    explanation: >-
+      Molecularly confirmed prenatal TD2 case documents polyhydramnios.
+- name: Redundant skin folds
+  description: >
+    Thickened redundant skin folds can be appreciated on prenatal imaging.
+  phenotype_term:
+    preferred_term: Redundant skin
+    term:
+      id: HP:0001582
+      label: Redundant skin
+  evidence:
+  - reference: PMID:11241532
+    reference_title: "Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three-dimensional ultrasound was able to enhance the visualization of
+      thickened, redundant skin folds and craniofacial and limb deformities
+      associated with TD.
+    explanation: >-
+      Prenatal imaging study documents redundant skin folds as part of the TD
+      fetal phenotype; included here because the same series contains a
+      molecularly confirmed TD2 case.
 - name: Severe global developmental delay
   description: >
-    All long-term TD survivors show severely delayed psychomotor development.
-    The highest developmental level achieved is equivalent to approximately
-    2 years of age, reflecting both primary CNS effects of FGFR3 K650E and
-    secondary consequences of craniosynostosis and hydrocephalus.
-  frequency: HP_0040281
+    Long-term survivors show severe psychomotor delay, with the highest
+    developmental level in the largest cohort approximating 2 years of age.
   notes: Observed in long-term survivors only; most cases are perinatally lethal.
   phenotype_term:
     preferred_term: Global developmental delay
@@ -719,7 +918,6 @@ phenotypes:
   description: >
     Long-term survivors show extreme growth deficiency with birth length
     averaging 36 cm and adult height below -15.2 SD.
-  frequency: HP_0040281
   notes: Observed in long-term survivors only.
   phenotype_term:
     preferred_term: Short stature
@@ -738,9 +936,8 @@ phenotypes:
       Quantifies the extreme growth deficiency in TD survivors.
 - name: Acanthosis nigricans (survivors)
   description: >
-    Skin disorders including acanthosis nigricans and seborrheic keratoses are
-    common in long-term survivors, reflecting FGFR3 effects on keratinocyte
-    biology.
+    Acanthosis nigricans is among the skin disorders reported in long-term
+    survivors.
   notes: >-
     Observed in long-term survivors. This skin finding is shared with
     SADDAN syndrome, which also has an FGFR3 K650 mutation (K650M).
@@ -1101,4 +1298,25 @@ references:
   findings: []
 - reference: PMID:18698630
   title: The population-based prevalence of achondroplasia and thanatophoric dysplasia in selected regions of the US.
+  findings: []
+- reference: PMID:3130852
+  title: Thanatophoric dysplasia and cloverleaf skull.
+  findings: []
+- reference: PMID:11241532
+  title: Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia.
+  findings: []
+- reference: PMID:23323754
+  title: "Thanatophoric dysplasia: autopsy findings over a 25-year period."
+  findings: []
+- reference: PMID:24075385
+  title: "Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II."
+  findings: []
+- reference: PMID:11965423
+  title: "[Thanatophoric dysplasia: report of 2 cases with neuropathological study]."
+  findings: []
+- reference: PMID:33520059
+  title: "Thanatophoric dysplasia: a case report."
+  findings: []
+- reference: PMID:23573386
+  title: Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo FGFR3 Missense Mutations located in cis.
   findings: []

--- a/references_cache/PMID_11241532.md
+++ b/references_cache/PMID_11241532.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:11241532"
+title: Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia.
+authors:
+- Chen CP
+- Chern SR
+- Shih JC
+- Wang W
+- Yeh LF
+- Chang TY
+- Tzen CY
+journal: Prenat Diagn
+year: '2001'
+doi: "10.1002/1097-0223(200102)21:2<89::aid-pd21>3.0.co;2-9"
+keywords:
+- Adult
+- DNA Restriction Enzymes/metabolism
+- Female
+- Gestational Age
+- Humans
+- Mutation
+- Polymerase Chain Reaction
+- Pregnancy
+- Prenatal Diagnosis
+- Protein-Tyrosine Kinases
+- Radiography
+- "Receptor, Fibroblast Growth Factor, Type 3"
+- "Receptors, Fibroblast Growth Factor/genetics"
+- "Thanatophoric Dysplasia/diagnosis, diagnostic imaging, genetics"
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Prenatal diagnosis and genetic analysis of type I and type II thanatophoric dysplasia.
+**Authors:** Chen CP, Chern SR, Shih JC, Wang W, Yeh LF, Chang TY, Tzen CY
+**Journal:** Prenat Diagn (2001)
+**DOI:** [10.1002/1097-0223(200102)21:2<89::aid-pd21>3.0.co;2-9](https://doi.org/10.1002/1097-0223(200102)21:2<89::aid-pd21>3.0.co;2-9)
+
+## Content
+
+1. Prenat Diagn. 2001 Feb;21(2):89-95. doi:
+10.1002/1097-0223(200102)21:2<89::aid-pd21>3.0.co;2-9.
+
+Prenatal diagnosis and genetic analysis of type I and type II thanatophoric
+dysplasia.
+
+Chen CP(1), Chern SR, Shih JC, Wang W, Yeh LF, Chang TY, Tzen CY.
+
+Author information:
+(1)Department of Obstetrics and Gynecology, Mackay Memorial Hospital, Taipei,
+Taiwan, ROC. cpc_mmh@yahoo.com
+
+Thanatophoric dysplasia (TD) is one of the most common neonatal lethal skeletal
+dysplasias. Prenatal sonographic and molecular genetic diagnoses of three cases
+of TD type I (TD1) and one case of TD type II (TD2) are presented here. Two
+fetuses of TD1 were characterized by polyhydramnios, macrocephaly, short limbs,
+a narrow thoracic cage and curved short femora, but without a cloverleaf skull
+at 27 and 31 weeks' gestation, respectively. The third fetus with TD1 was,
+however, not associated with macrocephaly, polyhydramnios, chest narrowing and
+severe femoral bowing on prenatal ultrasound at 18 weeks' gestation. The TD2
+fetus was characterized by polyhydramnios, short limbs, a narrow thoracic cage,
+straight short femora, hydrocephalus and a cloverleaf skull at 24 weeks'
+gestation. Three-dimensional ultrasound was able to enhance the visualization of
+thickened, redundant skin folds and craniofacial and limb deformities associated
+with TD. Molecular analysis of the fibroblast growth factor receptor 3 (FGFR3)
+gene by restriction enzyme digestion analysis and direct sequencing using
+cultured amniotic fluid cells or cord blood cells revealed a missense mutation
+of 742C-->T (Arg248Cys) in all cases with TD1 and a missense mutation of
+1948A-->G (Lys650Glu) in the case with TD2. The present report shows that
+adjunctive applications of molecular genetic analysis of the FGFR3 gene and
+three-dimensional ultrasound are useful for prenatal diagnosis of TD.
+
+Copyright 2001 John Wiley & Sons, Ltd.
+
+DOI: 10.1002/1097-0223(200102)21:2<89::aid-pd21>3.0.co;2-9
+PMID: 11241532 [Indexed for MEDLINE]

--- a/references_cache/PMID_11965423.md
+++ b/references_cache/PMID_11965423.md
@@ -1,0 +1,57 @@
+---
+reference_id: "PMID:11965423"
+title: "[Thanatophoric dysplasia: report of 2 cases with neuropathological study]."
+authors:
+- Noronha L
+- Prevedello LM
+- Maggio EM
+- Serapiao MJ
+- Torres LF
+journal: Arq Neuropsiquiatr
+year: '2002'
+doi: 10.1590/s0004-282x2002000100024
+keywords:
+- "Brain/abnormalities, pathology"
+- Female
+- Humans
+- "Infant, Newborn"
+- Male
+- "Skull/abnormalities, pathology"
+- Thanatophoric Dysplasia/pathology
+content_type: abstract_only
+---
+
+# [Thanatophoric dysplasia: report of 2 cases with neuropathological study].
+**Authors:** Noronha L, Prevedello LM, Maggio EM, Serapiao MJ, Torres LF
+**Journal:** Arq Neuropsiquiatr (2002)
+**DOI:** [10.1590/s0004-282x2002000100024](https://doi.org/10.1590/s0004-282x2002000100024)
+
+## Content
+
+1. Arq Neuropsiquiatr. 2002 Mar;60(1):133-7. doi:
+10.1590/s0004-282x2002000100024.
+
+[Thanatophoric dysplasia: report of 2 cases with neuropathological study].
+
+[Article in Portuguese]
+
+Noronha L(1), Prevedello LM, Maggio EM, Serapiao MJ, Torres LF.
+
+Author information:
+(1)Departamento de Patologia, Universidade Federal do Paraná, Curitiba, PR,
+Brasil.
+
+We report two cases of thanatophoric dysplasia (TD) with detailed
+neuropathologic evaluation. One case was representative of TD type I and the
+other TD type II. The case with TD type I showed macrocephaly, narrow thoracic
+cage, pulmonary hypoplasia and bowed limbs. Radiological study showed flat
+vertebral bodies, short curved appendicular skeleton and flaring of metaphyses.
+The other case (TD type 2) showed macrocephaly, cleft palate, short limbs and
+cloverleaf skull. Radiological findings were generalized platyspondy with
+excessive intervertebral disc space heights and a large head. Microscopic
+examination of both cases revealed temporal lobe polymicrogyria, abnormalities
+of the hippocampus and heterotopic neuroglial tissue within the meninges. There
+were no noticeable differences in CNS abnormalities between TD type I and II.
+
+DOI: 10.1590/s0004-282x2002000100024
+PMID: 11965423 [Indexed for MEDLINE]

--- a/references_cache/PMID_23323754.md
+++ b/references_cache/PMID_23323754.md
@@ -1,0 +1,56 @@
+---
+reference_id: "PMID:23323754"
+title: "Thanatophoric dysplasia: autopsy findings over a 25-year period."
+authors:
+- Vogt C
+- Blaas HG
+journal: Pediatr Dev Pathol
+year: '2013'
+doi: 10.2350/12-09-1253-OA.1
+keywords:
+- Autopsy
+- Humans
+- "Thanatophoric Dysplasia/epidemiology, pathology"
+content_type: abstract_only
+---
+
+# Thanatophoric dysplasia: autopsy findings over a 25-year period.
+**Authors:** Vogt C, Blaas HG
+**Journal:** Pediatr Dev Pathol (2013)
+**DOI:** [10.2350/12-09-1253-OA.1](https://doi.org/10.2350/12-09-1253-OA.1)
+
+## Content
+
+1. Pediatr Dev Pathol. 2013 May-Jun;16(3):160-7. doi: 10.2350/12-09-1253-OA.1.
+Epub  2013 Jan 16.
+
+Thanatophoric dysplasia: autopsy findings over a 25-year period.
+
+Vogt C(1), Blaas HG.
+
+Author information:
+(1)Department of Pathology and Medical Genetics, St Olavs Hospital, Trondheim
+University Hospital, Trondheim, Norway. christina.vogt@ntnu.no
+
+The aim of our study was to retrospectively assess morphological findings in
+thanatophoric dysplasia, particularly, in how many cases were cerebral
+manifestations with temporal lobe dysplasia identified. We also wanted to
+register and analyze the proportions between lung, brain, and body weight.
+Criteria for inclusion were an autopsy performed during the period ranging from
+1985 to 2009 with a diagnosis of thanatophoric dysplasia. During a 25-year
+period 25 cases of thanatophoric dysplasia were registered. Temporal lobe
+dysplasia was recognized in 52% of the cases, and after 1998 temporal lobe
+dysplasia was described in all cases. In 19 cases the brain/body weight ratio
+was increased, and in all cases the lung/body weight ratio was below the
+corresponding ratio calculated according to standard measurements. In all but
+one case the ratio of brain to lung weight was increased. This study focuses on
+morphological findings, stressing the importance of temporal lobe dysplasia in
+confirming a diagnosis of thanatophoric dysplasia. Lung/body, brain/body, and
+brain/lung weight ratios confirm macrocephaly and lung hypoplasia, which are
+constant findings in cases involving thanatophoric dysplasia. Femur and brain
+morphology inclusive histology remains the ultimate tool for confirmation of
+this lethal condition, although it has to be seen in a context inclusive of
+radiological examination.
+
+DOI: 10.2350/12-09-1253-OA.1
+PMID: 23323754 [Indexed for MEDLINE]

--- a/references_cache/PMID_23573386.md
+++ b/references_cache/PMID_23573386.md
@@ -1,0 +1,55 @@
+---
+reference_id: "PMID:23573386"
+title: Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo FGFR3 Missense Mutations located in cis.
+authors:
+- Marquis-Nicholson R
+- Aftimos S
+- Love DR
+journal: Sultan Qaboos Univ Med J
+year: '2013'
+doi: 10.12816/0003199
+content_type: abstract_only
+---
+
+# Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo FGFR3 Missense Mutations located in cis.
+**Authors:** Marquis-Nicholson R, Aftimos S, Love DR
+**Journal:** Sultan Qaboos Univ Med J (2013)
+**DOI:** [10.12816/0003199](https://doi.org/10.12816/0003199)
+
+## Content
+
+1. Sultan Qaboos Univ Med J. 2013 Feb;13(1):80-7. doi: 10.12816/0003199. Epub
+2013  Feb 27.
+
+Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo
+FGFR3 Missense Mutations located in cis.
+
+Marquis-Nicholson R(1), Aftimos S, Love DR.
+
+Author information:
+(1)Diagnostic Genetics, LabPLUS, Auckland City Hospital, Auckland, New Zealand;
+
+OBJECTIVES: Thanatophoric dysplasia (TD) is the most common form of lethal
+skeletal dysplasia. It is primarily an autosomal dominant disorder and is
+characterised by macrocephaly, a narrow thorax, short ribs, brachydactyly, and
+hypotonia. In addition to these core phenotypic features, TD type I involves
+micromelia with bowed femurs, while TD type II is characterised by micromelia
+with straight femurs and a moderate to severe clover-leaf deformity of the
+skull. Mutations in the FGFR3 gene are responsible for all cases of TD reported
+to date. The objective of the study here was to delineate further the mutational
+spectrum responsible for TD.
+METHODS: Conventional polymerase chain reaction (PCR), allele-specific PCR, and
+sequence analysis were used to identify FGFR3 gene mutations in a fetus with a
+lethal skeletal dysplasia consistent with TD, which was detected during a
+routine antenatal ultrasound examination.
+RESULTS: In this report we describe the identification of two de novo missense
+mutations in cis in the FGFR3 gene (p.Asn540Lys and p.Val555Met) in a fetus
+displaying phenotypic features consistent with TD.
+CONCLUSION: This is the second description of a case of TD occurring as a result
+of double missense FGFR3 gene mutations, suggesting that the spectrum of
+mutations involved in the pathogenesis of TD may be broader than previously
+recognised.
+
+DOI: 10.12816/0003199
+PMCID: PMC3616804
+PMID: 23573386

--- a/references_cache/PMID_24075385.md
+++ b/references_cache/PMID_24075385.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:24075385"
+title: "Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II."
+authors:
+- Chen CP
+- Chang TY
+- Lin MH
+- Chern SR
+- Su JW
+- Wang W
+journal: Taiwan J Obstet Gynecol
+year: '2013'
+doi: 10.1016/j.tjog.2013.05.003
+keywords:
+- Adult
+- Amnion/cytology
+- "Diagnosis, Differential"
+- "Encephalocele/diagnostic imaging, genetics"
+- Female
+- "Femur/abnormalities, diagnostic imaging"
+- Humans
+- "Hydrocephalus/diagnostic imaging, genetics"
+- "Occipital Bone/abnormalities, diagnostic imaging"
+- Point Mutation
+- Pregnancy
+- "Receptor, Fibroblast Growth Factor, Type 3/genetics"
+- "Skull/abnormalities, diagnostic imaging"
+- "Thanatophoric Dysplasia/diagnostic imaging, genetics"
+- Ultrasonography
+content_type: abstract_only
+---
+
+# Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II.
+**Authors:** Chen CP, Chang TY, Lin MH, Chern SR, Su JW, Wang W
+**Journal:** Taiwan J Obstet Gynecol (2013)
+**DOI:** [10.1016/j.tjog.2013.05.003](https://doi.org/10.1016/j.tjog.2013.05.003)
+
+## Content
+
+1. Taiwan J Obstet Gynecol. 2013 Sep;52(3):420-5. doi:
+10.1016/j.tjog.2013.05.003.
+
+Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a
+pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele,
+ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II.
+
+Chen CP(1), Chang TY, Lin MH, Chern SR, Su JW, Wang W.
+
+Author information:
+(1)Department of Obstetrics and Gynecology, Mackay Memorial Hospital, Taipei,
+Taiwan; Department of Medical Research, Mackay Memorial Hospital, Taipei,
+Taiwan; Department of Medicine, Mackay Medical College, New Taipei City, Taiwan;
+Department of Biotechnology, Asia University, Taichung, Taiwan; School of
+Chinese Medicine, College of Chinese Medicine, China Medical University,
+Taichung, Taiwan; Institute of Clinical and Community Health Nursing, National
+Yang-Ming University, Taipei, Taiwan; Department of Obstetrics and Gynecology,
+School of Medicine, National Yang-Ming University, Taipei, Taiwan. Electronic
+address: cpc_mmh@yahoo.com.
+
+OBJECTIVE: To present the ultrasound and molecular genetic diagnosis of
+thanatophoric dysplasia type II (TD2).
+CASE REPORT: A 35-year-old, primigravid woman was referred to our institution
+for genetic counseling and amniocentesis at 19 weeks of gestation because of
+advanced maternal age and sonographic abnormalities in the fetus. The prenatal
+ultrasound showed short straight femurs, prominent forehead, narrow chest, skin
+edema, short limbs, and cloverleaf skull consistent with the diagnosis of TD2.
+Amniocentesis revealed a karyotype of 46,XX. DNA testing for the FGFR3 gene
+using uncultured amniocytes revealed a heterozygous c.1948A>G, AAG>GAG
+transversion leading to a p.Lys650Glu(K650E) mutation in the FGFR3 gene. A
+prenatal ultrasound at 21 weeks of gestation showed ventriculomegaly, cloverleaf
+skull, straight femurs, micromelia, narrow chest, and pseudoencephalocele with a
+bulging occipital bone mimicking encephalocele. The pregnancy was subsequently
+terminated, and a 480-g malformed fetus was delivered with macrocephaly,
+depressed nasal bridge, short upturned nasal tip, hypoplastic midface, frontal
+bossing, short digits, trident-shaped hands, short limbs, cloverleaf skull,
+narrow chest, brachydactyly, nuchal edema, and bulging occipital bone.
+CONCLUSION: A prenatal diagnosis of cloverleaf skull, short limbs, straight
+femurs, and occipital pseudoencephalocele should include a differential
+diagnosis of TD2. A molecular analysis of FGFR3 using uncultured amniocytes is
+useful for the rapid confirmation of TD2 at prenatal diagnosis.
+
+Copyright © 2013. Published by Elsevier B.V.
+
+DOI: 10.1016/j.tjog.2013.05.003
+PMID: 24075385 [Indexed for MEDLINE]

--- a/references_cache/PMID_3130852.md
+++ b/references_cache/PMID_3130852.md
@@ -1,0 +1,54 @@
+---
+reference_id: "PMID:3130852"
+title: Thanatophoric dysplasia and cloverleaf skull.
+authors:
+- Langer LO Jr
+- Yang SS
+- Hall JG
+- Sommer A
+- Kottamasu SR
+- Golabi M
+- Krassikoff N
+journal: Am J Med Genet Suppl
+year: '1987'
+doi: 10.1002/ajmg.1320280521
+keywords:
+- Female
+- Humans
+- "Infant, Newborn"
+- Male
+- Osteochondrodysplasias/classification
+- Radiography
+- Skull/abnormalities
+- "Thanatophoric Dysplasia/classification, diagnostic imaging, pathology"
+content_type: abstract_only
+---
+
+# Thanatophoric dysplasia and cloverleaf skull.
+**Authors:** Langer LO Jr, Yang SS, Hall JG, Sommer A, Kottamasu SR, Golabi M, Krassikoff N
+**Journal:** Am J Med Genet Suppl (1987)
+**DOI:** [10.1002/ajmg.1320280521](https://doi.org/10.1002/ajmg.1320280521)
+
+## Content
+
+1. Am J Med Genet Suppl. 1987;3:167-79. doi: 10.1002/ajmg.1320280521.
+
+Thanatophoric dysplasia and cloverleaf skull.
+
+Langer LO Jr(1), Yang SS, Hall JG, Sommer A, Kottamasu SR, Golabi M, Krassikoff
+N.
+
+Author information:
+(1)Department of Radiology, University of Minnesota, Minneapolis.
+
+Nine infants with thanatophoric dysplasia (TD) and cloverleaf skull (CS) are
+reported. Twenty-two previously published CSTD cases are reviewed. These CSTD
+cases are compared to cases of TD without CS. It is concluded that there are two
+types of TD: type 1, with curved femora and very flat vertebral bodies; and type
+2, with straight femora and taller vertebral bodies. Consistent but subtle
+histopathological characteristics differentiate the two types. Only a very few
+type 1 cases have CS, and the CS is mild. Almost all type 2 cases have severe
+CS.
+
+DOI: 10.1002/ajmg.1320280521
+PMID: 3130852 [Indexed for MEDLINE]

--- a/references_cache/PMID_33520059.md
+++ b/references_cache/PMID_33520059.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:33520059"
+title: "Thanatophoric dysplasia: a case report."
+authors:
+- Jagun OE
+- Olusola-Bello MA
+- Adekanmbi AF
+- Jagun OO
+- Oduwole T
+journal: Pan Afr Med J
+year: '2020'
+doi: 10.11604/pamj.2020.37.220.21211
+keywords:
+- Adult
+- Female
+- Humans
+- Pregnancy
+- "Pregnancy Trimester, Third"
+- "Receptor, Fibroblast Growth Factor, Type 3/genetics"
+- "Thanatophoric Dysplasia/diagnostic imaging, genetics"
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Thanatophoric dysplasia: a case report.
+**Authors:** Jagun OE, Olusola-Bello MA, Adekanmbi AF, Jagun OO, Oduwole T
+**Journal:** Pan Afr Med J (2020)
+**DOI:** [10.11604/pamj.2020.37.220.21211](https://doi.org/10.11604/pamj.2020.37.220.21211)
+
+## Content
+
+1. Pan Afr Med J. 2020 Nov 5;37:220. doi: 10.11604/pamj.2020.37.220.21211.
+eCollection 2020.
+
+Thanatophoric dysplasia: a case report.
+
+Jagun OE(1), Olusola-Bello MA(2), Adekanmbi AF(3), Jagun OO(4), Oduwole T(5).
+
+Author information:
+(1)Department of Obstetrics and Gynaecology, Olabisi Onabanjo University
+Teaching Hospital, Olabisi Onabanjo University Sagamu, Ogun state, Nigeria.
+(2)Department of Radiology Olabisi Onabanjo University Sagamu, Sagamu, Nigeria.
+(3)Department of Paediatrics, Olabisi Onabanjo University Teaching Hospital
+Sagamu, Sagamu, Nigeria.
+(4)Department of Ophthamology, Babcock University Teaching Hospital, Ilishan,
+Nigeria.
+(5)Alpha Clinic and Ultrasound Unit, Sagamu, Ogun state, Nigeria.
+
+A case of thanatophoric dysplasia with sudden death at term is hereby presented.
+Thanatophoric dysplasia is an uncommon, lethal skeletal dysplasia which is
+associated with mutation in the extracellular region of fibroblast growth factor
+receptor 3 (FGFR3). It is an autosommal dominant condition that has sporadic
+occurrence and early ultrasound scan has not been of great benefit in its
+detection. Diagnosis is mostly made in the third trimester. The fetal death is
+usually due to severe respiratory insufficiency from a reduced thoracic capacity
+and hypoplastic lungs and/or respiratory failure due to brainstem compression.
+In view of the autosomal dominance of TD, it will be advisable for a woman with
+previous history to have prenatal screening to relieve parental anxiety and
+prevent late detection.
+
+Copyright: Olusoji Edward Jagun et al.
+
+DOI: 10.11604/pamj.2020.37.220.21211
+PMCID: PMC7821799
+PMID: 33520059 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/research/Thanatophoric_Dysplasia_Type_2-phenotype-curation-codex-issue-1458.md
+++ b/research/Thanatophoric_Dysplasia_Type_2-phenotype-curation-codex-issue-1458.md
@@ -1,0 +1,39 @@
+# Thanatophoric Dysplasia Type 2 phenotype curation notes for issue #1458
+
+Date: 2026-04-19
+Curator: Codex
+Scope: Phenotype section only for `kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml`
+
+## Curation approach
+
+- Prefer primary human clinical sources with subtype-specific TD2 wording when available.
+- Keep frequency only when the cited abstract directly supports it.
+- Remove mechanistic or prevalence claims from phenotype descriptions when the phenotype evidence was only associative.
+- Avoid adding isolated anomalies from single case reports unless they are clinically important or already central to TD2 recognition.
+
+## Phenotype evidence added or strengthened
+
+- `PMID:3130852`
+  - Supports `Cloverleaf skull` as very frequent in TD2: "Almost all type 2 cases have severe CS."
+- `PMID:11241532`
+  - Supports TD2 prenatal findings: narrow thoracic cage, hydrocephalus, cloverleaf skull, straight short femora, and polyhydramnios.
+  - Supports `Redundant skin folds` from 3D ultrasound wording in the same TD series.
+- `PMID:23323754`
+  - Supports `Pulmonary hypoplasia` as a constant morphologic finding in thanatophoric dysplasia.
+  - Supports `Temporal lobe dysplasia` as a recurring neuropathologic finding in a 25-case autopsy series.
+- `PMID:24075385`
+  - Supports subtype-specific TD2 facial and limb findings: macrocephaly, frontal bossing/prominent forehead, brachydactyly, narrow chest, straight femora, cloverleaf skull.
+- `PMID:11965423`
+  - Confirms that the CNS malformation pattern also occurs in TD2, including temporal lobe polymicrogyria and hippocampal abnormalities.
+- `PMID:33520059`
+  - Supports `Respiratory insufficiency` and its relationship to reduced thoracic capacity and hypoplastic lungs.
+- `PMID:23573386`
+  - Used cautiously for `Short ribs` because the abstract explicitly lists short ribs among core TD features while also distinguishing TD2 by straight femurs and severe cloverleaf deformity.
+
+## Unsupported or softened points
+
+- Removed unsupported frequency qualifiers from most phenotypes; retained a frequency only for `Cloverleaf skull`.
+- Softened `Hydrocephalus` from a generalized/common claim to a documented prenatal finding in some TD2 fetuses.
+- Softened `Small foramen magnum` to avoid overstating TD2-specific evidence from broader FGFR3 chondrodysplasia literature.
+- Simplified survivor phenotypes (`Global developmental delay`, `Short stature`, `Acanthosis nigricans`) to stay close to the cohort data without extra mechanistic inference.
+- Left out one-off anomalies such as pseudoencephalocele, encephalocele, cleft palate, holoprosencephaly, and vascular anomalies because they appear too case-specific for the core phenotype section.


### PR DESCRIPTION
## What changed
Focused the TD2 update on `kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml` phenotype curation only.

- strengthened core TD2 phenotype evidence with primary PMID-backed snippets
- added clinically important missing phenotypes with grounded HPO mappings where available
- removed unsupported phenotype frequency qualifiers except where the abstract directly supported frequency
- softened phenotype descriptions that previously overclaimed mechanism or prevalence
- added fetched `references_cache/` entries for the new PMIDs
- added a short `research/` provenance note documenting included and excluded phenotype findings

## Why
Issue #1458 asked for a phenotype-only pass that makes the TD2 phenotype section as complete and evidence-backed as possible without broadening into a full-page rewrite.

## Impact
The TD2 phenotype section is now more defensible for downstream use because the phenotype claims are tied more closely to exact abstract text, subtype-specific prenatal findings are represented, and unsupported frequency/mechanistic claims were trimmed back.

## Validation
Ran the exact requested commands:

```bash
just validate kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
just validate-references kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
just validate-terms kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
```

Results:
- `just validate ...`: passed
- `just validate-references ...`: all validations passed
- `just validate-terms ...`: validation passed

## Intentionally not changed
Did not broaden this into pathophysiology, treatment, prevalence, or page-wide rewriting beyond local description softening needed to keep phenotype claims evidence-aligned.
