### PR TITLE
[codex] Enhance OI type I phenotype evidence

### DIFF
--- a/kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type I
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-02-17T21:53:14Z'
+updated_date: '2026-04-19T06:40:19Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type I (OI type I) is the mildest form of osteogenesis
@@ -113,17 +113,30 @@ genetic:
 phenotypes:
 - name: Blue Sclerae
   description: >
-    Blue or blue-gray scleral hue is characteristic and persists into adulthood,
-    distinguishing type I from type IV OI where sclerae normalize with age.
+    Blue sclerae are a classic extraskeletal sign of osteogenesis imperfecta
+    type I.
   phenotype_term:
     preferred_term: Blue sclerae
     term:
       id: HP:0000592
       label: Blue sclerae
+  evidence:
+  - reference: PMID:6954526
+    reference_title: "Type I osteogenesis imperfecta: a nonfunctional allele for pro alpha 1 (I) chains of type I procollagen."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Type I osteogenesis imperfecta (OI) is a dominantly inherited disease
+      characterized clinically by bone fractures during childhood, blue
+      sclerae, and frequent hearing loss accompanied by a decreased content of
+      type I collagen in bone and skin.
+    explanation: >-
+      Landmark type I OI study identifying blue sclerae as part of the classic
+      clinical phenotype.
 - name: Recurrent Fractures
   description: >
-    Increased bone fragility leads to fractures, often with minimal trauma.
-    Fracture frequency is variable and typically decreases after puberty.
+    Recurrent long-bone fractures are a core skeletal manifestation, and
+    fracture rate declines with age.
   phenotype_term:
     preferred_term: Recurrent fractures
     term:
@@ -142,53 +155,94 @@ phenotypes:
     explanation: >-
       Quantifies fracture rate in COL1A1 haploinsufficiency patients and confirms
       that fracture frequency decreases with age.
-- name: Near-Normal Stature
+- name: Vertebral Compression Fractures
   description: >
-    Height is typically in the low-normal range, distinguishing type I from
-    the more severe forms with significant short stature.
+    Vertebral compression fractures are frequent in growing patients with
+    COL1A1 haploinsufficiency.
   phenotype_term:
-    preferred_term: Normal stature
+    preferred_term: Vertebral compression fracture
     term:
-      id: HP:0000002
-      label: Abnormality of body height
-  frequency: EXCLUDED
+      id: HP:0002953
+      label: Vertebral compression fracture
+  frequency: FREQUENT
   evidence:
   - reference: PMID:23529829
     reference_title: "Skeletal clinical characteristics of osteogenesis imperfecta caused by haploinsufficiency mutations in COL1A1."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The average final height Z-score was -1.1, representing a deficit of 8 to 10
-      cm
-      compared to the general population.
+      Vertebral compression fractures were observed in 71% of the 58 pediatric
+      patients who had lateral spine radiographs.
     explanation: >-
-      Documents that OI type I patients have only mild height reduction (Z-score -1.1),
-      confirming near-normal stature compared to severe OI types.
+      This cohort shows that vertebral compression fractures are a frequent and
+      clinically important component of the type I OI skeletal phenotype.
+- name: Scoliosis
+  description: >
+    Mild scoliosis occurs in a substantial minority of pediatric patients.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:23529829
+    reference_title: "Skeletal clinical characteristics of osteogenesis imperfecta caused by haploinsufficiency mutations in COL1A1."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Scoliosis was present in about 30% of pediatric patients but the Cobb
+      angle was <30 degrees in all cases.
+    explanation: >-
+      Supports scoliosis as a frequent but usually mild spinal manifestation in
+      pediatric type I OI.
 - name: Hearing Impairment
   description: >
-    Progressive hearing loss develops in approximately 50% of adults with OI
-    type I, typically beginning in the second or third decade.
+    Progressive hearing impairment usually begins in adulthood, with onset most
+    often in the second to fourth decades.
   phenotype_term:
     preferred_term: Hearing impairment
     term:
       id: HP:0000365
       label: Hearing impairment
-- name: Joint Hypermobility
+  evidence:
+  - reference: PMID:11276328
+    reference_title: "How common is hearing impairment in osteogenesis imperfecta?"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      It was found that the most common age of onset was in the second, third
+      and fourth decades of life. At the age of 50 approximately 50 per cent of
+      the patients had symptoms of hearing impairment; over the next 20 years
+      there was little further increase. Differences were shown between patients
+      with different clinical types of osteogenesis imperfecta as delineated in
+      the Sillence classification; hearing loss was significantly less common in
+      the type IV disease than in the type I disorder.
+    explanation: >-
+      Large OI survey showing typical adult onset of hearing impairment and
+      demonstrating that hearing loss is more common in type I than in type IV
+      disease.
+- name: Dentinogenesis Imperfecta
   description: >
-    Generalized joint hypermobility due to connective tissue laxity.
+    Dentinogenesis imperfecta can occur in a subset of children with
+    osteogenesis imperfecta type I.
   phenotype_term:
-    preferred_term: Joint hypermobility
+    preferred_term: Dentinogenesis imperfecta
     term:
-      id: HP:0001382
-      label: Joint hypermobility
-- name: Easy Bruising
-  description: >
-    Increased tendency to bruise due to connective tissue fragility.
-  phenotype_term:
-    preferred_term: Easy bruisability
-    term:
-      id: HP:0000978
-      label: Bruising susceptibility
+      id: HP:0000703
+      label: Dentinogenesis imperfecta
+  evidence:
+  - reference: PMID:20384825
+    reference_title: "Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      RESULTS: A total of ten patients had abnormal discolourations referable
+      to DI: four patients were affected by OI type I, three patients by OI
+      type III, and three patients by OI type IV.
+    explanation: >-
+      Pediatric cohort directly documenting dentinogenesis imperfecta in
+      children with type I OI.
 treatments:
 - name: Bisphosphonate Therapy
   description: >

--- a/kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type I
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T06:40:19Z'
+updated_date: '2026-04-19T15:05:51Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type I (OI type I) is the mildest form of osteogenesis
@@ -150,8 +150,8 @@ phenotypes:
     snippet: >-
       The average rate of long-bone fracture (femur, tibia/fibula, humerus, radius/ulna)
       in pediatric patients was 0.62 fractures per year, one-half of which affected
-      the
-      tibia/fibula. Long-bone fracture rate was negatively associated with age.
+      the tibia/fibula. Long-bone fracture rate was negatively associated with
+      age and lumbar spine areal bone mineral density.
     explanation: >-
       Quantifies fracture rate in COL1A1 haploinsufficiency patients and confirms
       that fracture frequency decreases with age.
@@ -184,7 +184,7 @@ phenotypes:
     term:
       id: HP:0002650
       label: Scoliosis
-  frequency: FREQUENT
+  frequency: OCCASIONAL
   evidence:
   - reference: PMID:23529829
     reference_title: "Skeletal clinical characteristics of osteogenesis imperfecta caused by haploinsufficiency mutations in COL1A1."
@@ -194,8 +194,8 @@ phenotypes:
       Scoliosis was present in about 30% of pediatric patients but the Cobb
       angle was <30 degrees in all cases.
     explanation: >-
-      Supports scoliosis as a frequent but usually mild spinal manifestation in
-      pediatric type I OI.
+      Supports scoliosis as an occasional and usually mild spinal manifestation
+      in pediatric type I OI.
 - name: Hearing Impairment
   description: >
     Progressive hearing impairment usually begins in adulthood, with onset most
@@ -246,8 +246,8 @@ phenotypes:
 treatments:
 - name: Bisphosphonate Therapy
   description: >
-    Bisphosphonates (pamidronate, zoledronic acid) are used to increase bone
-    mineral density and reduce fracture frequency, particularly in children.
+    Bisphosphonate therapy is used clinically in the management of skeletal
+    fragility in osteogenesis imperfecta, particularly in children.
   treatment_term:
     preferred_term: Bisphosphonate therapy
     term:

--- a/references_cache/PMID_11276328.md
+++ b/references_cache/PMID_11276328.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:11276328"
+title: "How common is hearing impairment in osteogenesis imperfecta?"
+authors:
+- Paterson CR
+- Monk EA
+- McAllion SJ
+journal: J Laryngol Otol
+year: '2001'
+doi: 10.1258/0022215011907442
+keywords:
+- Adolescent
+- Adult
+- Age of Onset
+- Aged
+- "Aged, 80 and over"
+- Child
+- "Child, Preschool"
+- "Hearing Disorders/epidemiology, etiology"
+- Humans
+- Incidence
+- Infant
+- "Infant, Newborn"
+- Middle Aged
+- "Osteogenesis Imperfecta/complications, epidemiology"
+- Pedigree
+- Phenotype
+content_type: abstract_only
+---
+
+# How common is hearing impairment in osteogenesis imperfecta?
+**Authors:** Paterson CR, Monk EA, McAllion SJ
+**Journal:** J Laryngol Otol (2001)
+**DOI:** [10.1258/0022215011907442](https://doi.org/10.1258/0022215011907442)
+
+## Content
+
+1. J Laryngol Otol. 2001 Apr;115(4):280-2. doi: 10.1258/0022215011907442.
+
+How common is hearing impairment in osteogenesis imperfecta?
+
+Paterson CR(1), Monk EA, McAllion SJ.
+
+Author information:
+(1)Department of Medicine, University of Dundee, Dundee, Scotland. 
+c.r.paterson@dundee.ac.uk.
+
+Hearing impairment has long been recognized as a common feature in osteogenesis 
+imperfecta. The figures in some publications could be taken to imply that, with 
+increasing age, the proportion of osteogenesis imperfecta patients with hearing 
+impairment approaches 100 per cent. The incidence of hearing loss in a large 
+survey of 1394 patients with osteogenesis imperfecta was examined. It was found 
+that the most common age of onset was in the second, third and fourth decades of 
+life. At the age of 50 approximately 50 per cent of the patients had symptoms of 
+hearing impairment; over the next 20 years there was little further increase. 
+Differences were shown between patients with different clinical types of 
+osteogenesis imperfecta as delineated in the Sillence classification; hearing 
+loss was significantly less common in the type IV disease than in the type I 
+disorder. Among the 29 families with osteogenesis imperfecta type IA there were 
+distinct differences in the likelihood of hearing loss. These findings provide 
+insights which will be valuable in giving patients advice on the likelihood of 
+developing hearing loss in the future.
+
+DOI: 10.1258/0022215011907442
+PMID: 11276328 [Indexed for MEDLINE]

--- a/references_cache/PMID_20384825.md
+++ b/references_cache/PMID_20384825.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:20384825"
+title: "Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study."
+authors:
+- Majorana A
+- Bardellini E
+- Brunelli PC
+- Lacaita M
+- Cazzolla AP
+- Favia G
+journal: Int J Paediatr Dent
+year: '2010'
+doi: 10.1111/j.1365-263X.2010.01033.x
+keywords:
+- Child
+- "Dentin/pathology, ultrastructure"
+- "Dentinogenesis Imperfecta/classification, complications, pathology"
+- "Dentition, Permanent"
+- Female
+- Humans
+- Male
+- "Microscopy, Confocal"
+- "Osteogenesis Imperfecta/classification, complications, pathology"
+- "Tooth, Deciduous"
+content_type: abstract_only
+---
+
+# Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical and ultrastructural study.
+**Authors:** Majorana A, Bardellini E, Brunelli PC, Lacaita M, Cazzolla AP, Favia G
+**Journal:** Int J Paediatr Dent (2010)
+**DOI:** [10.1111/j.1365-263X.2010.01033.x](https://doi.org/10.1111/j.1365-263X.2010.01033.x)
+
+## Content
+
+1. Int J Paediatr Dent. 2010 Mar;20(2):112-8. doi: 
+10.1111/j.1365-263X.2010.01033.x.
+
+Dentinogenesis imperfecta in children with osteogenesis imperfecta: a clinical 
+and ultrastructural study.
+
+Majorana A(1), Bardellini E, Brunelli PC, Lacaita M, Cazzolla AP, Favia G.
+
+Author information:
+(1)Department of Pediatric Dentistry, Dental School, University of Brescia, 
+Brescia, Italy. majorana@med.unibs.it
+
+AIM: The aim of this study was to assess the correlation between osteogenesis 
+imperfecta (OI) and dentinogenesis imperfecta (DI) from both a clinical and 
+histological point of view, particularly clarifying the structural and 
+ultrastructural dentine changes.
+DESIGN: Sixteen children (6-12 years aged) with diagnosis of OI were examined 
+for dental alterations referable to DI. For each patient, the OI type (I, III, 
+or IV) was recorded. Extracted or normally exfoliated primary teeth were 
+subjected to a histological examination (to both optical microscopy and confocal 
+laser-scanning microscopy).
+RESULTS: A total of ten patients had abnormal discolourations referable to DI: 
+four patients were affected by OI type I, three patients by OI type III, and 
+three patients by OI type IV. The discolourations, yellow/brown or opalescent 
+grey, could not be related to the different types of OI. Histological exam of 
+primary teeth showed severe pathological change in the dentin, structured into 
+four different layers. A collagen defect due to odontoblast dysfunction was 
+theorized to be on the base of the histological changes.
+CONCLUSIONS: There is no correlation between the type of OI and the type of 
+discolouration. The underlying dentinal defect seems to be related to an 
+odontoblast dysfunction.
+
+DOI: 10.1111/j.1365-263X.2010.01033.x
+PMID: 20384825 [Indexed for MEDLINE]


### PR DESCRIPTION
Closes #1502

## Summary
- replace unsupported or weakly supported OI type I phenotype claims with PMID-backed entries
- add clinically important phenotype evidence for vertebral compression fractures, scoliosis, adult-onset hearing impairment, and dentinogenesis imperfecta
- remove unsupported phenotype assertions for near-normal stature, joint hypermobility, and easy bruising from the phenotype section

## Validation
- `just validate kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml` ✅
- `just validate-references kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml` ✅
- `just validate-terms kb/disorders/Osteogenesis_Imperfecta_Type_I.yaml` ✅