### PR TITLE
[codex] Enhance SEDC phenotype evidence

### DIFF
--- a/kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml
+++ b/kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml
@@ -1,6 +1,6 @@
 name: Spondyloepiphyseal Dysplasia Congenita
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-07T23:34:58Z'
+updated_date: '2026-04-19T00:09:33Z'
 category: Mendelian
 description: >
   Spondyloepiphyseal dysplasia congenita (SEDC) is a type II collagenopathy caused
@@ -457,9 +457,8 @@ phenotypes:
 - category: Skeletal
   name: Disproportionate Short-Trunk Short Stature
   description: >
-    Short stature with disproportionately short trunk, present at birth.
-    Mean birth length is 45 cm at term.
-  frequency: HP_0040281
+    Disproportionate short stature with a shortened trunk is a cardinal
+    manifestation of SEDC and is typically evident at birth.
   phenotype_term:
     preferred_term: Disproportionate short-trunk short stature
     term:
@@ -478,14 +477,30 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "SEDC is a rare disease with a prevalence of 3.4/1,000,000. At birth patients with SEDC are short (mean length 45 cm at term) with flattened vertebras"
     explanation: Provides quantitative birth length data for SEDC.
+  phenotype_contexts:
+  - population: Molecularly confirmed SEDC or related COL2A1 phenotype cohort (n=93)
+    frequency: "80/93 (86%)"
+    notes: >-
+      This cohort included predominantly patients with radiographic SEDC
+      (64/93), with the remainder showing closely related COL2A1 phenotypes.
+    evidence:
+    - reference: PMID:25604898
+      reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The majority of the patients (80/93) had short stature, with
+        radiological features of SEDC (n = 64), others having SEMD (n = 5),
+        Kniest dysplasia (n = 7), spondyloperipheral dysplasia (n = 2), or
+        Torrance-like dysplasia (n = 2).
+      explanation: >-
+        Large molecularly confirmed COL2A1 cohort showing that short stature is
+        very common across SEDC and its closest related phenotypes.
 - category: Skeletal
   name: Platyspondyly
   description: >
-    Flattened vertebral bodies visible on spine radiographs, developing shortly
-    after birth in the lower thoracic and lumbar vertebral bodies. This
-    ultimately leads to wedge-shaped thoracic vertebrae and contributes to
-    short trunk.
-  frequency: HP_0040281
+    Flattened vertebral bodies are a characteristic radiographic hallmark and
+    become increasingly evident during infancy and childhood.
   phenotype_term:
     preferred_term: Platyspondyly
     term:
@@ -498,10 +513,197 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Spondyloepiphyseal dysplasia congenita (SEDC) is an autosomal dominantly inherited chondrodysplasia characterized by disproportionate short stature (short trunk), abnormal epiphyses, and flattened vertebral bodies."
     explanation: Flattened vertebral bodies (platyspondyly) is identified as a defining characteristic of SEDC.
+  - reference: PMID:31972903
+    reference_title: "Novel variants in COL2A1 causing rare spondyloepiphyseal dysplasia congenita."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Two probands were diagnosed as SEDC according to the phenotypes of
+      disproportionately short-trunk stature, kyphosis, lumbar lordosis and
+      adduction deformity of hips. Radiographs revealed kyphosis and lumbar
+      lordosis, flattened vertebral bodies, compressed femoral heads and
+      shortening of the femurs.
+    explanation: >-
+      Recent family-based report directly documenting flattened vertebral bodies
+      in molecularly confirmed SEDC.
+- category: Skeletal
+  name: Delayed Epiphyseal Ossification
+  description: >
+    Ossification delay particularly affects the pubic bones and proximal
+    femoral epiphyses; femoral heads may remain radiographically inapparent
+    until early childhood.
+  phenotype_term:
+    preferred_term: Delayed epiphyseal ossification
+    term:
+      id: HP:0002663
+      label: Delayed epiphyseal ossification
+  evidence:
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiographic findings include the delayed appearance of the epiphysis.
+      Femoral heads are not apparent on radiographs until the patient is
+      approximately 5 years of age.
+    explanation: >-
+      Observational SEDC study documenting delayed epiphyseal ossification,
+      especially at the femoral heads.
+  - reference: PMID:31824186
+    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ossification is absent in pubic bones and distal femoral epiphyses,
+      absent or reduced in cervical and sacral vertebras
+    explanation: >-
+      Review summarizing the characteristic neonatal pattern of delayed
+      ossification in SEDC.
+- category: Skeletal
+  name: Odontoid Hypoplasia
+  description: >
+    Underdevelopment of the odontoid process is a major cervical-spine
+    complication and predisposes to atlantoaxial instability and cord
+    compression.
+  phenotype_term:
+    preferred_term: Odontoid hypoplasia
+    term:
+      id: HP:0003311
+      label: Hypoplasia of the odontoid process
+  evidence:
+  - reference: PMID:25604898
+    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Odontoid hypoplasia was present in 56% (95% CI 38-74) and a correlation
+      between odontoid hypoplasia and short stature was observed.
+    explanation: >-
+      Large COL2A1 cohort showing that odontoid hypoplasia is common and
+      clinically important in SEDC-spectrum disease.
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cervical spine radiographs showed apparent atlantoaxial instability in
+      correlation with odontoid hypoplasia or os-odontoideum.
+    explanation: >-
+      SEDC cervical-spine series linking odontoid hypoplasia directly to
+      radiographic instability.
+  phenotype_contexts:
+  - population: Molecularly confirmed SEDC or related COL2A1 phenotype cohort (n=93)
+    frequency: "56% (95% CI 38-74)"
+    evidence:
+    - reference: PMID:25604898
+      reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Odontoid hypoplasia was present in 56% (95% CI 38-74) and a
+        correlation between odontoid hypoplasia and short stature was observed.
+      explanation: >-
+        Exact frequency estimate reported in the largest available
+        molecularly confirmed cohort.
+- category: Skeletal
+  name: Atlantoaxial Instability
+  description: >
+    Pathological C1-C2 motion may accompany odontoid hypoplasia or os
+    odontoideum and can be occult unless flexion-extension imaging is
+    obtained.
+  phenotype_term:
+    preferred_term: Atlantoaxial instability
+    term:
+      id: HP:0003467
+      label: Atlantoaxial instability
+  evidence:
+  - reference: PMID:25604898
+    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Atlanto-axial instability, was observed in 5 of the 18 patients (28%,
+      95% CI 10-54) in whom flexion-extension films of the cervical spine were
+      available; however, it was rarely accompanied by myelopathy.
+    explanation: >-
+      Cohort evidence showing that atlantoaxial instability is a recurrent
+      cervical complication when dynamic imaging is performed.
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cervical spine radiographs showed apparent atlantoaxial instability in
+      correlation with odontoid hypoplasia or os-odontoideum.
+    explanation: >-
+      Dedicated cervical-spine case series confirming atlantoaxial instability
+      as a central SEDC complication.
+  phenotype_contexts:
+  - population: >-
+      Patients with flexion-extension cervical films available within a
+      molecularly confirmed SEDC or related COL2A1 phenotype cohort (n=18)
+    frequency: "5/18 (28%, 95% CI 10-54)"
+    evidence:
+    - reference: PMID:25604898
+      reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Atlanto-axial instability, was observed in 5 of the 18 patients (28%,
+        95% CI 10-54) in whom flexion-extension films of the cervical spine
+        were available; however, it was rarely accompanied by myelopathy.
+      explanation: >-
+        Exact instability frequency reported for the dynamically imaged subgroup.
+- category: Neurological
+  name: Myelopathy
+  description: >
+    Cervical instability can produce progressive spinal cord compression with
+    myelopathic symptoms and neurologic decline.
+  phenotype_term:
+    preferred_term: Myelopathy
+    term:
+      id: HP:0002196
+      label: Myelopathy
+  evidence:
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinical picture of myelopathy has been encountered in 4 patients out of
+      10.
+    explanation: >-
+      Surgical cervical-spine series showing that clinically significant
+      myelopathy occurs in a substantial subset of severely affected children.
+  - reference: PMID:35989807
+    reference_title: "Management of Craniocervical Instability in Spondyloepiphyseal Dysplasia Congenita: Assessment of Literature and Presentation of Two Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Platyspondyly, scoliosis, ligamental laxity, and odontoid hypoplasia are
+      common, resulting in myelopathy in a high number of patients due to
+      atlantoaxial instability.
+    explanation: >-
+      Additional SEDC cervical-instability report underscoring myelopathy as a
+      major neurologic consequence of craniocervical disease.
+  phenotype_contexts:
+  - population: Children with SEDC selected for cervical spine abnormalities (n=10)
+    frequency: "4/10"
+    evidence:
+    - reference: PMID:30608389
+      reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Clinical picture of myelopathy has been encountered in 4 patients out
+        of 10.
+      explanation: >-
+        Exact frequency reported in a selected cervical-pathology cohort.
 - category: Craniofacial
   name: Flat Face
   description: >
-    Midface hypoplasia with flat facial profile and prominent eyes.
+    Midface hypoplasia with a flattened facial profile has been reported as
+    part of the craniofacial phenotype.
   phenotype_term:
     preferred_term: Flat face
     term:
@@ -517,8 +719,7 @@ phenotypes:
 - category: Craniofacial
   name: Cleft Palate
   description: >
-    Cleft palate, including submucous cleft palate, is a common feature in
-    SEDC and may be associated with Pierre Robin sequence.
+    Overt and submucous cleft palate are both reported in SEDC.
   phenotype_term:
     preferred_term: Cleft palate
     term:
@@ -540,8 +741,7 @@ phenotypes:
 - category: Ophthalmologic
   name: Myopia
   description: >
-    High myopia (5.00 diopters or more) due to vitreous abnormalities from
-    defective type II collagen. Reported in approximately 45% of SEDC patients.
+    Moderate-to-high myopia is a common ophthalmologic manifestation of SEDC.
   phenotype_term:
     preferred_term: Myopia
     term:
@@ -560,109 +760,153 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Ocular complications such as myopia have been reported in 45% of patients but retinal detachment is less frequent (12%) than in type 1 Strickler syndrome."
     explanation: Review providing frequency data for myopia in SEDC.
+  phenotype_contexts:
+  - population: Molecularly confirmed SEDC or related COL2A1 phenotype cohort (n=93)
+    frequency: "45% (95% CI 35-56)"
+    evidence:
+    - reference: PMID:25604898
+      reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Myopia was found in 45% (95% CI 35-56), and retinal detachment had
+        occurred in 12% (95% CI 6-21; median age 14 years; youngest age 3.5
+        years).
+      explanation: >-
+        Exact frequency estimate for myopia in the largest available
+        molecularly confirmed SEDC-spectrum cohort.
 - category: Ophthalmologic
   name: Retinal Detachment
   description: >
-    Increased risk of retinal detachment due to vitreous abnormalities. Occurs
-    in approximately 12% of SEDC patients, less frequently than in Stickler
-    syndrome type 1.
+    Retinal detachment occurs in a subset of patients and may begin in
+    childhood because of vitreoretinal degeneration and retinal traction.
   phenotype_term:
     preferred_term: Retinal detachment
     term:
       id: HP:0000541
       label: Retinal detachment
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:3977716
+    reference_title: "Spondyloepiphyseal dysplasia congenita. Light and electron microscopic studies of the eye."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Ocular complications such as myopia have been reported in 45% of patients but retinal detachment is less frequent (12%) than in type 1 Strickler syndrome."
-    explanation: Review quantifying retinal detachment frequency in SEDC at 12%.
-  - reference: PMID:6807266
-    reference_title: "Vitreoretinal degeneration in spondyloepiphyseal dysplasia congenita."
-    supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Retinal detachment was not encountered, although reports in the nonophthalmic literature claim up to 50% retinal detachment rate and poor visual prognosis in these patients."
-    explanation: This ophthalmic series did not observe retinal detachment in 18 patients, suggesting the true rate may be lower than some early reports claimed.
+    snippet: >-
+      Our observation of extensive vitreoretinal degeneration with traction of
+      the retina indicates that eyes of patients with SEDC are at an increased
+      risk for the development of retinal detachment.
+    explanation: >-
+      Histopathologic eye study showing a structural basis for retinal
+      detachment risk in SEDC.
+  phenotype_contexts:
+  - population: Molecularly confirmed SEDC or related COL2A1 phenotype cohort (n=93)
+    frequency: "12% (95% CI 6-21)"
+    onset:
+      min_age_years: 3.5
+      notes: Median age at retinal detachment was 14 years in this cohort.
+    evidence:
+    - reference: PMID:25604898
+      reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        retinal detachment had occurred in 12% (95% CI 6-21; median age 14
+        years; youngest age 3.5 years).
+      explanation: >-
+        Exact frequency and earliest reported age of retinal detachment in the
+        largest available molecularly confirmed cohort.
 - category: Auditory
-  name: Sensorineural Hearing Loss
+  name: Hearing Impairment
   description: >
-    Sensorineural hearing impairment occurs in 25-30% of SEDC patients, though
-    mixed hearing loss with a conductive component has also been documented.
+    Hearing loss is a recurrent extraskeletal manifestation; older reports
+    emphasized a sensorineural component, but conductive loss has also been
+    documented.
   phenotype_term:
-    preferred_term: Sensorineural hearing impairment
+    preferred_term: Hearing impairment
     term:
-      id: HP:0000407
-      label: Sensorineural hearing impairment
+      id: HP:0000365
+      label: Hearing impairment
   evidence:
   - reference: PMID:10743764
     reference_title: "Spondyloepiphyseal dysplasia congenita associated with conductive hearing loss."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Hearing loss has been reported to occur in 25 to 30% of affected patients. To date, all reports of associated hearing loss have indicated the presence of a sensorineural component."
-    explanation: Documents hearing loss prevalence in SEDC patients and notes that hearing loss typically has a sensorineural component.
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Adult patients suffer from sensorineural (25% to 30% of reported cases) or less frequently mixed hearing loss."
-    explanation: Review confirming the 25-30% frequency of sensorineural hearing loss in SEDC.
+    snippet: >-
+      Hearing loss has been reported to occur in 25 to 30% of affected
+      patients. To date, all reports of associated hearing loss have indicated
+      the presence of a sensorineural component. In this article, we report
+      the case of a child who was diagnosed with spondyloepiphyseal dysplasia
+      congenita and who was found to have a significant conductive hearing
+      loss
+    explanation: >-
+      Case report and literature review showing that hearing loss is a known
+      SEDC manifestation and that it need not be purely sensorineural.
+  phenotype_contexts:
+  - population: Molecularly confirmed SEDC or related COL2A1 phenotype cohort (n=93)
+    frequency: "37% (95% CI 27-48)"
+    notes: Seventeen patients in this cohort required hearing aids.
+    evidence:
+    - reference: PMID:25604898
+      reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Thirty-two patients complained of hearing loss (37%, 95% CI 27-48) of
+        whom 17 required hearing aids.
+      explanation: >-
+        Exact hearing-loss frequency and assistive-hearing burden in the
+        largest available molecularly confirmed cohort.
 - category: Skeletal
-  name: Odontoid Hypoplasia
+  name: Barrel-Shaped Chest
   description: >
-    Underdevelopment of the odontoid process creates risk of atlantoaxial
-    instability and cervical cord compression, a potentially life-threatening
-    complication requiring vigilance during intubation or surgery.
+    Barrel-shaped thorax is part of the characteristic skeletal habitus in
+    affected children.
   phenotype_term:
-    preferred_term: Odontoid hypoplasia
+    preferred_term: Barrel-shaped chest
     term:
-      id: HP:0003311
-      label: Hypoplasia of the odontoid process
+      id: HP:0001552
+      label: Barrel-shaped chest
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Frequently patients suffer from atlantoaxial instability due to odontoid hypoplasia that can cause cervical cord compression, especially when repairing during intubation or surgery."
-    explanation: Review emphasizing the clinical significance of odontoid hypoplasia and the risk of cervical cord compression.
-- category: Skeletal
-  name: Pectus Carinatum
-  description: >
-    Protuberant barrel chest deformity with pectus carinatum.
-  phenotype_term:
-    preferred_term: Pectus carinatum
-    term:
-      id: HP:0000768
-      label: Pectus carinatum
-  evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Adult patients also show flat face for skeletal hypoplasia with prominent eyes and cleft palate, barrel-chest and pectus carinatum."
-    explanation: Review documenting pectus carinatum as a recognized feature of adult SEDC patients.
+    snippet: >-
+      The clinical phenotypic characterizations: Table 1 and Figure 1
+      demonstrates typical clinical changes in SEDC patients: wide frontal
+      area, wide set eyes and full cheeks, short neck, barrel-shaped chest,
+      angular deformities of lower limb, lumbar hyper lordosis, protuberant
+      abdomen, coxa vara with subsequent development of waddling gait was
+      additional feature.
+    explanation: >-
+      Observational SEDC series documenting barrel-shaped chest among the
+      characteristic skeletal findings.
 - category: Skeletal
   name: Coxa Vara
   description: >
-    Hip deformity with reduced femoral neck angle, contributing to waddling
-    gait and early-onset hip osteoarthritis. Hip dislocation may also occur.
+    Hip deformity with reduced femoral neck angle contributes to gait
+    abnormality and progressive hip morbidity.
   phenotype_term:
     preferred_term: Coxa vara
     term:
       id: HP:0002812
       label: Coxa vara
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "coxa vara, dislocated hips, talipes equinovarus, clubfeet and waddling gate are reported"
-    explanation: Review documenting coxa vara among the lower limb abnormalities in SEDC.
+    snippet: >-
+      Angular deformity of the lower limbs, particularly genu valgum. Lumbar
+      lordosis is an apparent abnormality which in fact mostly related to hip
+      flexion contractures. Coxa vara leads to waddling gait.
+    explanation: >-
+      Observational SEDC study directly identifying coxa vara as a typical hip
+      deformity.
 - category: Skeletal
   name: Kyphoscoliosis
   description: >
-    Progressive kyphoscoliosis developing in childhood from platyspondyly and
-    vertebral body wedging. Lumbar lordosis is also characteristic.
+    Thoracic kyphosis and scoliosis can progress with growth and contribute to
+    substantial spinal deformity.
   phenotype_term:
     preferred_term: Kyphoscoliosis
     term:
@@ -676,21 +920,38 @@ phenotypes:
     snippet: "This ultimately leads to wedge-shaped thoracic vertebrae and severe kyphoscoliosis with lumbar lordosis."
     explanation: Review documenting progressive kyphoscoliosis as a consequence of platyspondyly in SEDC.
 - category: Skeletal
-  name: Clubfoot
+  name: Lumbar Hyperlordosis
   description: >
-    Congenital talipes equinovarus occurs in some affected individuals.
+    Marked lumbar lordosis is characteristic and often accompanies hip flexion
+    contractures and other spinal deformities.
   phenotype_term:
-    preferred_term: Talipes equinovarus
+    preferred_term: Lumbar hyperlordosis
     term:
-      id: HP:0001762
-      label: Talipes equinovarus
+      id: HP:0002938
+      label: Lumbar hyperlordosis
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:31972903
+    reference_title: "Novel variants in COL2A1 causing rare spondyloepiphyseal dysplasia congenita."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "coxa vara, dislocated hips, talipes equinovarus, clubfeet and waddling gate are reported"
-    explanation: Review listing talipes equinovarus among the SEDC features.
+    snippet: >-
+      Two probands were diagnosed as SEDC according to the phenotypes of
+      disproportionately short-trunk stature, kyphosis, lumbar lordosis and
+      adduction deformity of hips.
+    explanation: >-
+      Recent molecularly confirmed SEDC report directly documenting lumbar
+      lordosis in both probands.
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Angular deformity of the lower limbs, particularly genu valgum. Lumbar
+      lordosis is an apparent abnormality which in fact mostly related to hip
+      flexion contractures.
+    explanation: >-
+      Observational series describing lumbar lordosis as a characteristic SEDC
+      spinal finding.
 - category: Skeletal
   name: Waddling Gait
   description: >
@@ -701,60 +962,71 @@ phenotypes:
       id: HP:0002515
       label: Waddling gait
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "coxa vara, dislocated hips, talipes equinovarus, clubfeet and waddling gate are reported"
-    explanation: Review listing waddling gait as a reported feature.
+    snippet: >-
+      Angular deformity of the lower limbs, particularly genu valgum. Lumbar
+      lordosis is an apparent abnormality which in fact mostly related to hip
+      flexion contractures. Coxa vara leads to waddling gait.
+    explanation: >-
+      Observational SEDC study directly linking coxa vara to waddling gait.
 - category: Skeletal
   name: Genu Valgum
   description: >
-    Knock-knee deformity due to epiphyseal and metaphyseal dysplasia of the
-    distal femur and proximal tibia.
+    Angular lower-limb deformity including genu valgum has been reported in
+    affected children.
   phenotype_term:
     preferred_term: Genu valgum
     term:
       id: HP:0002857
       label: Genu valgum
-- category: Skeletal
-  name: Delayed Epiphyseal Ossification
-  description: >
-    Delayed and dysplastic ossification of epiphyses, particularly at the
-    femoral head and distal femoral epiphyses. Ossification is absent at
-    birth in pubic bones and distal femoral epiphyses, and absent or reduced
-    in cervical and sacral vertebrae.
-  phenotype_term:
-    preferred_term: Delayed epiphyseal ossification
-    term:
-      id: HP:0002663
-      label: Delayed epiphyseal ossification
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "ossification is absent in pubic bones and distal femoral epiphyses, absent or reduced in cervical and sacral vertebras"
-    explanation: Review detailing the pattern of absent or delayed ossification in neonatal SEDC.
+    snippet: >-
+      Angular deformity of the lower limbs, particularly genu valgum.
+    explanation: >-
+      Observational SEDC series explicitly naming genu valgum among the lower
+      limb deformities.
 - category: Respiratory
-  name: Respiratory Insufficiency
+  name: Respiratory Distress
   description: >
-    Severe SEDC can present with respiratory failure due to small rib cage,
-    tracheobronchomalacia, and respiratory muscle weakness. Infants with
-    severe SEDC may be stillborn or die shortly after birth from
-    hypoventilation.
+    Severe neonatal presentations can include respiratory distress;
+    concomitant cervical instability should be considered when pulmonary
+    compromise is present.
   phenotype_term:
-    preferred_term: Respiratory insufficiency
+    preferred_term: Respiratory distress
     term:
-      id: HP:0002093
-      label: Respiratory insufficiency
+      id: HP:0002098
+      label: Respiratory distress
   evidence:
-  - reference: PMID:31824186
-    reference_title: "COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita."
+  - reference: PMID:31523532
+    reference_title: "Spondyloepiphyseal Dysplasia Congenita: A Rare Cause of Respiratory Distress."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Infants with severe SEDC are often stillborn or premature and die shortly after birth because of hypoventilation."
-    explanation: Review documenting that severe SEDC can be lethal due to respiratory insufficiency.
+    snippet: >-
+      We here present the case of a three-hour-old girl with a short trunk and
+      craniofacial anomalies that brought in respiratory distress to the
+      neonatal intensive care unit.
+    explanation: >-
+      Direct neonatal case report showing that SEDC can present with
+      respiratory distress immediately after birth.
+  - reference: PMID:30608389
+    reference_title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Signs and symptoms of cervical instability include hypotonia, sleep
+      apnea, respiratory insufficiency, and myelopathy. Respiratory
+      insufficiency has been seen in infants with SEDC secondary to thoracic
+      dysplasia and cervical cord compression
+    explanation: >-
+      Cervical-spine series linking respiratory compromise to thoracic and
+      craniocervical disease in infantile SEDC.
 progression:
 - phase: Neonatal presentation
   age_range: birth
@@ -937,8 +1209,29 @@ references:
 - reference: DOI:10.3389/fgene.2022.960504
   title: Exploring and expanding the phenotype and genotype diversity in seven Chinese families with spondylo-epi-metaphyseal dysplasia
   findings: []
+- reference: PMID:1971141
+  title: "Spondyloepiphyseal dysplasia congenita: genetic linkage to type II collagen (COL2AI)."
+  findings: []
+- reference: PMID:10743764
+  title: Spondyloepiphyseal dysplasia congenita associated with conductive hearing loss.
+  findings: []
+- reference: PMID:11878179
+  title: "Cleft palate in spondyloepiphyseal dysplasia congenita: case reports."
+  findings: []
+- reference: PMID:25604898
+  title: A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype.
+  findings: []
+- reference: PMID:30608389
+  title: "The Managment of cervical spine abnormalities in children with spondyloepiphyseal dysplasia congenita: Observational study."
+  findings: []
+- reference: PMID:31523532
+  title: "Spondyloepiphyseal Dysplasia Congenita: A Rare Cause of Respiratory Distress."
+  findings: []
 - reference: PMID:31824186
   title: 'COL2A1 Gene Mutations: Mechanisms of Spondyloepiphyseal Dysplasia Congenita.'
+  findings: []
+- reference: PMID:35989807
+  title: "Management of Craniocervical Instability in Spondyloepiphyseal Dysplasia Congenita: Assessment of Literature and Presentation of Two Cases."
   findings: []
 - reference: PMID:3977716
   title: Spondyloepiphyseal dysplasia congenita. Light and electron microscopic studies of the eye.

--- a/references_cache/PMID_31972903.md
+++ b/references_cache/PMID_31972903.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:31972903"
+title: Novel variants in COL2A1 causing rare spondyloepiphyseal dysplasia congenita.
+authors:
+- Zheng WB
+- Li LJ
+- Zhao DC
+- Wang O
+- Jiang Y
+- Xia WB
+- Xing XP
+- Li M
+journal: Mol Genet Genomic Med
+year: '2020'
+doi: 10.1002/mgg3.1139
+keywords:
+- Adult
+- "Child, Preschool"
+- "Collagen Type II/chemistry, genetics"
+- Female
+- Humans
+- Male
+- Mutation
+- "Osteochondrodysplasias/genetics, pathology"
+- Pedigree
+- Phenotype
+- Protein Domains
+content_type: abstract_only
+---
+
+# Novel variants in COL2A1 causing rare spondyloepiphyseal dysplasia congenita.
+**Authors:** Zheng WB, Li LJ, Zhao DC, Wang O, Jiang Y, Xia WB, Xing XP, Li M
+**Journal:** Mol Genet Genomic Med (2020)
+**DOI:** [10.1002/mgg3.1139](https://doi.org/10.1002/mgg3.1139)
+
+## Content
+
+1. Mol Genet Genomic Med. 2020 Mar;8(3):e1139. doi: 10.1002/mgg3.1139. Epub 2020 
+Jan 23.
+
+Novel variants in COL2A1 causing rare spondyloepiphyseal dysplasia congenita.
+
+Zheng WB(1), Li LJ(1), Zhao DC(1), Wang O(1), Jiang Y(1), Xia WB(1), Xing XP(1), 
+Li M(1).
+
+Author information:
+(1)Key Laboratory of Endocrinology, Department of Endocrinology, National Health 
+and Family Planning Commission, Peking Union Medical College Hospital, Chinese 
+Academy of Medical Sciences and Peking Union Medical College, Beijing, China.
+
+BACKGROUND: Spondyloepiphyseal dysplasia congenita (SEDC) is an extremely rare 
+inherited chondrodysplasia characterized by abnormal epiphyses, short stature, 
+and flattened vertebral bodies. We investigate the phenotypes and the 
+disease-associated variants of SEDC in two unrelated Chinese families.
+METHODS: We identified disease-associated variants in two nonconsanguineous 
+families with SEDC using targeted next-generation sequencing and confirmed the 
+variants using Sanger sequencing. We investigated the phenotypes of the 
+patients, including clinical manifestations, bone turnover biomarkers, bone 
+mineral density and skeletal radiographic features.
+RESULTS: Two probands were diagnosed as SEDC according to the phenotypes of 
+disproportionately short-trunk stature, kyphosis, lumbar lordosis and adduction 
+deformity of hips. Radiographs revealed kyphosis and lumbar lordosis, flattened 
+vertebral bodies, compressed femoral heads and shortening of the femurs. Bone 
+mineral density of the probands was lower than that of age- and gender-matched 
+normal children, but bone turnover biomarker levels were within normal range. 
+Two novel heterozygous missense variants (NM_001844.5: c.1654 G>A, NP_001835.3: 
+p.Gly552Arg; NM_001844.5: c.3518G>T, NP_001835.3: p.Gly1173Val) in collagen type 
+II alpha 1 chain (COL2A1) were detected in the two families, which would impair 
+the formation of stable triple-helical type II collagen.
+CONCLUSIONS: We identified two novel disease-associated variants in COL2A1, 
+which led to severe SEDC. Our findings expanded the gene variant spectrum and 
+phenotypic spectrum of extremely rare type II collagenopathies.
+
+© 2020 The Authors. Molecular Genetics & Genomic Medicine published by Wiley 
+Periodicals, Inc.
+
+DOI: 10.1002/mgg3.1139
+PMCID: PMC7057085
+PMID: 31972903 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have no conflict of interest.

--- a/references_cache/PMID_35989807.md
+++ b/references_cache/PMID_35989807.md
@@ -1,0 +1,56 @@
+---
+reference_id: "PMID:35989807"
+title: "Management of Craniocervical Instability in Spondyloepiphyseal Dysplasia Congenita: Assessment of Literature and Presentation of Two Cases."
+authors:
+- Falls CJ
+- Page PS
+- Greeneway GP
+- Stadler JA
+journal: Cureus
+year: '2022'
+doi: 10.7759/cureus.27020
+content_type: abstract_only
+---
+
+# Management of Craniocervical Instability in Spondyloepiphyseal Dysplasia Congenita: Assessment of Literature and Presentation of Two Cases.
+**Authors:** Falls CJ, Page PS, Greeneway GP, Stadler JA
+**Journal:** Cureus (2022)
+**DOI:** [10.7759/cureus.27020](https://doi.org/10.7759/cureus.27020)
+
+## Content
+
+1. Cureus. 2022 Jul 19;14(7):e27020. doi: 10.7759/cureus.27020. eCollection 2022 
+Jul.
+
+Management of Craniocervical Instability in Spondyloepiphyseal Dysplasia 
+Congenita: Assessment of Literature and Presentation of Two Cases.
+
+Falls CJ(1), Page PS(2), Greeneway GP(3), Stadler JA(4).
+
+Author information:
+(1)Orthopedic Surgery, Baylor University Medical Center, Dallas, USA.
+(2)Neurological Surgery, University of Wisconsin, Madison, USA.
+(3)Neurosurgery, University of Wisconsin Hospitals and Clinics, Madison, USA.
+(4)Neurological Surgery, University of Wisconsin School of Medicine and Public 
+Health, Madison, USA.
+
+Spondyloepiphyseal dysplasia congenita (SEDC) is a rare autosomal dominant 
+skeletal dysplasia resulting in impairment of type II collagen function. 
+Phenotypically, this results in various skeletal, ligamentous, ocular, and 
+otologic abnormalities. Platyspondyly, scoliosis, ligamental laxity, and 
+odontoid hypoplasia are common, resulting in myelopathy in a high number of 
+patients due to atlantoaxial instability. Despite patients undergoing surgical 
+fixation, complication rates such as nonunion have been reported to be high. 
+Here within, we present two patients treated with occipitocervical fusion for 
+atlantoaxial instability and early symptoms of progressive myelopathy. We 
+additionally provide a detailed review of the literature to inform practitioners 
+of the spinal manifestations and clinical considerations in SEDC.
+
+Copyright © 2022, Falls et al.
+
+DOI: 10.7759/cureus.27020
+PMCID: PMC9386322
+PMID: 35989807
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.


### PR DESCRIPTION
## Summary
Enhance the phenotype section for `kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml` with narrower, PMID-backed clinical manifestations.

## What changed
- added missing clinically important phenotype entries for delayed epiphyseal ossification, atlantoaxial instability, myelopathy, barrel-shaped chest, lumbar hyperlordosis, and respiratory distress
- strengthened ocular, auditory, cervical-spine, and skeletal phenotypes with primary cohort or case-series evidence
- added exact frequency/onset context only where directly supported by PMID-backed cohorts
- removed or softened weaker unsupported claims, including replacing `Pectus Carinatum` with the better-supported `Barrel-Shaped Chest` and removing the unsupported clubfoot entry
- updated `references:` metadata and added the new cached references required by the phenotype evidence

## Validation
- `just validate kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`
- `just validate-references kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`
- `just validate-terms kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`

All three commands passed locally.
