### PR TITLE
[codex] Refine Kniest dysplasia hearing phenotype term

### DIFF
--- a/kb/disorders/Kniest_Dysplasia.yaml
+++ b/kb/disorders/Kniest_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Kniest Dysplasia
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T00:10:48Z'
+updated_date: '2026-04-19T00:33:21Z'
 category: Mendelian
 description: >
   Kniest dysplasia is a moderately severe type II collagenopathy caused by
@@ -889,10 +889,10 @@ phenotypes:
     Hearing loss is common and may include both conductive and sensorineural
     components.
   phenotype_term:
-    preferred_term: Mixed conductive and sensorineural hearing impairment
+    preferred_term: Mixed hearing impairment
     term:
-      id: HP:0000365
-      label: Hearing impairment
+      id: HP:0000410
+      label: Mixed hearing impairment
   evidence:
   - reference: PMID:25592122
     reference_title: Ophthalmic and molecular genetic findings in Kniest dysplasia.


### PR DESCRIPTION
## Summary
- follow up on review feedback from #1462 by tightening the hearing phenotype ontology grounding in `Kniest_Dysplasia.yaml`
- replace broad `HP:0000365` with the exact HPO term `HP:0000410` for mixed hearing impairment
- keep the underlying evidence unchanged because the existing Kniest-specific abstract already supports mixed conductive and sensorineural hearing loss

## Validation
- `just validate kb/disorders/Kniest_Dysplasia.yaml`
- `just validate-references kb/disorders/Kniest_Dysplasia.yaml`
- `just validate-terms kb/disorders/Kniest_Dysplasia.yaml`

Follow-up to #1462 and related to #1453.