### PR TITLE
[codex] Enhance BDA1 phenotype evidence

### DIFF
--- a/kb/disorders/Brachydactyly_Type_A1.yaml
+++ b/kb/disorders/Brachydactyly_Type_A1.yaml
@@ -1,6 +1,6 @@
 name: Brachydactyly Type A1
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-02-13T00:59:22Z'
+updated_date: '2026-04-19T07:24:02Z'
 category: Mendelian
 description: >
   Brachydactyly type A1 (BDA1) is the first recorded Mendelian autosomal dominant
@@ -110,9 +110,9 @@ pathophysiology:
 phenotypes:
 - name: Type A1 Brachydactyly
   description: >
-    Shortening or absence of the middle phalanges of all digits, the
-    defining feature of BDA1. This is the most specific brachydactyly
-    pattern, affecting middle phalanges predominantly.
+    The defining digital pattern of BDA1, caused by shortening or absence
+    of the middle phalanges with variable expressivity across affected
+    families.
   phenotype_term:
     preferred_term: Type A1 brachydactyly
     term:
@@ -129,22 +129,66 @@ phenotypes:
     supports: SUPPORT
     snippet: "Brachydactyly type A1 (BDA1), the first recorded Mendelian autosomal dominant disorder in humans, is characterized by a shortening or absence of the middle phalanges"
     explanation: "Confirms middle phalanx shortening/absence as the defining feature."
+  - reference: PMID:32209048
+    reference_title: "A novel variant of IHH in a Chinese family with brachydactyly type 1."
+    supports: SUPPORT
+    snippet: "The variant co-segregated with BDA-1 in the pedigree, showed 100% penetrance for phalange phenotype with variable expressivity."
+    explanation: "A five-generation family showed fully penetrant but variably severe phalangeal involvement."
 - name: Short Middle Phalanx of Finger
   description: >
-    Shortening of middle phalanges across multiple digits, the specific
-    skeletal manifestation of disrupted IHH signaling in digital growth
-    plates.
+    Uniform shortening of the finger middle phalanges is the core skeletal
+    abnormality in classic BDA1.
   phenotype_term:
     preferred_term: Short middle phalanx of finger
     term:
       id: HP:0005819
       label: Short middle phalanx of finger
   evidence:
-  - reference: PMID:11455389
-    reference_title: "Mutations in IHH, encoding Indian hedgehog, cause brachydactyly type A-1."
+  - reference: PMID:34315464
+    reference_title: "Deletion of 2 amino acids in IHH in a Japanese family with brachydactyly type A1."
     supports: SUPPORT
-    snippet: "characterized by shortening or missing of the middle phalanges"
-    explanation: "Short middle phalanges are the hallmark skeletal finding."
+    snippet: "Brachydactyly type A1 (BDA1) is an autosomal dominant disorder characterized by uniform shortening of the middle phalanges in all digits."
+    explanation: "Directly supports uniform shortening of the finger middle phalanges in a molecularly confirmed BDA1 family."
+  - reference: PMID:18629882
+    reference_title: "Deletion of 1 amino acid in Indian hedgehog leads to brachydactylyA1."
+    supports: SUPPORT
+    snippet: "Brachydactyly type A1 is a limb malformation characterized by a uniform shortening of the middle phalanges in all digits."
+    explanation: "Independent family report confirms uniform middle-phalanx shortening as the key digital abnormality."
+- name: Short Middle Phalanx of Toe
+  description: >
+    Toe middle phalanges can also be shortened or absent in BDA1, showing
+    that the malformation affects both hands and feet.
+  phenotype_term:
+    preferred_term: Short middle phalanx of toe
+    term:
+      id: HP:0003795
+      label: Short middle phalanx of toe
+  evidence:
+  - reference: PMID:30651074
+    reference_title: "p.E95K mutation in Indian hedgehog causing brachydactyly type A1 impairs IHH/Gli1 downstream transcriptional regulation."
+    supports: SUPPORT
+    snippet: "Brachydactyly type A1 (BDA1, OMIM 112500) is a rare inherited malformation characterized primarily by shortness or absence of middle bones of fingers and toes."
+    explanation: "Supports toe middle-phalanx involvement as part of the core BDA1 malformation pattern."
+  - reference: PMID:40606564
+    reference_title: "A Novel Heterozygous IHH c.331_333del Mutation Identified in a Fetus with Brachydactyly Type A1 Causes IHH Protein Maturation Failure in HEK293T Cells."
+    supports: SUPPORT
+    snippet: "Brachydactyly A1 (BDA1) is a rare disorder characterized by the disproportionate shortening of fingers and/or toes with or without symphalangism."
+    explanation: "Recent prenatal case report independently supports toe shortening within the BDA1 phenotype spectrum."
+- name: Short Stature
+  description: >
+    Short stature has been reported in some molecularly confirmed BDA1
+    families and appears variable rather than obligatory.
+  phenotype_term:
+    preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  evidence:
+  - reference: PMID:34315464
+    reference_title: "Deletion of 2 amino acids in IHH in a Japanese family with brachydactyly type A1."
+    supports: SUPPORT
+    snippet: "The proband, a 9-year-old boy, his siblings, and his father had shortened digits and a short stature of variable severity."
+    explanation: "Supports short stature as a variable associated manifestation in a molecularly confirmed BDA1 family."
 genetic:
 - name: IHH Missense Mutations
   association: Causative

--- a/references_cache/PMID_18629882.md
+++ b/references_cache/PMID_18629882.md
@@ -1,0 +1,57 @@
+---
+reference_id: "PMID:18629882"
+title: Deletion of 1 amino acid in Indian hedgehog leads to brachydactylyA1.
+authors:
+- Lodder EM
+- Hoogeboom AJ
+- Coert JH
+- de Graaff E
+journal: Am J Med Genet A
+year: '2008'
+doi: 10.1002/ajmg.a.32441
+keywords:
+- Amino Acid Sequence
+- "Finger Phalanges/abnormalities, diagnostic imaging"
+- "Hand Deformities, Congenital/diagnostic imaging, genetics"
+- Hedgehog Proteins/genetics
+- Humans
+- Infant
+- Male
+- "Models, Molecular"
+- Pedigree
+- Phenotype
+- Protein Conformation
+- Radiography
+- Sequence Deletion
+content_type: abstract_only
+---
+
+# Deletion of 1 amino acid in Indian hedgehog leads to brachydactylyA1.
+**Authors:** Lodder EM, Hoogeboom AJ, Coert JH, de Graaff E
+**Journal:** Am J Med Genet A (2008)
+**DOI:** [10.1002/ajmg.a.32441](https://doi.org/10.1002/ajmg.a.32441)
+
+## Content
+
+1. Am J Med Genet A. 2008 Aug 15;146A(16):2152-4. doi: 10.1002/ajmg.a.32441.
+
+Deletion of 1 amino acid in Indian hedgehog leads to brachydactylyA1.
+
+Lodder EM(1), Hoogeboom AJ, Coert JH, de Graaff E.
+
+Author information:
+(1)Department of Clinical Genetics, Erasmus MC, Rotterdam, The Netherlands.
+
+Brachydactyly type A1 is a limb malformation characterized by a uniform 
+shortening of the middle phalanges in all digits. Mutations in the Indian 
+hedgehog (IHH) gene were shown to be the cause of this autosomal dominant 
+disorder. The IHH protein is known to be an important signaling molecule 
+involved in chondrocyte formation. So far, only missense mutations in IHH have 
+been reported to cause BrachydactylyA1. We report here on the first deletion in 
+IHH, p.delE95, causing mild BrachydactylyA1 in a small Dutch family. This brings 
+the total number of different mutations found to cause BDA1 to 7.
+
+Copyright 2008 Wiley-Liss, Inc.
+
+DOI: 10.1002/ajmg.a.32441
+PMID: 18629882 [Indexed for MEDLINE]

--- a/references_cache/PMID_30651074.md
+++ b/references_cache/PMID_30651074.md
@@ -1,0 +1,115 @@
+---
+reference_id: "PMID:30651074"
+title: p.E95K mutation in Indian hedgehog causing brachydactyly type A1 impairs IHH/Gli1 downstream transcriptional regulation.
+authors:
+- Shen L
+- Ma G
+- Shi Y
+- Ruan Y
+- Yang X
+- Wu X
+- Xiong Y
+- Wan C
+- Yang C
+- Cai L
+- Xiong L
+- Gong X
+- He L
+- Qin S
+journal: BMC Genet
+year: '2019'
+doi: 10.1186/s12863-018-0697-5
+keywords:
+- "Brachydactyly/genetics, pathology"
+- Cell Movement/genetics
+- Cell Proliferation/genetics
+- Hedgehog Proteins/genetics
+- Humans
+- Mutation
+- Signal Transduction/genetics
+- "Transcription, Genetic/genetics"
+- Zinc Finger Protein GLI1/genetics
+content_type: abstract_only
+---
+
+# p.E95K mutation in Indian hedgehog causing brachydactyly type A1 impairs IHH/Gli1 downstream transcriptional regulation.
+**Authors:** Shen L, Ma G, Shi Y, Ruan Y, Yang X, Wu X, Xiong Y, Wan C, Yang C, Cai L, Xiong L, Gong X, He L, Qin S
+**Journal:** BMC Genet (2019)
+**DOI:** [10.1186/s12863-018-0697-5](https://doi.org/10.1186/s12863-018-0697-5)
+
+## Content
+
+1. BMC Genet. 2019 Jan 16;20(1):10. doi: 10.1186/s12863-018-0697-5.
+
+p.E95K mutation in Indian hedgehog causing brachydactyly type A1 impairs 
+IHH/Gli1 downstream transcriptional regulation.
+
+Shen L(1), Ma G(1), Shi Y(1), Ruan Y(1), Yang X(1), Wu X(1)(2), Xiong Y(1), Wan 
+C(1), Yang C(1), Cai L(1), Xiong L(3)(4)(5), Gong X(1), He L(6)(7)(8), Qin 
+S(9)(10).
+
+Author information:
+(1)Bio-X Institutes, Key Laboratory for the Genetics of Developmental and 
+Neuropsychiatric Disorders, Ministry of Education, Shanghai Jiao Tong 
+University, 209 Little White House, 1954 Hua Shan Road, Shanghai, 200030, 
+People's Republic of China.
+(2)School of Biomedical Engineering, Shanghai Jiao Tong University, Shanghai, 
+200240, People's Republic of China.
+(3)Center Laboratory, Baoan Maternal and Children Healthcare Hospital, Shenzhen, 
+China.
+(4)Key Laboratory of Birth Defects Research, Shenzhen, China.
+(5)Birth Defects Prevention Research and Transformation Team, Shenzhen, China.
+(6)Bio-X Institutes, Key Laboratory for the Genetics of Developmental and 
+Neuropsychiatric Disorders, Ministry of Education, Shanghai Jiao Tong 
+University, 209 Little White House, 1954 Hua Shan Road, Shanghai, 200030, 
+People's Republic of China. helin@bio-x.cn.
+(7)Institute for Nutritional Sciences, Shanghai Institutes for Biological 
+Sciences (SIBS), Chinese Academy of Sciences, Shanghai, 200031, People's 
+Republic of China. helin@bio-x.cn.
+(8)Shanghai Center for Women and Children's Health, Shanghai, 200062, People's 
+Republic of China. helin@bio-x.cn.
+(9)Bio-X Institutes, Key Laboratory for the Genetics of Developmental and 
+Neuropsychiatric Disorders, Ministry of Education, Shanghai Jiao Tong 
+University, 209 Little White House, 1954 Hua Shan Road, Shanghai, 200030, 
+People's Republic of China. chinsir@sjtu.edu.cn.
+(10)The Third Affiliated Hospital, Guangzhou Medical University, Guangzhou, 
+510150, People's Republic of China. chinsir@sjtu.edu.cn.
+
+BACKGROUND: Brachydactyly type A1 (BDA1, OMIM 112500) is a rare inherited 
+malformation characterized primarily by shortness or absence of middle bones of 
+fingers and toes. It is the first recorded disorder of the autosomal dominant 
+Mendelian trait. Indian hedgehog (IHH) gene is closely associated with BDA1, 
+which was firstly mapped and identified in Chinese families in 2000. Previous 
+studies have demonstrated that BDA1-related mutant IHH proteins affected 
+interactions with its receptors and impaired IHH signaling. However, how the 
+altered signaling pathway affects downstream transcriptional regulation remains 
+unclear.
+RESULTS: Based on the mouse C3H10T1/2 cell model for IHH signaling activation, 
+two recombinant human IHH-N proteins, including a wild type protein (WT, amino 
+acid residues 28-202) and a mutant protein (MT, p.E95k), were analyzed. We 
+identified 347, 47 and 4 Gli1 binding sites in the corresponding WT, MT and 
+control group by chromatin immunoprecipitation and the overlapping of these 
+three sets was poor. The putative cis regulated genes in WT group were enriched 
+in sensory perception and G-protein coupled receptor-signaling pathway. On the 
+other hand, putative cis regulated genes were enriched in Runx2-related pathways 
+in MT group. Differentially expressed genes in WT and MT groups indicated that 
+the alteration of mutant IHH signaling involved cell-cell signaling and cellular 
+migration. Cellular assay of migration and proliferation validated that the 
+mutant IHH signaling impaired these two cellular functions.
+CONCLUSIONS: In this study, we performed integrated genome-wide analyses to 
+characterize differences of IHH/Gli1 downstream regulation between wild type IHH 
+signaling and the E95K mutant signaling. Based on the cell model, our results 
+demonstrated that the E95K mutant signaling altered Gli1-DNA binding pattern, 
+impaired downstream gene expressions, and leaded to weakened cellular 
+proliferation and migration. This study may help to deepen the understanding of 
+pathogenesis of BDA1 and the role of IHH signaling in chondrogenesis.
+
+DOI: 10.1186/s12863-018-0697-5
+PMCID: PMC6335781
+PMID: 30651074 [Indexed for MEDLINE]
+
+Conflict of interest statement: ETHICS APPROVAL AND CONSENT TO PARTICIPATE: Not 
+applicable. CONSENT FOR PUBLICATION: Not applicable. COMPETING INTERESTS: The 
+authors declare that they have no competing interests. PUBLISHER’S NOTE: 
+Springer Nature remains neutral with regard to jurisdictional claims in 
+published maps and institutional affiliations.

--- a/references_cache/PMID_32209048.md
+++ b/references_cache/PMID_32209048.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:32209048"
+title: A novel variant of IHH in a Chinese family with brachydactyly type 1.
+authors:
+- Yang Q
+- Wang J
+- Tian X
+- Shen F
+- Lan J
+- Zhang Q
+- Fan X
+- Yi S
+- Li M
+- Shen Y
+journal: BMC Med Genet
+year: '2020'
+doi: 10.1186/s12881-020-01000-6
+keywords:
+- Adult
+- Amino Acid Substitution
+- Aspartic Acid/genetics
+- "Brachydactyly/diagnosis, genetics, pathology"
+- China
+- DNA Mutational Analysis
+- Family
+- Female
+- Genetic Predisposition to Disease
+- Glycine/genetics
+- Hedgehog Proteins/genetics
+- Humans
+- Male
+- Middle Aged
+- "Mutation, Missense"
+- Pedigree
+- "Polymorphism, Single Nucleotide"
+- Exome Sequencing
+- Young Adult
+content_type: abstract_only
+---
+
+# A novel variant of IHH in a Chinese family with brachydactyly type 1.
+**Authors:** Yang Q, Wang J, Tian X, Shen F, Lan J, Zhang Q, Fan X, Yi S, Li M, Shen Y
+**Journal:** BMC Med Genet (2020)
+**DOI:** [10.1186/s12881-020-01000-6](https://doi.org/10.1186/s12881-020-01000-6)
+
+## Content
+
+1. BMC Med Genet. 2020 Mar 24;21(1):60. doi: 10.1186/s12881-020-01000-6.
+
+A novel variant of IHH in a Chinese family with brachydactyly type 1.
+
+Yang Q(1), Wang J(1), Tian X(2), Shen F(1), Lan J(3), Zhang Q(1), Fan X(1), Yi 
+S(1), Li M(1), Shen Y(4)(5)(6).
+
+Author information:
+(1)Genetic and Metabolic Central Laboratory, Birth Defect Prevention Research 
+Institute, Maternal and Child Health Hospital, Children's Hospital of Guangxi 
+Zhuang Autonomous Region, Nanning, 530002, China.
+(2)Department of Ultrasonography, Maternal and Child Health Hospital, Children's 
+Hospital of Guangxi Zhuang Autonomous Region, Nanning, 530002, China.
+(3)Department of Gynaecology, Maternal and Child Health Hospital, Children's 
+Hospital of Guangxi Zhuang Autonomous Region, Nanning, 530002, China.
+(4)Genetic and Metabolic Central Laboratory, Birth Defect Prevention Research 
+Institute, Maternal and Child Health Hospital, Children's Hospital of Guangxi 
+Zhuang Autonomous Region, Nanning, 530002, China. 
+Yiping.shen@childrens.harvard.edu.
+(5)Department of Medical Genetics and Molecular Diagnostic Laboratory, Shanghai 
+Children's Medical Center, Shanghai Jiao Tong University School of Medicine, 
+Shanghai, 200127, China. Yiping.shen@childrens.harvard.edu.
+(6)Division of Genetics and Genomics, Boston Children's Hospital; Department of 
+Neurology, Harvard Medical School, Boston, MA, 02115, USA. 
+Yiping.shen@childrens.harvard.edu.
+
+BACKGROUND: Brachydactyly type A1(BDA-1) is an autosomal dominant disorder which 
+is caused by heterozygous pathogenic variants in a specific region of the 
+N-terminal active fragment of Indian Hedgehog (IHH). The disorder is mainly 
+characterized by shortening or missing of the middle phalanges. In this study, 
+Our purpose is to identify the pathogenic variations associated with BDA-1 
+involved in a five-generation Chinese family.
+METHODS: A BDA-1 family with 8 affected and 14 unaffected family members was 
+recruited. Whole exome sequencing (WES) was performed to identify the pathogenic 
+variant in the proband, and which was later confirmed and segregated by Sanger 
+sequencing. The significance of variants were assessed using several molecular 
+and bioinformatics analysis methods.
+RESULTS: We uncovered a novel heterozygous missense variant c.299A > G (p.D100G) 
+at the mutational hotspot of IHH gene following whole-exome sequencing of a 
+Chinese family with BDA-1. The variant co-segregated with BDA-1 in the pedigree, 
+showed 100% penetrance for phalange phenotype with variable expressivity.
+CONCLUSIONS: In conclusion, this study reports a five-generation Chinese family 
+with BDA-1 due to a novel pathogenic variant (c.299A > G (p.D100G)) of IHH and 
+expands the clinical and genetic spectrum of BDA-1.
+
+DOI: 10.1186/s12881-020-01000-6
+PMCID: PMC7092535
+PMID: 32209048 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_34315464.md
+++ b/references_cache/PMID_34315464.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:34315464"
+title: Deletion of 2 amino acids in IHH in a Japanese family with brachydactyly type A1.
+authors:
+- Ozaki N
+- Okuda H
+- Kobayashi H
+- Harada KH
+- Inoue S
+- Youssefian S
+- Koizumi A
+journal: BMC Med Genomics
+year: '2021'
+doi: 10.1186/s12920-021-01042-6
+keywords:
+- Child
+- Female
+- Humans
+- Male
+- Asian People/genetics
+- Brachydactyly/genetics
+- Hedgehog Proteins/genetics
+- Heterozygote
+- Japan
+- Pedigree
+- Sequence Deletion
+content_type: abstract_only
+---
+
+# Deletion of 2 amino acids in IHH in a Japanese family with brachydactyly type A1.
+**Authors:** Ozaki N, Okuda H, Kobayashi H, Harada KH, Inoue S, Youssefian S, Koizumi A
+**Journal:** BMC Med Genomics (2021)
+**DOI:** [10.1186/s12920-021-01042-6](https://doi.org/10.1186/s12920-021-01042-6)
+
+## Content
+
+1. BMC Med Genomics. 2021 Jul 27;14(1):190. doi: 10.1186/s12920-021-01042-6.
+
+Deletion of 2 amino acids in IHH in a Japanese family with brachydactyly type 
+A1.
+
+Ozaki N(1), Okuda H(2), Kobayashi H(3), Harada KH(4), Inoue S(2)(4), Youssefian 
+S(2)(5), Koizumi A(2)(4)(6).
+
+Author information:
+(1)Department of Pediatrics, Kadono-Sanjo Children's Clinic, Kyoto, Japan. 
+nozk@leto.eonet.ne.jp.
+(2)Department of Pain Pharmacogenetics, Kyoto University Graduate School of 
+Medicine, Kyoto, Japan.
+(3)Environmental and Molecular Medicine, Mie University Graduate School of 
+Medicine, Tsu, Japan.
+(4)Department of Health and Environmental Sciences, Kyoto University Graduate 
+School of Medicine, Kyoto, Japan.
+(5)Department of Molecular Biosciences, Kyoto University Graduate School of 
+Medicine, Kyoto, Japan.
+(6)Institute of Public Health and Welfare, Kyoto-Hokenkai, Kyoto, Japan.
+
+BACKGROUND: Brachydactyly type A1 (BDA1) is an autosomal dominant disorder 
+characterized by uniform shortening of the middle phalanges in all digits. It is 
+associated with variants in the Indian Hedgehog (IHH) gene, which plays a key 
+role in endochondral ossification. To date, heterozygous pathogenic IHH variants 
+involving several codons, which are restricted to a specific region of the 
+N-terminal active fragment of IHH, have been reported. The purpose of this study 
+was to identify the pathogenic variant in a Japanese family with BDA1 and to 
+evaluate its pathogenesis with regard to previous reports.
+METHODS: The proband, a 9-year-old boy, his siblings, and his father had 
+shortened digits and a short stature of variable severity. Based on physical 
+examinations, radiographic findings and family history, they were diagnosed with 
+BDA1. This family is the first case of an isolated malformation in Japan. Sanger 
+sequencing of IHH was performed on these individuals and on the proband's 
+unaffected mother. The significance of the variants was assessed using 
+three-dimensional analysis methods.
+RESULTS: Sanger sequencing showed a novel IHH heterozygous variant, 
+NM_002181.4:c.544_549delTCAAAG(p.Ser182Lys183del) 
+[NC_000002.12:g.219057461_219057466del].. These two residues are located outside 
+the cluster region considered a hotspot of pathogenic variants. 
+Three-dimensional modelling showed that S182 and K183 are located on the same 
+surface as other residues associated with BDA1. Analysis of residue interactions 
+across the interface between IHH and its interacting receptor protein revealed 
+the presence of hydrogen bonds between them.
+CONCLUSIONS: We report a novel variant, NM_002181.4:c.544_549delTCAAAG 
+(p.Ser182Lys183del) [NC_000002.12:g.219057461_219057466del] in a Japanese family 
+with BDA1. Indeed, neither variations in codons 182 or 183 nor with such 
+two-amino-acid deletions in IHH have been reported previously. Although these 
+two residues are located outside the cluster region considered a hotspot of 
+pathogenic variants, we speculate that this variant causes BDA1 through impaired 
+interactions between IHH and target receptor proteins in the same manner as 
+other pathogenic variants located in the cluster region. This report expands the 
+genetic spectrum of BDA1.
+
+© 2021. The Author(s).
+
+DOI: 10.1186/s12920-021-01042-6
+PMCID: PMC8314500
+PMID: 34315464 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_40606564.md
+++ b/references_cache/PMID_40606564.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:40606564"
+title: A Novel Heterozygous IHH c.331_333del Mutation Identified in a Fetus with Brachydactyly Type A1 Causes IHH Protein Maturation Failure in HEK293T Cells.
+authors:
+- Zhu T
+- Guan L
+- Chen D
+- Luo Y
+- Zhu M
+- Sun R
+- Shi J
+- Wang Q
+- Chen Y
+- Wang Y
+- Wang H
+- Lu Z
+- Wang D
+journal: Phenomics
+year: '2025'
+doi: 10.1007/s43657-024-00191-9
+content_type: abstract_only
+---
+
+# A Novel Heterozygous IHH c.331_333del Mutation Identified in a Fetus with Brachydactyly Type A1 Causes IHH Protein Maturation Failure in HEK293T Cells.
+**Authors:** Zhu T, Guan L, Chen D, Luo Y, Zhu M, Sun R, Shi J, Wang Q, Chen Y, Wang Y, Wang H, Lu Z, Wang D
+**Journal:** Phenomics (2025)
+**DOI:** [10.1007/s43657-024-00191-9](https://doi.org/10.1007/s43657-024-00191-9)
+
+## Content
+
+1. Phenomics. 2024 Dec 21;5(2):123-136. doi: 10.1007/s43657-024-00191-9. 
+eCollection 2025 Apr.
+
+A Novel Heterozygous IHH c.331_333del Mutation Identified in a Fetus with 
+Brachydactyly Type A1 Causes IHH Protein Maturation Failure in HEK293T Cells.
+
+Zhu T(#)(1)(2), Guan L(#)(3), Chen D(1)(4), Luo Y(1)(5), Zhu M(1), Sun R(1), Shi 
+J(1), Wang Q(1), Chen Y(1), Wang Y(1), Wang H(2), Lu Z(6), Wang D(1).
+
+Author information:
+(1)Department of Pediatrics, The First Affiliated Hospital of Wenzhou Medical 
+University, No. 2 Fuxue Road, Wenzhou, Zhejiang 325000 P. R. China.
+(2)Zhejiang Key Laboratory of Intelligent Cancer Biomarker Discovery and 
+Translation, First Affiliated Hospital, Wenzhou Medical University, Wenzhou, 
+325035 China.
+(3)Department of Ultrasound Imaging, The First Affiliated Hospital of Wenzhou 
+Medical University, Wenzhou, Zhejiang 325000 P. R. China.
+(4)Department of Pediatrics, Yongjia People's Hospital, Wenzhou, Zhejiang 325000 
+P.R. China.
+(5)Department of Pediatrics, Taizhou Women and Children's Hospital of Wenzhou 
+Medical University, Taizhou, Zhejiang 318000 P.R. China.
+(6)The Key Laboratory of Emergency and Disaster Medicine of Wenzhou, The First 
+Affiliated Hospital of Wenzhou Medical University, Wenzhou, Zhejiang 325000 P. 
+R. China.
+(#)Contributed equally
+
+Brachydactyly A1 (BDA1) is a rare disorder characterized by the disproportionate 
+shortening of fingers and/or toes with or without symphalangism. Mutations in 
+Indian hedgehog signaling molecule (IHH), which impair the effect of functional 
+IHH protein derived from its precursor IHH, are commonly identified in patients 
+with BDA1 or acrocapitofemoral dysplasia (ACFD). The ultrasound phenotype of 
+fetuses with IHH mutations has rarely been described. To better understand the 
+consequences of IHH mutation, we analyzed the characteristics of a Chinese fetus 
+with BDA1 caused by a novel heterozygous IHH mutation. Clinical data and genomic 
+DNA were collected from the proband and family members. Whole-exome sequencing 
+(WES) was performed to identify potential causative mutations. Sequence analysis 
+was performed to investigate the conservation of the affected leucine residue in 
+IHH. Protein 3D modeling was performed to predict the effects of the mutation on 
+protein structure. In vitro overexpression transfection experiments in human 
+embryonic kidney 293T (HEK293T) cell lines were performed to evaluate the 
+pathogenicity of the identified mutation. The fetal proband carried a novel 
+heterozygous mutation in IHH (NM_002181.4: c.331_333delCTG, NP_002172.2: 
+p.Leu111del) inherited from the father; this mutation manifested as shortening 
+of the limbs, with more severe shortening observed in the proximal extremities 
+than in the distal extremities, as evidenced by ultrasound. The Leu111 residue 
+is highly conserved among vertebrates, and deletion of this residue destabilizes 
+the protein structure. Western blotting analysis of HEK293T cells in 
+overexpression transfection experiments revealed that the Leu111del mutation led 
+to an increase in the level of the IHH precursor and a reduction in the level of 
+functional IHH protein compared with those in HEK293T cells expressing wild-type 
+IHH, indicating that this mutation might cause IHH protein dysmaturity. The 
+novel heterozygous mutation c.331_333delCTG (p.Leu111del) in the IHH gene is the 
+likely cause of BDA1 in this Chinese fetus. This mutation causes IHH protein 
+maturation failure. These findings contribute to our understanding of the 
+molecular pathogenesis of BDA1 and the clinical identification of fetal BDA1.
+
+© The Author(s) 2024.
+
+DOI: 10.1007/s43657-024-00191-9
+PMCID: PMC12209099
+PMID: 40606564
+
+Conflict of interest statement: Conflict of InterestThe authors have no relevant 
+financial or nonfinancial competing interests to disclose.

--- a/research/Brachydactyly_Type_A1-phenotype-curation-2026-04-19.md
+++ b/research/Brachydactyly_Type_A1-phenotype-curation-2026-04-19.md
@@ -1,0 +1,33 @@
+# Brachydactyly Type A1 phenotype curation notes
+
+Date: 2026-04-19
+Scope: phenotype-only curation for `kb/disorders/Brachydactyly_Type_A1.yaml`
+
+## Accepted phenotype assertions
+
+- `Type A1 brachydactyly`
+  Evidence used: PMID:11455389, PMID:21537345, PMID:32209048
+  Rationale: multiple abstracts explicitly describe shortening/absence of the middle phalanges, and one multigeneration family reports `100% penetrance for phalange phenotype with variable expressivity`.
+
+- `Short middle phalanx of finger`
+  Evidence used: PMID:34315464, PMID:18629882
+  Rationale: both abstracts explicitly state `uniform shortening of the middle phalanges in all digits`.
+
+- `Short middle phalanx of toe`
+  Evidence used: PMID:30651074, PMID:40606564
+  Rationale: both abstracts explicitly include toe involvement (`middle bones of fingers and toes`; `shortening of fingers and/or toes`).
+
+- `Short stature`
+  Evidence used: PMID:34315464
+  Rationale: direct abstract support in a molecularly confirmed BDA1 family, but stated as variable rather than obligatory.
+
+## Claims intentionally not added
+
+- Symphalangism as a standalone phenotype
+  Reason: PMID:40606564 mentions `with or without symphalangism`, but the abstract does not specify the joint pattern or body site. More detailed fusion findings in recent reports appear in figure captions/full text and would not survive abstract-only reference validation.
+
+- Specific metacarpal or metatarsal shortening, radial deviation, and digit-by-digit absent phalanges
+  Reason: useful supporting detail exists in figures/full text for PMID:32209048 and PMID:35669189, but not in the cached abstract text.
+
+- Generalized prenatal limb shortening as a disease-level phenotype
+  Reason: PMID:40606564 reports fetal limb shortening, but this currently looks like an isolated prenatal observation rather than a sufficiently established disorder-level phenotype for BDA1.


### PR DESCRIPTION
## Summary
- expand the `phenotypes` section in `kb/disorders/Brachydactyly_Type_A1.yaml` with PMID-backed finger, toe, and variable short-stature manifestations
- tighten existing phenotype wording so the claims stay within abstract-supported evidence
- add a focused research note documenting which phenotype candidates were accepted versus intentionally excluded
- cache the new PubMed references required for deterministic reference validation

## Why
Issue #1521 asked for a phenotype-only refresh of the Brachydactyly Type A1 entry with exact PMID support and conservative handling of unsupported claims.

## Scope
- updated: `kb/disorders/Brachydactyly_Type_A1.yaml`
- added: `research/Brachydactyly_Type_A1-phenotype-curation-2026-04-19.md`
- added relevant `references_cache/PMID_*.md` files for the cited phenotype papers
- intentionally did not broaden the page into non-phenotype sections beyond refreshing `updated_date`

## Validation
- `just validate kb/disorders/Brachydactyly_Type_A1.yaml` ✅
- `just validate-references kb/disorders/Brachydactyly_Type_A1.yaml` ✅
- `just validate-terms kb/disorders/Brachydactyly_Type_A1.yaml` ✅

Refs #1521