### PR TITLE
[codex] Enhance Osteoglophonic Dysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Osteoglophonic_Dysplasia.yaml
+++ b/kb/disorders/Osteoglophonic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Osteoglophonic Dysplasia
 creation_date: '2026-04-04T12:00:00Z'
-updated_date: '2026-04-19T15:05:25Z'
+updated_date: '2026-04-19T15:47:37Z'
 category: Mendelian
 description: >-
   Osteoglophonic dysplasia is a rare skeletal disorder caused by gain-of-function mutations
@@ -80,11 +80,11 @@ pathophysiology:
       id: GO:0060363
       label: cranial suture morphogenesis
   evidence:
-  - reference: PMID:29019756
+  - reference: PMID:38648328
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Most of these mutations are inherited in an autosomal dominant fashion and are gain-of-function-type mutations."
-    explanation: Gain-of-function FGFR1 mutations drive the craniosynostosis phenotype.
+    snippet: "Osteoglophonic dysplasia (OGD) is characterized by multisuture craniosynostosis (including cloverleaf skull)"
+    explanation: GeneReviews directly identifies multisuture craniosynostosis as a defining manifestation of OGD.
 - name: Impaired Endochondral Ossification
   description: >-
     FGFR1 overactivation impairs normal endochondral ossification in the growth
@@ -107,21 +107,15 @@ pathophysiology:
     explanation: Establishes that FGFR1 mutations disrupt both chondrogenesis and osteogenesis, underlying the endochondral ossification defect.
 - name: Aberrant Fibrous Tissue Formation
   description: >-
-    Constitutive FGFR1 signaling promotes aberrant fibrous tissue formation
-    within metaphyseal bone, producing the characteristic nonossifying fibrous
-    lesions (radiolucent metaphyseal defects) that give the disorder its name
-    ("hollowed-out bone").
-  biological_processes:
-  - preferred_term: Ossification
-    term:
-      id: GO:0001503
-      label: ossification
+    OGD is characterized by nonossifying fibrous lesions within metaphyseal
+    bone, producing the characteristic radiolucent defects that give the
+    disorder its name ("hollowed-out bone").
   evidence:
-  - reference: PMID:29019756
+  - reference: PMID:15625620
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Skeletal disorders caused by type 1 mutations include Pfeiffer syndrome (PS) and osteoglophonic dysplasia"
-    explanation: Osteoglophonic dysplasia, caused by FGFR1 mutations, is defined by its characteristic fibrous metaphyseal lesions.
+    snippet: "Indeed, patients with OD present with craniosynostosis, prominent supraorbital ridge, and depressed nasal bridge, as well as the rhizomelic dwarfism and nonossifying bone lesions that are characteristic of the disorder."
+    explanation: White et al. explicitly identify nonossifying bone lesions as a characteristic feature of OGD.
 phenotypes:
 - category: Craniofacial
   name: Multisuture craniosynostosis

--- a/kb/disorders/Osteoglophonic_Dysplasia.yaml
+++ b/kb/disorders/Osteoglophonic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Osteoglophonic Dysplasia
 creation_date: '2026-04-04T12:00:00Z'
-updated_date: '2026-04-19T15:47:37Z'
+updated_date: '2026-04-19T21:32:38Z'
 category: Mendelian
 description: >-
   Osteoglophonic dysplasia is a rare skeletal disorder caused by gain-of-function mutations
@@ -95,10 +95,12 @@ pathophysiology:
     term:
       id: GO:0001958
       label: endochondral ossification
+    modifier: DECREASED
   - preferred_term: Bone development
     term:
       id: GO:0060348
       label: bone development
+    modifier: DECREASED
   evidence:
   - reference: PMID:29019756
     supports: SUPPORT

--- a/kb/disorders/Osteoglophonic_Dysplasia.yaml
+++ b/kb/disorders/Osteoglophonic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Osteoglophonic Dysplasia
 creation_date: '2026-04-04T12:00:00Z'
-updated_date: '2026-04-04T18:00:00Z'
+updated_date: '2026-04-19T06:46:23Z'
 category: Mendelian
 description: >-
   Osteoglophonic dysplasia is a rare skeletal disorder caused by gain-of-function mutations
@@ -123,46 +123,383 @@ pathophysiology:
     snippet: "Skeletal disorders caused by type 1 mutations include Pfeiffer syndrome (PS) and osteoglophonic dysplasia"
     explanation: Osteoglophonic dysplasia, caused by FGFR1 mutations, is defined by its characteristic fibrous metaphyseal lesions.
 phenotypes:
-- name: Craniosynostosis
-  description: Premature fusion of cranial sutures leading to abnormal skull shape.
-  frequency: OBLIGATE
+- category: Craniofacial
+  name: Multisuture craniosynostosis
+  description: >-
+    Premature fusion of multiple cranial sutures is a defining manifestation and
+    can be severe enough to produce a cloverleaf skull configuration.
   phenotype_term:
-    preferred_term: Craniosynostosis
+    preferred_term: Multisuture craniosynostosis
     term:
       id: HP:0001363
       label: Craniosynostosis
   evidence:
-  - reference: PMID:29019756
+  - reference: PMID:38648328
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Skeletal disorders caused by type 1 mutations include Pfeiffer syndrome (PS) and osteoglophonic dysplasia"
-    explanation: Osteoglophonic dysplasia is grouped among FGFR1 craniosynostosis disorders.
-- name: Nonossifying fibrous metaphyseal lesions
+    snippet: "CLINICAL CHARACTERISTICS: Osteoglophonic dysplasia (OGD) is characterized by multisuture craniosynostosis (including cloverleaf skull)"
+    explanation: GeneReviews identifies multisuture craniosynostosis as a defining clinical feature of OGD.
+- category: Musculoskeletal
+  name: Disproportionate short-limb short stature
   description: >-
-    Characteristic radiolucent metaphyseal defects composed of fibrous tissue, the
-    namesake feature of osteoglophonic dysplasia ("hollowed-out bone"). These
-    nonossifying fibrous lesions are visible on skeletal radiographs and are a
-    distinguishing feature from other FGFR1-related craniosynostosis disorders.
-  frequency: OBLIGATE
+    Marked short stature with disproportionate limb shortening is a core skeletal
+    manifestation.
   phenotype_term:
-    preferred_term: Nonossifying fibrous metaphyseal lesions
+    preferred_term: Disproportionate short-limb short stature
+    term:
+      id: HP:0008873
+      label: Disproportionate short-limb short stature
+  evidence:
+  - reference: PMID:29147600
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "She presented with disproportionate short stature, craniosynostosis, a prominent supraorbital ridge, delayed teeth eruption, hypodontia, and multiple nonossifying bone lesions in the femur, tibia, and fibula."
+    explanation: The mutation-confirmed Indian case directly documents disproportionate short stature.
+- category: Musculoskeletal
+  name: Rhizomelia
+  description: >-
+    Proximal limb shortening contributes substantially to the dwarfing phenotype.
+  phenotype_term:
+    preferred_term: Rhizomelia
+    term:
+      id: HP:0008905
+      label: Rhizomelia
+  evidence:
+  - reference: PMID:15625620
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Indeed, patients with OD present with craniosynostosis, prominent supraorbital ridge, and depressed nasal bridge, as well as the rhizomelic dwarfism and nonossifying bone lesions that are characteristic of the disorder."
+    explanation: White et al. describe rhizomelic dwarfism as a characteristic skeletal feature of OGD.
+- category: Musculoskeletal
+  name: Nonossifying fibromas of the long bones
+  description: >-
+    Multiple metaphyseal or cystic lucent lesions, often involving the long bones
+    and sometimes the mandible, are a radiographic hallmark of OGD.
+  phenotype_term:
+    preferred_term: Nonossifying fibromas of the long bones
     term:
       id: HP:0000944
       label: Abnormal metaphysis morphology
   evidence:
-  - reference: PMID:29019756
+  - reference: PMID:15625620
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Skeletal disorders caused by type 1 mutations include Pfeiffer syndrome (PS) and osteoglophonic dysplasia"
-    explanation: Osteoglophonic dysplasia is distinguished by its fibrous metaphyseal lesions, differentiating it from other FGFR1 craniosynostosis syndromes.
-- name: Rhizomelic limb shortening
-  description: Disproportionate shortening of the proximal limb segments (humerus and femur) resulting in short stature.
-  frequency: OBLIGATE
+    snippet: "Indeed, patients with OD present with craniosynostosis, prominent supraorbital ridge, and depressed nasal bridge, as well as the rhizomelic dwarfism and nonossifying bone lesions that are characteristic of the disorder."
+    explanation: White et al. identify nonossifying bone lesions as characteristic of OGD.
+  - reference: PMID:29147600
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "She presented with disproportionate short stature, craniosynostosis, a prominent supraorbital ridge, delayed teeth eruption, hypodontia, and multiple nonossifying bone lesions in the femur, tibia, and fibula."
+    explanation: The Indian case localizes the lesions to the long bones; HPO lacks a more specific nonossifying fibroma term, so abnormal metaphysis morphology is the closest grounded fit.
+- category: Musculoskeletal
+  name: Platyspondyly
+  description: >-
+    Flattened vertebral bodies are a recurrent radiographic feature.
   phenotype_term:
-    preferred_term: Rhizomelic arm shortening
+    preferred_term: Platyspondyly
     term:
-      id: HP:0004991
-      label: Rhizomelic arm shortening
+      id: HP:0000926
+      label: Platyspondyly
+  evidence:
+  - reference: PMID:8995175
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The appearance and gradual enlargement of fibrous cortical defects and multiple nonossifying fibromata are documented in this report of a 2-year-old boy with a very rare skeletal dysplasia known as osteoglophonic dysplasia, characterized by multiple and recurrent craniosynostoses, platyspondyly, short tubular bones, and epiphyseal dysplasia."
+    explanation: Azouz and Kozlowski document platyspondyly as part of the characteristic radiographic phenotype.
+- category: Musculoskeletal
+  name: Epiphyseal dysplasia
+  description: >-
+    Epiphyseal involvement accompanies the spondylo-metaphyseal abnormalities in
+    some affected individuals.
+  phenotype_term:
+    preferred_term: Epiphyseal dysplasia
+    term:
+      id: HP:0002656
+      label: Epiphyseal dysplasia
+  evidence:
+  - reference: PMID:8995175
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The appearance and gradual enlargement of fibrous cortical defects and multiple nonossifying fibromata are documented in this report of a 2-year-old boy with a very rare skeletal dysplasia known as osteoglophonic dysplasia, characterized by multiple and recurrent craniosynostoses, platyspondyly, short tubular bones, and epiphyseal dysplasia."
+    explanation: The same radiology report identifies epiphyseal dysplasia as part of the OGD skeletal pattern.
+- category: Musculoskeletal
+  name: Osteopenia
+  description: >-
+    Reduced bone density is part of the characteristic radiographic phenotype and
+    likely contributes to bone fragility.
+  phenotype_term:
+    preferred_term: Osteopenia
+    term:
+      id: HP:0000938
+      label: Osteopenia
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Radiographs show copper beaten appearance to skull, multiple cystic long bone lesions consistent with non-ossifying fibromas, irregular vertebral bodies, and osteopenia with increased risk of fractures."
+    explanation: GeneReviews includes osteopenia in the characteristic radiographic findings of OGD.
+- category: Musculoskeletal
+  name: Pathologic fracture
+  description: >-
+    Fragility fractures can occur through dysplastic cystic lesions and may lead
+    to pseudoarthrosis in severe cases.
+  phenotype_term:
+    preferred_term: Pathologic fracture
+    term:
+      id: HP:0002756
+      label: Pathologic fracture
+  evidence:
+  - reference: PMID:8958322
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Manifestations, not previously reported in osteoglophonic dysplasia, present in the propositus are spontaneous fractures resulting in pseudoarthroses through cystic and dysplastic foci in his proximal femoral shafts and right humerus"
+    explanation: Spontaneous fractures through dysplastic bone are documented as an important, though apparently uncommon, complication.
+- category: Craniofacial
+  name: Frontal bossing
+  description: >-
+    Forehead prominence contributes to the characteristic craniofacial appearance.
+  phenotype_term:
+    preferred_term: Frontal bossing
+    term:
+      id: HP:0002007
+      label: Frontal bossing
+  evidence:
+  - reference: PMID:35148738
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The details of the 4-year follow-up showed that the signs of OD were more pronounced, including dwarfism, frontal bossing, delayed skeletal maturation, anteverted nares, micrognathia, and prominent ears, but the patient's impacted teeth and edentulous jaws remained unchanged."
+    explanation: The 4-year follow-up case directly documents frontal bossing.
+- category: Craniofacial
+  name: Prominent supraorbital ridges
+  description: >-
+    Supraorbital ridging is part of the characteristic facial gestalt.
+  phenotype_term:
+    preferred_term: Prominent supraorbital ridges
+    term:
+      id: HP:0000336
+      label: Prominent supraorbital ridges
+  evidence:
+  - reference: PMID:15625620
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Indeed, patients with OD present with craniosynostosis, prominent supraorbital ridge, and depressed nasal bridge, as well as the rhizomelic dwarfism and nonossifying bone lesions that are characteristic of the disorder."
+    explanation: White et al. identify prominent supraorbital ridging as a characteristic craniofacial manifestation.
+- category: Craniofacial
+  name: Depressed nasal bridge
+  description: >-
+    A depressed nasal bridge is a recurring facial feature.
+  phenotype_term:
+    preferred_term: Depressed nasal bridge
+    term:
+      id: HP:0005280
+      label: Depressed nasal bridge
+  evidence:
+  - reference: PMID:15625620
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Indeed, patients with OD present with craniosynostosis, prominent supraorbital ridge, and depressed nasal bridge, as well as the rhizomelic dwarfism and nonossifying bone lesions that are characteristic of the disorder."
+    explanation: White et al. describe depressed nasal bridge as part of the characteristic OGD facial phenotype.
+- category: Craniofacial
+  name: Proptosis
+  description: >-
+    Ocular prominence is part of the distinctive craniofacial phenotype.
+  phenotype_term:
+    preferred_term: Proptosis
+    term:
+      id: HP:0000520
+      label: Proptosis
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: GeneReviews includes proptosis among the distinctive craniofacial features of OGD.
+- category: Craniofacial
+  name: Hypertelorism
+  description: >-
+    Widely spaced eyes are part of the characteristic craniofacial dysmorphism.
+  phenotype_term:
+    preferred_term: Hypertelorism
+    term:
+      id: HP:0000316
+      label: Hypertelorism
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: The GeneReviews summary uses "widely spaced eyes," best represented by the HPO term hypertelorism.
+- category: Craniofacial
+  name: Midface retrusion
+  description: >-
+    Midfacial hypoplasia or retrusion is a recurrent and clinically important
+    facial manifestation.
+  phenotype_term:
+    preferred_term: Midface retrusion
+    term:
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: GeneReviews includes midface retrusion in the characteristic craniofacial pattern.
+- category: Craniofacial
+  name: Short nose
+  description: >-
+    Short nasal length is part of the recurring OGD facial gestalt.
+  phenotype_term:
+    preferred_term: Short nose
+    term:
+      id: HP:0003196
+      label: Short nose
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: Short nose is included in the GeneReviews craniofacial feature summary.
+- category: Craniofacial
+  name: Anteverted nares
+  description: >-
+    Upturned nostrils are part of the typical craniofacial phenotype.
+  phenotype_term:
+    preferred_term: Anteverted nares
+    term:
+      id: HP:0000463
+      label: Anteverted nares
+  evidence:
+  - reference: PMID:35148738
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The details of the 4-year follow-up showed that the signs of OD were more pronounced, including dwarfism, frontal bossing, delayed skeletal maturation, anteverted nares, micrognathia, and prominent ears, but the patient's impacted teeth and edentulous jaws remained unchanged."
+    explanation: The 4-year follow-up case directly documents anteverted nares.
+- category: Craniofacial
+  name: Low-set ears
+  description: >-
+    Low-set ears are part of the broader craniofacial dysmorphism.
+  phenotype_term:
+    preferred_term: Low-set ears
+    term:
+      id: HP:0000369
+      label: Low-set ears
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: GeneReviews includes low-set ears in the characteristic craniofacial phenotype.
+- category: Craniofacial
+  name: High palate
+  description: >-
+    A high palate contributes to the characteristic craniofacial and dental
+    phenotype.
+  phenotype_term:
+    preferred_term: High palate
+    term:
+      id: HP:0000218
+      label: High palate
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: GeneReviews includes high palate in the craniofacial phenotype summary.
+- category: Dental
+  name: Delayed eruption of teeth
+  description: >-
+    Tooth eruption is often severely delayed and may progress to functional
+    failure of eruption.
+  phenotype_term:
+    preferred_term: Delayed eruption of teeth
+    term:
+      id: HP:0000684
+      label: Delayed eruption of teeth
+  evidence:
+  - reference: PMID:29147600
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "She presented with disproportionate short stature, craniosynostosis, a prominent supraorbital ridge, delayed teeth eruption, hypodontia, and multiple nonossifying bone lesions in the femur, tibia, and fibula."
+    explanation: The Indian mutation-confirmed case directly documents delayed eruption of teeth.
+- category: Dental
+  name: Impacted teeth
+  description: >-
+    Multiple permanent teeth may remain unerupted and impacted despite root
+    development.
+  phenotype_term:
+    preferred_term: Impacted tooth
+    term:
+      id: HP:0011079
+      label: Impacted tooth
+  evidence:
+  - reference: PMID:16918680
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Radiographically, multiple lucent lesions were present in the tubular bones and mandible as well as several impacted teeth."
+    explanation: Roberts et al. directly document multiple impacted teeth in a long-term follow-up case.
+- category: Dental
+  name: Hypodontia
+  description: >-
+    Reduced tooth number is a recurrent dental manifestation; some reports also
+    describe clinically absent dentition.
+  phenotype_term:
+    preferred_term: Hypodontia
+    term:
+      id: HP:0000668
+      label: Hypodontia
+  evidence:
+  - reference: PMID:29147600
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Rhizomelic dwarfism, craniosynostosis, impacted teeth, hypodontia or anodontia, and multiple nonossifying bone lesions are the salient features of this condition."
+    explanation: Kuthiroly et al. list hypodontia, sometimes progressing to clinical anodontia, among the salient features of OGD.
+- category: Dental
+  name: Gingival overgrowth
+  description: >-
+    Gingival tissue overgrowth contributes to the characteristic oral phenotype.
+  phenotype_term:
+    preferred_term: Gingival overgrowth
+    term:
+      id: HP:0000212
+      label: Gingival overgrowth
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: GeneReviews includes gingival overgrowth among the characteristic craniofacial and oral features.
+- category: Metabolic
+  name: Hypophosphatemia
+  description: >-
+    Some patients develop hypophosphatemia, apparently related to excess FGF23.
+  phenotype_term:
+    preferred_term: Hypophosphatemia
+    term:
+      id: HP:0002148
+      label: Hypophosphatemia
+  evidence:
+  - reference: PMID:40260920
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patients may have hypophosphatemia due to high FGF23 levels."
+    explanation: The 2025 OGD update explicitly identifies hypophosphatemia as part of the disease spectrum and links it to elevated FGF23.
+- category: Musculoskeletal
+  name: Overlapping toe
+  description: >-
+    Overlapping toes were recently reported as a newly recognized appendicular
+    feature in two individuals with FGFR1-related OGD.
+  phenotype_term:
+    preferred_term: Overlapping toe
+    term:
+      id: HP:0001845
+      label: Overlapping toe
+  evidence:
+  - reference: PMID:40260920
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Both showed classic symptoms as well as signs not previously reported, including elevated frontal temperature and overlapping toes."
+    explanation: The 2025 case series expands the phenotype to include overlapping toes.
 genetic:
 - name: FGFR1 gain-of-function mutations
   association: Causative

--- a/kb/disorders/Osteoglophonic_Dysplasia.yaml
+++ b/kb/disorders/Osteoglophonic_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Osteoglophonic Dysplasia
 creation_date: '2026-04-04T12:00:00Z'
-updated_date: '2026-04-19T06:46:23Z'
+updated_date: '2026-04-19T15:05:25Z'
 category: Mendelian
 description: >-
   Osteoglophonic dysplasia is a rare skeletal disorder caused by gain-of-function mutations
@@ -500,6 +500,22 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Both showed classic symptoms as well as signs not previously reported, including elevated frontal temperature and overlapping toes."
     explanation: The 2025 case series expands the phenotype to include overlapping toes.
+- category: Craniofacial
+  name: Prognathism
+  description: >-
+    Relative mandibular prominence contributes to the characteristic craniofacial
+    profile.
+  phenotype_term:
+    preferred_term: Mandibular prognathia
+    term:
+      id: HP:0000303
+      label: Mandibular prognathia
+  evidence:
+  - reference: PMID:38648328
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "distinctive craniofacial features (prominent forehead, proptosis, widely spaced eyes, low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high palate, failure of tooth eruption, and gingival overgrowth)"
+    explanation: GeneReviews includes prognathism among the characteristic craniofacial features of OGD.
 genetic:
 - name: FGFR1 gain-of-function mutations
   association: Causative

--- a/references_cache/PMID_15625620.md
+++ b/references_cache/PMID_15625620.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:15625620"
+title: Mutations that cause osteoglophonic dysplasia define novel roles for FGFR1 in bone elongation.
+authors:
+- White KE
+- Cabral JM
+- Davis SI
+- Fishburn T
+- Evans WE
+- Ichikawa S
+- Fields J
+- Yu X
+- Shaw NJ
+- McLellan NJ
+- McKeown C
+- Fitzpatrick D
+- Yu K
+- Ornitz DM
+- Econs MJ
+journal: Am J Hum Genet
+year: '2005'
+doi: 10.1086/427956
+keywords:
+- Adult
+- Amino Acid Sequence
+- "Bone Diseases, Developmental/genetics"
+- DNA Mutational Analysis
+- Face/abnormalities
+- Humans
+- Karyotyping
+- Male
+- Maxillofacial Development/genetics
+- Middle Aged
+- Molecular Sequence Data
+- "Mutation, Missense"
+- Pedigree
+- Receptor Protein-Tyrosine Kinases/genetics
+- "Receptor, Fibroblast Growth Factor, Type 1"
+- "Receptors, Fibroblast Growth Factor/genetics"
+- Skull/abnormalities
+content_type: abstract_only
+---
+
+# Mutations that cause osteoglophonic dysplasia define novel roles for FGFR1 in bone elongation.
+**Authors:** White KE, Cabral JM, Davis SI, Fishburn T, Evans WE, Ichikawa S, Fields J, Yu X, Shaw NJ, McLellan NJ, McKeown C, Fitzpatrick D, Yu K, Ornitz DM, Econs MJ
+**Journal:** Am J Hum Genet (2005)
+**DOI:** [10.1086/427956](https://doi.org/10.1086/427956)
+
+## Content
+
+1. Am J Hum Genet. 2005 Feb;76(2):361-7. doi: 10.1086/427956. Epub 2004 Dec 28.
+
+Mutations that cause osteoglophonic dysplasia define novel roles for FGFR1 in 
+bone elongation.
+
+White KE(1), Cabral JM, Davis SI, Fishburn T, Evans WE, Ichikawa S, Fields J, Yu 
+X, Shaw NJ, McLellan NJ, McKeown C, Fitzpatrick D, Yu K, Ornitz DM, Econs MJ.
+
+Author information:
+(1)Department of Medical and Molecular Genetics, Indiana University School of 
+Medicine, Indianapolis, IN, USA.
+
+Activating mutations in the genes for fibroblast growth factor receptors 1-3 
+(FGFR1-3) are responsible for a diverse group of skeletal disorders. In general, 
+mutations in FGFR1 and FGFR2 cause the majority of syndromes involving 
+craniosynostosis, whereas the dwarfing syndromes are largely associated with 
+FGFR3 mutations. Osteoglophonic dysplasia (OD) is a "crossover" disorder that 
+has skeletal phenotypes associated with FGFR1, FGFR2, and FGFR3 mutations. 
+Indeed, patients with OD present with craniosynostosis, prominent supraorbital 
+ridge, and depressed nasal bridge, as well as the rhizomelic dwarfism and 
+nonossifying bone lesions that are characteristic of the disorder. We 
+demonstrate here that OD is caused by missense mutations in highly conserved 
+residues comprising the ligand-binding and transmembrane domains of FGFR1, thus 
+defining novel roles for this receptor as a negative regulator of long-bone 
+growth.
+
+DOI: 10.1086/427956
+PMCID: PMC1196382
+PMID: 15625620 [Indexed for MEDLINE]

--- a/references_cache/PMID_16918680.md
+++ b/references_cache/PMID_16918680.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:16918680"
+title: "Osteoglophonic dysplasia: dental and orthodontic implications."
+authors:
+- Roberts TS
+- Stephen L
+- Beighton P
+journal: Orthod Craniofac Res
+year: '2006'
+doi: 10.1111/j.1601-6343.2006.00369.x
+keywords:
+- Adult
+- "Bone Diseases, Developmental/genetics"
+- Craniofacial Abnormalities/genetics
+- Dwarfism/genetics
+- Female
+- Humans
+- Mouth Rehabilitation
+- "Orthodontics, Corrective"
+- "Tooth, Impacted/genetics"
+- "Tooth, Unerupted/genetics"
+content_type: abstract_only
+---
+
+# Osteoglophonic dysplasia: dental and orthodontic implications.
+**Authors:** Roberts TS, Stephen L, Beighton P
+**Journal:** Orthod Craniofac Res (2006)
+**DOI:** [10.1111/j.1601-6343.2006.00369.x](https://doi.org/10.1111/j.1601-6343.2006.00369.x)
+
+## Content
+
+1. Orthod Craniofac Res. 2006 Aug;9(3):153-6. doi: 
+10.1111/j.1601-6343.2006.00369.x.
+
+Osteoglophonic dysplasia: dental and orthodontic implications.
+
+Roberts TS(1), Stephen L, Beighton P.
+
+Author information:
+(1)Faculty of Dentistry, University of the Western Cape, Cape Town, South 
+Africa. troberts@uwc.ac.za
+
+AIMS AND OBJECTIVES: Documentation of dental and orthodontic implications of 
+osteoglophonic dysplasia (OGD).
+SETTINGS AND PARTICIPANTS: Case report describing oral and dental manifestations 
+of a female with OGD, aged 39 years, who was first documented three decades ago.
+RESULTS: This rare genetic disorder manifests with gross stunting of stature, 
+associated with severe craniofacial malformation and multiple unerupted teeth. 
+Radiographically, multiple lucent lesions were present in the tubular bones and 
+mandible as well as several impacted teeth.
+CONCLUSION: We concluded that prosthetic dental replacement in this patient 
+would be difficult because of the distorted jaw relationship and large alveolar 
+ridges. Equally, craniofacial reconstruction might be compromised by obstruction 
+of the nasal airways, difficulty in intubation and postoperative respiratory 
+problems.
+
+DOI: 10.1111/j.1601-6343.2006.00369.x
+PMID: 16918680 [Indexed for MEDLINE]

--- a/references_cache/PMID_20339250.md
+++ b/references_cache/PMID_20339250.md
@@ -1,0 +1,53 @@
+---
+reference_id: "PMID:20339250"
+title: "Osteoglophonic dysplasia: a case report."
+authors:
+- Shankar VN
+- Ajila V
+- Kumar G
+journal: J Oral Sci
+year: '2010'
+doi: 10.2334/josnusd.52.167
+keywords:
+- "Anodontia/diagnostic imaging, pathology"
+- "Bone Diseases, Developmental/diagnostic imaging, pathology"
+- "Child, Preschool"
+- Consanguinity
+- "Craniosynostoses/diagnostic imaging, pathology"
+- Female
+- Humans
+- Radiography
+- "Receptor, Fibroblast Growth Factor, Type 1/genetics"
+content_type: abstract_only
+---
+
+# Osteoglophonic dysplasia: a case report.
+**Authors:** Shankar VN, Ajila V, Kumar G
+**Journal:** J Oral Sci (2010)
+**DOI:** [10.2334/josnusd.52.167](https://doi.org/10.2334/josnusd.52.167)
+
+## Content
+
+1. J Oral Sci. 2010 Mar;52(1):167-71. doi: 10.2334/josnusd.52.167.
+
+Osteoglophonic dysplasia: a case report.
+
+Shankar VN(1), Ajila V, Kumar G.
+
+Author information:
+(1)Department of Oral Medicine and Radiology, Institute of Dental Studies and 
+Technologies, Uttar Pradesh, India. vnaveenshankar@gmail.com
+
+We report a rare case of osteoglophonic dysplasia affecting father and daughter. 
+Osteoglophonic dysplasia is a very rare skeletal dysplasia with 
+craniosynostosis, multiple radiolucencies of bone and clinical anodontia. It is 
+an autosomal dominant disorder characterised by short stature. The affected 
+children have normal intelligence. Close association with missense mutation of 
+fibroblast growth factor receptor-1 has been reported. Life expectancy depends 
+on the degree of cranial malformation. In previous reports, bone defects usually 
+resolved by adulthood, but multiple tooth impaction may cause aesthetic and 
+masticatory problems. Cytogenetic studies and routine laboratory tests were all 
+within normal limits.
+
+DOI: 10.2334/josnusd.52.167
+PMID: 20339250 [Indexed for MEDLINE]

--- a/references_cache/PMID_29147600.md
+++ b/references_cache/PMID_29147600.md
@@ -1,0 +1,56 @@
+---
+reference_id: "PMID:29147600"
+title: "Osteoglophonic Dysplasia: Phenotypic and Radiological Clues."
+authors:
+- Kuthiroly S
+- Yesodharan D
+- Ghosh A
+- White KE
+- Nampoothiri S
+journal: J Pediatr Genet
+year: '2017'
+doi: 10.1055/s-0037-1602816
+content_type: abstract_only
+---
+
+# Osteoglophonic Dysplasia: Phenotypic and Radiological Clues.
+**Authors:** Kuthiroly S, Yesodharan D, Ghosh A, White KE, Nampoothiri S
+**Journal:** J Pediatr Genet (2017)
+**DOI:** [10.1055/s-0037-1602816](https://doi.org/10.1055/s-0037-1602816)
+
+## Content
+
+1. J Pediatr Genet. 2017 Dec;6(4):247-251. doi: 10.1055/s-0037-1602816. Epub 2017
+ May 5.
+
+Osteoglophonic Dysplasia: Phenotypic and Radiological Clues.
+
+Kuthiroly S(1), Yesodharan D(1), Ghosh A(2), White KE(3), Nampoothiri S(1).
+
+Author information:
+(1)Department of Pediatric Genetics, Amrita Institute of Medical Sciences and 
+Research Center, Cochin, Kerala, India.
+(2)Department of Endocrinology Medicine, Ananthapuri Hospitals and Research 
+Centre, Thiruvananthapuram, Kerala, India.
+(3)Department of Medical and Molecular Genetics, Indiana University School of 
+Medicine, Indianapolis, Indiana, United States.
+
+Osteoglophonic dysplasia (OD) is an extremely rare, skeletal dysplasia with an 
+autosomal dominant mode of inheritance. Rhizomelic dwarfism, craniosynostosis, 
+impacted teeth, hypodontia or anodontia, and multiple nonossifying bone lesions 
+are the salient features of this condition. We report a 14-year-old girl with 
+clinical and radiological features consistent with OD. She presented with 
+disproportionate short stature, craniosynostosis, a prominent supraorbital 
+ridge, delayed teeth eruption, hypodontia, and multiple nonossifying bone 
+lesions in the femur, tibia, and fibula. She had hypophosphatemia, which is a 
+known association in this dysplasia. She also had advanced bone age, which is an 
+unreported feature of this dysplasia. This condition is caused by activating 
+mutations in FGFR1 . A missense mutation was detected in the FGFR1 , 
+NM_001174067 ( FGFR1 _v001):c.1115G > A [p.(Cys372Tyr)] confirming the 
+diagnosis; this is the first mutation-proven case to be reported from India.
+
+DOI: 10.1055/s-0037-1602816
+PMCID: PMC5687321
+PMID: 29147600
+
+Conflict of interest statement: Conflict of Interest None.

--- a/references_cache/PMID_35148738.md
+++ b/references_cache/PMID_35148738.md
@@ -1,0 +1,99 @@
+---
+reference_id: "PMID:35148738"
+title: "Abnormal eruption of teeth in relation to FGFR1 heterozygote mutation: a rare case of osteoglophonic dysplasia with 4-year follow-up."
+authors:
+- Zou Y
+- Lin H
+- Chen W
+- Chang L
+- Cai S
+- Lu YG
+- Xu L
+journal: BMC Oral Health
+year: '2022'
+doi: 10.1186/s12903-022-02069-6
+keywords:
+- Child
+- Follow-Up Studies
+- Heterozygote
+- Humans
+- Male
+- Mutation/genetics
+- Osteochondrodysplasias
+- "Receptor, Fibroblast Growth Factor, Type 1/genetics"
+- Tooth Eruption/genetics
+content_type: abstract_only
+---
+
+# Abnormal eruption of teeth in relation to FGFR1 heterozygote mutation: a rare case of osteoglophonic dysplasia with 4-year follow-up.
+**Authors:** Zou Y, Lin H, Chen W, Chang L, Cai S, Lu YG, Xu L
+**Journal:** BMC Oral Health (2022)
+**DOI:** [10.1186/s12903-022-02069-6](https://doi.org/10.1186/s12903-022-02069-6)
+
+## Content
+
+1. BMC Oral Health. 2022 Feb 11;22(1):36. doi: 10.1186/s12903-022-02069-6.
+
+Abnormal eruption of teeth in relation to FGFR1 heterozygote mutation: a rare 
+case of osteoglophonic dysplasia with 4-year follow-up.
+
+Zou Y(#)(1)(2), Lin H(#)(1)(2), Chen W(1)(2), Chang L(1)(2), Cai S(1)(2), Lu 
+YG(3)(4), Xu L(5)(6)(7).
+
+Author information:
+(1)Fujian Key Laboratory of Oral Diseases and Fujian Provincial Engineering 
+Research, Center of Oral Biomaterial and Stomatological Key Lab of Fujian 
+College and University, School and Hospital of Stomatology, Fujian Medical 
+University, Fuzhou, China.
+(2)Institute of Stomatology and Research Center of Dental Esthetics and 
+Biomechanics and Department of Orthodontics, School and Hospital of Stomatology, 
+Fujian Medical University, Fuzhou, China.
+(3)Fujian Key Laboratory of Oral Diseases and Fujian Provincial Engineering 
+Research, Center of Oral Biomaterial and Stomatological Key Lab of Fujian 
+College and University, School and Hospital of Stomatology, Fujian Medical 
+University, Fuzhou, China. fjlyg63@fjmu.edu.cn.
+(4)Department of Preventive Dentistry, Fujian Key Laboratory of Oral Diseases, 
+School of Stomatology, Fujian Medical University, Fuzhou, 350001, China. 
+fjlyg63@fjmu.edu.cn.
+(5)Fujian Key Laboratory of Oral Diseases and Fujian Provincial Engineering 
+Research, Center of Oral Biomaterial and Stomatological Key Lab of Fujian 
+College and University, School and Hospital of Stomatology, Fujian Medical 
+University, Fuzhou, China. xlyyydentist@fjmu.edu.cn.
+(6)Institute of Stomatology and Research Center of Dental Esthetics and 
+Biomechanics and Department of Orthodontics, School and Hospital of Stomatology, 
+Fujian Medical University, Fuzhou, China. xlyyydentist@fjmu.edu.cn.
+(7)Department of Orthodontics, Fujian Key Laboratory of Oral Diseases, School of 
+Stomatology, Fujian Medical University, Fuzhou, 350001, China. 
+xlyyydentist@fjmu.edu.cn.
+(#)Contributed equally
+
+BACKGROUND: We report a case and its 4-year follow-up of Osteoglophonic 
+dysplasia (OD), a rare disease that disturbs both skeletal and dental 
+development, which is usually caused by heterozygous FGFR1 mutations.
+CASE PRESENTATION: This article presents a case where a 6-year-old male patient 
+suffered dysregulation of tooth eruption and was diagnosed with osteogenic 
+dysplasia from a fibroblast growth factor receptor 1 (FGFR1) heterozygote 
+mutation. However, the number of teeth is within the normal range, and their 
+roots are well developed. Several interventions were implemented with varying 
+degrees of results. The details of the 4-year follow-up showed that the signs of 
+OD were more pronounced, including dwarfism, frontal bossing, delayed skeletal 
+maturation, anteverted nares, micrognathia, and prominent ears, but the 
+patient's impacted teeth and edentulous jaws remained unchanged.
+CONCLUSIONS: FGFR1 heterozygote mutation and OD present significant difficulty 
+for teeth eruption and subsequent intervention. Further measures ought to be 
+taken in recognizing various symptoms presented by the patient. This case 
+supports the significance of careful inquiry, comprehensive physical examination 
+and correct diagnosis as indispensable steps for clinical practice in patients 
+with unerupted teeth. Additionally, the detailed case and its 4-year follow-up 
+length may provide new insights into osteogenic dysplasia and patients with 
+impacted teeth while encouraging further exploration in treatment methods.
+
+© 2022. The Author(s).
+
+DOI: 10.1186/s12903-022-02069-6
+PMCID: PMC8832749
+PMID: 35148738 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_38648328.md
+++ b/references_cache/PMID_38648328.md
@@ -1,0 +1,93 @@
+---
+reference_id: "PMID:38648328"
+title: Osteoglophonic Dysplasia.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Othman AA
+- Babcock HE
+- Ferreira CR
+year: '1993'
+content_type: abstract_only
+---
+
+# Osteoglophonic Dysplasia.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Othman AA, Babcock HE, Ferreira CR
+
+## Content
+
+1. Osteoglophonic Dysplasia.
+
+Othman AA(1), Babcock HE(1), Ferreira CR(1).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors. 
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle; 
+1993–2026.
+2024 Apr 18.
+
+Author information:
+(1)National Human Genome Research Institute, National Institutes of Health, 
+Bethesda, Maryland
+
+CLINICAL CHARACTERISTICS: Osteoglophonic dysplasia (OGD) is characterized by 
+multisuture craniosynostosis (including cloverleaf skull), distinctive 
+craniofacial features (prominent forehead, proptosis, widely spaced eyes, 
+low-set ears, midface retrusion, short nose, anteverted nares, prognathism, high 
+palate, failure of tooth eruption, and gingival overgrowth), profound short 
+stature with rhizomelia, and short, broad hands and feet. Radiographs show 
+copper beaten appearance to skull, multiple cystic long bone lesions consistent 
+with non-ossifying fibromas, irregular vertebral bodies, and osteopenia with 
+increased risk of fractures.
+DIAGNOSIS/TESTING: The diagnosis of OGD is established in a proband with 
+characteristic clinical and imaging findings and a heterozygous pathogenic 
+gain-of-function variant in FGFR1 identified by molecular genetic testing.
+MANAGEMENT: Treatment of manifestations: Management of musculoskeletal 
+manifestations per skeletal dysplasia or physiatry clinic; address mobility 
+issues in those with bone deformity; early intervention such as physical 
+therapy, occupational therapy, and speech therapy to optimize developmental 
+outcomes; surgical repair in the first year of life in those with multisuture 
+craniosynostosis; early initiation of topical eye lubrication in those with 
+inadequate lid closure; jaw surgery to advance the midface; pediatric dental and 
+orthodontic care; surgical interventions as needed for sleep apnea; treatment 
+with phosphate as needed per endocrinologist; standard treatment of hernias per 
+gastroenterologist/surgeon. Surveillance: At each visit monitor growth, 
+developmental progress, and educational needs, and assess for recurrent and 
+pathologic fractures, incomplete eyelid closure, and manifestations of sleep 
+apnea. Clinical evaluation of head circumference and for manifestations of 
+increased intracranial pressure at least every three months in the first year of 
+life. Evaluation by a craniofacial orthodontist when secondary teeth have 
+erupted. Assess serum phosphate and serum FGF23 as recommended by 
+endocrinologist. Monitor body temperature following sedation for procedures. 
+Agents/circumstances to avoid: Sports restrictions may be necessary for 
+activities that carry a potential for head or neck injury; individuals with 
+severe proptosis need to wear protective eyewear during activities with risk of 
+eye injury. Evaluation of relatives at risk: It is appropriate to clarify the 
+genetic status of apparently asymptomatic older and younger at-risk relatives of 
+an affected individual in order to identify as early as possible those who would 
+benefit from prompt initiation of treatment of developmental and craniofacial 
+manifestations.
+GENETIC COUNSELING: OGD is inherited in an autosomal dominant manner. Most 
+individuals diagnosed with OGD represent simplex cases; some individuals 
+diagnosed with OGD have an affected parent. Each child of an individual with OGD 
+has a 50% chance of inheriting the FGFR1 pathogenic variant. Once the FGFR1 
+pathogenic variant has been identified in an affected family member, prenatal 
+and preimplantation genetic testing are possible. Because many individuals with 
+short stature have reproductive partners with short stature, offspring of 
+individuals with OGD may be at risk of having double heterozygosity for two 
+dominantly inherited bone growth disorders; the phenotypes of these individuals 
+are distinct from those of the parents, and the affected individuals have 
+serious sequelae and poor outcomes. Pregnant women carrying fetuses affected by 
+OGD should be monitored during pregnancy for features that can affect early 
+morbidity and mortality and should be encouraged to deliver in a hospital with 
+ready access to a pediatric otolaryngologist, plastic surgeon, neurosurgeon, and 
+pulmonary medicine specialist.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a 
+registered trademark of the University of Washington, Seattle. All rights 
+reserved. Test.
+
+PMID: 38648328

--- a/references_cache/PMID_40260920.md
+++ b/references_cache/PMID_40260920.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:40260920"
+title: New Phenotypic Features in FGFR1-Related Osteoglophonic Dysplasia.
+authors:
+- Othman AA
+- Babcock HE
+- Gill CS
+- Fraser JL
+- Regier DS
+- Kaur R
+- Simpson KL
+- Ferreira CR
+journal: Am J Med Genet A
+year: '2025'
+doi: 10.1002/ajmg.a.64092
+keywords:
+- "Child, Preschool"
+- Female
+- Humans
+- Male
+- "Bone Diseases, Developmental/genetics, diagnosis"
+- Fibroblast Growth Factor-23
+- Mutation
+- Phenotype
+- "Receptor, Fibroblast Growth Factor, Type 1/genetics"
+- Child
+content_type: abstract_only
+---
+
+# New Phenotypic Features in FGFR1-Related Osteoglophonic Dysplasia.
+**Authors:** Othman AA, Babcock HE, Gill CS, Fraser JL, Regier DS, Kaur R, Simpson KL, Ferreira CR
+**Journal:** Am J Med Genet A (2025)
+**DOI:** [10.1002/ajmg.a.64092](https://doi.org/10.1002/ajmg.a.64092)
+
+## Content
+
+1. Am J Med Genet A. 2025 Sep;197(9):e64092. doi: 10.1002/ajmg.a.64092. Epub 2025
+ Apr 22.
+
+New Phenotypic Features in FGFR1-Related Osteoglophonic Dysplasia.
+
+Othman AA(1), Babcock HE(1)(2), Gill CS(3), Fraser JL(4)(5)(6), Regier DS(6), 
+Kaur R(2), Simpson KL(6), Ferreira CR(2).
+
+Author information:
+(1)National Human Genome Research Institute, National Institutes of Health, 
+Bethesda, Maryland, USA.
+(2)Unit on Skeletal Genomics, Eunice Kennedy Shriver National Institute of Child 
+Health and Human Development, National Institutes of Health, Bethesda, Maryland, 
+USA.
+(3)Department of Orthopedic Surgery, University of Texas Southwestern Medical 
+Center and Scottish Rite for Children, Dallas, Texas, USA.
+(4)Prenatal Pediatrics Institute, Children's National Hospital, Washington, DC, 
+USA.
+(5)Center for Genetic Medicine Research, Children's National Hospital, 
+Washington, DC, USA.
+(6)Division of Genetics and Metabolism, Children's National Hospital, 
+Washington, DC, USA.
+
+Osteoglophonic dysplasia (OGD) is a rare skeletal disorder caused by certain 
+variants in FGFR1. The FGFR1 gene encodes a receptor vital for osteogenesis in 
+the axial and craniofacial skeleton. Key OGD features include craniosynostosis, 
+craniofacial dysmorphism, impacted teeth, rhizomelic shortening, and 
+nonossifying fibromas. Patients may have hypophosphatemia due to high FGF23 
+levels. We report two OGD patients with the c.1141T > C FGFR1 variant 
+[p.(Cys381Arg)], initially diagnosed with Pfeiffer syndrome. Both showed classic 
+symptoms as well as signs not previously reported, including elevated frontal 
+temperature and overlapping toes. This report emphasizes distinguishing OGD from 
+similar disorders and expanding the clinical phenotype.
+
+© 2025 Wiley Periodicals LLC. This article has been contributed to by U.S. 
+Government employees and their work is in the public domain in the USA.
+
+DOI: 10.1002/ajmg.a.64092
+PMCID: PMC12339206
+PMID: 40260920 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of Interest The authors report no 
+conflict of interest.

--- a/references_cache/PMID_7422392.md
+++ b/references_cache/PMID_7422392.md
@@ -1,0 +1,46 @@
+---
+reference_id: "PMID:7422392"
+title: Osteoglophonic dwarfism.
+authors:
+- Beighton P
+- Cremin BJ
+- Kozlowski K
+journal: Pediatr Radiol
+year: '1980'
+doi: 10.1007/BF01644343
+keywords:
+- "Bone Diseases, Developmental/diagnostic imaging"
+- Child
+- "Child, Preschool"
+- Dwarfism/diagnostic imaging
+- Female
+- Fibrous Dysplasia of Bone/diagnostic imaging
+- Humans
+- Lumbar Vertebrae/diagnostic imaging
+- Mandibular Diseases/diagnostic imaging
+- Radiography
+content_type: abstract_only
+---
+
+# Osteoglophonic dwarfism.
+**Authors:** Beighton P, Cremin BJ, Kozlowski K
+**Journal:** Pediatr Radiol (1980)
+**DOI:** [10.1007/BF01644343](https://doi.org/10.1007/BF01644343)
+
+## Content
+
+1. Pediatr Radiol. 1980 Sep;10(1):46-50. doi: 10.1007/BF01644343.
+
+Osteoglophonic dwarfism.
+
+Beighton P, Cremin BJ, Kozlowski K.
+
+A ten year old South African girl of mixed ancestry presented with gross facial 
+abnormalities and dwarfism consequent upon a bizarre skeletal dysplasia. The 
+main radiographic features were craniostenosis, fibrous dysplasia, metaphyseal 
+lucencies and platyspondyl. Intelligence was normal and there were no systemic 
+ramifications. The term "osteoglophonic dwarfism" is a succinct and apt 
+designation for this remarkable disorder.
+
+DOI: 10.1007/BF01644343
+PMID: 7422392 [Indexed for MEDLINE]

--- a/references_cache/PMID_8958322.md
+++ b/references_cache/PMID_8958322.md
@@ -1,0 +1,57 @@
+---
+reference_id: "PMID:8958322"
+title: "Osteoglophonic dysplasia: review and further delineation of the syndrome."
+authors:
+- Sklower Brooks S
+- Kassner G
+- Qazi Q
+- Keogh MJ
+- Gorlin RJ
+journal: Am J Med Genet
+year: '1996'
+doi: "10.1002/(SICI)1096-8628(19961211)66:2<154::AID-AJMG6>3.0.CO;2-R"
+keywords:
+- "Bone Diseases, Developmental/complications, genetics"
+- Cognition Disorders/etiology
+- "Craniofacial Dysostosis/complications, genetics"
+- "Fractures, Spontaneous/etiology"
+- Humans
+- Infant
+- "Infant, Newborn"
+- Male
+- Syndrome
+content_type: abstract_only
+---
+
+# Osteoglophonic dysplasia: review and further delineation of the syndrome.
+**Authors:** Sklower Brooks S, Kassner G, Qazi Q, Keogh MJ, Gorlin RJ
+**Journal:** Am J Med Genet (1996)
+**DOI:** [10.1002/(SICI)1096-8628(19961211)66:2<154::AID-AJMG6>3.0.CO;2-R](https://doi.org/10.1002/(SICI)1096-8628(19961211)66:2<154::AID-AJMG6>3.0.CO;2-R)
+
+## Content
+
+1. Am J Med Genet. 1996 Dec 11;66(2):154-62. doi: 
+10.1002/(SICI)1096-8628(19961211)66:2<154::AID-AJMG6>3.0.CO;2-R.
+
+Osteoglophonic dysplasia: review and further delineation of the syndrome.
+
+Sklower Brooks S(1), Kassner G, Qazi Q, Keogh MJ, Gorlin RJ.
+
+Author information:
+(1)NYS Institute for Basic Research in Developmental Disabilities, Staten 
+Island, NY 10314, USA.
+
+We report on a boy with clinical and radiologic findings of osteoglophonic 
+dysplasia. He had craniostenosis, "bizarre," expansile cystic lesions in the 
+diaphyses, delayed tooth eruption, and progressive rib expansion typical of the 
+syndrome. Initially delayed psychomotor development with later normal 
+intelligence, early feeding and breathing difficulty, and speech delay are also 
+characteristic of the disorder. Manifestations, not previously reported in 
+osteoglophonic dysplasia, present in the propositus are spontaneous fractures 
+resulting in pseudoarthroses through cystic and dysplastic foci in his proximal 
+femoral shafts and right humerus, pretibial dimples, hypospadias, marked rib 
+expansion, and absence of significant vertebral abnormality. These findings 
+expand the spectrum of osteoglophonic dysplasia.
+
+DOI: 10.1002/(SICI)1096-8628(19961211)66:2<154::AID-AJMG6>3.0.CO;2-R
+PMID: 8958322 [Indexed for MEDLINE]

--- a/references_cache/PMID_8995175.md
+++ b/references_cache/PMID_8995175.md
@@ -1,0 +1,45 @@
+---
+reference_id: "PMID:8995175"
+title: "Osteoglophonic dysplasia: appearance and progression of multiple nonossifying fibromata."
+authors:
+- Azouz EM
+- Kozlowski K
+journal: Pediatr Radiol
+year: '1997'
+doi: 10.1007/s002470050069
+keywords:
+- "Bone Diseases, Developmental/diagnostic imaging"
+- Bone and Bones/diagnostic imaging
+- "Child, Preschool"
+- "Craniofacial Dysostosis/complications, diagnostic imaging"
+- Humans
+- Male
+- Radiography
+content_type: abstract_only
+---
+
+# Osteoglophonic dysplasia: appearance and progression of multiple nonossifying fibromata.
+**Authors:** Azouz EM, Kozlowski K
+**Journal:** Pediatr Radiol (1997)
+**DOI:** [10.1007/s002470050069](https://doi.org/10.1007/s002470050069)
+
+## Content
+
+1. Pediatr Radiol. 1997 Jan;27(1):75-8. doi: 10.1007/s002470050069.
+
+Osteoglophonic dysplasia: appearance and progression of multiple nonossifying 
+fibromata.
+
+Azouz EM(1), Kozlowski K.
+
+Author information:
+(1)The Hospital for Sick Children, Toronto, Canada.
+
+The appearance and gradual enlargement of fibrous cortical defects and multiple 
+nonossifying fibromata are documented in this report of a 2-year-old boy with a 
+very rare skeletal dysplasia known as osteoglophonic dysplasia, characterized by 
+multiple and recurrent craniosynostoses, platyspondyly, short tubular bones, and 
+epiphyseal dysplasia.
+
+DOI: 10.1007/s002470050069
+PMID: 8995175 [Indexed for MEDLINE]

--- a/research/Osteoglophonic_Dysplasia-deep-research-manual.md
+++ b/research/Osteoglophonic_Dysplasia-deep-research-manual.md
@@ -1,0 +1,74 @@
+# Osteoglophonic Dysplasia Deep Research Notes
+
+Date: 2026-04-18
+Curator: Codex manual synthesis
+
+## Scope
+
+Disease: Osteoglophonic dysplasia
+
+Focus for issue #1506:
+- phenotype section only
+- add clinically important manifestations backed by exact PMID text
+- include frequency or onset only when directly supported
+- remove unsupported obligate-style assertions
+
+## Core Phenotype Sources Used
+
+- PMID:15625620
+  - Mutation-confirmed FGFR1 paper with direct abstract support for craniosynostosis, prominent supraorbital ridges, depressed nasal bridge, rhizomelic dwarfism, and nonossifying bone lesions.
+- PMID:16918680
+  - Dental follow-up case with direct abstract support for multiple unerupted teeth, several impacted teeth, and lucent jaw/long-bone lesions.
+- PMID:29147600
+  - Mutation-confirmed Indian case with direct abstract support for disproportionate short stature, delayed tooth eruption, hypodontia, long-bone nonossifying lesions, and hypophosphatemia.
+- PMID:35148738
+  - Four-year follow-up dental case with direct abstract support for frontal bossing and anteverted nares.
+- PMID:38648328
+  - 2024 GeneReviews synthesis with PMID-backed abstract text supporting multisuture craniosynostosis, multiple craniofacial features, delayed/failed tooth eruption, gingival overgrowth, osteopenia, and fracture risk.
+- PMID:8958322
+  - Review/case report supporting delayed tooth eruption, rib expansion, speech/developmental issues, and rare spontaneous fractures with pseudoarthroses.
+- PMID:8995175
+  - Radiology report supporting platyspondyly and epiphyseal dysplasia in addition to nonossifying fibromata.
+- PMID:40260920
+  - 2025 phenotype update supporting hypophosphatemia as part of the spectrum and adding overlapping toes as a newly reported feature.
+
+## Included in YAML
+
+Phenotypes added or materially strengthened:
+- multisuture craniosynostosis
+- disproportionate short-limb short stature
+- rhizomelia
+- nonossifying fibromas of the long bones
+- platyspondyly
+- epiphyseal dysplasia
+- osteopenia
+- pathologic fracture
+- frontal bossing
+- prominent supraorbital ridges
+- depressed nasal bridge
+- proptosis
+- hypertelorism
+- midface retrusion
+- short nose
+- anteverted nares
+- low-set ears
+- high palate
+- delayed eruption of teeth
+- impacted teeth
+- hypodontia
+- gingival overgrowth
+- hypophosphatemia
+- overlapping toe
+
+## Deliberate Omissions / Softening
+
+- No phenotype `frequency:` values were retained or added.
+  - The available abstracts reliably support disease-phenotype association, but they do not provide direct quantitative frequency bands for these manifestations.
+- Bone age was not modeled.
+  - PMID:29147600 reports advanced bone age, while PMID:35148738 reports delayed skeletal maturation, so the current literature is conflicting.
+- Developmental delay / speech delay were not promoted to core phenotypes.
+  - PMID:8958322 describes them, but older reports such as PMID:7422392 and PMID:20339250 emphasize normal intelligence or later normal cognition, suggesting variable expression rather than a stable core manifestation.
+- Elevated frontal temperature from PMID:40260920 was not modeled.
+  - It appears to be a newly reported observation in two individuals, but HPO grounding is less clear and clinical importance is currently less established than overlapping toes.
+- Short, broad hands and feet from PMID:38648328 were not separately encoded.
+  - The review clearly notes distal extremity involvement, but the closest exact HPO fits were less clean than the other added manifestations, so I kept the YAML focused on stronger mappings first.


### PR DESCRIPTION
## Summary
- rebuild the `phenotypes` section in `kb/disorders/Osteoglophonic_Dysplasia.yaml` with direct PMID-backed evidence instead of indirect FGFR review support
- add clinically important craniofacial, dental, skeletal, metabolic, and newly reported appendicular findings from the OGD literature
- add a manual research note and cache the PMIDs used for curation

## Why
Issue #1506 asks for a phenotype-focused refresh of the Osteoglophonic Dysplasia entry with specific, evidence-grounded manifestations, conservative term mapping, and removal of unsupported obligate claims.

## Validation
- `just validate kb/disorders/Osteoglophonic_Dysplasia.yaml`
- `just validate-references kb/disorders/Osteoglophonic_Dysplasia.yaml`
- `just validate-terms kb/disorders/Osteoglophonic_Dysplasia.yaml`

All three commands passed locally.
