### PR TITLE
[codex] Enhance AOII phenotype evidence

### DIFF
--- a/kb/disorders/Atelosteogenesis_Type_II.yaml
+++ b/kb/disorders/Atelosteogenesis_Type_II.yaml
@@ -1,6 +1,6 @@
 name: Atelosteogenesis Type II
 creation_date: '2026-03-04T07:56:34Z'
-updated_date: '2026-04-06T23:42:38Z'
+updated_date: '2026-04-19T02:18:29Z'
 category: Mendelian
 description: >
   Atelosteogenesis Type II is a severe SLC26A2-related chondrodysplasia characterized by
@@ -175,7 +175,7 @@ genetic:
 phenotypes:
 - name: Rhizomelia
   description: >
-    Severe rhizomelic shortening of the proximal limbs is a hallmark AOII skeletal phenotype.
+    Rhizomelic shortening of the proximal limbs is a characteristic AOII skeletal phenotype.
   phenotype_term:
     preferred_term: Rhizomelia
     term:
@@ -190,6 +190,24 @@ phenotypes:
       Clinical features of SLC26A2-related atelosteogenesis include rhizomelic limb shortening with normal-sized skull, hitchhiker thumbs, small chest, protuberant abdomen, cleft palate, and distinctive facial features (midface retrusion, depressed nasal bridge, epicanthus, micrognathia).
     explanation: >-
       This directly documents rhizomelic limb shortening.
+- name: Severe Micromelia
+  description: >
+    Generalized marked limb shortening is part of the reported AOII skeletal phenotype.
+  phenotype_term:
+    preferred_term: Severe Micromelia
+    term:
+      id: HP:0002983
+      label: Micromelia
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:1279661
+    reference_title: "Atelosteogenesis type II: sonographic and radiological correlation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Atelosteogenesis type II is a lethal chondrodysplasia characterized by severe micromelia, spinal abnormalities, talipes equinovarus, and abducted thumbs and toes.
+    explanation: >-
+      This directly supports severe generalized limb shortening in AOII.
 - name: Hitchhiker Thumb
   description: >
     Medially deviated abducted thumbs are characteristic of AOII.
@@ -207,9 +225,43 @@ phenotypes:
       Clinical features of SLC26A2-related atelosteogenesis include rhizomelic limb shortening with normal-sized skull, hitchhiker thumbs, small chest, protuberant abdomen, cleft palate, and distinctive facial features (midface retrusion, depressed nasal bridge, epicanthus, micrognathia).
     explanation: >-
       This directly reports hitchhiker thumbs in affected individuals.
+- name: Ulnar Deviation of Hands
+  description: >
+    Ulnar deviation of the fingers is part of the characteristic hand phenotype.
+  phenotype_term:
+    preferred_term: Ulnar deviation of the hand
+    term:
+      id: HP:0001193
+      label: Ulnar deviation of the hand or of fingers of the hand
+  evidence:
+  - reference: PMID:20301493
+    reference_title: "SLC26A2-Related Atelosteogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other typical findings are ulnar deviation of the fingers, gap between the first and second toes, and clubfoot.
+    explanation: >-
+      This directly supports ulnar deviation of the hand/fingers in AOII.
+- name: Sandal Gap
+  description: >
+    A widened gap between the first and second toes is part of the typical pedal phenotype.
+  phenotype_term:
+    preferred_term: Sandal gap
+    term:
+      id: HP:0001852
+      label: Sandal gap
+  evidence:
+  - reference: PMID:20301493
+    reference_title: "SLC26A2-Related Atelosteogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other typical findings are ulnar deviation of the fingers, gap between the first and second toes, and clubfoot.
+    explanation: >-
+      This directly supports a widened first interdigital space in AOII.
 - name: Narrow Chest
   description: >
-    Thoracic narrowing contributes to severe neonatal respiratory compromise.
+    Thoracic narrowing is part of the described neonatal skeletal phenotype.
   phenotype_term:
     preferred_term: Narrow chest
     term:
@@ -241,9 +293,26 @@ phenotypes:
       Clinical features of SLC26A2-related atelosteogenesis include rhizomelic limb shortening with normal-sized skull, hitchhiker thumbs, small chest, protuberant abdomen, cleft palate, and distinctive facial features (midface retrusion, depressed nasal bridge, epicanthus, micrognathia).
     explanation: >-
       This directly supports cleft palate as part of the AOII craniofacial phenotype.
+- name: Midface Retrusion
+  description: >
+    Midface retrusion contributes to the characteristic facial appearance.
+  phenotype_term:
+    preferred_term: Midface retrusion
+    term:
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:20301493
+    reference_title: "SLC26A2-Related Atelosteogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinical features of SLC26A2-related atelosteogenesis include rhizomelic limb shortening with normal-sized skull, hitchhiker thumbs, small chest, protuberant abdomen, cleft palate, and distinctive facial features (midface retrusion, depressed nasal bridge, epicanthus, micrognathia).
+    explanation: >-
+      This directly supports midface retrusion in AOII.
 - name: Depressed Nasal Bridge
   description: >
-    Midfacial retrusion with depressed nasal bridge contributes to recognizable facial dysmorphism.
+    Depressed nasal bridge is part of the characteristic facial dysmorphism.
   phenotype_term:
     preferred_term: Depressed nasal bridge
     term:
@@ -258,9 +327,26 @@ phenotypes:
       Clinical features of SLC26A2-related atelosteogenesis include rhizomelic limb shortening with normal-sized skull, hitchhiker thumbs, small chest, protuberant abdomen, cleft palate, and distinctive facial features (midface retrusion, depressed nasal bridge, epicanthus, micrognathia).
     explanation: >-
       This directly supports depressed nasal bridge.
+- name: Epicanthus
+  description: >
+    Epicanthal folds are part of the reported craniofacial phenotype.
+  phenotype_term:
+    preferred_term: Epicanthus
+    term:
+      id: HP:0000286
+      label: Epicanthus
+  evidence:
+  - reference: PMID:20301493
+    reference_title: "SLC26A2-Related Atelosteogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinical features of SLC26A2-related atelosteogenesis include rhizomelic limb shortening with normal-sized skull, hitchhiker thumbs, small chest, protuberant abdomen, cleft palate, and distinctive facial features (midface retrusion, depressed nasal bridge, epicanthus, micrognathia).
+    explanation: >-
+      This directly supports epicanthus in AOII.
 - name: Micrognathia
   description: >
-    Mandibular hypoplasia is commonly present in affected neonates.
+    Mandibular hypoplasia is part of the reported craniofacial phenotype.
   phenotype_term:
     preferred_term: Micrognathia
     term:
@@ -277,7 +363,7 @@ phenotypes:
       This directly supports micrognathia in the AOII phenotype spectrum.
 - name: Talipes Equinovarus
   description: >
-    Clubfoot is a frequent lower-limb deformity in AOII.
+    Clubfoot is part of the typical lower-limb phenotype.
   phenotype_term:
     preferred_term: Talipes equinovarus
     term:
@@ -292,6 +378,57 @@ phenotypes:
       Other typical findings are ulnar deviation of the fingers, gap between the first and second toes, and clubfoot.
     explanation: >-
       This directly supports clubfoot (talipes equinovarus).
+- name: Coronal Cleft Vertebrae
+  description: >
+    Coronal clefting of the vertebral bodies is a reported prenatal imaging finding.
+  phenotype_term:
+    preferred_term: Coronal cleft vertebrae
+    term:
+      id: HP:0003417
+      label: Coronal cleft vertebrae
+  evidence:
+  - reference: PMID:1279661
+    reference_title: "Atelosteogenesis type II: sonographic and radiological correlation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The feasibility of diagnosing the following morphological features by prenatal ultrasonography is demonstrated: coronal clefts of the vertebral bodies, metaphyseal and epiphyseal abnormalities, spinal deviations such as cervical kyphosis and a horizontal sacrum, additional ossification centres in the pelvis, and preaxial deviation of the thumbs and toes.
+    explanation: >-
+      This directly supports coronal cleft vertebral abnormalities in AOII.
+- name: Cervical Kyphosis
+  description: >
+    Cervical kyphosis is part of the reported spinal phenotype.
+  phenotype_term:
+    preferred_term: Cervical kyphosis
+    term:
+      id: HP:0002947
+      label: Cervical kyphosis
+  evidence:
+  - reference: PMID:1279661
+    reference_title: "Atelosteogenesis type II: sonographic and radiological correlation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The feasibility of diagnosing the following morphological features by prenatal ultrasonography is demonstrated: coronal clefts of the vertebral bodies, metaphyseal and epiphyseal abnormalities, spinal deviations such as cervical kyphosis and a horizontal sacrum, additional ossification centres in the pelvis, and preaxial deviation of the thumbs and toes.
+    explanation: >-
+      This directly supports cervical kyphosis in AOII.
+- name: Bowed Long Bones
+  description: >
+    Long bones are reported as shortened and bowed on radiographs.
+  phenotype_term:
+    preferred_term: Bowed long bones
+    term:
+      id: HP:0006487
+      label: Bowing of the long bones
+  evidence:
+  - reference: PMID:3799721
+    reference_title: "de la Chapelle dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other long bones were short and bowed.
+    explanation: >-
+      This directly supports bowing of the long bones in AOII.
 - name: Pulmonary Hypoplasia
   description: >
     Pulmonary hypoplasia is a major contributor to neonatal lethality.
@@ -326,6 +463,23 @@ phenotypes:
       SLC26A2-related atelosteogenesis is usually lethal at birth or shortly thereafter due to pulmonary hypoplasia and tracheobronchomalacia.
     explanation: >-
       This directly supports tracheobronchomalacia in AOII.
+- name: Laryngeal Stenosis
+  description: >
+    Laryngeal stenosis is part of the reported respiratory tract malformation triad.
+  phenotype_term:
+    preferred_term: Laryngeal stenosis
+    term:
+      id: HP:0001602
+      label: Laryngeal stenosis
+  evidence:
+  - reference: PMID:3799721
+    reference_title: "de la Chapelle dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Neonatal death occurred in all cases and may be attributed to a consistent triad of respiratory tract malformations: laryngeal stenosis, tracheobronchomalacia, and pulmonary hypoplasia.
+    explanation: >-
+      This directly supports laryngeal stenosis as a clinically important AOII airway manifestation.
 diagnosis:
 - name: Clinical, Radiologic, and Molecular Diagnosis
   description: >

--- a/references_cache/PMID_3799721.md
+++ b/references_cache/PMID_3799721.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:3799721"
+title: de la Chapelle dysplasia.
+authors:
+- Whitley CB
+- Burke BA
+- Granroth G
+- Gorlin RJ
+journal: Am J Med Genet
+year: '1986'
+doi: 10.1002/ajmg.1320250105
+keywords:
+- Belgium/ethnology
+- Consanguinity
+- "Diagnosis, Differential"
+- Female
+- Finland
+- "Genes, Recessive"
+- Humans
+- "Infant, Newborn"
+- Male
+- "Osteochondrodysplasias/diagnostic imaging, genetics, pathology"
+- Phenotype
+- Prenatal Diagnosis
+- Radiography
+content_type: abstract_only
+---
+
+# de la Chapelle dysplasia.
+**Authors:** Whitley CB, Burke BA, Granroth G, Gorlin RJ
+**Journal:** Am J Med Genet (1986)
+**DOI:** [10.1002/ajmg.1320250105](https://doi.org/10.1002/ajmg.1320250105)
+
+## Content
+
+1. Am J Med Genet. 1986 Sep;25(1):29-39. doi: 10.1002/ajmg.1320250105.
+
+de la Chapelle dysplasia.
+
+Whitley CB, Burke BA, Granroth G, Gorlin RJ.
+
+Since the description by de la Chapelle and colleagues of two sibs with a unique 
+skeletal dysplasia, two additional cases have occurred, one in the original 
+Finnish family and one sporadic patient born to unrelated parents of Belgian 
+descent. The original Finnish family has later had a fourth child, a normal 
+daughter who was found to be unaffected upon radiographic examination in the 
+19th week of gestation. These additional findings are compatible with recessive 
+inheritance. Physical features common to these four patients include cleft 
+palate, small thorax, moderately severe micromelia with small hands, and 
+equinovarus deformity. In each case, the ulnae and fibulae were reduced to an 
+almost triangular osseous remnant. Other long bones were short and bowed. 
+Neonatal death occurred in all cases and may be attributed to a consistent triad 
+of respiratory tract malformations: laryngeal stenosis, tracheobronchomalacia, 
+and pulmonary hypoplasia. Clinical and radiographic features are sufficiently 
+unique to distinguish de la Chapelle dysplasia from other disorders in the 
+spectrum of neonatal lethal osteochondrodysplasias. Lacunar halos were 
+identified as a distinctive histopathologic feature also observed in 
+achondrogenesis but not in several other skeletal dysplasias.
+
+DOI: 10.1002/ajmg.1320250105
+PMID: 3799721 [Indexed for MEDLINE]

--- a/references_cache/PMID_7632220.md
+++ b/references_cache/PMID_7632220.md
@@ -1,0 +1,62 @@
+---
+reference_id: "PMID:7632220"
+title: "De la Chapelle dysplasia (atelosteogenesis type II): case report and review of the literature [corrected]."
+authors:
+- Schrander-Stumpel C
+- Havenith M
+- Linden EV
+- Maertzdorf W
+- Offermans J
+- van der Harten J
+journal: Clin Dysmorphol
+year: '1994'
+keywords:
+- Adult
+- Asphyxia Neonatorum
+- Autopsy
+- "Cleft Palate/diagnostic imaging, genetics, pathology"
+- Diseases in Twins
+- Fatal Outcome
+- Female
+- "Genes, Recessive"
+- Humans
+- "Infant, Newborn"
+- Male
+- "Osteochondrodysplasias/diagnostic imaging, genetics, pathology"
+- Radiography
+content_type: abstract_only
+---
+
+# De la Chapelle dysplasia (atelosteogenesis type II): case report and review of the literature [corrected].
+**Authors:** Schrander-Stumpel C, Havenith M, Linden EV, Maertzdorf W, Offermans J, van der Harten J
+**Journal:** Clin Dysmorphol (1994)
+
+## Content
+
+1. Clin Dysmorphol. 1994 Oct;3(4):318-27.
+
+De la Chapelle dysplasia (atelosteogenesis type II): case report and review of 
+the literature [corrected].
+
+Schrander-Stumpel C(1), Havenith M, Linden EV, Maertzdorf W, Offermans J, van 
+der Harten J.
+
+Author information:
+(1)Department of Clinical Genetics, Academic Hospital Maastricht, The 
+Netherlands.
+
+Erratum in
+    Clin Dysmorphol 1995 Apr;4(2):183.
+
+We report a male infant with de la Chapelle dysplasia (atelosteogenesis type 
+II), a skeletal dysplasia characterized by severe shortening of the long bones, 
+deficient ossification of distinct parts of the skeleton, cleft palate and 
+neonatal death from asphyxia. This is a rare condition with only 10 patients 
+described in the literature. We report the clinical, radiographical and 
+histopathological data and summarize the data on the total of 11 patients. 
+Differential diagnosis with diastrophic dysplasia and atelosteogenesis (type I) 
+is discussed. On clinical and histological grounds we hypothesize that de la 
+Chapelle dysplasia and diastrophic dysplasia are closely related. The mode of 
+inheritance is autosomal recessive.
+
+PMID: 7632220 [Indexed for MEDLINE]

--- a/research/Atelosteogenesis_Type_II-deep-research-codex.md
+++ b/research/Atelosteogenesis_Type_II-deep-research-codex.md
@@ -1,0 +1,32 @@
+# Atelosteogenesis Type II phenotype curation notes
+
+Date: 2026-04-19
+Curator: Codex
+Scope: phenotype section only for `kb/disorders/Atelosteogenesis_Type_II.yaml`
+
+## Sources used
+
+- PMID:20301493, *SLC26A2-Related Atelosteogenesis.*
+- PMID:1279661, *Atelosteogenesis type II: sonographic and radiological correlation.*
+- PMID:3799721, *de la Chapelle dysplasia.*
+- PMID:7632220, *De la Chapelle dysplasia (atelosteogenesis type II): case report and review of the literature [corrected].*
+
+## Phenotypes added or tightened
+
+- Added `Micromelia` from PMID:1279661.
+- Added `Midface retrusion`, `Epicanthus`, `Ulnar deviation of the hand or of fingers of the hand`, and `Sandal gap` from PMID:20301493.
+- Added `Coronal cleft vertebrae` and `Cervical kyphosis` from PMID:1279661.
+- Added `Bowing of the long bones` and `Laryngeal stenosis` from PMID:3799721.
+- Softened unsupported wording such as `hallmark`, `commonly`, and `frequent` in free-text descriptions where the cited abstracts did not make a frequency claim.
+
+## Claims considered but not added
+
+- `Protuberant abdomen` is present in the GeneReviews text, but I did not add it because I did not confirm a clean, repo-validated HPO mapping during this pass.
+- `Metaphyseal and epiphyseal abnormalities`, `horizontal sacrum`, and `additional ossification centres in the pelvis` are clearly described in PMID:1279661, but I did not add them without a more confident term choice.
+- `Ulna/fibula hypoplasia` is described in PMID:3799721, but the abstract wording supports severe reduction rather than a clean absent-versus-hypoplastic distinction, so I left it out rather than overstate the ontology mapping.
+
+## Frequency and onset
+
+- No new `frequency` values were added.
+- No `onset` values were added.
+- Although prenatal detection is reported in PMID:1279661, I left onset unset because the abstracts here more clearly support prenatal detectability than a disease-wide onset annotation policy for individual phenotypes.


### PR DESCRIPTION
## Summary
Enhances the phenotype section for `kb/disorders/Atelosteogenesis_Type_II.yaml` with additional PMID-backed manifestations and tighter wording for existing claims.

## What Changed
- added clinically important AOII phenotypes with direct PubMed abstract support: micromelia, midface retrusion, epicanthus, ulnar deviation of the hands/fingers, sandal gap, coronal cleft vertebrae, cervical kyphosis, bowed long bones, and laryngeal stenosis
- kept phenotype ontology terms specific and validator-clean
- softened unsupported free-text wording that implied frequency without direct evidence
- added research provenance notes and cached the new PMID references required for deterministic validation

## Why
The prior phenotype section covered several hallmark findings but missed a number of repeatedly described craniofacial, axial skeletal, limb, and airway manifestations that are directly stated in the AOII literature.

## Validation
- `just validate kb/disorders/Atelosteogenesis_Type_II.yaml` -> passed
- `just validate-references kb/disorders/Atelosteogenesis_Type_II.yaml` -> passed
- `just validate-terms kb/disorders/Atelosteogenesis_Type_II.yaml` -> passed

## Notes
I intentionally did not broaden this into a full-page rewrite. I also left phenotype frequency and onset unset where the available abstracts supported the association but not a reliable quantitative or onset-specific claim.