### PR TITLE
[codex] Enhance phenotype evidence for Hypochondrogenesis

### DIFF
--- a/kb/disorders/Hypochondrogenesis.yaml
+++ b/kb/disorders/Hypochondrogenesis.yaml
@@ -1,6 +1,6 @@
 name: Hypochondrogenesis
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-03T10:30:00Z'
+updated_date: '2026-04-19T06:43:21Z'
 category: Mendelian
 description: >
   Hypochondrogenesis is a severe, usually lethal skeletal dysplasia in the type 2
@@ -291,50 +291,49 @@ genetic:
     explanation: Confirms that virtually all achondrogenesis II/hypochondrogenesis patients carry COL2A1 mutations, predominantly glycine substitutions.
 phenotypes:
 - category: Skeletal
-  name: Severe Micromelia
+  name: Micromelia
   description: >
-    Severely shortened limbs, though typically less extreme than in ACG2.
-    All four limbs are affected with disproportionate shortening.
+    Marked shortening of the extremities is evident prenatally and at birth,
+    with broad, short long bones on fetal imaging.
   phenotype_term:
     preferred_term: Micromelia
     term:
       id: HP:0002983
       label: Micromelia
   evidence:
-  - reference: PMID:6641761
-    reference_title: "Hypochondrogenesis."
+  - reference: PMID:11730591
+    reference_title: "[Achondrogenesis type II-hypochondrogenesis: radiological features. Case report]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The roentgenological signs were less severe than those of type II achondrogenesis."
-    explanation: Confirms that hypochondrogenesis represents a less severe form of short-limbed dwarfism compared to achondrogenesis type II.
-  - reference: PMID:3717210
-    reference_title: "Achondrogenesis II-hypochondrogenesis: variability versus heterogeneity."
+    snippet: "Clinical and radiological findings showed platyspondylic dwarfism with short extremities, narrow thorax and hydropic appearance."
+    explanation: Directly supports marked limb shortening in a neonate diagnosed with hypochondrogenesis.
+  - reference: PMID:11956729
+    reference_title: "Prenatal diagnosis of hypochondrogenesis using fetal MRI: a case report."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Review of the radiographic findings in these cases show a fairly continuous spectrum of bony defects, rather than two distinct radiographic syndromes."
-    explanation: Confirms the spectrum of skeletal severity in the achondrogenesis II-hypochondrogenesis continuum.
+    snippet: "Fetal MR findings were the presence of a conspicuous cartilaginous structure in the basioccipital region, ill-defined ossification of the cervical vertebral bodies, hypoplastic thorax, retarded ossification of the pubic bones, and broad, short long bones."
+    explanation: Prenatal MRI confirms that the long bones are broad and short in hypochondrogenesis.
 - category: Skeletal
   name: Platyspondyly
   description: >
-    Flattened vertebral bodies with variable ossification defects. Vertebral
-    ossification is markedly delayed or absent.
+    Flattened vertebral bodies are a core axial skeletal manifestation and may
+    coexist with delayed vertebral ossification.
   phenotype_term:
     preferred_term: Platyspondyly
     term:
       id: HP:0000926
       label: Platyspondyly
   evidence:
-  - reference: PMID:6641761
-    reference_title: "Hypochondrogenesis."
+  - reference: PMID:11730591
+    reference_title: "[Achondrogenesis type II-hypochondrogenesis: radiological features. Case report]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The delay in vertebral ossification, the absence of all the epiphyseal nuclei and of the tarsal bones might suggest the diagnosis of hypochondrogenesis, rather than that of spondyloepiphyseal dysplasia."
-    explanation: Confirms delayed vertebral ossification as a diagnostic feature of hypochondrogenesis.
+    snippet: "Clinical and radiological findings showed platyspondylic dwarfism with short extremities, narrow thorax and hydropic appearance."
+    explanation: Directly supports platyspondyly in a clinically diagnosed hypochondrogenesis case.
 - category: Skeletal
   name: Short Ribs
   description: >
-    Shortened ribs contributing to thoracic hypoplasia and restricted lung
-    development.
+    Shortened ribs contribute to thoracic narrowing.
   phenotype_term:
     preferred_term: Short ribs
     term:
@@ -350,20 +349,58 @@ phenotypes:
 - category: Skeletal
   name: Narrow Chest
   description: >
-    Severely narrowed thorax due to short ribs and reduced thoracic cage
-    development, directly causing pulmonary hypoplasia.
+    Thoracic hypoplasia produces a small, narrow chest.
   phenotype_term:
     preferred_term: Narrow chest
     term:
       id: HP:0000774
       label: Narrow chest
   evidence:
+  - reference: PMID:11730591
+    reference_title: "[Achondrogenesis type II-hypochondrogenesis: radiological features. Case report]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical and radiological findings showed platyspondylic dwarfism with short extremities, narrow thorax and hydropic appearance."
+    explanation: Directly supports thoracic narrowing in a clinically diagnosed hypochondrogenesis case.
   - reference: PMID:11956729
     reference_title: "Prenatal diagnosis of hypochondrogenesis using fetal MRI: a case report."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "ill-defined ossification of the cervical vertebral bodies, hypoplastic thorax, retarded ossification of the pubic bones, and broad, short long bones"
-    explanation: MRI-based prenatal diagnosis confirms hypoplastic (narrow) thorax as a key finding in hypochondrogenesis.
+    snippet: "Fetal MR findings were the presence of a conspicuous cartilaginous structure in the basioccipital region, ill-defined ossification of the cervical vertebral bodies, hypoplastic thorax, retarded ossification of the pubic bones, and broad, short long bones."
+    explanation: Prenatal MRI confirms hypoplastic thorax as a key skeletal manifestation.
+- category: Skeletal
+  name: Hypoplastic Ilia
+  description: >
+    The iliac bones are underdeveloped on radiography, contributing to the
+    characteristic pelvic dysplasia.
+  phenotype_term:
+    preferred_term: Hypoplastic ilia
+    term:
+      id: HP:0000946
+      label: Hypoplastic ilia
+  evidence:
+  - reference: PMID:3057886
+    reference_title: "Type II achondrogenesis-hypochondrogenesis: morphologic and immunohistopathologic studies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The clinical features were typical, and radiographs revealed short ribs, hypoplastic ilia, absence of ossification of sacrum, pubis, ischia, tali, calcanei, and many vertebral bodies; the long bones were short with mild metaphyseal flaring."
+    explanation: Radiographs directly document hypoplastic ilia in the achondrogenesis II-hypochondrogenesis spectrum.
+- category: Skeletal
+  name: Delayed Pubic Bone Ossification
+  description: >
+    Ossification of the pubic bones is delayed prenatally.
+  phenotype_term:
+    preferred_term: Delayed pubic bone ossification
+    term:
+      id: HP:0008788
+      label: Delayed pubic bone ossification
+  evidence:
+  - reference: PMID:11956729
+    reference_title: "Prenatal diagnosis of hypochondrogenesis using fetal MRI: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fetal MR findings were the presence of a conspicuous cartilaginous structure in the basioccipital region, ill-defined ossification of the cervical vertebral bodies, hypoplastic thorax, retarded ossification of the pubic bones, and broad, short long bones."
+    explanation: Prenatal MRI directly documents retarded ossification of the pubic bones.
 - category: Skeletal
   name: Delayed Epiphyseal Ossification
   description: >
@@ -381,61 +418,61 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "The delay in vertebral ossification, the absence of all the epiphyseal nuclei and of the tarsal bones might suggest the diagnosis of hypochondrogenesis"
     explanation: Original description confirms absent epiphyseal nuclei as a diagnostic feature.
-- category: Respiratory
-  name: Pulmonary Hypoplasia
+- category: Skeletal
+  name: Metaphyseal Widening
   description: >
-    Underdeveloped lungs due to small thorax, a major cause of perinatal
-    mortality. The severely reduced intrathoracic space prevents normal lung
-    growth and differentiation.
+    Long bones may show mild metaphyseal flaring on radiographs.
   phenotype_term:
-    preferred_term: Pulmonary hypoplasia
+    preferred_term: Metaphyseal widening
     term:
-      id: HP:0002089
-      label: Pulmonary hypoplasia
+      id: HP:0003016
+      label: Metaphyseal widening
   evidence:
-  - reference: PMID:11956729
-    reference_title: "Prenatal diagnosis of hypochondrogenesis using fetal MRI: a case report."
+  - reference: PMID:3057886
+    reference_title: "Type II achondrogenesis-hypochondrogenesis: morphologic and immunohistopathologic studies."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "ill-defined ossification of the cervical vertebral bodies, hypoplastic thorax, retarded ossification of the pubic bones, and broad, short long bones"
-    explanation: Hypoplastic thorax documented on prenatal imaging implies pulmonary hypoplasia as a secondary consequence of thoracic restriction.
+    snippet: "The clinical features were typical, and radiographs revealed short ribs, hypoplastic ilia, absence of ossification of sacrum, pubis, ischia, tali, calcanei, and many vertebral bodies; the long bones were short with mild metaphyseal flaring."
+    explanation: Radiographs directly document mild metaphyseal flaring in the long bones.
+- category: Respiratory
+  name: Respiratory Distress
+  description: >
+    Progressive respiratory compromise can occur in the neonatal period.
+  phenotype_term:
+    preferred_term: Respiratory distress
+    term:
+      id: HP:0002098
+      label: Respiratory distress
+  evidence:
+  - reference: PMID:11730591
+    reference_title: "[Achondrogenesis type II-hypochondrogenesis: radiological features. Case report]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The infant died on the third day of life from progressive respiratory distress."
+    explanation: Directly documents severe neonatal respiratory compromise in a hypochondrogenesis case.
 - category: Constitutional
   name: Hydrops Fetalis
   description: >
-    Fetal hydrops with fluid accumulation in multiple body compartments,
-    observed in many cases. May contribute to maternal mirror syndrome.
+    Hydropic appearance or generalized hydrops has been reported prenatally in
+    some affected fetuses.
   phenotype_term:
     preferred_term: Hydrops fetalis
     term:
       id: HP:0001789
       label: Hydrops fetalis
   evidence:
+  - reference: PMID:11730591
+    reference_title: "[Achondrogenesis type II-hypochondrogenesis: radiological features. Case report]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical and radiological findings showed platyspondylic dwarfism with short extremities, narrow thorax and hydropic appearance."
+    explanation: Hydropic appearance was reported in a clinically diagnosed hypochondrogenesis case.
   - reference: PMID:25823796
     reference_title: "Co-Occurence of Reciprocal Translocation and COL2A1 Mutation in a Fetus with Severe Skeletal Dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "a fetus who presented with generalized hydrops fetalis and severe micromelia during prenatal sonographic examinations"
-    explanation: Confirms hydrops fetalis as a presenting feature in a COL2A1-mutant fetus in the achondrogenesis II-hypochondrogenesis spectrum.
-- category: Craniofacial
-  name: Flat Face
-  description: >
-    Characteristic flat facial profile due to abnormal development of facial
-    cartilaginous and skeletal structures dependent on type II collagen.
-  phenotype_term:
-    preferred_term: Flat face
-    term:
-      id: HP:0012368
-      label: Flat face
-- category: Craniofacial
-  name: Depressed Nasal Bridge
-  description: >
-    Flattened nasal bridge contributing to the characteristic flat midface
-    appearance.
-  phenotype_term:
-    preferred_term: Depressed nasal bridge
-    term:
-      id: HP:0005280
-      label: Depressed nasal bridge
+    snippet: "Here, we report on the postmortem identification of a de novo heterozygous mutation in the COL2A1 gene (c.1529G>A, p.Gly510Asp) in a fetus who presented with generalized hydrops fetalis and severe micromelia during prenatal sonographic examinations."
+    explanation: Exact hydrops fetalis terminology is reported in a severe COL2A1 fetal case within the achondrogenesis II-hypochondrogenesis spectrum.
 - category: Craniofacial
   name: Micrognathia
   description: >
@@ -445,43 +482,29 @@ phenotypes:
     term:
       id: HP:0000347
       label: Micrognathia
-- category: Craniofacial
-  name: Cleft Palate
-  description: >
-    Opening in the roof of the mouth, reported in some cases.
-  frequency: OCCASIONAL
-  phenotype_term:
-    preferred_term: Cleft palate
-    term:
-      id: HP:0000175
-      label: Cleft palate
+  evidence:
+  - reference: PMID:12099566
+    reference_title: "Three-dimensional ultrasonographic presentation of micrognathia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Examples of micrognathia include 3 cases of Pierre Robin sequence, cerebrocostomandibular syndrome, Cornelia de Lange syndrome, and hypochondrogenesis."
+    explanation: This prenatal imaging series explicitly includes hypochondrogenesis among fetal cases with micrognathia.
 - category: Prenatal
   name: Polyhydramnios
   description: >
-    Excess amniotic fluid during pregnancy, sometimes observed in affected
-    pregnancies.
-  frequency: OCCASIONAL
+    Excess amniotic fluid has been reported during affected pregnancies.
   phenotype_term:
     preferred_term: Polyhydramnios
     term:
       id: HP:0001561
       label: Polyhydramnios
-- category: Skeletal
-  name: Short Neck
-  description: >
-    Shortened neck due to vertebral abnormalities and overall trunk shortening.
-  phenotype_term:
-    preferred_term: Short neck
-    term:
-      id: HP:0000470
-      label: Short neck
   evidence:
-  - reference: PMID:11956729
-    reference_title: "Prenatal diagnosis of hypochondrogenesis using fetal MRI: a case report."
+  - reference: PMID:11730591
+    reference_title: "[Achondrogenesis type II-hypochondrogenesis: radiological features. Case report]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "ill-defined ossification of the cervical vertebral bodies, hypoplastic thorax, retarded ossification of the pubic bones, and broad, short long bones"
-    explanation: Ill-defined cervical vertebral ossification contributes to the short neck phenotype observed in hypochondrogenesis.
+    snippet: "The abnormality was suspected after ultrasonography of a pregnant woman presenting weak fetal movements revealed shortening of the extremities, voluminous cranium and polyhydramnios."
+    explanation: Prenatal ultrasound in a hypochondrogenesis case directly documented polyhydramnios.
 experimental_models:
 - name: iPSC-Derived Chondrocyte Model
   description: >

--- a/references_cache/PMID_11730591.md
+++ b/references_cache/PMID_11730591.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:11730591"
+title: "[Achondrogenesis type II-hypochondrogenesis: radiological features.Case report]."
+authors:
+- Delgado Carrasco J
+- Casanova Morcillo A
+- Zabalza Alvillos M
+- Ayala Garcés A
+journal: An Esp Pediatr
+year: '2001'
+keywords:
+- "Chromosomes, Human, Pair 12"
+- Collagen Type II/genetics
+- Fatal Outcome
+- Female
+- Humans
+- "Infant, Newborn"
+- "Osteochondrodysplasias/congenital, diagnostic imaging, genetics"
+- Radiography
+content_type: abstract_only
+---
+
+# [Achondrogenesis type II-hypochondrogenesis: radiological features.Case report].
+**Authors:** Delgado Carrasco J, Casanova Morcillo A, Zabalza Alvillos M, Ayala Garcés A
+**Journal:** An Esp Pediatr (2001)
+
+## Content
+
+1. An Esp Pediatr. 2001 Dec;55(6):553-7.
+
+[Achondrogenesis type II-hypochondrogenesis: radiological features.Case report].
+
+[Article in Spanish]
+
+Delgado Carrasco J(1), Casanova Morcillo A, Zabalza Alvillos M, Ayala Garcés A.
+
+Author information:
+(1)Sección de Radiodiagnóstico Pediátrico.Hospital General Universitario 
+Gregorio Marañón. Universidad Complutense. Madrid.
+
+We present a case of lethal dysplasia in the neonatal period. The abnormality 
+was suspected after ultrasonography of a pregnant woman presenting weak fetal 
+movements revealed shortening of the extremities, voluminous cranium and 
+polyhydramnios. Clinical and radiological findings showed platyspondylic 
+dwarfism with short extremities, narrow thorax and hydropic appearance. The 
+infant died on the third day of life from progressive respiratory distress. In 
+the absence of histological, chondro-osseus and molecular studies, detailed 
+clinical and radiological studies, as well as the lethal evolution during the 
+neonatal period, guided the diagnosis of hypochondrogenesis. This entity, 
+together with achondrogenesis II (and other dysplasias), forms part of the same 
+spectrum of collagen type II abnormalities produced by a defect in the gene 
+(COL2A1) that codifies collagen II, located in chromosome 12 I(12q13.1-13.2). 
+When a heterozygote is produced, transmission is dominant autosomal. The 
+phenotype shows wide variation and severity depends on the mechanism and 
+location of the mutation. The definitive diagnosis is given by cytomolecular 
+studies, while individualization of the different entities is based on 
+histological data from the cartilage; clinical findings and skeletal radiology 
+serve as a guide.
+
+PMID: 11730591 [Indexed for MEDLINE]

--- a/references_cache/PMID_12099566.md
+++ b/references_cache/PMID_12099566.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:12099566"
+title: Three-dimensional ultrasonographic presentation of micrognathia.
+authors:
+- Lee W
+- McNie B
+- Chaiworapongsa T
+- Conoscenti G
+- Kalache KD
+- Vettraino IM
+- Romero R
+- Comstock CH
+journal: J Ultrasound Med
+year: '2002'
+doi: 10.7863/jum.2002.21.7.775
+keywords:
+- "Abnormalities, Multiple/diagnostic imaging"
+- Female
+- Humans
+- "Imaging, Three-Dimensional"
+- "Micrognathism/diagnostic imaging, embryology"
+- Pregnancy
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Three-dimensional ultrasonographic presentation of micrognathia.
+**Authors:** Lee W, McNie B, Chaiworapongsa T, Conoscenti G, Kalache KD, Vettraino IM, Romero R, Comstock CH
+**Journal:** J Ultrasound Med (2002)
+**DOI:** [10.7863/jum.2002.21.7.775](https://doi.org/10.7863/jum.2002.21.7.775)
+
+## Content
+
+1. J Ultrasound Med. 2002 Jul;21(7):775-81. doi: 10.7863/jum.2002.21.7.775.
+
+Three-dimensional ultrasonographic presentation of micrognathia.
+
+Lee W(1), McNie B, Chaiworapongsa T, Conoscenti G, Kalache KD, Vettraino IM, 
+Romero R, Comstock CH.
+
+Author information:
+(1)Department of Obstetrics and Gynecology, William Beaumont Hospital, Royal 
+Oak, Michigan 48073-6769, USA.
+
+OBJECTIVE: To present the variable appearance of micrognathia in fetuses by 
+three-dimensional ultrasonography and to describe practical methods for analysis 
+of these volume data.
+METHODS: Three-dimensional multiplanar imaging and surface-rendering techniques 
+were used to show various syndromes and diagnostic approaches for the evaluation 
+of fetal micrognathia.
+RESULTS: Nine cases of fetal micrognathia are presented. Orthogonal multiplanar 
+views were used to obtain a midsagittal facial profile. Examples of micrognathia 
+include 3 cases of Pierre Robin sequence, cerebrocostomandibular syndrome, 
+Cornelia de Lange syndrome, and hypochondrogenesis. Diagnostic pitfalls for 
+micrognathia are also shown.
+CONCLUSIONS: Three-dimensional multiplanar imaging increases the likelihood that 
+a true midline sagittal view of the facial profile is being analyzed. Surface 
+rendering provides another way to qualitatively evaluate the fetal chin from 
+different viewing perspectives. Three-dimensional ultrasonographic methods are 
+useful adjuncts to the preliminary diagnostic impression from two-dimensional 
+ultrasonography.
+
+DOI: 10.7863/jum.2002.21.7.775
+PMID: 12099566 [Indexed for MEDLINE]

--- a/research/Hypochondrogenesis-phenotype-evidence-2026-04-19.md
+++ b/research/Hypochondrogenesis-phenotype-evidence-2026-04-19.md
@@ -1,0 +1,47 @@
+# Hypochondrogenesis phenotype curation notes
+
+Date: 2026-04-19
+Target file: `kb/disorders/Hypochondrogenesis.yaml`
+Issue: `#1501`
+
+## Phenotypes retained or strengthened
+
+- `Micromelia`:
+  - PMID:11730591: "Clinical and radiological findings showed platyspondylic dwarfism with short extremities, narrow thorax and hydropic appearance."
+  - PMID:11956729: "Fetal MR findings were ... broad, short long bones."
+- `Platyspondyly`:
+  - PMID:11730591: "Clinical and radiological findings showed platyspondylic dwarfism..."
+- `Short ribs`:
+  - PMID:3057886: "radiographs revealed short ribs..."
+- `Narrow chest`:
+  - PMID:11730591: "... narrow thorax ..."
+  - PMID:11956729: "... hypoplastic thorax ..."
+- `Hypoplastic ilia`:
+  - PMID:3057886: "... hypoplastic ilia ..."
+- `Delayed pubic bone ossification`:
+  - PMID:11956729: "... retarded ossification of the pubic bones ..."
+- `Delayed epiphyseal ossification`:
+  - PMID:6641761: "... absence of all the epiphyseal nuclei and of the tarsal bones ..."
+- `Metaphyseal widening`:
+  - PMID:3057886: "... mild metaphyseal flaring."
+- `Respiratory distress`:
+  - PMID:11730591: "The infant died on the third day of life from progressive respiratory distress."
+- `Hydrops fetalis`:
+  - PMID:11730591: "... hydropic appearance."
+  - PMID:25823796: "... generalized hydrops fetalis ..."
+- `Micrognathia`:
+  - PMID:12099566: "Examples of micrognathia include ... hypochondrogenesis."
+- `Polyhydramnios`:
+  - PMID:11730591: "... revealed shortening of the extremities, voluminous cranium and polyhydramnios."
+
+## Claims removed or softened
+
+- Removed `Flat face` and `Depressed nasal bridge` from the phenotype section because no direct PMID-backed abstract support was confirmed for hypochondrogenesis.
+- Removed `Cleft palate` because no direct PMID-backed abstract support was confirmed for hypochondrogenesis itself.
+- Removed `Short neck` because the prior support was inferential rather than directly stated.
+- Replaced `Pulmonary hypoplasia` with directly evidenced `Respiratory distress`; thoracic hypoplasia remains represented by `Narrow chest`.
+
+## Notes
+
+- Frequency fields were omitted because the reviewed abstracts did not directly support frequency bands.
+- Pelvic and metaphyseal findings were added because they were directly stated in primary radiographic abstracts and were missing from the phenotype section.


### PR DESCRIPTION
## Summary
- tighten the `Hypochondrogenesis` phenotype section to PMID-backed findings only
- add directly supported pelvic and long-bone phenotypes including `Hypoplastic ilia`, `Delayed pubic bone ossification`, and `Metaphyseal widening`
- replace or remove unsupported/inferential phenotype claims, including swapping indirect pulmonary wording for directly evidenced neonatal respiratory distress
- add a short phenotype-focused research note and cache the two newly cited PubMed references

## Why
The phenotype block mixed well-supported radiographic findings with several unsupported or indirect claims. This change narrows the section to findings that are explicitly grounded in primary literature abstracts and avoids unsupported frequency assertions.

## Impact
The disorder entry is more specific, easier to validate, and safer to reuse for downstream phenotype queries because each retained phenotype now has direct literature support or a more cautious description.

## Validation
- `just validate kb/disorders/Hypochondrogenesis.yaml`
  - `Schema validation... No issues found`
  - `Term validation... ✅ Validation passed`
  - `Reference validation... Total checks: 0; All validations passed!`
  - `✓ All validations passed for kb/disorders/Hypochondrogenesis.yaml`
- `just validate-references kb/disorders/Hypochondrogenesis.yaml`
  - `Validation Summary: Total checks: 0`
  - `All validations passed!`
- `just validate-terms kb/disorders/Hypochondrogenesis.yaml`
  - `✅ Validation passed`

## Scope notes
- intentionally left unrelated dirty worktree files alone
- did not broaden the change beyond phenotype accuracy for `kb/disorders/Hypochondrogenesis.yaml`