### PR TITLE
[codex] Follow up Achondroplasia review cleanup

### DIFF
--- a/kb/disorders/Achondroplasia.yaml
+++ b/kb/disorders/Achondroplasia.yaml
@@ -695,6 +695,26 @@ treatments:
       term:
         id: NCIT:C152918
         label: Vosoritide
+  target_mechanisms:
+  - target: CNP-NPR2 counter-regulatory pathway
+    treatment_effect: ACTIVATES
+    description: >
+      Vosoritide acts as a CNP analog that activates the endogenous
+      CNP-NPR2 counter-regulatory pathway opposing FGFR3-MAPK overactivity
+      in growth plate chondrocytes.
+    evidence:
+    - reference: PMID:31269546
+      reference_title: "C-Type Natriuretic Peptide Analogue Therapy in Children with Achondroplasia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Vosoritide is a biologic analogue of C-type natriuretic peptide, a potent stimulator of endochondral ossification."
+      explanation: Clinical trial abstract directly identifies vosoritide as a CNP analog, supporting activation of the endogenous CNP-NPR2 signaling axis.
+    - reference: PMID:14702637
+      reference_title: "Overexpression of CNP in chondrocytes rescues achondroplasia through a MAPK-dependent pathway."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "These results demonstrate that activation of the CNP-GC-B system in endochondral bone formation constitutes a new therapeutic strategy for human achondroplasia."
+      explanation: Preclinical mouse data directly support activation of the CNP-GC-B/NPR2 pathway as the mechanistic basis for CNP-analog therapy in achondroplasia.
   evidence:
   - reference: PMID:31269546
     reference_title: "C-Type Natriuretic Peptide Analogue Therapy in Children with Achondroplasia."
@@ -837,10 +857,10 @@ computational_models:
 notes: >
   Key clinical features include the rhizomelic pattern of limb shortening, relative
   macrocephaly with frontal bossing and midface hypoplasia, trident hand configuration,
-  thoracolumbar kyphosis in infancy transitioning to lumbar hyperlordosis, and genu
-  varum. Major complications include foramen magnum stenosis with risk of sudden death
-  in infancy, progressive spinal stenosis, obstructive sleep apnea, recurrent otitis
-  media, hydrocephalus, and obesity. Intelligence is normal. The availability of
+  thoracolumbar kyphosis in infancy, and genu varum. Major complications include
+  foramen magnum stenosis with risk of sudden death in infancy, progressive spinal
+  stenosis, obstructive sleep apnea, recurrent otitis media, hydrocephalus, and
+  obesity. Intelligence is normal. The availability of
   vosoritide represents a paradigm shift in treatment, demonstrating that targeting
   the underlying molecular defect can improve growth outcomes. FGFR3-selective inhibitors
   (e.g., TYRA-300, infigratinib) are under preclinical and clinical investigation as


### PR DESCRIPTION
## Summary
- add a `target_mechanisms` link from vosoritide to the Achondroplasia `CNP-NPR2 counter-regulatory pathway` node
- soften the residual note text that previously asserted lumbar hyperlordosis despite that phenotype being intentionally omitted from the evidence-backed phenotype section

## Why
This is a small follow-up to the merged Achondroplasia phenotype PR. There were no unresolved review threads, but one review suggestion was worth implementing directly and one residual unsupported note claim was worth softening.

## Validation
- `just validate kb/disorders/Achondroplasia.yaml`
- `just validate-references kb/disorders/Achondroplasia.yaml`
- `just validate-terms kb/disorders/Achondroplasia.yaml`

## Not changed
- the animal-model review evidence-source classification was left as-is because the cited PMID is a review abstract rather than a clean primary animal-study abstract for the exact genotype described