### PR TITLE
[codex] Enhance SMD Kozlowski phenotype evidence

### DIFF
--- a/kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml
+++ b/kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml
@@ -1,6 +1,6 @@
 name: Spondylometaphyseal Dysplasia Kozlowski Type
 creation_date: "2026-04-03T00:00:00Z"
-updated_date: "2026-04-03T12:00:00Z"
+updated_date: "2026-04-19T02:17:57Z"
 category: Mendelian
 description: >
   Spondylometaphyseal dysplasia Kozlowski type (SMDK) is an autosomal dominant
@@ -250,10 +250,9 @@ phenotypes:
 - name: Disproportionate Short-Trunk Short Stature
   category: Clinical
   description: >
-    Disproportionate short stature with short trunk is a cardinal feature.
-    Adult height is typically 130-150 cm. Growth faltering becomes apparent
-    in early childhood and worsens with age.
-  frequency: VERY_FREQUENT
+    Postnatal disproportionate short stature with a short trunk is a core
+    manifestation of SMDK. Short stature may not be obvious at birth,
+    becomes more apparent during childhood, and can worsen with age.
   phenotype_term:
     preferred_term: Disproportionate short-trunk short stature
     term:
@@ -268,20 +267,19 @@ phenotypes:
     explanation: >
       Natural history study documenting progressive short stature in
       SMDK patients from age 5.
-  - reference: PMID:24830047
-    reference_title: "Autosomal Dominant TRPV4-Related Disorders."
+  - reference: PMID:8233993
+    reference_title: "Spondylometaphyseal dysplasia (Kozlowski type): case report."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "the four most severe forms have short stature that varies from mild to severe with progressive spinal deformity and involvement of the long bones and pelvis."
+    snippet: "Kozlowski syndrome is the most common type of spondylometaphyseal dysplasia (SMD). It is characterized by short stature (130 to 150 cm), pectus carinatum, limited elbow and hip movement, mild bowleg deformity, and curvature of the spinal column. Children with Kozlowski dwarfism usually are not recognized at birth, since they have normal clinical features, weight, and size."
     explanation: >
-      GeneReviews confirms short stature as a feature of SMDK and the
-      more severe TRPV4 skeletal dysplasias.
+      Older case literature supports the characteristic adult height range
+      and the fact that SMDK may not be clinically obvious at birth.
 - name: Platyspondyly
   category: Clinical
   description: >
     Generalized flattening of vertebral bodies on radiograph, with
     overfaced pedicles. Severe platyspondyly persists into adulthood.
-  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Platyspondyly
     term:
@@ -307,17 +305,24 @@ phenotypes:
 - name: Metaphyseal Irregularity
   category: Clinical
   description: >
-    Mild metaphyseal irregularities of the long bones, predominantly
-    affecting the proximal femora. Metaphyseal changes in other long
-    bones can be inconspicuous. Progressive destruction of the femoral
-    head may occur towards the end of puberty.
-  frequency: VERY_FREQUENT
+    Mild metaphyseal abnormalities are most evident in the pelvis and
+    proximal femora. Long-bone metaphyseal changes outside the proximal
+    femur can be subtle, while proximal femoral irregularity may progress
+    to femoral head destruction toward the end of puberty.
   phenotype_term:
     preferred_term: Metaphyseal irregularity
     term:
       id: HP:0003025
       label: Metaphyseal irregularity
   evidence:
+  - reference: PMID:19232556
+    reference_title: "Mutations in the gene encoding the calcium-permeable ion channel TRPV4 produce spondylometaphyseal dysplasia, Kozlowski type and metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "SMD Kozlowski type (SMDK) is a well-defined autosomal-dominant SMD characterized by significant scoliosis and mild metaphyseal abnormalities in the pelvis."
+    explanation: >
+      Landmark TRPV4 paper anchors the characteristic metaphyseal changes
+      of SMDK to the pelvis.
   - reference: PMID:39825918
     reference_title: "Comparison of the natural course of clinical and radiologic features in 13 patients with TRPV4-related skeletal dysplasias."
     supports: SUPPORT
@@ -330,7 +335,6 @@ phenotypes:
   category: Clinical
   description: >
     Progressive scoliosis is a significant feature.
-  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Scoliosis
     term:
@@ -345,12 +349,19 @@ phenotypes:
     explanation: >
       Identifies significant scoliosis as a defining characteristic of
       SMDK.
+  - reference: PMID:41225599
+    reference_title: "A novel TRPV4 variant in spondylometaphyseal dysplasia, kozlowski type reveals a previously unreported loss-of-function mechanism."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spondylometaphyseal Dysplasia, Kozlowski Type (SMDK) is an autosomal dominant skeletal disorder characterized by marked scoliosis, platyspondyly, overfaced pedicles, and mild metaphyseal changes."
+    explanation: >
+      Recent SMDK case report independently confirms scoliosis as a
+      defining skeletal manifestation.
 - name: Kyphosis
   category: Clinical
   description: >
-    Progressive kyphosis worsening with age. May contribute to
-    barrel-shaped chest appearance in adulthood.
-  frequency: VERY_FREQUENT
+    Kyphosis becomes more pronounced with increasing age and contributes
+    to progressive spinal deformity.
   phenotype_term:
     preferred_term: Kyphosis
     term:
@@ -368,31 +379,27 @@ phenotypes:
 - name: Pectus Carinatum
   category: Clinical
   description: >
-    Protrusion of the sternum and anterior chest wall. A barrel-shaped
-    chest may develop from late childhood to adulthood.
-  frequency: FREQUENT
+    Anterior protrusion of the sternum has been reported in classic SMDK
+    case descriptions.
   phenotype_term:
     preferred_term: Pectus carinatum
     term:
       id: HP:0000768
       label: Pectus carinatum
-- name: Barrel-Shaped Chest
-  category: Clinical
-  description: >
-    Barrel-shaped chest configuration developing gradually from late
-    childhood to adulthood.
-  frequency: FREQUENT
-  phenotype_term:
-    preferred_term: Barrel-shaped chest
-    term:
-      id: HP:0001552
-      label: Barrel-shaped chest
+  evidence:
+  - reference: PMID:8233993
+    reference_title: "Spondylometaphyseal dysplasia (Kozlowski type): case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Kozlowski syndrome is the most common type of spondylometaphyseal dysplasia (SMD). It is characterized by short stature (130 to 150 cm), pectus carinatum, limited elbow and hip movement, mild bowleg deformity, and curvature of the spinal column."
+    explanation: >
+      Historic case literature directly lists pectus carinatum among the
+      characteristic clinical findings of SMDK.
 - name: Brachydactyly
   category: Clinical
   description: >
     Shortness of fingers and toes. All TRPV4-related skeletal dysplasias
     are characterized by brachydactyly.
-  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Brachydactyly
     term:
@@ -407,32 +414,64 @@ phenotypes:
     explanation: >
       GeneReviews confirms brachydactyly as a universal feature of
       TRPV4 skeletal dysplasias including SMDK.
-- name: Waddling Gait
+  - reference: PMID:38721578
+    reference_title: "Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia: Spondylometaphyseal Dysplasia, Kozlowski Type."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Musculoskeletal examination revealed bony prominence bilaterally in the knee joints and contractures in knee and elbow joints with brachydactyly; muscle tone was increased, with brisk deep tendon reflexes."
+    explanation: >
+      SMDK-specific case report confirms brachydactyly in a genetically
+      confirmed patient.
+- name: Genu Varum
   category: Clinical
   description: >
-    Waddling gait pattern, contributing to early clinical recognition.
-  frequency: FREQUENT
+    Mild bowing of the lower extremities has been reported in SMDK.
   phenotype_term:
-    preferred_term: Waddling gait
+    preferred_term: Genu varum
     term:
-      id: HP:0002515
-      label: Waddling gait
-- name: Short Neck
+      id: HP:0002970
+      label: Genu varum
+  evidence:
+  - reference: PMID:8233993
+    reference_title: "Spondylometaphyseal dysplasia (Kozlowski type): case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Kozlowski syndrome is the most common type of spondylometaphyseal dysplasia (SMD). It is characterized by short stature (130 to 150 cm), pectus carinatum, limited elbow and hip movement, mild bowleg deformity, and curvature of the spinal column."
+    explanation: >
+      The case report describes a mild bowleg deformity, supporting genu
+      varum as a lower-limb manifestation.
+- name: Limitation of Joint Mobility
   category: Clinical
   description: >
-    Short neck associated with the short-trunk body habitus.
-  frequency: FREQUENT
+    Restricted elbow and hip movement has been described in SMDK, and
+    more severe cases can show fixed contractures of large joints.
   phenotype_term:
-    preferred_term: Short neck
+    preferred_term: Limitation of joint mobility
     term:
-      id: HP:0000470
-      label: Short neck
+      id: HP:0001376
+      label: Limitation of joint mobility
+  evidence:
+  - reference: PMID:8233993
+    reference_title: "Spondylometaphyseal dysplasia (Kozlowski type): case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Kozlowski syndrome is the most common type of spondylometaphyseal dysplasia (SMD). It is characterized by short stature (130 to 150 cm), pectus carinatum, limited elbow and hip movement, mild bowleg deformity, and curvature of the spinal column."
+    explanation: >
+      Directly supports restriction of joint mobility in the elbow and
+      hip in classic SMDK.
+  - reference: PMID:38721578
+    reference_title: "Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia: Spondylometaphyseal Dysplasia, Kozlowski Type."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Musculoskeletal examination revealed bony prominence bilaterally in the knee joints and contractures in knee and elbow joints with brachydactyly; muscle tone was increased, with brisk deep tendon reflexes."
+    explanation: >
+      Severe limitation of joint motion can progress to frank elbow and
+      knee contractures in complicated SMDK.
 - name: Bone Pain
   category: Clinical
   description: >
     Bone pain when running, walking, and climbing stairs, occurring
     from the age of 5 years and worsening with age.
-  frequency: FREQUENT
   phenotype_term:
     preferred_term: Bone pain
     term:
@@ -447,38 +486,44 @@ phenotypes:
     explanation: >
       Documents bone pain as a progressive symptom in SMDK patients,
       with onset around age 5.
-- name: Delayed Ossification of Carpal Bones
+- name: Atlantoaxial Instability
   category: Clinical
   description: >
-    Delayed ossification of the carpal bones visible on hand
-    radiographs.
-  frequency: FREQUENT
+    Upper cervical instability can complicate SMDK and increases the
+    risk of cervical cord compression.
   phenotype_term:
-    preferred_term: Delayed ossification of carpal bones
+    preferred_term: Atlantoaxial instability
     term:
-      id: HP:0001216
-      label: Delayed ossification of carpal bones
-- name: Hypoplasia of the Odontoid Process
-  category: Clinical
-  description: >
-    Odontoid hypoplasia may be present and can lead to cervical spine
-    instability, requiring surveillance.
-  frequency: OCCASIONAL
-  phenotype_term:
-    preferred_term: Hypoplasia of the odontoid process
-    term:
-      id: HP:0003311
-      label: Hypoplasia of the odontoid process
+      id: HP:0003467
+      label: Atlantoaxial instability
   evidence:
-  - reference: PMID:24830047
-    reference_title: "Autosomal Dominant TRPV4-Related Disorders."
+  - reference: PMID:38721578
+    reference_title: "Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia: Spondylometaphyseal Dysplasia, Kozlowski Type."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "assessment for odontoid hypoplasia before a child reaches school age and before surgical procedures involving general anesthesia"
+    snippet: "Magnetic resonance imaging of the spine revealed atlantoaxial instability with hyperintense signal changes at a cervicomedullary junction and upper cervical cord with thinning and spinal canal stenosis suggestive of compressive myelopathy with platyspondyly and anterior beaking of the spine at cervical, thoracic and lumbar vertebrae."
     explanation: >
-      GeneReviews surveillance recommendations confirm odontoid
-      hypoplasia as a recognized complication requiring monitoring in
-      TRPV4 skeletal dysplasias.
+      Direct SMDK case evidence for upper cervical instability as a
+      clinically important complication.
+- name: Myelopathy
+  category: Neurological
+  description: >
+    Cervical cord compression due to upper cervical instability can
+    produce compressive myelopathy in SMDK.
+  phenotype_term:
+    preferred_term: Myelopathy
+    term:
+      id: HP:0002196
+      label: Myelopathy
+  evidence:
+  - reference: PMID:38721578
+    reference_title: "Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia: Spondylometaphyseal Dysplasia, Kozlowski Type."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Magnetic resonance imaging of the spine revealed atlantoaxial instability with hyperintense signal changes at a cervicomedullary junction and upper cervical cord with thinning and spinal canal stenosis suggestive of compressive myelopathy with platyspondyly and anterior beaking of the spine at cervical, thoracic and lumbar vertebrae."
+    explanation: >
+      Direct case evidence that cervical instability in SMDK can lead to
+      compressive myelopathy.
 animal_models:
 - species: Mouse
   genotype: Trpv4 transgenic (mutant overexpression)

--- a/references_cache/PMID_38721578.md
+++ b/references_cache/PMID_38721578.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:38721578"
+title: "Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia: Spondylometaphyseal Dysplasia, Kozlowski Type."
+authors:
+- Gowda VK
+- Srinivasan VM
+- Reddy VM
+- Vamyanmane DK
+- Shivappa SK
+- Ramesh RH
+- Vishwanathan GB
+journal: J Pediatr Genet
+year: '2024'
+doi: 10.1055/s-0041-1741424
+content_type: abstract_only
+---
+
+# Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia: Spondylometaphyseal Dysplasia, Kozlowski Type.
+**Authors:** Gowda VK, Srinivasan VM, Reddy VM, Vamyanmane DK, Shivappa SK, Ramesh RH, Vishwanathan GB
+**Journal:** J Pediatr Genet (2024)
+**DOI:** [10.1055/s-0041-1741424](https://doi.org/10.1055/s-0041-1741424)
+
+## Content
+
+1. J Pediatr Genet. 2022 Jan 6;13(2):158-165. doi: 10.1055/s-0041-1741424.
+eCollection 2024 Jun.
+
+Compressive Myelopathy Secondary to TRPV4 Skeletal Dysplasia:
+Spondylometaphyseal Dysplasia, Kozlowski Type.
+
+Gowda VK(1), Srinivasan VM(1), Reddy VM(1), Vamyanmane DK(2), Shivappa SK(3),
+Ramesh RH(4), Vishwanathan GB(5).
+
+Author information:
+(1)Department of Pediatric Neurology, Indira Gandhi Institute of Child Health,
+Bengaluru, Karnataka, India.
+(2)Department of Pediatric Radiology, Indira Gandhi Institute of Child Health,
+Bengaluru, Karnataka, India.
+(3)Department of Pediatric Medicine, Indira Gandhi Institute of Child Health,
+Bengaluru, Karnataka, India.
+(4)Deparment of Pediatrics, BGS Global Institute of Medical Sciences, Bengaluru,
+India.
+(5)Center for Human Genetics, Bengaluru, Karnataka, India.
+
+Transient receptor potential vanilloid 4 channel ( TRPV4 ) gene mutations have
+been described in skeletal system and peripheral nervous system pathology. The
+case described here is a 9-year-old male child patient, born to a
+nonconsanguineous marriage with normal birth history who had difficulty in
+walking and stiffness of joints for the last 7 years, and progressive weakness
+of all four limbs and urine incontinence for 1 year following falls. Physical
+examination showed below-average weight and height and short trunk.
+Musculoskeletal examination revealed bony prominence bilaterally in the knee
+joints and contractures in knee and elbow joints with brachydactyly; muscle tone
+was increased, with brisk deep tendon reflexes. Skeletal survey showed
+platyspondyly with anterior beaking with metaphyseal dysplasia. Magnetic
+resonance imaging of the spine revealed atlantoaxial instability with
+hyperintense signal changes at a cervicomedullary junction and upper cervical
+cord with thinning and spinal canal stenosis suggestive of compressive
+myelopathy with platyspondyly and anterior beaking of the spine at cervical,
+thoracic and lumbar vertebrae. Exome sequencing revealed a heterozygous de novo
+variant c.2389G > A in exon 15 of TRPV4 , which results in the amino acid
+substitution p.Glu797Lys in the encoded protein. The characteristics observed
+indicated spondylometaphyseal dysplasia, Kozlowski type (SMD-K). The child
+underwent surgical intervention for compressive myelopathy by reduction of
+atlantoaxial dislocation with C1 lateral mass and C2 pars fusion using rib graft
+and fixation using screws and rods. To conclude, for any child presenting with
+progressive kyphoscoliosis, short stature, platyspondyly, and metaphyseal
+changes, a diagnosis of SMD-K should be considered and the patient and family
+should be advised to avoid spinal injuries.
+
+Thieme. All rights reserved.
+
+DOI: 10.1055/s-0041-1741424
+PMCID: PMC11076094
+PMID: 38721578
+
+Conflict of interest statement: Conflict of Interest None declared.

--- a/references_cache/PMID_8233993.md
+++ b/references_cache/PMID_8233993.md
@@ -1,0 +1,45 @@
+---
+reference_id: "PMID:8233993"
+title: "Spondylometaphyseal dysplasia (Kozlowski type): case report."
+authors:
+- Guzman CM
+- Aaron GR
+journal: Pediatr Dent
+year: '1993'
+keywords:
+- Child
+- "Diagnosis, Differential"
+- "Dwarfism/complications, diagnosis"
+- Female
+- Humans
+- Macroglossia/etiology
+- "Malocclusion, Angle Class III/complications"
+- "Mucopolysaccharidosis IV/complications, diagnosis"
+- "Osteochondrodysplasias/complications, pathology"
+- "Spinal Diseases/complications, diagnosis"
+- Syndrome
+- Tooth Abnormalities/etiology
+content_type: abstract_only
+---
+
+# Spondylometaphyseal dysplasia (Kozlowski type): case report.
+**Authors:** Guzman CM, Aaron GR
+**Journal:** Pediatr Dent (1993)
+
+## Content
+
+1. Pediatr Dent. 1993 Jan-Feb;15(1):49-52.
+
+Spondylometaphyseal dysplasia (Kozlowski type): case report.
+
+Guzman CM, Aaron GR.
+
+Kozlowski syndrome is the most common type of spondylometaphyseal dysplasia
+(SMD). It is characterized by short stature (130 to 150 cm), pectus carinatum,
+limited elbow and hip movement, mild bowleg deformity, and curvature of the
+spinal column. Children with Kozlowski dwarfism usually are not recognized at
+birth, since they have normal clinical features, weight, and size. This article
+reports the dental treatment and oral findings of a 14-year-old female patient
+with Kozlowski dwarfism.
+
+PMID: 8233993 [Indexed for MEDLINE]

--- a/research/Spondylometaphyseal_Dysplasia_Kozlowski_Type-phenotype-curation-codex.md
+++ b/research/Spondylometaphyseal_Dysplasia_Kozlowski_Type-phenotype-curation-codex.md
@@ -1,0 +1,68 @@
+# Spondylometaphyseal Dysplasia Kozlowski Type phenotype curation notes
+
+Date: 2026-04-18
+Curator: Codex
+Target file: `kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml`
+
+## Scope
+
+Focused only on the phenotype section. Goal was to keep clinically important
+manifestations that could be supported with exact PMID-backed abstract snippets,
+add missing phenotype findings that were directly supported, and remove or
+soften unsupported claims.
+
+## Phenotypes retained or strengthened
+
+- Disproportionate short-trunk short stature
+  - PMID:39825918 supports progression from age 5.
+  - PMID:8233993 supports the classic adult height range and that children may
+    not be recognized at birth.
+- Platyspondyly
+  - PMID:41225599 and PMID:39825918 support platyspondyly, with persistent
+    severe platyspondyly into later childhood/adulthood.
+- Metaphyseal irregularity
+  - PMID:19232556 supports mild pelvic metaphyseal abnormalities.
+  - PMID:39825918 supports proximal femoral irregularity with later femoral
+    head destruction.
+- Scoliosis
+  - PMID:19232556 and PMID:41225599 support scoliosis as a defining feature.
+- Kyphosis
+  - PMID:39825918 supports increasing kyphosis with age.
+- Brachydactyly
+  - PMID:24830047 supports brachydactyly across TRPV4 skeletal dysplasias.
+  - PMID:38721578 confirms brachydactyly in an SMDK case.
+- Bone pain
+  - PMID:39825918 supports onset around age 5 and age-related worsening.
+
+## Phenotypes added
+
+- Pectus carinatum
+  - PMID:8233993
+- Genu varum
+  - PMID:8233993 describes mild bowleg deformity.
+- Limitation of joint mobility
+  - PMID:8233993 describes limited elbow and hip movement.
+  - PMID:38721578 describes knee and elbow contractures in a complicated case.
+- Atlantoaxial instability
+  - PMID:38721578
+- Myelopathy
+  - PMID:38721578
+
+## Phenotypes removed or softened
+
+- Removed unsupported frequency qualifiers throughout the phenotype section.
+- Removed unsupported `Barrel-Shaped Chest`.
+- Removed unsupported `Waddling Gait`.
+- Removed unsupported `Short Neck`.
+- Removed unsupported `Delayed Ossification of Carpal Bones`.
+- Replaced `Hypoplasia of the Odontoid Process` with the directly supported
+  complication `Atlantoaxial Instability`.
+
+## Notes
+
+- OMIM/Orphanet comparison suggested additional findings such as carpal
+  ossification abnormalities and pelvic/hip features, but these were only kept
+  when an exact abstract-backed PMID could support the claim in the disorder
+  YAML.
+- Frequency and onset were only retained in narrative form when directly
+  supported by an abstract snippet.


### PR DESCRIPTION
## Summary

This PR strengthens the phenotype section for `kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml` with PMID-backed evidence only.

## What changed

- removed unsupported phenotype frequency qualifiers from the SMDK phenotype block
- removed weakly supported phenotype claims that did not have direct abstract-backed support
- strengthened core phenotype entries for short-trunk short stature, platyspondyly, metaphyseal irregularity, scoliosis, kyphosis, brachydactyly, and bone pain
- added evidence-backed phenotype entries for pectus carinatum, genu varum, limitation of joint mobility, atlantoaxial instability, and myelopathy
- added a short research provenance note for the phenotype curation pass
- added the required cached PMID records for the new references used in the phenotype section

## Why

The existing phenotype section contained several unsupported frequency assertions and several phenotype claims without direct evidence items. This pass keeps the section tightly scoped to phenotype accuracy and only retains or adds manifestations that could be grounded in exact PMID-backed evidence.

## Validation

- `just validate kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml` -> passed
- `just validate-references kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml` -> passed (`Total checks: 0`)
- `just validate-terms kb/disorders/Spondylometaphyseal_Dysplasia_Kozlowski_Type.yaml` -> passed

## Notes

- scope was intentionally limited to the phenotype section and related evidence/provenance only
- unrelated dirty worktree files were left untouched
- commit used targeted staging for the disorder YAML, the two new reference cache files, and the phenotype research note

Related to #1487