### PR TITLE
[codex] Enhance Fibrochondrogenesis phenotype evidence

### DIFF
--- a/kb/disorders/Fibrochondrogenesis.yaml
+++ b/kb/disorders/Fibrochondrogenesis.yaml
@@ -1,20 +1,21 @@
 name: Fibrochondrogenesis
 creation_date: "2026-04-02T12:00:00Z"
-updated_date: "2026-04-06T23:42:38Z"
+updated_date: "2026-04-19T06:45:17Z"
 category: Mendelian
 description: >
   Fibrochondrogenesis is a severe, usually lethal skeletal dysplasia most commonly caused
   by biallelic mutations in COL11A1 (type 1) or COL11A2 (type 2), encoding the alpha-1
   and alpha-2 chains of type XI collagen; rare autosomal dominant COL11A2 cases also occur. It is characterized by short-limbed dwarfism with dumbbell-shaped
   long bones, platyspondyly with vertebral clefting, short ribs with distal cupping, and a
-  distinctive flat face with micrognathia. The hallmark histopathological finding is fibrosis
+  distinctive craniofacial profile that includes midface hypoplasia, a small nose with
+  anteverted nares, and micrognathia. The hallmark histopathological finding is fibrosis
   of the growth plate cartilage with interwoven fibrous septa and fibroblastic dysplasia of
   chondrocytes, distinguishing it from other lethal osteochondrodysplasias such as
   thanatophoric dysplasia and achondrogenesis. Most affected individuals are stillborn or die
-  in the neonatal period from pulmonary hypoplasia. Rare survivors with homozygous null
-  mutations in COL11A1 have severe developmental delay, profound sensorineural deafness,
-  severe myopia, and progressive skeletal abnormalities. Heterozygous carriers may exhibit
-  mild ocular or auditory features.
+  in the neonatal period after severe respiratory compromise related to the small thorax. Rare
+  survivors with homozygous null mutations in COL11A1 have severe developmental delay,
+  profound sensorineural deafness, high myopia, and progressive skeletal abnormalities.
+  Heterozygous COL11A1 carriers may exhibit mild ocular findings.
 disease_term:
   preferred_term: fibrochondrogenesis
   term:
@@ -213,8 +214,8 @@ pathophysiology:
 phenotypes:
 - name: Severe Rhizomelic Micromelia
   description: >
-    Severely shortened limbs with rhizomelic predominance, detectable on prenatal
-    ultrasound as early as 17 weeks gestation.
+    Severely shortened limbs with rhizomelic predominance, often evident on prenatal
+    ultrasound.
   phenotype_term:
     preferred_term: Micromelia
     term:
@@ -233,6 +234,28 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Fibrochondrogenesis is a very rare form of lethal short-limb dwarfism, with 8 cases described since it was first reported in 1978."
     explanation: Confirms short-limb dwarfism as cardinal feature.
+- name: Metaphyseal Widening
+  description: >
+    Marked metaphyseal widening contributes to the characteristic dumbbell-shaped
+    appearance of the long bones.
+  phenotype_term:
+    preferred_term: Metaphyseal widening
+    term:
+      id: HP:0003016
+      label: Metaphyseal widening
+  evidence:
+  - reference: PMID:22246659
+    reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Radiographs showed characteristic findings of fibrochondrogenesis that included severe shortening of the long bones with very widened metaphyses"
+    explanation: Documents marked metaphyseal widening as a characteristic radiographic feature.
+  - reference: PMID:9759906
+    reference_title: "Prenatal ultrasonography: clinical and radiological findings in a boy with fibrochondrogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prenatal ultrasonography performed at 22 weeks of gestation revealed an intrauterine growth retardation, an apparently large head, an hypoplasia of the thorax, a prominent abdomen, rhizomelic limbs, and wide metaphysis."
+    explanation: Confirms that widened metaphyses can be recognized prenatally.
 - name: Dumbbell-Shaped Long Bones
   description: >
     Long bones have a characteristic dumbbell shape with broad metaphyseal flaring,
@@ -273,8 +296,8 @@ phenotypes:
     explanation: Confirms the characteristic pear-shaped platyspondyly pattern.
 - name: Short Ribs
   description: >
-    Severely shortened ribs with distal cupping, contributing to a narrow thorax
-    and respiratory insufficiency.
+    Severely shortened ribs with distal cupping, contributing to a small bell-shaped
+    thorax.
   phenotype_term:
     preferred_term: Short ribs
     term:
@@ -287,41 +310,116 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "The spine is platyspondylic with superior-inferior clefting defects, and the ribs are short and distally cupped."
     explanation: Documents short ribs with distal cupping as a characteristic finding.
-- name: Narrow Chest
+- name: Bell-Shaped Thorax
   description: >
-    Small, narrow thorax secondary to short ribs, contributing to pulmonary
-    hypoplasia and respiratory failure.
+    The thorax is small and bell-shaped because of the short, cupped ribs, contributing
+    to perinatal respiratory compromise.
   phenotype_term:
-    preferred_term: Narrow chest
+    preferred_term: Bell-shaped thorax
     term:
-      id: HP:0000774
-      label: Narrow chest
+      id: HP:0001591
+      label: Bell-shaped thorax
   evidence:
   - reference: PMID:22246659
     reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The chest is small and leads to perinatal respiratory problems which usually, but not always, result in lethality"
-    explanation: Directly describes the small chest and its role in lethality via respiratory compromise.
-- name: Flat Face
+    snippet: "Radiographs showed characteristic findings of fibrochondrogenesis that included severe shortening of the long bones with very widened metaphyses, moderate platyspondyly, delayed ossification of the cervical vertebral bodies, ischia and pubis, short cupped ribs giving a “bell-shaped” appearance to the thorax"
+    explanation: Documents the characteristic bell-shaped thorax caused by short cupped ribs.
+  - reference: PMID:38684309
+    reference_title: "[Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 due to compound heterozygous variants of COL11A1 gene]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prenatal ultrasound showed that the fetus had a small bell-shaped thorax, markedly shortened limbs, flat midface, a small nose with anteriorly tilted nostrils, and a small mandible."
+    explanation: Confirms that the small bell-shaped thorax can be identified prenatally.
+- name: Protuberant Abdomen
   description: >
-    Characteristic flat midface with depressed nasal bridge, contributing to
-    the distinctive facial appearance.
+    A protuberant abdomen accompanies the disproportionately small thorax in affected
+    fetuses and neonates.
   phenotype_term:
-    preferred_term: Flat face
+    preferred_term: Protuberant abdomen
     term:
-      id: HP:0012368
-      label: Flat face
+      id: HP:0001538
+      label: Protuberant abdomen
   evidence:
   - reference: PMID:22246659
     reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "short long bones and short ribs with broad metaphyses, a flat midface, and vertebral bodies which show distinctive hypoplastic posterior ends"
-    explanation: Explicitly describes the flat midface as a characteristic feature of fibrochondrogenesis.
+    snippet: "The child, who died at birth, had the typical facial features of fibrochondrogenesis presenting with a relatively large skull with a wide anterior fontanelle, midface hypoplasia with a small nose and anteverted nares, micrognathia, significant shortening of all limb segments with relatively normal hands and feet, and a small thorax with a protuberant abdomen."
+    explanation: Documents the protuberant abdomen as part of the characteristic body habitus.
+  - reference: PMID:9759906
+    reference_title: "Prenatal ultrasonography: clinical and radiological findings in a boy with fibrochondrogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prenatal ultrasonography performed at 22 weeks of gestation revealed an intrauterine growth retardation, an apparently large head, an hypoplasia of the thorax, a prominent abdomen, rhizomelic limbs, and wide metaphysis."
+    explanation: Confirms a prominent abdomen as a prenatal finding.
+- name: Midface Retrusion
+  description: >
+    Characteristic midface hypoplasia gives the face a flat appearance.
+  phenotype_term:
+    preferred_term: Midface hypoplasia
+    term:
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:22246659
+    reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The child, who died at birth, had the typical facial features of fibrochondrogenesis presenting with a relatively large skull with a wide anterior fontanelle, midface hypoplasia with a small nose and anteverted nares, micrognathia"
+    explanation: Documents midface hypoplasia as a characteristic craniofacial feature.
+  - reference: PMID:38684309
+    reference_title: "[Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 due to compound heterozygous variants of COL11A1 gene]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prenatal ultrasound showed that the fetus had a small bell-shaped thorax, markedly shortened limbs, flat midface, a small nose with anteriorly tilted nostrils, and a small mandible."
+    explanation: Confirms the flat midface on prenatal imaging.
+- name: Short Nose
+  description: >
+    A short or small nose is part of the characteristic craniofacial gestalt.
+  phenotype_term:
+    preferred_term: Short nose
+    term:
+      id: HP:0003196
+      label: Short nose
+  evidence:
+  - reference: PMID:22246659
+    reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The child, who died at birth, had the typical facial features of fibrochondrogenesis presenting with a relatively large skull with a wide anterior fontanelle, midface hypoplasia with a small nose and anteverted nares, micrognathia"
+    explanation: Documents a small nose as part of the typical facial phenotype.
+  - reference: PMID:38684309
+    reference_title: "[Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 due to compound heterozygous variants of COL11A1 gene]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prenatal ultrasound showed that the fetus had a small bell-shaped thorax, markedly shortened limbs, flat midface, a small nose with anteriorly tilted nostrils, and a small mandible."
+    explanation: Confirms the short/small nose on prenatal ultrasound.
+- name: Anteverted Nares
+  description: >
+    The nostrils are characteristically anteverted.
+  phenotype_term:
+    preferred_term: Anteverted nares
+    term:
+      id: HP:0000463
+      label: Anteverted nares
+  evidence:
+  - reference: PMID:22246659
+    reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The child, who died at birth, had the typical facial features of fibrochondrogenesis presenting with a relatively large skull with a wide anterior fontanelle, midface hypoplasia with a small nose and anteverted nares, micrognathia"
+    explanation: Documents anteverted nares as part of the typical facial phenotype.
+  - reference: PMID:38684309
+    reference_title: "[Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 due to compound heterozygous variants of COL11A1 gene]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prenatal ultrasound showed that the fetus had a small bell-shaped thorax, markedly shortened limbs, flat midface, a small nose with anteriorly tilted nostrils, and a small mandible."
+    explanation: Confirms anteverted nostrils on prenatal ultrasound.
 - name: Micrognathia
   description: >
-    Mandibular hypoplasia, a consistent craniofacial finding.
+    Mandibular hypoplasia is a recurrent craniofacial finding and may be severe.
   phenotype_term:
     preferred_term: Micrognathia
     term:
@@ -334,46 +432,33 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "the fetus showed severe micrognathia and a bifid tongue."
     explanation: Documents severe micrognathia in a 17-week fetus with fibrochondrogenesis.
-- name: Cleft Palate
-  description: >
-    Cleft palate observed in some affected individuals.
-  phenotype_term:
-    preferred_term: Cleft palate
-    term:
-      id: HP:0000175
-      label: Cleft palate
-- name: Pulmonary Hypoplasia
-  description: >
-    Underdeveloped lungs resulting from a small thoracic cavity. This is the
-    primary cause of neonatal death.
-  phenotype_term:
-    preferred_term: Pulmonary hypoplasia
-    term:
-      id: HP:0002089
-      label: Pulmonary hypoplasia
-  evidence:
   - reference: PMID:22246659
     reference_title: "Dominant and recessive forms of fibrochondrogenesis resulting from mutations at a second locus, COL11A2."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The chest is small and leads to perinatal respiratory problems which usually, but not always, result in lethality"
-    explanation: Describes the small chest causing respiratory insufficiency and lethality, consistent with pulmonary hypoplasia as the mechanism of death.
-- name: Polyhydramnios
+    snippet: "The child, who died at birth, had the typical facial features of fibrochondrogenesis presenting with a relatively large skull with a wide anterior fontanelle, midface hypoplasia with a small nose and anteverted nares, micrognathia"
+    explanation: Confirms micrognathia in an additional neonatal case.
+- name: Bifid Tongue
   description: >
-    Excess amniotic fluid, a frequent prenatal finding associated with impaired
-    fetal swallowing due to skeletal abnormalities.
+    Bifid tongue has been reported as an additional oral manifestation.
   phenotype_term:
-    preferred_term: Polyhydramnios
+    preferred_term: Bifid tongue
     term:
-      id: HP:0001561
-      label: Polyhydramnios
+      id: HP:0010297
+      label: Bifid tongue
+  evidence:
+  - reference: PMID:9475607
+    reference_title: "Fibrochondrogenesis in a 17-week fetus: a case expanding the phenotype."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "the fetus showed severe micrognathia and a bifid tongue."
+    explanation: Authors highlighted bifid tongue as a newly described manifestation that expands the phenotype.
 - name: Sensorineural Hearing Impairment (Survivors)
   category: Sensory
   subtype: Type 1
   description: >
-    Profound sensorineural deafness observed in the rare surviving patients
-    with homozygous null COL11A1 mutations. Carriers of loss-of-function alleles
-    may also develop early-onset hearing loss.
+    Profound sensorineural deafness has been reported in the rare surviving patients
+    with homozygous null COL11A1 mutations.
   phenotype_term:
     preferred_term: Profound sensorineural hearing impairment
     term:
@@ -386,14 +471,14 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "These patients show additional symptoms which include developmental delay, profound sensory-neural deafness, severe myopia and progressive severe skeletal abnormalities."
     explanation: Documents profound sensorineural deafness in surviving fibrochondrogenesis patients.
-- name: Severe Myopia (Survivors)
+- name: High Myopia (Survivors)
   category: Sensory
   subtype: Type 1
   description: >
-    Severe myopia in surviving patients, reflecting the role of type XI collagen
-    in the vitreous humor. Heterozygous carriers may also develop myopia.
+    High myopia has been reported in the rare surviving patients with homozygous
+    null COL11A1 mutations.
   phenotype_term:
-    preferred_term: Severe myopia
+    preferred_term: High myopia
     term:
       id: HP:0011003
       label: High myopia
@@ -441,8 +526,9 @@ genetic:
     site, or frameshift) and a missense glycine substitution in the triple helical
     domain. Homozygous null mutations found in consanguineous families.
   notes: >
-    Carriers of missense alleles develop myopia; carriers of loss-of-function alleles
-    may develop early-onset hearing loss.
+    Some heterozygous COL11A1 carriers have been reported with ocular findings,
+    while normal hearing was documented in carriers of the null alleles described
+    in the Emirati series.
   evidence:
   - reference: PMID:21035103
     reference_title: "Fibrochondrogenesis results from mutations in the COL11A1 type XI collagen gene."
@@ -535,8 +621,8 @@ diagnosis:
 - name: Prenatal Ultrasound
   description: >
     Fibrochondrogenesis can be detected prenatally by ultrasound as early as 17 weeks
-    gestation. Key findings include severe micromelia, narrow thorax, and
-    polyhydramnios. However, prenatal diagnosis was achieved in only 20% of published
+    gestation. Key findings include severe micromelia, a small bell-shaped thorax,
+    and widened metaphyses. However, prenatal diagnosis was achieved in only 20% of published
     cases, reflecting the rarity of the condition and overlap with other lethal
     skeletal dysplasias.
   evidence:

--- a/references_cache/PMID_38684309.md
+++ b/references_cache/PMID_38684309.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:38684309"
+title: "[Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 due to compound heterozygous variants of COL11A1 gene]."
+authors:
+- Wu J
+- Lyu Y
+- Xyu S
+- Wang X
+journal: Zhonghua Yi Xue Yi Chuan Xue Za Zhi
+year: '2024'
+doi: 10.3760/cma.j.cn511374-20231219-00341
+keywords:
+- Humans
+- Female
+- Pregnancy
+- Phenotype
+- Heterozygote
+- Collagen Type XI/genetics
+- "Ultrasonography, Prenatal"
+- Fetus/abnormalities
+- Exome Sequencing
+- Adult
+- Mutation
+- Prenatal Diagnosis
+- Genetic Testing
+content_type: abstract_only
+---
+
+# [Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 due to compound heterozygous variants of COL11A1 gene].
+**Authors:** Wu J, Lyu Y, Xyu S, Wang X
+**Journal:** Zhonghua Yi Xue Yi Chuan Xue Za Zhi (2024)
+**DOI:** [10.3760/cma.j.cn511374-20231219-00341](https://doi.org/10.3760/cma.j.cn511374-20231219-00341)
+
+## Content
+
+1. Zhonghua Yi Xue Yi Chuan Xue Za Zhi. 2024 May 10;41(5):601-605. doi: 
+10.3760/cma.j.cn511374-20231219-00341.
+
+[Prenatal phenotype and genetic analysis of a fetus with Fibrochondrogenesis 1 
+due to compound heterozygous variants of COL11A1 gene].
+
+[Article in Chinese]
+
+Wu J(1), Lyu Y, Xyu S, Wang X.
+
+Author information:
+(1)Graduate Training Base of Jinzhou Medical University, Chaoyang Central 
+Hospital, Chaoyang, Liaoning 122000, China. 1553548426@qq.com.
+
+OBJECTIVE: To explore the genetic etiology of a fetus with short limbs 
+identified by prenatal ultrasonography.
+METHODS: A fetus detected with short limb malformations at Shengjing Hospital 
+Affiliated to China Medical University on October 25, 2021 was selected as the 
+study subject. Prenatal ultrasound and post-abortion imaging were carried out to 
+determine the phenotypic characteristics of the fetus. Amniotic fluid sample of 
+the fetus and peripheral blood samples of its parents were collected. Following 
+extraction of genomic DNA, whole-exome sequencing was carried out. Candidate 
+variants were verified by Sanger sequencing. Online software was used to predict 
+the structural changes of the mutant proteins.
+RESULTS: Prenatal ultrasound showed that the fetus had a small bell-shaped 
+thorax, markedly shortened limbs, flat midface, a small nose with anteriorly 
+tilted nostrils, and a small mandible. Post-abortion CT showed typical short and 
+wide fetal ribs, cupped metaphyses at both ends, short long bones with wide 
+metaphyses, resulting in a dumbbell-shaped appearance and curved thoracic 
+vertebrae. Whole-exome sequencing revealed that the fetus had harbored compound 
+heterozygous variants of the COL11A1 gene, namely c.2251G>T and c.3790G>T, both 
+of which were predicted to alter the important Gly-X-Y structure of collagen 
+protein. Sanger sequencing confirmed that the variants were respectively 
+inherited from its parents.
+CONCLUSION: A rare fetus with Fibrochondrogenesis type 1 due to compound 
+heterozygous variants of the COL11A1 gene has been diagnosed. Above finding has 
+enabled genetic counseling and reproductive guidance for this family.
+
+DOI: 10.3760/cma.j.cn511374-20231219-00341
+PMID: 38684309 [Indexed for MEDLINE]

--- a/references_cache/PMID_9759906.md
+++ b/references_cache/PMID_9759906.md
@@ -1,0 +1,52 @@
+---
+reference_id: "PMID:9759906"
+title: "Prenatal ultrasonography: clinical and radiological findings in a boy with fibrochondrogenesis."
+authors:
+- Mégarbané A
+- Haddad S
+- Berjaoui L
+journal: Am J Perinatol
+year: '1998'
+doi: 10.1055/s-2007-993966
+keywords:
+- Bone and Bones/abnormalities
+- "Diagnosis, Differential"
+- Fatal Outcome
+- Female
+- "Fibrous Dysplasia of Bone/diagnostic imaging, genetics"
+- Humans
+- "Infant, Newborn"
+- Male
+- Pregnancy
+- Radiography
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Prenatal ultrasonography: clinical and radiological findings in a boy with fibrochondrogenesis.
+**Authors:** Mégarbané A, Haddad S, Berjaoui L
+**Journal:** Am J Perinatol (1998)
+**DOI:** [10.1055/s-2007-993966](https://doi.org/10.1055/s-2007-993966)
+
+## Content
+
+1. Am J Perinatol. 1998 Jul;15(7):403-7. doi: 10.1055/s-2007-993966.
+
+Prenatal ultrasonography: clinical and radiological findings in a boy with 
+fibrochondrogenesis.
+
+Mégarbané A(1), Haddad S, Berjaoui L.
+
+Author information:
+(1)Unité de Génétique Médicale, Faculté de Médecine, Université Saint-Joseph, 
+Beirut, Lebanon.
+
+Fibrochondrogenesis, a rare lethal chondrodysplasia has been reported on nine 
+patients. We report on a boy with fibrochondrogenesis whose parents were second 
+cousins. Prenatal ultrasonography performed at 22 weeks of gestation revealed an 
+intrauterine growth retardation, an apparently large head, an hypoplasia of the 
+thorax, a prominent abdomen, rhizomelic limbs, and wide metaphysis. The latest 
+have never been reported in other lethal dysplasias.
+
+DOI: 10.1055/s-2007-993966
+PMID: 9759906 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- enrich the Fibrochondrogenesis phenotype section with additional PMID-backed craniofacial, thoracic, abdominal, and metaphyseal findings
- replace weakly inferred phenotype claims with directly supported annotations and tighten survivor-only sensory findings
- add the new PubMed cache entries needed for the phenotype evidence

## Why
Issue #1500 asked for a phenotype-focused curation pass that improves completeness without broadening into an unrelated rewrite.

## Validation
- `just validate kb/disorders/Fibrochondrogenesis.yaml`
- `just validate-references kb/disorders/Fibrochondrogenesis.yaml`
- `just validate-terms kb/disorders/Fibrochondrogenesis.yaml`

All three commands passed.

Refs #1500