### PR TITLE
[codex] Enhance phenotype evidence for Osteogenesis Imperfecta Type III

### DIFF
--- a/kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type III
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-07T16:11:39Z'
+updated_date: '2026-04-19T06:42:04Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type III is the most severe non-lethal form of OI,
@@ -106,87 +106,282 @@ genetic:
 phenotypes:
 - name: Severe Short Stature
   description: >
-    Profound growth deficiency with adult height often under 100 cm due to
-    progressive skeletal deformity and impaired bone growth.
+    Marked growth failure is a core manifestation of type III OI, with very low
+    childhood height z-scores and diminished growth velocity.
   phenotype_term:
     preferred_term: Severe short stature
     term:
       id: HP:0003510
       label: Severe short stature
   evidence:
-  - reference: PMID:25943292
-    reference_title: "Severe osteogenesis imperfecta Type-III and its challenging treatment in newborn and preschool children. A systematic review."
+  - reference: PMID:29970925
+    reference_title: "Growth characteristics in individuals with osteogenesis imperfecta in North America: results from a multicenter study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Other usual findings are muscle hypotonia, joint hypermobility and short
-      stature.
+      In children, the median z-scores for height in OI types I, III, and IV
+      were -0.66, -6.91, and -2.79, respectively. Growth velocity was
+      diminished in OI types III and IV.
     explanation: >-
-      Systematic review of OI type III confirms short stature as a usual
-      finding in this severe form.
-- name: Progressive Skeletal Deformity
-  description: >
-    Progressive bowing of long bones, kyphoscoliosis, and chest wall
-    deformities that worsen with repeated fractures and weight bearing.
-  phenotype_term:
-    preferred_term: Abnormality of the skeletal system
-    term:
-      id: HP:0000924
-      label: Abnormality of the skeletal system
-  evidence:
-  - reference: PMID:25943292
-    reference_title: "Severe osteogenesis imperfecta Type-III and its challenging treatment in newborn and preschool children. A systematic review."
+      This large multicenter cohort directly quantifies profound short stature
+      and reduced growth velocity in type III OI.
+  - reference: PMID:1739868
+    reference_title: "Osteogenesis imperfecta: a clinical study of the first ten years of life."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Fractures and weak bones may consequently cause limb and spinal
-      deformity and chronic physical disability.
+      Although types III and IV patients suffered from severe short stature,
+      serum insulin-like growth factor (IGF) I was in the normal range.
     explanation: >-
-      Confirms that fractures and bone weakness lead to progressive limb
-      and spinal deformity in OI type III.
-- name: Multiple Fractures
+      Pediatric natural history data also explicitly describe severe short
+      stature in type III OI.
+- name: Recurrent Fractures
   description: >
-    Hundreds of fractures over a lifetime, occurring with minimal trauma.
+    Marked bone fragility causes repeated fractures, often beginning at or
+    around birth in the severe type III phenotype.
   phenotype_term:
     preferred_term: Recurrent fractures
     term:
       id: HP:0002757
       label: Recurrent fractures
   evidence:
-  - reference: PMID:25943292
-    reference_title: "Severe osteogenesis imperfecta Type-III and its challenging treatment in newborn and preschool children. A systematic review."
+  - reference: PMID:458828
+    reference_title: "Genetic heterogeneity in osteogenesis imperfecta."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The disease is characterised in particular by bone fragility, decreased
-      bone mass and increased incidence of fractures.
+      A third group, two thirds of whom had fractures at birth, showed severe
+      progressive deformity of limbs and spine.
     explanation: >-
-      Systematic review confirms increased fracture incidence as a cardinal
-      feature of severe OI type III.
+      The original Sillence series shows that fractures are already present at
+      birth in many patients with the type III phenotype.
+  - reference: PMID:29970925
+    reference_title: "Growth characteristics in individuals with osteogenesis imperfecta in North America: results from a multicenter study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PURPOSE: Osteogenesis imperfecta (OI) predisposes people to recurrent
+      fractures, bone deformities, and short stature.
+    explanation: >-
+      This large North American cohort supports recurrent fractures as a core
+      clinical manifestation in the OI population that includes many type III
+      individuals.
+- name: Scoliosis
+  description: >
+    Progressive spinal curvature is a major source of morbidity in type III OI.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  evidence:
+  - reference: PMID:24500586
+    reference_title: "Behavior of scoliosis during growth in children with osteogenesis imperfecta."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Scoliosis prevalence (68%) and mean progression rate (6° per year) were
+      the highest in the group of patients with the most severe osteogenesis
+      imperfecta (modified Sillence type III).
+    explanation: >-
+      This pediatric natural history study directly shows that scoliosis is
+      common and rapidly progressive in type III OI.
+  - reference: PMID:35604455
+    reference_title: "Prevalence of scoliosis and impaired pulmonary function in patients with type III osteogenesis imperfecta."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All 42 patients had scoliosis, with a mean curve of 66° (95% CI of
+      range).
+    explanation: >-
+      A dedicated type III cohort found scoliosis in every evaluated patient,
+      underscoring its central clinical importance.
+- category: Respiratory
+  name: Restrictive Ventilatory Defect
+  description: >
+    Pulmonary impairment in type III OI shows a restrictive pattern and worsens
+    with increasing thoracic scoliosis.
+  phenotype_term:
+    preferred_term: Restrictive ventilatory defect
+    term:
+      id: HP:0002091
+      label: Restrictive ventilatory defect
+  evidence:
+  - reference: PMID:35604455
+    reference_title: "Prevalence of scoliosis and impaired pulmonary function in patients with type III osteogenesis imperfecta."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Restrictive lung pathophysiology was shown in our study population with a
+      mean FEV1/FVC ratio of 0.85.
+    explanation: >-
+      This type III cohort directly demonstrates a restrictive ventilatory
+      pattern on pulmonary function testing.
 - name: Dentinogenesis Imperfecta
   description: >
-    Abnormal dentin formation producing opalescent, discolored teeth that
-    are prone to breakage. Present in most type III patients.
+    Structural dentin abnormality with discoloration and fragility is a
+    recurrent dental manifestation in type III OI.
   phenotype_term:
     preferred_term: Dentinogenesis imperfecta
     term:
       id: HP:0000703
       label: Dentinogenesis imperfecta
   evidence:
-  - reference: PMID:30725642
-    reference_title: "Osteogenesis Imperfecta."
+  - reference: PMID:1739868
+    reference_title: "Osteogenesis imperfecta: a clinical study of the first ten years of life."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Other manifestations include blue sclerae, dentinogenesis imperfecta,
-      short stature, and deafness in adulthood.
+      Only fracture nonunion, dentinogenesis imperfecta, and congenital cardiac
+      malformations were more frequent in type III than in type IV.
     explanation: >-
-      StatPearls review confirms dentinogenesis imperfecta as a recognized
-      manifestation of osteogenesis imperfecta.
-- name: Triangular Facies
+      Pediatric natural history data directly identify dentinogenesis
+      imperfecta as more frequent in type III than in type IV OI.
+  - reference: PMID:30143849
+    reference_title: "Osteogenesis imperfecta and the teeth, eyes, and ears-a study of non-skeletal phenotypes in adults."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Dentinogenesis imperfecta was diagnosed in one fourth of the patients,
+      based on clinical and radiographic findings. This condition was
+      predominately seen in patients with moderate to severe OI.
+    explanation: >-
+      Adult cohort data confirm that dentinogenesis imperfecta is concentrated
+      in the more severe OI phenotypes that include type III.
+- name: Hearing Impairment
   description: >
-    Characteristic triangular face shape with prominent forehead and
-    underdeveloped midface.
+    Hearing loss can occur in childhood in type III OI and may be conductive,
+    sensorineural, or mixed.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: PMID:31876392
+    reference_title: "Hearing loss in individuals with osteogenesis imperfecta in North America: Results from a multicenter study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Individuals with OI Types III and IV are at a higher risk to develop HL
+      in the first decade of life when compared to OI Type I.
+    explanation: >-
+      This multicenter study supports early-onset hearing impairment in the
+      more severe type III/IV forms of OI.
+  - reference: PMID:30143849
+    reference_title: "Osteogenesis imperfecta and the teeth, eyes, and ears-a study of non-skeletal phenotypes in adults."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most prevalent type of hearing loss (HL) was sensorineural hearing
+      loss, whereas conductive HL was solely seen in patients with OI type III.
+    explanation: >-
+      Adult cohort data show that hearing loss in type III OI can include a
+      conductive component.
+- name: Wormian Bones
+  description: >
+    Accessory sutural bones are a recurrent cranial radiographic finding in the
+    more severe type III/IV forms of OI.
+  phenotype_term:
+    preferred_term: Wormian bones
+    term:
+      id: HP:0002645
+      label: Wormian bones
+  evidence:
+  - reference: PMID:16961127
+    reference_title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These three abnormalities and wormian bones were predominantly found in
+      OI Types III and IV as well as in patients exhibiting dentinal
+      abnormality.
+    explanation: >-
+      This cephalometric cohort directly links wormian bones to the severe type
+      III/IV OI phenotypes.
+- name: Basilar Impression
+  description: >
+    Skull-base deformity with upward displacement of the posterior fossa floor
+    occurs in severe OI and is enriched in types III and IV.
+  phenotype_term:
+    preferred_term: Basilar impression
+    term:
+      id: HP:0005758
+      label: Basilar impression
+  evidence:
+  - reference: PMID:16961127
+    reference_title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The normal mean distances were exceeded by more than two standard
+      deviations (SDs) in 28.3 to 35.2%, and by more than three SDs in 13.2 to
+      16.6% of the patients with OI. The latter figures reliably reflect the
+      prevalence of basilar impression.
+    explanation: >-
+      This study provides direct radiographic evidence for basilar impression in
+      OI and identifies skull-base abnormalities as concentrated in types III
+      and IV.
+- name: Popcorn Calcification
+  description: >
+    Metaphyseal and epiphyseal "popcorn" calcifications around the growth plate
+    usually emerge in childhood and most often involve the distal femora and
+    proximal tibiae.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Popcorn calcification
+    term:
+      id: HP:6000871
+      label: Popcorn calcification
+  evidence:
+  - reference: PMID:18798308
+    reference_title: "Popcorn calcification in osteogenesis imperfecta: incidence, progression, and molecular correlation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Popcorn calcifications were present in 13 of 25 type III (52%), but only
+      2 of 20 type IV (10%), OI children. The mean age of onset was 7.0 years,
+      with a range of 4-14 years.
+    explanation: >-
+      In a type III/IV pediatric cohort, 13/25 type III patients had popcorn
+      calcifications (52%), which falls in the FREQUENT band, and the mean age
+      of onset was 7.0 years.
+- name: Blue Sclerae
+  description: >
+    Blue scleral hue can occur in type III OI, but it may be subtler than in
+    type I and can lessen with age.
+  phenotype_term:
+    preferred_term: Blue sclerae
+    term:
+      id: HP:0000592
+      label: Blue sclerae
+  evidence:
+  - reference: PMID:458828
+    reference_title: "Genetic heterogeneity in osteogenesis imperfecta."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The density of scleral blueness appeared less than that seen in the first
+      group of patients and approximated that seen in normal children and
+      adults. Moreover, the blueness appeared to decrease with age.
+    explanation: >-
+      The original Sillence cohort shows that blue sclerae in type III OI are
+      variable and tend to fade with age rather than remaining a defining
+      lifelong finding.
+  - reference: PMID:9248835
+    reference_title: "Histopathologic and electron-microscopic features of corneal and scleral collagen fibers in osteogenesis imperfecta type III."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The sclera had a blue color and was moderately thinned, especially at the
+      equator.
+    explanation: >-
+      Pathologic examination of an eye from a patient with type III OI provides
+      direct case-level support that blue sclerae can occur in this subtype.
+- name: Triangular Face
+  description: >
+    Triangular facial shape has been reported as part of the craniofacial
+    phenotype of type III OI.
   phenotype_term:
     preferred_term: Triangular face
     term:
@@ -205,68 +400,8 @@ phenotypes:
       posterior crossbite, dentinogenesis imperfecta presenting amber
       discoloration.
     explanation: >-
-      This type III OI case report directly documents triangular face as part of
-      the craniofacial phenotype.
-- name: Kyphoscoliosis
-  description: >
-    Progressive spinal curvature contributing to respiratory compromise
-    and mobility limitations.
-  phenotype_term:
-    preferred_term: Kyphoscoliosis
-    term:
-      id: HP:0002751
-      label: Kyphoscoliosis
-  evidence:
-  - reference: PMID:25943292
-    reference_title: "Severe osteogenesis imperfecta Type-III and its challenging treatment in newborn and preschool children. A systematic review."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Fractures and weak bones may consequently cause limb and spinal
-      deformity and chronic physical disability.
-    explanation: >-
-      Confirms spinal deformity as a consequence of bone fragility in
-      OI type III.
-- name: Hearing Impairment
-  description: >
-    Progressive hearing loss, often beginning in childhood.
-  phenotype_term:
-    preferred_term: Hearing impairment
-    term:
-      id: HP:0000365
-      label: Hearing impairment
-  evidence:
-  - reference: PMID:33844744
-    reference_title: "Observed Frequency and Characteristics of Hearing Loss in Osteogenesis Imperfecta."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Overall, nine (30%) patients had hearing loss (15/60 ears). Of these,
-      six had bilateral hearing loss. Of the 15 affected ears, six showed
-      conductive hearing loss, five sensorineural hearing loss, and four
-      mixed hearing loss.
-    explanation: >-
-      Prospective cohort study of OI patients demonstrating 30% prevalence
-      of hearing loss, with conductive, sensorineural, and mixed types.
-- name: Blue Sclerae
-  description: >
-    Sclerae may be blue at birth but often normalize during childhood.
-  phenotype_term:
-    preferred_term: Blue sclerae
-    term:
-      id: HP:0000592
-      label: Blue sclerae
-  evidence:
-  - reference: PMID:30725642
-    reference_title: "Osteogenesis Imperfecta."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Other manifestations include blue sclerae, dentinogenesis imperfecta,
-      short stature, and deafness in adulthood.
-    explanation: >-
-      StatPearls review confirms blue sclerae as a recognized
-      manifestation of osteogenesis imperfecta.
+      This type III case report provides direct subtype-specific evidence for
+      triangular face as part of the craniofacial phenotype.
 treatments:
 - name: Bisphosphonate Therapy
   description: >

--- a/references_cache/PMID_16961127.md
+++ b/references_cache/PMID_16961127.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:16961127"
+title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
+authors:
+- Kovero O
+- Pynnönen S
+- Kuurila-Svahn K
+- Kaitila I
+- Waltimo-Sirén J
+journal: J Neurosurg
+year: '2006'
+doi: 10.3171/jns.2006.105.3.361
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Cephalometry/methods
+- Female
+- Foramen Magnum
+- Humans
+- Male
+- Middle Aged
+- Osteogenesis Imperfecta/pathology
+- Platybasia/pathology
+- Skull Base/abnormalities
+content_type: abstract_only
+---
+
+# Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers.
+**Authors:** Kovero O, Pynnönen S, Kuurila-Svahn K, Kaitila I, Waltimo-Sirén J
+**Journal:** J Neurosurg (2006)
+**DOI:** [10.3171/jns.2006.105.3.361](https://doi.org/10.3171/jns.2006.105.3.361)
+
+## Content
+
+1. J Neurosurg. 2006 Sep;105(3):361-70. doi: 10.3171/jns.2006.105.3.361.
+
+Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation 
+of 54 patients and 108 control volunteers.
+
+Kovero O(1), Pynnönen S, Kuurila-Svahn K, Kaitila I, Waltimo-Sirén J.
+
+Author information:
+(1)Department of Oral Radiology, Institute of Dentistry, University of Helsinki, 
+Finland.
+
+Comment in
+    J Neurosurg. 2006 Sep;105(3):359; discussion 359-60. doi: 
+10.3171/jns.2006.105.3.359.
+
+OBJECT: Osteogenesis imperfecta (OI), which usually results from mutations in 
+type I collagen genes, causes bone fragility and deformities. The head is often 
+abnormally shaped, and changes in skull base anatomy in the form of basilar 
+impression and basilar invagination have been reported. The authors analyzed the 
+skull base anatomy on standardized lateral cephalograms from 54 patients with OI 
+(Types I, III, and IV) and 108 control volunteers. They were surprised to find 
+that the previously used diagnostic measures for basilar abnormality in patients 
+with OI were exceeded in 6.5 to 7.4% of the controls, and hence needed to be 
+reevaluated.
+METHODS: The authors calculated the distance from the odontoid process to four 
+reference lines, including a novel one, in the controls. The normal mean 
+distances were exceeded by more than two standard deviations (SDs) in 28.3 to 
+35.2%, and by more than three SDs in 13.2 to 16.6% of the patients with OI. The 
+latter figures reliably reflect the prevalence of basilar impression. As a sign 
+of basilar invagination the odontoid process protruded into the foramen magnum 
+or reached the foramen magnum level in 22.2% of the patients with OI, whereas 
+none of the controls showed this feature. Platybasia (an anterior cranial base 
+angle > 146 degrees) was present in 11.1% of the patients but in none of the 
+controls.
+CONCLUSIONS: Platybasia, basilar impression, and basilar invagination were often 
+coexpressed, but each was also present as an isolated abnormality. These three 
+abnormalities and wormian bones were predominantly found in OI Types III and IV 
+as well as in patients exhibiting dentinal abnormality.
+
+DOI: 10.3171/jns.2006.105.3.361
+PMID: 16961127 [Indexed for MEDLINE]

--- a/references_cache/PMID_18798308.md
+++ b/references_cache/PMID_18798308.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:18798308"
+title: "Popcorn calcification in osteogenesis imperfecta: incidence, progression, and molecular correlation."
+authors:
+- Obafemi AA
+- Bulas DI
+- Troendle J
+- Marini JC
+journal: Am J Med Genet A
+year: '2008'
+doi: 10.1002/ajmg.a.32508
+keywords:
+- Adolescent
+- Adult
+- Calcinosis/diagnostic imaging
+- Child
+- "Child, Preschool"
+- Collagen/genetics
+- Collagen Type I/genetics
+- "Collagen Type I, alpha 1 Chain"
+- Female
+- Femur/diagnostic imaging
+- Humans
+- Male
+- Mutation
+- "Osteogenesis Imperfecta/classification, diagnostic imaging, genetics"
+- Radiography
+- Retrospective Studies
+- Tibia/diagnostic imaging
+content_type: abstract_only
+---
+
+# Popcorn calcification in osteogenesis imperfecta: incidence, progression, and molecular correlation.
+**Authors:** Obafemi AA, Bulas DI, Troendle J, Marini JC
+**Journal:** Am J Med Genet A (2008)
+**DOI:** [10.1002/ajmg.a.32508](https://doi.org/10.1002/ajmg.a.32508)
+
+## Content
+
+1. Am J Med Genet A. 2008 Nov 1;146A(21):2725-32. doi: 10.1002/ajmg.a.32508.
+
+Popcorn calcification in osteogenesis imperfecta: incidence, progression, and 
+molecular correlation.
+
+Obafemi AA(1), Bulas DI, Troendle J, Marini JC.
+
+Author information:
+(1)Bone and Extracellular Matrix Branch, The Eunice Kennedy Shriver National 
+Institute of Child Health and Human Development, NIH, Bethesda, Maryland 20892, 
+USA.
+
+Osteogenesis imperfecta (OI) is a heritable disorder characterized by 
+osteoporosis and increased susceptibility to fracture. All children with severe 
+OI have extreme short stature and some have "popcorn" calcifications, areas of 
+disorganized hyperdense lines in the metaphysis and epiphysis around the growth 
+plate on lower limb radiographs. Popcorn calcifications were noted on 
+radiographs of two children with non-lethal type VIII OI, a recessive form 
+caused by P3H1 deficiency. To determine the incidence, progression, and 
+molecular correlations of popcorn calcifications, we retrospectively examined 
+serial lower limb radiographs of 45 children with type III or IV OI and known 
+dominant mutations in type I collagen. Popcorn calcifications were present in 13 
+of 25 type III (52%), but only 2 of 20 type IV (10%), OI children. The mean age 
+of onset was 7.0 years, with a range of 4-14 years. All children with popcorn 
+calcifications had this finding in their distal femora, and most also had 
+calcifications in proximal tibiae. While unilateral popcorn calcification 
+contributes to femoral growth deficiency and leg length discrepancy, severe 
+linear growth deficiency, and metaphyseal flare do not differ significantly 
+between type III OI patients with and without popcorn calcifications. The type I 
+collagen mutations associated with popcorn calcifications occur equally in both 
+COL1A1 and COL1A2, and have no preferential location along the chains. These 
+data demonstrate that popcorn calcifications are a frequent feature of severe 
+OI, but do not distinguish cases with defects in collagen structure (primarily 
+dominant type III OI) or modification (recessive type VIII OI).
+
+Copyright 2008 Wiley-Liss, Inc.
+
+DOI: 10.1002/ajmg.a.32508
+PMCID: PMC6320686
+PMID: 18798308 [Indexed for MEDLINE]

--- a/references_cache/PMID_24500586.md
+++ b/references_cache/PMID_24500586.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:24500586"
+title: Behavior of scoliosis during growth in children with osteogenesis imperfecta.
+authors:
+- Anissipour AK
+- Hammerberg KW
+- Caudill A
+- Kostiuk T
+- Tarima S
+- Zhao HS
+- Krzak JJ
+- Smith PA
+journal: J Bone Joint Surg Am
+year: '2014'
+doi: 10.2106/JBJS.L.01596
+keywords:
+- Adolescent
+- Age Factors
+- Child
+- "Child, Preschool"
+- Disease Progression
+- Female
+- Growth/physiology
+- Humans
+- Infant
+- Male
+- "Osteogenesis Imperfecta/complications, physiopathology, surgery"
+- Retrospective Studies
+- "Scoliosis/complications, physiopathology, surgery"
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Behavior of scoliosis during growth in children with osteogenesis imperfecta.
+**Authors:** Anissipour AK, Hammerberg KW, Caudill A, Kostiuk T, Tarima S, Zhao HS, Krzak JJ, Smith PA
+**Journal:** J Bone Joint Surg Am (2014)
+**DOI:** [10.2106/JBJS.L.01596](https://doi.org/10.2106/JBJS.L.01596)
+
+## Content
+
+1. J Bone Joint Surg Am. 2014 Feb 5;96(3):237-43. doi: 10.2106/JBJS.L.01596.
+
+Behavior of scoliosis during growth in children with osteogenesis imperfecta.
+
+Anissipour AK(1), Hammerberg KW(2), Caudill A(2), Kostiuk T(1), Tarima S(3), 
+Zhao HS(3), Krzak JJ(2), Smith PA(2).
+
+Author information:
+(1)Department of Orthopaedic Surgery, Midwestern University, Chicago College of 
+Osteopathic Medicine, 555 31st Street, Downers Grove, IL 60515. E-mail address 
+for A.K. Anissipour: aanissipour@gmail.com. E-mail address for T. Kostiuk: 
+tkostiuk4@hotmail.com.
+(2)Shriners Hospitals for Children, 2211 North Oak Park Avenue, Chicago, IL 
+60707. E-mail address for K.W. Hammerberg: khammerberg@shrinenet.org. E-mail 
+address for A. Caudill: acaudill@shrinenet.org. E-mail address for J.J. Krzak: 
+jkrzak@shrinenet.org. E-ma.
+(3)Division of Biostatistics, Institute for Health and Society, Medical College 
+of Wisconsin, 8701 West Watertown Plank Road, Milwaukee, WI 53226. E-mail 
+address for S. Tarima: starima@mcw.edu. E-mail address for H.S. Zhao: 
+szhao@mcw.edu.
+
+BACKGROUND: Spinal deformities are common in patients with osteogenesis 
+imperfecta, a heritable disorder that causes bone fragility. The purpose of this 
+study was to describe the behavior of spinal curvature during growth in patients 
+with osteogenesis imperfecta and establish its relationship to disease severity 
+and medical treatment with bisphosphonates.
+METHODS: The medical records and radiographs of 316 patients with osteogenesis 
+imperfecta were retrospectively reviewed. The severity of osteogenesis 
+imperfecta was classified with the modified Sillence classification. Serial 
+curve measurements were recorded throughout the follow-up period for each 
+patient with scoliosis. Regression analysis was used to determine the effect of 
+disease severity (Sillence type), patient age, and bisphosphonate treatment on 
+the progression of scoliosis as measured with the Cobb method.
+RESULTS: Of the 316 patients with osteogenesis imperfecta, 157 had associated 
+scoliosis, a prevalence of 50%. Scoliosis prevalence (68%) and mean progression 
+rate (6° per year) were the highest in the group of patients with the most 
+severe osteogenesis imperfecta (modified Sillence type III). A group with 
+intermediate osteogenesis imperfecta severity, modified Sillence type IV, 
+demonstrated intermediate scoliosis values (54%, 4° per year). The patient group 
+with the mildest form of osteogenesis imperfecta, modified Sillence type I, had 
+the lowest scoliosis prevalence (39%) and rate of progression (1° per year). 
+Early treatment-before the patient reached the age of six years-of type-III 
+osteogenesis imperfecta with bisphosphonate therapy decreased the curve 
+progression rate by 3.8° per year, which was a significant decrease. 
+Bisphosphonate treatment had no demonstrated beneficial effect on curve behavior 
+in patients with other types of osteogenesis imperfecta or in patients of older 
+age.
+CONCLUSIONS: The prevalence of scoliosis in association with osteogenesis 
+imperfecta is high. Progression rates of scoliosis in children with osteogenesis 
+imperfecta are variable, depending on the Sillence type of osteogenesis 
+imperfecta. High rates of scoliosis progression in type-III and type-IV 
+osteogenesis imperfecta contrast with a benign course in type I. Bisphosphonate 
+therapy initiated before the patient reaches the age of six years can modulate 
+curve progression in type-III osteogenesis imperfecta.
+
+DOI: 10.2106/JBJS.L.01596
+PMCID: PMC6948836
+PMID: 24500586 [Indexed for MEDLINE]

--- a/references_cache/PMID_30143849.md
+++ b/references_cache/PMID_30143849.md
@@ -1,0 +1,117 @@
+---
+reference_id: "PMID:30143849"
+title: "Osteogenesis imperfecta and the teeth, eyes, and ears-a study of non-skeletal phenotypes in adults."
+authors:
+- Hald JD
+- Folkestad L
+- Swan CZ
+- Wanscher J
+- Schmidt M
+- Gjørup H
+- Haubek D
+- Leonhard CH
+- Larsen DA
+- Hjortdal JØ
+- Harsløf T
+- Duno M
+- Lund AM
+- Jensen JB
+- Brixen K
+- Langdahl B
+journal: Osteoporos Int
+year: '2018'
+doi: 10.1007/s00198-018-4663-x
+keywords:
+- Adult
+- Aged
+- Denmark/epidemiology
+- "Dentinogenesis Imperfecta/diagnosis, epidemiology"
+- "Eye Diseases, Hereditary/diagnosis, epidemiology"
+- Female
+- "Hearing Loss/diagnosis, epidemiology, etiology"
+- Humans
+- Male
+- Middle Aged
+- "Osteogenesis Imperfecta/complications, diagnosis, epidemiology"
+- Phenotype
+- Young Adult
+content_type: abstract_only
+---
+
+# Osteogenesis imperfecta and the teeth, eyes, and ears-a study of non-skeletal phenotypes in adults.
+**Authors:** Hald JD, Folkestad L, Swan CZ, Wanscher J, Schmidt M, Gjørup H, Haubek D, Leonhard CH, Larsen DA, Hjortdal JØ, Harsløf T, Duno M, Lund AM, Jensen JB, Brixen K, Langdahl B
+**Journal:** Osteoporos Int (2018)
+**DOI:** [10.1007/s00198-018-4663-x](https://doi.org/10.1007/s00198-018-4663-x)
+
+## Content
+
+1. Osteoporos Int. 2018 Dec;29(12):2781-2789. doi: 10.1007/s00198-018-4663-x.
+Epub  2018 Aug 24.
+
+Osteogenesis imperfecta and the teeth, eyes, and ears-a study of non-skeletal 
+phenotypes in adults.
+
+Hald JD(1), Folkestad L(2)(3), Swan CZ(4)(5), Wanscher J(6), Schmidt M(7), 
+Gjørup H(8), Haubek D(7), Leonhard CH(9), Larsen DA(9), Hjortdal JØ(9), Harsløf 
+T(10), Duno M(11), Lund AM(11), Jensen JB(12), Brixen K(2), Langdahl B(10).
+
+Author information:
+(1)Department of Endocrinology and Internal Medicine, Aarhus University 
+Hospital, DK-8200, Aarhus N, Denmark. janniehald@gmail.com.
+(2)Department of Endocrinology, Odense University Hospital, Odense, Denmark.
+(3)Department of Clinical Research, University of Southern Denmark, Odense, 
+Denmark.
+(4)Department of Otorhinolaryngology and Head & Neck Surgery, Aarhus University 
+Hospital, Aarhus, Denmark.
+(5)Department of Clinical Medicine, Aarhus University, Aarhus, Denmark.
+(6)Department of ENT Head and Neck Surgery, Odense University Hospital, Odense, 
+Denmark.
+(7)Section for Pediatric Dentistry, Department of Dentistry and Oral Health, 
+Health, Aarhus University, Aarhus, Denmark.
+(8)Centre of Oral Health in Rare Diseases, Department of Maxillofacial Surgery, 
+Aarhus University Hospital, Aarhus, Denmark.
+(9)Department of Ophthalmology, Aarhus University Hospital, Aarhus, Denmark.
+(10)Department of Endocrinology and Internal Medicine, Aarhus University 
+Hospital, DK-8200, Aarhus N, Denmark.
+(11)Centre for Inherited Metabolic Diseases, Departments of Paediatrics and 
+Clinical Genetics, Rigshospitalet, Copenhagen, Denmark.
+(12)Department of Endocrinology, Hvidovre Hospital, Hvidovre, Denmark.
+
+Osteogenesis imperfecta (OI) is a disease causing bone fragility; however, it 
+potentially affects all organs with a high content of collagen, including ears, 
+teeth, and eyes. The study is cross-sectional and compares non-skeletal 
+characteristics in adults with OI that clinicians should be aware of when caring 
+for patients with OI.
+INTRODUCTION: Osteogenesis imperfecta (OI) is a hereditary connective tissue 
+disorder. The skeletal fragility is pronounced; however, OI leads to a number of 
+extra-skeletal symptoms related to the ubiquity of collagen type 1 throughout 
+the human body. The vast majority of knowledge is derived from studies performed 
+in the pediatric population. Thus, we aimed to investigate the nature and 
+prevalence of ophthalmologic, odontologic, and otologic phenotypes in an adult 
+population with OI.
+METHODS: The study population comprises 85 Danish OI patients (age 
+44.9 ± 15.9 years). Fifty-eight patients had OI type I, 12 OI type III, and 15 
+OI type IV according to the classification by Sillence. Audiometric evaluations 
+and dental examinations were performed in 62 and 73 patients, respectively. 
+Ophthalmologic investigations were performed in 64 patients, including 
+measurements of the central corneal thickness.
+RESULTS: All patients, except two, had corneal thickness below the normal 
+reference value. Patients with OI type I and patients with a quantitative 
+collagen defect had thinner corneas compared to patients with OI type III and 
+other patients with a qualitative collagen defect. One patient in this cohort 
+was diagnosed with and treated for acute glaucoma. Dentinogenesis imperfecta was 
+diagnosed in one fourth of the patients, based on clinical and radiographic 
+findings. This condition was predominately seen in patients with moderate to 
+severe OI. Hearing loss requiring treatment was found in 15 of 62 patients, of 
+whom three were untreated. The most prevalent type of hearing loss (HL) was 
+sensorineural hearing loss, whereas conductive HL was solely seen in patients 
+with OI type III. The patients with the most severe degrees of HL were patients 
+with mild forms of OI. Age was associated with increased HL.
+CONCLUSION: Although significant health problems outside the skeleton are 
+frequent in adult patients with OI, the patients are not consistently monitored 
+and treated for their symptoms. Clinicians treating adult patients with OI 
+should be aware of non-skeletal health issues and consider including regular 
+interdisciplinary check-ups in the management plan for adult OI patients.
+
+DOI: 10.1007/s00198-018-4663-x
+PMID: 30143849 [Indexed for MEDLINE]

--- a/references_cache/PMID_31876392.md
+++ b/references_cache/PMID_31876392.md
@@ -1,0 +1,119 @@
+---
+reference_id: "PMID:31876392"
+title: "Hearing loss in individuals with osteogenesis imperfecta in North America: Results from a multicenter study."
+authors:
+- Machol K
+- Hadley TD
+- Schmidt J
+- Cuthbertson D
+- Traboulsi H
+- Silva RC
+- Citron C
+- Khan S
+- Citron K
+- Carter E
+- Brookler K
+- Shapiro JR
+- Steiner RD
+- Byers PH
+- Glorieux FH
+- Durigova M
+- Smith P
+- Bober MB
+- Sutton VR
+- Lee BH
+- Members of the BBD Consortium
+- Nagamani SCS
+- Raggio C
+journal: Am J Med Genet A
+year: '2020'
+doi: 10.1002/ajmg.a.61464
+keywords:
+- Adolescent
+- Adult
+- Child
+- Collagen Type I/genetics
+- "Collagen Type I, alpha 1 Chain"
+- Female
+- Genotype
+- "Hearing Loss/epidemiology, genetics, pathology"
+- Humans
+- Male
+- Middle Aged
+- Mutation
+- North America/epidemiology
+- Osteogenesis Imperfecta/physiopathology
+- Phenotype
+- Young Adult
+content_type: abstract_only
+---
+
+# Hearing loss in individuals with osteogenesis imperfecta in North America: Results from a multicenter study.
+**Authors:** Machol K, Hadley TD, Schmidt J, Cuthbertson D, Traboulsi H, Silva RC, Citron C, Khan S, Citron K, Carter E, Brookler K, Shapiro JR, Steiner RD, Byers PH, Glorieux FH, Durigova M, Smith P, Bober MB, Sutton VR, Lee BH, Members of the BBD Consortium, Nagamani SCS, Raggio C
+**Journal:** Am J Med Genet A (2020)
+**DOI:** [10.1002/ajmg.a.61464](https://doi.org/10.1002/ajmg.a.61464)
+
+## Content
+
+1. Am J Med Genet A. 2020 Apr;182(4):697-704. doi: 10.1002/ajmg.a.61464. Epub
+2019  Dec 26.
+
+Hearing loss in individuals with osteogenesis imperfecta in North America: 
+Results from a multicenter study.
+
+Machol K(1)(2), Hadley TD(1), Schmidt J(1), Cuthbertson D(3), Traboulsi H(4)(2), 
+Silva RC(4)(2), Citron C(5), Khan S(5), Citron K(5), Carter E(5), Brookler K(5), 
+Shapiro JR(6)(7), Steiner RD(8)(9), Byers PH(10)(11), Glorieux FH(12), Durigova 
+M(12), Smith P(13), Bober MB(14), Sutton VR(1)(2), Lee BH(1)(2); Members of the 
+BBD Consortium; Nagamani SCS(1)(2), Raggio C(5).
+
+Author information:
+(1)Department of Molecular and Human Genetics, Baylor College of Medicine, 
+Houston, Texas.
+(2)Texas Children's Hospital, Houston, Texas.
+(3)College of Medicine, University of South Florida, Tampa, Florida.
+(4)Department of Otolaryngology-Head and Neck Surgery, Baylor College of 
+Medicine, Houston, Texas.
+(5)Department of Pediatric Orthopedic Surgery, Hospital for Special Surgery, New 
+York, New York.
+(6)Department of Bone and Osteogenesis Imperfecta, Kennedy Krieger Institute, 
+Baltimore, Maryland.
+(7)Department of Medicine at Uniformed Services, University of the Health 
+Sciences, Bethesda, Maryland.
+(8)University of Wisconsin School of Medicine and Public Health, Madison, 
+Wisconsin.
+(9)Pediatrics and Molecular and Medical Genetics, Oregon Health & Science 
+University, Portland, Oregon.
+(10)Department of Medicine, Division of Medical Genetics, University of 
+Washington, Seattle.
+(11)Department of Pathology, Division of Medical Genetics, University of 
+Washington, Seattle.
+(12)Shriner's Hospital for Children and McGill University, Montreal, Quebec, 
+Canada.
+(13)Motion Analysis Laboratory, Shriners Hospitals for Children, Chicago, 
+Illinois.
+(14)Division of Orthogenetics, Alfred I. duPont Hospital for Children, 
+Wilmington, Delaware.
+
+Hearing loss (HL) is an extra-skeletal manifestation of the connective tissue 
+disorder osteogenesis imperfecta (OI). Systematic evaluation of the prevalence 
+and characteristics of HL in COL1A1/COL1A2-related OI will contribute to a 
+better clinical management of individuals with OI. We collected and analyzed 
+pure-tone audiometry data from 312 individuals with OI who were enrolled in the 
+Linked Clinical Research Centers and the Brittle Bone Disorders Consortium. The 
+prevalence, type, and severity of HL in COL1A1/COL1A2-related OI are reported. 
+We show that the prevalence of HL in OI is 28% and increased with age in Type I 
+OI but not in Types III and IV. Individuals with OI Types III and IV are at a 
+higher risk to develop HL in the first decade of life when compared to OI Type 
+I. We also show that the prevalence of SNHL is higher in females with OI 
+compared to males. This study reveals new insights regarding prevalence of HL in 
+OI including a lower general prevalence of HL in COL1A1/COL1A2-related OI than 
+previously reported (28.3 vs. 65%) and high prevalence of SNHL in females. Our 
+data support the need in early routine hearing evaluation in all types of OI 
+that can be adjusted to the severity of the skeletal disease.
+
+© 2019 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.a.61464
+PMCID: PMC7385724
+PMID: 31876392 [Indexed for MEDLINE]

--- a/references_cache/PMID_35604455.md
+++ b/references_cache/PMID_35604455.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:35604455"
+title: Prevalence of scoliosis and impaired pulmonary function in patients with type III osteogenesis imperfecta.
+authors:
+- Keuning MC
+- Leeuwerke SJG
+- van Dijk PR
+- Harsevoort AGJ
+- Grotjohan HP
+- Franken AAM
+- Janus GJM
+journal: Eur Spine J
+year: '2022'
+doi: 10.1007/s00586-022-07260-5
+keywords:
+- Humans
+- Lung Diseases
+- "Osteogenesis Imperfecta/complications, diagnostic imaging, epidemiology"
+- Prevalence
+- Retrospective Studies
+- "Scoliosis/complications, diagnostic imaging, epidemiology"
+content_type: abstract_only
+---
+
+# Prevalence of scoliosis and impaired pulmonary function in patients with type III osteogenesis imperfecta.
+**Authors:** Keuning MC, Leeuwerke SJG, van Dijk PR, Harsevoort AGJ, Grotjohan HP, Franken AAM, Janus GJM
+**Journal:** Eur Spine J (2022)
+**DOI:** [10.1007/s00586-022-07260-5](https://doi.org/10.1007/s00586-022-07260-5)
+
+## Content
+
+1. Eur Spine J. 2022 Sep;31(9):2295-2300. doi: 10.1007/s00586-022-07260-5. Epub 
+2022 May 23.
+
+Prevalence of scoliosis and impaired pulmonary function in patients with type 
+III osteogenesis imperfecta.
+
+Keuning MC(1), Leeuwerke SJG(2), van Dijk PR(3), Harsevoort AGJ(4), Grotjohan 
+HP(5), Franken AAM(6), Janus GJM(4).
+
+Author information:
+(1)Department of Orthopaedic Surgery, University Medical Center, University of 
+Groningen, Groningen, The Netherlands. m.c.keuning@umcg.nl.
+(2)Department of Surgery, University Medical Center, University of Groningen, 
+Groningen, The Netherlands.
+(3)Department of Endocrinology, University Medical Center, University of 
+Groningen, Groningen, The Netherlands.
+(4)Department of Orthopaedic Surgery, Isala, Zwolle, The Netherlands.
+(5)Department of Pulmonary Medicine, Isala, Zwolle, The Netherlands.
+(6)Department of Internal Medicine, Isala, Zwolle, The Netherlands.
+
+PURPOSE: Osteogenesis Imperfecta (OI) is a rare group of congenital genetic 
+disorders that consists of a collagen synthesis defect. The most severe 
+phenotype is type III OI. Characterized by progressive bone deformity, fragility 
+and pulmonary impairment, causing significant morbidity and mortality. Also, 
+multilevel spine deformities are observed, such as scoliosis. The literature on 
+the pathophysiology of pulmonary impairment in relation to scoliosis in these 
+patients is scarce and conflicting. This study aims to determine the prevalence 
+of scoliosis and its relation to pulmonary function in type III OI patients.
+METHODS: This retrospective cohort study took place between April 2020 and 
+November 2021. Forty-two patients with type III OI were included. 
+Anterior-posterior spine radiographs were evaluated for scoliosis. Pulmonary 
+function was assessed using spirometry and partial pressure of carbon dioxide.
+RESULTS: All 42 patients had scoliosis, with a mean curve of 66° (95% CI of 
+range). Vital lung capacity was decreased, compared to a non-OI population (mean 
+1.57 L). This was correlated to the degree of scoliosis (st. β - 0.40, 
+P = 0.03), especially in increasing thoracic curves. Restrictive lung 
+pathophysiology was shown in our study population with a mean FEV1/FVC ratio of 
+0.85.
+CONCLUSIONS: Increasing thoracic scoliosis was correlated with decreased vital 
+lung capacity in our study population of type III OI patients. High FEV1/FVC 
+ratios found in this study population show restrictive lung pathophysiology. 
+Therefore, it is plausible that the pulmonary impairment found in type III OI 
+patients is a combined issue, partly associated to scoliosis and partly 
+intrinsic to OI.
+
+© 2022. The Author(s).
+
+DOI: 10.1007/s00586-022-07260-5
+PMID: 35604455 [Indexed for MEDLINE]

--- a/references_cache/PMID_458828.md
+++ b/references_cache/PMID_458828.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:458828"
+title: Genetic heterogeneity in osteogenesis imperfecta.
+authors:
+- Sillence DO
+- Senn A
+- Danks DM
+journal: J Med Genet
+year: '1979'
+doi: 10.1136/jmg.16.2.101
+keywords:
+- Adolescent
+- Adult
+- Australia
+- Child
+- "Child, Preschool"
+- Female
+- "Genes, Dominant"
+- "Genes, Lethal"
+- "Genes, Recessive"
+- Genetic Variation
+- Humans
+- Infant
+- "Infant, Newborn"
+- Male
+- "Osteogenesis Imperfecta/epidemiology, genetics"
+- Pedigree
+- Sclera/abnormalities
+- Syndrome
+- Terminology as Topic
+content_type: abstract_only
+---
+
+# Genetic heterogeneity in osteogenesis imperfecta.
+**Authors:** Sillence DO, Senn A, Danks DM
+**Journal:** J Med Genet (1979)
+**DOI:** [10.1136/jmg.16.2.101](https://doi.org/10.1136/jmg.16.2.101)
+
+## Content
+
+1. J Med Genet. 1979 Apr;16(2):101-16. doi: 10.1136/jmg.16.2.101.
+
+Genetic heterogeneity in osteogenesis imperfecta.
+
+Sillence DO, Senn A, Danks DM.
+
+An epidemiological and genetical study of osteogenesis imperfecta (OI) in 
+Victoria, Australia confirmed that there are at least four distinct syndromes at 
+present called OI. The largest group of patients showed autosomal dominant 
+inheritance of osteoporosis leading to fractures and distinctly blue sclerae. A 
+large proportion of adults had presenile deafness or a family history of 
+presenile conductive hearing loss. A second group, who comprised the majority of 
+newborns with neonatal fractures, all died before or soon after birth. These had 
+characteristic broad, crumpled femora and beaded ribs in skeletal x-rays. 
+Autosomal recessive inheritance was likely for some, if not all, of these cases. 
+A third group, two thirds of whom had fractures at birth, showed severe 
+progressive deformity of limbs and spine. The density of scleral blueness 
+appeared less than that seen in the first group of patients and approximated 
+that seen in normal children and adults. Moreover, the blueness appeared to 
+decrease with age. All patients in this group were sporadic cases. The mode of 
+inheritance was not resolved by the study, but it is likely that the group is 
+heterogeneous with both dominant and recessive genotypes responsible for the 
+syndrome. The fourth group of patients showed dominant inheritance of 
+osteoporosis leading to fractures, with variable deformity of long bones, but 
+normal sclerae.
+
+DOI: 10.1136/jmg.16.2.101
+PMCID: PMC1012733
+PMID: 458828 [Indexed for MEDLINE]

--- a/references_cache/PMID_9248835.md
+++ b/references_cache/PMID_9248835.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:9248835"
+title: Histopathologic and electron-microscopic features of corneal and scleral collagen fibers in osteogenesis imperfecta type III.
+authors:
+- Mietz H
+- Kasner L
+- Green WR
+journal: Graefes Arch Clin Exp Ophthalmol
+year: '1997'
+doi: 10.1007/BF00947058
+keywords:
+- Adolescent
+- "Basement Membrane/abnormalities, ultrastructure"
+- Collagen/ultrastructure
+- Corneal Diseases/pathology
+- Corneal Stroma/ultrastructure
+- Humans
+- Male
+- Osteogenesis Imperfecta/pathology
+- Sclera/ultrastructure
+- Scleral Diseases/pathology
+content_type: abstract_only
+---
+
+# Histopathologic and electron-microscopic features of corneal and scleral collagen fibers in osteogenesis imperfecta type III.
+**Authors:** Mietz H, Kasner L, Green WR
+**Journal:** Graefes Arch Clin Exp Ophthalmol (1997)
+**DOI:** [10.1007/BF00947058](https://doi.org/10.1007/BF00947058)
+
+## Content
+
+1. Graefes Arch Clin Exp Ophthalmol. 1997 Jul;235(7):405-10. doi: 
+10.1007/BF00947058.
+
+Histopathologic and electron-microscopic features of corneal and scleral 
+collagen fibers in osteogenesis imperfecta type III.
+
+Mietz H(1), Kasner L, Green WR.
+
+Author information:
+(1)Wilmer Ophthalmological Institute, Johns Hopkins Medical Institutions, 
+Baltimore, Maryland, USA. h.mietz@uni-koeln.de
+
+BACKGROUND: This report describes the histopathologic and electron-microscopic 
+features of an eye from a patient with osteogenesis imperfecta type III. In 
+particular, the diameters of corneal stromal and scleral collagen fibers were 
+determined.
+METHODS: The eyes of an 18-year-old white male with osteogenesis imperfecta type 
+III were examined by light and electron microscopy and the pathological features 
+were compared with an age-matched control eye.
+RESULTS: The cornea was clear. The sclera had a blue color and was moderately 
+thinned, especially at the equator. Light microscopy revealed absence of 
+Bowman's layer. Transmission electron microscopy confirmed complete absence of 
+Bowman's layer without evidence of scarring or inflammation. The collagen fibers 
+of the corneal stromal lamellae were about 25% narrower than in the control, but 
+the cornea was otherwise unremarkable ultrastructurally. The collagen fibers of 
+the sclera were approximately 50% narrower than in the control and were much 
+more uniform in size. Prominent portions of elastic fibers, which are usually 
+only present in a small number in the inner portion of the sclera, were present 
+throughout the sclera.
+CONCLUSION: We propose that it is the uniformity of the scleral collagen fibers 
+which gives the sclera translucence, producing the blue color often observed 
+clinically in osteogenesis imperfecta. Absence of Bowman's layer of the cornea 
+did not interfere with the stability of the cornea in this case. This appears to 
+be the first published pathological examination of the eye in osteogenesis 
+imperfecta type III.
+
+DOI: 10.1007/BF00947058
+PMID: 9248835 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- strengthen the `phenotypes` section in `kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml` with more subtype III-specific cohort evidence
- replace broad or weakly supported phenotype claims with better-grounded terms and PMID-backed snippets
- add new supporting reference caches for the PMIDs now cited by the disorder entry

## What Changed
- replaced generic review-backed phenotype assertions with stronger evidence for severe short stature, recurrent fractures, scoliosis, restrictive ventilatory defect, dentinogenesis imperfecta, hearing impairment, wormian bones, basilar impression, popcorn calcification, and variable blue sclerae
- added a softened craniofacial phenotype entry for triangular face based on explicit type III case evidence
- removed the broad `Abnormality of the skeletal system` placeholder phenotype and the weakly supported kyphoscoliosis claim
- added frequency only where directly supported (`Popcorn calcification`, 13/25 type III children = 52%)
- updated `updated_date`

## Why
Issue #1504 asks for the phenotype section of the OI type III entry to be as complete and evidence-backed as possible, with unsupported claims removed or softened and phenotype terms kept specific.

## Validation
- `just validate kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml`
  - passed: `✓ All validations passed for kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml`
- `just validate-references kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml`
  - passed: `Validation Summary: Total checks: 0; All validations passed!`
- `just validate-terms kb/disorders/Osteogenesis_Imperfecta_Type_III.yaml`
  - passed: `✅ Validation passed`

## Notes
- unrelated dirty worktree changes were left unstaged
- refs #1504