### PR TITLE
[codex] Fix COL10A1 HGNC mapping in Schmid disorder entry

### DIFF
--- a/kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml
+++ b/kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml
@@ -106,7 +106,7 @@ pathophysiology:
   genes:
   - preferred_term: COL10A1
     term:
-      id: hgnc:2206
+      id: hgnc:2185
       label: COL10A1
   molecular_functions:
   - preferred_term: extracellular matrix structural constituent conferring tensile strength


### PR DESCRIPTION
## Summary
Follow-up cleanup after the merged Schmid phenotype PR.

## What changed
- corrected the lone incorrect `COL10A1` HGNC mapping in `kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
- changed `hgnc:2206` to the adapter-backed `hgnc:2185`

## Why
During review follow-up, the suggested HGNC inconsistency was worth re-checking locally. The review comment's claim that `hgnc:2186` was correct turned out to be wrong, but there was still one real bad mapping left in the file: `hgnc:2206`, which resolves to `COL4A4`, not `COL10A1`.

## Not changed
- did not add `Lumbar lordosis`, because I did not find a clean cache-backed PMID quote that fits the repo's evidence workflow
- did not touch unrelated local modifications present in other files/worktrees

## Validation
- `just validate kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
  - passed
- `just validate-terms kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
  - passed
- `just validate-references kb/disorders/Metaphyseal_Chondrodysplasia_Schmid_Type.yaml`
  - passed