### PR TITLE
[codex] Enhance Omodysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Omodysplasia.yaml
+++ b/kb/disorders/Omodysplasia.yaml
@@ -1,6 +1,6 @@
 name: Omodysplasia
 creation_date: "2026-04-02T12:00:00Z"
-updated_date: "2026-04-03T12:00:00Z"
+updated_date: "2026-04-19T02:26:30Z"
 category: Mendelian
 description: >
   Omodysplasia is a rare skeletal dysplasia characterized by severe rhizomelic
@@ -346,11 +346,10 @@ pathophysiology:
 phenotypes:
 - category: Musculoskeletal
   name: Rhizomelic limb shortening
-  frequency: VERY_FREQUENT
   description: >
-    Severe shortening predominantly affecting the proximal segments of the limbs
-    (humeri and femora). In the recessive form, both upper and lower extremities
-    are severely affected. In the dominant form, humeral shortening predominates.
+    Proximal limb shortening is a core manifestation. In GPC6-related disease,
+    both upper and lower limbs may be markedly involved, whereas FZD2-related
+    disease can show upper-limb-predominant rhizomelia.
   phenotype_term:
     preferred_term: Rhizomelic limb shortening
     term:
@@ -366,20 +365,57 @@ phenotypes:
       and knees and a distinct face with a short nose, depressed nasal bridge,
       long philtrum, midline haemangiomas in infants and cryptorchidism in males
     explanation: >-
-      Rhizomelic dwarfism is described as a cardinal clinical feature across
-      multiple cases.
+      Supports rhizomelic limb shortening as a hallmark of recessive
+      omodysplasia.
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The proband was a 16-year-old boy, who has been followed from infancy to
+      adolescence. He presented with rhizomelic short stature with elbow
+      restriction
+    explanation: >-
+      Confirms that rhizomelic shortening can also occur in FZD2-related
+      dominant omodysplasia.
+  phenotype_contexts:
+  - subtype: OMOD1
+    onset:
+      onset_category: ANTENATAL
+      notes: Second-semester ultrasonography documented short humeri and femora prenatally.
+    evidence:
+    - reference: PMID:9508243
+      reference_title: "Autosomal-recessive omodysplasia: prenatal diagnosis and histomorphometric assessment of the physeal plates of the long bones."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Second-semester ultrasonography of a female fetus documented short
+        femora and humeri and dislocation of the radii
+      explanation: >-
+        Demonstrates antenatal manifestation of proximal long-bone shortening in
+        recessive omodysplasia.
 - category: Musculoskeletal
   name: Short humerus
-  frequency: VERY_FREQUENT
   description: >
-    Markedly shortened humeri with distal tapering producing a club-like
-    appearance on radiographs, often with broad proximal metaphyses.
+    The humeri are short and often show distal tapering or relative
+    broadening/undermodeling on radiographs.
   phenotype_term:
     preferred_term: Short humerus
     term:
       id: HP:0005792
       label: Short humerus
   evidence:
+  - reference: PMID:2729357
+    reference_title: Omodysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three cases of a new congenital bone disorder associating facial
+      anomalies (depressed nasal bridge, broad base of the nose, long philtrum)
+      with short humeri
+    explanation: >-
+      Original description of dominant omodysplasia identified short humeri as a
+      defining skeletal feature.
   - reference: PMID:29383834
     reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
     supports: SUPPORT
@@ -388,42 +424,50 @@ phenotypes:
       Radiological examination in infancy showed short, broad humeri with
       relatively narrow distal ends
     explanation: >-
-      Confirms short humeri with characteristic distal narrowing as a
-      consistent radiological finding.
+      Confirms shortened humeri with distal narrowing in molecularly confirmed
+      OMOD2.
 - category: Musculoskeletal
   name: Short femur
   subtype: OMOD1
-  frequency: VERY_FREQUENT
   description: >
-    Shortened femora with distal tapering, primarily severe in the recessive form.
+    The femora are shortened in recessive omodysplasia and may show distal
+    tapering or undermodeling.
   phenotype_term:
     preferred_term: Short femur
     term:
       id: HP:0003097
       label: Short femur
   evidence:
+  - reference: PMID:9508243
+    reference_title: "Autosomal-recessive omodysplasia: prenatal diagnosis and histomorphometric assessment of the physeal plates of the long bones."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Second-semester ultrasonography of a female fetus documented short
+      femora and humeri and dislocation of the radii
+    explanation: >-
+      Provides direct evidence that femoral shortening is part of the recessive
+      phenotype and can be detected prenatally.
   - reference: PMID:32655339
     reference_title: "Novel Clinical and Radiological Findings in a Family with Autosomal Recessive Omodysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Both upper and lower limbs are severely affected. These manifestations
-      contrast with normal height and limb shortening restricted to the arms in
-      autosomal dominant omodysplasia (FZD2-related)
+      The pathognomonic radiological findings were distally tapered humeri and
+      femora as well as severe proximal radioulnar diastasis
     explanation: >-
-      Distinguishes the severe four-limb involvement in OMOD1 from the
-      predominantly upper-limb involvement in OMOD2.
+      Confirms the characteristic tapered femoral morphology in molecularly
+      confirmed recessive omodysplasia.
 - category: Musculoskeletal
-  name: Dislocated radial head
-  frequency: VERY_FREQUENT
+  name: Proximal radial head dislocation
   description: >
-    Congenital dislocation of the radial head, typically proximal, with
-    radioulnar diastasis. A pathognomonic radiological finding.
+    Radial head dislocation is a characteristic elbow abnormality and is often
+    accompanied by proximal radioulnar diastasis.
   phenotype_term:
-    preferred_term: Dislocated radial head
+    preferred_term: Proximal radial head dislocation
     term:
-      id: HP:0003083
-      label: Dislocated radial head
+      id: HP:0005070
+      label: Proximal radial head dislocation
   evidence:
   - reference: PMID:14566439
     reference_title: "Recessive omodysplasia: five new cases and review of the literature."
@@ -433,14 +477,40 @@ phenotypes:
       Radiological findings are distal hypoplasia of the short humerus and femur
       with characteristic radial dislocation and radioulnar diastasis
     explanation: >-
-      Identifies radial dislocation and radioulnar diastasis as characteristic
-      radiological findings.
+      Identifies radial head dislocation with radioulnar diastasis as a
+      characteristic radiologic feature of recessive omodysplasia.
+  - reference: PMID:25759469
+    reference_title: "A mutation in FRIZZLED2 impairs Wnt signaling and causes autosomal dominant omodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Autosomal dominant omodysplasia is a rare skeletal dysplasia
+      characterized by short humeri, radial head dislocation, short first
+      metacarpals, facial dysmorphism and genitourinary anomalies
+    explanation: >-
+      Confirms that radial head dislocation is also part of the dominant
+      FZD2-related phenotype.
+  phenotype_contexts:
+  - subtype: OMOD1
+    onset:
+      onset_category: ANTENATAL
+      notes: Prenatal ultrasonography documented dislocation of the radii in a recessive case.
+    evidence:
+    - reference: PMID:9508243
+      reference_title: "Autosomal-recessive omodysplasia: prenatal diagnosis and histomorphometric assessment of the physeal plates of the long bones."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Second-semester ultrasonography of a female fetus documented short
+        femora and humeri and dislocation of the radii
+      explanation: >-
+        Shows antenatal detection of the forearm/elbow dislocation pattern in
+        recessive omodysplasia.
 - category: Musculoskeletal
   name: Limited elbow extension
-  frequency: VERY_FREQUENT
   description: >
-    Restricted elbow movement, particularly limited extension and supination,
-    resulting from the abnormal radial head and humeral morphology.
+    Elbow motion is restricted, particularly extension, in both recessive and
+    dominant disease.
   phenotype_term:
     preferred_term: Limited elbow extension
     term:
@@ -455,36 +525,87 @@ phenotypes:
       Clinical features are rhizomelic dwarfism with limited extension of elbows
       and knees
     explanation: >-
-      Limited elbow extension is a consistent clinical finding across reported
-      cases.
+      Supports elbow extension limitation in recessive omodysplasia.
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He presented with rhizomelic short stature with elbow restriction, mild
+      facial dysmorphism
+    explanation: >-
+      Confirms elbow restriction in a molecularly confirmed dominant case.
+- category: Musculoskeletal
+  name: Limited knee extension
+  subtype: OMOD1
+  description: >
+    Knee extension can be limited in the recessive form alongside the elbow
+    contracture phenotype.
+  phenotype_term:
+    preferred_term: Limited knee extension
+    term:
+      id: HP:0003066
+      label: Limited knee extension
+  evidence:
+  - reference: PMID:14566439
+    reference_title: "Recessive omodysplasia: five new cases and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinical features are rhizomelic dwarfism with limited extension of elbows
+      and knees
+    explanation: >-
+      Directly supports limitation of knee extension in recessive omodysplasia.
+  - reference: PMID:32655339
+    reference_title: "Novel Clinical and Radiological Findings in a Family with Autosomal Recessive Omodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Affected individuals manifest with rhizomelic short stature, decreased
+      mobility of elbow and knee joints as well as craniofacial anomalies
+    explanation: >-
+      Confirms recurrent knee-joint mobility limitation in molecularly
+      confirmed GPC6-related disease.
 - category: Musculoskeletal
   name: Short first metacarpal
   subtype: OMOD2
-  frequency: VERY_FREQUENT
   description: >
-    Shortened first metacarpals, a characteristic finding in the dominant form.
+    Shortening of the first metacarpals is a characteristic hand finding in the
+    dominant form.
   phenotype_term:
     preferred_term: Short first metacarpal
     term:
       id: HP:0010034
       label: Short 1st metacarpal
   evidence:
+  - reference: PMID:25759469
+    reference_title: "A mutation in FRIZZLED2 impairs Wnt signaling and causes autosomal dominant omodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Autosomal dominant omodysplasia is a rare skeletal dysplasia
+      characterized by short humeri, radial head dislocation, short first
+      metacarpals, facial dysmorphism and genitourinary anomalies
+    explanation: >-
+      Establishes short first metacarpals as part of the core dominant
+      phenotype.
   - reference: PMID:29383834
     reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      a rare autosomal dominant (AD) skeletal dysplasia characterized by
-      shortened humeri, short first metacarpal, craniofacial dysmorphism
+      Radiological examination in infancy showed short, broad humeri with
+      relatively narrow distal ends, mildly broad femora, thick proximal ulnae
+      with hypoplastic, dislocated proximal radii, and short first metacarpals
     explanation: >-
-      Short first metacarpal is listed as a defining feature of OMOD2.
+      Provides radiographic confirmation of first-metacarpal shortening in OMOD2.
 - category: Musculoskeletal
   name: Disproportionate short-limb short stature
   subtype: OMOD1
-  frequency: VERY_FREQUENT
   description: >
-    Short stature with disproportionate short limbs is a hallmark of the
-    recessive form. Stature may be relatively preserved in the dominant form.
+    Generalized short stature with disproportionate limb shortening is a major
+    feature of recessive omodysplasia; stature can be near normal in dominant
+    disease.
   phenotype_term:
     preferred_term: Disproportionate short-limb short stature
     term:
@@ -500,14 +621,13 @@ phenotypes:
       short-limbed short stature, craniofacial dysmorphism, and variable
       developmental delay
     explanation: >-
-      Short-limbed short stature is described as a defining characteristic
+      Supports disproportionate short-limb short stature as a defining feature
       of the recessive form.
 - category: Craniofacial
   name: Depressed nasal bridge
-  frequency: VERY_FREQUENT
   description: >
-    A flat or depressed nasal bridge is a consistent craniofacial feature across
-    both subtypes.
+    A depressed nasal bridge is part of the characteristic facial gestalt in
+    both recessive and dominant reports.
   phenotype_term:
     preferred_term: Depressed nasal bridge
     term:
@@ -521,12 +641,22 @@ phenotypes:
     snippet: >-
       a distinct face with a short nose, depressed nasal bridge, long philtrum
     explanation: >-
-      Depressed nasal bridge is listed among the distinct facial features.
+      Supports depressed nasal bridge in recessive omodysplasia.
+  - reference: PMID:2729357
+    reference_title: Omodysplasia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three cases of a new congenital bone disorder associating facial
+      anomalies (depressed nasal bridge, broad base of the nose, long philtrum)
+      with short humeri
+    explanation: >-
+      Original dominant omodysplasia cases also showed a depressed nasal bridge.
 - category: Craniofacial
   name: Long philtrum
-  frequency: VERY_FREQUENT
   description: >
-    An elongated philtrum is a characteristic craniofacial finding.
+    Long philtrum is part of the recurrent facial phenotype in both recessive
+    and dominant omodysplasia.
   phenotype_term:
     preferred_term: Long philtrum
     term:
@@ -540,12 +670,23 @@ phenotypes:
     snippet: >-
       a distinct face with a short nose, depressed nasal bridge, long philtrum
     explanation: >-
-      Long philtrum is a consistent facial feature across reported cases.
+      Supports long philtrum in recessive omodysplasia.
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      craniofacial dysmorphism (frontal bossing, depressed nasal bridge, bifid
+      nasal tip, and long philtrum)
+    explanation: >-
+      Confirms that long philtrum is also part of the dominant OMOD2 facial
+      phenotype.
 - category: Craniofacial
   name: Frontal bossing
-  frequency: FREQUENT
+  subtype: OMOD2
   description: >
-    Prominent forehead, particularly noted in the dominant form.
+    Frontal bossing is part of the Robinow-like craniofacial phenotype reported
+    in dominant omodysplasia.
   phenotype_term:
     preferred_term: Frontal bossing
     term:
@@ -560,12 +701,12 @@ phenotypes:
       craniofacial dysmorphism (frontal bossing, depressed nasal bridge, bifid
       nasal tip, and long philtrum)
     explanation: >-
-      Frontal bossing is listed as a craniofacial feature of the dominant form.
+      Frontal bossing is listed among the defining craniofacial features of OMOD2.
 - category: Craniofacial
   name: Short nose
-  frequency: VERY_FREQUENT
   description: >
-    A short nose with anteverted nostrils is a cardinal facial feature.
+    Short nose is part of the characteristic facial appearance in both forms,
+    although the accompanying nasal configuration differs across reports.
   phenotype_term:
     preferred_term: Short nose
     term:
@@ -579,11 +720,148 @@ phenotypes:
     snippet: >-
       a distinct face with a short nose, depressed nasal bridge, long philtrum
     explanation: >-
-      Short nose is consistently described across omodysplasia cases.
+      Supports short nose in recessive omodysplasia.
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He presented with rhizomelic short stature with elbow restriction, mild
+      facial dysmorphism (depressed broad bridge, short nose, anteverted
+      nostrils, long philtrum, and low-set ears), and genital hypoplasia
+    explanation: >-
+      Confirms short nose in a molecularly confirmed dominant case.
+- category: Craniofacial
+  name: Anteverted nares
+  subtype: OMOD2
+  description: >
+    Anteverted nares are part of the reported dominant craniofacial phenotype.
+  phenotype_term:
+    preferred_term: Anteverted nares
+    term:
+      id: HP:0000463
+      label: Anteverted nares
+  evidence:
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He presented with rhizomelic short stature with elbow restriction, mild
+      facial dysmorphism (depressed broad bridge, short nose, anteverted
+      nostrils, long philtrum, and low-set ears), and genital hypoplasia
+    explanation: >-
+      Directly supports anteverted nares in FZD2-related dominant omodysplasia.
+- category: Craniofacial
+  name: Bifid nasal tip
+  subtype: OMOD2
+  description: >
+    Bifid nasal tip has been reported as part of the OMOD2 facial phenotype.
+  phenotype_term:
+    preferred_term: Bifid nasal tip
+    term:
+      id: HP:0000456
+      label: Bifid nasal tip
+  evidence:
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      craniofacial dysmorphism (frontal bossing, depressed nasal bridge, bifid
+      nasal tip, and long philtrum)
+    explanation: >-
+      Directly supports bifid nasal tip in dominant omodysplasia.
+- category: Craniofacial
+  name: Low-set ears
+  subtype: OMOD2
+  description: >
+    Low-set ears were described in a molecularly confirmed dominant case.
+  phenotype_term:
+    preferred_term: Low-set ears
+    term:
+      id: HP:0000369
+      label: Low-set ears
+  evidence:
+  - reference: PMID:29383834
+    reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He presented with rhizomelic short stature with elbow restriction, mild
+      facial dysmorphism (depressed broad bridge, short nose, anteverted
+      nostrils, long philtrum, and low-set ears), and genital hypoplasia
+    explanation: >-
+      Supports low-set ears as part of the OMOD2 facial phenotype.
+- category: Craniofacial
+  name: Cleft lip
+  subtype: OMOD2
+  description: >
+    Orofacial clefting with cleft lip has been reported in a subset of
+    molecularly confirmed FZD2-related cases.
+  phenotype_term:
+    preferred_term: Cleft lip
+    term:
+      id: HP:0410030
+      label: Cleft lip
+  evidence:
+  - reference: PMID:29230162
+    reference_title: "A Novel de novo FZD2 Mutation in a Patient with Autosomal Dominant Omodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We described a heterozygous de novo mutation (G434V) in the frizzled
+      class receptor 2 (FZD2) gene in a patient with distinct facial features
+      including hypertelorism, bilateral cleft lip/palate, short nose with a
+      broad nasal bridge, microretrognathia
+    explanation: >-
+      Documents cleft lip in a molecularly confirmed dominant case.
+  - reference: PMID:41022130
+    reference_title: "[Omodysplasia Type II - first publication of de novo Mutation in FZD2 Gene]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We describe a prenatally detected case with shortened upper extremities,
+      cleft lip and palate and suspected genital hypoplasia
+    explanation: >-
+      Additional recent prenatal case confirms that cleft lip can be part of
+      the OMOD2 spectrum.
+- category: Craniofacial
+  name: Cleft palate
+  subtype: OMOD2
+  description: >
+    Cleft palate has been reported with FZD2-related dominant omodysplasia,
+    usually alongside cleft lip.
+  phenotype_term:
+    preferred_term: Cleft palate
+    term:
+      id: HP:0000175
+      label: Cleft palate
+  evidence:
+  - reference: PMID:29230162
+    reference_title: "A Novel de novo FZD2 Mutation in a Patient with Autosomal Dominant Omodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We described a heterozygous de novo mutation (G434V) in the frizzled
+      class receptor 2 (FZD2) gene in a patient with distinct facial features
+      including hypertelorism, bilateral cleft lip/palate, short nose with a
+      broad nasal bridge, microretrognathia
+    explanation: >-
+      Documents cleft palate in a molecularly confirmed dominant case.
+  - reference: PMID:41022130
+    reference_title: "[Omodysplasia Type II - first publication of de novo Mutation in FZD2 Gene]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We describe a prenatally detected case with shortened upper extremities,
+      cleft lip and palate and suspected genital hypoplasia
+    explanation: >-
+      Additional recent prenatal case confirms that cleft palate can be part of
+      the OMOD2 spectrum.
 - category: Dermatological
   name: Facial midline hemangioma
   subtype: OMOD1
-  frequency: FREQUENT
   description: >
     Midline facial hemangiomas in infancy are reported in the recessive form.
   phenotype_term:
@@ -604,7 +882,6 @@ phenotypes:
 - category: Genitourinary
   name: Cryptorchidism
   subtype: OMOD1
-  frequency: FREQUENT
   description: >
     Cryptorchidism in males is a recurrent feature in the recessive form.
   phenotype_term:
@@ -622,17 +899,16 @@ phenotypes:
     explanation: >-
       Cryptorchidism is described as a feature in males with the recessive form.
 - category: Genitourinary
-  name: Genital hypoplasia
+  name: External genital hypoplasia
   subtype: OMOD2
-  frequency: FREQUENT
   description: >
-    Genital hypoplasia including micropenis has been reported in males with
-    the dominant form.
+    Hypoplastic male external genitalia are part of the dominant phenotype;
+    ambiguous genitalia was reported in one affected boy.
   phenotype_term:
-    preferred_term: Micropenis
+    preferred_term: External genital hypoplasia
     term:
-      id: HP:0000054
-      label: Micropenis
+      id: HP:0003241
+      label: External genital hypoplasia
   evidence:
   - reference: PMID:29383834
     reference_title: "Nonsense mutations in FZD2 cause autosomal-dominant omodysplasia: Robinow syndrome-like phenotypes."
@@ -643,18 +919,57 @@ phenotypes:
       (depressed broad bridge, short nose, anteverted nostrils, long philtrum,
       and low-set ears), and genital hypoplasia
     explanation: >-
-      Genital hypoplasia is described as a feature of dominant omodysplasia.
-- category: Neurological
-  name: Intellectual disability
-  frequency: OCCASIONAL
+      Supports genital hypoplasia in a molecularly confirmed dominant case.
+  - reference: PMID:12210345
+    reference_title: "Omodysplasia: an affected mother and son."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Her son had ambiguous genitalia and similar skeletal manifestations as
+      his mother. A comparison to other known and suspected cases of dominant
+      omodysplasia is presented. Our observations confirm the existence of a
+      dominant variant of omodysplasia, document genital hypoplasia as an
+      important feature of this syndrome in males
+    explanation: >-
+      Independent dominant family confirms that male genital hypoplasia is an
+      important feature and can present as ambiguous genitalia.
+- category: Cardiovascular
+  name: Congenital heart defect
+  subtype: OMOD1
   description: >
-    Variable developmental delay and intellectual disability have been reported,
-    more consistently in the recessive form and occasionally in the dominant form.
+    Congenital heart defects have been reported in recessive omodysplasia, but
+    current evidence supports them as an uncommon associated finding rather than
+    a core diagnostic feature.
   phenotype_term:
-    preferred_term: Intellectual disability
+    preferred_term: Congenital heart defect
     term:
-      id: HP:0001249
-      label: Intellectual disability
+      id: HP:0001627
+      label: Abnormal heart morphology
+  evidence:
+  - reference: PMID:8209882
+    reference_title: "Parental consanguinity in two sibs with omodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Two sibs with omodysplasia were born to phenotypically normal but
+      consanguineous parents. They had severe micromelic dwarfism, facial
+      anomalies, and mental retardation. One had a congenital heart defect
+    explanation: >-
+      Documents congenital heart defect in a molecularly confirmed recessive
+      family, supporting inclusion as an associated but apparently uncommon
+      extraskeletal manifestation.
+- category: Neurological
+  name: Global developmental delay
+  subtype: OMOD1
+  description: >
+    Neurodevelopmental delay has been reported variably in recessive
+    omodysplasia; current evidence does not support treating intellectual
+    disability as a consistent dominant-feature claim.
+  phenotype_term:
+    preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
   evidence:
   - reference: PMID:19481194
     reference_title: "Mutations in the heparan-sulfate proteoglycan glypican 6 (GPC6) impair endochondral ossification and cause recessive omodysplasia."
@@ -664,16 +979,8 @@ phenotypes:
       short-limbed short stature, craniofacial dysmorphism, and variable
       developmental delay
     explanation: >-
-      Variable developmental delay is described in the recessive form.
-  - reference: PMID:30455931
-    reference_title: "Two unrelated patients with autosomal dominant omodysplasia and FRIZZLED2 mutations."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      intellectual disability as seen in our patient is not typical
-    explanation: >-
-      Intellectual disability can occur in dominant omodysplasia but is
-      acknowledged as atypical.
+      Supports variable developmental delay in GPC6-related recessive
+      omodysplasia.
 genetic:
 - name: GPC6 mutations
   subtype: OMOD1

--- a/references_cache/PMID_12210345.md
+++ b/references_cache/PMID_12210345.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:12210345"
+title: "Omodysplasia: an affected mother and son."
+authors:
+- Venditti CP
+- Farmer J
+- Russell KL
+- Friedrich CA
+- Alter C
+- Canning D
+- Whitaker L
+- Mennuti MT
+- Driscoll DA
+- Zackai EH
+journal: Am J Med Genet
+year: '2002'
+doi: 10.1002/ajmg.10555
+keywords:
+- "Abnormalities, Multiple/diagnostic imaging, genetics, pathology"
+- Adult
+- "Dwarfism/genetics, pathology"
+- Face/abnormalities
+- Female
+- "Femur/abnormalities, diagnostic imaging"
+- "Growth Disorders/diagnostic imaging, genetics, pathology"
+- "Hand Deformities, Congenital/diagnostic imaging, genetics, pathology"
+- Humans
+- "Humerus/abnormalities, diagnostic imaging"
+- "Infant, Newborn"
+- Male
+- Mothers
+- "Osteochondrodysplasias/diagnostic imaging, genetics, pathology"
+- Pregnancy
+- Radiography
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Omodysplasia: an affected mother and son.
+**Authors:** Venditti CP, Farmer J, Russell KL, Friedrich CA, Alter C, Canning D, Whitaker L, Mennuti MT, Driscoll DA, Zackai EH
+**Journal:** Am J Med Genet (2002)
+**DOI:** [10.1002/ajmg.10555](https://doi.org/10.1002/ajmg.10555)
+
+## Content
+
+1. Am J Med Genet. 2002 Aug 1;111(2):169-77. doi: 10.1002/ajmg.10555.
+
+Omodysplasia: an affected mother and son.
+
+Venditti CP(1), Farmer J, Russell KL, Friedrich CA, Alter C, Canning D, Whitaker 
+L, Mennuti MT, Driscoll DA, Zackai EH.
+
+Author information:
+(1)Division of Human Genetics and Molecular Biology, Children's Hospital of 
+Philadelphia, Philadelphia, Pennsylvania 19104, USA.
+
+We describe a second family with mother to son transmission of omodysplasia, a 
+rare skeletal dysplasia characterized by shortened humeri, shortened first 
+metacarpals and craniofacial dysmorphism. The mother in this family had been 
+diagnosed previously with Robinow syndrome; subsequently, her diagnosis was 
+reclassified. Her pregnancy was closely monitored antenatally with serial 
+ultrasound examinations. Delayed ossification of the humerus was noted 
+prenatally. Her son had ambiguous genitalia and similar skeletal manifestations 
+as his mother. A comparison to other known and suspected cases of dominant 
+omodysplasia is presented. Our observations confirm the existence of a dominant 
+variant of omodysplasia, document genital hypoplasia as an important feature of 
+this syndrome in males and highlight the need to differentiate this entity from 
+Robinow syndrome.
+
+Copyright 2002 Wiley-Liss, Inc.
+
+DOI: 10.1002/ajmg.10555
+PMID: 12210345 [Indexed for MEDLINE]

--- a/references_cache/PMID_2729357.md
+++ b/references_cache/PMID_2729357.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:2729357"
+title: Omodysplasia.
+authors:
+- Maroteaux P
+- Sauvegrain J
+- Chrispin A
+- Farriaux JP
+journal: Am J Med Genet
+year: '1989'
+doi: 10.1002/ajmg.1320320321
+keywords:
+- "Abnormalities, Multiple/diagnostic imaging, pathology"
+- Adult
+- Elbow/abnormalities
+- Face/abnormalities
+- Female
+- "Femur/abnormalities, diagnostic imaging"
+- "Growth Disorders/congenital, diagnostic imaging"
+- Humans
+- "Humerus/abnormalities, diagnostic imaging"
+- Infant
+- "Infant, Newborn"
+- Male
+- "Osteochondrodysplasias/congenital, pathology"
+- Radiography
+content_type: abstract_only
+---
+
+# Omodysplasia.
+**Authors:** Maroteaux P, Sauvegrain J, Chrispin A, Farriaux JP
+**Journal:** Am J Med Genet (1989)
+**DOI:** [10.1002/ajmg.1320320321](https://doi.org/10.1002/ajmg.1320320321)
+
+## Content
+
+1. Am J Med Genet. 1989 Mar;32(3):371-5. doi: 10.1002/ajmg.1320320321.
+
+Omodysplasia.
+
+Maroteaux P(1), Sauvegrain J, Chrispin A, Farriaux JP.
+
+Author information:
+(1)Clinique Maurice Lamy, Hopital des Enfants-Malades, France.
+
+Three cases of a new congenital bone disorder associating facial anomalies 
+(depressed nasal bridge, broad base of the nose, long philtrum) with short 
+humeri. The complex skeletal abnormalities consist of a defect of growth of the 
+distal end of the humerus, a hypoplastic everted condyle, an upper radioulnar 
+diastasis, and a anterolateral dislocation of the head of the radius. The 
+condition is dominantly inherited. Two other cases with the same facial 
+anomalies and osteoarticular abnormalities of the upper limbs are described. 
+These cases also showed a severe micromelic dwarfism due to shortness of the 
+long bones, particularly the femora. The present authors consider that these 
+represent variable expressivity of the same disorder and propose that this 
+condition be called omodysplasia (from the Greek term for humerus).
+
+DOI: 10.1002/ajmg.1320320321
+PMID: 2729357 [Indexed for MEDLINE]

--- a/references_cache/PMID_41022130.md
+++ b/references_cache/PMID_41022130.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:41022130"
+title: "[Omodysplasia Type II - first publication of de novo Mutation in FZD2 Gene]."
+authors:
+- Jurk S
+- Schröck K
+- Biskup S
+- Stepan H
+- Springer C
+journal: Z Geburtshilfe Neonatol
+year: '2026'
+doi: 10.1055/a-2689-2624
+keywords:
+- Humans
+- Female
+- Frizzled Receptors/genetics
+- Mutation/genetics
+- "Abnormalities, Multiple/genetics, diagnosis"
+- Genetic Predisposition to Disease/genetics
+- Pregnancy
+- Male
+content_type: abstract_only
+---
+
+# [Omodysplasia Type II - first publication of de novo Mutation in FZD2 Gene].
+**Authors:** Jurk S, Schröck K, Biskup S, Stepan H, Springer C
+**Journal:** Z Geburtshilfe Neonatol (2026)
+**DOI:** [10.1055/a-2689-2624](https://doi.org/10.1055/a-2689-2624)
+
+## Content
+
+1. Z Geburtshilfe Neonatol. 2026 Feb;230(1):51-54. doi: 10.1055/a-2689-2624. Epub
+ 2025 Sep 29.
+
+[Omodysplasia Type II - first publication of de novo Mutation in FZD2 Gene].
+
+[Article in German; Abstract available in German from the publisher]
+
+Jurk S(1), Schröck K(2), Biskup S(3), Stepan H(4), Springer C(1).
+
+Author information:
+(1)Geburtshilfe und Pränataldiagnostik, St. Elisabeth-Krankenhaus Leipzig, 
+Leipzig, Germany.
+(2)Humangenetik, MVZ Mitteldeutscher Praxisverbund Humangenetik GmbH, Leipzig, 
+Germany.
+(3)Humangenetik, CeGaT und Praxis für Humangenetik Tübingen, Tübingen, Germany.
+(4)Geburtsmedizin, Universitätsfrauenklinik Leipzig, Leipzig, Germany.
+
+Omodysplasia type II (autosomal dominant) is a very rare skeletal dysplasia with 
+facial dysmorphism and urogenital abnormalities. Causal are alterations in the 
+FZD2 gene. We describe a prenatally detected case with shortened upper 
+extremities, cleft lip and palate and suspected genital hypoplasia. The de novo 
+mutation in the FZD2 gene in the affected fetus, which has not been described 
+yet, was found in the literature and is most likely the cause of the symptoms. 
+To our knowledge, it is the first publication of the de novo mutation in the 
+FZD2 gene.
+
+Publisher: Die Omodysplasie Typ II (autosomal-dominant) ist eine sehr seltene 
+Erkrankung, welche mit einer Skelettanomalie, fazialen Dysmorphie und 
+urogenitalen Auffälligkeiten einhergeht. Kausal finden sich Alterationen im 
+FZD2-Gen. Wir beschreiben einen pränatal detektierten Fall mit verkürzten oberen 
+Extremitäten, Lippen-Kiefer-Gaumenspalte und Verdacht auf Genitalhypoplasie. 
+Beim betroffenen Fetus wurde in der Literatur die noch nicht beschriebene de 
+novo Mutation im Gen FZD2 nachgewiesen, die höchstwahrscheinlich ursächlich für 
+die Symptomatik ist. Nach unserem Wissen, ist es die Erstpublikation der de novo 
+Mutation im Gen FZD2.
+
+Thieme. All rights reserved.
+
+DOI: 10.1055/a-2689-2624
+PMID: 41022130 [Indexed for MEDLINE]
+
+Conflict of interest statement: Die Autorinnen/Autoren geben an, dass kein 
+Interessenkonflikt besteht.

--- a/references_cache/PMID_8209882.md
+++ b/references_cache/PMID_8209882.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:8209882"
+title: Parental consanguinity in two sibs with omodysplasia.
+authors:
+- Baxová A
+- Maroteaux P
+- Barosová J
+- Netriová I
+journal: Am J Med Genet
+year: '1994'
+doi: 10.1002/ajmg.1320490303
+keywords:
+- Adult
+- "Bone Diseases, Developmental/diagnostic imaging, genetics, pathology"
+- Consanguinity
+- Dwarfism/genetics
+- Face/abnormalities
+- Female
+- "Genes, Recessive"
+- Humans
+- "Humerus/abnormalities, diagnostic imaging"
+- Infant
+- "Infant, Newborn"
+- Intellectual Disability/genetics
+- Male
+- Pedigree
+- Radiography
+content_type: abstract_only
+---
+
+# Parental consanguinity in two sibs with omodysplasia.
+**Authors:** Baxová A, Maroteaux P, Barosová J, Netriová I
+**Journal:** Am J Med Genet (1994)
+**DOI:** [10.1002/ajmg.1320490303](https://doi.org/10.1002/ajmg.1320490303)
+
+## Content
+
+1. Am J Med Genet. 1994 Feb 1;49(3):263-5. doi: 10.1002/ajmg.1320490303.
+
+Parental consanguinity in two sibs with omodysplasia.
+
+Baxová A(1), Maroteaux P, Barosová J, Netriová I.
+
+Author information:
+(1)Department of Clinical Genetics, Dérerova nemocniaca, Bratislava, Slovakia.
+
+Comment in
+    Am J Med Genet. 1995 Sep 25;58(4):377-8. doi: 10.1002/ajmg.1320580416.
+
+Two sibs with omodysplasia were born to phenotypically normal but consanguineous 
+parents. They had severe micromelic dwarfism, facial anomalies, and mental 
+retardation. One had a congenital heart defect. The radiographic findings are 
+typical: hypoplastic distal end of the humerus with radioulnar diastasis. 
+Parental consanguinity and clinical manifestations in 2 sibs suggest autosomal 
+recessive inheritance.
+
+DOI: 10.1002/ajmg.1320490303
+PMID: 8209882 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- tighten the phenotype section in `kb/disorders/Omodysplasia.yaml` to use PMID-backed claims only
- add missing clinically important OMOD1/OMOD2 phenotypes supported by exact source text
- remove unsupported frequency inflation and correct the dominant genital phenotype mapping
- add the new PMID caches needed for the revised phenotype evidence

## Why
Issue #1485 asks for the Omodysplasia phenotype section to be as complete and evidence-backed as possible without broadening into an unrelated full-page rewrite.

## Impact
The disorder entry now distinguishes recurrent/core findings from limited associated findings more carefully, adds prenatal/contextual evidence where it is directly stated, and reduces overclaiming in the phenotype section.

## Validation
- `just validate kb/disorders/Omodysplasia.yaml`
- `just validate-references kb/disorders/Omodysplasia.yaml`
- `just validate-terms kb/disorders/Omodysplasia.yaml`

All three commands passed.