### PR TITLE
[codex] Enhance CCD phenotype evidence

### DIFF
--- a/kb/disorders/Cleidocranial_Dysplasia.yaml
+++ b/kb/disorders/Cleidocranial_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Cleidocranial Dysplasia
 creation_date: '2026-03-04T07:37:20Z'
-updated_date: '2026-04-07T00:12:52Z'
+updated_date: '2026-04-19T06:45:02Z'
 category: Mendelian
 description: >
   Cleidocranial dysplasia is a RUNX2-related skeletal dysplasia characterized by
@@ -144,8 +144,9 @@ genetic:
 phenotypes:
 - name: Aplasia/Hypoplasia of the Clavicles
   description: >
-    Clavicular hypoplasia or aplasia is a hallmark feature and underlies shoulder
-    hypermobility in many affected individuals.
+    Clavicular hypoplasia or aplasia is a hallmark skeletal manifestation of
+    cleidocranial dysplasia.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Aplasia/Hypoplasia of the clavicles
     term:
@@ -163,10 +164,19 @@ phenotypes:
       skeletal changes.
     explanation: >-
       This directly supports clavicular abnormalities as a defining phenotype.
+  - reference: PMID:35638029
+    reference_title: "Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clavicular dysplasia was present in 98.6% of cases"
+    explanation: >-
+      The 72-case systematic review reports clavicular dysplasia in 98.6% of
+      cases, which falls in the VERY_FREQUENT band (80-99%).
 - name: Large Fontanelles
   description: >
-    Persistent large fontanelles and delayed suture closure are characteristic of
-    impaired intramembranous ossification.
+    Persistent large fontanelles with delayed cranial suture closure reflect the
+    impaired intramembranous ossification of CCD.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Large fontanelles
     term:
@@ -184,10 +194,150 @@ phenotypes:
       skeletal changes.
     explanation: >-
       This supports persistent patent sutures/fontanelles as core CCD features.
+  - reference: PMID:35638029
+    reference_title: "Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Open fontanels or cranial sutures, the presence of at least one of the
+      typical CCD facies (frontal bossing, brachycephaly, hypertelorism, or
+      depression of the nasal bridge), and supernumerary teeth were reported in
+      92%, 85%, and 88% of cases, respectively.
+    explanation: >-
+      In the ordered list in the abstract, open fontanels or cranial sutures
+      correspond to the first percentage (92%), which falls in the
+      VERY_FREQUENT band (80-99%).
+- name: Wormian Bones
+  description: >
+    Wormian bones are a recurrent radiographic manifestation in the persistently
+    open cranial sutures of CCD.
+  phenotype_term:
+    preferred_term: Wormian bones
+    term:
+      id: HP:0002645
+      label: Wormian bones
+  evidence:
+  - reference: PMID:23633875
+    reference_title: "Cleidocranial dysplasia with hearing loss."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The skull findings are brachycephaly, delayed or failed closure of the
+      fontanelles, presence of open skull sutures and multiple wormian bones
+      with pronounced frontal bossing.
+    explanation: >-
+      This abstract directly documents multiple wormian bones as part of the
+      characteristic cranial phenotype.
+- name: Frontal Bossing
+  description: >
+    Frontal bossing contributes to the typical craniofacial appearance of CCD.
+  phenotype_term:
+    preferred_term: Frontal bossing
+    term:
+      id: HP:0002007
+      label: Frontal bossing
+  evidence:
+  - reference: PMID:23633875
+    reference_title: "Cleidocranial dysplasia with hearing loss."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The skull findings are brachycephaly, delayed or failed closure of the
+      fontanelles, presence of open skull sutures and multiple wormian bones
+      with pronounced frontal bossing.
+    explanation: >-
+      This abstract directly supports frontal bossing as part of the cranial
+      phenotype.
+- name: Brachycephaly
+  description: >
+    Brachycephaly is part of the characteristic craniofacial phenotype in CCD.
+  phenotype_term:
+    preferred_term: Brachycephaly
+    term:
+      id: HP:0000248
+      label: Brachycephaly
+  evidence:
+  - reference: PMID:23633875
+    reference_title: "Cleidocranial dysplasia with hearing loss."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The skull findings are brachycephaly, delayed or failed closure of the
+      fontanelles, presence of open skull sutures and multiple wormian bones
+      with pronounced frontal bossing.
+    explanation: >-
+      This abstract directly supports brachycephaly as a cranial manifestation
+      of CCD.
+- name: Short Stature
+  description: >
+    Short stature is a variably expressed but recurrent component of the CCD
+    skeletal phenotype.
+  phenotype_term:
+    preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  evidence:
+  - reference: PMID:35638029
+    reference_title: "Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "short stature was present in 71% of cases"
+    explanation: >-
+      This systematic review supports short stature as part of the CCD
+      phenotype, but the reported proportion varies across cohorts, so no single
+      frequency band is assigned.
+  - reference: PMID:28027977
+    reference_title: "Cleidocranial dysplasia: Clinical, endocrinologic and molecular findings in 15 patients from 11 families."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "short stature present at a rate of 28.6%"
+    explanation: >-
+      This smaller 15-patient cohort reported a substantially lower rate than
+      the systematic review, reinforcing that short stature is variable in CCD.
+- name: Scoliosis
+  description: >
+    Scoliosis is a clinically important associated skeletal manifestation in
+    some affected individuals.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  evidence:
+  - reference: PMID:35638029
+    reference_title: "Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      other skeletal abnormalities such as scoliosis, pubic symphysis
+      diastasis, and flat feet were found
+    explanation: >-
+      This systematic review explicitly lists scoliosis among the associated
+      skeletal abnormalities seen in CCD.
+- name: Short Middle Phalanx of the 5th Finger
+  description: >
+    Brachymesophalangy of the fifth finger is part of the characteristic hand
+    skeletal phenotype described in CCD.
+  phenotype_term:
+    preferred_term: Short middle phalanx of the 5th finger
+    term:
+      id: HP:0004220
+      label: Short middle phalanx of the 5th finger
+  evidence:
+  - reference: PMID:38534443
+    reference_title: "New Genetic Variants of RUNX2 in Mexican Families Cause Cleidocranial Dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "short middle phalanx of the fifth fingers"
+    explanation: >-
+      This recent CCD clinical/genetic report explicitly includes shortening of
+      the fifth-finger middle phalanx in the characteristic skeletal phenotype.
 - name: Supernumerary Tooth
   description: >
-    Multiple supernumerary teeth are common and contribute to delayed/abnormal
-    eruption patterns.
+    Supernumerary teeth contribute to the complex eruption abnormalities of
+    CCD.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Supernumerary tooth
     term:
@@ -205,9 +355,42 @@ phenotypes:
       skeletal changes.
     explanation: >-
       This directly supports supernumerary dentition as a hallmark CCD feature.
+  - reference: PMID:35638029
+    reference_title: "Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Open fontanels or cranial sutures, the presence of at least one of the
+      typical CCD facies (frontal bossing, brachycephaly, hypertelorism, or
+      depression of the nasal bridge), and supernumerary teeth were reported in
+      92%, 85%, and 88% of cases, respectively.
+    explanation: >-
+      In the ordered list in the abstract, supernumerary teeth correspond to the
+      third percentage (88%), which falls in the VERY_FREQUENT band (80-99%).
+- name: Persistence of Primary Teeth
+  description: >
+    Failure to shed retained primary teeth is a characteristic dental
+    manifestation in CCD.
+  phenotype_term:
+    preferred_term: Persistence of primary teeth
+    term:
+      id: HP:0006335
+      label: Persistence of primary teeth
+  evidence:
+  - reference: PMID:25206109
+    reference_title: "Cleidocranial dysplasia: case report of three siblings."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      prolonged retention of primary teeth and delayed eruption of permanent
+      teeth were evident.
+    explanation: >-
+      This abstract directly supports persistent retention of primary teeth in
+      CCD.
 - name: Delayed Eruption of Permanent Teeth
   description: >
-    Delayed eruption of permanent dentition is a frequent oral manifestation.
+    Delayed eruption of permanent dentition is a characteristic oral
+    manifestation in CCD.
   phenotype_term:
     preferred_term: Delayed eruption of permanent teeth
     term:
@@ -224,47 +407,81 @@ phenotypes:
     explanation: >-
       This provides direct clinical evidence for delayed permanent tooth eruption
       in CCD.
-- name: Wormian Bones
+- name: Hypoplasia of the Maxilla
   description: >
-    Wormian bones are common radiographic findings in the persistently open
-    cranial sutures of CCD.
+    Maxillary hypoplasia contributes to the characteristic dentofacial
+    phenotype of CCD.
   phenotype_term:
-    preferred_term: Wormian bones
+    preferred_term: Hypoplasia of the maxilla
     term:
-      id: HP:0002645
-      label: Wormian bones
+      id: HP:0000327
+      label: Hypoplasia of the maxilla
   evidence:
-  - reference: PMID:25206109
-    reference_title: "Cleidocranial dysplasia: case report of three siblings."
+  - reference: PMID:23633875
+    reference_title: "Cleidocranial dysplasia with hearing loss."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oral manifestations exhibit a hypoplastic maxilla with high-arched palate."
+    explanation: >-
+      This abstract directly supports maxillary hypoplasia as an oral-facial
+      manifestation in CCD.
+- name: High Palate
+  description: >
+    High-arched palate is part of the characteristic oral phenotype in CCD.
+  phenotype_term:
+    preferred_term: High palate
+    term:
+      id: HP:0000218
+      label: High palate
+  evidence:
+  - reference: PMID:23633875
+    reference_title: "Cleidocranial dysplasia with hearing loss."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oral manifestations exhibit a hypoplastic maxilla with high-arched palate."
+    explanation: >-
+      This abstract directly supports high-arched palate as an oral manifestation
+      of CCD.
+- name: Osteoporosis
+  description: >
+    Reduced bone density with osteoporosis is a clinically relevant skeletal
+    manifestation in some CCD cohorts.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Osteoporosis
+    term:
+      id: HP:0000939
+      label: Osteoporosis
+  evidence:
+  - reference: PMID:28027977
+    reference_title: "Cleidocranial dysplasia: Clinical, endocrinologic and molecular findings in 15 patients from 11 families."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      A-P view of the skull demonstrated widening of sutures and a few wormian
-      bones
+      Our clinical evaluations revealed that short stature present at a rate of
+      28.6%, osteoporosis at a rate of 57.1% and osteopenia at 21.4%.
     explanation: >-
-      Full-text case imaging documents wormian bones in affected family members.
-- name: Short Stature
+      In this 15-patient cohort, osteoporosis was reported in 57.1% of cases,
+      which falls in the FREQUENT band (30-79%).
+- name: Conductive Hearing Loss
   description: >
-    Mild to moderate short stature is common in the CCD skeletal phenotype
-    spectrum.
+    Audiologic evaluation in CCD can demonstrate a conductive component of
+    hearing impairment.
   phenotype_term:
-    preferred_term: Short stature
+    preferred_term: Conductive hearing loss
     term:
-      id: HP:0004322
-      label: Short stature
+      id: HP:0000405
+      label: Conductive hearing impairment
   evidence:
-  - reference: PMID:10204840
-    reference_title: "Cleidocranial dysplasia: clinical and molecular genetics."
+  - reference: PMID:32894534
+    reference_title: "Audiological evaluation of patients with cleidocranial dysplasia (CCD)."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Cleidocranial dysplasia (CCD) (MIM 119600) is an autosomal dominant
-      skeletal dysplasia characterised by abnormal clavicles, patent sutures and
-      fontanelles, supernumerary teeth, short stature, and a variety of other
-      skeletal changes.
+    snippet: "A slight conductive hearing loss was diagnosed in 3 out of 4 patients."
     explanation: >-
-      This directly supports short stature as part of the characteristic CCD
-      phenotype.
+      This dedicated audiology cohort directly supports a conductive hearing-loss
+      phenotype in CCD, but no global disease-wide frequency is assigned because
+      the study was limited to four selected children.
 treatments:
 - name: Orthopedic and Dental Correction
   description: >

--- a/references_cache/PMID_23633875.md
+++ b/references_cache/PMID_23633875.md
@@ -1,0 +1,50 @@
+---
+reference_id: "PMID:23633875"
+title: Cleidocranial dysplasia with hearing loss.
+authors:
+- Candamourty R
+- Venkatachalam S
+- Yuvaraj V
+- Kumar GS
+journal: J Nat Sci Biol Med
+year: '2013'
+doi: 10.4103/0976-9668.107318
+content_type: abstract_only
+---
+
+# Cleidocranial dysplasia with hearing loss.
+**Authors:** Candamourty R, Venkatachalam S, Yuvaraj V, Kumar GS
+**Journal:** J Nat Sci Biol Med (2013)
+**DOI:** [10.4103/0976-9668.107318](https://doi.org/10.4103/0976-9668.107318)
+
+## Content
+
+1. J Nat Sci Biol Med. 2013 Jan;4(1):245-9. doi: 10.4103/0976-9668.107318.
+
+Cleidocranial dysplasia with hearing loss.
+
+Candamourty R(1), Venkatachalam S, Yuvaraj V, Kumar GS.
+
+Author information:
+(1)Department of Oral and Maxillofacial Surgery, Indira Gandhi Institute of 
+Dental Sciences, Mahatma Gandhi Medical College and Research Institute Campus, 
+Pillaiyarkuppam, Pondicherry, India.
+
+Cleidocranial dysplasia is an inherited skeletal anomaly that affects primarily 
+the skull, clavicle, and dentition, which can occur spontaneously, but most are 
+inherited in autosomal dominant mode. The skull findings are brachycephaly, 
+delayed or failed closure of the fontanelles, presence of open skull sutures and 
+multiple wormian bones with pronounced frontal bossing. The syndrome is notable 
+for aplasia or hypoplasia of the clavicles. The neck appears long and narrow and 
+the shoulders markedly droop. Oral manifestations exhibit a hypoplastic maxilla 
+with high-arched palate. Crowding of teeth is produced by retention of deciduous 
+teeth, delayed eruption of permanent teeth, and the presence of a large number 
+of unerupted supernumerary teeth. We report a case of CCD in a 12-year-old girl 
+who presented with an unaesthetic facial appearance, unerupted permanent 
+dentition with hearing loss.
+
+DOI: 10.4103/0976-9668.107318
+PMCID: PMC3633291
+PMID: 23633875
+
+Conflict of interest statement: Conflict of Interest: None declared

--- a/references_cache/PMID_28027977.md
+++ b/references_cache/PMID_28027977.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:28027977"
+title: "Cleidocranial dysplasia: Clinical, endocrinologic and molecular findings in 15 patients from 11 families."
+authors:
+- Dinçsoy Bir F
+- Dinçkan N
+- Güven Y
+- Baş F
+- Altunoğlu U
+- Kuvvetli SS
+- Poyrazoğlu Ş
+- Toksoy G
+- Kayserili H
+- Uyguner ZO
+journal: Eur J Med Genet
+year: '2017'
+doi: 10.1016/j.ejmg.2016.12.007
+keywords:
+- Adolescent
+- Adult
+- Body Height/genetics
+- Bone Density/genetics
+- Child
+- "Child, Preschool"
+- Clavicle/pathology
+- "Cleidocranial Dysplasia/genetics, pathology"
+- Core Binding Factor Alpha 1 Subunit/genetics
+- Facies
+- Female
+- Growth Disorders/genetics
+- Humans
+- Male
+- Malocclusion/genetics
+- Middle Aged
+- "Osteoporosis/complications, genetics"
+content_type: abstract_only
+---
+
+# Cleidocranial dysplasia: Clinical, endocrinologic and molecular findings in 15 patients from 11 families.
+**Authors:** Dinçsoy Bir F, Dinçkan N, Güven Y, Baş F, Altunoğlu U, Kuvvetli SS, Poyrazoğlu Ş, Toksoy G, Kayserili H, Uyguner ZO
+**Journal:** Eur J Med Genet (2017)
+**DOI:** [10.1016/j.ejmg.2016.12.007](https://doi.org/10.1016/j.ejmg.2016.12.007)
+
+## Content
+
+1. Eur J Med Genet. 2017 Mar;60(3):163-168. doi: 10.1016/j.ejmg.2016.12.007. Epub
+ 2016 Dec 24.
+
+Cleidocranial dysplasia: Clinical, endocrinologic and molecular findings in 15 
+patients from 11 families.
+
+Dinçsoy Bir F(1), Dinçkan N(2), Güven Y(3), Baş F(4), Altunoğlu U(5), Kuvvetli 
+SS(6), Poyrazoğlu Ş(4), Toksoy G(5), Kayserili H(7), Uyguner ZO(5).
+
+Author information:
+(1)Department of Medical Genetics, Medical Faculty, Çanakkale Onsekiz Mart 
+University, Çanakkale, Turkey. Electronic address: firdevsdincsoy@gmail.com.
+(2)Department of Medical Genetics, Istanbul Medical Faculty, Istanbul 
+University, Istanbul, Turkey; Department of Diagnostic and Biomedical Sciences, 
+Center for Craniofacial Research, University of Texas Health Science Center, 
+Houston, TX, USA.
+(3)Departmentof Pedodontics, Faculty of Dentistry, Istanbul University, 
+Istanbul, Turkey.
+(4)Pediatric Endocrinology Unit, Department of Pediatrics, Istanbul Medical 
+Faculty, Istanbul University, Istanbul, Turkey.
+(5)Department of Medical Genetics, Istanbul Medical Faculty, Istanbul 
+University, Istanbul, Turkey.
+(6)Department of Pedodontics, Faculty of Dentistry, Yeditepe University, 
+Istanbul, Turkey.
+(7)Medical Genetics, Medical Faculty, Koç University, Istanbul, Turkey.
+
+Cleidocranial dysplasia (CCD) is an autosomal dominant disorder characterized by 
+skeletal anomalies such as delayed closure of the cranial sutures, 
+underdeveloped or absent clavicles, multiple dental abnormalities, short stature 
+and osteoporosis. RUNX2, encoding Runt DNA-binding domain protein important in 
+osteoblast differentiation, is the only known gene related to the disease and 
+identified as responsible in 70% of the cases. Our clinical evaluations revealed 
+that short stature present at a rate of 28.6%, osteoporosis at a rate of 57.1% 
+and osteopenia at 21.4%. In this study, RUNX2 sequencing revealed nine different 
+variations in 11 families, eight being pathogenic of which one was novel gross 
+insertion (c.1271_1272ins20) and one other being predicted benign in frame gross 
+deletion (c.241_258del).
+
+Copyright © 2016 Elsevier Masson SAS. All rights reserved.
+
+DOI: 10.1016/j.ejmg.2016.12.007
+PMID: 28027977 [Indexed for MEDLINE]

--- a/references_cache/PMID_32894534.md
+++ b/references_cache/PMID_32894534.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:32894534"
+title: Audiological evaluation of patients with cleidocranial dysplasia (CCD).
+authors:
+- Hojan-Jezierska D
+- Urbaniak-Olejnik M
+- Turska-Malińska R
+- Matthews-Kozanecka M
+- Loba W
+- Komar D
+- Stieler O
+- Majewska A
+journal: Eur Rev Med Pharmacol Sci
+year: '2020'
+doi: 10.26355/eurrev_202008_22624
+keywords:
+- Acoustic Impedance Tests
+- Acoustic Stimulation
+- Adolescent
+- "Audiometry, Pure-Tone"
+- Auditory Threshold
+- Child
+- Cleidocranial Dysplasia/diagnosis
+- Female
+- Humans
+- Male
+content_type: abstract_only
+---
+
+# Audiological evaluation of patients with cleidocranial dysplasia (CCD).
+**Authors:** Hojan-Jezierska D, Urbaniak-Olejnik M, Turska-Malińska R, Matthews-Kozanecka M, Loba W, Komar D, Stieler O, Majewska A
+**Journal:** Eur Rev Med Pharmacol Sci (2020)
+**DOI:** [10.26355/eurrev_202008_22624](https://doi.org/10.26355/eurrev_202008_22624)
+
+## Content
+
+1. Eur Rev Med Pharmacol Sci. 2020 Aug;24(16):8281-8287. doi: 
+10.26355/eurrev_202008_22624.
+
+Audiological evaluation of patients with cleidocranial dysplasia (CCD).
+
+Hojan-Jezierska D(1), Urbaniak-Olejnik M, Turska-Malińska R, Matthews-Kozanecka 
+M, Loba W, Komar D, Stieler O, Majewska A.
+
+Author information:
+(1)Department of Hearing Healthcare Profession, Chair of Biophysics, Poznan 
+University of Medical Sciences, Poznań, Poland. amajewska@ump.edu.pl.
+
+OBJECTIVE: The description of clinical manifestation of hearing problems in 
+cleidocranial dysplasia (CCD) remains limited and incomplete, since CCD 
+constitutes a rare congenital disorder. The study aims to provide a complex 
+panel analysis of the auditory system in patients suffering from the disease.
+PATIENTS AND METHODS: The study group consisted of 4 children with CCD (aged: 
+12-15), who underwent orthodontic treatment. A full panel analysis of their 
+auditory systems was performed, including high-frequency audiometry and a new 
+method of middle ear assessment - WBT (Wideband Tympanometry).
+RESULTS: A slight conductive hearing loss was diagnosed in 3 out of 4 patients. 
+While high frequency audiometry has shown a deterioration of hearing in 3 
+patients, in one case, the obtained thresholds were within the normal range. A 
+decrease of absorbance in low frequencies has been observed in one or both ears. 
+Only one patient has had a shift of maximum absorbance towards high frequencies 
+in the left ear.
+CONCLUSIONS: The presented manuscript is the first with a complete evaluation of 
+the auditory system comprising 4 cases of children in a similar age group. All 
+of the examined patients presented an air-bone gap indicating conductive 
+disorders.
+
+DOI: 10.26355/eurrev_202008_22624
+PMID: 32894534 [Indexed for MEDLINE]

--- a/references_cache/PMID_35638029.md
+++ b/references_cache/PMID_35638029.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:35638029"
+title: "Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America."
+authors:
+- Cano-Pérez E
+- Gómez-Alegría C
+- Herrera FP
+- Gómez-Camargo D
+- Malambo-García D
+journal: Ann Med Surg (Lond)
+year: '2022'
+doi: 10.1016/j.amsu.2022.103611
+content_type: abstract_only
+---
+
+# Demographic, clinical, and radiological characteristics of cleidocranial dysplasia: A systematic review of cases reported in south America.
+**Authors:** Cano-Pérez E, Gómez-Alegría C, Herrera FP, Gómez-Camargo D, Malambo-García D
+**Journal:** Ann Med Surg (Lond) (2022)
+**DOI:** [10.1016/j.amsu.2022.103611](https://doi.org/10.1016/j.amsu.2022.103611)
+
+## Content
+
+1. Ann Med Surg (Lond). 2022 Apr 10;77:103611. doi: 10.1016/j.amsu.2022.103611. 
+eCollection 2022 May.
+
+Demographic, clinical, and radiological characteristics of cleidocranial 
+dysplasia: A systematic review of cases reported in south America.
+
+Cano-Pérez E(1), Gómez-Alegría C(2), Herrera FP(3), Gómez-Camargo D(1)(4), 
+Malambo-García D(1)(4).
+
+Author information:
+(1)Grupo de Investigación UNIMOL, Facultad de Medicina, Universidad de 
+Cartagena, Cartagena de Indias, Colombia.
+(2)Grupo de Investigación UNIMOL, Departamento de Farmacia, Facultad de 
+Ciencias, Universidad Nacional de Colombia, Sede Bogotá, Bogotá, Colombia.
+(3)Grupo de Investigación en Atención Primaria en Salud/Telesalud, Facultad de 
+Medicina, Universidad de Cartagena, Cartagena, Colombia.
+(4)Doctorado en Medicina Tropical, Facultad de Medicina, Universidad de 
+Cartagena, Cartagena de Indias, Colombia.
+
+INTRODUCTION: Cleidocranial dysplasia (CCD) is a rare disease characterized by 
+craniofacial, skeletal, and oral anomalies. The disease prevalence is estimated 
+to be 1 per million inhabitants; thus, only a few studies have described large 
+cohorts of CCD patients. This study reviewed the clinical-radiological and 
+demographic characteristics of patients with CCD in South America.
+METHODS: We conducted a systematic review of all cases of CCD reported in South 
+America following the PRISMA guidelines. Demographic information (sex, age at 
+diagnosis, origin, reason for consultation, and family history) was also 
+recorded. CCD signs were divided into "craniofacial" and "skeletal" categories.
+RESULTS: A total of 72 cases were included. We found that oral anomalies were 
+the most common reason for consultation leading to a diagnosis in patients, with 
+a median age at diagnosis of 14 years. Fifty percent of the patients were women. 
+Open fontanels or cranial sutures, the presence of at least one of the typical 
+CCD facies (frontal bossing, brachycephaly, hypertelorism, or depression of the 
+nasal bridge), and supernumerary teeth were reported in 92%, 85%, and 88% of 
+cases, respectively. Clavicular dysplasia was present in 98.6% of cases, and 
+other skeletal abnormalities such as scoliosis, pubic symphysis diastasis, and 
+flat feet were found; short stature was present in 71% of cases, and one case 
+presented cognitive deficits.
+CONCLUSION: Although the phenotypic spectrum of CCD is variable, clavicular 
+dysplasia, open fontanels or cranial sutures, dental anomalies, and at least one 
+of the typical CCD facies are present in at least 80% of cases.
+
+© 2022 The Authors.
+
+DOI: 10.1016/j.amsu.2022.103611
+PMCID: PMC9142397
+PMID: 35638029
+
+Conflict of interest statement: The authors have no conflicts of interest to 
+declare.

--- a/references_cache/PMID_38534443.md
+++ b/references_cache/PMID_38534443.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:38534443"
+title: New Genetic Variants of RUNX2 in Mexican Families Cause Cleidocranial Dysplasia.
+authors:
+- Toral López J
+- Gómez Martinez S
+- Rivera Vega MDR
+- Hernández-Zamora E
+- Cuevas Covarrubias S
+- Ibarra Castrejón BA
+- González Huerta LM
+journal: Biology (Basel)
+year: '2024'
+doi: 10.3390/biology13030173
+content_type: abstract_only
+---
+
+# New Genetic Variants of RUNX2 in Mexican Families Cause Cleidocranial Dysplasia.
+**Authors:** Toral López J, Gómez Martinez S, Rivera Vega MDR, Hernández-Zamora E, Cuevas Covarrubias S, Ibarra Castrejón BA, González Huerta LM
+**Journal:** Biology (Basel) (2024)
+**DOI:** [10.3390/biology13030173](https://doi.org/10.3390/biology13030173)
+
+## Content
+
+1. Biology (Basel). 2024 Mar 8;13(3):173. doi: 10.3390/biology13030173.
+
+New Genetic Variants of RUNX2 in Mexican Families Cause Cleidocranial Dysplasia.
+
+Toral López J(1), Gómez Martinez S(2), Rivera Vega MDR(2), Hernández-Zamora 
+E(3), Cuevas Covarrubias S(2), Ibarra Castrejón BA(2), González Huerta LM(2).
+
+Author information:
+(1)Department of Medical Genetics, Centro Médico Ecatepec ISSEMYM, Ecatepec 
+55000, México State, Mexico.
+(2)Servicio de Genética, Hospital General de México "Eduardo Liceaga" (HGM), 
+México City 06720, Mexico.
+(3)Medicina Genómica, Instituto Nacional de Rehabilitación "Luis Guillermo 
+Ibarra Ibarra", México City 14389, Mexico.
+
+Cleidocranial dysplasia (CCD) is an autosomal dominant skeletal dysplasia 
+characterized by persistent open skull sutures with bulging calvaria, 
+hypoplasia, or aplasia of clavicles permitting abnormal opposition of the 
+shoulders; wide public symphysis; short middle phalanx of the fifth fingers; and 
+vertebral, craniofacial, and dental anomalies. It is a rare disease, with a 
+prevalence of 1-9/1,000,000, high penetrance, and variable expression. The gene 
+responsible for CCD is the Runt-related transcription factor 2 (RUNX2) gene. We 
+characterize the clinical, genetic, and bioinformatic results of four CCD cases: 
+two cases within Mexican families with six affected members, nine asymptomatic 
+individuals, and two sporadic cases with CCD, with one hundred healthy controls. 
+Genomic DNA analyses of the RUNX2 gene were performed for Sanger sequencing. 
+Bioinformatics tools were used to predict the function, stability, and 
+structural changes of the mutated RUNX2 proteins. Three novel heterozygous 
+mutations (c.651_652delTA; c.538_539delinsCA; c.662T>A) and a previously 
+reported mutation (c.674G>A) were detected. In silico analysis showed that all 
+mutations had functional, stability-related, and structural alterations in the 
+RUNX2 protein. Our results show novel mutations that enrich the pool of RUNX2 
+gene mutations with CCD. Moreover, the proband 1 presented clinical data not 
+previously reported that could represent an expanded phenotype of severe 
+expression.
+
+DOI: 10.3390/biology13030173
+PMCID: PMC10968410
+PMID: 38534443
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/research/Cleidocranial_Dysplasia-phenotype-issue-1499.md
+++ b/research/Cleidocranial_Dysplasia-phenotype-issue-1499.md
@@ -1,0 +1,41 @@
+# Cleidocranial Dysplasia phenotype curation notes for issue #1499
+
+Date: 2026-04-19
+
+Scope: phenotype-only enrichment for `kb/disorders/Cleidocranial_Dysplasia.yaml`
+
+## Papers used
+
+- PMID:35638029
+  - 72-case South America systematic review.
+  - Used for frequency-backed support of clavicular dysplasia, open fontanels or cranial sutures, and supernumerary teeth.
+  - Used as association support for scoliosis.
+  - Used to document that short stature frequency varies across cohorts.
+
+- PMID:28027977
+  - 15-patient cohort with endocrinologic/bone density data.
+  - Used for osteoporosis frequency support.
+  - Used as a counterpoint showing lower short-stature prevalence than the systematic review, so no short-stature frequency was asserted.
+
+- PMID:23633875
+  - Human case report abstract with compact craniofacial/oral summary.
+  - Used for brachycephaly, frontal bossing, wormian bones, maxillary hypoplasia, and high palate.
+
+- PMID:25206109
+  - Existing cached CCD family report.
+  - Used for persistence of primary teeth and delayed eruption of permanent teeth.
+
+- PMID:32894534
+  - CCD audiology cohort.
+  - Used for conductive hearing loss association only; no disease-wide frequency assigned because the study was a small selected cohort.
+
+- PMID:38534443
+  - 2024 CCD clinical/genetic report.
+  - Used for short middle phalanx of the 5th finger.
+
+## Deliberate curation decisions
+
+- Added frequency only where the abstract directly gave a percentage tied to the phenotype.
+- Left onset unmodeled because the reviewed abstracts did not provide clean onset statements for the selected phenotypes.
+- Softened unsupported wording such as "common" when the evidence was qualitative only or when cohort estimates conflicted.
+- Did not add hypertelorism, depressed nasal bridge, or widened pubic symphysis because the available abstract evidence in hand was not specific enough for a clean phenotype-level assertion with confident HPO grounding in this pass.


### PR DESCRIPTION
## Summary
- enrich `kb/disorders/Cleidocranial_Dysplasia.yaml` with additional PMID-backed CCD phenotypes focused on cranial, skeletal, dental, and audiologic manifestations
- add frequency only where the abstract directly supported it and soften unsupported wording where cohort estimates were conflicting
- add the fetched PubMed cache files and a phenotype curation note for issue `#1499`

## Why
Issue #1499 asked for a phenotype-only CCD pass that improves completeness while keeping assertions tightly evidence-backed and ontology-grounded.

## Validation
- `just validate kb/disorders/Cleidocranial_Dysplasia.yaml`
- `just validate-references kb/disorders/Cleidocranial_Dysplasia.yaml`
- `just validate-terms kb/disorders/Cleidocranial_Dysplasia.yaml`

All three commands completed successfully.