### PR TITLE
[codex] issue #1486: enhance Opsismodysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Opsismodysplasia.yaml
+++ b/kb/disorders/Opsismodysplasia.yaml
@@ -1,6 +1,6 @@
 name: Opsismodysplasia
 creation_date: "2026-04-02T00:00:00Z"
-updated_date: "2026-04-07T00:00:00Z"
+updated_date: "2026-04-19T02:21:57Z"
 category: Mendelian
 description: >
   Opsismodysplasia is a rare autosomal recessive skeletal chondrodysplasia caused by
@@ -265,35 +265,44 @@ pathophysiology:
     snippet: "Renal phosphate wasting is associated with severe bone demineralization and a more severe phenotype."
     explanation: Establishes that phosphate wasting worsens the skeletal phenotype.
 phenotypes:
-- name: Prenatal-onset short stature
+- name: Severe short stature
   category: Clinical
   description: >
-    Severe short stature is present from birth, with prenatal onset detectable
-    by ultrasound. Limbs are disproportionately shortened.
-  frequency: HP_0040281
+    Marked linear growth impairment is a core manifestation of
+    opsismodysplasia.
   phenotype_term:
     preferred_term: Severe short stature
     term:
       id: HP:0003510
       label: Severe short stature
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:40620719
+    reference_title: "Pamidronate Treatment of a Patient with Opsismodysplasia and a Novel INPPL1 Variant: Efficacy, Mechanism, and Clinical Outcomes."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: GeneReviews entry establishing the cardinal features of the disorder.
+    snippet: "Initial evaluations showed severe short stature and low bone mineral density (DEXA SDS: -3.16)."
+    explanation: Recent case evidence confirms severe short stature as a core phenotype.
 - name: Micromelia
   category: Clinical
   description: >
     Extremely short limbs with disproportionate shortening, particularly of the
     hands and feet.
-  frequency: HP_0040281
   phenotype_term:
     preferred_term: Micromelia
     term:
       id: HP:0002983
       label: Micromelia
+  phenotype_contexts:
+  - onset:
+      onset_category: ANTENATAL
+      notes: The landmark molecular series described limb shortening as pre- and postnatal.
+    evidence:
+    - reference: PMID:23273569
+      reference_title: "Exome sequencing identifies INPPL1 mutations as a cause of opsismodysplasia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Opsismodysplasia (OPS) is a severe autosomal-recessive chondrodysplasia characterized by pre- and postnatal micromelia with extremely short hands and feet."
+      explanation: Directly supports antenatal onset of micromelia.
   evidence:
   - reference: PMID:23273569
     reference_title: "Exome sequencing identifies INPPL1 mutations as a cause of opsismodysplasia."
@@ -301,29 +310,27 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Opsismodysplasia (OPS) is a severe autosomal-recessive chondrodysplasia characterized by pre- and postnatal micromelia with extremely short hands and feet."
     explanation: Micromelia with short hands and feet is a defining feature.
-- name: Platyspondyly
+- name: Severe platyspondyly
   category: Clinical
   description: >
     Flattened vertebral bodies are a consistent radiographic finding.
-  frequency: HP_0040281
   phenotype_term:
-    preferred_term: Platyspondyly
+    preferred_term: Severe platyspondyly
     term:
-      id: HP:0000926
-      label: Platyspondyly
+      id: HP:0004565
+      label: Severe platyspondyly
   evidence:
-  - reference: PMID:23552673
-    reference_title: "Exome sequencing identifies a novel INPPL1 mutation in opsismodysplasia."
+  - reference: PMID:23273569
+    reference_title: "Exome sequencing identifies INPPL1 mutations as a cause of opsismodysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Opsismodysplasia is an autosomal recessive skeletal disorder characterized by facial dysmorphism, micromelia, platyspondyly and retarded bone maturation."
-    explanation: Platyspondyly is listed as a cardinal feature.
+    snippet: "The main radiological features are severe platyspondyly, squared metacarpals, delayed skeletal ossification, and metaphyseal cupping."
+    explanation: The landmark molecular cohort identifies severe platyspondyly as a main radiographic feature.
 - name: Delayed skeletal maturation
   category: Clinical
   description: >
     Markedly delayed bone age with retarded ossification of epiphyses is a
     hallmark radiographic finding.
-  frequency: HP_0040281
   phenotype_term:
     preferred_term: Delayed skeletal maturation
     term:
@@ -341,22 +348,37 @@ phenotypes:
   description: >
     Concave, cupped metaphyses of the long bones and tubular bones of the hands
     and feet are characteristic radiographic findings.
-  frequency: HP_0040281
   phenotype_term:
     preferred_term: Metaphyseal cupping
     term:
       id: HP:0003021
       label: Metaphyseal cupping
   evidence:
-  - reference: PMID:39911177
-    reference_title: "A Case of Opsismodysplasia with a Novel INPPL1 Variant."
+  - reference: PMID:23273569
+    reference_title: "Exome sequencing identifies INPPL1 mutations as a cause of opsismodysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Opsismodysplasia is a rare autosomal recessive genetic skeletal disorder characterized by short stature, short limbs, small hands and feet, delayed bone age, severe platyspondyly, metaphyseal cupping, and facial dysmorphism."
-    explanation: Metaphyseal cupping is listed among the defining radiographic features.
+    snippet: "The main radiological features are severe platyspondyly, squared metacarpals, delayed skeletal ossification, and metaphyseal cupping."
+    explanation: The defining molecular cohort lists metaphyseal cupping among the main radiographic abnormalities.
+- name: Delayed epiphyseal ossification
+  category: Clinical
+  description: >
+    Delayed mineralization and appearance of secondary ossification centers is a
+    defining radiographic feature.
+  phenotype_term:
+    preferred_term: Delayed epiphyseal ossification
+    term:
+      id: HP:0002663
+      label: Delayed epiphyseal ossification
+  evidence:
+  - reference: PMID:26157786
+    reference_title: "Opsismodysplasia: Phosphate Wasting Osteodystrophy Responds to Bisphosphonate Therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The main radiological features are severe platyspondyly, short long bones including squared metacarpals, delayed epiphyseal ossification, and metaphyseal flaring and cupping (7–10)."
+    explanation: This case-based review directly identifies delayed epiphyseal ossification as a core radiographic abnormality.
 - name: Relative macrocephaly
   category: Clinical
-  frequency: HP_0040281
   description: >
     Head circumference is relatively large compared to the shortened trunk and
     limbs, contributing to the characteristic craniofacial appearance.
@@ -366,15 +388,31 @@ phenotypes:
       id: HP:0004482
       label: Relative macrocephaly
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:39911177
+    reference_title: "A Case of Opsismodysplasia with a Novel INPPL1 Variant."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Relative macrocephaly is listed among the characteristic facial features.
+    snippet: "He had dysmorphic findings including relative macrocephaly, midface hypoplasia, depressed nasal bridge, anteverted nostrils, long philtrum, small hands and feet, and brachydactyly."
+    explanation: Recent case evidence documents relative macrocephaly as part of the characteristic craniofacial gestalt.
+- name: Large fontanelles
+  category: Clinical
+  description: >
+    Delayed closure and persistent widening of the anterior fontanelle have been
+    reported in surviving children.
+  phenotype_term:
+    preferred_term: Large fontanelles
+    term:
+      id: HP:0000239
+      label: Large fontanelles
+  evidence:
+  - reference: PMID:24953221
+    reference_title: "Opsismodysplasia resulting from an insertion mutation in the SH2 domain, which destabilizes INPPL1."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "She had wide open anterior fontanelles which closed at six years of age."
+    explanation: This patient report shows persistent large fontanelles well beyond infancy.
 - name: Frontal bossing
   category: Clinical
-  frequency: HP_0040281
   description: Prominent forehead.
   phenotype_term:
     preferred_term: Frontal bossing
@@ -382,31 +420,29 @@ phenotypes:
       id: HP:0002007
       label: Frontal bossing
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:34094554
+    reference_title: "Prenatal-onset INPPL1-related skeletal dysplasia in two unrelated families: Diagnosis and prediction of lethality."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Prominent forehead (frontal bossing) is a characteristic facial feature.
+    snippet: "Opsismodysplasia is an autosomal recessive osteochondrodysplasia disorders characterized by a severe delay in bone maturation. This leads to rhizomelic micromelia with small hands and feet, relative macrocephaly, and craniofacial dysmorphism including frontal bossing, short nose with anteverted nares and depressed nasal bridge, long philtrum, and abnormal ears."
+    explanation: Prenatal imaging demonstrates frontal bossing in an affected fetus.
 - name: Midface retrusion
   category: Clinical
-  frequency: HP_0040281
   description: Underdevelopment of the midface structures.
   phenotype_term:
-    preferred_term: Midface retrusion
+    preferred_term: Midface hypoplasia
     term:
       id: HP:0011800
       label: Midface retrusion
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:39911177
+    reference_title: "A Case of Opsismodysplasia with a Novel INPPL1 Variant."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Midface retrusion is among the characteristic facial features.
+    snippet: "He had dysmorphic findings including relative macrocephaly, midface hypoplasia, depressed nasal bridge, anteverted nostrils, long philtrum, small hands and feet, and brachydactyly."
+    explanation: The reported midface hypoplasia corresponds to the characteristic midfacial retrusion seen in opsismodysplasia.
 - name: Depressed nasal bridge
   category: Clinical
-  frequency: HP_0040281
   description: Flattened nasal bridge.
   phenotype_term:
     preferred_term: Depressed nasal bridge
@@ -414,15 +450,14 @@ phenotypes:
       id: HP:0005280
       label: Depressed nasal bridge
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:39911177
+    reference_title: "A Case of Opsismodysplasia with a Novel INPPL1 Variant."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Depressed nasal bridge is among the characteristic facial features.
+    snippet: "He had dysmorphic findings including relative macrocephaly, midface hypoplasia, depressed nasal bridge, anteverted nostrils, long philtrum, small hands and feet, and brachydactyly."
+    explanation: The depressed nasal bridge is explicitly reported in a recent molecularly confirmed case.
 - name: Short nose
   category: Clinical
-  frequency: HP_0040281
   description: Shortened nasal length.
   phenotype_term:
     preferred_term: Short nose
@@ -430,15 +465,14 @@ phenotypes:
       id: HP:0003196
       label: Short nose
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:34094554
+    reference_title: "Prenatal-onset INPPL1-related skeletal dysplasia in two unrelated families: Diagnosis and prediction of lethality."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Short nose is among the characteristic facial features.
+    snippet: "Examination of the newborn (case A) shows short limbs with small trident hands and feet, and craniofacial dysmorphism including hypertelorism, depressed nasal bridge, short nose with anteverted nares and depressed nasal bridge, long philtrum, and low set deformed ears."
+    explanation: The postnatal examination in a molecularly confirmed newborn documents a short nose.
 - name: Anteverted nares
   category: Clinical
-  frequency: HP_0040281
   description: Upturned nostrils.
   phenotype_term:
     preferred_term: Anteverted nares
@@ -446,15 +480,14 @@ phenotypes:
       id: HP:0000463
       label: Anteverted nares
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:34094554
+    reference_title: "Prenatal-onset INPPL1-related skeletal dysplasia in two unrelated families: Diagnosis and prediction of lethality."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Anteverted nares is among the characteristic facial features.
+    snippet: "Examination of the newborn (case A) shows short limbs with small trident hands and feet, and craniofacial dysmorphism including hypertelorism, depressed nasal bridge, short nose with anteverted nares and depressed nasal bridge, long philtrum, and low set deformed ears."
+    explanation: The newborn examination explicitly reports anteverted nares.
 - name: Long philtrum
   category: Clinical
-  frequency: HP_0040281
   description: Increased distance between the nasal base and upper lip.
   phenotype_term:
     preferred_term: Long philtrum
@@ -462,15 +495,14 @@ phenotypes:
       id: HP:0000343
       label: Long philtrum
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:39911177
+    reference_title: "A Case of Opsismodysplasia with a Novel INPPL1 Variant."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Long philtrum is among the characteristic facial features.
+    snippet: "He had dysmorphic findings including relative macrocephaly, midface hypoplasia, depressed nasal bridge, anteverted nostrils, long philtrum, small hands and feet, and brachydactyly."
+    explanation: The long philtrum is part of the recurrent craniofacial phenotype.
 - name: Bowing of the long bones
   category: Clinical
-  frequency: HP_0040281
   description: Bowed long bones, particularly of the lower extremities.
   phenotype_term:
     preferred_term: Bowing of the long bones
@@ -478,54 +510,147 @@ phenotypes:
       id: HP:0006487
       label: Bowing of the long bones
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:27233067
+    reference_title: "Novel compound heterozygous mutations in inositol polyphosphate phosphatase-like 1 in a family with severe opsismodysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "INPPL1-related opsismodysplasia is characterized by prenatal-onset short stature, short, bowed limbs, characteristic facial features (relative macrocephaly, prominent forehead, midface retrusion, depressed nasal bridge, short nose, anteverted nares, relatively long philtrum)."
-    explanation: Bowed limbs are listed as a characteristic feature.
-- name: Delayed epiphyseal ossification
+    snippet: "Radiographs of fetus #2 showed hydropic changes and short limbs with flaring and metaphyseal cupping were reported. Both distal femoral metaphyses appeared irregular and the radii, femora and tibae were bowed (Figure 1)."
+    explanation: Prenatal radiographs in a severe familial case document bowing of multiple long bones.
+- name: Flat acetabular roof
   category: Clinical
-  frequency: HP_0040281
   description: >
-    Delayed ossification of the epiphyses is a defining radiographic feature,
-    central to the disease name (opsismo- = late maturation).
+    Pelvic radiographs can show horizontally oriented, dysplastic acetabular
+    roofs.
   phenotype_term:
-    preferred_term: Delayed epiphyseal ossification
+    preferred_term: Flat acetabular roof
     term:
-      id: HP:0002663
-      label: Delayed epiphyseal ossification
+      id: HP:0003180
+      label: Flat acetabular roof
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:27233067
+    reference_title: "Novel compound heterozygous mutations in inositol polyphosphate phosphatase-like 1 in a family with severe opsismodysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "small hands and feet, delayed epiphyseal mineralization, metaphyseal cupping, and platyspondyly."
-    explanation: GeneReviews identifies delayed epiphyseal mineralization as a core radiographic feature of INPPL1-related opsismodysplasia.
+    snippet: "The iliac bones were decreased in vertical height with horizontal orientation of the acetabular roofs."
+    explanation: This radiographic description directly supports a flat acetabular roof phenotype.
+- name: Narrow chest
+  category: Clinical
+  description: >
+    A small thorax is a recurrent prenatal and postnatal finding and likely
+    contributes to respiratory compromise in severe cases.
+  phenotype_term:
+    preferred_term: Narrow chest
+    term:
+      id: HP:0000774
+      label: Narrow chest
+  evidence:
+  - reference: PMID:34094554
+    reference_title: "Prenatal-onset INPPL1-related skeletal dysplasia in two unrelated families: Diagnosis and prediction of lethality."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Chest appears narrow and abdomen is protuberant."
+    explanation: Prenatal imaging demonstrates a narrow thorax in severe opsismodysplasia.
 - name: Scoliosis
   category: Clinical
   description: >
-    Spinal curvature has been reported in surviving patients and is recapitulated
-    in zebrafish inppl1a mutants, supporting a conserved role for SHIP2 in
-    spine morphogenesis.
+    Spinal curvature can develop in surviving children.
   phenotype_term:
     preferred_term: Scoliosis
     term:
       id: HP:0002650
       label: Scoliosis
   evidence:
-  - reference: PMID:40504975
-    reference_title: "INPPL1-Related Opsismodysplasia."
+  - reference: PMID:26157786
+    reference_title: "Opsismodysplasia: Phosphate Wasting Osteodystrophy Responds to Bisphosphonate Therapy."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Complications include increased risk of fractures, cervical spine abnormalities, scoliosis, bone pain, respiratory issues, and delayed gross motor skills."
-    explanation: GeneReviews identifies scoliosis as a recurrent clinical complication in affected individuals.
-  - reference: PMID:40209709
-    reference_title: "Cell expansion for notochord mechanics and endochondral bone lengthening in zebrafish depends on the 5'-inositol phosphatase Inppl1a."
+    snippet: "She was identified to have scoliosis with a 42° right thoracic curve, and a 57° left lumbar curve."
+    explanation: Detailed follow-up of a surviving child documents clinically significant scoliosis.
+- name: Respiratory insufficiency
+  category: Clinical
+  description: >
+    Respiratory compromise ranges from neonatal distress to progressive
+    respiratory failure in more severe cases.
+  phenotype_term:
+    preferred_term: Respiratory insufficiency
+    term:
+      id: HP:0002093
+      label: Respiratory insufficiency
+  evidence:
+  - reference: PMID:26157786
+    reference_title: "Opsismodysplasia: Phosphate Wasting Osteodystrophy Responds to Bisphosphonate Therapy."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
-    snippet: "We demonstrate that inppl1a-dependent vacuolated cell expansion is essential to establish normal mechanical properties of the notochord and to facilitate the development of a straight spine."
-    explanation: Zebrafish inppl1a mutants develop scoliosis, supporting this phenotype in the INPPL1-related disease spectrum.
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These cases provide evidence of the variability in severity of findings in siblings with opsismodysplasia and suggest that those with phosphate wasting have more severe skeletal findings and respiratory compromise."
+    explanation: The sibling case report identifies respiratory compromise as a major clinical complication.
+- name: Hypoplasia of the odontoid process
+  category: Clinical
+  description: >
+    Craniocervical abnormalities can include odontoid hypoplasia, creating
+    potential concern for cervical instability.
+  phenotype_term:
+    preferred_term: Hypoplasia of the odontoid process
+    term:
+      id: HP:0003311
+      label: Hypoplasia of the odontoid process
+  evidence:
+  - reference: PMID:26157786
+    reference_title: "Opsismodysplasia: Phosphate Wasting Osteodystrophy Responds to Bisphosphonate Therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cervical spine films show odontoid hypoplasia, with no evidence of atlantoaxial or occipitocervical instability."
+    explanation: Follow-up cervical imaging in a surviving child documented odontoid hypoplasia.
+- name: Polyhydramnios
+  category: Clinical
+  description: >
+    Polyhydramnios has been reported during affected pregnancies and can be an
+    early prenatal clue.
+  phenotype_term:
+    preferred_term: Polyhydramnios
+    term:
+      id: HP:0001561
+      label: Polyhydramnios
+  evidence:
+  - reference: PMID:20422326
+    reference_title: "Opsismodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "During the antenatal period, polyhydramnios was noted."
+    explanation: This neonatal case report documents polyhydramnios as a prenatal finding.
+- name: Hydrocephalus
+  category: Clinical
+  description: >
+    Hydrocephalus appears to be a rare associated finding rather than a core
+    manifestation.
+  phenotype_term:
+    preferred_term: Hydrocephalus
+    term:
+      id: HP:0000238
+      label: Hydrocephalus
+  evidence:
+  - reference: PMID:16473316
+    reference_title: "A further case of opsismodysplasia with hydrocephalus."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "She also had hydrocephaly, a rare finding in opsismodysplasia."
+    explanation: This report supports hydrocephalus as an uncommon but documented associated feature.
+- name: Motor delay
+  category: Clinical
+  description: >
+    Delayed motor development has been reported in some survivors, likely
+    reflecting the severity of the skeletal disease.
+  phenotype_term:
+    preferred_term: Motor delay
+    term:
+      id: HP:0001270
+      label: Motor delay
+  evidence:
+  - reference: PMID:24953221
+    reference_title: "Opsismodysplasia resulting from an insertion mutation in the SH2 domain, which destabilizes INPPL1."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "She achieved neuromotor developmental milestones late."
+    explanation: This long-term follow-up report documents delayed motor milestone acquisition.
 - name: Hypophosphatemic rickets
   category: Clinical
   description: >
@@ -549,6 +674,23 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "We now demonstrate an association between opsismodysplasia, hypophosphatemic rickets, and FGF23 elevation."
     explanation: Establishes the association with FGF23-mediated phosphate wasting.
+- name: Renal phosphate wasting
+  category: Clinical
+  description: >
+    Renal phosphate wasting occurs in a subset of patients and can mark a more
+    severe course with osteodystrophy.
+  phenotype_term:
+    preferred_term: Renal phosphate wasting
+    term:
+      id: HP:0000117
+      label: Renal phosphate wasting
+  evidence:
+  - reference: PMID:23273567
+    reference_title: "Whole-genome analysis reveals that mutations in inositol polyphosphate phosphatase-like 1 cause opsismodysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Opsismodysplasia is a rare, autosomal-recessive skeletal dysplasia characterized by short stature, characteristic facial features, and in some cases severe renal phosphate wasting."
+    explanation: The gene discovery study identifies renal phosphate wasting as a clinically important subset phenotype.
 - name: Reduced bone mineral density
   category: Clinical
   description: >
@@ -566,9 +708,14 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Renal phosphate wasting is associated with severe bone demineralization and a more severe phenotype."
     explanation: Bone demineralization is a feature, exacerbated by phosphate wasting.
+  - reference: PMID:40620719
+    reference_title: "Pamidronate Treatment of a Patient with Opsismodysplasia and a Novel INPPL1 Variant: Efficacy, Mechanism, and Clinical Outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Initial evaluations showed severe short stature and low bone mineral density (DEXA SDS: -3.16)."
+    explanation: Recent case evidence shows reduced bone mineral density even without hypophosphatemic rickets.
 - name: Short foot
   category: Clinical
-  frequency: HP_0040281
   description: >
     Extremely short tubular bones of the feet with concave metaphyses.
   phenotype_term:
@@ -583,23 +730,22 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "very retarded bone maturation; marked shortness of the bones of the hands and of the feet with concave metaphyses; and thin, lamellar vertebral bodies."
     explanation: Short feet with concave metaphyses are defining features from the original description.
-- name: Small hand
+- name: Short metacarpal
   category: Clinical
-  frequency: HP_0040281
   description: >
-    Extremely short tubular bones of the hands with concave metaphyses.
+    Hand radiographs show striking shortening of the metacarpals and phalanges.
   phenotype_term:
-    preferred_term: Small hand
+    preferred_term: Short metacarpal
     term:
-      id: HP:0200055
-      label: Small hand
+      id: HP:0010049
+      label: Short metacarpal
   evidence:
-  - reference: PMID:6496568
-    reference_title: "Opsismodysplasia: a new type of chondrodysplasia with predominant involvement of the bones of the hand and the vertebrae."
+  - reference: PMID:39911177
+    reference_title: "A Case of Opsismodysplasia with a Novel INPPL1 Variant."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "very retarded bone maturation; marked shortness of the bones of the hands and of the feet with concave metaphyses; and thin, lamellar vertebral bodies."
-    explanation: Short hands with concave metaphyses are defining features from the original description.
+    snippet: "Delayed bone age, short metacarpals and phalanges, wide and irregular metaphysis, platyspondyly, anterior beaking of the vertebrae, T12 vertebral hypoplasia, and acetabular dysplasia were noted on X-rays."
+    explanation: This recent molecularly confirmed case documents the characteristic marked shortening of the metacarpals.
 genetic:
 - name: INPPL1 biallelic variants
   gene_term:

--- a/references_cache/PMID_16473316.md
+++ b/references_cache/PMID_16473316.md
@@ -1,0 +1,56 @@
+---
+reference_id: "PMID:16473316"
+title: A further case of opsismodysplasia with hydrocephalus.
+authors:
+- Ramos FJ
+- González JP
+- Cortabarria C
+- Domenech E
+- Pérez-González J
+- Bueno M
+journal: Eur J Med Genet
+year: '2006'
+doi: 10.1016/j.ejmg.2005.04.002
+keywords:
+- "Abnormalities, Multiple/diagnosis"
+- "Bone Diseases, Developmental/congenital, diagnosis, genetics, pathology"
+- Female
+- "Genes, Recessive"
+- "Hand Deformities, Congenital/genetics"
+- Humans
+- Hydrocephalus/etiology
+- "Infant, Newborn"
+- "Limb Deformities, Congenital/genetics"
+- Male
+- Musculoskeletal Abnormalities/genetics
+content_type: abstract_only
+---
+
+# A further case of opsismodysplasia with hydrocephalus.
+**Authors:** Ramos FJ, González JP, Cortabarria C, Domenech E, Pérez-González J, Bueno M
+**Journal:** Eur J Med Genet (2006)
+**DOI:** [10.1016/j.ejmg.2005.04.002](https://doi.org/10.1016/j.ejmg.2005.04.002)
+
+## Content
+
+1. Eur J Med Genet. 2006 Jan-Feb;49(1):93-100. doi: 10.1016/j.ejmg.2005.04.002.
+
+A further case of opsismodysplasia with hydrocephalus.
+
+Ramos FJ(1), González JP, Cortabarria C, Domenech E, Pérez-González J, Bueno M.
+
+Author information:
+(1)Dpto. de Pediatría, Serv. Neonatología y Genética, Hospital Clínico 
+Universitario, Facultad de Medicina, Universidad de Zaragoza, C/ Domingo Miral 
+s/n, Zaragoza 50009, Spain. framos@unizar.es
+
+We present a case of opsismodysplasia, a very rare skeletal dysplasia, in a term 
+newborn female who had short length, short extremities and markedly short 
+fingers. Radiological studies demonstrated severe platyspondyly, absence of 
+epiphyseal ossification centers, short tubular bones, especially severe in hands 
+and feet, with metaphyseal cupping. She also had hydrocephaly, a rare finding in 
+opsismodysplasia. In our literature review we have found 24 cases, 17 born alive 
+and seven terminations of pregnancy (TOPs).
+
+DOI: 10.1016/j.ejmg.2005.04.002
+PMID: 16473316 [Indexed for MEDLINE]

--- a/references_cache/PMID_20422326.md
+++ b/references_cache/PMID_20422326.md
@@ -1,0 +1,48 @@
+---
+reference_id: "PMID:20422326"
+title: Opsismodysplasia.
+authors:
+- Lewis LE
+- Ramesh Bhat Y
+- Naik P
+- Sethi K
+- Girisha KM
+journal: Indian J Pediatr
+year: '2010'
+doi: 10.1007/s12098-010-0043-z
+keywords:
+- "Abnormalities, Multiple/pathology"
+- "Diagnosis, Differential"
+- Female
+- Humans
+- "Infant, Newborn"
+- Osteochondrodysplasias/pathology
+content_type: abstract_only
+---
+
+# Opsismodysplasia.
+**Authors:** Lewis LE, Ramesh Bhat Y, Naik P, Sethi K, Girisha KM
+**Journal:** Indian J Pediatr (2010)
+**DOI:** [10.1007/s12098-010-0043-z](https://doi.org/10.1007/s12098-010-0043-z)
+
+## Content
+
+1. Indian J Pediatr. 2010 May;77(5):567-8. doi: 10.1007/s12098-010-0043-z. Epub 
+2010 Mar 19.
+
+Opsismodysplasia.
+
+Lewis LE(1), Ramesh Bhat Y, Naik P, Sethi K, Girisha KM.
+
+Author information:
+(1)Neonatal Intensive Care Unit and Genetics Clinic, Department of Pediatrics, 
+Kasturba Medical College, Manipal, India.
+
+Opsismodysplasia is a rare osteochondrodysplasia with micromelia and 
+platyspondyly. We report on a neonate with opsismodysplasia. During the 
+antenatal period, polyhydramnios was noted. This is the first report of 
+opsismodysplasia from India. Significant observation was antenatal 
+polyhydramnios.
+
+DOI: 10.1007/s12098-010-0043-z
+PMID: 20422326 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
Enhances the phenotype section for `kb/disorders/Opsismodysplasia.yaml` with PMID-backed primary literature evidence.

## What Changed
- replaced GeneReviews-backed phenotype assertions with primary clinical literature where available
- removed unsupported phenotype `frequency` claims
- added clinically important missing phenotypes including large fontanelles, respiratory insufficiency, narrow chest, polyhydramnios, hydrocephalus, motor delay, renal phosphate wasting, and odontoid hypoplasia
- tightened several phenotype ontology mappings to more specific HPO terms such as severe platyspondyly and short metacarpal
- cached the new PubMed references required for the added evidence

## Why
Issue #1486 asks for the Opsismodysplasia phenotype section to be as complete and evidence-backed as possible without broadening into unrelated page rewrites.

## Validation
- `just validate kb/disorders/Opsismodysplasia.yaml`
- `just validate-references kb/disorders/Opsismodysplasia.yaml`
- `just validate-terms kb/disorders/Opsismodysplasia.yaml`

All three commands passed locally.
