### PR TITLE
[codex] Add low bone density phenotype to SEDC

### DIFF
--- a/kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml
+++ b/kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml
@@ -1,6 +1,6 @@
 name: Spondyloepiphyseal Dysplasia Congenita
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T00:09:33Z'
+updated_date: '2026-04-19T00:31:41Z'
 category: Mendelian
 description: >
   Spondyloepiphyseal dysplasia congenita (SEDC) is a type II collagenopathy caused
@@ -559,6 +559,29 @@ phenotypes:
     explanation: >-
       Review summarizing the characteristic neonatal pattern of delayed
       ossification in SEDC.
+- category: Skeletal
+  name: Reduced Bone Mineral Density
+  description: >
+    Reduced bone mineral density has been reported in molecularly confirmed
+    SEDC probands, suggesting that skeletal fragility may extend beyond the
+    classic epiphyseal and vertebral dysplasia.
+  phenotype_term:
+    preferred_term: Reduced bone mineral density
+    term:
+      id: HP:0004349
+      label: Reduced bone mineral density
+  evidence:
+  - reference: PMID:31972903
+    reference_title: "Novel variants in COL2A1 causing rare spondyloepiphyseal dysplasia congenita."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Bone mineral density of the probands was lower than that of age- and
+      gender-matched normal children, but bone turnover biomarker levels were
+      within normal range.
+    explanation: >-
+      Family-based molecularly confirmed SEDC report documenting low bone
+      mineral density in both probands.
 - category: Skeletal
   name: Odontoid Hypoplasia
   description: >


### PR DESCRIPTION
## Summary
Follow-up to #1468 after checking review state.

## Context
PR #1468 was already merged and had no unresolved review threads. The only review note I considered directly relevant to the original phenotype-completeness scope was the non-blocking suggestion to model reduced bone mineral density from `PMID:31972903`.

## What changed
- added `Reduced Bone Mineral Density` to `kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`
- grounded the phenotype to `HP:0004349` and cited the exact PMID-backed evidence from the two-proband SEDC family report
- updated `updated_date`

## Validation
- `just validate kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`
- `just validate-references kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`
- `just validate-terms kb/disorders/Spondyloepiphyseal_Dysplasia_Congenita.yaml`

All three commands passed locally.
