### PR TITLE
[codex] Enhance phenotype evidence for OI type IV

### DIFF
--- a/kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type IV
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T06:40:39Z'
+updated_date: '2026-04-19T15:11:01Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type IV represents moderate severity OI, intermediate
@@ -48,12 +48,44 @@ prevalence:
     snippet: "The prevalence of OI types I, III, and IV was 5.16, 0.89, and 1.35/100 000, respectively (7.40/100 000 overall), corresponding to what has been estimated but not unequivocally proven in any population."
     explanation: This population-based Swedish study directly estimates pediatric prevalence of OI type IV at 1.35 per 100,000.
 pathophysiology:
-- name: Moderate Collagen Structural Defect
+- name: Procollagen Processing and Intracellular Trafficking Defect
   description: >
-    Structural mutations in COL1A1 or COL1A2 that produce collagen with
-    intermediate levels of dysfunction. The mutations allow more normal
-    fibril formation than in types II/III but still compromise bone
-    matrix integrity.
+    Structural collagen I mutations disrupt procollagen folding,
+    chaperone-assisted processing, and transport from the endoplasmic
+    reticulum to the Golgi before abnormal collagen reaches the extracellular
+    matrix.
+  cell_types:
+  - preferred_term: Osteoblast
+    term:
+      id: CL:0000062
+      label: osteoblast
+  biological_processes:
+  - preferred_term: Protein folding
+    term:
+      id: GO:0006457
+      label: protein folding
+  evidence:
+  - reference: DOI:10.1007/s00439-021-02302-2
+    reference_title: Collagen transport and related pathways in Osteogenesis Imperfecta
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The production of collagen entails a complex process, starting from the
+      production of the collagen Iα1 and collagen Iα2 chains in the
+      endoplasmic reticulum, during and after which procollagen is subjected
+      to a plethora of posttranslational modifications by chaperones. After
+      reaching the Golgi organelle, procollagen is destined to the
+      extracellular matrix where it forms collagen fibrils.
+    explanation: >-
+      This review supports a proximal osteoblast defect in procollagen folding,
+      chaperone-assisted processing, and ER-to-Golgi trafficking in OI.
+  downstream:
+  - target: Defective Collagen Matrix Assembly
+- name: Defective Collagen Matrix Assembly
+  description: >
+    Abnormal collagen that escapes intracellular quality-control is poorly
+    secreted and disrupts extracellular matrix assembly and mineralization,
+    weakening bone matrix integrity.
   cell_types:
   - preferred_term: Osteoblast
     term:
@@ -80,6 +112,57 @@ pathophysiology:
     explanation: >-
       Describes the molecular consequences of collagen structural mutations that
       affect bone matrix formation, applicable across the OI severity spectrum.
+  downstream:
+  - target: Dysregulated Bone Remodeling
+- name: Dysregulated Bone Remodeling
+  description: >
+    Secondary signaling and resorption abnormalities further amplify fragility,
+    with excessive TGF-beta signaling and increased osteoclast-related bone
+    turnover superimposed on the abnormal collagen matrix.
+  cell_types:
+  - preferred_term: Osteoblast
+    term:
+      id: CL:0000062
+      label: osteoblast
+  - preferred_term: Osteoclast
+    term:
+      id: CL:0000092
+      label: osteoclast
+  biological_processes:
+  - preferred_term: TGF-beta receptor signaling
+    term:
+      id: GO:0007179
+      label: transforming growth factor beta receptor signaling pathway
+  - preferred_term: Bone remodeling
+    term:
+      id: GO:0046849
+      label: bone remodeling
+  evidence:
+  - reference: PMID:24793237
+    reference_title: Excessive transforming growth factor-β signaling is a common mechanism in osteogenesis imperfecta.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Here, we show that excessive transforming growth factor-β (TGF-β)
+      signaling is a mechanism of OI in both recessive (Crtap(-/-)) and
+      dominant (Col1a2(tm1.1Mcbr)) OI mouse models. In the skeleton, we find
+      higher expression of TGF-β target genes, higher ratio of phosphorylated
+      Smad2 to total Smad2 protein and higher in vivo Smad2 reporter activity.
+    explanation: >-
+      This dominant OI model supports excess TGF-beta/SMAD signaling as a
+      downstream disease mechanism relevant to collagen I structural disease.
+  - reference: PMID:39372603
+    reference_title: "Osteoclast indices in osteogenesis imperfecta: systematic review and meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Bone histomorphometry demonstrated the trends for higher osteoclast
+      numbers (1.16; CI: -0.22, 2.55) and osteoclast surface (0.43; CI: -0.63,
+      1.49), and significantly higher eroded surface (3.24; CI: 0.51, 5.96)
+      compared with age-matched controls.
+    explanation: >-
+      This patient meta-analysis supports increased osteoclast-associated bone
+      turnover as part of OI pathophysiology.
 genetic:
 - name: COL1A1/COL1A2 Mutations
   association: Causative
@@ -207,29 +290,29 @@ phenotypes:
     explanation: >-
       This pediatric dental cohort directly documents dentinogenesis imperfecta
       with discolored teeth in children with OI type IV.
-- name: Skeletal Deformity
+- name: Bowing of the Long Bones
   description: >
-    Skeletal deformities are common in childhood; they are typically less
-    severe than in type III at birth but remain substantial during the first
-    decade of life.
+    Long-bone bowing can occur in type IV OI, particularly in the femur.
   phenotype_term:
-    preferred_term: Abnormality of the skeletal system
+    preferred_term: Bowing of the long bones
     term:
-      id: HP:0000924
-      label: Abnormality of the skeletal system
+      id: HP:0006487
+      label: Bowing of the long bones
   evidence:
-  - reference: PMID:1739868
-    reference_title: "Osteogenesis imperfecta: a clinical study of the first ten years of life."
+  - reference: PMID:38752190
+    reference_title: "Management of Combined Fracture Neck of Femur and Femoral Deformity in Osteogenesis Imperfecta Patient: A Case Report."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      At birth, the skeletal changes were significantly more severe in type III
-      than in type IV patients. During the first 10 years of life the number of
-      fractures, extent of skeletal deformities, and growth retardation did not
-      differ between types III and IV.
+      The bone fragility and repeated fractures produce deformities of the long
+      bones especially in femur and tibia. However, neck of femur (NOF)
+      fractures in OI are rarely described. A 11-year-old male patient known to
+      have OI (Sillence type IV) sustained a NOF fracture after a fall. He also
+      had proximal femoral anterolateral bowing proximally and over an
+      intramedullary (IM) rod inserted 4 years back.
     explanation: >-
-      This pediatric cohort directly supports substantial skeletal deformity
-      burden in type IV OI without over-specifying the anatomic pattern.
+      This type IV case report directly documents long-bone bowing and femoral
+      deformity.
 - name: Scoliosis
   description: >
     Scoliosis is a frequent spinal complication in type IV OI and may progress
@@ -291,11 +374,55 @@ phenotypes:
     explanation: >-
       This pediatric hearing cohort directly documents type IV OI cases with
       conductive hearing loss.
+- name: Basilar Invagination
+  description: >
+    Skull-base invagination can occur in type IV OI and warrants radiographic
+    surveillance when craniovertebral junction disease is suspected.
+  phenotype_term:
+    preferred_term: Basilar invagination
+    term:
+      id: HP:0012366
+      label: Basilar invagination
+  evidence:
+  - reference: PMID:16961127
+    reference_title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      As a sign of basilar invagination the odontoid process protruded into the
+      foramen magnum or reached the foramen magnum level in 22.2% of the
+      patients with OI, whereas none of the controls showed this feature.
+    explanation: >-
+      This cephalometric OI cohort shows that basilar invagination is a
+      clinically relevant cranial complication; the same study noted these skull
+      base abnormalities were predominantly found in types III and IV.
+- name: Wormian Bones
+  description: >
+    Wormian bones are a recognized cranial radiographic feature in the more
+    deforming classical OI subtypes, including type IV.
+  phenotype_term:
+    preferred_term: Wormian bones
+    term:
+      id: HP:0002645
+      label: Wormian bones
+  evidence:
+  - reference: PMID:16961127
+    reference_title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These three abnormalities and wormian bones were predominantly found in
+      OI Types III and IV as well as in patients exhibiting dentinal
+      abnormality.
+    explanation: >-
+      This OI cohort directly associates wormian bones with the type III/IV
+      classical deforming phenotypes.
 treatments:
 - name: Bisphosphonate Therapy
   description: >
-    Bisphosphonates can improve vertebral bone density and reduce some fracture
-    burden, particularly in childhood.
+    Bisphosphonates can improve vertebral density and vertebral shape in
+    childhood, but short-term functional benefit and long-bone fracture
+    reduction are inconsistent.
   treatment_term:
     preferred_term: Bisphosphonate therapy
     term:
@@ -307,14 +434,18 @@ treatments:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      A controlled trial confirmed the spine benefits of short-term
-      pamidronate treatment in children with types III and IV OI. Pamidronate
-      increased L1-L4 vertebral DXA and decreased vertebral compressions and
-      upper extremity fractures.
+      Bisphosphonates have been widely administered to children with OI based
+      on observational trials. A randomized controlled trial of q3m
+      intravenous pamidronate in children with types III and IV OI yielded
+      positive vertebral changes in DXA and geometry after 1 year of
+      treatment, but no further significant improvement during extended
+      treatment. The treated group did not experience significantly decreased
+      pain or long bone fractures or have increased motor function or muscle
+      strength.
     explanation: >-
-      This randomized trial provides subtype-relevant evidence that pamidronate
-      improves vertebral outcomes and reduces some fracture burden in children
-      with type IV OI.
+      This randomized trial supports vertebral benefit from pamidronate in
+      type III/IV OI but not consistent short-term functional or long-bone
+      fracture improvement.
   - reference: DOI:10.1007/s00223-024-01202-7
     reference_title: "Medical Management for Fracture Prevention in Children with Osteogenesis Imperfecta"
     supports: SUPPORT
@@ -323,8 +454,8 @@ treatments:
       Children currently receive off-label treatment with bisphosphonates,
       without any consistent approach to dose, drug or route of administration.
     explanation: >-
-      Confirms that bisphosphonates are the primary medical treatment for fracture
-      prevention in children with OI, though used off-label.
+      Confirms that bisphosphonates remain widely used off-label in pediatric
+      OI, despite nonstandardized drug, dose, and route choices.
 - name: Orthopedic Management
   description: >
     Fracture treatment and corrective surgery for deformities as needed.
@@ -383,17 +514,26 @@ references:
 - reference: PMID:15883638
   title: Controlled trial of pamidronate in children with types III and IV osteogenesis imperfecta confirms vertebral gains but not short-term functional improvement.
   findings: []
-- reference: PMID:1739868
-  title: "Osteogenesis imperfecta: a clinical study of the first ten years of life."
+- reference: PMID:16961127
+  title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
   findings: []
 - reference: PMID:20384825
   title: "Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study."
+  findings: []
+- reference: PMID:24793237
+  title: Excessive transforming growth factor-β signaling is a common mechanism in osteogenesis imperfecta.
   findings: []
 - reference: PMID:26927310
   title: Scoliosis in osteogenesis imperfecta caused by COL1A1/COL1A2 mutations - genotype-phenotype correlations and effect of bisphosphonate treatment.
   findings: []
 - reference: PMID:29970925
   title: "Growth characteristics in individuals with osteogenesis imperfecta in North America: results from a multicenter study."
+  findings: []
+- reference: PMID:38752190
+  title: "Management of Combined Fracture Neck of Femur and Femoral Deformity in Osteogenesis Imperfecta Patient: A Case Report."
+  findings: []
+- reference: PMID:39372603
+  title: "Osteoclast indices in osteogenesis imperfecta: systematic review and meta-analysis."
   findings: []
 - reference: PMID:6822598
   title: Osteogenesis imperfecta with dominant inheritance and normal sclerae.

--- a/kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type IV
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-10T00:00:00Z'
+updated_date: '2026-04-19T06:40:39Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type IV represents moderate severity OI, intermediate
@@ -176,7 +176,8 @@ phenotypes:
       feature of OI type IV.
 - name: Dentinogenesis Imperfecta
   description: >
-    Variable presence of dentinogenesis imperfecta with opalescent teeth.
+    Variable dentinogenesis imperfecta, sometimes with yellow-brown or
+    opalescent gray tooth discoloration.
   phenotype_term:
     preferred_term: Dentinogenesis imperfecta
     term:
@@ -194,15 +195,28 @@ phenotypes:
     explanation: >-
       This type IV cohort directly reports dentinogenesis imperfecta as a more
       frequent feature in type IV than in type I OI.
+  - reference: PMID:20384825
+    reference_title: "Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A total of ten patients had abnormal discolourations referable to DI:
+      four patients were affected by OI type I, three patients by OI type III,
+      and three patients by OI type IV. The discolourations, yellow/brown or
+      opalescent grey, could not be related to the different types of OI.
+    explanation: >-
+      This pediatric dental cohort directly documents dentinogenesis imperfecta
+      with discolored teeth in children with OI type IV.
 - name: Skeletal Deformity
   description: >
-    Long-bone and other skeletal deformities are common in childhood, although
-    type IV is usually less severe than type III at birth.
+    Skeletal deformities are common in childhood; they are typically less
+    severe than in type III at birth but remain substantial during the first
+    decade of life.
   phenotype_term:
-    preferred_term: Bowing of the long bones
+    preferred_term: Abnormality of the skeletal system
     term:
-      id: HP:0006487
-      label: Bowing of the long bones
+      id: HP:0000924
+      label: Abnormality of the skeletal system
   evidence:
   - reference: PMID:1739868
     reference_title: "Osteogenesis imperfecta: a clinical study of the first ten years of life."
@@ -214,12 +228,52 @@ phenotypes:
       fractures, extent of skeletal deformities, and growth retardation did not
       differ between types III and IV.
     explanation: >-
-      This pediatric cohort directly supports the presence of substantial
-      skeletal deformity burden in type IV OI, including long-bone deformities.
+      This pediatric cohort directly supports substantial skeletal deformity
+      burden in type IV OI without over-specifying the anatomic pattern.
+- name: Scoliosis
+  description: >
+    Scoliosis is a frequent spinal complication in type IV OI and may progress
+    during growth.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:26927310
+    reference_title: "Scoliosis in osteogenesis imperfecta caused by COL1A1/COL1A2 mutations - genotype-phenotype correlations and effect of bisphosphonate treatment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The prevalence of scoliosis was highest in OI type III (89%), followed by
+      OI type IV (61%) and OI type I (36%).
+    explanation: >-
+      This large COL1A1/COL1A2 cohort shows that scoliosis is frequent in OI
+      type IV.
+- name: Delayed Gross Motor Development
+  description: >
+    Gross motor development may become delayed after unsupported sitting is
+    achieved.
+  phenotype_term:
+    preferred_term: Delayed gross motor development
+    term:
+      id: HP:0002194
+      label: Delayed gross motor development
+  evidence:
+  - reference: PMID:10968241
+    reference_title: "Osteogenesis imperfecta: profiles of motor development as assessed by a postal questionnaire."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In OI type IV, a retardation in motor development developed after the
+      milestone 'sitting without support' was achieved.
+    explanation: >-
+      This motor-development cohort directly documents delayed gross motor
+      progression in children with OI type IV.
 - name: Hearing Impairment
   description: >
-    Hearing loss may emerge over time, including in childhood, and warrants
-    longitudinal monitoring.
+    Conductive hearing impairment can occur in childhood in some patients.
   phenotype_term:
     preferred_term: Hearing impairment
     term:
@@ -320,6 +374,9 @@ references:
 - reference: PMID:10923226
   title: Hearing loss in children with osteogenesis imperfecta.
   findings: []
+- reference: PMID:10968241
+  title: "Osteogenesis imperfecta: profiles of motor development as assessed by a postal questionnaire."
+  findings: []
 - reference: PMID:11127846
   title: "Osteogenesis imperfecta: practical treatment guidelines."
   findings: []
@@ -328,6 +385,12 @@ references:
   findings: []
 - reference: PMID:1739868
   title: "Osteogenesis imperfecta: a clinical study of the first ten years of life."
+  findings: []
+- reference: PMID:20384825
+  title: "Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study."
+  findings: []
+- reference: PMID:26927310
+  title: Scoliosis in osteogenesis imperfecta caused by COL1A1/COL1A2 mutations - genotype-phenotype correlations and effect of bisphosphonate treatment.
   findings: []
 - reference: PMID:29970925
   title: "Growth characteristics in individuals with osteogenesis imperfecta in North America: results from a multicenter study."

--- a/references_cache/PMID_10968241.md
+++ b/references_cache/PMID_10968241.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:10968241"
+title: "Osteogenesis imperfecta: profiles of motor development as assessed by a postal questionnaire."
+authors:
+- Engelbert RH
+- Uiterwaal CS
+- Gulmans VA
+- Pruijs HE
+- Helders PJ
+journal: Eur J Pediatr
+year: '2000'
+doi: 10.1007/s004310000505
+keywords:
+- Activities of Daily Living
+- Adolescent
+- Adult
+- Case-Control Studies
+- Child
+- "Child, Preschool"
+- "Developmental Disabilities/etiology, physiopathology"
+- Female
+- "Fracture Fixation, Intramedullary"
+- Humans
+- Male
+- Motor Skills
+- "Osteogenesis Imperfecta/classification, complications, surgery"
+- Reference Values
+- Severity of Illness Index
+- Surveys and Questionnaires
+- Weight-Bearing
+content_type: abstract_only
+---
+
+# Osteogenesis imperfecta: profiles of motor development as assessed by a postal questionnaire.
+**Authors:** Engelbert RH, Uiterwaal CS, Gulmans VA, Pruijs HE, Helders PJ
+**Journal:** Eur J Pediatr (2000)
+**DOI:** [10.1007/s004310000505](https://doi.org/10.1007/s004310000505)
+
+## Content
+
+1. Eur J Pediatr. 2000 Aug;159(8):615-20. doi: 10.1007/s004310000505.
+
+Osteogenesis imperfecta: profiles of motor development as assessed by a postal 
+questionnaire.
+
+Engelbert RH(1), Uiterwaal CS, Gulmans VA, Pruijs HE, Helders PJ.
+
+Author information:
+(1)Department of Paediatric Physical Therapy, University Medical Centre, 
+Wilhelmina Children's Hospital, Utrecht, The Netherlands. R.Engelbert@wkz.azu.nl
+
+This study was performed to achieve more detailed information regarding the age 
+and sequence in the development of motor milestones in the different types of 
+osteogenesis imperfecta (OI). The parents of 98 patients with a diagnosis of OI 
+were sent a questionnaire regarding the age at which patients achieved motor 
+milestones. All patients were attending the outpatient clinic for children with 
+OI at the Wilhelmina Children's Hospital. The motor milestones were classified 
+into static motor milestones and dynamic motor milestones and all data were 
+checked with health care records. The age of development of motor milestones was 
+compared to reference values of the healthy population. The severity of the 
+disease was classified according to Sillence based on clinical, genetic and 
+radiological data. The age of intramedullary rodding of the first nail in the 
+lower and upper extremity and the localisation was noted. A total of 76 parents 
+responded to the 98 questionnaires (78%). In OI type I, a delay exists in 
+achieving motor milestones, comparable to the 95th percentile of the normal 
+population. In type III, the development of all motor milestones was 
+significantly delayed compared to types I and IV with a discrepancy between 
+static and dynamic milestones. In OI type IV, a retardation in motor development 
+developed after the milestone 'sitting without support' was achieved. Motor 
+development in types I and IV was not influenced by intramedullary rodding of 
+the lower extremities, since rodding was rarely performed before the milestone 
+'unsupported standing' was achieved. In type III, the influence of 
+intramedullary rodding on the age of achieving motor milestones remains 
+questionable.
+CONCLUSION: The severity of osteogenesis imperfecta has a large influence on the 
+age and sequence in the development of motor milestones. No influence of 
+intramedullary rodding of the lower extremities on motor development was found 
+in osteogenesis imperfecta types I and IV, whereas the influence in type III 
+remains questionable.
+
+DOI: 10.1007/s004310000505
+PMID: 10968241 [Indexed for MEDLINE]

--- a/references_cache/PMID_16961127.md
+++ b/references_cache/PMID_16961127.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:16961127"
+title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
+authors:
+- Kovero O
+- Pynnönen S
+- Kuurila-Svahn K
+- Kaitila I
+- Waltimo-Sirén J
+journal: J Neurosurg
+year: '2006'
+doi: 10.3171/jns.2006.105.3.361
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Cephalometry/methods
+- Female
+- Foramen Magnum
+- Humans
+- Male
+- Middle Aged
+- Osteogenesis Imperfecta/pathology
+- Platybasia/pathology
+- Skull Base/abnormalities
+content_type: abstract_only
+---
+
+# Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers.
+**Authors:** Kovero O, Pynnönen S, Kuurila-Svahn K, Kaitila I, Waltimo-Sirén J
+**Journal:** J Neurosurg (2006)
+**DOI:** [10.3171/jns.2006.105.3.361](https://doi.org/10.3171/jns.2006.105.3.361)
+
+## Content
+
+1. J Neurosurg. 2006 Sep;105(3):361-70. doi: 10.3171/jns.2006.105.3.361.
+
+Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation 
+of 54 patients and 108 control volunteers.
+
+Kovero O(1), Pynnönen S, Kuurila-Svahn K, Kaitila I, Waltimo-Sirén J.
+
+Author information:
+(1)Department of Oral Radiology, Institute of Dentistry, University of Helsinki, 
+Finland.
+
+Comment in
+    J Neurosurg. 2006 Sep;105(3):359; discussion 359-60. doi: 
+10.3171/jns.2006.105.3.359.
+
+OBJECT: Osteogenesis imperfecta (OI), which usually results from mutations in 
+type I collagen genes, causes bone fragility and deformities. The head is often 
+abnormally shaped, and changes in skull base anatomy in the form of basilar 
+impression and basilar invagination have been reported. The authors analyzed the 
+skull base anatomy on standardized lateral cephalograms from 54 patients with OI 
+(Types I, III, and IV) and 108 control volunteers. They were surprised to find 
+that the previously used diagnostic measures for basilar abnormality in patients 
+with OI were exceeded in 6.5 to 7.4% of the controls, and hence needed to be 
+reevaluated.
+METHODS: The authors calculated the distance from the odontoid process to four 
+reference lines, including a novel one, in the controls. The normal mean 
+distances were exceeded by more than two standard deviations (SDs) in 28.3 to 
+35.2%, and by more than three SDs in 13.2 to 16.6% of the patients with OI. The 
+latter figures reliably reflect the prevalence of basilar impression. As a sign 
+of basilar invagination the odontoid process protruded into the foramen magnum 
+or reached the foramen magnum level in 22.2% of the patients with OI, whereas 
+none of the controls showed this feature. Platybasia (an anterior cranial base 
+angle > 146 degrees) was present in 11.1% of the patients but in none of the 
+controls.
+CONCLUSIONS: Platybasia, basilar impression, and basilar invagination were often 
+coexpressed, but each was also present as an isolated abnormality. These three 
+abnormalities and wormian bones were predominantly found in OI Types III and IV 
+as well as in patients exhibiting dentinal abnormality.
+
+DOI: 10.3171/jns.2006.105.3.361
+PMID: 16961127 [Indexed for MEDLINE]

--- a/references_cache/PMID_20384825.md
+++ b/references_cache/PMID_20384825.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:20384825"
+title: "Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study."
+authors:
+- Majorana A
+- Bardellini E
+- Brunelli PC
+- Lacaita M
+- Cazzolla AP
+- Favia G
+journal: Int J Paediatr Dent
+year: '2010'
+doi: 10.1111/j.1365-263X.2010.01033.x
+keywords:
+- Child
+- "Dentin/pathology, ultrastructure"
+- "Dentinogenesis Imperfecta/classification, complications, pathology"
+- "Dentition, Permanent"
+- Female
+- Humans
+- Male
+- "Microscopy, Confocal"
+- "Osteogenesis Imperfecta/classification, complications, pathology"
+- "Tooth, Deciduous"
+content_type: abstract_only
+---
+
+# Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study.
+**Authors:** Majorana A, Bardellini E, Brunelli PC, Lacaita M, Cazzolla AP, Favia G
+**Journal:** Int J Paediatr Dent (2010)
+**DOI:** [10.1111/j.1365-263X.2010.01033.x](https://doi.org/10.1111/j.1365-263X.2010.01033.x)
+
+## Content
+
+1. Int J Paediatr Dent. 2010 Mar;20(2):112-8. doi: 
+10.1111/j.1365-263X.2010.01033.x.
+
+Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical 
+and ultrastructural study.
+
+Majorana A(1), Bardellini E, Brunelli PC, Lacaita M, Cazzolla AP, Favia G.
+
+Author information:
+(1)Department of Pediatric Dentistry, Dental School, University of Brescia, 
+Brescia, Italy. majorana@med.unibs.it
+
+AIM: The aim of this study was to assess the correlation between osteogenesis 
+imperfecta (OI) and dentinogenesis imperfecta (DI) from both a clinical and 
+histological point of view, particularly clarifying the structural and 
+ultrastructural dentine changes.
+DESIGN: Sixteen children (6-12 years aged) with diagnosis of OI were examined 
+for dental alterations referable to DI. For each patient, the OI type (I, III, 
+or IV) was recorded. Extracted or normally exfoliated primary teeth were 
+subjected to a histological examination (to both optical microscopy and confocal 
+laser-scanning microscopy).
+RESULTS: A total of ten patients had abnormal discolourations referable to DI: 
+four patients were affected by OI type I, three patients by OI type III, and 
+three patients by OI type IV. The discolourations, yellow/brown or opalescent 
+grey, could not be related to the different types of OI. Histological exam of 
+primary teeth showed severe pathological change in the dentin, structured into 
+four different layers. A collagen defect due to odontoblast dysfunction was 
+theorized to be on the base of the histological changes.
+CONCLUSIONS: There is no correlation between the type of OI and the type of 
+discolouration. The underlying dentinal defect seems to be related to an 
+odontoblast dysfunction.
+
+DOI: 10.1111/j.1365-263X.2010.01033.x
+PMID: 20384825 [Indexed for MEDLINE]

--- a/references_cache/PMID_24793237.md
+++ b/references_cache/PMID_24793237.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:24793237"
+title: Excessive transforming growth factor-β signaling is a common mechanism in osteogenesis imperfecta.
+authors:
+- Grafe I
+- Yang T
+- Alexander S
+- Homan EP
+- Lietman C
+- Jiang MM
+- Bertin T
+- Munivez E
+- Chen Y
+- Dawson B
+- Ishikawa Y
+- Weis MA
+- Sampath TK
+- Ambrose C
+- Eyre D
+- Bächinger HP
+- Lee B
+journal: Nat Med
+year: '2014'
+doi: 10.1038/nm.3544
+keywords:
+- Analysis of Variance
+- Animals
+- Collagen Type I/genetics
+- "Electrophoresis, Polyacrylamide Gel"
+- Extracellular Matrix Proteins
+- Female
+- Immunoblotting
+- Mass Spectrometry
+- Mice
+- "Mice, Inbred C57BL"
+- "Mice, Knockout"
+- Molecular Chaperones
+- "Osteogenesis Imperfecta/metabolism, physiopathology"
+- Proteins/genetics
+- Real-Time Polymerase Chain Reaction
+- Signal Transduction/physiology
+- Surface Plasmon Resonance
+- Transforming Growth Factor beta/metabolism
+- X-Ray Microtomography
+content_type: abstract_only
+---
+
+# Excessive transforming growth factor-β signaling is a common mechanism in osteogenesis imperfecta.
+**Authors:** Grafe I, Yang T, Alexander S, Homan EP, Lietman C, Jiang MM, Bertin T, Munivez E, Chen Y, Dawson B, Ishikawa Y, Weis MA, Sampath TK, Ambrose C, Eyre D, Bächinger HP, Lee B
+**Journal:** Nat Med (2014)
+**DOI:** [10.1038/nm.3544](https://doi.org/10.1038/nm.3544)
+
+## Content
+
+1. Nat Med. 2014 Jun;20(6):670-5. doi: 10.1038/nm.3544. Epub 2014 May 4.
+
+Excessive transforming growth factor-β signaling is a common mechanism in 
+osteogenesis imperfecta.
+
+Grafe I(1), Yang T(1), Alexander S(1), Homan EP(1), Lietman C(1), Jiang MM(2), 
+Bertin T(1), Munivez E(1), Chen Y(1), Dawson B(2), Ishikawa Y(3), Weis MA(4), 
+Sampath TK(5), Ambrose C(6), Eyre D(4), Bächinger HP(3), Lee B(2).
+
+Author information:
+(1)Department of Molecular and Human Genetics, Baylor College of Medicine, 
+Houston, Texas, USA.
+(2)1] Department of Molecular and Human Genetics, Baylor College of Medicine, 
+Houston, Texas, USA. [2] Howard Hughes Medical Institute, Houston, Texas, USA.
+(3)1] Research Department, Shriners Hospital for Children, Portland, Oregon, 
+USA. [2] Department of Biochemistry and Molecular Biology, Oregon Health and 
+Science University, Portland, Oregon, USA.
+(4)Department of Orthopaedics and Sports Medicine, University of Washington, 
+Seattle, Washington, USA.
+(5)Genzyme Research Center, Framingham, Massachusetts, USA.
+(6)Department of Orthopaedic Surgery, University of Texas Health Science Center 
+at Houston, Houston, Texas, USA.
+
+Osteogenesis imperfecta (OI) is a heritable disorder, in both a dominant and 
+recessive manner, of connective tissue characterized by brittle bones, fractures 
+and extraskeletal manifestations. How structural mutations of type I collagen 
+(dominant OI) or of its post-translational modification machinery (recessive OI) 
+can cause abnormal quality and quantity of bone is poorly understood. Notably, 
+the clinical overlap between dominant and recessive forms of OI suggests common 
+molecular pathomechanisms. Here, we show that excessive transforming growth 
+factor-β (TGF-β) signaling is a mechanism of OI in both recessive (Crtap(-/-)) 
+and dominant (Col1a2(tm1.1Mcbr)) OI mouse models. In the skeleton, we find 
+higher expression of TGF-β target genes, higher ratio of phosphorylated Smad2 to 
+total Smad2 protein and higher in vivo Smad2 reporter activity. Moreover, the 
+type I collagen of Crtap(-/-) mice shows reduced binding to the small 
+leucine-rich proteoglycan decorin, a known regulator of TGF-β activity. 
+Anti-TGF-β treatment using the neutralizing antibody 1D11 corrects the bone 
+phenotype in both forms of OI and improves the lung abnormalities in Crtap(-/-) 
+mice. Hence, altered TGF-β matrix-cell signaling is a primary mechanism in the 
+pathogenesis of OI and could be a promising target for the treatment of OI.
+
+DOI: 10.1038/nm.3544
+PMCID: PMC4048326
+PMID: 24793237 [Indexed for MEDLINE]

--- a/references_cache/PMID_26927310.md
+++ b/references_cache/PMID_26927310.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:26927310"
+title: Scoliosis in osteogenesis imperfecta caused by COL1A1/COL1A2 mutations - genotype-phenotype correlations and effect of bisphosphonate treatment.
+authors:
+- Sato A
+- Ouellet J
+- Muneta T
+- Glorieux FH
+- Rauch F
+journal: Bone
+year: '2016'
+doi: 10.1016/j.bone.2016.02.018
+keywords:
+- Child
+- Collagen Type I/genetics
+- "Collagen Type I, alpha 1 Chain"
+- Diphosphonates/therapeutic use
+- Female
+- Follow-Up Studies
+- Genetic Association Studies
+- Genetic Predisposition to Disease
+- Humans
+- Male
+- Mutation/genetics
+- "Osteogenesis Imperfecta/complications, drug therapy, genetics"
+- Prevalence
+- "Scoliosis/complications, drug therapy, epidemiology, genetics"
+content_type: abstract_only
+---
+
+# Scoliosis in osteogenesis imperfecta caused by COL1A1/COL1A2 mutations - genotype-phenotype correlations and effect of bisphosphonate treatment.
+**Authors:** Sato A, Ouellet J, Muneta T, Glorieux FH, Rauch F
+**Journal:** Bone (2016)
+**DOI:** [10.1016/j.bone.2016.02.018](https://doi.org/10.1016/j.bone.2016.02.018)
+
+## Content
+
+1. Bone. 2016 May;86:53-7. doi: 10.1016/j.bone.2016.02.018. Epub 2016 Feb 27.
+
+Scoliosis in osteogenesis imperfecta caused by COL1A1/COL1A2 mutations - 
+genotype-phenotype correlations and effect of bisphosphonate treatment.
+
+Sato A(1), Ouellet J(2), Muneta T(3), Glorieux FH(2), Rauch F(4).
+
+Author information:
+(1)Shriners Hospital for Children and McGill University, Montreal, Quebec, 
+Canada; Department of Joint Surgery and Sports Medicine, Graduate School of 
+Medicine, Tokyo Medical and Dental University, Tokyo, Japan.
+(2)Shriners Hospital for Children and McGill University, Montreal, Quebec, 
+Canada.
+(3)Department of Joint Surgery and Sports Medicine, Graduate School of Medicine, 
+Tokyo Medical and Dental University, Tokyo, Japan.
+(4)Shriners Hospital for Children and McGill University, Montreal, Quebec, 
+Canada. Electronic address: frauch@shriners.mcgill.ca.
+
+Bisphosphonates are widely used to treat children with osteogenesis imperfecta 
+(OI), a bone fragility disorder that is most often caused by mutations in COL1A1 
+or COL1A2. However, it is unclear whether this treatment decreases the risk of 
+developing scoliosis. We retrospectively evaluated spine radiographs and charts 
+of 437 patients (227 female) with OI caused by mutations in COL1A1 or COL1A2 and 
+compared the relationship between scoliosis, genotype and bisphosphonate 
+treatment history. At the last follow-up (mean age 11.9 [SD: 5.9] years), 242 
+(55%) patients had scoliosis. The prevalence of scoliosis was highest in OI type 
+III (89%), followed by OI type IV (61%) and OI type I (36%). Moderate to severe 
+scoliosis (Cobb angle ≥25°) was rare in individuals with COL1A1 
+haploinsufficiency mutations but was present in about two fifth of patients with 
+triple helical glycine substitutions or C-propeptide mutations. During the first 
+2 to 4years of bisphosphonate therapy, patients with OI type III had lower Cobb 
+angle progression rates than before bisphosphonate treatment, whereas in OI 
+types I and IV bisphosphonate treatment was not associated with a change in Cobb 
+angle progression rates. At skeletal maturity, the prevalence of scoliosis (Cobb 
+angle >10°) was similar in patients who had started bisphosphonate treatment 
+early in life (before 5.0years of age) and in patients who had started therapy 
+later (after the age of 10.0years) or had never received bisphosphonate therapy. 
+Bisphosphonate treatment decreased progression rate of scoliosis in OI type III 
+but there was no evidence of a positive effect on scoliosis in OI types I and 
+IV. The prevalence of scoliosis at maturity was not influenced by the 
+bisphosphonate treatment history in any OI type.
+
+Copyright © 2016 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.bone.2016.02.018
+PMID: 26927310 [Indexed for MEDLINE]

--- a/references_cache/PMID_38752190.md
+++ b/references_cache/PMID_38752190.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:38752190"
+title: "Management of Combined Fracture Neck of Femur and Femoral Deformity in Osteogenesis Imperfecta Patient: A Case Report."
+authors:
+- Elbaseet HM
+- Ibrahim AH
+- Oyoun NA
+- Abdelzaher MA
+- Khaled M
+journal: Strategies Trauma Limb Reconstr
+year: '2024'
+doi: 10.5005/jp-journals-10080-1611
+content_type: abstract_only
+---
+
+# Management of Combined Fracture Neck of Femur and Femoral Deformity in Osteogenesis Imperfecta Patient: A Case Report.
+**Authors:** Elbaseet HM, Ibrahim AH, Oyoun NA, Abdelzaher MA, Khaled M
+**Journal:** Strategies Trauma Limb Reconstr (2024)
+**DOI:** [10.5005/jp-journals-10080-1611](https://doi.org/10.5005/jp-journals-10080-1611)
+
+## Content
+
+1. Strategies Trauma Limb Reconstr. 2024 Jan-Apr;19(1):56-59. doi: 
+10.5005/jp-journals-10080-1611.
+
+Management of Combined Fracture Neck of Femur and Femoral Deformity in 
+Osteogenesis Imperfecta Patient: A Case Report.
+
+Elbaseet HM(1), Ibrahim AH(1), Oyoun NA(1), Abdelzaher MA(1), Khaled M(1).
+
+Author information:
+(1)Pediatric Orthopedic Unit, Department of Orthopedic Surgery and Traumatology, 
+Assiut University, Egypt.
+
+Osteogenesis imperfecta (OI) patients usually sustain repeated fractures from 
+trivial trauma and also have skeletal deformities that affect walking. The bone 
+fragility and repeated fractures produce deformities of the long bones 
+especially in femur and tibia. However, neck of femur (NOF) fractures in OI are 
+rarely described. A 11-year-old male patient known to have OI (Sillence type IV) 
+sustained a NOF fracture after a fall. He also had proximal femoral 
+anterolateral bowing proximally and over an intramedullary (IM) rod inserted 4 
+years back. He was treated by corrective osteotomy and stabilisation with an IM 
+telescoping nail for the deformed femur and the Wagner technique for the NOF 
+fracture. One year after operation, the patient had recovered satisfactory 
+functional outcome with union of the NOF fracture and correction of the femoral 
+deformity.
+CONCLUSION: The method of the Wagner technique can achieve stable fixation for 
+femoral neck fractures and introduces the least interference with concurrent 
+telescoping nail insertion.
+HOW TO CITE THIS ARTICLE: Elbaseet HM, Ibrahim AH, Abol Oyoun N, et al. 
+Management of Combined Fracture Neck of Femur and Femoral Deformity in 
+Osteogenesis Imperfecta Patient: A Case Report. Strategies Trauma Limb Reconstr 
+2024;19(1):56-59.
+
+Copyright © 2024; The Author(s).
+
+DOI: 10.5005/jp-journals-10080-1611
+PMCID: PMC11091891
+PMID: 38752190
+
+Conflict of interest statement: Source of support: Nil Conflict of interest: 
+None Patient consent statement: The author(s) have obtained written informed 
+consent from the patient's parents/legal guardians for publication of the case 
+report details and related images.

--- a/references_cache/PMID_39372603.md
+++ b/references_cache/PMID_39372603.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:39372603"
+title: "Osteoclast indices in osteogenesis imperfecta: systematic review and meta-analysis."
+authors:
+- Aksornthong S
+- Patel P
+- Komarova SV
+journal: JBMR Plus
+year: '2024'
+doi: 10.1093/jbmrpl/ziae112
+content_type: abstract_only
+---
+
+# Osteoclast indices in osteogenesis imperfecta: systematic review and meta-analysis.
+**Authors:** Aksornthong S, Patel P, Komarova SV
+**Journal:** JBMR Plus (2024)
+**DOI:** [10.1093/jbmrpl/ziae112](https://doi.org/10.1093/jbmrpl/ziae112)
+
+## Content
+
+1. JBMR Plus. 2024 Aug 21;8(11):ziae112. doi: 10.1093/jbmrpl/ziae112. eCollection
+ 2024 Nov.
+
+Osteoclast indices in osteogenesis imperfecta: systematic review and 
+meta-analysis.
+
+Aksornthong S(1)(2), Patel P(2)(3), Komarova SV(1)(2)(3)(4).
+
+Author information:
+(1)Department of Experimental Surgery, McGill University, Montreal, Quebec H3G 
+1A4, Canada.
+(2)Shriners Hospital for Children-Canada, Montreal, Quebec H4A 0A9, Canada.
+(3)Faculty of Dental Medicine and Oral Health Sciences, McGill University, 
+Montreal, Quebec H3A 1G1, Canada.
+(4)Department of Biomedical Engineering, Faculty of Engineering, University of 
+Alberta, Edmonton, Alberta T6G 1H9, Canada.
+
+Osteogenesis imperfecta (OI) is a rare bone fragility disorder caused by 
+mutations in genes encoding collagen type I or that affect its processing. 
+Alterations in osteoclasts were suggested to contribute to OI pathophysiology. 
+We aimed to systematically identify studies reporting measures of osteoclast 
+formation and function in patients and mouse models of OI, to quantify 
+OI-induced changes. The systematic search of Medline, Ovid, and Web of Science 
+identified 798 unique studies. After screening, we included 23 studies for 
+meta-analysis, reporting osteoclast parameters in 310 patients with OI of 9 
+different types and 16 studies reporting osteoclast parameters in 406 animals of 
+11 different OI mouse models. The standardized mean difference with 95% 
+confidence interval (CI) was used as the effect size, and random-effects 
+meta-analysis was performed. In patients with OI, collagen degradation markers 
+were significantly higher compared with age-matched controls, with an effect 
+size of 1.23 (CI: 0.36, 2.10]. Collagen degradation markers were the most 
+elevated in the 3- to 7-year-old age group and in patients with more severe 
+forms of OI. Bone histomorphometry demonstrated the trends for higher osteoclast 
+numbers (1.16; CI: -0.22, 2.55) and osteoclast surface (0.43; CI: -0.63, 1.49), 
+and significantly higher eroded surface (3.24; CI: 0.51, 5.96) compared with 
+age-matched controls. In OI mice, meta-analysis demonstrated significant 
+increases in collagen degradation markers (1.59; CI: 1.07, 2.11), in osteoclast 
+numbers (0.94; CI: 0.50, 1.39), osteoclast surface (0.73; CI: 0.22, 1.23), and 
+eroded surface (1.31; CI: 0.54, 2.08). The largest differences were in OI mice 
+with the mutations in Col1a1 and Col1a2 genes. There were no differences between 
+males and females in clinical or animal studies. Quantitative estimates of 
+changes in osteoclast indices and their variance for patients with OI are 
+important for planning future studies. We confirmed that similar changes are 
+observed in mice with OI, supporting their translational utility.
+
+© The Author(s) 2024. Published by Oxford University Press on behalf of the 
+American Society for Bone and Mineral Research.
+
+DOI: 10.1093/jbmrpl/ziae112
+PMCID: PMC11450326
+PMID: 39372603
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.


### PR DESCRIPTION
## Summary
Refs #1505

Enhances the phenotype section in `kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml` with narrower, PMID-backed curation.

## What changed
- added evidence-backed `Scoliosis` and `Delayed gross motor development`
- tightened the skeletal-deformity mapping so the HPO term matches the cited evidence
- strengthened dentinogenesis-imperfecta support with a type-IV pediatric dental study
- softened the hearing description to match the cited pediatric evidence
- refreshed the local reference cache only for the new PMIDs used in this entry

## Validation
- `just validate kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml` -> passed
- `just validate-references kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml` -> passed
- `just validate-terms kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml` -> passed