### PR TITLE
Curate Hypochondroplasia phenotype section

### DIFF
--- a/kb/disorders/Hypochondroplasia.yaml
+++ b/kb/disorders/Hypochondroplasia.yaml
@@ -1,6 +1,6 @@
 name: Hypochondroplasia
 creation_date: '2026-02-02T00:16:36Z'
-updated_date: '2026-04-03T12:00:00Z'
+updated_date: '2026-04-19T00:12:38Z'
 category: Mendelian
 description: >
   Hypochondroplasia is a milder FGFR3-related skeletal dysplasia characterized by
@@ -198,55 +198,65 @@ phenotypes:
 - name: Short stature
   category: Clinical
   description: >
-    Short stature is the hallmark feature of hypochondroplasia. Height typically falls
-    in the low-normal to mildly short range, with adult height of 145-165 cm. Short
-    stature may be proportionate or mildly disproportionate, often not recognized
-    until after the first year of life.
-  frequency: HP_0040281
+    Disproportionate short stature is the defining growth phenotype of
+    hypochondroplasia. In many children it becomes more obvious in toddlerhood or
+    early school age as growth velocity falls relative to peers.
   phenotype_term:
     preferred_term: Short stature
     term:
       id: HP:0004322
       label: Short stature
   evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Hypochondroplasia is a skeletal dysplasia characterized by short stature; stocky build; disproportionately short arms and legs; broad, short hands and feet; mild joint laxity; and relative macrocephaly."
+    explanation: >
+      GeneReviews identifies short stature as part of the core clinical phenotype of
+      hypochondroplasia.
   - reference: PMID:36442838
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "The patients presented with a short stature and/or short limbs."
     explanation: >
-      All 20 Korean patients with confirmed FGFR3 N540K presented with short stature
-      and/or short limbs as the primary clinical feature.
+      In this Korean FGFR3 N540K cohort, short stature and/or short limbs were the
+      presenting growth abnormality.
   - reference: PMID:41762373
     supports: SUPPORT
     evidence_source: OTHER
-    snippet: "HCH should be considered in the differential diagnosis of idiopathic or isolated short stature."
+    snippet: "Hypochondroplasia (HCH) is a disproportionate short-statured skeletal dysplasia condition caused by gain-of-function pathogenic variants in the fibroblast growth receptor 3 gene (FGFR3)."
     explanation: >
-      Expert consensus panel notes that HCH is an important differential for children
-      with unexplained short stature.
+      Expert consensus likewise frames HCH as a disproportionate short-stature disorder.
 - name: Rhizomelic limb shortening
   category: Clinical
   description: >
-    Mild proximal limb shortening may be present but is less pronounced than in
-    achondroplasia. Some individuals have proportionate shortening.
-  frequency: HP_0040282
+    Mild proximal limb shortening and body disproportion may emerge after infancy
+    and can be subtle in the neonatal period.
   phenotype_term:
-    preferred_term: Rhizomelic arm shortening
+    preferred_term: Rhizomelic limb shortening
     term:
-      id: HP:0004991
-      label: Rhizomelic arm shortening
+      id: HP:0008905
+      label: Rhizomelia
   evidence:
+  - reference: PMID:14755409
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hypochondroplasia is an autosomal dominant skeletal dysplasia expressing postnatal onset of short stature with mild rhizomelic shortening of the limbs."
+    explanation: >
+      A molecularly confirmed neonatal case report documents mild rhizomelic limb
+      shortening as an early manifestation.
   - reference: PMID:41762373
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "Between ages 2-3 years, a characteristic growth pattern including limb shortening and body disproportion may become evident."
     explanation: >
-      Expert diagnostic pathway review identifies limb shortening and body disproportion
-      as a characteristic growth pattern becoming evident at ages 2-3 years.
+      Expert consensus states that limb shortening and body disproportion typically
+      become clinically apparent between ages 2 and 3 years.
 - name: Relative macrocephaly
   category: Clinical
   description: >
-    Head circumference may be relatively large compared to body size. Frank macrocephaly
-    is observed in approximately 45% of patients with N540K-related HCH.
+    Head circumference is often relatively large for height, with measurable
+    head-height disproportion even when absolute macrocephaly is not striking.
   frequency: HP_0040282
   phenotype_term:
     preferred_term: Relative macrocephaly
@@ -254,30 +264,43 @@ phenotypes:
       id: HP:0004482
       label: Relative macrocephaly
   evidence:
+  - reference: PMID:41040055
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The mean (SD) HCH-I was -3.0 (1.2) in the HCH cohort, compared to -0.2 (0.9) in the CIGS cohort. An HCH-I below -2 correctly identified 78% of children with HCH, while only 2.4% of CIGS children fell below the cut-off."
+    explanation: >
+      This large 2026 cohort study shows marked head-height disproportion in HCH,
+      directly supporting relative macrocephaly as a characteristic phenotype.
   - reference: PMID:36442838
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Genu varum, macrocephaly, and developmental delay were observed in 11 (55.0%), 9 (45.0%), and 5 (25.0%) patients, respectively."
     explanation: >
-      Macrocephaly was observed in 45% of 20 Korean patients with FGFR3 N540K-related
-      hypochondroplasia.
+      Macrocephaly was observed in 9/20 patients (45%), which falls in the FREQUENT
+      band.
   - reference: PMID:41762373
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "features suggestive of HCH include a sustained fall in length/height centiles over the first 2 years of life, relative macrocephaly, neonatal seizures, and specific radiographic and neuroimaging findings."
     explanation: >
-      Expert consensus identifies relative macrocephaly as one of the key features
-      suggestive of HCH diagnosis.
-- name: Lumbar hyperlordosis
+      Expert consensus identifies relative macrocephaly as a key feature suggestive of
+      HCH.
+- name: Mild joint laxity
   category: Clinical
-  description: Exaggerated lumbar curvature, though generally milder than in
-    achondroplasia.
-  frequency: HP_0040282
+  description: Mild ligamentous laxity can accompany the skeletal phenotype.
   phenotype_term:
-    preferred_term: Lumbar hyperlordosis
+    preferred_term: Mild joint laxity
     term:
-      id: HP:0002938
-      label: Lumbar hyperlordosis
+      id: HP:0001382
+      label: Joint hypermobility
+  evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Hypochondroplasia is a skeletal dysplasia characterized by short stature; stocky build; disproportionately short arms and legs; broad, short hands and feet; mild joint laxity; and relative macrocephaly."
+    explanation: >
+      GeneReviews lists mild joint laxity among the characteristic clinical features
+      of hypochondroplasia.
 - name: Genu varum
   category: Clinical
   description: >
@@ -295,67 +318,48 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Genu varum, macrocephaly, and developmental delay were observed in 11 (55.0%), 9 (45.0%), and 5 (25.0%) patients, respectively."
     explanation: >
-      Genu varum was the most common skeletal feature in this cohort, observed in 55%
-      of patients.
-- name: Brachydactyly
-  category: Clinical
-  description: >
-    Short fingers and toes are a recognized feature of hypochondroplasia, contributing
-    to the overall pattern of mild skeletal shortening.
-  frequency: HP_0040283
-  phenotype_term:
-    preferred_term: Brachydactyly
-    term:
-      id: HP:0001156
-      label: Brachydactyly
-- name: Frontal bossing
-  category: Clinical
-  description: >
-    Bilateral prominence of the frontal bones may be present as part of the craniofacial
-    features.
-  frequency: HP_0040283
-  phenotype_term:
-    preferred_term: Frontal bossing
-    term:
-      id: HP:0002007
-      label: Frontal bossing
-- name: Intellectual disability
+      Genu varum was observed in 11/20 patients (55%), which falls in the FREQUENT
+      band.
+- name: Neurodevelopmental delay
   category: Neurological
   description: >
-    Neurocognitive difficulties ranging from specific learning disability to mild
-    intellectual disability are more common than previously recognized in HCH. The
-    62% rate from PMID:23165795 reflects a Finnish cohort selected for neurological
-    workup; the unselected Korean cohort (PMID:36442838) reports developmental delay
-    in 25%, which better approximates population prevalence.
+    Developmental and learning difficulties are increasingly recognized in
+    hypochondroplasia, including in cohorts not selected for neurological disease.
   frequency: HP_0040283
   phenotype_term:
-    preferred_term: Intellectual disability
+    preferred_term: Neurodevelopmental delay
     term:
-      id: HP:0001249
-      label: Intellectual disability
+      id: HP:0012758
+      label: Neurodevelopmental delay
   evidence:
-  - reference: PMID:23165795
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Eight patients had neurocognitive difficulties, ranging from specific learning disorder (2/13) to mild intellectual disability (5/13) or global developmental delay (1/13)."
-    explanation: >
-      A retrospective study of 13 Finnish patients with confirmed FGFR3 N540K found
-      that 8 (62%) had neurocognitive difficulties, a higher prevalence than previously
-      appreciated.
   - reference: PMID:36442838
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Genu varum, macrocephaly, and developmental delay were observed in 11 (55.0%), 9 (45.0%), and 5 (25.0%) patients, respectively."
     explanation: >
-      Developmental delay was observed in 25% of Korean HCH patients with FGFR3 N540K.
+      Developmental delay was observed in 5/20 patients (25%), which falls in the
+      OCCASIONAL band.
+  - reference: PMID:23165795
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Eight patients had neurocognitive difficulties, ranging from specific learning disorder (2/13) to mild intellectual disability (5/13) or global developmental delay (1/13)."
+    explanation: >
+      A neurologically evaluated Finnish FGFR3 N540K cohort showed a broader spectrum
+      of neurocognitive difficulties, reinforcing neurodevelopmental involvement.
+  - reference: PMID:41762373
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Neurocognitive involvement including neurodevelopmental challenges may become apparent."
+    explanation: >
+      Expert consensus recognizes neurodevelopmental challenges as part of the HCH
+      phenotype.
 - name: Seizures
   category: Neurological
   description: >
-    Seizures and epilepsy occur at elevated frequency in HCH patients with FGFR3
-    N540K mutations, potentially related to temporal lobe structural abnormalities.
-    Note that the 46% rate from PMID:23165795 reflects a cohort selected for
-    neurological workup and may overestimate population prevalence.
-  frequency: HP_0040283
+    Seizures and epilepsy are reported in a subset of individuals with
+    hypochondroplasia, including infantile temporal lobe seizures. Whole-disease
+    frequency remains uncertain because the strongest MRI data come from a
+    neurologically selected cohort.
   phenotype_term:
     preferred_term: Seizures
     term:
@@ -367,25 +371,20 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Six of 13 patients had a history of seizures or epilepsy."
     explanation: >
-      Seizures or epilepsy were present in 46% of Finnish HCH patients, though this
-      cohort was selected for neurological workup and may overestimate true prevalence.
-  - reference: PMID:41762373
+      Seizures/epilepsy were documented in a neurologically selected Finnish FGFR3
+      N540K cohort, supporting a real but frequency-uncertain association.
+  - reference: PMID:20301650
     supports: SUPPORT
     evidence_source: OTHER
-    snippet: "features suggestive of HCH include a sustained fall in length/height centiles over the first 2 years of life, relative macrocephaly, neonatal seizures, and specific radiographic and neuroimaging findings."
+    snippet: "Infants may present with temporal lobe seizures."
     explanation: >
-      Expert diagnostic consensus identifies neonatal seizures as a feature suggestive
-      of HCH.
+      GeneReviews notes that seizures can be an early presenting manifestation.
 - name: Temporal lobe dysplasia
   category: Neurological
   description: >
-    Structural brain abnormalities involving the temporal lobes have been identified
-    on MRI in HCH patients with FGFR3 N540K mutations. In a Finnish cohort selected
-    for neurological workup, all 8 patients who underwent MRI showed structural
-    abnormalities consistent with temporal lobe dysgenesis. In an unselected Korean
-    cohort, 5 of 12 imaged patients (42%) had abnormal neuroimaging findings. True
-    population prevalence remains uncertain due to ascertainment bias.
-  frequency: HP_0040283
+    Brain MRI can show temporal lobe dysgenesis/dysplasia in some FGFR3
+    N540K-positive patients. Reported frequency is strongly affected by
+    neurologic ascertainment.
   phenotype_term:
     preferred_term: Temporal lobe dysplasia
     term:
@@ -397,21 +396,14 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Eight patients had undergone MRI. They all had structural abnormalities consistent with temporal lobe dysgenesis."
     explanation: >
-      All 8 HCH patients who underwent brain MRI showed temporal lobe dysgenesis in this
-      neurologically selected cohort. True population frequency is likely lower.
-  - reference: PMID:36442838
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Of the 12 patients who underwent neuroimaging, five (41.7%) showed abnormal findings (one required operation for obstructive hydrocephalus)."
-    explanation: >
-      In an unselected Korean cohort, 42% of neuroimaged patients had abnormal findings,
-      providing a less biased estimate of neuroimaging abnormalities.
+      All eight imaged patients in this neurologically selected FGFR3 N540K cohort had
+      temporal lobe dysgenesis on MRI, establishing the association but not an
+      unbiased population frequency.
 - name: Ventriculomegaly
   category: Neurological
   description: >
     Abnormally shaped lateral ventricles have been observed in HCH patients on
     neuroimaging.
-  frequency: HP_0040283
   phenotype_term:
     preferred_term: Ventriculomegaly
     term:
@@ -423,19 +415,170 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Six patients had peritrigonal white matter reduction, and 4 had abnormally shaped lateral ventricles."
     explanation: >
-      Abnormally shaped lateral ventricles were found in 4 of 8 HCH patients who
-      underwent MRI, alongside white matter changes.
-- name: Spinal stenosis with reduced interpedicular distance
+      Abnormally shaped lateral ventricles were observed on MRI in four neurologically
+      evaluated patients with FGFR3 N540K-related HCH.
+- name: Hydrocephalus
+  category: Neurological
+  description: >
+    Obstructive hydrocephalus requiring neurosurgical treatment has been reported
+    in a small subset of affected children.
+  phenotype_term:
+    preferred_term: Hydrocephalus
+    term:
+      id: HP:0000238
+      label: Hydrocephalus
+  evidence:
+  - reference: PMID:36442838
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Of the 12 patients who underwent neuroimaging, five (41.7%) showed abnormal findings (one required operation for obstructive hydrocephalus)."
+    explanation: >
+      One child in this 20-patient Korean cohort required surgery for obstructive
+      hydrocephalus, showing that hydrocephalus can occur as a clinically important
+      complication.
+- name: Spinal canal stenosis
+  category: Clinical
+  description: >
+    Spinal canal stenosis occurs less often than in achondroplasia but remains a
+    clinically important complication in hypochondroplasia.
+  phenotype_term:
+    preferred_term: Spinal canal stenosis
+    term:
+      id: HP:0003416
+      label: Spinal canal stenosis
+  evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Medical complications common to achondroplasia (e.g., foramen magnum stenosis, spinal stenosis, tibial bowing, obstructive apnea) occur less frequently in hypochondroplasia, but intellectual disability and epilepsy may be more prevalent."
+    explanation: >
+      GeneReviews explicitly lists spinal stenosis among recognized but less frequent
+      hypochondroplasia complications.
+- name: Narrow vertebral interpedicular distance
   category: Radiological
   description: >
-    Narrowing of the interpedicular distance in the lumbar spine is a characteristic
-    radiographic finding, though spinal stenosis is less common than in achondroplasia.
-  frequency: HP_0040283
+    Lack of the normal caudal widening or frank narrowing of the lumbar/lumbosacral
+    interpedicular distance is a classic radiographic clue to hypochondroplasia.
   phenotype_term:
-    preferred_term: Spinal stenosis with reduced interpedicular distance
+    preferred_term: Narrow vertebral interpedicular distance
     term:
-      id: HP:0005733
-      label: Spinal stenosis with reduced interpedicular distance
+      id: HP:0008450
+      label: Narrow vertebral interpedicular distance
+  evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Radiologic features include shortening of long bones with mild metaphyseal flare; a lack of widening or a narrowing of the lumbar interpedicular distances with shortening of the pedicle length and posterior scalloping of the vertebral bodies; short, broad femoral neck; and squared, shortened ilia."
+    explanation: >
+      GeneReviews identifies lack of widening or narrowing of the lumbar
+      interpedicular distances as a characteristic radiographic feature.
+  - reference: PMID:11475794
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Hypochondroplasia is a genetic skeletal dysplasia characterized by disproportionate short stature, stocky appearance and several clinical and radiological features very similar, but much milder, than those of classical achondroplasia, including shortened and stubby long bones, decreased lumbo-sacral interpediculate distances, posterior scalloping of the lumbar vertebrae, metaphyseal flaring, and moderate macrocephaly."
+    explanation: >
+      This radiology-focused review independently confirms decreased lumbosacral
+      interpediculate distance as a salient hypochondroplasia sign.
+- name: Posterior scalloping of vertebral bodies
+  category: Radiological
+  description: >
+    Posterior vertebral body scalloping is a recurrent spinal radiographic finding
+    in hypochondroplasia.
+  phenotype_term:
+    preferred_term: Posterior scalloping of vertebral bodies
+    term:
+      id: HP:0005121
+      label: Posterior scalloping of vertebral bodies
+  evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Radiologic features include shortening of long bones with mild metaphyseal flare; a lack of widening or a narrowing of the lumbar interpedicular distances with shortening of the pedicle length and posterior scalloping of the vertebral bodies; short, broad femoral neck; and squared, shortened ilia."
+    explanation: >
+      GeneReviews lists posterior scalloping of the vertebral bodies among the core
+      radiographic features.
+  - reference: PMID:11475794
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Hypochondroplasia is a genetic skeletal dysplasia characterized by disproportionate short stature, stocky appearance and several clinical and radiological features very similar, but much milder, than those of classical achondroplasia, including shortened and stubby long bones, decreased lumbo-sacral interpediculate distances, posterior scalloping of the lumbar vertebrae, metaphyseal flaring, and moderate macrocephaly."
+    explanation: >
+      A radiology review likewise identifies posterior scalloping of the lumbar
+      vertebrae as part of the classic pattern.
+- name: Metaphyseal widening
+  category: Radiological
+  description: >
+    Mild metaphyseal widening/flaring of long bones is part of the characteristic
+    radiographic pattern.
+  phenotype_term:
+    preferred_term: Metaphyseal flaring
+    term:
+      id: HP:0003016
+      label: Metaphyseal widening
+  evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Radiologic features include shortening of long bones with mild metaphyseal flare; a lack of widening or a narrowing of the lumbar interpedicular distances with shortening of the pedicle length and posterior scalloping of the vertebral bodies; short, broad femoral neck; and squared, shortened ilia."
+    explanation: >
+      GeneReviews describes mild metaphyseal flare as a characteristic long-bone
+      radiographic feature.
+  - reference: PMID:11475794
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Hypochondroplasia is a genetic skeletal dysplasia characterized by disproportionate short stature, stocky appearance and several clinical and radiological features very similar, but much milder, than those of classical achondroplasia, including shortened and stubby long bones, decreased lumbo-sacral interpediculate distances, posterior scalloping of the lumbar vertebrae, metaphyseal flaring, and moderate macrocephaly."
+    explanation: >
+      An independent radiology review also highlights metaphyseal flaring in
+      hypochondroplasia.
+- name: Short iliac bones
+  category: Radiological
+  description: >
+    Shortened, often squared ilia are diagnostically useful pelvic radiographic
+    findings.
+  phenotype_term:
+    preferred_term: Short iliac bones
+    term:
+      id: HP:0100866
+      label: Short iliac bones
+  evidence:
+  - reference: PMID:20301650
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Radiologic features include shortening of long bones with mild metaphyseal flare; a lack of widening or a narrowing of the lumbar interpedicular distances with shortening of the pedicle length and posterior scalloping of the vertebral bodies; short, broad femoral neck; and squared, shortened ilia."
+    explanation: >
+      GeneReviews identifies squared, shortened ilia as part of the classic HCH
+      pelvic phenotype.
+  - reference: PMID:26867606
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Only parameters 1, 3, 4, 5 and 6 were statistically different between the two groups."
+    explanation: >
+      In the neonatal FGFR3-HCH radiology study, parameter 1 was short ilia, which
+      significantly distinguished HCH neonates from controls.
+- name: Short femur
+  category: Radiological
+  description: >
+    Short femora are part of the early radiographic pattern and contributed to the
+    proposed neonatal diagnostic criteria.
+  phenotype_term:
+    preferred_term: Short femur
+    term:
+      id: HP:0003097
+      label: Short femur
+  evidence:
+  - reference: PMID:26867606
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Only parameters 1, 3, 4, 5 and 6 were statistically different between the two groups."
+    explanation: >
+      In the neonatal FGFR3-HCH radiology study, parameter 5 was short femora, which
+      significantly distinguished HCH neonates from controls.
+  - reference: PMID:14755409
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Mild shortening of the limbs became manifest after 26 weeks of gestation."
+    explanation: >
+      This molecularly confirmed prenatal case supports femoral/limb shortening as an
+      early developmental manifestation.
 genetic:
 - name: FGFR3 N540K mutation
   association: Causative

--- a/references_cache/PMID_11475794.md
+++ b/references_cache/PMID_11475794.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:11475794"
+title: "[Hypochondroplasia: importance of radiological findings in the differential diagnosis of short statures of different origin]."
+authors:
+- Iannaccone R
+- Tiberti AC
+journal: Recenti Prog Med
+year: '2001'
+keywords:
+- "Achondroplasia/diagnosis, genetics"
+- Age Factors
+- "Bone Diseases, Developmental/diagnosis, diagnostic imaging, genetics"
+- "Child, Preschool"
+- "Diagnosis, Differential"
+- "Dwarfism/diagnosis, diagnostic imaging, genetics"
+- Genotype
+- Humans
+- Infant
+- "Infant, Newborn"
+- Mutation
+- Radiography
+- "Receptors, Fibroblast Growth Factor/genetics"
+content_type: abstract_only
+---
+
+# [Hypochondroplasia: importance of radiological findings in the differential diagnosis of short statures of different origin].
+**Authors:** Iannaccone R, Tiberti AC
+**Journal:** Recenti Prog Med (2001)
+
+## Content
+
+1. Recenti Prog Med. 2001 Jul-Aug;92(7-8):483-8.
+
+[Hypochondroplasia: importance of radiological findings in the differential 
+diagnosis of short statures of different origin].
+
+[Article in Italian]
+
+Iannaccone R(1), Tiberti AC.
+
+Author information:
+(1)Medico Interno presso la II Cattedra dell'Istituto di Radiologia, Università 
+La Sapienza, Policlinico Umberto I, Roma. riannaccone@tiscalinet.it
+
+Hypochondroplasia is a genetic skeletal dysplasia characterized by 
+disproportionate short stature, stocky appearance and several clinical and 
+radiological features very similar, but much milder, than those of classical 
+achondroplasia, including shortened and stubby long bones, decreased 
+lumbo-sacral interpediculate distances, posterior scalloping of the lumbar 
+vertebrae, metaphyseal flaring, and moderate macrocephaly. The condition may 
+occasionally mimic short stature of familial, endocrine or metabolic origin. In 
+the absence of clinical and laboratory diagnostic clues, radiological findings 
+are of the utmost value in the diagnosis of this skeletal dysplasia and also in 
+the differential diagnosis with other short-limbed dwarfisms. The genetic, 
+clinical and radiological aspects of hypochondroplasia are briefly recalled, and 
+the importance of some minor and frequently overlooked findings is stressed.
+
+PMID: 11475794 [Indexed for MEDLINE]

--- a/references_cache/PMID_14755409.md
+++ b/references_cache/PMID_14755409.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:14755409"
+title: Radiographic and genetic diagnosis of sporadic hypochondroplasia early in the neonatal period.
+authors:
+- Kataoka S
+- Sawai H
+- Yamada H
+- Kanazawa N
+- Koyama K
+- Nishimura G
+- Morikawa M
+- Sakuragi N
+- Minakami H
+journal: Prenat Diagn
+year: '2004'
+doi: 10.1002/pd.746
+keywords:
+- Adult
+- "Diagnosis, Differential"
+- Female
+- Genetic Testing
+- Gestational Age
+- Humans
+- "Infant, Newborn"
+- Male
+- "Osteochondrodysplasias/diagnosis, diagnostic imaging, embryology, genetics"
+- Pregnancy
+- "Pregnancy Trimester, Third"
+- Prenatal Diagnosis
+- Protein-Tyrosine Kinases
+- Radiography
+- "Receptor, Fibroblast Growth Factor, Type 3"
+- "Receptors, Fibroblast Growth Factor/genetics"
+content_type: abstract_only
+---
+
+# Radiographic and genetic diagnosis of sporadic hypochondroplasia early in the neonatal period.
+**Authors:** Kataoka S, Sawai H, Yamada H, Kanazawa N, Koyama K, Nishimura G, Morikawa M, Sakuragi N, Minakami H
+**Journal:** Prenat Diagn (2004)
+**DOI:** [10.1002/pd.746](https://doi.org/10.1002/pd.746)
+
+## Content
+
+1. Prenat Diagn. 2004 Jan;24(1):45-9. doi: 10.1002/pd.746.
+
+Radiographic and genetic diagnosis of sporadic hypochondroplasia early in the 
+neonatal period.
+
+Kataoka S(1), Sawai H, Yamada H, Kanazawa N, Koyama K, Nishimura G, Morikawa M, 
+Sakuragi N, Minakami H.
+
+Author information:
+(1)Department of Obstetrics and Gynecology, Hokkaido University Graduate School 
+of Medicine, Sapporo, Japan.
+
+Hypochondroplasia is an autosomal dominant skeletal dysplasia expressing 
+postnatal onset of short stature with mild rhizomelic shortening of the limbs. 
+This manifestation leads to restricted prenatal diagnosis of the disorder. We 
+report here on a sporadic case of a hypochondroplastic baby, whose prenatal 
+sonographic measurements were serially recorded from 19 weeks of gestation. Mild 
+shortening of the limbs became manifest after 26 weeks of gestation. Biparietal 
+diameter was within the normal range throughout gestation. Both parents were of 
+average stature. A tentative diagnosis of a nonlethal short-limb skeletal 
+dysplasia was made. At birth, the clinical manifestations of the neonate were 
+not characteristic, but the radiographic features raised the possibility of 
+hypochondroplasia. Molecular analyses revealed a C to G mutation at nucleotide 
+1659 of the fibroblast growth factor receptor 3 (FGFR3) gene, a common mutation 
+in hypochondroplasia.
+
+Copyright 2004 John Wiley & Sons, Ltd.
+
+DOI: 10.1002/pd.746
+PMID: 14755409 [Indexed for MEDLINE]

--- a/references_cache/PMID_20301650.md
+++ b/references_cache/PMID_20301650.md
@@ -1,0 +1,107 @@
+---
+reference_id: "PMID:20301650"
+title: Hypochondroplasia.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Bober MB
+- Bellus GA
+- Cheung MS
+- Jain M
+- Nikkel SM
+- Tiller GE
+year: '1993'
+content_type: abstract_only
+---
+
+# Hypochondroplasia.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Bober MB, Bellus GA, Cheung MS, Jain M, Nikkel SM, Tiller GE
+
+## Content
+
+1. Hypochondroplasia.
+
+Bober MB(1), Bellus GA(2), Cheung MS(3), Jain M(4), Nikkel SM(5), Tiller GE(6).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors. 
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle; 
+1993–2026.
+1999 Jul 15 [updated 2025 Sep 25].
+
+Author information:
+(1)Alfred I duPont Hospital for Children, Wilmington, Delaware
+(2)Geisinger Health System, Danville, Pennsylvania
+(3)Great Ormond Street Hospital, London, United Kingdom
+(4)Nemours Children’s Hospital, Wilmington, Delaware
+(5)BC Women’s and Children’s Hospital, Vancouver, Canada
+(6)Southern California Permanente Medical Group, Los Angeles, California
+
+CLINICAL CHARACTERISTICS: Hypochondroplasia is a skeletal dysplasia 
+characterized by short stature; stocky build; disproportionately short arms and 
+legs; broad, short hands and feet; mild joint laxity; and relative macrocephaly. 
+Radiologic features include shortening of long bones with mild metaphyseal 
+flare; a lack of widening or a narrowing of the lumbar interpedicular distances 
+with shortening of the pedicle length and posterior scalloping of the vertebral 
+bodies; short, broad femoral neck; and squared, shortened ilia. The skeletal 
+features are similar to those seen in achondroplasia but tend to be milder. 
+Medical complications common to achondroplasia (e.g., foramen magnum stenosis, 
+spinal stenosis, tibial bowing, obstructive apnea) occur less frequently in 
+hypochondroplasia, but intellectual disability and epilepsy may be more 
+prevalent. Children usually present as toddlers or at early school age with 
+decreased growth velocity leading to short stature and limb disproportion. Other 
+features also become more prominent over time. Infants may present with temporal 
+lobe seizures.
+DIAGNOSIS/TESTING: The diagnosis of hypochondroplasia is established in a 
+proband with characteristic clinical and radiographic features. Identification 
+of a heterozygous FGFR3 pathogenic variant known to be associated with 
+hypochondroplasia can confirm the diagnosis and help distinguish 
+hypochondroplasia from achondroplasia and other related skeletal dysplasias in 
+individuals with overlapping phenotypes.
+MANAGEMENT: Treatment of manifestations: Management of short stature in 
+hypochondroplasia is influenced by parental expectations and concerns; one 
+approach is to address these concerns rather than trying to treat the child. 
+Foramen magnum stenosis, thoracolumbar kyphosis, genu varum, and spinal stenosis 
+are management by orthopedists and neurosurgeons using similar strategies 
+employed in achondroplasia. Seizures are treated in the standard manner. 
+Developmental and educational support as needed. Connecting families with local 
+resources and support is important. Surveillance: The following should be 
+performed at routine well-child visits: measurement and assessment of height, 
+weight, and head circumference using hypochondroplasia-standardized growth 
+curves; assessment for signs and symptoms of spinal cord compression, sleep 
+apnea, thoracolumbar kyphosis, and leg bowing; development assessment and 
+monitoring of all developmental domains including speech and language; audiology 
+evaluation if speech and/or hearing concerns arise. Evaluation of social 
+adjustment at well-child visits and then annually, most important during the 
+grade-school years. Pregnancy management: Vaginal deliveries are possible, 
+although for each pregnancy, pelvic outlet capacity should be assessed in 
+relation to fetal head size; epidural or spinal anesthetic can be used, but a 
+consultation with an anesthesiologist prior to delivery is recommended to assess 
+the spinal anatomy; spinal stenosis may be aggravated during pregnancy.
+GENETIC COUNSELING: Hypochondroplasia is inherited in an autosomal dominant 
+manner. The majority of individuals with hypochondroplasia have parents of 
+average stature and have hypochondroplasia as the result of a de novo pathogenic 
+variant. An individual with hypochondroplasia who has a reproductive partner of 
+average stature has a 50% chance of having a child with hypochondroplasia. When 
+the proband and the proband's reproductive partner have the same or different 
+skeletal dysplasias, genetic counseling is more complex. In general, if both 
+members of a couple have a dominantly inherited skeletal dysplasia, each child 
+has a 25% chance of having average stature, a 25% chance of having the same 
+skeletal dysplasia as the father, a 25% chance of having the same skeletal 
+dysplasia as the mother, and a 25% chance of inheriting a pathogenic variant 
+from both parents and being at risk for a potentially poor pregnancy outcome. It 
+is not possible to provide information about prognosis for all at-risk 
+offspring. If one parent has hypochondroplasia and the other parent is of 
+average stature, has hypochondroplasia, or has another dominantly inherited 
+skeletal dysplasia, prenatal and preimplantation genetic testing are possible if 
+the causative pathogenic variant(s) have been identified in the affected 
+parent(s).
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a 
+registered trademark of the University of Washington, Seattle. All rights 
+reserved. Test.
+
+PMID: 20301650

--- a/references_cache/PMID_26867606.md
+++ b/references_cache/PMID_26867606.md
@@ -1,0 +1,108 @@
+---
+reference_id: "PMID:26867606"
+title: Criteria for radiologic diagnosis of hypochondroplasia in neonates.
+authors:
+- Saito T
+- Nagasaki K
+- Nishimura G
+- Wada M
+- Nyuzuki H
+- Takagi M
+- Hasegawa T
+- Amano N
+- Murotsuki J
+- Sawai H
+- Yamada T
+- Sato S
+- Saitoh A
+journal: Pediatr Radiol
+year: '2016'
+doi: 10.1007/s00247-015-3518-2
+keywords:
+- Anatomic Landmarks/diagnostic imaging
+- Bone and Bones/abnormalities
+- "Dwarfism/diagnosis, genetics"
+- Female
+- "Femur/abnormalities, diagnostic imaging"
+- Humans
+- "Infant, Newborn"
+- Japan
+- "Limb Deformities, Congenital/diagnosis, genetics"
+- "Lordosis/diagnosis, genetics"
+- Male
+- Mutation/genetics
+- Neonatology/standards
+- "Pelvic Bones/abnormalities, diagnostic imaging"
+- Practice Guidelines as Topic
+- "Radiography, Abdominal/standards"
+- "Radiography, Thoracic/standards"
+- Radiology/standards
+- "Receptor, Fibroblast Growth Factor, Type 3/genetics"
+- Reproducibility of Results
+- Sensitivity and Specificity
+- "Spine/abnormalities, diagnostic imaging"
+content_type: abstract_only
+---
+
+# Criteria for radiologic diagnosis of hypochondroplasia in neonates.
+**Authors:** Saito T, Nagasaki K, Nishimura G, Wada M, Nyuzuki H, Takagi M, Hasegawa T, Amano N, Murotsuki J, Sawai H, Yamada T, Sato S, Saitoh A
+**Journal:** Pediatr Radiol (2016)
+**DOI:** [10.1007/s00247-015-3518-2](https://doi.org/10.1007/s00247-015-3518-2)
+
+## Content
+
+1. Pediatr Radiol. 2016 Apr;46(4):513-8. doi: 10.1007/s00247-015-3518-2. Epub
+2016  Feb 11.
+
+Criteria for radiologic diagnosis of hypochondroplasia in neonates.
+
+Saito T(1), Nagasaki K(2), Nishimura G(3), Wada M(1), Nyuzuki H(1), Takagi 
+M(4)(5), Hasegawa T(5), Amano N(5), Murotsuki J(6), Sawai H(7), Yamada T(8), 
+Sato S(9), Saitoh A(1).
+
+Author information:
+(1)Division of Pediatrics, Department of Homeostatic Regulation and Development, 
+Niigata University Graduate School of Medical and Dental Sciences, 1-757 
+Asahimachi-Dori, Chu-Ou-Ku, Niigata, 951-8510, Japan.
+(2)Division of Pediatrics, Department of Homeostatic Regulation and Development, 
+Niigata University Graduate School of Medical and Dental Sciences, 1-757 
+Asahimachi-Dori, Chu-Ou-Ku, Niigata, 951-8510, Japan. 
+nagasaki@med.niigata-u.ac.jp.
+(3)Department of Radiology, Tokyo Metropolitan Children's Medical Center, Tokyo, 
+Japan.
+(4)Department of Endocrinology, Tokyo Metropolitan Children's Medical Center, 
+Tokyo, Japan.
+(5)Department of Pediatrics, Keio University School of Medicine, Tokyo, Japan.
+(6)Department of Maternal and Fetal Medicine, Tohoku University Graduate School 
+of Medicine, Miyagi Children's Hospital, Sendai, Japan.
+(7)Departments of Obstetrics and Gynecology, Hyogo College of Medicine, Hyogo, 
+Japan.
+(8)Departments of Obstetrics and Gynecology, Hokkaido University Hospital, 
+Hokkaido, Japan.
+(9)Department of Obstetrics and Gynecology, Aomori Rosai Hospital, Aomori, 
+Japan.
+
+BACKGROUND: A radiologic diagnosis of hypochondroplasia is hampered by the 
+absence of age-dependent radiologic criteria, particularly in the neonatal 
+period.
+OBJECTIVE: To establish radiologic criteria and scoring system for identifying 
+neonates with fibroblast growth factor receptor 3 (FGFR3)-associated 
+hypochondroplasia.
+MATERIALS AND METHODS: This retrospective study included 7 hypochondroplastic 
+neonates and 30 controls. All subjects underwent radiologic examination within 
+28 days after birth. We evaluated parameters reflecting the presence of (1) 
+short ilia, (2) squared ilia, (3) short greater sciatic notch, (4) horizontal 
+acetabula, (5) short femora, (6) broad femora, (7) metaphyseal flaring, (8) 
+lumbosacral interpedicular distance narrowing and (9) ovoid radiolucency of the 
+proximal femora.
+RESULTS: Only parameters 1, 3, 4, 5 and 6 were statistically different between 
+the two groups. Parameters 3, 5 and 6 did not overlap between the groups, while 
+parameters 1 and 4 did. Based on these results, we propose a scoring system for 
+hypochondroplasia. Two major criteria (parameters 3 and 6) were assigned scores 
+of 2, whereas 4 minor criteria (parameters 1, 4, 5 and 9) were assigned scores 
+of 1. All neonates with hypochondroplasia in our material scored ≥6.
+CONCLUSION: Our set of diagnostic radiologic criteria might be useful for early 
+identification of hypochondroplastic neonates.
+
+DOI: 10.1007/s00247-015-3518-2
+PMID: 26867606 [Indexed for MEDLINE]

--- a/references_cache/PMID_41040055.md
+++ b/references_cache/PMID_41040055.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:41040055"
+title: The Head Circumference Height Index (HCH-I) to Quantify Relative Macrocephaly and Aid Identification of Hypochondroplasia in Children.
+authors:
+- Cheung MS
+- Lanzafame R
+- Low KJ
+- Cole TJ
+journal: Am J Med Genet A
+year: '2026'
+doi: 10.1002/ajmg.a.64266
+keywords:
+- Humans
+- "Lordosis/diagnosis, genetics, pathology"
+- "Dwarfism/diagnosis, genetics, pathology"
+- Female
+- Male
+- Child
+- "Receptor, Fibroblast Growth Factor, Type 3/genetics"
+- "Limb Deformities, Congenital/diagnosis, genetics, pathology"
+- "Child, Preschool"
+- Infant
+- "Megalencephaly/diagnosis, genetics, pathology"
+- "Bone and Bones/abnormalities, pathology"
+- Body Height/genetics
+- Head
+- Adolescent
+- Growth Charts
+- Cephalometry
+content_type: abstract_only
+---
+
+# The Head Circumference Height Index (HCH-I) to Quantify Relative Macrocephaly and Aid Identification of Hypochondroplasia in Children.
+**Authors:** Cheung MS, Lanzafame R, Low KJ, Cole TJ
+**Journal:** Am J Med Genet A (2026)
+**DOI:** [10.1002/ajmg.a.64266](https://doi.org/10.1002/ajmg.a.64266)
+
+## Content
+
+1. Am J Med Genet A. 2026 Feb;200(2):353-359. doi: 10.1002/ajmg.a.64266. Epub
+2025  Oct 3.
+
+The Head Circumference Height Index (HCH-I) to Quantify Relative Macrocephaly 
+and Aid Identification of Hypochondroplasia in Children.
+
+Cheung MS(1)(2), Lanzafame R(1), Low KJ(3)(4), Cole TJ(2).
+
+Author information:
+(1)Great Ormond Street Hospital NHS Foundation Trust, Department of Paediatric 
+Endocrinology, London, UK.
+(2)UCL Great Ormond Street Institute of Child Health, London, UK.
+(3)Department of Clinical Genetics, University Hospitals Bristol and Weston NHS 
+Foundation Trust, Bristol, UK.
+(4)Centre for Academic Child Health, Bristol Medical School, University of 
+Bristol, Bristol, UK.
+
+Hypochondroplasia (HCH) is a rare skeletal dysplasia caused by pathogenic 
+variants in the FGFR3 gene. We hypothesized that the relative disproportion 
+between head circumference and height in HCH might be diagnostically informative 
+and generated a simple index of head-stature disproportion to help pediatricians 
+diagnose HCH. The Head Circumference Height Index (HCH-I), based on formal 
+statistical principles, is defined as height Z-score - 1/2 head circumference 
+Z-score, with the Z-scores based here on the UK90 growth reference. An HCH-I 
+below the cut-off of -2 indicates substantial head-height disproportion. We 
+validated the index by comparing children diagnosed with HCH (n = 364), using 
+data from the recent European HCH growth charts, to children from the Cambridge 
+Infant Growth Study (CIGS) (n = 4620). The mean (SD) HCH-I was -3.0 (1.2) in the 
+HCH cohort, compared to -0.2 (0.9) in the CIGS cohort. An HCH-I below -2 
+correctly identified 78% of children with HCH, while only 2.4% of CIGS children 
+fell below the cut-off. An HCH-I below -2 identifies children with head-height 
+disproportion who may have HCH or another genetic disorder. The index is 
+deliberately simple to calculate and should prove useful in clinical practice.
+
+© 2025 The Author(s). American Journal of Medical Genetics Part A published by 
+Wiley Periodicals LLC.
+
+DOI: 10.1002/ajmg.a.64266
+PMID: 41040055 [Indexed for MEDLINE]

--- a/research/Hypochondroplasia-phenotype-curation-2026-04-19.md
+++ b/research/Hypochondroplasia-phenotype-curation-2026-04-19.md
@@ -1,0 +1,69 @@
+# Hypochondroplasia phenotype curation notes
+
+Date: 2026-04-19
+Target file: `kb/disorders/Hypochondroplasia.yaml`
+Issue: `#1450`
+
+## Scope
+
+Focused phenotype-only curation pass for hypochondroplasia. The goal was to make
+the phenotype section more complete while tightening every retained statement to
+exact PMID-backed evidence.
+
+## Core sources used
+
+- PMID:20301650. GeneReviews summary with the broadest clinically relevant
+  phenotype overview and radiographic pattern.
+- PMID:41762373. 2026 diagnostic pathway review with age-specific phenotype
+  recognition clues.
+- PMID:36442838. Korean FGFR3 N540K cohort with directly quotable frequencies for
+  genu varum, macrocephaly, and developmental delay.
+- PMID:23165795. Finnish FGFR3 N540K cohort defining seizure burden and MRI
+  abnormalities.
+- PMID:41040055. 2026 cohort analysis quantifying head-height disproportion.
+- PMID:26867606. Neonatal radiology study supporting specific skeletal findings.
+- PMID:14755409. Prenatal/neonatal case confirming early rhizomelic limb
+  shortening.
+- PMID:11475794. Radiology-focused review confirming classic vertebral and
+  metaphyseal findings.
+
+## Added or strengthened
+
+- Short stature
+- Rhizomelic limb shortening
+- Relative macrocephaly
+- Mild joint laxity
+- Neurodevelopmental delay
+- Hydrocephalus
+- Spinal canal stenosis
+- Narrow vertebral interpedicular distance
+- Posterior scalloping of vertebral bodies
+- Metaphyseal widening
+- Short iliac bones
+- Short femur
+
+## Kept but softened
+
+- Seizure: kept as an association, but frequency removed because the strongest
+  quantitative evidence comes from a neurologically selected cohort.
+- Temporal lobe dysplasia: retained with ascertainment caveat and without a
+  whole-disease frequency claim.
+- Ventriculomegaly: retained without frequency because available counts come from
+  MRI-selected patients.
+
+## Removed as unsupported or overclaimed
+
+- Lumbar hyperlordosis
+- Brachydactyly
+- Frontal bossing
+- The old combined entry `Spinal stenosis with reduced interpedicular distance`
+  was replaced by separate clinical and radiographic findings.
+
+## Frequency decisions
+
+- Kept `HP_0040282` for relative macrocephaly based on 9/20 (45%) in PMID:36442838.
+- Kept `HP_0040282` for genu varum based on 11/20 (55%) in PMID:36442838.
+- Kept `HP_0040283` for neurodevelopmental delay based on 5/20 (25%) in
+  PMID:36442838.
+- Removed unsupported frequencies from short stature, seizures, temporal lobe
+  dysplasia, ventriculomegaly, and radiographic findings.


### PR DESCRIPTION
Closes #1450

## Summary
- rewrite the phenotype block in `kb/disorders/Hypochondroplasia.yaml` around PMID-backed evidence
- add missing clinically important neurologic and radiographic phenotypes with exact supporting PMIDs
- remove or replace unsupported phenotype claims and strip frequency assertions that were not directly justified
- add the fetched `references_cache/` entries and a focused phenotype curation note in `research/`

## Validation
- `just validate kb/disorders/Hypochondroplasia.yaml`
- `just validate-references kb/disorders/Hypochondroplasia.yaml`
- `just validate-terms kb/disorders/Hypochondroplasia.yaml`

All three commands passed locally.