### PR TITLE
[codex] Enhance AOIII phenotype evidence

### DIFF
--- a/kb/disorders/Atelosteogenesis_Type_III.yaml
+++ b/kb/disorders/Atelosteogenesis_Type_III.yaml
@@ -1,6 +1,6 @@
 name: Atelosteogenesis Type III
 creation_date: '2026-03-04T07:57:38Z'
-updated_date: '2026-04-07T02:14:34Z'
+updated_date: '2026-04-19T02:18:59Z'
 category: Mendelian
 description: >
   Atelosteogenesis Type III is a severe FLNB-related skeletal dysplasia with marked
@@ -127,6 +127,32 @@ genetic:
     explanation: >-
       This explicitly names missense FLNB mutations in AOIII.
 phenotypes:
+- name: Disproportionate Short-Limb Short Stature
+  description: >
+    AOIII is a severe short-limbed skeletal dysplasia with disproportionate limb
+    shortening.
+  phenotype_term:
+    preferred_term: Disproportionate short-limb short stature
+    term:
+      id: HP:0008873
+      label: Disproportionate short-limb short stature
+  evidence:
+  - reference: PMID:2368807
+    reference_title: "Atelosteogenesis type III: a distinct skeletal dysplasia with features overlapping atelosteogenesis and oto-palato-digital syndrome type II."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We present 5 cases of a short-limb dwarfism syndrome whose manifestations overlap those of atelosteogenesis and oto-palato-digital syndrome Type II.
+    explanation: >-
+      The original AOIII case series directly identifies the condition as a short-limb dwarfism syndrome.
+  - reference: PMID:20301736
+    reference_title: "FLNB-Related Disorders."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      FLNB-AO1 and FLNB-AO3 are characterized by severe short-limbed dwarfism; dislocated hips, knees, and elbows; and clubfeet.
+    explanation: >-
+      GeneReviews summarizes AOIII within the FLNB spectrum as severe short-limbed dwarfism.
 - name: Rhizomelia
   description: >
     Rhizomelic shortening of the limbs is a key skeletal feature.
@@ -144,6 +170,32 @@ phenotypes:
       There was rhizomelic shortness of the limbs and a club-foot.
     explanation: >-
       This directly supports rhizomelic limb shortening.
+- name: Large Joint Dislocations
+  description: >
+    Congenital dislocations involving the hips, knees, and elbows are part of
+    the core appendicular phenotype.
+  phenotype_term:
+    preferred_term: Large joint dislocations
+    term:
+      id: HP:0005008
+      label: Large joint dislocations
+  evidence:
+  - reference: PMID:16752402
+    reference_title: "Mutations in two regions of FLNB result in atelosteogenesis I and III."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      AOI and AOIII are autosomal dominant lethal skeletal dysplasias characterized by overlapping clinical findings that include vertebral abnormalities, disharmonious skeletal maturation, hypoplastic long bones, and joint dislocations.
+    explanation: >-
+      This primary AOI/AOIII mutation series directly identifies joint dislocations as part of the shared phenotype.
+  - reference: PMID:20301736
+    reference_title: "FLNB-Related Disorders."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      FLNB-AO1 and FLNB-AO3 are characterized by severe short-limbed dwarfism; dislocated hips, knees, and elbows; and clubfeet.
+    explanation: >-
+      GeneReviews localizes the dislocations to the large joints most often emphasized in AOIII.
 - name: Talipes Equinovarus
   description: >
     Club-foot deformity is present at birth.
@@ -314,6 +366,43 @@ phenotypes:
       The infant experienced recurrent apnea and persistent severe tracheomalacia, which necessitated tracheostomy at 5 months of age.
     explanation: >-
       This directly supports tracheomalacia as a major AOIII complication.
+- name: Apnea
+  description: >
+    Recurrent apnea has been documented in surviving infants with severe airway
+    involvement.
+  phenotype_term:
+    preferred_term: Apnea
+    term:
+      id: HP:0002104
+      label: Apnea
+  evidence:
+  - reference: PMID:1442028
+    reference_title: "Atelosteogenesis type 3: the first patient in Japan and a survivor for more than 1 year."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The infant experienced recurrent apnea and persistent severe tracheomalacia, which necessitated tracheostomy at 5 months of age.
+    explanation: >-
+      This directly supports recurrent apnea as part of the respiratory phenotype.
+- name: Motor Delay
+  description: >
+    Motor developmental delay has been reported in a longer-term survivor,
+    although published evidence does not establish whether it is primary or
+    secondary to prolonged respiratory and orthopedic morbidity.
+  phenotype_term:
+    preferred_term: Motor delay
+    term:
+      id: HP:0001270
+      label: Motor delay
+  evidence:
+  - reference: PMID:1442028
+    reference_title: "Atelosteogenesis type 3: the first patient in Japan and a survivor for more than 1 year."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Despite his multiple skeletal deformities and respiratory problems, this patient survived more than 1 year with motoneuronal developmental delay.
+    explanation: >-
+      This surviving infant had documented motor developmental delay, but the available abstract does not define mechanism.
 diagnosis:
 - name: Radiographic and Molecular Diagnosis
   description: >

--- a/references_cache/PMID_20301736.md
+++ b/references_cache/PMID_20301736.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:20301736"
+title: FLNB-Related Disorders.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Robertson S
+- Meira J
+year: '1993'
+content_type: abstract_only
+---
+
+# FLNB-Related Disorders.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Robertson S, Meira J
+
+## Content
+
+1. FLNB-Related Disorders.
+
+Robertson S(1), Meira J(2).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2008 Oct 9 [updated 2025 Sep 11].
+
+Author information:
+(1)Professor of Paediatric Genetics, Department of Paediatrics and Child Health,
+Dunedin School of Medicine, University of Otago, Dunedin, New Zealand
+(2)Professor, State University of Bahia (UNEB), Salvador, Bahia, Brazil
+
+CLINICAL CHARACTERISTICS: The FLNB-related disorders can be divided into two
+groups of conditions caused by loss of function or gain of function of
+filamin-B. Biallelic loss-of-function pathogenic variants in FLNB cause
+spondylocarpotarsal synostosis syndrome (FLNB-SCT). Monoallelic gain-of-function
+pathogenic variants in FLNB cause a spectrum of phenotypic severity ranging from
+apparently isolated clubfoot to Larsen syndrome (FLNB-LS), atelosteogenesis type
+3 (FLNB-AO3), and atelosteogenesis type 1 (FLNB-AO1), which is perinatal lethal.
+For the purposes of this GeneReview, the previously described entities Piepkorn
+dysplasia and boomerang dysplasia are subsumed under the FLNB-AO1 spectrum.
+FLNB-SCT is characterized by postnatal disproportionate short stature; scoliosis
+and lordosis due to vertebral fusions; carpal and tarsal synostosis; and,
+variably, clubfeet, hearing loss, and dental enamel hypoplasia. FLNB-LS is
+characterized by combinations of congenital dislocations of the hip, knee, and
+elbow; clubfeet (equinovarus or equinovalgus foot deformities); scoliosis and
+cervical kyphosis (which can be associated with a cervical myelopathy); short,
+broad, spatulate distal phalanges; distinctive craniofacial features (prominent
+forehead, depressed nasal bridge, malar flattening, and widely spaced eyes);
+vertebral anomalies; and supernumerary carpal and tarsal ossification centers.
+Individuals with FLNB-LS may also present with midline cleft palate and hearing
+loss. FLNB-AO1 and FLNB-AO3 are characterized by severe short-limbed dwarfism;
+dislocated hips, knees, and elbows; and clubfeet. FLNB-AO1 is lethal in the
+perinatal period. At its most severe, the spectrum of phenotypes assigned
+FLNB-AO1 can present with perinatal-lethal micromelic dwarfism characterized by
+flipper-like limbs (polysyndactyly with complete syndactyly of all fingers and
+toes, hypoplastic or absent first digits, and duplicated intermediate and distal
+phalanges); macrobrachycephaly; prominent forehead; hypertelorism; and
+proptosis. Occasional features include cleft palate, omphalocele, and cardiac
+and genitourinary anomalies. In individuals with FLNB-AO3, survival beyond the
+neonatal period is possible with intensive and invasive respiratory support.
+DIAGNOSIS/TESTING: The diagnosis of FLNB-SCT is established in a proband by
+identification of biallelic loss-of-function pathogenic variants in FLNB by
+molecular genetic testing. The diagnosis of other FLNB-related disorders (LS,
+AO1, AO3) is established in a proband by identification of a heterozygous
+gain-of-function pathogenic variant in FLNB by molecular genetic testing.
+MANAGEMENT: Treatment of manifestations: Cervical spine instability in
+asymptomatic infants can be successfully managed with posterior arthrodesis.
+Function can be stabilized (if not improved) in infants with myelopathic signs
+by a combination of anterior decompression and circumferential arthrodesis. Hip
+dislocation in individuals with FLNB-LS usually requires operative reduction.
+Scoliosis and clubfeet are managed in a routine manner. Anesthetic agents that
+allow more rapid induction and recovery are preferred in those with
+laryngotracheomalacia. When possible, cleft palate and hearing loss are best
+managed by multidisciplinary teams. Surveillance: Annual orthopedic evaluation
+for progressive scoliosis; feeding and growth assessment for those with cleft
+palate by a multidisciplinary team; annual audiologic and dental evaluations.
+Pregnancy management: Delivery of an affected infant has the potential to be
+complicated by extended breech presentation due to dislocation of the hips and
+knees.
+GENETIC COUNSELING: FLNB-SCT is inherited in an autosomal recessive manner. If
+both parents are known to be heterozygous for an FLNB pathogenic variant, each
+sib of an affected individual has at conception a 25% chance of inheriting
+biallelic pathogenic variants and being affected, a 50% chance of inheriting one
+pathogenic variant and being heterozygous, and a 25% chance of inheriting
+neither of the familial FLNB pathogenic variants. Heterozygous sibs of a proband
+with FLNB-SCT can exhibit mild reductions in stature but no other medically
+significant phenotypic manifestations. Once the FLNB pathogenic variant(s) have
+been identified in an affected family member, heterozygote testing for at-risk
+relatives and prenatal/preimplantation genetic testing are possible. FLNB-LS,
+FLNB-AO1, FLNB-AO3, and FLNB-related apparently isolated clubfoot are inherited
+in an autosomal dominant manner. Comparatively mild (e.g., FLNB-LS) and severe
+(e.g., FLNB-AO3) forms of the autosomal dominant FLNB-related disorders can
+occur in the same family. Some individuals diagnosed with an autosomal dominant
+FLNB-related disorder have the disorder as the result of a pathogenic variant
+inherited from a heterozygous or mosaic parent. Some individuals have the
+disorder as the result of a de novo pathogenic variant (the vast majority of
+lethal FLNB conditions are the result of de novo pathogenic variants). Each
+child of a proband who is heterozygous for an FLNB pathogenic variant has a 50%
+chance of inheriting the pathogenic variant. Each child of a proband with
+somatic mosaicism for an FLNB pathogenic variant has up to a 50% chance of
+inheriting the pathogenic variant. Offspring who inherit an FLNB pathogenic
+variant from a proband with somatic mosaicism may be more severely affected than
+the proband. Once the FLNB pathogenic variant has been identified in an affected
+family member, prenatal/preimplantation genetic testing are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 20301736

--- a/research/Atelosteogenesis_Type_III-deep-research-manual.md
+++ b/research/Atelosteogenesis_Type_III-deep-research-manual.md
@@ -1,0 +1,49 @@
+---
+provider: manual_pubmed_review
+model: n/a
+cached: false
+start_time: '2026-04-19T01:20:00Z'
+end_time: '2026-04-19T02:15:00Z'
+duration_seconds: 3300.0
+citation_count: 6
+notes: >
+  Manual phenotype-focused curation review completed from PubMed / cached
+  reference text before revising `kb/disorders/Atelosteogenesis_Type_III.yaml`.
+  The goal was to maximize phenotype completeness without adding claims that
+  could not be supported by exact PMID-backed text.
+---
+
+## Question
+
+Deep-review the phenotype manifestations of Atelosteogenesis Type III and identify which phenotype assertions for the disorder file are directly supportable from exact PMID-backed evidence, which clinically important phenotypes are missing, and which candidate claims should be omitted or softened.
+
+## Output
+
+# Atelosteogenesis Type III phenotype curation note
+
+## Core phenotype additions supported
+
+- **Disproportionate short-limb short stature** is directly supportable from the original AOIII delineation as a "short-limb dwarfism syndrome" (PMID:2368807) and from the updated FLNB GeneReviews summary describing FLNB-AO3 as "severe short-limbed dwarfism" (PMID:20301736).
+- **Large joint dislocations** were missing from the file despite being a hallmark of the FLNB-AO3 phenotype. Primary mutation-series evidence supports joint dislocations in AOI/AOIII (PMID:16752402), and GeneReviews localizes these to the hips, knees, and elbows in AO3 (PMID:20301736).
+- **Apnea** is directly documented in the 1992 long-term survivor report together with severe tracheomalacia and tracheostomy requirement (PMID:1442028).
+- **Motor delay** is supportable only in a qualified way from the same survivor report, which states the infant survived more than one year "with motoneuronal developmental delay" (PMID:1442028). Because this may reflect secondary morbidity rather than a primary neurodevelopmental effect, the YAML description should stay cautious.
+
+## Existing phenotype claims retained
+
+- **Rhizomelia**, **clubfoot**, **humeral hypoplasia**, **coronal cleft vertebrae**, **scoliosis**, **hypertelorism**, **flat/depressed nasal bridge**, **micrognathia**, **cleft palate**, **broad thumbs**, and **tracheomalacia** are all directly supportable from the abstract of the Japanese survivor report (PMID:1442028).
+
+## Candidate claims not added or intentionally softened
+
+- **Pelvic hypoplasia, rib hypoplasia, and generalized vertebral hypoplasia** are mentioned in broader AOIII summaries (for example PMID:27258362), but the abstract language is too introductory and nonspecific to map confidently to narrower HPO terms without overclaiming.
+- **Specific toe phenotypes** were not added. PMID:1442028 notes that the feet had abnormalities similar to the short broad thumbs, but the abstract does not localize the finding clearly enough to justify `Broad hallux` or another toe-specific HPO term.
+- **Intellectual disability / global developmental delay** were not added. PMID:8008496 mentions prognosis for physical and intellectual disability only at a high level, without a clean disease-level assertion or count.
+- **Frequency and onset qualifiers** were omitted because none of the usable AOIII phenotype abstracts directly quantify occurrence or provide a cohort-based onset statement for the added entries.
+
+## PubMed set reviewed
+
+- PMID:1442028
+- PMID:2368807
+- PMID:8008496
+- PMID:10076882
+- PMID:16752402
+- PMID:20301736


### PR DESCRIPTION
## Summary
- expand the AOIII phenotype section with PMID-backed hallmark findings for severe short-limb short stature, large-joint dislocations, apnea, and cautiously qualified motor delay
- retain the existing directly supported craniofacial, limb, vertebral, and tracheomalacia entries
- add a focused manual research note and the generated PMID cache entry needed for deterministic reference validation

## Why
Issue #1481 asked for a phenotype-only AOIII enrichment pass with exact PMID support, no unsupported frequency/onset claims, and no unrelated page rewrite.

## Validation
- `just validate kb/disorders/Atelosteogenesis_Type_III.yaml` -> passed
- `just validate-references kb/disorders/Atelosteogenesis_Type_III.yaml` -> passed (`Total checks: 0`)
- `just validate-terms kb/disorders/Atelosteogenesis_Type_III.yaml` -> passed

## Notes
- I did not broaden pelvic/rib/toe or cognitive phenotype claims where the available abstract-level PMID evidence was too nonspecific.
- Unrelated dirty worktree files were left untouched.

Refs #1481