### PR TITLE
[codex] Follow up TD2 review suggestions

### DIFF
--- a/kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
+++ b/kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml
@@ -1,6 +1,6 @@
 name: Thanatophoric Dysplasia Type 2
 creation_date: '2026-02-02T00:16:36Z'
-updated_date: '2026-04-19T00:07:48Z'
+updated_date: '2026-04-19T00:32:14Z'
 category: Mendelian
 description: >
   Thanatophoric dysplasia type 2 (TD2) is a severe, usually lethal skeletal dysplasia
@@ -580,17 +580,18 @@ phenotypes:
       id: HP:0000773
       label: Short ribs
   evidence:
-  - reference: PMID:23573386
-    reference_title: "Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo FGFR3 Missense Mutations located in cis."
+  - reference: PMID:20301540
+    reference_title: "Thanatophoric Dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      It is primarily an autosomal dominant disorder and is characterised by
-      macrocephaly, a narrow thorax, short ribs, brachydactyly, and hypotonia.
+      Other features common to type 1 and type 2 include: short ribs, narrow thorax,
+      relative macrocephaly, distinctive facial features, brachydactyly, hypotonia,
+      and redundant skin folds along the limbs.
     explanation: >-
-      The abstract lists short ribs among the core clinical features of
-      thanatophoric dysplasia shared across subtypes, supporting inclusion in
-      TD2.
+      GeneReviews explicitly lists short ribs among the features shared by TD1
+      and TD2, providing stronger subtype-relevant evidence than the prior
+      citation from a non-K650E case introduction.
 - name: Narrow thorax
   description: >
     Severely narrow thorax present prenatally and persisting postnatally.
@@ -738,6 +739,49 @@ phenotypes:
       edema, and bulging occipital bone.
     explanation: >-
       Molecularly confirmed TD2 case documents short digits and brachydactyly.
+- name: Trident hand
+  description: >
+    Characteristic hand configuration with short fingers and increased spacing
+    between the digits, producing a trident appearance.
+  phenotype_term:
+    preferred_term: Trident hand
+    term:
+      id: HP:0004060
+      label: Trident hand
+  evidence:
+  - reference: PMID:24075385
+    reference_title: "Rapid detection of K650E mutation in FGFR3 using uncultured amniocytes in a pregnancy affected with fetal cloverleaf skull, occipital pseudoencephalocele, ventriculomegaly, straight short femurs, and thanatophoric dysplasia type II."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The pregnancy was subsequently terminated, and a 480-g malformed fetus was
+      delivered with macrocephaly, depressed nasal bridge, short upturned nasal
+      tip, hypoplastic midface, frontal bossing, short digits, trident-shaped
+      hands, short limbs, cloverleaf skull, narrow chest, brachydactyly, nuchal
+      edema, and bulging occipital bone.
+    explanation: >-
+      Molecularly confirmed TD2 case explicitly documents trident-shaped hands.
+- name: Hypotonia
+  description: >
+    Decreased muscle tone is reported among the clinical features shared by TD1
+    and TD2.
+  phenotype_term:
+    preferred_term: Hypotonia
+    term:
+      id: HP:0001252
+      label: Hypotonia
+  evidence:
+  - reference: PMID:20301540
+    reference_title: "Thanatophoric Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other features common to type 1 and type 2 include: short ribs, narrow thorax,
+      relative macrocephaly, distinctive facial features, brachydactyly, hypotonia,
+      and redundant skin folds along the limbs.
+    explanation: >-
+      GeneReviews explicitly lists hypotonia among the features shared by TD1
+      and TD2.
 - name: Respiratory insufficiency
   description: >
     Severe respiratory failure is typical in the perinatal period, and long-term
@@ -1317,6 +1361,6 @@ references:
 - reference: PMID:33520059
   title: "Thanatophoric dysplasia: a case report."
   findings: []
-- reference: PMID:23573386
-  title: Molecular Analysis of a Case of Thanatophoric Dysplasia Reveals Two de novo FGFR3 Missense Mutations located in cis.
+- reference: PMID:20301540
+  title: Thanatophoric Dysplasia.
   findings: []


### PR DESCRIPTION
## Summary
This follow-up addresses the substantive review suggestions that still looked worth taking after merged PR #1464.

## What changed
- replaced the weak `Short ribs` citation with stronger subtype-shared evidence from `PMID:20301540`
- added `Trident hand` from the molecularly confirmed TD2 case in `PMID:24075385`
- added `Hypotonia` from `PMID:20301540`
- updated the top-level reference list accordingly

## Why
The prior `Short ribs` support came from a non-K650E case introduction and was weaker than the available subtype-relevant review evidence. The fetal TD2 case already supported a specific `Trident hand` phenotype, and `Hypotonia` was explicitly listed as shared across TD1 and TD2.

## Validation
- `just validate kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml`
- `just validate-references kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml`
- `just validate-terms kb/disorders/Thanatophoric_Dysplasia_Type_2.yaml`

All three passed locally.

## Notes
- This supersedes closed PR #1470, which replayed the already-merged TD2 payload because it was based on the pre-merge branch history.
- This PR is intentionally one-file and phenotype-only.