### PR TITLE
[codex] Enhance phenotype evidence for Strudwick type

### DIFF
--- a/kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml
+++ b/kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml
@@ -1,6 +1,6 @@
 name: Spondyloepimetaphyseal Dysplasia Strudwick Type
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T06:45:03Z'
+updated_date: '2026-04-19T07:03:05Z'
 category: Mendelian
 description: >
   Spondyloepimetaphyseal dysplasia Strudwick type (SEMD Strudwick) is a rare
@@ -812,10 +812,6 @@ treatments:
     Regular ophthalmologic evaluation for myopia progression and retinal
     detachment screening. Type II collagen abnormalities in the vitreous
     create ongoing risk for retinal complications.
-- name: Audiologic Monitoring
-  description: >
-    Regular hearing assessments for early detection and management of
-    sensorineural hearing loss.
 - name: Physical Therapy and Orthotic Devices
   description: >
     Rehabilitation and orthotic support to manage mobility limitations
@@ -825,14 +821,6 @@ treatments:
     term:
       id: MAXO:0000482
       label: orthotic device usage
-- name: Cleft Palate Repair
-  description: >
-    Surgical repair when cleft palate is present.
-  treatment_term:
-    preferred_term: Cleft repair surgery
-    term:
-      id: MAXO:0000004
-      label: surgical procedure
 - name: Pulmonary Monitoring
   description: >
     Monitoring for restrictive lung disease secondary to severe

--- a/kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml
+++ b/kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml
@@ -1,14 +1,14 @@
 name: Spondyloepimetaphyseal Dysplasia Strudwick Type
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-07T14:40:03Z'
+updated_date: '2026-04-19T06:45:03Z'
 category: Mendelian
 description: >
   Spondyloepimetaphyseal dysplasia Strudwick type (SEMD Strudwick) is a rare
   autosomal dominant type II collagenopathy caused by heterozygous missense
   mutations in COL2A1, typically glycine substitutions within the Gly-X-Y
   triple-helical repeat. The disorder is characterized by disproportionate
-  short-trunk dwarfism, progressive kyphoscoliosis, pectus carinatum, cleft
-  palate, and distinctive dappled or flocculated metaphyseal changes on
+  short-trunk short stature, progressive kyphoscoliosis, pectus carinatum,
+  and distinctive dappled or flocculated metaphyseal changes on
   radiographs. Mutant type II procollagen is retained in the endoplasmic
   reticulum of chondrocytes, where it may trigger ER stress and the unfolded
   protein response or, in some variants, evade ER quality control entirely
@@ -323,7 +323,7 @@ phenotypes:
 - category: Skeletal
   name: Disproportionate Short-Trunk Short Stature
   description: >
-    Short stature with disproportionately short trunk evident from birth.
+    Short stature with disproportionately short trunk.
     Limbs are shortened but hands and feet are typically average-sized.
   phenotype_term:
     preferred_term: Disproportionate short-trunk short stature
@@ -338,6 +338,31 @@ phenotypes:
       The Strudwick type of spondyloepimetaphyseal dysplasia (SEMD) is characterized by disproportionate short stature, pectus carinatum, and scoliosis, as well as dappled metaphyses (which are not seen in SEDC).
     explanation: >-
       Disproportionate short stature is one of the defining features of SEMD Strudwick.
+- category: Skeletal
+  name: Limb Undergrowth
+  description: >
+    Limb shortening accompanies the short-trunk dysplasia and is evident in
+    detailed Strudwick family and longitudinal case reports.
+  phenotype_term:
+    preferred_term: Limb undergrowth
+    term:
+      id: HP:0009826
+      label: Limb undergrowth
+  evidence:
+  - reference: PMID:12925722
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the autosomal dominant Strudwick-type SEMD in a three-generation family, showing specific phenotypical features such as chest deformity, limb shortening, myopia and early-onset degenerative osteoarthrosis
+    explanation: >-
+      Direct Strudwick family report identifies limb shortening as part of the phenotype.
+  - reference: PMID:8723096
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The skeletal radiographs showed an evolution from short tubular bones, delayed epiphyseal development, and mild vertebral involvement to severe metaphyseal dysplasia with dappling irregularities, and hip "dysplasia."
+    explanation: >-
+      Longitudinal radiographic follow-up in Gly154Arg SEMD cases, later cited as consistent with the Strudwick subtype, documents appendicular shortening.
 - category: Skeletal
   name: Scoliosis
   description: >
@@ -359,8 +384,8 @@ phenotypes:
 - category: Skeletal
   name: Kyphosis
   description: >
-    Exaggerated anterior convexity of the thoracic spine, often progressive
-    and contributing to restrictive lung disease when severe.
+    Exaggerated anterior convexity of the thoracic spine that can be severe
+    and progressive.
   phenotype_term:
     preferred_term: Kyphosis
     term:
@@ -391,6 +416,13 @@ phenotypes:
       The orthopaedic manifestations of patients can be hypoplastic odontoid peg with atlantoaxial instability, severe kyphosis or lordosis of dorsal and lumbar spines, hip subluxation, coxa vara and early severe hip osteoarthritis, and malalignment of lower limbs like genu valgum or club foot.
     explanation: >-
       Lordosis of dorsal and lumbar spines documented in SEMD Strudwick patients.
+  - reference: PMID:1870932
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Features in common include delayed ossification of the public bones and proximal femoral epiphyses, coxa vara, odontoid hypoplasia and lumbar lordosis.
+    explanation: >-
+      Classic radiology case report documents lumbar lordosis from birth.
 - category: Skeletal
   name: Pectus Carinatum
   description: >
@@ -409,24 +441,6 @@ phenotypes:
     explanation: >-
       Pectus carinatum is a characteristic feature of SEMD Strudwick.
 - category: Skeletal
-  name: Platyspondyly
-  description: >
-    Flattened vertebral bodies visible on spine radiographs, reflecting
-    disrupted endochondral ossification of the vertebral growth plates.
-  phenotype_term:
-    preferred_term: Platyspondyly
-    term:
-      id: HP:0000926
-      label: Platyspondyly
-  evidence:
-  - reference: PMID:18328979
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      The spondylo-epi-metaphyseal dysplasias (SEMD) are a heterogeneous group of disorders comprising more than 20 distinct entities with differing modes of inheritance, all defined by the combination of vertebral, epiphyseal and metaphyseal abnormalities.
-    explanation: >-
-      Vertebral abnormalities (including platyspondyly) are a defining component of the SEMD group.
-- category: Skeletal
   name: Metaphyseal Dysplasia
   description: >
     Characteristic dappled or flocculated metaphyseal changes on radiographs,
@@ -438,6 +452,18 @@ phenotypes:
     term:
       id: HP:0100255
       label: Metaphyseal dysplasia
+  phenotype_contexts:
+  - onset:
+      onset_category: INFANTILE
+      notes: The classic Strudwick radiology case reported metaphyseal irregularity developing during infancy.
+    evidence:
+    - reference: PMID:1870932
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The distinguishing radiologic feature of this condition is the striking irregularity of long bone metaphyses which develops during infancy.
+      explanation: >-
+        Supports infantile onset of the hallmark metaphyseal irregularity.
   evidence:
   - reference: PMID:7550321
     supports: SUPPORT
@@ -453,25 +479,51 @@ phenotypes:
       A mild degree of metaphyseal dysplasia can be seen in the so-called Strudwick variant of spondyloepimetaphyseal dysplasia and is generally mild or absent in other forms.
     explanation: >-
       Confirms metaphyseal dysplasia as a defining feature of the Strudwick variant of SEMD.
-- category: Skeletal
-  name: Epiphyseal Dysplasia
-  description: >
-    Delayed epiphyseal ossification resulting in small, flattened, and
-    irregular epiphyses. Epiphyseal involvement contributes to joint
-    incongruity and premature arthropathy.
-  phenotype_term:
-    preferred_term: Epiphyseal dysplasia
-    term:
-      id: HP:0002656
-      label: Epiphyseal dysplasia
-  evidence:
-  - reference: PMID:18328979
+  - reference: PMID:1870932
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      epiphyseal dysplasia is often a predominant feature, and the course of the disease is marked by premature osteoarthritis
+      The distinguishing radiologic feature of this condition is the striking irregularity of long bone metaphyses which develops during infancy.
     explanation: >-
-      Epiphyseal dysplasia is identified as a predominant feature in SEMD disorders.
+      Classic Strudwick case report directly supports infantile onset of the hallmark metaphyseal irregularity.
+- category: Skeletal
+  name: Delayed Epiphyseal Ossification
+  description: >
+    Delayed ossification and development of the proximal femoral epiphyses is
+    present from birth and persists as part of the evolving radiographic
+    phenotype.
+  phenotype_term:
+    preferred_term: Delayed epiphyseal ossification
+    term:
+      id: HP:0002663
+      label: Delayed epiphyseal ossification
+  phenotype_contexts:
+  - onset:
+      onset_category: CONGENITAL
+      notes: Delayed proximal femoral epiphyseal ossification was present at birth in the classic Strudwick radiology case.
+    evidence:
+    - reference: PMID:1870932
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Features in common include delayed ossification of the public bones and proximal femoral epiphyses, coxa vara, odontoid hypoplasia and lumbar lordosis.
+      explanation: >-
+        Supports congenital onset of delayed proximal femoral epiphyseal ossification.
+  evidence:
+  - reference: PMID:1870932
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Features in common include delayed ossification of the public bones and proximal femoral epiphyses, coxa vara, odontoid hypoplasia and lumbar lordosis.
+    explanation: >-
+      Direct Strudwick case report documents delayed ossification of the proximal femoral epiphyses at birth.
+  - reference: PMID:8723096
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The skeletal radiographs showed an evolution from short tubular bones, delayed epiphyseal development, and mild vertebral involvement to severe metaphyseal dysplasia with dappling irregularities, and hip "dysplasia."
+    explanation: >-
+      Longitudinal Gly154Arg SEMD cases document delayed epiphyseal development during follow-up.
 - category: Skeletal
   name: Coxa Vara
   description: >
@@ -490,6 +542,13 @@ phenotypes:
       The orthopaedic manifestations of patients can be hypoplastic odontoid peg with atlantoaxial instability, severe kyphosis or lordosis of dorsal and lumbar spines, hip subluxation, coxa vara and early severe hip osteoarthritis, and malalignment of lower limbs like genu valgum or club foot.
     explanation: >-
       Coxa vara documented as an orthopaedic manifestation in SEMD Strudwick.
+  - reference: PMID:1870932
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Features in common include delayed ossification of the public bones and proximal femoral epiphyses, coxa vara, odontoid hypoplasia and lumbar lordosis.
+    explanation: >-
+      Classic radiology case documents coxa vara in congenital Strudwick presentation.
 - category: Skeletal
   name: Genu Valgum
   description: >
@@ -527,21 +586,6 @@ phenotypes:
       The orthopaedic manifestations of patients can be hypoplastic odontoid peg with atlantoaxial instability, severe kyphosis or lordosis of dorsal and lumbar spines, hip subluxation, coxa vara and early severe hip osteoarthritis, and malalignment of lower limbs like genu valgum or club foot.
     explanation: >-
       Atlantoaxial instability with hypoplastic odontoid peg documented in SEMD Strudwick patients.
-  - reference: PMID:18328979
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      A systematic survey of odontoid hypoplasia responsible for atlantoaxial instability with a risk of spinal cord is also required.
-    explanation: >-
-      Review highlights the importance of systematic surveillance for odontoid hypoplasia and atlantoaxial instability in SEMD.
-  - reference: PMID:25604898
-    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Atlanto-axial instability, was observed in 5 of the 18 patients (28%, 95% CI 10-54) in whom flexion-extension films of the cervical spine were available
-    explanation: >-
-      Quantifies atlantoaxial instability at 28% in the subset of COL2A1 patients with appropriate imaging.
 - category: Skeletal
   name: Hypoplasia of the Odontoid Process
   description: >
@@ -560,24 +604,13 @@ phenotypes:
       The orthopaedic manifestations of patients can be hypoplastic odontoid peg with atlantoaxial instability, severe kyphosis or lordosis of dorsal and lumbar spines, hip subluxation, coxa vara and early severe hip osteoarthritis, and malalignment of lower limbs like genu valgum or club foot.
     explanation: >-
       Hypoplastic odontoid peg documented as an orthopaedic manifestation in SEMD Strudwick.
-  - reference: PMID:25604898
-    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+  - reference: PMID:1870932
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Odontoid hypoplasia was present in 56% (95% CI 38-74) and a correlation between odontoid hypoplasia and short stature was observed.
+      Features in common include delayed ossification of the public bones and proximal femoral epiphyses, coxa vara, odontoid hypoplasia and lumbar lordosis.
     explanation: >-
-      Quantifies odontoid hypoplasia at 56% in a large COL2A1 cohort with correlation to short stature.
-- category: Craniofacial
-  name: Cleft Palate
-  description: >
-    Cleft palate occurs in some affected individuals, reflecting impaired
-    endochondral ossification of craniofacial skeletal elements.
-  phenotype_term:
-    preferred_term: Cleft palate
-    term:
-      id: HP:0000175
-      label: Cleft palate
+      Classic Strudwick case report documents odontoid hypoplasia at birth.
 - category: Ophthalmologic
   name: Myopia
   description: >
@@ -597,14 +630,13 @@ phenotypes:
       the autosomal dominant Strudwick-type SEMD in a three-generation family, showing specific phenotypical features such as chest deformity, limb shortening, myopia and early-onset degenerative osteoarthrosis
     explanation: >-
       Myopia documented as a specific phenotypical feature in a three-generation family.
-  - reference: PMID:25604898
-    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+  - reference: PMID:25383842
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Myopia was found in 45% (95% CI 35-56), and retinal detachment had occurred in 12% (95% CI 6-21; median age 14 years; youngest age 3.5 years).
+      He was highly myopic and had a visual acuity of 20/80 in the right eye and counting fingers in the left eye.
     explanation: >-
-      Large COL2A1 cohort including SEMD patients quantifies myopia frequency at 45%.
+      Direct Strudwick retinal case report shows that the myopia can be high-grade.
 - category: Ophthalmologic
   name: Retinal Detachment
   description: >
@@ -617,33 +649,13 @@ phenotypes:
       id: HP:0000541
       label: Retinal detachment
   evidence:
-  - reference: PMID:25604898
-    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
+  - reference: PMID:25383842
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Myopia was found in 45% (95% CI 35-56), and retinal detachment had occurred in 12% (95% CI 6-21; median age 14 years; youngest age 3.5 years).
+      A 13-year-old patient diagnosed with spondyloepimetaphyseal dysplasia-Strudwick type presented with a localized superior temporal retinal detachment in the right eye and a 180° giant retinal tear with an associated macula-off retinal detachment in the left eye.
     explanation: >-
-      Large COL2A1 cohort including SEMD patients quantifies retinal detachment at 12%, with earliest case at 3.5 years.
-- category: Auditory
-  name: Sensorineural Hearing Impairment
-  description: >
-    Sensorineural hearing loss may occur, consistent with the role of type II
-    collagen in inner ear structures.
-  phenotype_term:
-    preferred_term: Sensorineural hearing impairment
-    term:
-      id: HP:0000407
-      label: Sensorineural hearing impairment
-  evidence:
-  - reference: PMID:25604898
-    reference_title: "A study of the clinical and radiological features in a cohort of 93 patients with a COL2A1 mutation causing spondyloepiphyseal dysplasia congenita or a related phenotype."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Thirty-two patients complained of hearing loss (37%, 95% CI 27-48) of whom 17 required hearing aids.
-    explanation: >-
-      Large COL2A1 cohort including SEMD patients quantifies hearing loss at 37%.
+      Direct Strudwick case report documents bilateral rhegmatogenous retinal detachment in adolescence.
 - category: Musculoskeletal
   name: Early-Onset Osteoarthritis
   description: >
@@ -670,23 +682,6 @@ phenotypes:
       The orthopaedic manifestations of patients can be hypoplastic odontoid peg with atlantoaxial instability, severe kyphosis or lordosis of dorsal and lumbar spines, hip subluxation, coxa vara and early severe hip osteoarthritis, and malalignment of lower limbs like genu valgum or club foot.
     explanation: >-
       Early severe hip osteoarthritis documented with 30-year follow-up.
-  - reference: PMID:18328979
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      epiphyseal dysplasia is often a predominant feature, and the course of the disease is marked by premature osteoarthritis
-    explanation: >-
-      Review confirms premature osteoarthritis marks the disease course across SEMD disorders.
-- category: Respiratory
-  name: Restrictive Ventilatory Defect
-  description: >
-    Severe kyphoscoliosis can restrict chest wall compliance and impair
-    respiratory mechanics, leading to restrictive lung disease.
-  phenotype_term:
-    preferred_term: Restrictive ventilatory defect
-    term:
-      id: HP:0002091
-      label: Restrictive ventilatory defect
 - category: Skeletal
   name: Hip Subluxation
   description: >

--- a/references_cache/PMID_1870932.md
+++ b/references_cache/PMID_1870932.md
@@ -1,0 +1,49 @@
+---
+reference_id: "PMID:1870932"
+title: "Spondylometepiphyseal dysplasia congenita, Strudwick type."
+authors:
+- Shebib SM
+- Chudley AE
+- Reed MH
+journal: Pediatr Radiol
+year: '1991'
+doi: 10.1007/BF02018630
+keywords:
+- Bone and Bones/pathology
+- "Child, Preschool"
+- Follow-Up Studies
+- Humans
+- Infant
+- "Infant, Newborn"
+- Male
+- "Osteochondrodysplasias/classification, congenital"
+- Spinal Diseases/congenital
+content_type: abstract_only
+---
+
+# Spondylometepiphyseal dysplasia congenita, Strudwick type.
+**Authors:** Shebib SM, Chudley AE, Reed MH
+**Journal:** Pediatr Radiol (1991)
+**DOI:** [10.1007/BF02018630](https://doi.org/10.1007/BF02018630)
+
+## Content
+
+1. Pediatr Radiol. 1991;21(4):298-300. doi: 10.1007/BF02018630.
+
+Spondylometepiphyseal dysplasia congenita, Strudwick type.
+
+Shebib SM(1), Chudley AE, Reed MH.
+
+Author information:
+(1)Department of Radiology, University of Manitoba, Winnipeg, Canada.
+
+A case of spondylometepiphyseal dysplasia congenita, Strudwick type is 
+presented. At birth, this condition cannot be distinguished from 
+spondyloepiphyseal dysplasia congenita. Features in common include delayed 
+ossification of the public bones and proximal femoral epiphyses, coxa vara, 
+odontoid hypoplasia and lumbar lordosis. The distinguishing radiologic feature 
+of this condition is the striking irregularity of long bone metaphyses which 
+develops during infancy.
+
+DOI: 10.1007/BF02018630
+PMID: 1870932 [Indexed for MEDLINE]

--- a/references_cache/PMID_25383842.md
+++ b/references_cache/PMID_25383842.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:25383842"
+title: Bilateral rhegmatogenous retinal detachment in spondyloepimetaphyseal dysplasia-Strudwick type.
+authors:
+- Szigiato AA
+- Hillier RJ
+- Muni RH
+journal: Retin Cases Brief Rep
+year: '2015'
+doi: 10.1097/ICB.0000000000000079
+keywords:
+- Adolescent
+- Humans
+- Laser Therapy/methods
+- Male
+- "Myopia, Degenerative/etiology"
+- Osteochondrodysplasias/complications
+- Retinal Detachment/etiology
+- Retinal Perforations/etiology
+- Vitrectomy/methods
+content_type: abstract_only
+---
+
+# Bilateral rhegmatogenous retinal detachment in spondyloepimetaphyseal dysplasia-Strudwick type.
+**Authors:** Szigiato AA, Hillier RJ, Muni RH
+**Journal:** Retin Cases Brief Rep (2015)
+**DOI:** [10.1097/ICB.0000000000000079](https://doi.org/10.1097/ICB.0000000000000079)
+
+## Content
+
+1. Retin Cases Brief Rep. 2015 Winter;9(1):51-4. doi:
+10.1097/ICB.0000000000000079.
+
+Bilateral rhegmatogenous retinal detachment in spondyloepimetaphyseal 
+dysplasia-Strudwick type.
+
+Szigiato AA(1), Hillier RJ, Muni RH.
+
+Author information:
+(1)*Faculty of Medicine, University of Toronto, Toronto, Ontario, Canada; 
+†Department of Ophthalmology, Royal Victoria Infirmary, Newcastle upon Tyne, 
+United Kingdom; and ‡Department of Ophthalmology, St Michael's Hospital, 
+Toronto, Ontario, Canada.
+
+PURPOSE: To document the diagnosis and repair of bilateral retinal detachments 
+in a child with spondyloepimetaphyseal dysplasia-Strudwick type, a rare 
+autosomal dominant genetic disorder involving abnormal production of Type II 
+collagen.
+METHODS: Case report.
+RESULTS: A 13-year-old patient diagnosed with spondyloepimetaphyseal 
+dysplasia-Strudwick type presented with a localized superior temporal retinal 
+detachment in the right eye and a 180° giant retinal tear with an associated 
+macula-off retinal detachment in the left eye. He was highly myopic and had a 
+visual acuity of 20/80 in the right eye and counting fingers in the left eye. He 
+underwent a pars plana vitrectomy in the left eye and laser retinoplexy in the 
+right eye, achieving complete reattachment and/or stabilization of both retinae, 
+with a visual acuity of 20/60 in the right eye and 20/100 in the left eye at 3 
+months postoperatively.
+CONCLUSION: Patients with spondyloepimetaphyseal dysplasia-Strudwick type may be 
+at a higher risk of developing myopia, vitreoretinal degeneration, and a 
+subsequent retinal detachment, although the scientific literature provides a 
+loose association between these conditions. Critically, we propose a temporal 
+association between retinal detachment and the onset of puberty in these 
+patients and suggest that a dilated retinal screening examination should be 
+scheduled at around the time of puberty for patients with spondyloepimetaphyseal 
+dysplasia-Strudwick type to detect any asymptomatic retinal pathology.
+
+DOI: 10.1097/ICB.0000000000000079
+PMID: 25383842 [Indexed for MEDLINE]

--- a/references_cache/PMID_8723096.md
+++ b/references_cache/PMID_8723096.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:8723096"
+title: Phenotypic expressions of a Gly 154Arg mutation in type II collagen in two unrelated patients with spondyloepimetaphyseal dysplasia (SEMD).
+authors:
+- Kaitila I
+- Körkkö J
+- Marttinen E
+- Ala-Kokko L
+journal: Am J Med Genet
+year: '1996'
+doi: "10.1002/(SICI)1096-8628(19960503)63:1<111::AID-AJMG21>3.0.CO;2-Q"
+keywords:
+- Adult
+- Aging
+- Amino Acid Sequence
+- Arginine
+- Base Sequence
+- Bone Development
+- Bone and Bones/diagnostic imaging
+- Collagen/genetics
+- Female
+- Genotype
+- Glycine
+- Humans
+- "Infant, Newborn"
+- Male
+- Molecular Sequence Data
+- "Osteochondrodysplasias/classification, genetics, physiopathology"
+- Pedigree
+- Phenotype
+- Point Mutation
+- Polymerase Chain Reaction
+- Radiography
+- Spine/diagnostic imaging
+content_type: abstract_only
+---
+
+# Phenotypic expressions of a Gly 154Arg mutation in type II collagen in two unrelated patients with spondyloepimetaphyseal dysplasia (SEMD).
+**Authors:** Kaitila I, Körkkö J, Marttinen E, Ala-Kokko L
+**Journal:** Am J Med Genet (1996)
+**DOI:** [10.1002/(SICI)1096-8628(19960503)63:1<111::AID-AJMG21>3.0.CO;2-Q](https://doi.org/10.1002/(SICI)1096-8628(19960503)63:1<111::AID-AJMG21>3.0.CO;2-Q)
+
+## Content
+
+1. Am J Med Genet. 1996 May 3;63(1):111-22. doi: 
+10.1002/(SICI)1096-8628(19960503)63:1<111::AID-AJMG21>3.0.CO;2-Q.
+
+Phenotypic expressions of a Gly 154Arg mutation in type II collagen in two 
+unrelated patients with spondyloepimetaphyseal dysplasia (SEMD).
+
+Kaitila I(1), Körkkö J, Marttinen E, Ala-Kokko L.
+
+Author information:
+(1)Department Clinical Genetics, Helsinki University Hospital, Finland.
+
+Type II collagenopathies consist of chondrodysplasias ranging from lethal to 
+mild in severity. A large number of mutations has been found in the COL2A1 gene. 
+Glycine substitutions have been the most common types of mutation. 
+Genotype-phenotype correlations in type II collagenopathies have not been 
+established, partly because of insufficient clinical and radiographic 
+description of the patients. We found a glycine-to-arginine substitution at 
+position 154 in type II collagen in two unrelated isolated propositi with 
+spondyloepimetaphyseal dysplasia and provide a comparative clinical and 
+radiographic analysis from birth to young adulthood for this condition. The 
+clinical phenotype was disproportionate short stature with varus/valgus 
+deformities of the lower limbs requiring corrective osteotomies, and lumbar 
+lordosis. The skeletal radiographs showed an evolution from short tubular bones, 
+delayed epiphyseal development, and mild vertebral involvement to severe 
+metaphyseal dysplasia with dappling irregularities, and hip "dysplasia." The 
+metaphyseal abnormalities disappeared by adulthood.
+
+DOI: 10.1002/(SICI)1096-8628(19960503)63:1<111::AID-AJMG21>3.0.CO;2-Q
+PMID: 8723096 [Indexed for MEDLINE]

--- a/research/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type-phenotype-curation-2026-04-18.md
+++ b/research/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type-phenotype-curation-2026-04-18.md
@@ -1,0 +1,26 @@
+# Spondyloepimetaphyseal Dysplasia Strudwick Type phenotype curation note
+
+Issue: `#1508`
+Date: `2026-04-18`
+
+## Phenotype papers used
+
+- `PMID:7550321` established the core Strudwick phenotype from the original COL2A1 paper: disproportionate short stature, pectus carinatum, scoliosis, and dappled metaphyses.
+- `PMID:12925722` provided direct Strudwick family evidence for chest deformity, limb shortening, myopia, and early-onset degenerative osteoarthrosis.
+- `PMID:16280719` provided the strongest abstract-level Strudwick evidence for the orthopedic complications: hypoplastic odontoid peg, atlantoaxial instability, kyphosis/lordosis, hip subluxation, coxa vara, genu valgum, club foot, and early severe hip osteoarthritis.
+- `PMID:1870932` was the key source for onset-supported radiographic phenotypes: delayed ossification of proximal femoral epiphyses, coxa vara, odontoid hypoplasia, lumbar lordosis, and metaphyseal irregularity developing during infancy.
+- `PMID:8723096` added longitudinal radiographic detail from Gly154Arg SEMD cases later cited as Strudwick-consistent in `PMID:12925722`: short tubular bones, delayed epiphyseal development, and severe metaphyseal dysplasia with dappling irregularities.
+- `PMID:25383842` provided direct Strudwick evidence for high myopia and bilateral rhegmatogenous retinal detachment in adolescence.
+
+## Claims intentionally removed or downgraded
+
+- `Cleft palate` was removed from the phenotype section because I did not find an abstract-level Strudwick-specific PMID supporting it.
+- `Sensorineural hearing impairment` was removed because the existing support came from a mixed COL2A1 cohort rather than Strudwick-specific cases.
+- `Restrictive ventilatory defect` was removed because I did not identify direct phenotype evidence in a Strudwick abstract.
+- `Platyspondyly` was removed because the existing evidence supported only broad SEMD vertebral involvement, not a clearly Strudwick-specific abstract-level platyspondyly claim.
+
+## Curation approach
+
+- Preferred Strudwick-specific case reports or families over mixed COL2A1 cohorts.
+- Added `onset` only where the abstract explicitly supported congenital or infantile timing.
+- Replaced broader phenotype wording with more specific terms when the abstract directly supported the narrower claim, for example `Delayed epiphyseal ossification`.


### PR DESCRIPTION
## Summary
- tighten the phenotype section for `Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml` around Strudwick-specific PMID-backed findings
- add directly supported phenotypes and onset evidence for infantile metaphyseal change and congenital delayed proximal femoral epiphyseal ossification
- remove or downgrade weaker phenotype claims that were not supported by Strudwick-specific abstract-level evidence

## What changed
- added `Limb undergrowth` with family and longitudinal radiographic support
- replaced a broader epiphyseal claim with `Delayed epiphyseal ossification`
- strengthened myopia and retinal detachment with Strudwick-specific case evidence
- removed unsupported or weakly grounded phenotype claims including cleft palate, hearing impairment, restrictive ventilatory defect, and platyspondyly
- added new cached references for `PMID:1870932`, `PMID:8723096`, and `PMID:25383842`
- added a phenotype curation research note documenting source selection and removals

## Validation
- `just validate kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml`
- `just validate-references kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml`
- `just validate-terms kb/disorders/Spondyloepimetaphyseal_Dysplasia_Strudwick_Type.yaml`

All three commands passed locally.
