### PR TITLE
[codex] Enhance phenotype evidence for autosomal recessive osteopetrosis

### DIFF
--- a/kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml
+++ b/kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Recessive Osteopetrosis Type 2
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-02-16T20:19:38Z'
+updated_date: '2026-04-19T07:25:24Z'
 category: Mendelian
 description: >
   Autosomal recessive osteopetrosis type 2 (ARO2) is a severe sclerosing bone
@@ -129,49 +129,265 @@ pathophysiology:
       id: UBERON:0003128
       label: cranium
 phenotypes:
-- name: Osteopetrosis
+- name: Increased bone mineral density
   description: >
-    Severe generalized increase in skeletal density due to complete
-    failure of osteoclast-mediated bone resorption. Dense but
-    structurally abnormal bone obliterates the medullary cavity.
+    Generalized osteosclerosis with narrowing or obliteration of marrow
+    cavities is the defining skeletal manifestation of TCIRG1-related
+    autosomal recessive osteopetrosis.
   phenotype_term:
-    preferred_term: Osteopetrosis
+    preferred_term: Increased bone mineral density
     term:
-      id: HP:0011002
-      label: Osteopetrosis
+      id: HP:0011001
+      label: Increased bone mineral density
   evidence:
-  - reference: PMID:10888887
-    reference_title: "Defects in TCIRG1 subunit of the vacuolar proton pump are responsible for a subset of human autosomal recessive osteopetrosis."
+  - reference: PMID:34545712
+    reference_title: "Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis."
     supports: SUPPORT
-    snippet: "Osteopetrosis includes a group of inherited diseases in which inadequate bone resorption is caused by osteoclast dysfunction"
-    explanation: "Defines osteopetrosis as the hallmark feature of osteoclast dysfunction."
-- name: Pancytopenia
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Osteopetrosis is characterized by increased bone density and bone marrow cavity stenosis"
+    explanation: "An autosomal recessive osteopetrosis cohort including TCIRG1 cases identified increased bone density with marrow cavity stenosis as a core manifestation."
+  - reference: PMID:40462430
+    reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical manifestations included systemic osteosclerosis (14 cases, 100%)"
+    explanation: "A pediatric osteopetrosis cohort found systemic osteosclerosis in all affected children; all TCIRG1 cases had malignant phenotypes."
+- name: Anemia
   description: >
-    Bone marrow failure from obliteration of the medullary cavity by
-    unresorbed bone. Presents with anemia, thrombocytopenia, and
-    leukopenia, often with compensatory extramedullary hematopoiesis
-    causing hepatosplenomegaly.
+    Progressive medullary cavity compromise causes clinically important
+    anemia early in the malignant infantile phenotype.
   phenotype_term:
-    preferred_term: Pancytopenia
+    preferred_term: Anemia
     term:
-      id: HP:0001876
-      label: Pancytopenia
+      id: HP:0001903
+      label: Anemia
   evidence:
-  - reference: PMID:10888887
-    reference_title: "Defects in TCIRG1 subunit of the vacuolar proton pump are responsible for a subset of human autosomal recessive osteopetrosis."
+  - reference: PMID:34545712
+    reference_title: "Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis."
     supports: SUPPORT
-    snippet: "Infantile malignant autosomal recessive osteopetrosis (MIM 259700) is a severe bone disease with a fatal outcome, generally within the first decade of life"
-    explanation: "The fatal outcome is largely due to bone marrow failure causing pancytopenia."
-- name: Cranial Nerve Compression
+    evidence_source: HUMAN_CLINICAL
+    snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
+    explanation: "The autosomal recessive osteopetrosis cohort explicitly presented with anemia."
+  - reference: PMID:40462430
+    reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical manifestations included systemic osteosclerosis (14 cases, 100%), anemia (12 cases, 86%)"
+    explanation: "A pediatric osteopetrosis cohort found anemia in most affected children; all TCIRG1 cases had malignant phenotypes."
+- name: Thrombocytopenia
   description: >
-    Progressive narrowing of cranial nerve foramina due to skull
-    thickening, causing optic nerve compression (blindness), facial
-    nerve palsy, and sensorineural hearing loss.
+    Bone marrow failure commonly includes thrombocytopenia, contributing
+    to bleeding risk in severe infantile disease.
   phenotype_term:
-    preferred_term: Cranial nerve compression
+    preferred_term: Thrombocytopenia
     term:
-      id: HP:0001293
-      label: Cranial nerve compression
+      id: HP:0001873
+      label: Thrombocytopenia
+  evidence:
+  - reference: PMID:34545712
+    reference_title: "Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
+    explanation: "The autosomal recessive osteopetrosis cohort explicitly presented with thrombocytopenia."
+  - reference: PMID:40462430
+    reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical manifestations included systemic osteosclerosis (14 cases, 100%), anemia (12 cases, 86%), infections (10 cases, 71%), thrombocytopenia (9 cases, 64%)"
+    explanation: "A pediatric osteopetrosis cohort found thrombocytopenia in most children with malignant disease enrichment among TCIRG1 cases."
+- name: Hepatosplenomegaly
+  description: >
+    Hepatosplenomegaly reflects compensatory extramedullary hematopoiesis
+    in response to marrow failure.
+  phenotype_term:
+    preferred_term: Hepatosplenomegaly
+    term:
+      id: HP:0001433
+      label: Hepatosplenomegaly
+  evidence:
+  - reference: PMID:34545712
+    reference_title: "Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
+    explanation: "Hepatosplenomegaly was part of the presenting phenotype in an autosomal recessive osteopetrosis cohort that included multiple TCIRG1 cases."
+  - reference: PMID:18946580
+    reference_title: "Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with infantile malignant osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patient was a 5-year-old girl with macrocephaly, facial dysmorphism, blindness, mental retardation, hepatosplenomegaly, pancytopenia, and osteosclerotic changes in the skull and limb."
+    explanation: "A TCIRG1-associated infantile malignant osteopetrosis case directly documented hepatosplenomegaly."
+- name: Recurrent infections
+  description: >
+    Recurrent infections are common in severe disease and likely reflect
+    marrow failure with impaired hematopoiesis.
+  phenotype_term:
+    preferred_term: Recurrent infections
+    term:
+      id: HP:0002719
+      label: Recurrent infections
+  evidence:
+  - reference: PMID:34545712
+    reference_title: "Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
+    explanation: "Repeated infections were part of the presenting phenotype in an autosomal recessive osteopetrosis cohort."
+  - reference: PMID:30898950
+    reference_title: "Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In addition, growth retardation and recurrent infections requiring long-term antibiotic use are common."
+    explanation: "A TCIRG1-related malignant infantile osteopetrosis report highlights recurrent infections as a common clinical problem."
+- name: Visual impairment
+  description: >
+    Skull-base overgrowth and narrowing of osseous foramina can compress
+    the optic apparatus, causing visual impairment that may progress to
+    blindness.
+  phenotype_term:
+    preferred_term: Visual impairment
+    term:
+      id: HP:0000505
+      label: Visual impairment
+  evidence:
+  - reference: PMID:30898950
+    reference_title: "Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestations can also occur due to narrowing of osseous foramina resulting in visual impairment, hearing loss, facial palsy and hydrocephalus."
+    explanation: "Malignant infantile osteopetrosis causes visual impairment through cranial foraminal narrowing."
+  - reference: PMID:18946580
+    reference_title: "Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with infantile malignant osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patient was a 5-year-old girl with macrocephaly, facial dysmorphism, blindness, mental retardation, hepatosplenomegaly, pancytopenia, and osteosclerotic changes in the skull and limb."
+    explanation: "A TCIRG1-associated case shows that visual involvement may be severe enough to cause blindness."
+- name: Hearing impairment
+  description: >
+    Bony narrowing of cranial foramina and temporal bone involvement can
+    cause clinically significant hearing loss.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: PMID:30898950
+    reference_title: "Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestations can also occur due to narrowing of osseous foramina resulting in visual impairment, hearing loss, facial palsy and hydrocephalus."
+    explanation: "The malignant infantile phenotype includes hearing loss from cranial foraminal narrowing."
+- name: Hydrocephalus
+  description: >
+    Hydrocephalus is a recognized cranial complication of severe
+    autosomal recessive osteopetrosis and may be an early presenting
+    feature.
+  phenotype_term:
+    preferred_term: Hydrocephalus
+    term:
+      id: HP:0000238
+      label: Hydrocephalus
+  evidence:
+  - reference: PMID:34519872
+    reference_title: "Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autosomal recessive osteopetrosis has a variable presentation, most commonly including failure to thrive, hypocalcemia, seizures, hepatosplenomegaly, hydrocephalus, vision or hearing loss, and cytopenias."
+    explanation: "A clinical report on malignant infantile osteopetrosis identifies hydrocephalus among the common presenting manifestations."
+  - reference: PMID:30898950
+    reference_title: "Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological manifestations can also occur due to narrowing of osseous foramina resulting in visual impairment, hearing loss, facial palsy and hydrocephalus."
+    explanation: "Independent clinical evidence links malignant infantile osteopetrosis to hydrocephalus from cranial narrowing."
+- name: Macrocephaly
+  description: >
+    Progressive cranial overgrowth can produce macrocephaly, often with
+    frontal bossing in infants.
+  phenotype_term:
+    preferred_term: Macrocephaly
+    term:
+      id: HP:0000256
+      label: Macrocephaly
+  evidence:
+  - reference: PMID:18946580
+    reference_title: "Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with infantile malignant osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patient was a 5-year-old girl with macrocephaly, facial dysmorphism, blindness, mental retardation, hepatosplenomegaly, pancytopenia, and osteosclerotic changes in the skull and limb."
+    explanation: "A TCIRG1-associated infantile malignant osteopetrosis case directly documented macrocephaly."
+  - reference: PMID:34519872
+    reference_title: "Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "At 6 months, the infant had macrocephaly and frontal bossing with a bulging fontanelle."
+    explanation: "Hydrocephalus-associated infantile osteopetrosis can present with macrocephaly and frontal bossing."
+- name: Failure to thrive
+  description: >
+    Poor growth and nutritional failure are part of the common early
+    presentation of severe autosomal recessive osteopetrosis.
+  phenotype_term:
+    preferred_term: Failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
+  evidence:
+  - reference: PMID:34519872
+    reference_title: "Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autosomal recessive osteopetrosis has a variable presentation, most commonly including failure to thrive, hypocalcemia, seizures, hepatosplenomegaly, hydrocephalus, vision or hearing loss, and cytopenias."
+    explanation: "Failure to thrive is listed among the common presenting manifestations of autosomal recessive osteopetrosis."
+- name: Hypocalcemia
+  description: >
+    Impaired bone resorption is commonly accompanied by hypocalcemia in
+    severe infantile presentations.
+  phenotype_term:
+    preferred_term: Hypocalcemia
+    term:
+      id: HP:0002901
+      label: Hypocalcemia
+  evidence:
+  - reference: PMID:34519872
+    reference_title: "Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autosomal recessive osteopetrosis has a variable presentation, most commonly including failure to thrive, hypocalcemia, seizures, hepatosplenomegaly, hydrocephalus, vision or hearing loss, and cytopenias."
+    explanation: "Hypocalcemia is identified as a common manifestation of autosomal recessive osteopetrosis."
+- name: Seizure
+  description: >
+    Seizures can occur in the malignant infantile phenotype, often in the
+    setting of metabolic derangements such as hypocalcemia.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:34519872
+    reference_title: "Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autosomal recessive osteopetrosis has a variable presentation, most commonly including failure to thrive, hypocalcemia, seizures, hepatosplenomegaly, hydrocephalus, vision or hearing loss, and cytopenias."
+    explanation: "Seizures are listed among the common presenting manifestations of autosomal recessive osteopetrosis."
+- name: Neurodevelopmental delay
+  description: >
+    Severe disease may be accompanied by delayed neurodevelopment,
+    particularly when early neurologic complications occur.
+  phenotype_term:
+    preferred_term: developmental delay
+    term:
+      id: HP:0012758
+      label: Neurodevelopmental delay
+  evidence:
+  - reference: PMID:40462430
+    reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical manifestations included systemic osteosclerosis (14 cases, 100%), anemia (12 cases, 86%), infections (10 cases, 71%), thrombocytopenia (9 cases, 64%), hepatosplenomegaly (8 cases, 57%), and developmental delay (5 cases, 36%)."
+    explanation: "A pediatric osteopetrosis cohort documented developmental delay in a substantial subset of children; all TCIRG1 cases in the cohort had malignant phenotypes."
 genetic:
 - name: TCIRG1 Mutations
   association: Causative

--- a/references_cache/PMID_18946580.md
+++ b/references_cache/PMID_18946580.md
@@ -1,0 +1,56 @@
+---
+reference_id: "PMID:18946580"
+title: Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with infantile malignant osteopetrosis.
+authors:
+- Abbaszadegan MR
+- Modarresi A
+- Khadivi-Zand F
+- Velayati A
+journal: Saudi Med J
+year: '2008'
+keywords:
+- "Abnormalities, Multiple/genetics"
+- "Child, Preschool"
+- Female
+- Gene Deletion
+- Humans
+- Iran
+- Osteopetrosis/genetics
+- Vacuolar Proton-Translocating ATPases/genetics
+content_type: abstract_only
+---
+
+# Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with infantile malignant osteopetrosis.
+**Authors:** Abbaszadegan MR, Modarresi A, Khadivi-Zand F, Velayati A
+**Journal:** Saudi Med J (2008)
+
+## Content
+
+1. Saudi Med J. 2008 Oct;29(10):1494-6.
+
+Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with 
+infantile malignant osteopetrosis.
+
+Abbaszadegan MR(1), Modarresi A, Khadivi-Zand F, Velayati A.
+
+Author information:
+(1)Division of Human Genetics, Immunology Reasearch Center, Avicenna Research 
+Institute, Mashhad University of Medical Sciences, Bu-Ali Square, Mashhad, Iran. 
+abbaszadeganmr@mums.ac.ir
+
+Infantile malignant osteopetrosis (arOP) is an autosomal recessive disorder. 
+Mutations in the T-cell immune regulator 1 (TCIRG1) gene were found as the cause 
+of arOP. We found the first Iranian patient with a rare gross deletion in this 
+gene. The patient was a 5-year-old girl with macrocephaly, facial dysmorphism, 
+blindness, mental retardation, hepatosplenomegaly, pancytopenia, and 
+osteosclerotic changes in the skull and limb. Molecular analysis was performed 
+using reverse transcriptase-polymerase chain reaction for exons 10-19 of the 
+TCIRG1 gene followed by whole gene sequencing. She showed a 275 bp unexpected 
+amplified segment. Sequencing revealed a gross deletion in exons 10-15 
+transcript region of TCIRG1 that affected codon 389 to 518. Various types of 
+mutations in the TCIRG1 gene in arOP have been reported, however, gross 
+deletions are reported rarely. This gross deletion is the first mutation 
+reported among Iranian patients in this gene. This deletion is also the largest 
+deletion of TCIRG1 gene reported to date.
+
+PMID: 18946580 [Indexed for MEDLINE]

--- a/references_cache/PMID_30898950.md
+++ b/references_cache/PMID_30898950.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:30898950"
+title: Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult.
+authors:
+- Dunphy L
+- Warfield A
+- Williams R
+journal: BMJ Case Rep
+year: '2019'
+doi: 10.1136/bcr-2018-224452
+keywords:
+- "Anti-Bacterial Agents/administration & dosage"
+- Female
+- Humans
+- "Mandible/diagnostic imaging, pathology"
+- "Meropenem/administration & dosage"
+- "Osteomyelitis/complications, drug therapy, microbiology, pathology"
+- Osteopetrosis/complications
+- "Streptococcus constellatus/isolation & purification"
+- "Streptococcus mitis/isolation & purification"
+- "Streptococcus oralis/isolation & purification"
+- Young Adult
+content_type: abstract_only
+---
+
+# Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult.
+**Authors:** Dunphy L, Warfield A, Williams R
+**Journal:** BMJ Case Rep (2019)
+**DOI:** [10.1136/bcr-2018-224452](https://doi.org/10.1136/bcr-2018-224452)
+
+## Content
+
+1. BMJ Case Rep. 2019 Mar 20;12(3):e224452. doi: 10.1136/bcr-2018-224452.
+
+Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in 
+an adult.
+
+Dunphy L(1), Warfield A(2), Williams R(3).
+
+Author information:
+(1)Department of Surgery, Milton Keynes University Hospital, Milton Keynes, UK.
+(2)Department of Histopathology, Queen Elizabeth Hospital Birmingham, 
+Birmingham, UK.
+(3)Department of Oral and Maxillofacial Surgery, The Queen Elizabeth Hospital, 
+Birmingham, UK.
+
+Malignant infantile osteopetrosis (MIOP), an autosomal-recessive disorder, is 
+extremely rare, presenting early in life with extreme sclerosis of the skeleton 
+and reduced activity of osteoclasts. It was first described by Albers Schonberg 
+in 1904. Disease manifestations include compensatory extramedullary 
+haematopoiesis at sites such as the liver and spleen, hepatosplenomegaly, 
+anaemia and thrombocytopaenia. Neurological manifestations can also occur due to 
+narrowing of osseous foramina resulting in visual impairment, hearing loss, 
+facial palsy and hydrocephalus. In addition, growth retardation and recurrent 
+infections requiring long-term antibiotic use are common. The incidence of MIOP 
+is 1/2 000 000 and if untreated, then it has a fatal outcome, with the majority 
+of cases occurring within the first 5 years of life. At present, the only 
+potentially curative option is a haematopoietic stem cell transplant. We present 
+a 21-year-old woman, diagnosed with malignant infantile osteopetrosis, due to a 
+mutation in the T-cell immune regulator 1 gene when aged 6 weeks, presenting 
+with chronic osteomyelitis of her left mandible. As malignant infantile 
+osteopetrosis has a high mortality in infancy, we felt it prudent to report this 
+rare case in a patient surviving to adulthood.
+
+© BMJ Publishing Group Limited 2019. No commercial re-use. See rights and 
+permissions. Published by BMJ.
+
+DOI: 10.1136/bcr-2018-224452
+PMCID: PMC6453288
+PMID: 30898950 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None declared.

--- a/references_cache/PMID_34519872.md
+++ b/references_cache/PMID_34519872.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:34519872"
+title: "Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis."
+authors:
+- Lee A
+- Cortez S
+- Yang P
+- Aum D
+- Singh P
+- Gooch C
+- Smyth M
+journal: Childs Nerv Syst
+year: '2021'
+doi: 10.1007/s00381-021-05345-y
+keywords:
+- Female
+- Humans
+- "Hydrocephalus/diagnostic imaging, etiology, surgery"
+- Hyperostosis
+- Infant
+- "Osteopetrosis/complications, diagnostic imaging"
+- Skull
+- Ventriculoperitoneal Shunt
+content_type: abstract_only
+---
+
+# Neonatal hydrocephalus: an atypical presentation of malignant infantile osteopetrosis.
+**Authors:** Lee A, Cortez S, Yang P, Aum D, Singh P, Gooch C, Smyth M
+**Journal:** Childs Nerv Syst (2021)
+**DOI:** [10.1007/s00381-021-05345-y](https://doi.org/10.1007/s00381-021-05345-y)
+
+## Content
+
+1. Childs Nerv Syst. 2021 Dec;37(12):3695-3703. doi: 10.1007/s00381-021-05345-y. 
+Epub 2021 Sep 14.
+
+Neonatal hydrocephalus: an atypical presentation of malignant infantile 
+osteopetrosis.
+
+Lee A(1)(2), Cortez S(3), Yang P(4), Aum D(4), Singh P(5), Gooch C(5), Smyth 
+M(4).
+
+Author information:
+(1)Department of Pediatrics, Division of Genetics and Genomic Medicine, 
+Washington University in St Louis, Saint Louis, MO, USA. leeangela@wustl.edu.
+(2)Saint Louis Children's Hospital, One Children's Place, MO, 63110, Saint 
+Louis, USA. leeangela@wustl.edu.
+(3)Department of Pediatrics, Division of Pediatric Endocrinology and Diabetes, 
+Washington University in St Louis, , Saint Louis, MO, USA.
+(4)Department of Neurological Surgery and Pediatrics, St. Louis Children's 
+Hospital, Washington University in St. Louis, Saint Louis, MO, USA.
+(5)Department of Pediatrics, Division of Genetics and Genomic Medicine, 
+Washington University in St Louis, Saint Louis, MO, USA.
+
+PURPOSE: Autosomal recessive osteopetrosis has a variable presentation, most 
+commonly including failure to thrive, hypocalcemia, seizures, 
+hepatosplenomegaly, hydrocephalus, vision or hearing loss, and cytopenias. 
+Multiple symptoms are usually seen at presentation. The variability of 
+presentation often delays diagnosis and subsequent treatment. Here, we present a 
+case of an infant with this condition who initially presented with 
+triventricular hydrocephalus with Chiari I malformation. This alone is not a 
+common presentation of this disease, and we present this case to highlight 
+autosomal recessive osteopetrosis as a potential diagnosis in infants presenting 
+with hydrocephalus and discuss the other associated symptoms, management, and 
+prognosis of this condition.
+CASE REPORT: The patient was a full-term infant with a routine newborn period. 
+At 6 months, the infant had macrocephaly and frontal bossing with a bulging 
+fontanelle. She was found to have hydrocephalus with moderate ventriculomegaly 
+involving the third and lateral ventricles with an associated Chiari 1 
+malformation. The infant was asymptomatic at the time. The infant was promptly 
+referred to neurosurgery and underwent an uncomplicated ventriculoperitoneal 
+shunt placement. Post-operative X-rays showed increased density of the skull 
+with other bone changes suggestive of autosomal recessive osteopetrosis. 
+Subsequent lab work and imaging studies were consistent with this condition. The 
+diagnosis was confirmed by genetic testing, and the patient has undergone 
+treatment with hematopoietic stem cell transplant.
+CONCLUSION: Hydrocephalus is a common feature of this condition, typically seen 
+in conjunction with other systemic symptoms and laboratory findings. Our patient 
+had a limited initial presentation of triventricular hydrocephalus with Chiari I 
+malformation and was otherwise clinically asymptomatic. There is limited 
+literature of such a presentation, and we highlight this case to increase 
+awareness, as timely diagnosis of these patients is critical for treatment and 
+future outcomes.
+
+© 2021. The Author(s), under exclusive licence to Springer-Verlag GmbH Germany, 
+part of Springer Nature.
+
+DOI: 10.1007/s00381-021-05345-y
+PMID: 34519872 [Indexed for MEDLINE]

--- a/references_cache/PMID_34545712.md
+++ b/references_cache/PMID_34545712.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:34545712"
+title: Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis.
+authors:
+- Liang H
+- Li N
+- Yao RE
+- Yu T
+- Ding L
+- Chen J
+- Wang J
+journal: Mol Genet Genomic Med
+year: '2021'
+doi: 10.1002/mgg3.1815
+keywords:
+- "Child, Preschool"
+- Chloride Channels/genetics
+- Female
+- "Genes, Recessive"
+- Humans
+- Infant
+- Male
+- Mutation
+- "Osteopetrosis/genetics, pathology"
+- Vacuolar Proton-Translocating ATPases/genetics
+content_type: abstract_only
+---
+
+# Clinical and molecular characterization of five Chinese patients with autosomal recessive osteopetrosis.
+**Authors:** Liang H, Li N, Yao RE, Yu T, Ding L, Chen J, Wang J
+**Journal:** Mol Genet Genomic Med (2021)
+**DOI:** [10.1002/mgg3.1815](https://doi.org/10.1002/mgg3.1815)
+
+## Content
+
+1. Mol Genet Genomic Med. 2021 Nov;9(11):e1815. doi: 10.1002/mgg3.1815. Epub 2021
+ Sep 21.
+
+Clinical and molecular characterization of five Chinese patients with autosomal 
+recessive osteopetrosis.
+
+Liang H(1), Li N(2)(3), Yao RE(2)(3), Yu T(2)(3), Ding L(1), Chen J(1), Wang 
+J(2)(3).
+
+Author information:
+(1)Key Laboratory of Pediatric Hematology and Oncology, Ministry of Health, 
+Department of Hematology and Oncology, Shanghai Children's Medical Center, 
+Shanghai Jiao Tong University School of Medicine, Shanghai, China.
+(2)Department of Medical Genetics and Molecular Diagnostic Laboratory, Shanghai 
+Children's Medical Center, Shanghai Jiao Tong University School of Medicine, 
+Shanghai, China.
+(3)Shanghai Key Laboratory of Clinical Molecular Diagnostics for Pediatrics, 
+Shanghai, China.
+
+BACKGROUND: Osteopetrosis is characterized by increased bone density and bone 
+marrow cavity stenosis due to a decrease in the number of osteoclasts or the 
+dysfunction of their differentiation and absorption properties usually caused by 
+biallelic variants of the TCIRG1 and CLCN7 genes.
+METHODS: In this study, we describe five Chinese children who presented with 
+anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased 
+bone density. Whole-exome sequencing identified five compound heterozygous 
+variants of the CLCN7 and TCIRG1 genes in these patients.
+RESULTS: Patient 1 had a novel variant c.1555C>T (p.L519F) and a previously 
+reported pathogenic variant c.2299C>T (p.R767W) in CLCN7. Patient 2 harbored a 
+novel missense variant (c.1025T>C; p.L342P) and a novel splicing variant 
+(c.286-9G>A) in CLCN7. Patients 3A and 3B from one family displayed the same 
+compound heterozygous TCIRG1 variant, including a novel frameshift variant 
+(c.1370del; p.T457Tfs*71) and a novel splicing variant (c.1554+2T>C). In Patient 
+4, two novel variants were identified in the TCIRG1 gene: c.676G>T; p.E226* and 
+c.1191del; p.P398Sfs*5. Patient 5 harbored two known pathogenic variants, 
+c.909C>A (p.Y303*) and c.2008C>T (p.R670*), in TCIRG1. Analysis of the products 
+obtained from the reverse transcription-polymerase chain reaction revealed that 
+the c.286-9G>A variant in CLCN7 of patient 2 leads to intron 3 retention, 
+resulting in the formation of a premature termination codon (p.E95Vfs*8). These 
+five patients were eventually diagnosed with autosomal recessive osteopetrosis, 
+and the three children with TCIRG1 variants received hematopoietic stem cell 
+transplantation.
+CONCLUSIONS: Our results expand the spectrum of variation of genes related to 
+osteopetrosis and deepen the understanding of the relationship between the 
+genotype and clinical characteristics of osteopetrosis.
+
+© 2021 The Authors. Molecular Genetics & Genomic Medicine published by Wiley 
+Periodicals LLC.
+
+DOI: 10.1002/mgg3.1815
+PMCID: PMC8606217
+PMID: 34545712 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have declared no conflict of 
+interest.

--- a/references_cache/PMID_40462430.md
+++ b/references_cache/PMID_40462430.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:40462430"
+title: "[Clinical and genetic characteristics of osteopetrosis in children]."
+authors:
+- Wang M
+- Jiang AS
+- Zhu CL
+- Wang J
+- Wang YP
+- Gao S
+- Li Y
+- Chen TP
+- Liu HJ
+- Wang J
+journal: Zhongguo Dang Dai Er Ke Za Zhi
+year: '2025'
+doi: 10.7499/j.issn.1008-8830.2411167
+keywords:
+- Humans
+- Osteopetrosis/genetics
+- Male
+- Female
+- Infant
+- "Child, Preschool"
+- Retrospective Studies
+- Vacuolar Proton-Translocating ATPases/genetics
+- Child
+- Chloride Channels/genetics
+- Mutation
+- Receptor Activator of Nuclear Factor-kappa B
+content_type: abstract_only
+---
+
+# [Clinical and genetic characteristics of osteopetrosis in children].
+**Authors:** Wang M, Jiang AS, Zhu CL, Wang J, Wang YP, Gao S, Li Y, Chen TP, Liu HJ, Wang J
+**Journal:** Zhongguo Dang Dai Er Ke Za Zhi (2025)
+**DOI:** [10.7499/j.issn.1008-8830.2411167](https://doi.org/10.7499/j.issn.1008-8830.2411167)
+
+## Content
+
+1. Zhongguo Dang Dai Er Ke Za Zhi. 2025 May 15;27(5):568-573. doi: 
+10.7499/j.issn.1008-8830.2411167.
+
+[Clinical and genetic characteristics of osteopetrosis in children].
+
+[Article in Chinese; Abstract available in Chinese from the publisher]
+
+Wang M(1), Jiang AS(1), Zhu CL(1), Wang J(1), Wang YP(1), Gao S(1), Li Y(1), 
+Chen TP(1), Liu HJ(1), Wang J(1).
+
+Author information:
+(1)Department of Hematology and Oncology, Anhui Provincial Children's Hospital, 
+Hefei 230022, China.
+
+OBJECTIVES: To study the clinical and genetic characteristics of osteopetrosis 
+(OPT) in children.
+METHODS: A retrospective analysis was performed on the clinical data of 14 
+children with OPT. Whole-exome sequencing was used to detect pathogenic genes, 
+and clinical phenotypes and genotypic features were summarized.
+RESULTS: Among the 14 children (10 males and 4 females), the median age at 
+diagnosis was 8 months. Clinical manifestations included systemic osteosclerosis 
+(14 cases, 100%), anemia (12 cases, 86%), infections (10 cases, 71%), 
+thrombocytopenia (9 cases, 64%), hepatosplenomegaly (8 cases, 57%), and 
+developmental delay (5 cases, 36%). Malignant osteopetrosis (MOP) cases had 
+lower platelet counts, creatine kinase isoenzyme, and serum calcium levels, but 
+higher white blood cell counts, lactate dehydrogenase, and alkaline phosphatase 
+levels compared to non-MOP cases (P<0.05). Genetic testing identified 15 
+variants in 12 patients, including 8 variants in the CLCN7 gene (53%), 6 in the 
+TCIRG1 gene (40%), and 1 in the TNFRSF11A gene (7%). Three novel CLCN7 variants 
+were identified: c.2351G>C, c.1215-43C>T, and c.1534G>A. All four patients with 
+TCIRG1 variants exhibited MOP clinical phenotypes. Of the seven patients with 
+CLCN7 variants, 4 presented with intermediate OPT, 2 with benign OPT, and 1 with 
+MOP.
+CONCLUSIONS: Clinical phenotypes of OPT in children are heterogeneous, 
+predominantly involving CLCN7 and TCIRG1 gene variants, with a correlation 
+between clinical phenotypes and genotypes.
+
+Publisher: 目的: 分析儿童骨硬化症（osteopetrosis, OPT）的临床和遗传学特征。方法: 
+回顾性分析2015年5月—2024年3月收治的14例OPT患儿的临床资料，采用全外显子组测序技术检测OPT相关致病基因，并总结临床表型和基因型特点。结果: 
+14例患儿，男性10例，女性4例，中位就诊年龄8个月。OPT患儿临床表现主要为全身性骨硬化（14例，100%）、贫血（12例，86%）、感染（10例，71%）、血小板减少（9例，64%）、肝脾大（8例，57%）和发育迟缓（5例，36%）等。恶性型OPT（malignant 
+osteopetrosis, 
+MOP）患儿的血小板计数、肌酸激酶同工酶和血钙低于非MOP患儿，而白细胞计数、乳酸脱氢酶和碱性磷酸酶高于非MOP患儿（P<0.05）。12例患儿完成基因检测，共检出15种变异，CLCN7基因变异8个（53%），TCIRG1基因变异6个（40%），TNFRSF11A基因变异1个（7%）。CLCN7基因发现3个新位点变异，为c.2351G>C、c.1215-43C>T和c.1534G>A。4例TCIRG1基因型患儿的临床表型均为MOP。7例CLCN7基因型患儿中，中间型OPT 
+4例，良性型OPT 2例，MOP 1例。结论: OPT患儿的临床表型具有异质性，基因型以CLCN7和TCIRG1基因变异为主，临床表型与基因型之间有一定关联。.
+
+DOI: 10.7499/j.issn.1008-8830.2411167
+PMCID: PMC12169871
+PMID: 40462430 [Indexed for MEDLINE]
+
+Conflict of interest statement: 所有作者均声明不存在利益冲突。


### PR DESCRIPTION
Closes #1520

## What changed
- replaced the sparse phenotype section in `kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` with a PMID-backed set of clinically important phenotypes
- added specific HPO-grounded manifestations for marrow failure, hepatosplenomegaly, recurrent infections, cranial complications, growth/metabolic findings, and neurodevelopmental involvement
- removed the unsupported generic cranial-nerve phenotype claim in favor of more specific evidence-backed phenotypes
- added the fetched PubMed cache files required for deterministic reference validation

## Why
The previous phenotype section was under-complete and leaned on indirect or unsupported claims. This change constrains the section to manifestations supported by exact cached PMID snippets and keeps the ontology mappings more specific.

## Validation
- `just validate kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` -> passed
- `just validate-references kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` -> passed (`Total checks: 0; All validations passed!`)
- `just validate-terms kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` -> passed
