### PR TITLE
[codex] Enhance Brachyolmia phenotype evidence

### DIFF
--- a/kb/disorders/Brachyolmia.yaml
+++ b/kb/disorders/Brachyolmia.yaml
@@ -1,6 +1,6 @@
 name: Brachyolmia
 creation_date: "2026-04-02T12:00:00Z"
-updated_date: "2026-04-02T14:00:00Z"
+updated_date: "2026-04-19T02:20:10Z"
 category: Mendelian
 description: >
   Brachyolmia (Greek: 'short trunk') is a clinically and genetically heterogeneous group
@@ -359,16 +359,22 @@ phenotypes:
 - category: Skeletal
   name: Disproportionate short-trunk short stature
   description: >
-    Short stature with disproportionately short trunk is the cardinal clinical feature of
-    all brachyolmia subtypes. In the PAPSS2 form, short stature becomes conspicuous
-    during childhood. In the TRPV4 form, growth may be normal in early childhood and
-    deteriorate with increasing spinal involvement.
+    Short stature with a disproportionately short trunk is a core manifestation of
+    brachyolmia. In PAPSS2-related disease, the short-trunk pattern often becomes
+    conspicuous during childhood, whereas in TRPV4-related disease growth may be
+    relatively preserved in early childhood before worsening with spinal involvement.
   phenotype_term:
     preferred_term: Disproportionate short-trunk short stature
     term:
       id: HP:0003521
       label: Disproportionate short-trunk short stature
   evidence:
+  - reference: PMID:38192829
+    reference_title: "Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype analyses of Egyptian and Pakistani patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Brachyolmia is a heterogeneous group of developmental disorders characterized by a short trunk, short stature, scoliosis, and generalized platyspondyly without significant deformities in the long bones."
+    explanation: Supports short trunk and short stature as defining manifestations of brachyolmia.
   - reference: PMID:22791835
     reference_title: "PAPSS2 mutations cause autosomal recessive brachyolmia."
     supports: SUPPORT
@@ -384,15 +390,21 @@ phenotypes:
 - category: Skeletal
   name: Generalized platyspondyly
   description: >
-    Flattened vertebral bodies with rectangular shape and irregular endplates are the
-    radiographic hallmark shared across all brachyolmia subtypes. In the PAPSS2 form,
-    narrow intervertebral disc spaces and short over-faced pedicles are additional features.
+    Generalized platyspondyly is the defining radiographic finding of brachyolmia.
+    PAPSS2-related disease often adds irregular end plates, narrow disc spaces, and
+    short over-faced pedicles.
   phenotype_term:
     preferred_term: Platyspondyly
     term:
       id: HP:0000926
       label: Platyspondyly
   evidence:
+  - reference: PMID:24677493
+    reference_title: "Autosomal dominant brachyolmia in a large Swedish family: phenotypic spectrum and natural course."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The disorder is characterized by disproportionate short stature with short trunk, scoliosis and platyspondyly."
+    explanation: Confirms platyspondyly as a defining radiographic feature in TRPV4-related brachyolmia.
   - reference: PMID:31313512
     reference_title: "PAPSS2-related brachyolmia: Clinical and radiological phenotype in 18 new cases."
     supports: SUPPORT
@@ -442,8 +454,8 @@ phenotypes:
 - category: Skeletal
   name: Scoliosis
   description: >
-    Scoliosis is a common clinical feature, particularly in the TRPV4 autosomal
-    dominant form, where it contributes to progressive spinal deformity.
+    Scoliosis is a recurrent spinal deformity in brachyolmia and is especially
+    prominent in TRPV4-related disease.
   phenotype_term:
     preferred_term: Scoliosis
     term:
@@ -456,6 +468,24 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "a short trunk, scoliosis and mild short stature"
     explanation: Lists scoliosis as a defining clinical feature of brachyolmia.
+- category: Skeletal
+  name: Short femur
+  subtype: AR-PAPSS2
+  description: >
+    Short femora can be the prenatal presenting sign of PAPSS2-related brachyolmia
+    before the later short-spine phenotype becomes apparent.
+  phenotype_term:
+    preferred_term: Short femur
+    term:
+      id: HP:0003097
+      label: Short femur
+  evidence:
+  - reference: PMID:31313512
+    reference_title: "PAPSS2-related brachyolmia: Clinical and radiological phenotype in 18 new cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Eight patients presented prenatally with short femora, whereas later in childhood their short-spine phenotype emerged."
+    explanation: Supports prenatal short femora as an early manifestation of PAPSS2-related brachyolmia.
 - category: Skeletal
   name: Short femoral neck
   subtype: AR-PAPSS2
@@ -510,6 +540,24 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "precocious calcification of rib cartilages, short femoral neck, and mildly shortened metacarpals"
     explanation: Precocious rib cartilage calcification is a characteristic radiographic feature of PAPSS2 brachyolmia.
+- category: Skeletal
+  name: Short metacarpals
+  subtype: AR-PAPSS2
+  description: >
+    Mild metacarpal shortening is part of the minor long-bone/hand involvement seen
+    in PAPSS2-related brachyolmia.
+  phenotype_term:
+    preferred_term: Short metacarpals
+    term:
+      id: HP:0010049
+      label: Short metacarpal
+  evidence:
+  - reference: PMID:22791835
+    reference_title: "PAPSS2 mutations cause autosomal recessive brachyolmia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Their radiographic features included rectangular vertebral bodies with irregular endplates and narrow intervertebral discs, precocious calcification of rib cartilages, short femoral neck, and mildly shortened metacarpals."
+    explanation: Supports mild metacarpal shortening as part of the PAPSS2-related skeletal phenotype.
 - category: Neurological
   name: Chronic back pain
   subtype: AD-TRPV4
@@ -550,9 +598,8 @@ phenotypes:
   name: Amelogenesis imperfecta
   subtype: LTBP3
   description: >
-    Hypoplastic amelogenesis imperfecta with thin to absent dental enamel is specific
-    to the LTBP3-related form. Affected individuals have small, yellow, spaced teeth
-    due to absent or very thin enamel.
+    Hypoplastic amelogenesis imperfecta with almost absent enamel is the defining
+    dental manifestation of the LTBP3-related form.
   phenotype_term:
     preferred_term: Amelogenesis imperfecta
     term:
@@ -565,6 +612,114 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "an identical phenotype, characterized by significant short stature with brachyolmia and hypoplastic amelogenesis imperfecta (AI) with almost absent enamel"
     explanation: Amelogenesis imperfecta is a consistent feature specifically of the LTBP3-related form.
+- category: Dental
+  name: Hypodontia
+  subtype: LTBP3
+  description: >
+    Missing teeth are part of the dental anomalies and short stature syndrome
+    phenotype caused by LTBP3 variants.
+  phenotype_term:
+    preferred_term: Hypodontia
+    term:
+      id: HP:0000668
+      label: Hypodontia
+  evidence:
+  - reference: PMID:35352826
+    reference_title: "Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Mutations in LTBP3 are associated with Dental Anomalies and Short Stature syndrome (DASS; MIM 601216), which is characterized by hypoplastic type amelogenesis imperfecta, hypodontia, underdeveloped maxilla, short stature, brachyolmia, aneurysm and dissection of the thoracic aorta."
+    explanation: Establishes hypodontia as a core dental phenotype of LTBP3-related DASS/brachyolmia.
+- category: Craniofacial
+  name: Maxillary hypoplasia
+  subtype: LTBP3
+  description: >
+    Underdevelopment of the maxilla is part of the craniofacial phenotype in
+    LTBP3-related DASS/brachyolmia.
+  phenotype_term:
+    preferred_term: Maxillary hypoplasia
+    term:
+      id: HP:0000327
+      label: Hypoplasia of the maxilla
+  evidence:
+  - reference: PMID:35352826
+    reference_title: "Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Mutations in LTBP3 are associated with Dental Anomalies and Short Stature syndrome (DASS; MIM 601216), which is characterized by hypoplastic type amelogenesis imperfecta, hypodontia, underdeveloped maxilla, short stature, brachyolmia, aneurysm and dissection of the thoracic aorta."
+    explanation: Directly supports maxillary underdevelopment in the LTBP3-related phenotype.
+- category: Cardiovascular
+  name: Thoracic aortic aneurysm
+  subtype: LTBP3
+  description: >
+    Thoracic aortic aneurysm is a clinically important extra-skeletal manifestation
+    reported in LTBP3-related DASS/brachyolmia.
+  phenotype_term:
+    preferred_term: Thoracic aortic aneurysm
+    term:
+      id: HP:0012727
+      label: Thoracic aortic aneurysm
+  evidence:
+  - reference: PMID:35352826
+    reference_title: "Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Mutations in LTBP3 are associated with Dental Anomalies and Short Stature syndrome (DASS; MIM 601216), which is characterized by hypoplastic type amelogenesis imperfecta, hypodontia, underdeveloped maxilla, short stature, brachyolmia, aneurysm and dissection of the thoracic aorta."
+    explanation: Supports thoracic aortic aneurysm as part of the recognized LTBP3-related syndrome.
+- category: Cardiovascular
+  name: Aortic dissection
+  subtype: LTBP3
+  description: >
+    Aortic dissection has been reported as part of the cardiovascular risk profile
+    in LTBP3-related DASS/brachyolmia.
+  phenotype_term:
+    preferred_term: Aortic dissection
+    term:
+      id: HP:0002647
+      label: Aortic dissection
+  evidence:
+  - reference: PMID:35352826
+    reference_title: "Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Mutations in LTBP3 are associated with Dental Anomalies and Short Stature syndrome (DASS; MIM 601216), which is characterized by hypoplastic type amelogenesis imperfecta, hypodontia, underdeveloped maxilla, short stature, brachyolmia, aneurysm and dissection of the thoracic aorta."
+    explanation: Supports aortic dissection as part of the recognized cardiovascular phenotype of LTBP3-related disease.
+- category: Skeletal
+  name: Osteopenia
+  subtype: LTBP3
+  description: >
+    Reduced bone density has been reported as an additional skeletal finding in
+    LTBP3-related DASS.
+  phenotype_term:
+    preferred_term: Osteopenia
+    term:
+      id: HP:0000938
+      label: Osteopenia
+  evidence:
+  - reference: PMID:38192829
+    reference_title: "Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype analyses of Egyptian and Pakistani patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Skeletal assessment documented short webbed neck, broad chest, evidences of mild long bones involvement, short distal phalanges, pes planus and osteopenic bone texture as additional associated findings expanding the clinical phenotype of DASS."
+    explanation: Supports osteopenic bone texture as an additional skeletal manifestation of LTBP3-related DASS.
+- category: Musculoskeletal
+  name: Pes planus
+  subtype: LTBP3
+  description: >
+    Flat feet are reported as an additional musculoskeletal finding in
+    LTBP3-related DASS.
+  phenotype_term:
+    preferred_term: Pes planus
+    term:
+      id: HP:0001763
+      label: Pes planus
+  evidence:
+  - reference: PMID:38192829
+    reference_title: "Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype analyses of Egyptian and Pakistani patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Skeletal assessment documented short webbed neck, broad chest, evidences of mild long bones involvement, short distal phalanges, pes planus and osteopenic bone texture as additional associated findings expanding the clinical phenotype of DASS."
+    explanation: Supports pes planus as part of the expanded clinical phenotype of LTBP3-related DASS.
 biochemical:
 - name: Low serum DHEAS
   subtype: AR-PAPSS2

--- a/references_cache/PMID_35352826.md
+++ b/references_cache/PMID_35352826.md
@@ -1,0 +1,100 @@
+---
+reference_id: "PMID:35352826"
+title: Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome.
+authors:
+- Kantaputra P
+- Guven Y
+- Kalayci T
+- Özer PK
+- Panyarak W
+- Intachai W
+- Olsen B
+- Carlson BM
+- Praditsap O
+- Tongsima S
+- Ngamphiw C
+- Jatooratthawichot P
+- Tucker AS
+- Ketudat Cairns JR
+journal: Clin Genet
+year: '2022'
+doi: 10.1111/cge.14134
+keywords:
+- Amelogenesis Imperfecta/genetics
+- Dwarfism/genetics
+- Humans
+- Latent TGF-beta Binding Proteins/genetics
+- Male
+- Osteochondrodysplasias/genetics
+- Phenotype
+- Tooth Abnormalities/genetics
+- Transforming Growth Factor beta/genetics
+content_type: abstract_only
+---
+
+# Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome.
+**Authors:** Kantaputra P, Guven Y, Kalayci T, Özer PK, Panyarak W, Intachai W, Olsen B, Carlson BM, Praditsap O, Tongsima S, Ngamphiw C, Jatooratthawichot P, Tucker AS, Ketudat Cairns JR
+**Journal:** Clin Genet (2022)
+**DOI:** [10.1111/cge.14134](https://doi.org/10.1111/cge.14134)
+
+## Content
+
+1. Clin Genet. 2022 Jul;102(1):66-71. doi: 10.1111/cge.14134. Epub 2022 Mar 31.
+
+Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental 
+anomalies and short stature syndrome.
+
+Kantaputra P(1)(2), Guven Y(3), Kalayci T(4), Özer PK(5), Panyarak W(6), 
+Intachai W(1), Olsen B(7), Carlson BM(8), Praditsap O(9), Tongsima S(10), 
+Ngamphiw C(10), Jatooratthawichot P(11), Tucker AS(12), Ketudat Cairns JR(11).
+
+Author information:
+(1)Center of Excellence in Medical Genetics Research, Chiang Mai University, 
+Chiang Mai, Thailand.
+(2)Division of Pediatric Dentistry, Department of Orthodontics and Pediatric 
+Dentistry, Faculty of Dentistry, Chiang Mai University, Chiang Mai, Thailand.
+(3)Department of Pedodontics, Faculty of Dentistry, Istanbul University, 
+Istanbul, Turkey.
+(4)Department of Medical Genetics, Istanbul Faculty of Medicine, Istanbul 
+University, Istanbul, Turkey.
+(5)Istanbul Medical Faculty, Department of Cardiology, Istanbul University, 
+Istanbul, Turkey.
+(6)Division of Oral and Maxillofacial Radiology, Faculty of Dentistry, Chiang 
+Mai University, Chiang Mai, Thailand.
+(7)Department of Developmental Biology, Harvard School of Dental Medicine, 
+Harvard University, Boston, Massachusetts, USA.
+(8)Department of Anatomy and Cell Biology, University of Michigan, Ann Arbor, 
+Michigan, USA.
+(9)Siriraj Genomics, Office of the Dean, Faculty of Medicine Siriraj Hospital, 
+Mahidol University, Bangkok, Thailand.
+(10)National Biobank of Thailand, National Science and Technology Development 
+Agency, Pathum Thani, Thailand.
+(11)School of Chemistry, Institute of Science, Suranaree University of 
+Technology, Nakhon Ratchasima, Thailand.
+(12)Centre for Craniofacial and Regenerative Biology, King's College London, 
+Guy's Hospital, London, UK.
+
+Mutations in LTBP3 are associated with Dental Anomalies and Short Stature 
+syndrome (DASS; MIM 601216), which is characterized by hypoplastic type 
+amelogenesis imperfecta, hypodontia, underdeveloped maxilla, short stature, 
+brachyolmia, aneurysm and dissection of the thoracic aorta. Here we report a 
+novel (p.Arg545ProfsTer22) and a recurrent (c.3107-2A > G) LTBP3 variants, in a 
+Turkish family affected with DASS. The proband, who carried compound 
+heterozygous variant c.3107-2A > G, p.Arg545ProfsTer22, was most severely 
+affected with DASS. The proband's father, who carried the heterozygous variant 
+c.3107-2A > G had short stature and prognathic mandible. The mother and brother 
+of the proband carried the heterozygous variant p.Arg545ProfsTer22, but only the 
+mother showed any DASS characteristics. The c.3107-2A > G and the 
+p.Arg545ProfsTer22 variants are expected to result in abnormal LTPB3 protein, 
+failure of TGFβ-LAP-LTBP3 complex formation, and subsequent disruption of TGFβ 
+secretion and activation. This is the first report of heterozygous carriers of 
+LTBP3 variants showing phenotypes. The new findings of DASS found in this family 
+include taurodontism, single-rooted molars, abnormal dentin, calcified dental 
+pulp blood vessels, prognathic mandible, failure of mandibular tooth eruption, 
+interatrial septal aneurysm, secundum atrial septal defect, tricuspid valve 
+prolapse, and a recurrent glenohumeral joint dislocation.
+
+© 2022 John Wiley & Sons A/S. Published by John Wiley & Sons Ltd.
+
+DOI: 10.1111/cge.14134
+PMID: 35352826 [Indexed for MEDLINE]

--- a/references_cache/PMID_38192829.md
+++ b/references_cache/PMID_38192829.md
@@ -1,0 +1,107 @@
+---
+reference_id: "PMID:38192829"
+title: "Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype analyses of Egyptian and Pakistani patients."
+authors:
+- Nawaz H
+- Parveen A
+- Khan SA
+- Zalan AK
+- Khan MA
+- Muhammad N
+- Hassib NF
+- Mostafa MI
+- Elhossini RM
+- Roshdy NN
+- Ullah A
+- Arif A
+- Khan S
+- Ammerpohl O
+- Wasif N
+journal: Heliyon
+year: '2024'
+doi: 10.1016/j.heliyon.2023.e23688
+content_type: abstract_only
+---
+
+# Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype analyses of Egyptian and Pakistani patients.
+**Authors:** Nawaz H, Parveen A, Khan SA, Zalan AK, Khan MA, Muhammad N, Hassib NF, Mostafa MI, Elhossini RM, Roshdy NN, Ullah A, Arif A, Khan S, Ammerpohl O, Wasif N
+**Journal:** Heliyon (2024)
+**DOI:** [10.1016/j.heliyon.2023.e23688](https://doi.org/10.1016/j.heliyon.2023.e23688)
+
+## Content
+
+1. Heliyon. 2023 Dec 14;10(1):e23688. doi: 10.1016/j.heliyon.2023.e23688. 
+eCollection 2024 Jan 15.
+
+Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype 
+analyses of Egyptian and Pakistani patients.
+
+Nawaz H(1), Parveen A(2)(3), Khan SA(1)(4), Zalan AK(5), Khan MA(6), Muhammad 
+N(1), Hassib NF(7)(8), Mostafa MI(7), Elhossini RM(9), Roshdy NN(10), Ullah 
+A(11)(12), Arif A(3), Khan S(1), Ammerpohl O(13), Wasif N(13)(14).
+
+Author information:
+(1)Department of Biotechnology and Genetic Engineering, Kohat University of 
+Science and Technology (KUST), Kohat, Pakistan.
+(2)Department of Biochemistry, Faculty of Life Sciences, Gulab Devi Educational 
+Complex, Gulab Devi Hospital, 54000, Lahore, Pakistan.
+(3)Faculty of Science and Technology, University of Central Punjab (UCP), 
+Lahore, Pakistan.
+(4)Department of Computer Science and Bioinformatics, Khushal Khan Khatak 
+University, Karak, Pakistan.
+(5)BDS, MDS Registrar Pediatric Dentistry, Department of Pediatric Dentistry, 
+School of Dentistry, PIMS, Islamabad, Pakistan.
+(6)Dental Material, Institute of Basic Medical Sciences, Khyber Medical 
+University Peshawar, Peshawar, Pakistan.
+(7)Orodental Genetics Department, Human Genetics and Genome Research Institute, 
+National Research Centre, Cairo, 12622, Egypt.
+(8)School of Dentistry, New Giza University, Giza, Egypt.
+(9)Clinical Genetics Department, Human Genetics and Genome Research Institute, 
+National Research Centre, Cairo, 12622, Egypt.
+(10)Endodontics, Faculty of Dentistry, Cairo University, Cairo, 11553, Egypt.
+(11)Department of Biomedicine, Aarhus University, Aarhus, Denmark.
+(12)The Novo Nordisk Foundation Center for Genomic Mechanisms of Disease, Broad 
+Institute of MIT and Harvard, Cambridge, MA, 02142, USA.
+(13)Institute of Human Genetics, Ulm University and Ulm University Medical 
+Center, 89081, Ulm, Germany.
+(14)Institute of Human Genetics, University Hospital Schleswig-Holstein, Campus 
+Kiel, D-24105, Kiel, Germany.
+
+Brachyolmia is a heterogeneous group of developmental disorders characterized by 
+a short trunk, short stature, scoliosis, and generalized platyspondyly without 
+significant deformities in the long bones. DASS (Dental Abnormalities and Short 
+Stature), caused by alterations in the LTBP3 gene, was previously considered as 
+a subtype of brachyolmia. The present study investigated three unrelated 
+consanguineous families (A, B, C) with Brachyolmia and DASS from Egypt and 
+Pakistan. In our Egyptian patients, we also observed hearing impairment. Exome 
+sequencing was performed to determine the genetic causes of the diverse clinical 
+conditions in the patients. Exome sequencing identified a novel homozygous 
+splice acceptor site variant (LTBP3:c.3629-1G > T; p. ?) responsible for DASS 
+phenotypes and a known homozygous missense variant (CABP2: c.590T > C; 
+p.Ile197Thr) causing hearing impairment in the Egyptian patients. In addition, 
+two previously reported homozygous frameshift variants (LTBP3:c.132delG; 
+p.Pro45Argfs*25) and (LTBP3:c.2216delG; p.Gly739Alafs*7) were identified in 
+Pakistani patients. This study emphasizes the vital role of LTBP3 in the axial 
+skeleton and tooth morphogenesis and expands the mutational spectrum of LTBP3. 
+We are reporting LTBP3 variants in seven patients of three families, majorly 
+causing brachyolmia with dental and cardiac anomalies. Skeletal assessment 
+documented short webbed neck, broad chest, evidences of mild long bones 
+involvement, short distal phalanges, pes planus and osteopenic bone texture as 
+additional associated findings expanding the clinical phenotype of DASS. The 
+current study reveals that the hearing impairment phenotype in Egyptian patients 
+of family A has a separate transmission mechanism independent of LTBP3.
+
+© 2023 The Authors. Published by Elsevier Ltd.
+
+DOI: 10.1016/j.heliyon.2023.e23688
+PMCID: PMC10772639
+PMID: 38192829
+
+Conflict of interest statement: The authors declare the following financial 
+interests/personal relationships which may be considered as potential competing 
+interests:Naveed Wasif reports financial support was provided by 
+10.13039/100005156Alexander von Humboldt Foundation. Saadullah Khan reports 
+financial support was provided by Higher Education Commission Pakistan. Nehal F. 
+Hassib reports financial support was provided by 10.13039/100007787National 
+Research Centre, Cairo. The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_40927400.md
+++ b/references_cache/PMID_40927400.md
@@ -1,0 +1,55 @@
+---
+reference_id: "PMID:40927400"
+title: "PAPSS2-Related Brachyolmia: Clinical and Radiographic Features and Growth Hormone Therapy of One Chinese Case."
+authors:
+- Long W
+- Luo X
+journal: Clin Case Rep
+year: '2025'
+doi: 10.1002/ccr3.70788
+content_type: abstract_only
+---
+
+# PAPSS2-Related Brachyolmia: Clinical and Radiographic Features and Growth Hormone Therapy of One Chinese Case.
+**Authors:** Long W, Luo X
+**Journal:** Clin Case Rep (2025)
+**DOI:** [10.1002/ccr3.70788](https://doi.org/10.1002/ccr3.70788)
+
+## Content
+
+1. Clin Case Rep. 2025 Sep 7;13(9):e70788. doi: 10.1002/ccr3.70788. eCollection 
+2025 Sep.
+
+PAPSS2-Related Brachyolmia: Clinical and Radiographic Features and Growth 
+Hormone Therapy of One Chinese Case.
+
+Long W(1), Luo X(1).
+
+Author information:
+(1)Department of Pediatrics Tongji Hospital, Tongji Medical College, Huazhong 
+University of Science and Technology Wuhan Hubei China.
+
+Brachyolmia type 4 (BCYM4, OMIM 612847) is a rare skeletal dysplasia 
+characterized by mild epiphyseal and metaphyseal abnormalities. We report a 
+Chinese boy with brachyolmia caused by a novel compound heterozygous mutation in 
+the PAPSS2 gene. Prenatal ultrasound revealed shortened long bones, and his 
+birth length was markedly reduced (45 cm, -3.11 SD). Clinical and radiographic 
+findings were consistent with brachyolmia, and genetic analysis confirmed the 
+diagnosis of BCYM4 at 2 years and 9 months old. During follow-up, the patient 
+exhibited progressive growth retardation. Under pediatric orthopedics 
+supervision, growth hormone (GH) therapy was initiated to ameliorate his short 
+stature since 5 years and 6 months old. Over a 2-year and 3-month treatment 
+period, GH therapy significantly improved his growth velocity, with his height 
+increasing from -5.02 SD to -3.87 SD. Notably, severe growth restriction was 
+evident as early as 25 weeks' gestation, and spinal radiographs demonstrated 
+persistent skeletal abnormalities. This case expands the phenotypic spectrum of 
+BCYM4 and provides evidence supporting the efficacy of GH therapy in improving 
+growth outcomes in patients with skeletal dysplasia-associated short stature.
+
+© 2025 The Author(s). Clinical Case Reports published by John Wiley & Sons Ltd.
+
+DOI: 10.1002/ccr3.70788
+PMCID: PMC12414804
+PMID: 40927400
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/research/Brachyolmia-phenotype-curation-2026-04-18.md
+++ b/research/Brachyolmia-phenotype-curation-2026-04-18.md
@@ -1,0 +1,52 @@
+# Brachyolmia phenotype curation notes
+
+Date: 2026-04-18
+Target file: `kb/disorders/Brachyolmia.yaml`
+Scope: phenotype section only
+
+## Primary phenotype papers used
+
+- PMID:22791835
+  "PAPSS2 mutations cause autosomal recessive brachyolmia."
+  Key phenotype statements used: short-trunk short stature becoming conspicuous during childhood; irregular endplates and narrow intervertebral discs; precocious rib cartilage calcification; short femoral neck; mildly shortened metacarpals.
+
+- PMID:23824674
+  "Clinical and radiographic features of the autosomal recessive form of brachyolmia caused by PAPSS2 mutations."
+  Key phenotype statements used: spinal deformity; platyspondyly with rectangular vertebral bodies and irregular end plates; proximal femoral metaphyseal change with short femoral neck and striation.
+
+- PMID:31313512
+  "PAPSS2-related brachyolmia: Clinical and radiological phenotype in 18 new cases."
+  Key phenotype statements used: prenatal short femora in 8 patients; platyspondyly with elongated vertebral bodies, irregular end plates, narrow disc spaces and short over-faced pedicles; pain, stiffness and spinal deformity; low DHEAS.
+
+- PMID:18587396
+  "Gain-of-function mutations in TRPV4 cause autosomal dominant brachyolmia."
+  Key phenotype statements used: short trunk, scoliosis and mild short stature.
+
+- PMID:24677493
+  "Autosomal dominant brachyolmia in a large Swedish family: phenotypic spectrum and natural course."
+  Key phenotype statements used: scoliosis and platyspondyly in TRPV4-related disease; pain by school age; paresthesias; progressive growth deterioration with spinal involvement.
+
+- PMID:25669657
+  "Mutations in the latent TGF-beta binding protein 3 (LTBP3) gene cause brachyolmia with amelogenesis imperfecta."
+  Key phenotype statements used: significant short stature with brachyolmia and hypoplastic amelogenesis imperfecta with almost absent enamel.
+
+- PMID:35352826
+  "Expanding genotypic and phenotypic spectrums of LTBP3 variants in dental anomalies and short stature syndrome."
+  Key phenotype statements used: hypodontia; underdeveloped maxilla; thoracic aortic aneurysm and dissection as part of LTBP3-related DASS.
+
+- PMID:38192829
+  "Brachyolmia, dental anomalies and short stature (DASS): Phenotype and genotype analyses of Egyptian and Pakistani patients."
+  Key phenotype statements used: short trunk, short stature, scoliosis and generalized platyspondyly as defining brachyolmia features; osteopenic bone texture and pes planus as additional LTBP3-associated findings.
+
+## Curation decisions
+
+- Added high-confidence PAPSS2 skeletal phenotypes: prenatal short femora and short metacarpals.
+- Added high-confidence LTBP3 phenotypes not previously represented: hypodontia, maxillary hypoplasia, thoracic aortic aneurysm, aortic dissection, osteopenia and pes planus.
+- Softened wording that implied unsupported frequency, especially around scoliosis and generalized "all subtype" claims.
+- Simplified the amelogenesis imperfecta description to stay within exact published support.
+
+## Considered but not added
+
+- CABP2-related hearing impairment from PMID:38192829 was excluded because the paper states it had a separate transmission mechanism independent of LTBP3.
+- One-family LTBP3 findings such as interatrial septal aneurysm, secundum atrial septal defect, tricuspid valve prolapse and recurrent glenohumeral dislocation were noted but not added in this pass because the evidence in the abstract presents them as newly observed family-level findings rather than established core brachyolmia manifestations.
+- Broad proximal interphalangeal joints, broad ilia and short distal phalanges were not added because the exact HPO term mapping needed more time than was justified for this phenotype-only issue.


### PR DESCRIPTION
## Summary
- expand `kb/disorders/Brachyolmia.yaml` with PMID-backed phenotype findings for PAPSS2- and LTBP3-related brachyolmia
- add missing clinically important subtype-specific phenotypes, including prenatal PAPSS2 findings and LTBP3 dental/cardiovascular manifestations
- soften phenotype wording that implied unsupported prevalence or subtype generalization
- add a short phenotype curation note in `research/` and commit the fetched reference cache files required for deterministic validation

## Why
Issue #1482 asked for the phenotype section to be made as complete and evidence-backed as possible without broadening into an unrelated full-page rewrite.

## Impact
- improves phenotype completeness for diagnosis-oriented and subtype-aware curation
- grounds new phenotype assertions in exact PMID-backed evidence
- preserves unrelated dirty files in the worktree by limiting the commit to the disorder YAML, research note, and fetched reference caches

## Validation
- `just validate kb/disorders/Brachyolmia.yaml`
- `just validate-references kb/disorders/Brachyolmia.yaml`
- `just validate-terms kb/disorders/Brachyolmia.yaml`

All three commands passed locally.

Closes #1482