### PR TITLE
[codex] Enhance Pycnodysostosis phenotype section

### DIFF
--- a/kb/disorders/Pycnodysostosis.yaml
+++ b/kb/disorders/Pycnodysostosis.yaml
@@ -132,7 +132,7 @@ phenotypes:
     reference_title: "Clinical and animal research findings in pycnodysostosis and gene mutations of cathepsin K from 1996 to 2011."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Skeletal abnormalities, including short stature, an increase in bone density with pathologic fractures, and open fontanels and sutures, are the typical phenotypes of pycnodysostosis."
+    snippet: "including short stature, an increase in bone density with pathologic fractures"
     explanation: Review of 159 reported patients lists short stature as a typical phenotype.
 - category: Skeletal
   name: Recurrent fractures
@@ -149,7 +149,7 @@ phenotypes:
     reference_title: "Clinical and animal research findings in pycnodysostosis and gene mutations of cathepsin K from 1996 to 2011."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Skeletal abnormalities, including short stature, an increase in bone density with pathologic fractures, and open fontanels and sutures, are the typical phenotypes of pycnodysostosis."
+    snippet: "an increase in bone density with pathologic fractures"
     explanation: Review of 159 reported patients identifies pathologic fractures as a typical skeletal phenotype.
 - category: Skeletal
   name: Brachydactyly
@@ -168,6 +168,23 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "All patients had facial dysmorphism with frontal bossing and the hands and feet had short digits with overlying cutaneous wrinkles that tapered off with large overriding nails."
     explanation: Pediatric ENT case series documents short digits of the hands and feet, supporting brachydactyly.
+- category: Skeletal
+  name: Acroosteolysis of the distal phalanges
+  description: >
+    Resorption of the terminal phalanges is a cardinal distinguishing feature of
+    pycnodysostosis.
+  phenotype_term:
+    preferred_term: acroosteolysis of the distal phalanges
+    term:
+      id: HP:0009839
+      label: Osteolytic defects of the distal phalanges of the hand
+  evidence:
+  - reference: PMID:28576543
+    reference_title: "Pycnodysostosis at otorhinolaryngology."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "acroosteolysis of the distal phalanges."
+    explanation: ENT case series abstract names acroosteolysis of the distal phalanges as a cardinal diagnostic feature; HPO grounds this to the exact-synonym hand distal-phalange osteolysis term.
 - category: Skeletal
   name: Clavicular dysplasia
   description: >
@@ -302,7 +319,7 @@ phenotypes:
     reference_title: "Pycnodysostosis at otorhinolaryngology."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Pycnodysostosis is characterized by short stature, characteristic facial appearance (delayed closure of fontanelles and cranial sutures, mandibular hypoplasia and angle disorder, blue sclera), and acroosteolysis of the distal phalanges."
+    snippet: "characteristic facial appearance (delayed closure of fontanelles and cranial sutures, mandibular hypoplasia and angle disorder, blue sclera)"
     explanation: ENT case series abstract lists blue sclera as part of the characteristic facial phenotype.
 - category: Ophthalmologic
   name: Proptosis
@@ -315,12 +332,12 @@ phenotypes:
       id: HP:0000520
       label: Proptosis
   evidence:
-  - reference: PMID:28576543
-    reference_title: "Pycnodysostosis at otorhinolaryngology."
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Midfacial hypoplasia and malocclusion were observed in seven of the eight patients (87.5%), four (50%) had micrognathia, and five (62.5%) had proptosis."
-    explanation: Pediatric ENT series documents proptosis in 5 of 8 affected patients.
+    snippet: "ocular proptosis (8 of 8)"
+    explanation: Pediatric cohort documents proptosis in all eight evaluated children.
 - category: Dermatologic
   name: Nail dysplasia
   description: >
@@ -384,7 +401,7 @@ phenotypes:
     reference_title: "Pycnodysostosis: Characteristics of teeth, mouth and jaws."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The examined patients with PDO were characterized by dental crowding, malocclusion (anterior crossbite, posterior open bite), hypercementosis, obliterated pulp chambers and deviations in mandibular morphology."
+    snippet: "dental crowding, malocclusion (anterior crossbite, posterior open bite)"
     explanation: Dedicated oro-dental cohort study identifies dental crowding as a characteristic dental manifestation.
 - category: Dental
   name: Dental malocclusion
@@ -401,7 +418,7 @@ phenotypes:
     reference_title: "Pycnodysostosis: Characteristics of teeth, mouth and jaws."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The examined patients with PDO were characterized by dental crowding, malocclusion (anterior crossbite, posterior open bite), hypercementosis, obliterated pulp chambers and deviations in mandibular morphology."
+    snippet: "malocclusion (anterior crossbite, posterior open bite)"
     explanation: Dedicated oro-dental cohort study identifies malocclusion as a characteristic dental manifestation.
 - category: Respiratory
   name: Obstructive sleep apnea

--- a/kb/disorders/Pycnodysostosis.yaml
+++ b/kb/disorders/Pycnodysostosis.yaml
@@ -1,6 +1,6 @@
 name: Pycnodysostosis
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-02-13T01:20:31Z'
+updated_date: '2026-04-19T06:44:39Z'
 category: Mendelian
 description: >
   Pycnodysostosis is an autosomal recessive osteochondrodysplasia caused by
@@ -101,28 +101,29 @@ pathophysiology:
     snippet: "cathepsin K is a major protease in bone resorption"
     explanation: "Establishes cathepsin K as the primary bone matrix-degrading enzyme."
 phenotypes:
-- name: Osteosclerosis
+- category: Skeletal
+  name: Generalized osteosclerosis
   description: >
-    Generalized increase in bone density due to impaired bone matrix
-    resorption. Unlike osteopetrosis, the defect is in organic matrix
-    degradation rather than mineral dissolution.
+    Diffuse increased bone density is a core radiographic feature of
+    pycnodysostosis.
   phenotype_term:
-    preferred_term: Osteopetrosis
+    preferred_term: generalized osteosclerosis
     term:
-      id: HP:0011002
-      label: Osteopetrosis
+      id: HP:0005789
+      label: Generalized osteosclerosis
   evidence:
   - reference: PMID:8703060
     reference_title: "Pycnodysostosis, a lysosomal disease caused by cathepsin K deficiency."
     supports: SUPPORT
-    snippet: "an autosomal recessive osteochondrodysplasia characterized by osteosclerosis and short stature"
-    explanation: "Osteosclerosis is a defining feature of pycnodysostosis."
-- name: Short Stature
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pycnodysostosis, an autosomal recessive osteochondrodysplasia characterized by osteosclerosis and short stature, maps to chromosome 1q21."
+    explanation: Foundational clinical description of generalized osteosclerosis in pycnodysostosis.
+- category: Skeletal
+  name: Short stature
   description: >
-    Proportionate short stature due to impaired bone remodeling
-    and turnover affecting skeletal growth.
+    Short stature is a characteristic growth phenotype in affected individuals.
   phenotype_term:
-    preferred_term: Short stature
+    preferred_term: short stature
     term:
       id: HP:0004322
       label: Short stature
@@ -130,15 +131,16 @@ phenotypes:
   - reference: PMID:21569238
     reference_title: "Clinical and animal research findings in pycnodysostosis and gene mutations of cathepsin K from 1996 to 2011."
     supports: SUPPORT
-    snippet: "Skeletal abnormalities, including short stature, an increase in bone density with pathologic fractures, and open fontanels and sutures, are the typical phenotypes of pycnodysostosis"
-    explanation: "Short stature listed as a typical pycnodysostosis phenotype."
-- name: Pathologic Fractures
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Skeletal abnormalities, including short stature, an increase in bone density with pathologic fractures, and open fontanels and sutures, are the typical phenotypes of pycnodysostosis."
+    explanation: Review of 159 reported patients lists short stature as a typical phenotype.
+- category: Skeletal
+  name: Recurrent fractures
   description: >
-    Recurrent fractures from structurally abnormal bone despite
-    increased density. The accumulated undigested collagen matrix
-    weakens bone mechanical properties.
+    Fragile sclerotic bone predisposes affected individuals to pathologic or
+    recurrent fractures.
   phenotype_term:
-    preferred_term: Recurrent fractures
+    preferred_term: recurrent fractures
     term:
       id: HP:0002757
       label: Recurrent fractures
@@ -146,24 +148,278 @@ phenotypes:
   - reference: PMID:21569238
     reference_title: "Clinical and animal research findings in pycnodysostosis and gene mutations of cathepsin K from 1996 to 2011."
     supports: SUPPORT
-    snippet: "short stature, an increase in bone density with pathologic fractures"
-    explanation: "Pathologic fractures are a typical feature of pycnodysostosis."
-- name: Open Fontanelles
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Skeletal abnormalities, including short stature, an increase in bone density with pathologic fractures, and open fontanels and sutures, are the typical phenotypes of pycnodysostosis."
+    explanation: Review of 159 reported patients identifies pathologic fractures as a typical skeletal phenotype.
+- category: Skeletal
+  name: Brachydactyly
   description: >
-    Persistently open fontanelles and cranial sutures, a characteristic
-    feature that distinguishes pycnodysostosis from other sclerosing
-    bone disorders.
+    Short digits of the hands and feet are recurrent appendicular findings in
+    pycnodysostosis.
   phenotype_term:
-    preferred_term: Large fontanelles
+    preferred_term: brachydactyly
     term:
-      id: HP:0000239
-      label: Large fontanelles
+      id: HP:0001156
+      label: Brachydactyly
   evidence:
-  - reference: PMID:21569238
-    reference_title: "Clinical and animal research findings in pycnodysostosis and gene mutations of cathepsin K from 1996 to 2011."
+  - reference: PMID:28576543
+    reference_title: "Pycnodysostosis at otorhinolaryngology."
     supports: SUPPORT
-    snippet: "open fontanels and sutures, are the typical phenotypes of pycnodysostosis"
-    explanation: "Open fontanelles and sutures are a characteristic diagnostic feature."
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All patients had facial dysmorphism with frontal bossing and the hands and feet had short digits with overlying cutaneous wrinkles that tapered off with large overriding nails."
+    explanation: Pediatric ENT case series documents short digits of the hands and feet, supporting brachydactyly.
+- category: Skeletal
+  name: Clavicular dysplasia
+  description: >
+    Abnormal clavicular morphology, particularly involving the acromial ends, is
+    reported in affected children.
+  phenotype_term:
+    preferred_term: clavicular dysplasia
+    term:
+      id: HP:0000889
+      label: Abnormal clavicle morphology
+  evidence:
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "dysplastic acromial ends of the clavicles (6 of 8)"
+    explanation: Pediatric cohort documents abnormal clavicular morphology affecting the acromial ends.
+- category: Craniofacial
+  name: Delayed closure of the anterior fontanelle
+  description: >
+    Persistence of a large anterior fontanelle beyond the expected age is a
+    common cranial finding.
+  phenotype_term:
+    preferred_term: delayed closure of the anterior fontanelle
+    term:
+      id: HP:0001476
+      label: Delayed closure of the anterior fontanelle
+  evidence:
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "large fontanel with delayed closure (8 of 8)"
+    explanation: Cohort data directly support delayed closure of the anterior fontanelle.
+- category: Craniofacial
+  name: Delayed cranial suture closure
+  description: >
+    Persistently open or delayed-closing cranial sutures are a hallmark skull
+    abnormality in pycnodysostosis.
+  phenotype_term:
+    preferred_term: delayed cranial suture closure
+    term:
+      id: HP:0000270
+      label: Delayed cranial suture closure
+  evidence:
+  - reference: PMID:40523612
+    reference_title: "Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, radiological and cephalometric diagnostic criteria. A systematic review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "unclosed cranial sutures (97 %)"
+    explanation: Systematic review of 69 reported patients identifies unclosed cranial sutures as a near-constant maxillofacial feature.
+- category: Craniofacial
+  name: Frontal bossing
+  description: >
+    Frontal bossing is a recurrent component of the characteristic craniofacial
+    appearance.
+  phenotype_term:
+    preferred_term: frontal bossing
+    term:
+      id: HP:0002007
+      label: Frontal bossing
+  evidence:
+  - reference: PMID:40523612
+    reference_title: "Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, radiological and cephalometric diagnostic criteria. A systematic review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "frontal bossing (92 %)"
+    explanation: Systematic review identifies frontal bossing as a common craniofacial feature in published cases.
+- category: Craniofacial
+  name: Midface retrusion
+  description: >
+    Maxillary and midfacial hypoplasia produce a retrusive middle third of the
+    face.
+  phenotype_term:
+    preferred_term: midface retrusion
+    term:
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:40523612
+    reference_title: "Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, radiological and cephalometric diagnostic criteria. A systematic review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "midfacial hypoplasia (100 %)"
+    explanation: Systematic review of reported patients supports midface retrusion through universal midfacial hypoplasia in the reviewed maxillofacial cohort.
+- category: Craniofacial
+  name: Micrognathia
+  description: >
+    A small mandible is a frequent feature of the pycnodysostosis facial
+    phenotype.
+  phenotype_term:
+    preferred_term: micrognathia
+    term:
+      id: HP:0000347
+      label: Micrognathia
+  evidence:
+  - reference: PMID:40523612
+    reference_title: "Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, radiological and cephalometric diagnostic criteria. A systematic review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "micrognathia (92 %)"
+    explanation: Systematic review identifies micrognathia as a recurrent craniofacial finding in published cases.
+- category: Craniofacial
+  name: Obtuse angle of mandible
+  description: >
+    Loss of the normal gonial angle is a diagnostically important mandibular
+    abnormality.
+  phenotype_term:
+    preferred_term: obtuse angle of mandible
+    term:
+      id: HP:0005446
+      label: Obtuse angle of mandible
+  evidence:
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "obtuse mandibular angle (8 of 8)"
+    explanation: Pediatric cohort documents obtuse mandibular angle in all eight evaluated patients.
+- category: Ophthalmologic
+  name: Blue sclerae
+  description: >
+    Blue sclerae are part of the characteristic craniofacial and ocular
+    appearance described in pycnodysostosis.
+  phenotype_term:
+    preferred_term: blue sclerae
+    term:
+      id: HP:0000592
+      label: Blue sclerae
+  evidence:
+  - reference: PMID:28576543
+    reference_title: "Pycnodysostosis at otorhinolaryngology."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pycnodysostosis is characterized by short stature, characteristic facial appearance (delayed closure of fontanelles and cranial sutures, mandibular hypoplasia and angle disorder, blue sclera), and acroosteolysis of the distal phalanges."
+    explanation: ENT case series abstract lists blue sclera as part of the characteristic facial phenotype.
+- category: Ophthalmologic
+  name: Proptosis
+  description: >
+    Prominent eyes or proptosis occur as part of the characteristic
+    craniofacial phenotype.
+  phenotype_term:
+    preferred_term: proptosis
+    term:
+      id: HP:0000520
+      label: Proptosis
+  evidence:
+  - reference: PMID:28576543
+    reference_title: "Pycnodysostosis at otorhinolaryngology."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Midfacial hypoplasia and malocclusion were observed in seven of the eight patients (87.5%), four (50%) had micrognathia, and five (62.5%) had proptosis."
+    explanation: Pediatric ENT series documents proptosis in 5 of 8 affected patients.
+- category: Dermatologic
+  name: Nail dysplasia
+  description: >
+    Dysplastic nails are a recurrent appendageal feature in affected children.
+  phenotype_term:
+    preferred_term: nail dysplasia
+    term:
+      id: HP:0002164
+      label: Nail dysplasia
+  evidence:
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "dysplastic nails (8 of 8)"
+    explanation: Pediatric cohort documents nail dysplasia in all eight evaluated children.
+- category: Dental
+  name: Delayed eruption of teeth
+  description: >
+    Delayed eruption affects the dentition and contributes to the characteristic
+    oral phenotype.
+  phenotype_term:
+    preferred_term: delayed eruption of teeth
+    term:
+      id: HP:0000684
+      label: Delayed eruption of teeth
+  evidence:
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "delayed teeth eruption (8 of 8)"
+    explanation: Pediatric cohort documents delayed eruption in all eight evaluated children.
+- category: Dental
+  name: Enamel hypoplasia
+  description: >
+    Enamel hypoplasia is part of the recurrent dental phenotype.
+  phenotype_term:
+    preferred_term: enamel hypoplasia
+    term:
+      id: HP:0006297
+      label: Enamel hypoplasia
+  evidence:
+  - reference: PMID:11474477
+    reference_title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "enamel hypoplasia (7 of 8)"
+    explanation: Pediatric cohort documents enamel hypoplasia in most evaluated children.
+- category: Dental
+  name: Dental crowding
+  description: >
+    Marked crowding is a recurrent orthodontic problem in pycnodysostosis.
+  phenotype_term:
+    preferred_term: dental crowding
+    term:
+      id: HP:0000678
+      label: Dental crowding
+  evidence:
+  - reference: PMID:38532649
+    reference_title: "Pycnodysostosis: Characteristics of teeth, mouth and jaws."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The examined patients with PDO were characterized by dental crowding, malocclusion (anterior crossbite, posterior open bite), hypercementosis, obliterated pulp chambers and deviations in mandibular morphology."
+    explanation: Dedicated oro-dental cohort study identifies dental crowding as a characteristic dental manifestation.
+- category: Dental
+  name: Dental malocclusion
+  description: >
+    Malocclusion, including anterior crossbite and posterior open bite, is a
+    recurrent dentofacial manifestation.
+  phenotype_term:
+    preferred_term: dental malocclusion
+    term:
+      id: HP:0000689
+      label: Dental malocclusion
+  evidence:
+  - reference: PMID:38532649
+    reference_title: "Pycnodysostosis: Characteristics of teeth, mouth and jaws."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The examined patients with PDO were characterized by dental crowding, malocclusion (anterior crossbite, posterior open bite), hypercementosis, obliterated pulp chambers and deviations in mandibular morphology."
+    explanation: Dedicated oro-dental cohort study identifies malocclusion as a characteristic dental manifestation.
+- category: Respiratory
+  name: Obstructive sleep apnea
+  description: >
+    Upper-airway narrowing can lead to clinically significant obstructive sleep
+    apnea.
+  phenotype_term:
+    preferred_term: obstructive sleep apnea
+    term:
+      id: HP:0002870
+      label: Obstructive sleep apnea
+  evidence:
+  - reference: PMID:28576543
+    reference_title: "Pycnodysostosis at otorhinolaryngology."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Video recordings showed that six of the eight patients (75%) had respiratory distress and four (50%) had sleep apnea."
+    explanation: Pediatric ENT case series documents obstructive sleep apnea in half of the evaluated patients.
 genetic:
 - name: CTSK Mutations
   association: Causative

--- a/references_cache/PMID_11474477.md
+++ b/references_cache/PMID_11474477.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:11474477"
+title: "Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy."
+authors:
+- Soliman AT
+- Ramadan MA
+- Sherif A
+- Aziz Bedair ES
+- Rizk MM
+journal: Metabolism
+year: '2001'
+doi: 10.1053/meta.2001.24924
+keywords:
+- Adolescent
+- Brain/pathology
+- Child
+- "Growth Hormone/physiology, therapeutic use"
+- Humans
+- Insulin-Like Growth Factor I/physiology
+- Magnetic Resonance Imaging
+- "Osteosclerosis/diagnostic imaging, drug therapy, pathology"
+- Radiography
+content_type: abstract_only
+---
+
+# Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear growth after growth hormone therapy.
+**Authors:** Soliman AT, Ramadan MA, Sherif A, Aziz Bedair ES, Rizk MM
+**Journal:** Metabolism (2001)
+**DOI:** [10.1053/meta.2001.24924](https://doi.org/10.1053/meta.2001.24924)
+
+## Content
+
+1. Metabolism. 2001 Aug;50(8):905-11. doi: 10.1053/meta.2001.24924.
+
+Pycnodysostosis: clinical, radiologic, and endocrine evaluation and linear 
+growth after growth hormone therapy.
+
+Soliman AT(1), Ramadan MA, Sherif A, Aziz Bedair ES, Rizk MM.
+
+Author information:
+(1)Department of Pediatrics, Alexandria University, Alexandria, Egypt.
+
+Pycnodysostosis is a rare hereditary bone abnormality with an autosomal 
+recessive mode of inheritance. We report the clinical, radiologic, and endocrine 
+status of 8 children with this rare disease. All patients had the characteristic 
+phenotype of the disorder including short stature (8 of 8), increased bone 
+density (7 of 8), separated cranial sutures (8 of 8), large fontanel with 
+delayed closure (8 of 8), obtuse mandibular angle (8 of 8), delayed teeth 
+eruption (8 of 8), enamel hypoplasia (7 of 8), dysplastic acromial ends of the 
+clavicles (6 of 8), frontal bossing (6 of 8), ocular proptosis (8 of 8), and 
+dysplastic nails (8 of 8). Developmental evaluation according to the revised 
+Denever developmental screening showed normal motor, fine motor-adaptive 
+language, and personal social abilities in all the children. All had normal 
+hepatic and renal functions. Serum calcium and phosphorus concentrations were 
+normal. Two children had low serum alkaline phosphatase concentration. Short 
+stature is a characteristic feature of pycnodysostosis. Seven of the 8 children 
+were born short (length standard deviation score [SDS] = -3 to -1.5). 
+Deceleration of linear growth was significant during the first 3 years of life. 
+All the children had height SDS below -3 at the end of their third year of life. 
+Although short stature is a feature of this genetic disorder, defective growth 
+hormone (GH) secretion in response to provocation with clonidine and glucagon 
+was found in 4 of the 8 patients. These 4 patients had pituitary hypoplasia on 
+the magnetic resonance imaging (MRI) of their brain. In addition, 3 of these 4 
+patients had demyelination of the cerebrum. Patients with pycnodysostosis (n = 
+8) had low circulating concentrations of insulin-like growth factor-1 (IGF-1) 
+compared with normal age-matched short children with constitutional short 
+stature (CSS). IGF-I increased significantly after injecting GH for 3 days in 
+these patients. Physiologic replacement with GH (18 U/m(2)/week) divided in 
+daily evening doses subcutaneously increased IGF-1 concentration and improved 
+linear growth velocity and height standard deviation scores (HtSDS) in the 4 
+children with GH deficiency. These data ruled out GH resistance and proved the 
+usefulness of GH therapy in the management of short stature in these patients. 
+In summary, some patients with pycnodysostosis have partial GH deficiency and 
+low IGF-1 concentration. GH therapy markedly increases IGF-I secretion and 
+improves their linear growth. MRI study of the brain including the 
+hypothalamic-pituitary area is recommended in these children because of the high 
+incidence of pituitary hypoplasia and cerebral demyelination.
+
+Copyright 2001 by W.B. Saunders Company
+
+DOI: 10.1053/meta.2001.24924
+PMID: 11474477 [Indexed for MEDLINE]

--- a/references_cache/PMID_28576543.md
+++ b/references_cache/PMID_28576543.md
@@ -1,0 +1,132 @@
+---
+reference_id: "PMID:28576543"
+title: Pycnodysostosis at otorhinolaryngology.
+authors:
+- Baglam T
+- Binnetoglu A
+- Fatih Topuz M
+- Baş Ikizoglu N
+- Ersu R
+- Turan S
+- Sarı M
+journal: Int J Pediatr Otorhinolaryngol
+year: '2017'
+doi: 10.1016/j.ijporl.2017.02.009
+keywords:
+- "Adenoidectomy/adverse effects, methods"
+- Adenoids/pathology
+- Adolescent
+- Cephalometry
+- Child
+- "Diagnosis, Differential"
+- Female
+- Humans
+- Male
+- Otolaryngology
+- Palatine Tonsil/pathology
+- Polysomnography
+- "Pycnodysostosis/complications, diagnosis, therapy"
+- Quality of Life
+- Retrospective Studies
+- "Sleep Apnea Syndromes/etiology, surgery"
+- "Sleep Apnea, Obstructive/surgery"
+- "Tonsillectomy/adverse effects, methods"
+content_type: abstract_only
+---
+
+# Pycnodysostosis at otorhinolaryngology.
+**Authors:** Baglam T, Binnetoglu A, Fatih Topuz M, Baş Ikizoglu N, Ersu R, Turan S, Sarı M
+**Journal:** Int J Pediatr Otorhinolaryngol (2017)
+**DOI:** [10.1016/j.ijporl.2017.02.009](https://doi.org/10.1016/j.ijporl.2017.02.009)
+
+## Content
+
+1. Int J Pediatr Otorhinolaryngol. 2017 Apr;95:91-96. doi: 
+10.1016/j.ijporl.2017.02.009. Epub 2017 Feb 11.
+
+Pycnodysostosis at otorhinolaryngology.
+
+Baglam T(1), Binnetoglu A(2), Fatih Topuz M(3), Baş Ikizoglu N(4), Ersu R(5), 
+Turan S(6), Sarı M(7).
+
+Author information:
+(1)Marmara University, School of Medicine, Department of Otorhinolaryngology, 
+Fevzi Çakmak Parish MuhsinYazıcıoğlust. No: 10, Kaynarca, Pendik, Istanbul, 
+Turkey. Electronic address: tekinbaglam@yahoo.com.
+(2)Marmara University, School of Medicine, Department of Otorhinolaryngology, 
+Fevzi Çakmak Parish MuhsinYazıcıoğlust. No: 10, Kaynarca, Pendik, Istanbul, 
+Turkey. Electronic address: adembinnet@hotmail.com.
+(3)Dumlupinar University, School of Medicine, Department of Otorhinolaryngology, 
+Istiklal Parish Okmeydani St. No:10, Merkez, Kütahya, Turkey. Electronic 
+address: drfatihtopuz@yahoo.com.
+(4)Marmara University, School of Medicine, Department of Otorhinolaryngology, 
+Fevzi Çakmak Parish MuhsinYazıcıoğlust. No: 10, Kaynarca, Pendik, Istanbul, 
+Turkey. Electronic address: nilaybas@yahoo.com.
+(5)Marmara University, School of Medicine, Department of Otorhinolaryngology, 
+Fevzi Çakmak Parish MuhsinYazıcıoğlust. No: 10, Kaynarca, Pendik, Istanbul, 
+Turkey. Electronic address: rersu@yahoo.com.
+(6)Marmara University, School of Medicine, Department of Otorhinolaryngology, 
+Fevzi Çakmak Parish MuhsinYazıcıoğlust. No: 10, Kaynarca, Pendik, Istanbul, 
+Turkey. Electronic address: serap.turan@marmara.edu.tr.
+(7)Marmara University, School of Medicine, Department of Otorhinolaryngology, 
+Fevzi Çakmak Parish MuhsinYazıcıoğlust. No: 10, Kaynarca, Pendik, Istanbul, 
+Turkey. Electronic address: drmuratsari@yahoo.com.
+
+AIM: Pycnodysostosis is a rare autosomal, recessive, skeletal dysplasia caused 
+by a mutation in the cathepsin k gene. Pycnodysostosis is characterized by short 
+stature, characteristic facial appearance (delayed closure of fontanelles and 
+cranial sutures, mandibular hypoplasia and angle disorder, blue sclera), and 
+acroosteolysis of the distal phalanges. Our aim was to describe the 
+otorhinolaryngologic findings, differential diagnoses, various treatment 
+options, and followup in eight cases of pycnodysostosis.
+METHOD: This retrospective clinical study used data from eight patients 
+diagnosed with pycnodysostosis by a single pediatric endocrinologist primarily 
+based on clinical and radiographic findings. All patients were referred to the 
+otorhinolaryngology outpatient clinic by the pediatric endocrinology unit of the 
+Marmara University between February 2013 and March 2015. Detailed medical 
+histories were obtained in all cases and otorhinolaryngologic physical 
+examination, blood assays, electrocardiogram, lateral skull X-rays, chest 
+radiograph, cephalometric investigations, tympanograms, and audiograms were also 
+carried out. Sleep videos of patients were recorded and those with upper airway 
+problems were evaluated for sleep apnea by polysomnography. Informed consent 
+form was obtained from the parents of all patients.
+RESULTS: Eight patients (7 females and 1 male) displaying proportionate dwarfism 
+were included in the study. They had a mean age of 14.7 years (range: 13-16 y), 
+the mean height of 141.3 cm (range 132-155 cm), and mean weight of 44.4 kg 
+(range: 39.6-49.3 kg). All patients had facial dysmorphism with frontal bossing 
+and the hands and feet had short digits with overlying cutaneous wrinkles that 
+tapered off with large overriding nails. Midfacial hypoplasia and malocclusion 
+were observed in seven of the eight patients (87.5%), four (50%) had 
+micrognathia, and five (62.5%) had proptosis. Tympanograms and audiograms of all 
+patients were type A and normal, and the mean of the pure tone audiogram was 
+13.3 dB (range: 10-16 dB). All patients had a narrow and grooved palate with 
+disturbed dentition; two of them (25%) had mild markedness of the tongue base, 
+five (62.5%) had grade 3 and three (37.5%) had grade 2 tonsillar hypertrophy, 
+and five (62.5%) had adenoid hypertrophy. One patient (12.5%) had grade 3 
+Mallampati, four (50%) showed grade 2 Mallampati while three (37.5%) patients 
+displayed grade 1 Mallampati score. Further, while six (75%) patients had no 
+uvular pathology, one (12.5%) patient presented with uvular elongation and 
+another patient had a bifid uvula. Cephalometric measurements such as PAS-UP 
+(mean 5.67 mm; range: 5.0-7.6 mm) and PAS-TP (mean 9.61 mm; range: 8.5-12.2 mm) 
+were lower than that of normal subjects. Video recordings showed that six of the 
+eight patients (75%) had respiratory distress and four (50%) had sleep apnea. 
+Polysomnography in these patients with sleep apnea showed that two had mild OSA 
+(AHI: 18.2 and 20.1 events/hour) and two had severe OSA (AHI: 53.4 and 62.8 
+events/hour). For upper airway problems, an adenotonsillectomy was performed in 
+two (25%) patients while two others required an adenoidectomy. Positive pressure 
+ventilation was recommended in two patients with persistent sleep apnea after 
+adeno/adenotonsillectomy. However, because of the parental objections, the 
+follow-up polysomnographs could not be obtained.
+CONCLUSION: Pycnodysostosis is a very rare form of bone dysplasia. 
+Otorhinolaryngologically, proper follow-up of these patients and appropriate 
+treatment of upper airway problems are important to achieve an acceptable 
+quality of life. Adeno/adenotonsillectomy and positive pressure ventilation, 
+used as conservative approaches in treating upper airway problems, are effective 
+and could be used instead of an aggressive surgery such as tracheotomy or 
+maxillomandibular advancement. This study, to the best of our knowledge, is the 
+largest ENT case series on pycnodysostosis.
+
+Copyright © 2017 Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.ijporl.2017.02.009
+PMID: 28576543 [Indexed for MEDLINE]

--- a/references_cache/PMID_38532649.md
+++ b/references_cache/PMID_38532649.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:38532649"
+title: "Pycnodysostosis: Characteristics of teeth, mouth and jaws."
+authors:
+- Ferlias N
+- Gjørup H
+- Doherty MA
+- Pedersen TK
+journal: Orthod Craniofac Res
+year: '2024'
+doi: 10.1111/ocr.12782
+keywords:
+- Humans
+- Female
+- Male
+- Cone-Beam Computed Tomography
+- "Pycnodysostosis/diagnostic imaging, pathology"
+- Malocclusion/diagnostic imaging
+- Adolescent
+- Child
+- Young Adult
+- Temporomandibular Joint Disorders/diagnostic imaging
+- Adult
+content_type: abstract_only
+---
+
+# Pycnodysostosis: Characteristics of teeth, mouth and jaws.
+**Authors:** Ferlias N, Gjørup H, Doherty MA, Pedersen TK
+**Journal:** Orthod Craniofac Res (2024)
+**DOI:** [10.1111/ocr.12782](https://doi.org/10.1111/ocr.12782)
+
+## Content
+
+1. Orthod Craniofac Res. 2024 Aug;27(4):656-664. doi: 10.1111/ocr.12782. Epub
+2024  Mar 26.
+
+Pycnodysostosis: Characteristics of teeth, mouth and jaws.
+
+Ferlias N(1), Gjørup H(2), Doherty MA(3)(4), Pedersen TK(1)(5).
+
+Author information:
+(1)Department of Dentistry and Oral Health, Section of Orthodontics, Aarhus 
+University, Aarhus, Denmark.
+(2)Department of Oral and Maxillofacial Surgery, Center for Oral Health in Rare 
+Diseases, Aarhus University Hospital, Aarhus, Denmark.
+(3)Childhood Cancer Research Group, Danish Cancer Research Institute, 
+Copenhagen, Denmark.
+(4)Department of Pediatrics and Adolescent Medicine, Aarhus University Hospital, 
+Aarhus, Denmark.
+(5)Department of Oral and Maxillofacial Surgery, Aarhus University Hospital, 
+Aarhus, Denmark.
+
+OBJECTIVES: To describe the clinical and radiographic oro-dental characteristics 
+of patients with pycnodysostosis (PDO).
+MATERIALS & METHODS: A short interview and clinical examination of seven 
+patients with PDO were performed as well as assessment of the temporomandibular 
+joints and masticatory muscles using the diagnostic criteria for 
+temporomandibular disorders, DC-TMD form. A full set of records were taken 
+including photos and intraoral scan. Finally, existing cone beam computed 
+tomography (CBCT) images and radiographs were also studied.
+RESULTS: All patients presented with bimaxillary micrognathia, five had a convex 
+profile, and two had a straight profile. In addition, posterior open bite, Angle 
+Class III molar relation with accompanying anterior crossbite and a grooved 
+median palate were common findings. No patient showed symptoms of 
+temporomandibular disorder (TMD) apart from some clicking. Finally, the main 
+radiographic findings were the obtuse mandibular angle, the frontal bossing, the 
+elongation of the coronoid/condylar process and the presence of hypercementosis 
+with obliterated pulp chambers.
+CONCLUSION: The examined patients with PDO were characterized by dental 
+crowding, malocclusion (anterior crossbite, posterior open bite), 
+hypercementosis, obliterated pulp chambers and deviations in mandibular 
+morphology. In conclusion, patients with PDO have a specific need for dental and 
+orthodontic monitoring with focus on crowding and posterior open bite. The 
+patients will benefit from a long-term orthodontic plan including extractions.
+
+© 2024 The Authors. Orthodontics & Craniofacial Research published by John Wiley 
+& Sons Ltd.
+
+DOI: 10.1111/ocr.12782
+PMID: 38532649 [Indexed for MEDLINE]

--- a/references_cache/PMID_40523612.md
+++ b/references_cache/PMID_40523612.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:40523612"
+title: "Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, radiological and cephalometric diagnostic criteria. A systematic review."
+authors:
+- Bovis M
+- Brotons A
+- Antunes D
+- Colard T
+- Philip-Alliez C
+- Ferri J
+journal: J Stomatol Oral Maxillofac Surg
+year: '2025'
+doi: 10.1016/j.jormas.2025.102430
+keywords:
+- Humans
+- "Pycnodysostosis/diagnosis, diagnostic imaging, complications"
+- Cephalometry
+- Male
+- Female
+content_type: abstract_only
+---
+
+# Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, radiological and cephalometric diagnostic criteria. A systematic review.
+**Authors:** Bovis M, Brotons A, Antunes D, Colard T, Philip-Alliez C, Ferri J
+**Journal:** J Stomatol Oral Maxillofac Surg (2025)
+**DOI:** [10.1016/j.jormas.2025.102430](https://doi.org/10.1016/j.jormas.2025.102430)
+
+## Content
+
+1. J Stomatol Oral Maxillofac Surg. 2025 Oct;126(5S):102430. doi: 
+10.1016/j.jormas.2025.102430. Epub 2025 Jun 14.
+
+Oral and maxillofacial manifestations of Pycnodysostosis: a summary of clinical, 
+radiological and cephalometric diagnostic criteria. A systematic review.
+
+Bovis M(1), Brotons A(2), Antunes D(3), Colard T(4), Philip-Alliez C(2), Ferri 
+J(3).
+
+Author information:
+(1)Department of Maxillofacial Surgery and Stomatology, Lille University Medical 
+School, France. Electronic address: marine.bovis@hotmail.fr.
+(2)Department of Dentofacial Orthopaedics, Marseille School of Dentistry, 
+France.
+(3)Department of Maxillofacial Surgery and Stomatology, Lille University Medical 
+School, France.
+(4)Université de Lille, CHU Lille, Oral Radiology Department, F-59000 Lille, 
+France; Université de Bordeaux, CNRS, MC, PACEA, UMR 5199, F-33600 Pessac, 
+France.
+
+Pycnodysostosis (PYCD) is a rare osteosclerotic disorder with distinct 
+craniofacial features. Diagnosis remains challenging due to overlap with other 
+skeletal dysplasias. The aim of this systematic review was to identify clinical, 
+radiological, and cephalometric maxillofacial features in PYCD and to evaluate 
+their diagnostic relevance. Following PRISMA and AMSTAR guidelines, a search was 
+conducted in Pubmed, Web of Science and Cochrane Library databases. Studies were 
+included if they reported characteristics of the cranial vault, face, or oral 
+cavity. Of the 345 publications identified, 46 studies comprising a total of 69 
+patients were included. The cohort consisted of 58 % female and 42 % male 
+patients, with a mean age of 20 years and a consanguinity rate of 38 %. Key 
+diagnostic features included frontal bossing (92 %), unclosed cranial sutures 
+(97 %), sclerotic ossification (90 %), midfacial hypoplasia (100 %), exorbitis 
+(83 %), maxillary sinus hypoplasia (97 %), micrognathia (92 %), severely obtuse 
+gonial angle (100 %), narrow and grooved palate (100-73 %) and severe dental 
+crowding (91 %). The cephalometric analysis, available for 17 patients, revealed 
+maxillary and mandibular retrognathia (p = 9.17e-06 and 7.646e-05), with no 
+predominance skeletal class, facial hyperdivergence (p = 0.047), and cranial 
+base morphology contributing to these dysmorphies (p = 9,31e-04).
+
+Copyright © 2025 Elsevier Masson SAS. All rights reserved.
+
+DOI: 10.1016/j.jormas.2025.102430
+PMID: 40523612 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest The authors 
+declare that they have no known competing financial interests or personal 
+relationships that could have appeared to influence the work reported in this 
+paper.

--- a/research/Pycnodysostosis-deep-research-codex.md
+++ b/research/Pycnodysostosis-deep-research-codex.md
@@ -1,0 +1,50 @@
+---
+provider: codex
+model: gpt-5
+date: '2026-04-19'
+issue: 1507
+focus: phenotype section only
+---
+
+## Question
+
+Make the phenotype section of `kb/disorders/Pycnodysostosis.yaml` as complete
+and evidence-backed as possible using exact PMID-supported phenotype evidence,
+while avoiding an unrelated broad rewrite.
+
+## Selected PMID-backed phenotype evidence
+
+- `PMID:8703060`
+  Foundational clinical description supporting generalized osteosclerosis and
+  short stature.
+- `PMID:21569238`
+  Review of 159 reported patients supporting the typical core phenotype set of
+  short stature, increased bone density with pathologic fractures, and open
+  fontanels/sutures.
+- `PMID:11474477`
+  Eight-child cohort supporting delayed fontanel closure, obtuse mandibular
+  angle, delayed tooth eruption, enamel hypoplasia, clavicular dysplasia,
+  proptosis, and nail dysplasia.
+- `PMID:28576543`
+  Eight-patient ENT series supporting brachydactyly/short digits, blue sclerae,
+  midfacial hypoplasia, micrognathia, proptosis, malocclusion, and sleep apnea.
+- `PMID:38532649`
+  Dedicated oro-dental cohort supporting dental crowding and dental
+  malocclusion.
+- `PMID:40523612`
+  Systematic review of 69 reported patients supporting frontal bossing,
+  unclosed cranial sutures, midfacial hypoplasia, micrognathia, obtuse gonial
+  angle, and severe dental crowding.
+
+## Curation decisions
+
+- Replaced the overly broad `HP:0011002` `Osteopetrosis` mapping with
+  `HP:0005789` `Generalized osteosclerosis`.
+- Split the prior broad open-fontanelle claim into `Delayed closure of the
+  anterior fontanelle` and `Delayed cranial suture closure`.
+- Added only phenotypes directly named in abstracts or abstract result lines.
+- Kept phenotype ontology terms specific but avoided terms that were more
+  specific than the abstract wording could safely support.
+- Omitted `frequency:` and structured `onset:` annotations because the
+  available quantitative signals were cohort- or review-specific and not clean
+  whole-disease estimates.


### PR DESCRIPTION
## Summary
- expand the phenotype section of `kb/disorders/Pycnodysostosis.yaml` with PMID-backed skeletal, craniofacial, ophthalmologic, dermatologic, dental, and respiratory manifestations
- replace the overly broad `Osteopetrosis` phenotype mapping with the more specific `Generalized osteosclerosis` term
- add the fetched reference cache files needed for deterministic reference validation and a focused research note for issue #1507

## Why
- issue #1507 asks for a phenotype-only enrichment pass with exact PMID-backed evidence, tighter ontology grounding, and removal of unsupported broad claims
- frequency and onset annotations were intentionally omitted where the abstracts did not provide clean whole-disease support

## Validation
- `just validate kb/disorders/Pycnodysostosis.yaml` ✅
- `just validate-references kb/disorders/Pycnodysostosis.yaml` ✅
- `just validate-terms kb/disorders/Pycnodysostosis.yaml` ✅

Closes #1507