### PR TITLE
[codex] Enhance Metatropic Dysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Metatropic_Dysplasia.yaml
+++ b/kb/disorders/Metatropic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Metatropic Dysplasia
 creation_date: '2026-03-04T18:40:20Z'
-updated_date: '2026-04-07T14:40:03Z'
+updated_date: '2026-04-19T02:21:10Z'
 category: Mendelian
 description: >
   Metatropic dysplasia is a TRPV4-associated autosomal dominant skeletal dysplasia
@@ -191,15 +191,25 @@ genetic:
     explanation: >-
       This places metatropic dysplasia within a TRPV4 skeletal dysplasia spectrum and supports causality.
 phenotypes:
-- name: Short Stature
+- name: Disproportionate Short-Limb Short Stature
   description: >
-    Short stature is a common growth phenotype in TRPV4-related metatropic dysplasia.
+    Metatropic dysplasia causes disproportionate short stature with marked limb
+    shortening; progressive spinal deformity later accentuates the altered body
+    proportions.
   phenotype_term:
-    preferred_term: Short stature
+    preferred_term: Disproportionate short-limb short stature
     term:
-      id: HP:0004322
-      label: Short stature
+      id: HP:0008873
+      label: Disproportionate short-limb short stature
   evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Metatropic dysplasia is a clinical heterogeneous skeletal dysplasia characterized by short extremities, a short trunk with progressive kyphoscoliosis, and craniofacial abnormalities that include a prominent forehead, midface hypoplasia, and a squared-off jaw.
+    explanation: >-
+      This directly supports disproportion driven by short extremities in metatropic dysplasia.
   - reference: PMID:21658220
     reference_title: "TRPV4 related skeletal dysplasias: a phenotypic spectrum highlighted byclinical, radiographic, and molecular studies in 21 new families."
     supports: SUPPORT
@@ -242,6 +252,96 @@ phenotypes:
       Autosomal dominant brachyolmia, spondylometaphyseal dysplasia Kozlowski type (SMDK) and metatropic dysplasia (MD) are currently considered three distinct skeletal dysplasias with some shared clinical features, including short stature, platyspondyly, and progressive scoliosis.
     explanation: >-
       This supports platyspondyly as a shared and recurrent feature.
+- name: Joint Contractures
+  description: >
+    Progressive joint contractures are part of the core musculoskeletal
+    phenotype and contribute to worsening mobility.
+  phenotype_term:
+    preferred_term: Joint contractures
+    term:
+      id: HP:0001371
+      label: Flexion contracture
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      progressive joint contractures and distinct facial characteristics with a prominent forehead and squared-off jaw.
+    explanation: >-
+      This full-text summary identifies progressive joint contractures as a primary clinical finding.
+- name: Hypoplasia of the Odontoid Process
+  description: >
+    Odontoid hypoplasia can contribute to cervical instability and warrants
+    clinical surveillance.
+  phenotype_term:
+    preferred_term: Hypoplasia of the odontoid process
+    term:
+      id: HP:0003311
+      label: Hypoplasia of the odontoid process
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Additional clinical findings, which may not be present in all cases, include odontoid hypoplasia with cervical instability and sensorineural hearing loss [Kannu et al., 2007; Geneviève et al., 2008].
+    explanation: >-
+      This directly supports odontoid hypoplasia as a recognized additional clinical manifestation.
+- name: Spinal Canal Stenosis
+  description: >
+    Spinal canal narrowing or stenosis is a clinically important spinal
+    complication reported in larger metatropic dysplasia care cohorts.
+  phenotype_term:
+    preferred_term: Spinal canal stenosis
+    term:
+      id: HP:0003416
+      label: Spinal canal stenosis
+  evidence:
+  - reference: PMID:28321993
+    reference_title: Metatropic dysplasia-a skeletal dysplasia with challenging airway and other anesthetic concerns.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In addition to the airway difficulties, spinal canal narrowing or stenosis was widely prevalent, and no neuraxial anesthetic was performed in any of our patients.
+    explanation: >-
+      This cohort study identifies spinal canal narrowing/stenosis as a prevalent co-morbid manifestation.
+- name: Thoracic Hypoplasia
+  description: >
+    Severe cases can have a small chest reflecting thoracic hypoplasia, which
+    contributes to early respiratory compromise.
+  phenotype_term:
+    preferred_term: Thoracic hypoplasia
+    term:
+      id: HP:0005257
+      label: Thoracic hypoplasia
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Complications can include a small chest with some degree of respiratory compromise beginning in the neonatal period, and unrelenting kyphoscoliosis.
+    explanation: >-
+      This directly supports a small thorax/chest in the severe end of the phenotype spectrum.
+- name: Neonatal Respiratory Distress
+  description: >
+    Respiratory compromise can begin in the neonatal period, particularly in
+    patients with a small thorax.
+  phenotype_term:
+    preferred_term: Neonatal respiratory distress
+    term:
+      id: HP:0002643
+      label: Neonatal respiratory distress
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Complications can include a small chest with some degree of respiratory compromise beginning in the neonatal period, and unrelenting kyphoscoliosis.
+    explanation: >-
+      This full-text clinical summary directly supports neonatal-onset respiratory compromise in severe cases.
 - name: Metaphyseal Widening
   description: >
     Marked metaphyseal flaring/widening contributes to long-bone deformity.
@@ -276,14 +376,69 @@ phenotypes:
       Radiographic findings show dumbbell-shaped long bones with widened metaphyses, very flat and dense vertebral bodies, a halberd-shaped pelvis, and brachydactyly with markedly delayed carpal ossification.
     explanation: >-
       This directly supports dumbbell-shaped long bones as a hallmark feature.
-- name: Limb Undergrowth
+- name: Halberd-Shaped Pelvis
   description: >
-    Short extremities reflect significant appendicular undergrowth.
+    A halberd-shaped pelvis is part of the characteristic radiographic skeletal
+    pattern.
   phenotype_term:
-    preferred_term: Limb undergrowth
+    preferred_term: Halberd-shaped pelvis
     term:
-      id: HP:0009826
-      label: Limb undergrowth
+      id: HP:0002826
+      label: Halberd-shaped pelvis
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiographic findings show dumbbell-shaped long bones with widened metaphyses, very flat and dense vertebral bodies, a halberd-shaped pelvis, and brachydactyly with markedly delayed carpal ossification.
+    explanation: >-
+      This directly supports a halberd-shaped pelvis as a characteristic radiographic manifestation.
+- name: Brachydactyly
+  description: >
+    Shortening of the digits accompanies the broader appendicular skeletal
+    dysplasia.
+  phenotype_term:
+    preferred_term: Brachydactyly
+    term:
+      id: HP:0001156
+      label: Brachydactyly
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiographic findings show dumbbell-shaped long bones with widened metaphyses, very flat and dense vertebral bodies, a halberd-shaped pelvis, and brachydactyly with markedly delayed carpal ossification.
+    explanation: >-
+      This directly supports brachydactyly as part of the radiographic phenotype.
+- name: Delayed Ossification of Carpal Bones
+  description: >
+    Markedly delayed carpal ossification is a characteristic hand radiographic
+    abnormality.
+  phenotype_term:
+    preferred_term: Delayed ossification of carpal bones
+    term:
+      id: HP:0001216
+      label: Delayed ossification of carpal bones
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Radiographic findings show dumbbell-shaped long bones with widened metaphyses, very flat and dense vertebral bodies, a halberd-shaped pelvis, and brachydactyly with markedly delayed carpal ossification.
+    explanation: >-
+      This directly supports delayed carpal ossification as a hallmark radiographic feature.
+- name: Frontal Bossing
+  description: >
+    Prominent forehead/frontal bossing contributes to the characteristic facial
+    appearance.
+  phenotype_term:
+    preferred_term: Frontal bossing
+    term:
+      id: HP:0002007
+      label: Frontal bossing
   evidence:
   - reference: PMID:20425821
     reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
@@ -292,7 +447,42 @@ phenotypes:
     snippet: >-
       Metatropic dysplasia is a clinical heterogeneous skeletal dysplasia characterized by short extremities, a short trunk with progressive kyphoscoliosis, and craniofacial abnormalities that include a prominent forehead, midface hypoplasia, and a squared-off jaw.
     explanation: >-
-      This supports severe appendicular undergrowth/short extremities.
+      This abstract identifies a prominent forehead as part of the characteristic craniofacial phenotype.
+- name: Midface Retrusion
+  description: >
+    Midface hypoplasia/retrusion is part of the characteristic facial gestalt.
+  phenotype_term:
+    preferred_term: Midface retrusion
+    term:
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Metatropic dysplasia is a clinical heterogeneous skeletal dysplasia characterized by short extremities, a short trunk with progressive kyphoscoliosis, and craniofacial abnormalities that include a prominent forehead, midface hypoplasia, and a squared-off jaw.
+    explanation: >-
+      This abstract directly supports midface hypoplasia, here mapped to the specific HPO concept of midface retrusion.
+- name: Sensorineural Hearing Loss
+  description: >
+    Sensorineural hearing loss is a recognized but non-obligate additional
+    manifestation.
+  phenotype_term:
+    preferred_term: Sensorineural hearing impairment
+    term:
+      id: HP:0000407
+      label: Sensorineural hearing impairment
+  evidence:
+  - reference: PMID:20425821
+    reference_title: "Dominant TRPV4 mutations in nonlethal and lethal metatropic dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Additional clinical findings, which may not be present in all cases, include odontoid hypoplasia with cervical instability and sensorineural hearing loss [Kannu et al., 2007; Geneviève et al., 2008].
+    explanation: >-
+      This full-text summary supports sensorineural hearing loss as a recognized additional clinical finding.
 diagnosis:
 - name: Clinical, Radiographic, and Molecular Diagnosis
   description: >

--- a/research/Metatropic_Dysplasia-deep-research-codex.md
+++ b/research/Metatropic_Dysplasia-deep-research-codex.md
@@ -1,0 +1,82 @@
+---
+provider: codex_manual_pubmed_review
+model: gpt-5
+cached: false
+start_time: '2026-04-19T01:45:00Z'
+end_time: '2026-04-19T02:21:10Z'
+duration_seconds: 2170.0
+citation_count: 5
+notes: >
+  Phenotype-focused curation research for issue #1484. Primary aim was to expand
+  the phenotype section with only exact PMID-backed manifestations and to avoid
+  generalizing niche overlap findings beyond what the literature directly
+  supports.
+---
+
+## Question
+
+What phenotype manifestations of metatropic dysplasia are directly supported by
+primary PMID-backed evidence and precise HPO mappings?
+
+## Key sources reviewed
+
+- PMID:20425821, Camacho et al. 2010. Core clinical and radiographic phenotype
+  plus additional manifestations from the cached full text.
+- PMID:21658220, Andreucci et al. 2011. Spectrum cohort including 15 metatropic
+  dysplasia patients; useful for shared short stature/platyspondyly/progressive
+  scoliosis language.
+- PMID:19232556, Krakow et al. 2009. Nonlethal metatropic dysplasia within the
+  TRPV4 spectrum; useful for progressive scoliosis, metaphyseal involvement, and
+  carpal ossification delay.
+- PMID:28321993, Theroux et al. 2017. Largest metatropic dysplasia anesthetic
+  cohort; useful for spinal canal narrowing/stenosis and airway-related
+  complications.
+- PMID:21964829, Unger et al. 2011. Severe overlap phenotype with fetal akinesia
+  and congenital contractures.
+
+## Phenotypes selected for YAML curation
+
+- Disproportionate short-limb short stature
+  Evidence basis: PMID:20425821 plus PMID:21658220.
+- Kyphoscoliosis
+  Evidence basis: PMID:20425821.
+- Platyspondyly
+  Evidence basis: PMID:21658220.
+- Joint contractures
+  Evidence basis: PMID:20425821 full text.
+- Hypoplasia of the odontoid process
+  Evidence basis: PMID:20425821 full text.
+- Spinal canal stenosis
+  Evidence basis: PMID:28321993.
+- Thoracic hypoplasia and neonatal respiratory distress
+  Evidence basis: PMID:20425821 full text.
+- Metaphyseal widening
+  Evidence basis: PMID:20425821.
+- Dumbbell-shaped long bones
+  Evidence basis: PMID:20425821.
+- Halberd-shaped pelvis
+  Evidence basis: PMID:20425821.
+- Brachydactyly
+  Evidence basis: PMID:20425821.
+- Delayed ossification of carpal bones
+  Evidence basis: PMID:20425821 and PMID:19232556.
+- Frontal bossing and midface retrusion
+  Evidence basis: PMID:20425821.
+- Sensorineural hearing impairment
+  Evidence basis: PMID:20425821 full text.
+
+## Manifestations reviewed but not generalized into the main phenotype list
+
+- Fetal akinesia
+  PMID:21964829 supports this in severe overlap cases caused by certain TRPV4
+  variants, but the paper explicitly frames it as unusual and mutation-specific,
+  so it was not generalized as a core phenotype of metatropic dysplasia.
+- Difficult airway
+  PMID:28321993 supports this as a peri-anesthetic management problem, but it is
+  more a procedural consequence of the skeletal phenotype than a clean disease
+  phenotype term for the YAML phenotype section.
+- Squared-off jaw
+  PMID:20425821 clearly mentions it, but I did not add it because the
+  corresponding HPO grounding was less straightforward than the other
+  craniofacial findings and the current issue prioritized well-grounded ontology
+  specificity.


### PR DESCRIPTION
## Summary
- expand the `Metatropic_Dysplasia.yaml` phenotype section with PMID-backed core skeletal, craniofacial, cervical, thoracic, respiratory, and hearing manifestations
- replace the vague short-stature entry with a more specific disproportionate short-limb short stature term and remove the less-grounded redundant limb undergrowth entry
- add a focused research note documenting which phenotype findings were included and which niche findings were intentionally not generalized

## Why
Issue #1484 asked for a phenotype-only enhancement of `kb/disorders/Metatropic_Dysplasia.yaml` with exact PMID-backed evidence, specific HPO grounding, and removal or softening of unsupported claims.

## Validation
- `just validate kb/disorders/Metatropic_Dysplasia.yaml`
- `just validate-references kb/disorders/Metatropic_Dysplasia.yaml`
- `just validate-terms kb/disorders/Metatropic_Dysplasia.yaml`

All three commands passed locally.

## Scope Notes
- kept the change focused to the phenotype section plus phenotype-specific research provenance
- did not broaden this into unrelated page-wide edits or commit unrelated dirty files already present in the worktree