### PR TITLE
Enhance phenotype section for Leri-Weill Dyschondrosteosis

### DIFF
--- a/kb/disorders/Leri-Weill_Dyschondrosteosis.yaml
+++ b/kb/disorders/Leri-Weill_Dyschondrosteosis.yaml
@@ -1,6 +1,6 @@
 name: Leri-Weill Dyschondrosteosis
 creation_date: "2026-04-02T12:00:00Z"
-updated_date: "2026-04-02T16:30:00Z"
+updated_date: "2026-04-19T02:29:56Z"
 category: Mendelian
 description: >
   Leri-Weill dyschondrosteosis (LWD) is a pseudoautosomal dominant skeletal
@@ -256,14 +256,47 @@ pathophysiology:
       Review confirms sex- and age-dependent severity of skeletal features
       in SHOX deficiency.
 phenotypes:
+- category: Growth
+  name: Disproportionate short stature
+  description: >
+    Short stature with relatively preserved trunk proportions and
+    disproportionate shortening of the extremities. Increased sitting-height
+    proportion and reduced arm-span proportion are characteristic auxological
+    findings.
+  phenotype_term:
+    preferred_term: Disproportionate short stature
+    term:
+      id: HP:0003498
+      label: Disproportionate short stature
+  evidence:
+  - reference: PMID:25110390
+    reference_title: "Skeletal Deformity Associated with SHOX Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A decreased extremity/trunk ratio with a fairly preserved sitting
+      height and head circumference is a characteristic auxological finding
+      of patients with LWD
+    explanation: >-
+      Directly supports disproportionate short stature with relatively
+      preserved trunk and head proportions in LWD.
+  - reference: PMID:33143726
+    reference_title: "SHOX deficiency in children with growth impairment: evaluation of known and new auxological and radiological indicators."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most predictive auxological indicators of SHOX-D were an increased
+      sitting height/height ratio and a decreased arm span/height ratio.
+    explanation: >-
+      This broader SHOX-deficiency cohort supports the same disproportionate
+      growth pattern seen in LWD, the more syndromic end of the SHOX-deficiency
+      spectrum.
 - category: Skeletal
   name: Mesomelic short stature
-  frequency: VERY_FREQUENT
   description: >
-    Disproportionate short stature with predominant shortening of the
-    middle (mesomelic) segments of the limbs, specifically the forearm
-    (radius and ulna) and lower leg (tibia and fibula). Adult height is
-    typically 2-4 SD below the mean.
+    Disproportionate shortening of the middle limb segments, especially the
+    forearms and lower legs. Mesomelia may first become evident in school-aged
+    children and becomes more pronounced with age.
   phenotype_term:
     preferred_term: Mesomelic short stature
     term:
@@ -281,17 +314,27 @@ phenotypes:
       in school-aged children and increases with age in frequency and
       severity.
     explanation: >-
-      GeneReviews confirms mesomelic short stature as part of the classic
-      LWD triad, with onset in childhood and progressive severity.
+      GeneReviews identifies mesomelia as a core LWD manifestation and
+      directly supports school-age onset with age-dependent progression.
+  - reference: PMID:9590293
+    reference_title: "Mutation and deletion of the pseudoautosomal gene SHOX cause Leri-Weill dyschondrosteosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Leri-Weill Dyschondrosteosis (LWD; OMIM 127300) is a dominantly
+      inherited skeletal dysplasia characterized by disproportionate short
+      stature with predominantly mesomelic limb shortening.
+    explanation: >-
+      Landmark SHOX-LWD linkage paper supports mesomelic limb shortening as
+      part of the defining phenotype.
 - category: Skeletal
   name: Madelung deformity
-  frequency: VERY_FREQUENT
-  notes: More frequent and severe in females than males.
+  frequency: FREQUENT
+  notes: More common and more severe in females than males; typically develops in mid-to-late childhood.
   description: >
-    Bilateral Madelung deformity of the wrist characterized by bowing and
-    shortening of the distal radius, dorsal subluxation of the distal ulna,
-    and a triangular configuration of the carpal bones. This results from
-    premature fusion of the medial and volar portions of the distal radial
+    Wrist deformity with bowing and shortening of the distal radius, dorsal
+    subluxation of the distal ulna, and abnormal alignment of the radius,
+    ulna, and carpal bones due to premature fusion of the distal radial
     growth plate.
   phenotype_term:
     preferred_term: Madelung deformity
@@ -299,28 +342,16 @@ phenotypes:
       id: HP:0003067
       label: Madelung deformity
   evidence:
-  - reference: PMID:9590293
-    reference_title: "Mutation and deletion of the pseudoautosomal gene SHOX cause Leri-Weill dyschondrosteosis."
+  - reference: PMID:11739418
+    reference_title: "Phenotypes Associated with SHOX Deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Expression is variable and consistently more severe in females, who
-      frequently display the Madelung deformity of the forearm (shortening
-      and bowing of the radius with dorsal subluxation of the distal ulna).
+      Madelung deformity was present in 74% of LWD children and adults
+      and was more frequent and severe in females than males.
     explanation: >-
-      Original SHOX-LWD linkage paper describes Madelung deformity as the
-      characteristic forearm finding in LWD, with female predominance.
-  - reference: PMID:25110390
-    reference_title: "Skeletal Deformity Associated with SHOX Deficiency."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      The most characteristic feature in patients with SHOX deficiency is
-      Madelung deformity, a cluster of anatomical changes in the wrist that
-      can be attributed to premature epiphyseal fusion of the distal radius.
-    explanation: >-
-      Review confirms Madelung deformity as the most characteristic skeletal
-      feature, attributing it to premature epiphyseal fusion.
+      74% falls in the FREQUENT band (30-79%) and directly supports female
+      predominance in genetically confirmed LWD.
   - reference: PMID:20301394
     reference_title: "SHOX Deficiency Disorders."
     supports: SUPPORT
@@ -330,47 +361,58 @@ phenotypes:
       carpal bones at the wrist) typically develops in mid-to-late childhood
       and is more common and severe in females.
     explanation: >-
-      GeneReviews confirms female predominance and childhood onset of
-      Madelung deformity.
-  - reference: PMID:11739418
-    reference_title: "Phenotypes Associated with SHOX Deficiency."
+      GeneReviews directly supports the usual childhood onset and sex bias.
+  - reference: PMID:9590293
+    reference_title: "Mutation and deletion of the pseudoautosomal gene SHOX cause Leri-Weill dyschondrosteosis."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Madelung deformity was present in 74% of LWD children and adults
-      and was more frequent and severe in females than males.
+      Expression is variable and consistently more severe in females, who
+      frequently display the Madelung deformity of the forearm (shortening
+      and bowing of the radius with dorsal subluxation of the distal ulna).
     explanation: >-
-      Large clinical series quantifying Madelung deformity prevalence at
-      74% in genetically confirmed LWD, with female predominance.
+      Supports the characteristic radiographic-anatomic components of the
+      deformity and the female-predominant severity.
 - category: Skeletal
   name: Short forearm
-  frequency: VERY_FREQUENT
   description: >
-    Bilateral shortening of the forearm due to decreased longitudinal growth
-    of the radius and ulna, the hallmark mesomelic segment affected in LWD.
+    Forearm shortening due to reduced growth of the radius and ulna, a major
+    contributor to upper-limb mesomelic disproportion in LWD.
   phenotype_term:
     preferred_term: Short forearm
     term:
       id: HP:0005773
       label: Short forearm
   evidence:
-  - reference: PMID:25110390
-    reference_title: "Skeletal Deformity Associated with SHOX Deficiency."
+  - reference: PMID:32295321
+    reference_title: "Detection of SHOX Gene Variations in Patients with Skeletal Abnormalities with or without Short Stature."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The mesomelic short stature of LWD can be explained as a result of
-      impaired linear growth of the radius, ulna, tibia and fibula.
+      Madelung’s deformity, cubitus valgus, muscular hypertrophy and short
+      forearm were the most common phenotypic features, as well as short
+      stature.
     explanation: >-
-      Confirms impaired linear growth of the radius and ulna as the basis
-      for forearm shortening in LWD.
+      Supports short forearm as a recurrent phenotype in a mostly
+      LWD-compatible SHOX-deficiency cohort.
+  - reference: PMID:17182655
+    reference_title: "Genotypes and phenotypes in children with short stature: clinical indicators of SHOX haploinsufficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      detailed examination revealed that certain bone deformities and
+      dysmorphic signs, such as short forearm and lower leg, cubitus
+      valgus, Madelung deformity, high-arched palate and muscular
+      hypertrophy, differed markedly between participants with or without
+      SHOX gene defects (p<0.001).
+    explanation: >-
+      Large multinational pediatric cohort supports short forearm as a key
+      clinical discriminator of SHOX haploinsufficiency.
 - category: Skeletal
   name: Short tibia
-  frequency: FREQUENT
   description: >
-    Shortening of the tibia contributing to mesomelic limb disproportion in
-    the lower extremities. Tibial involvement is typically less pronounced
-    than radial/ulnar shortening.
+    Tibial shortening contributing to the lower-leg component of mesomelic
+    disproportion, often accompanied by fibular shortening.
   phenotype_term:
     preferred_term: Short tibia
     term:
@@ -382,22 +424,20 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      impaired linear growth of the radius, ulna, tibia and fibula
+      The mesomelic short stature of LWD can be explained as a result of
+      impaired linear growth of the radius, ulna, tibia and fibula.
     explanation: >-
-      Confirms tibial shortening as part of the mesomelic limb growth
-      impairment in LWD.
+      Directly supports tibial involvement as part of lower-leg mesomelic
+      shortening in LWD.
 - category: Skeletal
-  name: Bowing of the forearm bones
-  frequency: FREQUENT
+  name: Radial bowing
   description: >
-    Bowing of the radius, contributing to the Madelung deformity complex.
-    The curvature results from asymmetric growth plate closure at the
-    distal radius.
+    Bowing of the radius as part of the Madelung deformity complex.
   phenotype_term:
-    preferred_term: Bowed forearm bones
+    preferred_term: Radial bowing
     term:
-      id: HP:0003956
-      label: Bowed forearm bones
+      id: HP:0002986
+      label: radial bowing
   evidence:
   - reference: PMID:9590293
     reference_title: "Mutation and deletion of the pseudoautosomal gene SHOX cause Leri-Weill dyschondrosteosis."
@@ -407,15 +447,13 @@ phenotypes:
       shortening and bowing of the radius with dorsal subluxation of the
       distal ulna
     explanation: >-
-      Confirms bowing of the radius as a component of the Madelung
-      deformity in LWD.
+      Supports radial bowing as a characteristic structural component of
+      Madelung deformity in LWD.
 - category: Skeletal
   name: Dorsal subluxation of the distal ulna
-  frequency: FREQUENT
   description: >
-    Dorsal displacement of the distal ulna relative to the radius, a
-    component of Madelung deformity that produces prominence at the
-    dorsal wrist.
+    Dorsal displacement of the distal ulna relative to the radius, producing
+    dorsal wrist prominence and contributing to Madelung deformity.
   phenotype_term:
     preferred_term: Dorsal subluxation of ulna
     term:
@@ -429,15 +467,13 @@ phenotypes:
     snippet: >-
       dorsal subluxation of the ulnar head
     explanation: >-
-      Confirms dorsal subluxation of the distal ulna as a component of
-      Madelung deformity in SHOX deficiency.
-- category: Skeletal
+      Directly supports dorsal ulna subluxation as part of the wrist
+      deformity in SHOX deficiency/LWD.
+- category: Musculoskeletal
   name: Limited wrist movement
-  frequency: FREQUENT
   description: >
-    Restricted range of motion at the wrist, particularly supination and
-    dorsiflexion, secondary to the altered anatomy of the distal
-    radioulnar joint in Madelung deformity.
+    Restricted wrist range of motion associated with symptomatic Madelung
+    deformity.
   phenotype_term:
     preferred_term: Limited wrist movement
     term:
@@ -452,60 +488,94 @@ phenotypes:
       Clinical manifestations induced by Madelung deformity include wrist
       pain, deformation and limited joint motion
     explanation: >-
-      Confirms limited wrist motion as a clinical consequence of Madelung
-      deformity in SHOX deficiency.
-- category: Skeletal
-  name: Short stature
-  frequency: VERY_FREQUENT
+      Supports restricted wrist motion as a functional consequence of
+      Madelung deformity.
+- category: Musculoskeletal
+  name: Wrist pain
   description: >
-    Overall reduced adult height, typically 2-4 SD below the population
-    mean. The short stature is disproportionate due to mesomelic limb
-    shortening while trunk length is relatively preserved.
+    Mechanical wrist pain associated with symptomatic Madelung deformity.
   phenotype_term:
-    preferred_term: Short stature
+    preferred_term: Wrist pain
     term:
-      id: HP:0004322
-      label: Short stature
+      id: HP:0009763
+      label: Limb pain
   evidence:
   - reference: PMID:25110390
     reference_title: "Skeletal Deformity Associated with SHOX Deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      A decreased extremity/trunk ratio with a fairly preserved sitting
-      height and head circumference is a characteristic auxological finding
-      of patients with LWD
+      Clinical manifestations induced by Madelung deformity include wrist
+      pain, deformation and limited joint motion
     explanation: >-
-      Confirms disproportionate short stature with preserved trunk length
-      as characteristic of LWD.
+      Supports wrist pain as a clinically important symptomatic manifestation
+      of Madelung deformity.
+- category: Musculoskeletal
+  name: Muscle hypertrophy
+  description: >
+    Apparent muscular hypertrophy of the limbs, reflected clinically by
+    increased limb girth relative to height and used as a screening clue for
+    SHOX deficiency.
+  phenotype_term:
+    preferred_term: Muscle hypertrophy
+    term:
+      id: HP:0003712
+      label: Skeletal muscle hypertrophy
+  evidence:
+  - reference: PMID:32295321
+    reference_title: "Detection of SHOX Gene Variations in Patients with Skeletal Abnormalities with or without Short Stature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Madelung’s deformity, cubitus valgus, muscular hypertrophy and short
+      forearm were the most common phenotypic features, as well as short
+      stature.
+    explanation: >-
+      Supports muscular hypertrophy as a recurrent phenotype in a mostly
+      LWD-compatible SHOX-deficiency cohort.
+  - reference: PMID:17182655
+    reference_title: "Genotypes and phenotypes in children with short stature: clinical indicators of SHOX haploinsufficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      detailed examination revealed that certain bone deformities and
+      dysmorphic signs, such as short forearm and lower leg, cubitus
+      valgus, Madelung deformity, high-arched palate and muscular
+      hypertrophy, differed markedly between participants with or without
+      SHOX gene defects (p<0.001).
+    explanation: >-
+      Large multinational pediatric cohort supports muscular hypertrophy as
+      a discriminating SHOX-deficiency phenotype.
 - category: Skeletal
   name: Cubitus valgus
-  frequency: OCCASIONAL
   description: >
-    Increased carrying angle of the elbow, sometimes observed as part of
-    the skeletal phenotype.
+    Increased carrying angle of the elbow, a recurrent associated skeletal
+    feature in LWD/SHOX haploinsufficiency.
   phenotype_term:
     preferred_term: Cubitus valgus
     term:
       id: HP:0002967
       label: Cubitus valgus
   evidence:
-  - reference: PMID:25110390
-    reference_title: "Skeletal Deformity Associated with SHOX Deficiency."
+  - reference: PMID:10599728
+    reference_title: "Skeletal features and growth patterns in 14 patients with haploinsufficiency of SHOX: implications for the development of Turner syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      cubitus valgus, short forearm, bowing of the forearm, muscular
-      hypertrophy and dislocation of the ulna
+      Skeletal assessment showed that three patients had no discernible
+      skeletal abnormalities, one patient exhibited short 4th metacarpals
+      and borderline cubitus valgus, and the remaining 10 patients had
+      Madelung deformity and/or mesomelia characteristic of
+      Léri-Weill dyschondrosteosis (LWD), together with short 4th
+      metacarpals and/or cubitus valgus.
     explanation: >-
-      Cubitus valgus is listed among the clinical screening indicators
-      for SHOX deficiency.
+      Directly supports cubitus valgus as an associated skeletal feature in
+      a molecularly defined LWD cohort.
 - category: Skeletal
   name: High arched palate
-  frequency: OCCASIONAL
   description: >
-    High-arched palate observed in some individuals with SHOX deficiency,
-    representing one of the less specific skeletal features.
+    High palate reported as an associated craniofacial-skeletal feature in
+    some affected individuals.
   phenotype_term:
     preferred_term: High palate
     term:
@@ -520,14 +590,13 @@ phenotypes:
       The prevalence of increased carrying angle, high arched palate,
       and scoliosis was similar in the two populations.
     explanation: >-
-      High arched palate documented in LWD clinical series as a feature
-      shared with Turner syndrome.
+      Supports high-arched palate as a recurrent associated feature in the
+      LWD cohort.
 - category: Skeletal
   name: Short 4th metacarpal
-  frequency: OCCASIONAL
   description: >
-    Shortened fourth metacarpal bone, a minor skeletal feature associated
-    with SHOX haploinsufficiency.
+    Shortening of the fourth metacarpal as a recurrent minor hand anomaly in
+    SHOX haploinsufficiency/LWD.
   phenotype_term:
     preferred_term: Short 4th metacarpal
     term:
@@ -539,18 +608,20 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      haploinsufficiency of SHOX causes not only short stature but also
-      Turner skeletal anomalies (such as short 4th metacarpals, cubitus
-      valgus, and LWD)
+      Skeletal assessment showed that three patients had no discernible
+      skeletal abnormalities, one patient exhibited short 4th metacarpals
+      and borderline cubitus valgus, and the remaining 10 patients had
+      Madelung deformity and/or mesomelia characteristic of
+      Léri-Weill dyschondrosteosis (LWD), together with short 4th
+      metacarpals and/or cubitus valgus.
     explanation: >-
-      Short 4th metacarpals identified as a Turner-like skeletal anomaly
-      attributable to SHOX haploinsufficiency.
+      Directly supports short fourth metacarpals as a recurrent associated
+      feature in a molecularly defined LWD cohort.
 - category: Skeletal
   name: Scoliosis
-  frequency: OCCASIONAL
   description: >
-    Scoliosis occurring in some individuals with SHOX deficiency, likely
-    secondary to mesomelic limb asymmetry.
+    Scoliosis reported as an associated skeletal feature in some individuals
+    with LWD.
   phenotype_term:
     preferred_term: Scoliosis
     term:
@@ -565,7 +636,7 @@ phenotypes:
       The prevalence of increased carrying angle, high arched palate,
       and scoliosis was similar in the two populations.
     explanation: >-
-      Scoliosis documented in LWD clinical series as an associated feature.
+      Supports scoliosis as a recurrent associated feature in the LWD cohort.
 genetic:
 - name: SHOX deletions and point mutations
   association: Causative

--- a/references_cache/PMID_14557470.md
+++ b/references_cache/PMID_14557470.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:14557470"
+title: Auxology is a valuable instrument for the clinical diagnosis of SHOX haploinsufficiency in school-age children with unexplained short stature.
+authors:
+- Binder G
+- Ranke MB
+- Martin DD
+journal: J Clin Endocrinol Metab
+year: '2003'
+doi: 10.1210/jc.2003-030136
+keywords:
+- Adolescent
+- Body Height/genetics
+- Bone Development/physiology
+- Child
+- Female
+- Genetic Testing/methods
+- Growth Disorders/genetics
+- "Hand Deformities, Congenital/genetics"
+- Haplotypes
+- Homeodomain Proteins/genetics
+- Humans
+- Male
+- Microsatellite Repeats
+- Pedigree
+- Short Stature Homeobox Protein
+content_type: abstract_only
+---
+
+# Auxology is a valuable instrument for the clinical diagnosis of SHOX haploinsufficiency in school-age children with unexplained short stature.
+**Authors:** Binder G, Ranke MB, Martin DD
+**Journal:** J Clin Endocrinol Metab (2003)
+**DOI:** [10.1210/jc.2003-030136](https://doi.org/10.1210/jc.2003-030136)
+
+## Content
+
+1. J Clin Endocrinol Metab. 2003 Oct;88(10):4891-6. doi: 10.1210/jc.2003-030136.
+
+Auxology is a valuable instrument for the clinical diagnosis of SHOX
+haploinsufficiency in school-age children with unexplained short stature.
+
+Binder G(1), Ranke MB, Martin DD.
+
+Author information:
+(1)University Children's Hospital, 72076 Tübingen, Germany.
+gdbinder@med.uni-tyebingen.de
+
+SHOX (short stature homeobox-containing gene) mutations causing
+haploinsufficiency have been reported in some individuals with idiopathic short
+stature and in many patients with Leri-Weill-dyschondrosteosis. Around 80% of
+SHOX mutations are complete gene deletions, whereas diverse point mutations
+account for the rest. The aim of this study was to estimate the prevalence of
+SHOX mutations in children with idiopathic short stature and to give an unbiased
+characterization of the haploinsufficiency phenotype of such children. We
+recruited 140 children (61 girls), in our clinic, with idiopathic short stature,
+which was defined by the presence of normal IGF-I and free T(4); a normal
+karyotype in females; the absence of endomysium antibodies, of chronic organic,
+psychological, or syndromatic disease; and by the lack of clear signs of any
+osteodysplasia. Height, arm span, and sitting height were recorded, and
+subischial leg length was calculated. Two highly polymorphic microsatellite
+markers located around the SHOX coding region (CA-SHOX repeat and DXYS233) were
+PCR-amplified with fluorescent primers and separated in an automatic sequencing
+machine. Analysis of parental DNA was performed in the probands who had only one
+fragment size of each of both markers. SHOX haploinsufficiency caused by a SHOX
+deletion was confirmed in three probands (2%), all females, who carried a de
+novo deletion through loss of the paternal allele. Their auxological data
+revealed a significant shortening of arms and legs in the presence of a
+low-normal sitting height, when compared with the other 137 children tested.
+Therefore, the extremities-trunk ratio (sum of leg length and arm span, divided
+by sitting height) for total height was significantly lower in the three SHOX
+haploinsufficient probands, in comparison with the whole group. This observation
+was confirmed with the auxological data of five additional patients (four
+females) previously diagnosed with SHOX haploinsufficiency; all but the youngest
+girl had height-adjusted extremities-trunk ratios more than 1 SD below the mean.
+All children with SHOX haploinsufficiency exhibited at least one characteristic
+radiological sign of Leri-Weill-dyschondrosteosis in their left-hand
+radiography, namely triangularization of the distal radial epiphysis,
+pyramidalization of the distal carpal row, or lucency of the distal ulnar border
+of the radius. Our observations suggest that it is rational to limit SHOX
+mutation screening to children with an extremities-trunk ratio less than 1.95 +
+1/2 height (m) and to add a critical judgment of the hand radiography.
+
+DOI: 10.1210/jc.2003-030136
+PMID: 14557470 [Indexed for MEDLINE]

--- a/references_cache/PMID_32295321.md
+++ b/references_cache/PMID_32295321.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:32295321"
+title: Detection of SHOX Gene Variations in Patients with Skeletal Abnormalities with or without Short Stature.
+authors:
+- Gürsoy S
+- Hazan F
+- Aykut A
+- Nalbantoğlu Ö
+- Korkmaz HA
+- Demir K
+- Özkan B
+- Çoğulu Ö
+journal: J Clin Res Pediatr Endocrinol
+year: '2020'
+doi: 10.4274/jcrpe.galenos.2020.2019.0001
+keywords:
+- Adolescent
+- Adult
+- Child
+- Dwarfism/physiopathology
+- Family
+- Female
+- Follow-Up Studies
+- "Growth Disorders/epidemiology, genetics, pathology"
+- Humans
+- Male
+- Mutation
+- "Osteochondrodysplasias/epidemiology, genetics, pathology"
+- Prognosis
+- Short Stature Homeobox Protein/genetics
+- Young Adult
+content_type: abstract_only
+---
+
+# Detection of SHOX Gene Variations in Patients with Skeletal Abnormalities with or without Short Stature.
+**Authors:** Gürsoy S, Hazan F, Aykut A, Nalbantoğlu Ö, Korkmaz HA, Demir K, Özkan B, Çoğulu Ö
+**Journal:** J Clin Res Pediatr Endocrinol (2020)
+**DOI:** [10.4274/jcrpe.galenos.2020.2019.0001](https://doi.org/10.4274/jcrpe.galenos.2020.2019.0001)
+
+## Content
+
+1. J Clin Res Pediatr Endocrinol. 2020 Nov 25;12(4):358-365. doi:
+10.4274/jcrpe.galenos.2020.2019.0001. Epub 2020 Apr 16.
+
+Detection of SHOX Gene Variations in Patients with Skeletal Abnormalities with
+or without Short Stature.
+
+Gürsoy S(1), Hazan F(2), Aykut A(3), Nalbantoğlu Ö(4), Korkmaz HA(5), Demir
+K(6), Özkan B(4), Çoğulu Ö(7).
+
+Author information:
+(1)University of Health Sciences Turkey, Dr. Behçet Uz Child Disease and
+Pediatric Surgery Training and Research Hospital, Clinic of Pediatric Genetics,
+İzmir, Turkey
+(2)University of Health Sciences Turkey, Dr. Behçet Uz Child Disease and
+Pediatric Surgery Training and Research Hospital, Clinic of Medical Genetics,
+İzmir, Turkey
+(3)Ege University Faculty of Medicine, Department of Medical Genetics, İzmir,
+Turkey
+(4)University of Health Sciences Turkey, Dr. Behçet Uz Child Disease and
+Pediatric Surgery Training and Research Hospital, Clinic of Pediatric
+Endocrinology, İzmir, Turkey
+(5)Manisa City Hospital, Clinic of Pediatric Endocrinology, Manisa, Turkey
+(6)Dokuz Eylül University Faculty of Medicine, Department of Pediatric
+Endocrinology, İzmir, Turkey
+(7)Ege University Faculty of Medicine, Department of Pediatric Genetics, İzmir,
+Turkey
+
+OBJECTIVE: SHOX gene mutations constitute one of the genetic causes of short
+stature. The clinical phenotype includes variable degrees of growth impairment,
+such as Langer mesomelic dysplasia (LMD), Léri-Weill dyschondrosteosis (LWD) or
+idiopathic short stature (ISS). The aim of this study was to describe the
+clinical features and molecular results of SHOX deficiency in a group of Turkish
+patients who had skeletal findings with and without short stature.
+METHODS: Forty-six patients with ISS, disproportionate short stature or skeletal
+findings without short stature from 35 different families were included. SHOX
+gene analysis was performed using Sanger sequencing and multiplex
+ligation-dependent probe amplification analysis.
+RESULTS: Three different point mutations (two nonsense, one frameshift) and one
+whole SHOX gene deletion were detected in 15 patients from four different
+families. While 4/15 patients had LMD, the remaining patients had clinical
+features compatible with LWD. Madelung’s deformity, cubitus valgus, muscular
+hypertrophy and short forearm were the most common phenotypic features, as well
+as short stature. Additionally, hearing loss was detected in two patients with
+LMD.
+CONCLUSION: This study has presented the clinical spectrum and molecular
+findings of 15 patients with SHOX gene mutations or deletions. SHOX deficiency
+should be especially considered in patients who have disproportionate short
+stature or forearm anomalies with or without short stature. Although most of the
+patients had partial or whole gene deletions, SHOX gene sequencing should be
+performed in suspected cases. Furthermore, conductive hearing loss may rarely
+accompany these clinical manifestations.
+
+DOI: 10.4274/jcrpe.galenos.2020.2019.0001
+PMCID: PMC7711637
+PMID: 32295321 [Indexed for MEDLINE]

--- a/references_cache/PMID_33143726.md
+++ b/references_cache/PMID_33143726.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:33143726"
+title: "SHOX deficiency in children with growth impairment: evaluation of known and new auxological and radiological indicators."
+authors:
+- Vannelli S
+- Baffico M
+- Buganza R
+- Verna F
+- Vinci G
+- Tessaris D
+- Di Rosa G
+- Borraccino A
+- de Sanctis L
+journal: Ital J Pediatr
+year: '2020'
+doi: 10.1186/s13052-020-00927-z
+keywords:
+- Adolescent
+- Arm Bones/diagnostic imaging
+- Body Height
+- Child
+- "Child, Preschool"
+- Female
+- "Growth Disorders/diagnostic imaging, genetics, pathology"
+- Haploinsufficiency/genetics
+- Humans
+- Male
+- Retrospective Studies
+- Short Stature Homeobox Protein/genetics
+content_type: abstract_only
+---
+
+# SHOX deficiency in children with growth impairment: evaluation of known and new auxological and radiological indicators.
+**Authors:** Vannelli S, Baffico M, Buganza R, Verna F, Vinci G, Tessaris D, Di Rosa G, Borraccino A, de Sanctis L
+**Journal:** Ital J Pediatr (2020)
+**DOI:** [10.1186/s13052-020-00927-z](https://doi.org/10.1186/s13052-020-00927-z)
+
+## Content
+
+1. Ital J Pediatr. 2020 Nov 3;46(1):163. doi: 10.1186/s13052-020-00927-z.
+
+SHOX deficiency in children with growth impairment: evaluation of known and new
+auxological and radiological indicators.
+
+Vannelli S(1)(2), Baffico M(3), Buganza R(4)(5)(6), Verna F(4)(5), Vinci
+G(4)(5), Tessaris D(4)(5), Di Rosa G(7), Borraccino A(5), de Sanctis L(4)(5).
+
+Author information:
+(1)Pediatric Endocrinology, Regina Margherita Children's Hospital, Turin, Italy.
+silvia.vannelli@unito.it.
+(2)Department of Public Health and Pediatric Sciences, University of Turin,
+Turin, Italy. silvia.vannelli@unito.it.
+(3)Laboratory of Human Genetics, Galliera Hospitals, Genoa, Italy.
+(4)Pediatric Endocrinology, Regina Margherita Children's Hospital, Turin, Italy.
+(5)Department of Public Health and Pediatric Sciences, University of Turin,
+Turin, Italy.
+(6)Postgraduate School of Pediatrics, University of Turin, Turin, Italy.
+(7)Pediatric Radiology, Regina Margherita Children's Hospital, Turin, Italy.
+
+BACKGROUND: The phenotypic features of SHOX deficiency (SHOX-D) are highly
+variable and can be very mild, especially in young children. The aim of this
+retrospective study was to evaluate auxological and radiological indicators that
+could be predictive of SHOX-D in children.
+METHODS: Molecular analysis of the SHOX gene was performed in 296 subjects with
+growth impairment or skeletal disproportion, without alternative diagnosis.
+Auxological variables and radiographs of the hand, wrist and forearm were
+evaluated.
+RESULTS: SHOX mutations (88% inherited, 12% de novo) were identified in 52
+subjects. The most predictive auxological indicators of SHOX-D were an increased
+sitting height/height ratio and a decreased arm span/height ratio. The convexity
+of distal radial metaphysis at X-ray, not yet reported in literature, was also
+found to be predictive of SHOX-D. In young children, stratification of data by
+bone age also highlighted ulnar tilt, lucency of the ulnar border of the distal
+radius and enlarged radius as the radiological signs most related to SHOX-D .
+CONCLUSIONS: In this study, the analysis of auxological and radiological
+indicators in SHOX-D children allowed to identify an additional early
+radiological sign and underlines the importance of family auxological
+evaluation.
+
+DOI: 10.1186/s13052-020-00927-z
+PMCID: PMC7640664
+PMID: 33143726 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/research/Leri-Weill_Dyschondrosteosis-phenotype-curation-codex.md
+++ b/research/Leri-Weill_Dyschondrosteosis-phenotype-curation-codex.md
@@ -1,0 +1,33 @@
+## Leri-Weill Dyschondrosteosis phenotype curation notes
+
+Date: 2026-04-18
+Issue: #1483
+Scope: phenotype section only for `kb/disorders/Leri-Weill_Dyschondrosteosis.yaml`
+
+### Primary phenotype papers used
+
+| PMID | Cohort / source | Phenotype signals used in curation |
+| --- | --- | --- |
+| 11739418 | 21 LWD families / 43 affected individuals with confirmed SHOX abnormalities | Madelung deformity present in 74% of children and adults; female predominance; high-arched palate and scoliosis reported in the LWD cohort. |
+| 10599728 | 14 Japanese patients with SHOX-region haploinsufficiency | Mesomelia/LWD phenotype in 10/14; short 4th metacarpals and/or cubitus valgus; skeletal lesions worse with age and in females. |
+| 17182655 | Multinational cohort of 1608 short children screened for SHOX defects | Short forearm/lower leg, cubitus valgus, Madelung deformity, high-arched palate, and muscular hypertrophy discriminate SHOX-deficient children from non-SHOX short stature controls. |
+| 14557470 | School-age SHOX-haploinsufficient children with auxology/radiography | Lower extremity-trunk ratio; characteristic LWD wrist radiographic signs including triangularization of the distal radial epiphysis, pyramidalization of the distal carpal row, and lucency of the distal ulnar border of the radius. |
+| 20301394 | GeneReviews | Core LWD triad; mesomelia may be evident in school age; Madelung deformity usually appears in mid-to-late childhood and is more severe in females. |
+| 25110390 | Review anchored in SHOX-deficiency skeletal pathology | Characteristic auxological disproportion in LWD; impaired growth of radius/ulna/tibia/fibula; wrist pain and limited motion as symptomatic consequences of Madelung deformity. |
+| 32295321 | 15 Turkish patients with SHOX variants/deletions (4 LMD, remainder LWD-compatible) | Short forearm, cubitus valgus, and muscular hypertrophy listed among the most common phenotypes. |
+| 33143726 | 296 children with growth impairment or skeletal disproportion screened for SHOX deficiency | Increased sitting height/height ratio and decreased arm span/height ratio as the strongest auxological indicators; useful to support disproportionate growth pattern. |
+
+### Curation decisions
+
+- Kept an explicit `frequency:` only for Madelung deformity because PMID:11739418 directly reports `74%`, which maps to `FREQUENT`.
+- Removed unsupported frequency bands from mesomelia, short forearm, short tibia, wrist limitation, cubitus valgus, high palate, short 4th metacarpal, and scoliosis.
+- Replaced generic `Short stature` with `Disproportionate short stature` to better reflect the evidence-backed auxological pattern in LWD.
+- Added `Wrist pain` because PMID:25110390 explicitly describes it as a clinical manifestation of Madelung deformity.
+- Added `Muscle hypertrophy` because it is repeatedly reported as a recurrent SHOX-deficiency/LWD-compatible feature in PMIDs 17182655 and 32295321.
+- Tightened `Bowing of the forearm bones` to `Radial bowing` for a more specific ontology mapping.
+- Did not add separate radiographic phenotypes such as triangularization of the distal radial epiphysis or pyramidalization of the carpal row in the YAML because the ontology mapping was not obviously clean enough for a specific, validator-safe phenotype term in this pass.
+
+### Validation expectations
+
+- New phenotype PMIDs requiring cache refresh: 14557470, 32295321, 33143726.
+- All snippets selected for YAML are abstract-safe except PMID:25110390, which already has a cached full-text-derived reference in this repo and was reused only with exact text already present in the cache.


### PR DESCRIPTION
## Summary
- tighten the phenotype section in `kb/disorders/Leri-Weill_Dyschondrosteosis.yaml` to PMID-backed, clinically important manifestations
- add missing phenotypes including disproportionate short stature, radial bowing, wrist pain, and muscle hypertrophy where direct evidence supported them
- remove unsupported frequency claims and soften phenotype descriptions where the literature supported presence but not prevalence

## Validation
- `just validate kb/disorders/Leri-Weill_Dyschondrosteosis.yaml`
- `just validate-references kb/disorders/Leri-Weill_Dyschondrosteosis.yaml`
- `just validate-terms kb/disorders/Leri-Weill_Dyschondrosteosis.yaml`

Refs #1483