### PR TITLE
[codex] Enhance phenotype evidence for Atelosteogenesis Type I

### DIFF
--- a/kb/disorders/Atelosteogenesis_Type_I.yaml
+++ b/kb/disorders/Atelosteogenesis_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Atelosteogenesis Type I
 creation_date: '2026-03-04T07:42:25Z'
-updated_date: '2026-04-07T02:14:34Z'
+updated_date: '2026-04-19T02:14:01Z'
 category: Mendelian
 description: >
   Atelosteogenesis type I is a severe autosomal dominant FLNB-related skeletal
@@ -138,49 +138,71 @@ genetic:
 phenotypes:
 - name: Disproportionate Short-Limb Short Stature
   description: >
-    Severe long-bone hypoplasia causes profound disproportionate short-limb short
-    stature.
+    Affected neonates have severe short-limbed dwarfism.
   phenotype_term:
     preferred_term: Disproportionate short-limb short stature
     term:
       id: HP:0008873
       label: Disproportionate short-limb short stature
   evidence:
-  - reference: PMID:16752402
-    reference_title: "Mutations in two regions of FLNB result in atelosteogenesis I and III."
+  - reference: PMID:24624349
+    reference_title: "Identification of a de novo heterozygous missense FLNB mutation in lethal atelosteogenesis type I by exome sequencing."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      AOI and AOIII are autosomal dominant lethal skeletal dysplasias
-      characterized by overlapping clinical findings that include vertebral
-      abnormalities, disharmonious skeletal maturation, hypoplastic long bones,
-      and joint dislocations.
+      Atelosteogenesis type I (AO-I) is a rare lethal skeletal dysplastic
+      disorder characterized by severe short-limbed dwarfism and dislocated
+      hips, knees, and elbows.
     explanation: >-
-      This supports severe limb hypoplasia and disproportionate skeletal growth
-      failure.
+      This directly supports severe disproportionate short-limb short stature in
+      AOI.
+- name: Rhizomelia
+  description: >
+    Molecularly confirmed cases show marked shortening of the proximal limb
+    segments.
+  phenotype_term:
+    preferred_term: Rhizomelic limb shortening
+    term:
+      id: HP:0008905
+      label: Rhizomelia
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both children had typical manifestations of AO type I, with severe
+      rhizomelic shortening of the extremities, limited elbow and knee
+      extension with mild webbing, pectus excavatum, broad thumbs with
+      brachydactyly that was most marked for digits 3-5, dislocated hips and
+      bilateral talipes equinovarus.
+    explanation: >-
+      This directly supports proximal limb shortening as a characteristic AOI
+      skeletal manifestation.
 - name: Joint Dislocation
   description: >
-    Congenital large-joint dislocations are prominent in the AOI phenotype.
+    Congenital large-joint dislocations prominently affect the hips, knees, and
+    elbows.
   phenotype_term:
     preferred_term: Joint dislocation
     term:
       id: HP:0001373
       label: Joint dislocation
   evidence:
-  - reference: PMID:16752402
-    reference_title: "Mutations in two regions of FLNB result in atelosteogenesis I and III."
+  - reference: PMID:24624349
+    reference_title: "Identification of a de novo heterozygous missense FLNB mutation in lethal atelosteogenesis type I by exome sequencing."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      AOI and AOIII are autosomal dominant lethal skeletal dysplasias
-      characterized by overlapping clinical findings that include vertebral
-      abnormalities, disharmonious skeletal maturation, hypoplastic long bones,
-      and joint dislocations.
+      Atelosteogenesis type I (AO-I) is a rare lethal skeletal dysplastic
+      disorder characterized by severe short-limbed dwarfism and dislocated
+      hips, knees, and elbows.
     explanation: >-
-      This directly supports joint dislocations as a core AOI finding.
+      This directly supports congenital large-joint dislocation in AOI.
 - name: Abnormality of the Vertebral Column
   description: >
-    Vertebral developmental defects are central radiographic findings in AOI.
+    Vertebral developmental and ossification defects are recurrent radiographic
+    findings in AOI.
   phenotype_term:
     preferred_term: Abnormality of the vertebral column
     term:
@@ -197,10 +219,23 @@ phenotypes:
       abnormalities, disharmonious skeletal maturation, hypoplastic long bones,
       and joint dislocations.
     explanation: >-
-      This directly supports major vertebral abnormalities in AOI.
+      This multi-patient FLNB series supports vertebral abnormalities as a core
+      AOI feature.
+  - reference: PMID:12454961
+    reference_title: "Prenatal diagnosis of atelosteogenesis type I at 21 weeks' gestation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Fetal ultrasonography (US) revealed absent or deficient ossification of the
+      posterior neural arches of the thoracic spine, humeri, radii, ulnae,
+      fibulae, and short tubular bones other than the distal phalanges, in
+      addition to extremely short, thick femora.
+    explanation: >-
+      This directly documents deficient thoracic vertebral ossification in a
+      prenatally diagnosed AOI fetus.
 - name: Fibular Aplasia
   description: >
-    Absent or severely deficient fibular ossification is a characteristic limb
+    Absent or severely deficient fibular ossification is a recurrent severe limb
     abnormality in AOI.
   phenotype_term:
     preferred_term: Fibular aplasia
@@ -220,10 +255,154 @@ phenotypes:
     explanation: >-
       This prenatal AOI case directly documents absent/deficient fibular
       ossification.
+- name: Talipes Equinovarus
+  description: >
+    Bilateral clubfoot is reported in molecularly confirmed AOI.
+  phenotype_term:
+    preferred_term: Talipes equinovarus
+    term:
+      id: HP:0001762
+      label: Talipes equinovarus
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both children had typical manifestations of AO type I, with severe
+      rhizomelic shortening of the extremities, limited elbow and knee
+      extension with mild webbing, pectus excavatum, broad thumbs with
+      brachydactyly that was most marked for digits 3-5, dislocated hips and
+      bilateral talipes equinovarus.
+    explanation: >-
+      This directly supports bilateral talipes equinovarus in AOI.
+- name: Brachydactyly
+  description: >
+    Distal digit shortening, especially involving digits 3-5, is reported in
+    molecularly confirmed AOI.
+  phenotype_term:
+    preferred_term: Brachydactyly
+    term:
+      id: HP:0001156
+      label: Brachydactyly
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both children had typical manifestations of AO type I, with severe
+      rhizomelic shortening of the extremities, limited elbow and knee
+      extension with mild webbing, pectus excavatum, broad thumbs with
+      brachydactyly that was most marked for digits 3-5, dislocated hips and
+      bilateral talipes equinovarus.
+    explanation: >-
+      This directly supports brachydactyly as part of the distal limb phenotype.
+- name: Broad Thumb
+  description: >
+    Broad thumbs are part of the distal limb malformation pattern in some
+    molecularly confirmed cases.
+  phenotype_term:
+    preferred_term: Broad thumb
+    term:
+      id: HP:0011304
+      label: Broad thumb
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both children had typical manifestations of AO type I, with severe
+      rhizomelic shortening of the extremities, limited elbow and knee
+      extension with mild webbing, pectus excavatum, broad thumbs with
+      brachydactyly that was most marked for digits 3-5, dislocated hips and
+      bilateral talipes equinovarus.
+    explanation: >-
+      This directly supports broad thumbs in AOI.
+- name: Pectus Excavatum
+  description: >
+    Pectus excavatum is reported in molecularly confirmed AOI.
+  phenotype_term:
+    preferred_term: Pectus excavatum
+    term:
+      id: HP:0000767
+      label: Pectus excavatum
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both children had typical manifestations of AO type I, with severe
+      rhizomelic shortening of the extremities, limited elbow and knee
+      extension with mild webbing, pectus excavatum, broad thumbs with
+      brachydactyly that was most marked for digits 3-5, dislocated hips and
+      bilateral talipes equinovarus.
+    explanation: >-
+      This directly supports pectus excavatum in AOI.
+- name: Hypertelorism
+  description: >
+    Hypertelorism contributes to the recognizable craniofacial phenotype in some
+    molecularly confirmed cases.
+  phenotype_term:
+    preferred_term: Hypertelorism
+    term:
+      id: HP:0000316
+      label: Hypertelorism
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Facial features included proptosis, hypertelorism, downslanting palpebral
+      fissures, cleft palate, and retromicrognathia.
+    explanation: >-
+      This directly supports hypertelorism as part of the AOI craniofacial
+      phenotype.
+- name: Micrognathia
+  description: >
+    Mandibular hypoplasia is part of the craniofacial phenotype in some
+    molecularly confirmed cases.
+  phenotype_term:
+    preferred_term: Micrognathia
+    term:
+      id: HP:0000347
+      label: Micrognathia
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Facial features included proptosis, hypertelorism, downslanting palpebral
+      fissures, cleft palate, and retromicrognathia.
+    explanation: >-
+      This directly supports retromicrognathia/micrognathia in AOI.
+- name: Cleft Palate
+  description: >
+    Cleft palate is reported in molecularly confirmed AOI and expands the
+    craniofacial phenotype beyond limb and vertebral findings.
+  phenotype_term:
+    preferred_term: Cleft palate
+    term:
+      id: HP:0000175
+      label: Cleft palate
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Facial features included proptosis, hypertelorism, downslanting palpebral
+      fissures, cleft palate, and retromicrognathia.
+    explanation: >-
+      This directly supports cleft palate in AOI.
 - name: Pulmonary Hypoplasia
   description: >
-    Pulmonary hypoplasia contributes to severe perinatal respiratory compromise
-    in AOI.
+    Pulmonary hypoplasia is a major contributor to severe perinatal respiratory
+    compromise in AOI.
   phenotype_term:
     preferred_term: Pulmonary hypoplasia
     term:
@@ -240,6 +419,36 @@ phenotypes:
       magna.
     explanation: >-
       This case provides direct evidence of pulmonary hypoplasia in AOI.
+  - reference: PMID:9779808
+    reference_title: "Prenatal ultrasonographic description and postnatal pathological findings in atelosteogenesis type 1."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pulmonary hypoplasia is a characteristic finding that has been presumed to
+      be the cause of neonatal lethality.
+    explanation: >-
+      This supports pulmonary hypoplasia as a characteristic and clinically
+      important AOI complication.
+- name: Tracheomalacia
+  description: >
+    Severe airway malacia is a documented contributor to respiratory failure and
+    death in AOI.
+  phenotype_term:
+    preferred_term: Tracheomalacia
+    term:
+      id: HP:0002779
+      label: Tracheomalacia
+  evidence:
+  - reference: PMID:9779808
+    reference_title: "Prenatal ultrasonographic description and postnatal pathological findings in atelosteogenesis type 1."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Detailed neonatal and postmortem examination showed severe subglottic
+      hypoplasia and tracheomalacia.
+    explanation: >-
+      This directly supports tracheomalacia as part of the lethal airway
+      phenotype in AOI.
 diagnosis:
 - name: Prenatal Ultrasound and MRI
   description: >

--- a/kb/disorders/Atelosteogenesis_Type_I.yaml
+++ b/kb/disorders/Atelosteogenesis_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Atelosteogenesis Type I
 creation_date: '2026-03-04T07:42:25Z'
-updated_date: '2026-04-19T02:14:01Z'
+updated_date: '2026-04-19T02:43:29Z'
 category: Mendelian
 description: >
   Atelosteogenesis type I is a severe autosomal dominant FLNB-related skeletal
@@ -59,11 +59,9 @@ prevalence:
     snippet: "BACKGROUND: Atelosteogenesis type I (AO-I) is a rare lethal skeletal dysplastic disorder characterized by severe short-limbed dwarfism and dislocated hips, knees, and elbows."
     explanation: A modern AOI report explicitly characterizes the disorder as rare and lethal, consistent with the absence of population-level prevalence estimates.
 pathophysiology:
-- name: Cartilage Matrix and Growth Plate Dysfunction
+- name: Impaired Skeletogenesis
   description: >
-    Pathogenic FLNB variants disrupt actin-cytoskeleton organization and impair
-    normal skeletogenesis, leading to severe defects in growth plate maturation
-    and ossification.
+    Pathogenic FLNB variants impair normal skeletogenesis.
   genes:
   - preferred_term: FLNB
     term:
@@ -361,6 +359,46 @@ phenotypes:
     explanation: >-
       This directly supports hypertelorism as part of the AOI craniofacial
       phenotype.
+- name: Proptosis
+  description: >
+    Proptosis is part of the craniofacial phenotype in some molecularly
+    confirmed cases.
+  phenotype_term:
+    preferred_term: Proptosis
+    term:
+      id: HP:0000520
+      label: Proptosis
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Facial features included proptosis, hypertelorism, downslanting palpebral
+      fissures, cleft palate, and retromicrognathia.
+    explanation: >-
+      This directly supports proptosis as part of the AOI craniofacial
+      phenotype.
+- name: Downslanting Palpebral Fissures
+  description: >
+    Downslanting palpebral fissures are part of the craniofacial phenotype in
+    some molecularly confirmed cases.
+  phenotype_term:
+    preferred_term: Downslanting palpebral fissures
+    term:
+      id: HP:0000494
+      label: Downslanted palpebral fissures
+  evidence:
+  - reference: PMID:23401428
+    reference_title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Facial features included proptosis, hypertelorism, downslanting palpebral
+      fissures, cleft palate, and retromicrognathia.
+    explanation: >-
+      This directly supports downslanting palpebral fissures as part of the AOI
+      craniofacial phenotype.
 - name: Micrognathia
   description: >
     Mandibular hypoplasia is part of the craniofacial phenotype in some
@@ -464,27 +502,6 @@ diagnosis:
       diagnosis of AO I to be made.
     explanation: >-
       This directly supports prenatal imaging-based diagnostic workflow for AOI.
-treatments:
-- name: Supportive Perinatal Care
-  description: >
-    No curative therapy exists; management is supportive and focuses on
-    perinatal respiratory and comfort care.
-  treatment_term:
-    preferred_term: supportive care
-    term:
-      id: MAXO:0000950
-      label: supportive care
-  evidence:
-  - reference: PMID:12454961
-    reference_title: "Prenatal diagnosis of atelosteogenesis type I at 21 weeks' gestation."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Autopsy corroborated not only pulmonary hypoplasia but also laryngeal
-      stenosis.
-    explanation: >-
-      Severe airway and pulmonary abnormalities in AOI support the need for
-      primarily supportive perinatal management.
 notes: >
   Atelosteogenesis type I is usually fatal in the perinatal period. Most known
   cases are sporadic and reflect de novo heterozygous FLNB variants.

--- a/references_cache/PMID_23401428.md
+++ b/references_cache/PMID_23401428.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:23401428"
+title: "Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue."
+authors:
+- Li BC
+- Hogue J
+- Eilers M
+- Mehrotra P
+- Hyland J
+- Holm T
+- Prosen T
+- Slavotinek AM
+journal: Am J Med Genet A
+year: '2013'
+doi: 10.1002/ajmg.a.35792
+keywords:
+- Contractile Proteins/genetics
+- Fatal Outcome
+- Female
+- Filamins
+- Humans
+- "Infant, Newborn"
+- Male
+- Microfilament Proteins/genetics
+- "Mutation, Missense"
+- "Osteochondrodysplasias/diagnostic imaging, genetics"
+- Pregnancy
+- Premature Birth
+- Radiography
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Clinical report: Two patients with atelosteogenesis type I caused by missense mutations affecting the same FLNB residue.
+**Authors:** Li BC, Hogue J, Eilers M, Mehrotra P, Hyland J, Holm T, Prosen T, Slavotinek AM
+**Journal:** Am J Med Genet A (2013)
+**DOI:** [10.1002/ajmg.a.35792](https://doi.org/10.1002/ajmg.a.35792)
+
+## Content
+
+1. Am J Med Genet A. 2013 Mar;161A(3):619-25. doi: 10.1002/ajmg.a.35792. Epub
+2013  Feb 11.
+
+Clinical report: Two patients with atelosteogenesis type I caused by missense 
+mutations affecting the same FLNB residue.
+
+Li BC(1), Hogue J, Eilers M, Mehrotra P, Hyland J, Holm T, Prosen T, Slavotinek 
+AM.
+
+Author information:
+(1)Division of Genetics, Department of Pediatrics, University of California, San 
+Francisco, California 94143-0748, USA.
+
+We present two patients with Atelosteogenesis Type I (AO type I) caused by two 
+novel Filamin B (FLNB) mutations affecting the same FLNB residue: c.542G > A, 
+predicting p.Gly181Asp and c.542G > C, predicting p.Gly181Arg. Both children had 
+typical manifestations of AO type I, with severe rhizomelic shortening of the 
+extremities, limited elbow and knee extension with mild webbing, pectus 
+excavatum, broad thumbs with brachydactyly that was most marked for digits 3-5, 
+dislocated hips and bilateral talipes equinovarus. Facial features included 
+proptosis, hypertelorism, downslanting palpebral fissures, cleft palate, and 
+retromicrognathia. The clinical course of one child was influenced by airway 
+instability and bronchopulmonary dysplasia that complicated intubation and 
+prevented separation from ventilator support. Respiratory insufficiency with 
+tracheal hypoplasia, laryngeal stenosis, and pulmonary hypoplasia have all been 
+described in patients with AO type I and we conclude that compromised pulmonary 
+function is a major contributor to morbidity and mortality in this condition.
+
+Copyright © 2013 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.a.35792
+PMID: 23401428 [Indexed for MEDLINE]

--- a/references_cache/PMID_9779808.md
+++ b/references_cache/PMID_9779808.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:9779808"
+title: Prenatal ultrasonographic description and postnatal pathological findings in atelosteogenesis type 1.
+authors:
+- Bejjani BA
+- Oberg KC
+- Wilkins I
+- Moise A
+- Langston C
+- Superti-Furga A
+- Lupski JR
+journal: Am J Med Genet
+year: '1998'
+keywords:
+- "Abnormalities, Multiple/pathology"
+- "Bone and Bones/abnormalities, diagnostic imaging, pathology"
+- Female
+- Gestational Age
+- Humans
+- "Infant, Newborn"
+- "Limb Deformities, Congenital/diagnostic imaging, pathology"
+- Male
+- Pregnancy
+- Prenatal Diagnosis
+- Radiography
+- Ultrasonography
+content_type: abstract_only
+---
+
+# Prenatal ultrasonographic description and postnatal pathological findings in atelosteogenesis type 1.
+**Authors:** Bejjani BA, Oberg KC, Wilkins I, Moise A, Langston C, Superti-Furga A, Lupski JR
+**Journal:** Am J Med Genet (1998)
+
+## Content
+
+1. Am J Med Genet. 1998 Oct 12;79(5):392-5.
+
+Prenatal ultrasonographic description and postnatal pathological findings in 
+atelosteogenesis type 1.
+
+Bejjani BA(1), Oberg KC, Wilkins I, Moise A, Langston C, Superti-Furga A, Lupski 
+JR.
+
+Author information:
+(1)Department of Molecular and Human Genetics, Baylor College of Medicine, 
+Houston, Texas 77030, USA. bbejjani@bcm.tmc.edu
+
+Atelosteogenesis type 1 (AO1) is a rare lethal chondrodysplasia characterized by 
+incomplete ossification of cartilage anlagen. Histologically, the cartilage 
+contains irregular clusters that occasionally include giant chondrocytes. 
+Pulmonary hypoplasia is a characteristic finding that has been presumed to be 
+the cause of neonatal lethality. We report on a male fetus with AO1 and document 
+the early ultrasonographic/ radiologic progression of this disorder from 15 
+weeks gestation until delivery at 41 weeks. While the radiological findings we 
+describe are typical of AO1 by the lack of proximal and middle phalangeal 
+ossification, the complete radiological picture showed considerable overlap with 
+boomerang dysplasia. Although pulmonary hypoplasia was present, it was moderate 
+and considered unlikely to be the sole cause of death. Detailed neonatal and 
+postmortem examination showed severe subglottic hypoplasia and tracheomalacia. 
+The tracheal walls were supported by thin and pliable cartilaginous plates that 
+allowed luminal collapse with minimal pressure. The marked luminal narrowing, 
+tracheomalacia, and temporal proximity of extubation to demise support tracheal 
+collapse as a major contributor to the death in AO1. The detailed description of 
+this patient should contribute to earlier diagnosis of this condition; 
+anticipation of the poor prognosis in AO1 is essential for appropriate genetic 
+counseling of the parents and for determining postnatal treatment options.
+
+PMID: 9779808 [Indexed for MEDLINE]

--- a/research/Atelosteogenesis_Type_I-phenotype-curation-issue-1479.md
+++ b/research/Atelosteogenesis_Type_I-phenotype-curation-issue-1479.md
@@ -1,0 +1,41 @@
+## Issue
+
+Enhance the phenotype section for `kb/disorders/Atelosteogenesis_Type_I.yaml`
+without broadening into a full-page rewrite.
+
+## PMID-backed phenotype evidence used
+
+- `PMID:24624349`
+  - Abstract support: severe short-limbed dwarfism; dislocated hips, knees, and elbows.
+  - YAML use: `Disproportionate Short-Limb Short Stature`, `Joint Dislocation`.
+
+- `PMID:23401428`
+  - Abstract support: severe rhizomelic shortening of the extremities, pectus excavatum, broad thumbs, brachydactyly, dislocated hips, bilateral talipes equinovarus.
+  - Abstract support: facial features included hypertelorism, cleft palate, and retromicrognathia.
+  - YAML use: `Rhizomelia`, `Talipes Equinovarus`, `Brachydactyly`, `Broad Thumb`, `Pectus Excavatum`, `Hypertelorism`, `Micrognathia`, `Cleft Palate`.
+
+- `PMID:16752402`
+  - Abstract support: vertebral abnormalities, disharmonious skeletal maturation, hypoplastic long bones, and joint dislocations in AOI/AOIII.
+  - YAML use: retained vertebral phenotype support and kept the phenotype block grounded in a multi-patient FLNB series rather than single-case reports alone.
+
+- `PMID:12454961`
+  - Abstract support: absent or deficient ossification of the posterior neural arches of the thoracic spine, humeri, radii, ulnae, fibulae, and short tubular bones; extremely short, thick femora; pulmonary hypoplasia; laryngeal stenosis; large cisterna magna.
+  - YAML use: strengthened `Abnormality of the Vertebral Column`, retained `Fibular Aplasia`, retained `Pulmonary Hypoplasia`.
+
+- `PMID:9779808`
+  - Abstract support: incomplete ossification of cartilage anlagen; pulmonary hypoplasia as a characteristic finding; severe subglottic hypoplasia and tracheomalacia.
+  - YAML use: added recurrent support for `Pulmonary Hypoplasia`; added `Tracheomalacia`.
+
+## Claims intentionally not added as standalone AOI phenotypes
+
+- `Hitchhiker thumbs`, `midfacial flattening`, `renal microcysts`, `abnormal pancreatic duct branching`, `caecal malrotation`, and `retinal dysplasia` were left out because the support was isolated to small autopsy series or appeared as overlap findings rather than clearly grounded core AOI manifestations for this issue.
+
+- `Large cisterna magna` was not added because it is currently supported by a single prenatal case report and did not appear strong enough to elevate into the main AOI phenotype block for this focused curation pass.
+
+- Airway narrowing terms more specific than `Tracheomalacia` were not added in YAML because the abstract evidence was strongest for tracheomalacia, while laryngeal/subglottic narrowing language was less straightforward to ground to a single specific HPO term without risking ontology mismatch.
+
+## Curation approach
+
+- Prefer phenotype terms already used elsewhere in the repo when they fit the literature cleanly.
+- Avoid adding `frequency` or structured `onset` because the AOI literature used here did not provide robust quantitative phenotype frequencies, and the phenotype evidence was mostly fetal/newborn case material rather than cohort-level onset summaries.
+- Soften wording for single-series findings by describing them as reported or documented rather than universal hallmarks.

--- a/research/Atelosteogenesis_Type_I-phenotype-curation-issue-1479.md
+++ b/research/Atelosteogenesis_Type_I-phenotype-curation-issue-1479.md
@@ -11,8 +11,8 @@ without broadening into a full-page rewrite.
 
 - `PMID:23401428`
   - Abstract support: severe rhizomelic shortening of the extremities, pectus excavatum, broad thumbs, brachydactyly, dislocated hips, bilateral talipes equinovarus.
-  - Abstract support: facial features included hypertelorism, cleft palate, and retromicrognathia.
-  - YAML use: `Rhizomelia`, `Talipes Equinovarus`, `Brachydactyly`, `Broad Thumb`, `Pectus Excavatum`, `Hypertelorism`, `Micrognathia`, `Cleft Palate`.
+  - Abstract support: facial features included proptosis, hypertelorism, downslanting palpebral fissures, cleft palate, and retromicrognathia.
+  - YAML use: `Rhizomelia`, `Talipes Equinovarus`, `Brachydactyly`, `Broad Thumb`, `Pectus Excavatum`, `Proptosis`, `Hypertelorism`, `Downslanting Palpebral Fissures`, `Micrognathia`, `Cleft Palate`.
 
 - `PMID:16752402`
   - Abstract support: vertebral abnormalities, disharmonious skeletal maturation, hypoplastic long bones, and joint dislocations in AOI/AOIII.
@@ -39,3 +39,4 @@ without broadening into a full-page rewrite.
 - Prefer phenotype terms already used elsewhere in the repo when they fit the literature cleanly.
 - Avoid adding `frequency` or structured `onset` because the AOI literature used here did not provide robust quantitative phenotype frequencies, and the phenotype evidence was mostly fetal/newborn case material rather than cohort-level onset summaries.
 - Soften wording for single-series findings by describing them as reported or documented rather than universal hallmarks.
+- Keep non-phenotype sections minimal in this issue-specific pass; treatment claims without direct treatment evidence were removed rather than supported indirectly with pathology snippets.


### PR DESCRIPTION
## Summary
- expand the AOI phenotype section with PMID-backed skeletal, airway, and craniofacial findings
- replace or tighten broad phenotype claims with more specific, abstract-supported HPO-grounded entries
- add a focused research note documenting phenotype additions and deliberately excluded weaker single-case findings

## Validation
- `just validate kb/disorders/Atelosteogenesis_Type_I.yaml`
- `just validate-references kb/disorders/Atelosteogenesis_Type_I.yaml`
- `just validate-terms kb/disorders/Atelosteogenesis_Type_I.yaml`

## Issue
- Closes #1479