### PR TITLE
[codex] Enhance Campomelic Dysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Campomelic_Dysplasia.yaml
+++ b/kb/disorders/Campomelic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Campomelic Dysplasia
 creation_date: '2026-03-04T07:35:50Z'
-updated_date: '2026-04-07T00:12:52Z'
+updated_date: '2026-04-19T00:10:02Z'
 category: Mendelian
 description: >
   Campomelic dysplasia is a severe SOX9-related skeletal dysplasia with abnormal
@@ -219,54 +219,237 @@ genetic:
       in campomelic dysplasia.
 phenotypes:
 - name: Bowing of the Long Bones
+  frequency: FREQUENT
   description: >
-    Anterolateral bowing of long bones, especially in the lower limbs, is a
-    defining phenotype of campomelic dysplasia.
+    Bowed femora and tibiae are a core skeletal manifestation of campomelic
+    dysplasia, although campomelia can be mild or absent in the acampomelic
+    variant.
   phenotype_term:
     preferred_term: Bowing of the long bones
     term:
       id: HP:0006487
       label: Bowing of the long bones
   evidence:
-  - reference: PMID:24800790
-    reference_title: "Campomelic dysplasia."
+  - reference: PMID:11754051
+    reference_title: "Acampomelic campomelic syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Campomelic dysplasia is a rare hereditary congenital osteochondral
-      dysplasia characterized by abnormal bowing of the lower limbs, sex
-      reversal in males, and other skeletal and extraskeletal abnormalities.
+    snippet: "Campomelia (bowed limbs) is seen in most but not all patients, defining a so-called acampomelic campomelic dysostosis (ACD)."
     explanation: >-
-      This directly supports the hallmark campomelic limb-bowing phenotype.
-- name: Short Stature
+      This directly supports bowed long bones as a characteristic phenotype.
+      Author wording "most but not all patients" supports the FREQUENT band.
+- name: Bell-Shaped Thorax
   description: >
-    Severe skeletal dysplasia typically causes shortness of stature with
-    shortened limbs.
+    A small bell-shaped thorax is a characteristic thoracic manifestation and
+    contributes to respiratory compromise.
   phenotype_term:
-    preferred_term: Short stature
+    preferred_term: Bell-shaped thorax
     term:
-      id: HP:0004322
-      label: Short stature
+      id: HP:0001591
+      label: Bell-shaped thorax
   evidence:
-  - reference: PMID:36741086
-    reference_title: "Case report: A de novo Non-sense SOX9 mutation (p.Q417*) located in transactivation domain is Responsible for Campomelic Dysplasia."
+  - reference: PMID:11754051
+    reference_title: "Acampomelic campomelic syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Campomelic dysplasia (CD) is an autosomal dominant skeletal dysplasia
-      syndrome characterized by shortness and bowing of lower extremities, and
-      often accompanied by XY sex reversal.
+      Additional radiological and clinical findings are 11 pairs of ribs and a
+      bell-shaped thorax, hypoplastic scapulae, narrow iliac wings,
+      non-mineralized thoracic pedicles, clubbed feet, Robin sequence, typical
+      facial anomalies and tracheomalacia.
     explanation: >-
-      This supports shortness as part of the core phenotypic presentation.
+      This review abstract identifies bell-shaped thorax as part of the typical
+      campomelic dysplasia skeletal phenotype.
+- name: 11 Pairs of Ribs
+  description: >
+    Reduced rib number is a recurrent radiographic feature in campomelic
+    dysplasia.
+  phenotype_term:
+    preferred_term: 11 pairs of ribs
+    term:
+      id: HP:0000878
+      label: 11 pairs of ribs
+  evidence:
+  - reference: PMID:11754051
+    reference_title: "Acampomelic campomelic syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Additional radiological and clinical findings are 11 pairs of ribs and a
+      bell-shaped thorax, hypoplastic scapulae, narrow iliac wings,
+      non-mineralized thoracic pedicles, clubbed feet, Robin sequence, typical
+      facial anomalies and tracheomalacia.
+    explanation: >-
+      This review abstract directly supports reduced rib number as a recurrent
+      campomelic dysplasia finding.
+- name: Hypoplastic Scapulae
+  description: >
+    Hypoplastic scapulae are a characteristic radiographic finding in
+    campomelic dysplasia.
+  phenotype_term:
+    preferred_term: Hypoplastic scapulae
+    term:
+      id: HP:0000882
+      label: Hypoplastic scapulae
+  evidence:
+  - reference: PMID:11754051
+    reference_title: "Acampomelic campomelic syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Additional radiological and clinical findings are 11 pairs of ribs and a
+      bell-shaped thorax, hypoplastic scapulae, narrow iliac wings,
+      non-mineralized thoracic pedicles, clubbed feet, Robin sequence, typical
+      facial anomalies and tracheomalacia.
+    explanation: >-
+      This review abstract directly identifies hypoplastic scapulae within the
+      classic radiographic phenotype of campomelic dysplasia.
+- name: Hip Dislocation
+  description: >
+    Congenital hip dislocation is a recurrent orthopedic manifestation in
+    campomelic dysplasia.
+  phenotype_term:
+    preferred_term: Hip dislocation
+    term:
+      id: HP:0002827
+      label: Hip dislocation
+  evidence:
+  - reference: PMID:6344634
+    reference_title: "The campomelic syndrome: review, report of 17 cases, and follow-up on the currently 17-year-old boy first reported by Maroteaux et al in 1971."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Usually the hips are dislocated and talipes equinovarus deformities are present."
+    explanation: >-
+      This clinicoradiographic review directly supports hip dislocation as a
+      recurrent orthopedic phenotype in campomelic dysplasia.
+- name: Clubfoot
+  description: >
+    Clubfoot is a characteristic limb malformation and contributes to the
+    orthopedic burden of campomelic dysplasia.
+  phenotype_term:
+    preferred_term: clubfoot
+    term:
+      id: HP:0001762
+      label: Talipes equinovarus
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Campomelic dysplasia (CD) is a skeletal dysplasia characterized by
+      distinctive facies, Pierre Robin sequence with cleft palate, shortening
+      and bowing of long bones, and clubfeet.
+    explanation: >-
+      GeneReviews identifies clubfeet among the defining clinical
+      characteristics of campomelic dysplasia.
+- name: Pierre-Robin Sequence
+  description: >
+    Pierre-Robin sequence with cleft palate is a characteristic craniofacial
+    presentation in campomelic dysplasia.
+  phenotype_term:
+    preferred_term: Pierre-Robin sequence
+    term:
+      id: HP:0000201
+      label: Pierre-Robin sequence
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Campomelic dysplasia (CD) is a skeletal dysplasia characterized by
+      distinctive facies, Pierre Robin sequence with cleft palate, shortening
+      and bowing of long bones, and clubfeet.
+    explanation: >-
+      GeneReviews identifies Pierre-Robin sequence with cleft palate as part of
+      the characteristic craniofacial presentation.
+- name: Cleft Palate
+  description: >
+    Cleft palate contributes to feeding and airway morbidity and is often part
+    of Pierre-Robin sequence in campomelic dysplasia.
+  phenotype_term:
+    preferred_term: Cleft palate
+    term:
+      id: HP:0000175
+      label: Cleft palate
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Campomelic dysplasia (CD) is a skeletal dysplasia characterized by
+      distinctive facies, Pierre Robin sequence with cleft palate, shortening
+      and bowing of long bones, and clubfeet.
+    explanation: >-
+      GeneReviews explicitly includes cleft palate among the defining clinical
+      characteristics of campomelic dysplasia.
+- name: Micrognathia
+  description: >
+    Micrognathia is a recurrent craniofacial abnormality that can worsen airway
+    obstruction.
+  phenotype_term:
+    preferred_term: Micrognathia
+    term:
+      id: HP:0000347
+      label: Micrognathia
+  evidence:
+  - reference: PMID:17185244
+    reference_title: "Novel SOX9 gene mutation in campomelic dysplasia with autosomal sex reversal."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The presenting phenotypes included dysmorphic face with macrocephaly,
+      prominent forehead, low nasal bridge, cleft palate and micrognathia.
+    explanation: >-
+      This directly supports micrognathia as part of the craniofacial phenotype
+      of campomelic dysplasia.
+- name: Laryngotracheomalacia
+  description: >
+    Airway cartilage weakness with laryngotracheomalacia contributes to
+    respiratory compromise in campomelic dysplasia.
+  phenotype_term:
+    preferred_term: Laryngotracheomalacia
+    term:
+      id: HP:0008755
+      label: Laryngotracheomalacia
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other findings include laryngotracheomalacia with respiratory compromise
+      and ambiguous genitalia or normal female external genitalia in most
+      individuals with a 46,XY karyotype.
+    explanation: >-
+      GeneReviews identifies laryngotracheomalacia as an important airway
+      manifestation contributing to respiratory compromise.
 - name: Respiratory Insufficiency
   description: >
-    Neonatal respiratory insufficiency is a major life-threatening manifestation
-    in classic campomelic dysplasia.
+    Respiratory insufficiency is a major life-threatening manifestation in
+    campomelic dysplasia.
   phenotype_term:
     preferred_term: Respiratory insufficiency
     term:
       id: HP:0002093
       label: Respiratory insufficiency
+  phenotype_contexts:
+  - onset:
+      onset_category: NEONATAL
+      notes: Respiratory failure is typically manifest in the neonatal period in severe classic campomelic dysplasia.
+    evidence:
+    - reference: PMID:24800790
+      reference_title: "Campomelic dysplasia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is usually fatal in the neonatal period because of respiratory
+        insufficiency.
+      explanation: >-
+        This abstract places respiratory insufficiency in the neonatal period,
+        supporting a NEONATAL onset context for this manifestation.
   evidence:
   - reference: PMID:24800790
     reference_title: "Campomelic dysplasia."
@@ -277,87 +460,155 @@ phenotypes:
       insufficiency.
     explanation: >-
       This sentence directly supports respiratory insufficiency as a core severe
-      phenotype.
+      phenotype in campomelic dysplasia.
 - name: Sex Reversal
   description: >
-    Many affected 46,XY individuals show sex reversal due to disrupted SOX9
-    function in sex determination pathways.
+    Many affected individuals with a 46,XY karyotype show sex reversal due to
+    disrupted SOX9-dependent gonadal differentiation.
   phenotype_term:
     preferred_term: Sex reversal
     term:
       id: HP:0012245
       label: Sex reversal
   evidence:
-  - reference: PMID:17185244
-    reference_title: "Novel SOX9 gene mutation in campomelic dysplasia with autosomal sex reversal."
+  - reference: PMID:11754051
+    reference_title: "Acampomelic campomelic syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sex reversal occurs in most patients with an XY karyotype."
+    explanation: >-
+      This review abstract directly supports sex reversal as a major phenotype
+      in affected individuals with a 46,XY karyotype.
+- name: Ambiguous Genitalia
+  description: >
+    Some affected individuals with a 46,XY karyotype present with ambiguous
+    external genitalia.
+  phenotype_term:
+    preferred_term: Ambiguous genitalia
+    term:
+      id: HP:0000062
+      label: Ambiguous genitalia
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Campomelic dysplasia (CD; OMIM  # 114290) is an autosomal dominant,
-      frequently lethal dysplasia syndrome whose primary features include angular
-      bowing and shortening of the limbs, and sex reversal in the majority of
-      affected XY individuals.
+      Other findings include laryngotracheomalacia with respiratory compromise
+      and ambiguous genitalia or normal female external genitalia in most
+      individuals with a 46,XY karyotype.
     explanation: >-
-      This directly supports high prevalence of sex reversal among affected
-      46,XY individuals.
+      GeneReviews directly supports ambiguous genitalia as part of the
+      campomelic dysplasia phenotype spectrum in affected 46,XY individuals.
 - name: Female External Genitalia in 46,XY Individual
   description: >
-    Some affected neonates with a 46,XY karyotype present with female external
-    genitalia.
+    Some affected individuals with a 46,XY karyotype have normal female
+    external genitalia.
   phenotype_term:
     preferred_term: Female external genitalia in individual with 46,XY karyotype
     term:
       id: HP:0008730
       label: Female external genitalia in individual with 46,XY karyotype
   evidence:
-  - reference: PMID:17185244
-    reference_title: "Novel SOX9 gene mutation in campomelic dysplasia with autosomal sex reversal."
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The karyotype was 46,XY despite female external genitalia.
+      Other findings include laryngotracheomalacia with respiratory compromise
+      and ambiguous genitalia or normal female external genitalia in most
+      individuals with a 46,XY karyotype.
     explanation: >-
-      This case evidence directly supports 46,XY sex reversal phenotype.
-- name: Cleft Palate
+      GeneReviews directly supports normal female external genitalia as a
+      recognized presentation in affected 46,XY individuals.
+- name: Short Stature
   description: >
-    Cleft palate is a frequent craniofacial manifestation in campomelic
-    dysplasia and contributes to feeding/airway morbidity.
+    Short stature is particularly recognized among long-term survivors of
+    campomelic dysplasia.
   phenotype_term:
-    preferred_term: Cleft palate
+    preferred_term: Short stature
     term:
-      id: HP:0000175
-      label: Cleft palate
+      id: HP:0004322
+      label: Short stature
   evidence:
-  - reference: PMID:17185244
-    reference_title: "Novel SOX9 gene mutation in campomelic dysplasia with autosomal sex reversal."
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The presenting phenotypes included dysmorphic face with macrocephaly,
-      prominent forehead, low nasal bridge, cleft palate and micrognathia.
+      Many affected infants die in the neonatal period; additional findings
+      identified in long-term survivors include short stature, cervical spine
+      instability with cord compression, progressive scoliosis, and hearing
+      impairment.
     explanation: >-
-      This directly supports cleft palate as part of the CD phenotypic spectrum.
+      GeneReviews identifies short stature as a later feature in long-term
+      survivors.
+- name: Cervical Spine Instability
+  description: >
+    Long-term survivors can develop cervical spine instability, sometimes with
+    spinal cord compression.
+  phenotype_term:
+    preferred_term: Cervical spine instability
+    term:
+      id: HP:0010646
+      label: Cervical spine instability
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Many affected infants die in the neonatal period; additional findings
+      identified in long-term survivors include short stature, cervical spine
+      instability with cord compression, progressive scoliosis, and hearing
+      impairment.
+    explanation: >-
+      GeneReviews identifies cervical spine instability with cord compression as
+      an important long-term complication in survivors.
 - name: Scoliosis
   description: >
-    Progressive scoliosis can occur as part of the axial skeletal dysplasia in
-    campomelic dysplasia.
+    Progressive scoliosis is an important later orthopedic complication among
+    long-term survivors of campomelic dysplasia.
   phenotype_term:
     preferred_term: Scoliosis
     term:
       id: HP:0002650
       label: Scoliosis
   evidence:
-  - reference: PMID:17185244
-    reference_title: "Novel SOX9 gene mutation in campomelic dysplasia with autosomal sex reversal."
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Skeletal deformities characteristic of CD were observed, including narrow
-      thoracic cage, hypoplastic scapulae, scoliosis and short limbs with
-      anterolateral femoral and tibial bowing.
+      Many affected infants die in the neonatal period; additional findings
+      identified in long-term survivors include short stature, cervical spine
+      instability with cord compression, progressive scoliosis, and hearing
+      impairment.
     explanation: >-
-      This case description directly documents scoliosis within characteristic CD
-      skeletal deformities.
+      GeneReviews identifies progressive scoliosis as an important long-term
+      manifestation in survivors.
+- name: Hearing Impairment
+  description: >
+    Hearing impairment has been reported in long-term survivors of campomelic
+    dysplasia.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: PMID:20301724
+    reference_title: "Campomelic Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Many affected infants die in the neonatal period; additional findings
+      identified in long-term survivors include short stature, cervical spine
+      instability with cord compression, progressive scoliosis, and hearing
+      impairment.
+    explanation: >-
+      GeneReviews identifies hearing impairment among the longer-term
+      manifestations in survivors.
 treatments:
 - name: Neonatal Respiratory Support
   description: >

--- a/references_cache/PMID_11754051.md
+++ b/references_cache/PMID_11754051.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:11754051"
+title: Acampomelic campomelic syndrome.
+authors:
+- Moog U
+- Jansen NJ
+- Scherer G
+- Schrander-Stumpel CT
+journal: Am J Med Genet
+year: '2001'
+keywords:
+- "Bone Diseases, Developmental/genetics, pathology"
+- "Child, Preschool"
+- Follow-Up Studies
+- High Mobility Group Proteins/genetics
+- Humans
+- Infant
+- "Infant, Newborn"
+- Male
+- Mutation
+- "Mutation, Missense"
+- SOX9 Transcription Factor
+- Transcription Factors/genetics
+content_type: abstract_only
+---
+
+# Acampomelic campomelic syndrome.
+**Authors:** Moog U, Jansen NJ, Scherer G, Schrander-Stumpel CT
+**Journal:** Am J Med Genet (2001)
+
+## Content
+
+1. Am J Med Genet. 2001 Dec 1;104(3):239-45.
+
+Acampomelic campomelic syndrome.
+
+Moog U(1), Jansen NJ, Scherer G, Schrander-Stumpel CT.
+
+Author information:
+(1)Department of Clinical Genetics, University of Maastricht, PO Box 1475, 6201 
+BL Maastricht, The Netherlands. ute.moog@gen.unimaas.nl
+
+Campomelic syndrome (or campomelic dysostosis, CD; MIM *114290) is an autosomal 
+dominant skeletal malformation syndrome characterized by shortness and bowing of 
+long bones, especially of the lower limbs. Additional radiological and clinical 
+findings are 11 pairs of ribs and a bell-shaped thorax, hypoplastic scapulae, 
+narrow iliac wings, non-mineralized thoracic pedicles, clubbed feet, Robin 
+sequence, typical facial anomalies and tracheomalacia. The disorder is 
+frequently lethal due to respiratory distress. Sex reversal occurs in most 
+patients with an XY karyotype. CD is caused by heterozygous mutations in the 
+SOX9 gene, an SRY-related gene at 17q24.3-q25.1 with pleiotropic effects on the 
+skeletal and genital systems. In addition, cases with chromosomal rearrangements 
+involving 17q have been described that are most likely caused by disturbing one 
+or more cis-regulatory elements from an extended control region. Campomelia 
+(bowed limbs) is seen in most but not all patients, defining a so-called 
+acampomelic campomelic dysostosis (ACD). Half of the CD cases with 17q 
+rearrangements have no or mild campomelia. Furthermore, campomelia is absent or 
+only mildly present in a small subgroup of cases with a normal karyotype. We 
+present a chromosomally normal boy with ACD and his clinical follow-up up to the 
+age of 2 years, in whom a heterozygous SOX9 missense mutation (H165Y) was 
+identified. A SOX9 missense mutation was published in two other patients with 
+ACD. Although up to now a general genotype-phenotype correlation could not be 
+established for CD, a correlation emerges for the ACD variant that needs further 
+confirmation.
+
+Copyright 2001 Wiley-Liss, Inc.
+
+PMID: 11754051 [Indexed for MEDLINE]

--- a/references_cache/PMID_20301724.md
+++ b/references_cache/PMID_20301724.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:20301724"
+title: Campomelic Dysplasia.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Unger S
+- Scherer G
+- Superti-Furga A
+year: '1993'
+content_type: abstract_only
+---
+
+# Campomelic Dysplasia.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Unger S, Scherer G, Superti-Furga A
+
+## Content
+
+1. Campomelic Dysplasia.
+
+Unger S(1), Scherer G(2), Superti-Furga A(3).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors. 
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle; 
+1993–2026.
+2008 Jul 31 [updated 2023 Apr 6].
+
+Author information:
+(1)Medical Genetics Service, Centre Hospitalier Universitaire Vaudois, Lausanne, 
+Switzerland
+(2)Institute of Human Genetics, University of Freiburg, Freiburg, Germany
+(3)Leenaards Professor of Pediatrics, University of Lausanne;, Centre 
+Hospitalier Universitaire Vaudois, Lausanne, Switzerland
+
+CLINICAL CHARACTERISTICS: Campomelic dysplasia (CD) is a skeletal dysplasia 
+characterized by distinctive facies, Pierre Robin sequence with cleft palate, 
+shortening and bowing of long bones, and clubfeet. Other findings include 
+laryngotracheomalacia with respiratory compromise and ambiguous genitalia or 
+normal female external genitalia in most individuals with a 46,XY karyotype. 
+Many affected infants die in the neonatal period; additional findings identified 
+in long-term survivors include short stature, cervical spine instability with 
+cord compression, progressive scoliosis, and hearing impairment.
+DIAGNOSIS/TESTING: The diagnosis of CD is usually based on clinical and 
+radiographic findings. Identification of a heterozygous pathogenic variant in 
+SOX9 by molecular genetic testing can confirm the diagnosis if clinical and 
+radiographic features are inconclusive.
+MANAGEMENT: Treatment of manifestations: Care of children with cleft palate by a 
+craniofacial team using routine measures; in persons with a 46,XY karyotype and 
+undermasculinization of the genitalia, the gonads should be removed because of 
+the increased risk for gonadoblastoma; care of hip subluxation and clubfeet 
+using standard protocols; hearing aids for those with hearing impairment; 
+surgery as needed for cervical vertebral instability and progressive 
+cervicothoracic kyphoscoliosis that compromises lung function. Prevention of 
+secondary complications: If a cervical spine abnormality is identified, special 
+care should be exercised for any surgical procedure. Surveillance: Annual 
+monitoring of spinal curvature.
+GENETIC COUNSELING: CD is inherited in an autosomal dominant manner. To date, 
+most probands have CD as the result of a de novo pathogenic variant in SOX9; 
+thus, parents of probands are not typically affected. However, a few adults have 
+been diagnosed with CD following the birth of an affected child. Recurrence in 
+sibs has occurred and somatic and germline mosaicism have been reported. 
+Prenatal testing for a pregnancy at increased risk is possible if the pathogenic 
+variant in the family is known.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a 
+registered trademark of the University of Washington, Seattle. All rights 
+reserved. Test.
+
+PMID: 20301724

--- a/references_cache/PMID_6344634.md
+++ b/references_cache/PMID_6344634.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:6344634"
+title: "The campomelic syndrome: review, report of 17 cases, and follow-up on the currently 17-year-old boy first reported by Maroteaux et al in 1971."
+authors:
+- Houston CS
+- Opitz JM
+- Spranger JW
+- Macpherson RI
+- Reed MH
+- Gilbert EF
+- Herrmann J
+- Schinzel A
+journal: Am J Med Genet
+year: '1983'
+doi: 10.1002/ajmg.1320150103
+keywords:
+- "Abnormalities, Multiple/genetics, pathology, physiopathology"
+- Adolescent
+- Bone and Bones/abnormalities
+- Cartilage/abnormalities
+- Female
+- Genitalia/abnormalities
+- H-Y Antigen
+- Humans
+- "Infant, Newborn"
+- Male
+- "Respiratory Distress Syndrome, Newborn/genetics"
+- Respiratory System/physiopathology
+- Syndrome
+content_type: abstract_only
+---
+
+# The campomelic syndrome: review, report of 17 cases, and follow-up on the currently 17-year-old boy first reported by Maroteaux et al in 1971.
+**Authors:** Houston CS, Opitz JM, Spranger JW, Macpherson RI, Reed MH, Gilbert EF, Herrmann J, Schinzel A
+**Journal:** Am J Med Genet (1983)
+**DOI:** [10.1002/ajmg.1320150103](https://doi.org/10.1002/ajmg.1320150103)
+
+## Content
+
+1. Am J Med Genet. 1983 May;15(1):3-28. doi: 10.1002/ajmg.1320150103.
+
+The campomelic syndrome: review, report of 17 cases, and follow-up on the 
+currently 17-year-old boy first reported by Maroteaux et al in 1971.
+
+Houston CS, Opitz JM, Spranger JW, Macpherson RI, Reed MH, Gilbert EF, Herrmann 
+J, Schinzel A.
+
+We report 17 cases of the campomelic syndrome (CS) and a follow-up of one of the 
+original patients of Maroteaux et al who is now 17 years old. Our review is 
+based on 97 patients, including our own. An infant with the CS presents at birth 
+with spectacularly short and bowed femora and tibiae. The initial chest 
+radiograph confirms the diagnosis by demonstrating extremely small bladeless 
+scapulae and hypoplastic pedicles of many thoracic vertebrae. Ossification of 
+the sternal segments, pubis, talus, and knee epiphyses is also retarded. Usually 
+the hips are dislocated and talipes equinovarus deformities are present. There 
+is a small chondrocranium and a disproportionately large neurocranium. The 
+bell-shaped chest, narrow superiorly, does not explain the degree of respiratory 
+distress that soon ensues. Narrow airways from defective tracheo-bronchial 
+cartilage can often be demonstrated on the radiograph, but micrognathia, 
+retroglossia, cleft palate, hypoplastic lungs, and even CNS-based hypotonia 
+contribute to the respiratory problem. Internal anomalies include frequent 
+absence of olfactory bulbs and tracts and dilatation of cerebral ventricles, 
+heart defects (PDA, VSD, stenosis of aortic isthmus), hydroureter and 
+hydronephrosis, renal hypoplasia, renal hypoplasia, and rarely renal cysts.
+
+DOI: 10.1002/ajmg.1320150103
+PMID: 6344634 [Indexed for MEDLINE]

--- a/research/issue-1451-campomelic-dysplasia-phenotypes.md
+++ b/research/issue-1451-campomelic-dysplasia-phenotypes.md
@@ -1,0 +1,39 @@
+# Issue #1451: Campomelic Dysplasia phenotype curation
+
+Date: 2026-04-19
+
+Scope:
+- Restrict edits to the phenotype section of `kb/disorders/Campomelic_Dysplasia.yaml`
+- Add clinically important phenotypes only when supported by exact PMID-backed abstract text
+- Add frequency/onset only where the abstract directly supports the extra claim
+
+Primary references used:
+- PMID:11754051, *Acampomelic campomelic syndrome.*
+  - Used for: bowed long bones, bell-shaped thorax, 11 pairs of ribs, hypoplastic scapulae, sex reversal
+  - Key abstract language: characteristic skeletal phenotype list; "Campomelia (bowed limbs) is seen in most but not all patients"; "Sex reversal occurs in most patients with an XY karyotype"
+- PMID:20301724, *Campomelic Dysplasia.*
+  - Used for: clubfoot, Pierre-Robin sequence, cleft palate, laryngotracheomalacia, ambiguous genitalia, female external genitalia in 46,XY individuals, short stature, cervical spine instability, scoliosis, hearing impairment
+  - Key abstract language: GeneReviews clinical characteristics sentence for core craniofacial/limb findings and long-term survivor complications
+- PMID:6344634, *The campomelic syndrome: review, report of 17 cases, and follow-up on the currently 17-year-old boy first reported by Maroteaux et al in 1971.*
+  - Used for: hip dislocation
+  - Key abstract language: "Usually the hips are dislocated..."
+- PMID:17185244, *Novel SOX9 gene mutation in campomelic dysplasia with autosomal sex reversal.*
+  - Used for: micrognathia
+  - Key abstract language: explicit case-level craniofacial phenotype list including cleft palate and micrognathia
+- PMID:24800790, *Campomelic dysplasia.*
+  - Used for: respiratory insufficiency and neonatal onset context
+  - Key abstract language: "It is usually fatal in the neonatal period because of respiratory insufficiency"
+
+Frequency/onset decisions:
+- `Bowing of the Long Bones`: assigned `frequency: FREQUENT`
+  - Rationale: PMID:11754051 states campomelia is seen in "most but not all patients"
+- `Respiratory Insufficiency`: added `phenotype_contexts` with `onset_category: NEONATAL`
+  - Rationale: PMID:24800790 explicitly places respiratory insufficiency in the neonatal period
+
+Claims softened or constrained:
+- `Short Stature` was reframed as a finding of long-term survivors rather than a blanket statement for all affected individuals
+- `Sex Reversal`, `Ambiguous Genitalia`, and `Female External Genitalia in 46,XY Individual` were all explicitly constrained to affected individuals with a 46,XY karyotype
+- No frequency was assigned to genital, airway, craniofacial, or survivor phenotypes unless the abstract text provided a direct qualitative frequency signal
+
+Not added despite being mentioned in older literature abstracts:
+- Cardiac, renal, and CNS anomalies from PMID:6344634 were not added in this pass because the goal was to strengthen the core phenotype section with findings that are both clinically important and better grounded across the modern Campomelic Dysplasia literature.


### PR DESCRIPTION
## Summary
- strengthen `kb/disorders/Campomelic_Dysplasia.yaml` phenotype coverage with PMID-backed skeletal, thoracic, craniofacial, airway, genital, and survivor phenotypes
- replace thin or overgeneralized phenotype claims with more specific, better-supported wording
- add only directly supported frequency/onset qualifiers (`Bowing of the Long Bones` frequency and neonatal onset context for `Respiratory Insufficiency`)
- add a focused research note documenting the phenotype literature used

## Why
Issue #1451 asked for the Campomelic Dysplasia phenotype section to be made as complete and evidence-backed as possible without broad unrelated rewrites.

## Validation
- `UV_LINK_MODE=copy just validate kb/disorders/Campomelic_Dysplasia.yaml`
- `UV_LINK_MODE=copy just validate-references kb/disorders/Campomelic_Dysplasia.yaml`
- `UV_LINK_MODE=copy just validate-terms kb/disorders/Campomelic_Dysplasia.yaml`

## Notes
- intentionally limited the commit to `kb/`, `references_cache/`, and `research/` files relevant to Campomelic Dysplasia
- did not broaden into mechanism/treatment/general page rewrites

Refs #1451