### PR TITLE
Follow up Hypochondroplasia review cleanups

### DIFF
--- a/kb/disorders/Hypochondroplasia.yaml
+++ b/kb/disorders/Hypochondroplasia.yaml
@@ -1,6 +1,6 @@
 name: Hypochondroplasia
 creation_date: '2026-02-02T00:16:36Z'
-updated_date: '2026-04-19T00:12:38Z'
+updated_date: '2026-04-19T00:33:11Z'
 category: Mendelian
 description: >
   Hypochondroplasia is a milder FGFR3-related skeletal dysplasia characterized by
@@ -550,10 +550,11 @@ phenotypes:
   - reference: PMID:26867606
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Only parameters 1, 3, 4, 5 and 6 were statistically different between the two groups."
+    snippet: "We evaluated parameters reflecting the presence of (1) short ilia, (2) squared ilia, (3) short greater sciatic notch, (4) horizontal acetabula, (5) short femora, (6) broad femora, (7) metaphyseal flaring, (8) lumbosacral interpedicular distance narrowing and (9) ovoid radiolucency of the proximal femora. RESULTS: Only parameters 1, 3, 4, 5 and 6 were statistically different between the two groups."
     explanation: >
-      In the neonatal FGFR3-HCH radiology study, parameter 1 was short ilia, which
-      significantly distinguished HCH neonates from controls.
+      This abstract explicitly defines parameter 1 as short ilia and reports it among
+      the radiographic features that significantly distinguished HCH neonates from
+      controls.
 - name: Short femur
   category: Radiological
   description: >
@@ -568,10 +569,11 @@ phenotypes:
   - reference: PMID:26867606
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Only parameters 1, 3, 4, 5 and 6 were statistically different between the two groups."
+    snippet: "We evaluated parameters reflecting the presence of (1) short ilia, (2) squared ilia, (3) short greater sciatic notch, (4) horizontal acetabula, (5) short femora, (6) broad femora, (7) metaphyseal flaring, (8) lumbosacral interpedicular distance narrowing and (9) ovoid radiolucency of the proximal femora. RESULTS: Only parameters 1, 3, 4, 5 and 6 were statistically different between the two groups."
     explanation: >
-      In the neonatal FGFR3-HCH radiology study, parameter 5 was short femora, which
-      significantly distinguished HCH neonates from controls.
+      This abstract explicitly defines parameter 5 as short femora and reports it
+      among the radiographic features that significantly distinguished HCH neonates
+      from controls.
   - reference: PMID:14755409
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
@@ -660,6 +662,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: vosoritide
+      term:
+        id: NCIT:C152918
+        label: Vosoritide
   evidence:
   - reference: PMID:38813446
     supports: SUPPORT
@@ -676,8 +683,8 @@ treatments:
   treatment_term:
     preferred_term: Growth hormone therapy
     term:
-      id: MAXO:0000058
-      label: pharmacotherapy
+      id: MAXO:0000780
+      label: human growth hormone replacement therapy
   evidence:
   - reference: PMID:36442838
     supports: SUPPORT


### PR DESCRIPTION
## Summary
This follow-up addresses relevant review suggestions left on merged PR #1465 without reopening the full phenotype curation branch.

Changes in this PR:
- make the two PMID:26867606 phenotype evidence snippets self-supporting by including the evaluated radiographic parameters
- add `therapeutic_agent` for vosoritide
- replace the generic growth-hormone pharmacotherapy treatment term with the more specific MAXO term for human growth hormone replacement therapy

## Validation
- `just validate kb/disorders/Hypochondroplasia.yaml`
- `just validate-references kb/disorders/Hypochondroplasia.yaml`
- `just validate-terms kb/disorders/Hypochondroplasia.yaml`