### PR TITLE
[codex] Enhance OI type VII phenotype evidence

### DIFF
--- a/kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml
@@ -74,7 +74,7 @@ pathophysiology:
   - reference: PMID:17055431
     reference_title: "CRTAP is required for prolyl 3- hydroxylation and mutations cause recessive osteogenesis imperfecta."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: MODEL_ORGANISM
     snippet: >-
       CRTAP can form a complex with P3H1 and cyclophilin B (CYPB), and Crtap-/-
       bone and cartilage collagens show decreased prolyl 3-hydroxylation. Moreover,
@@ -337,26 +337,6 @@ phenotypes:
     explanation: >-
       The founding cohort documents early lower-extremity deformity as part of
       the phenotype.
-- name: Popcorn Epiphyses
-  description: >
-    Bulbous irregular "popcorn" epiphyses have been reported in surviving
-    severe cases, supporting associated growth-plate dysplasia.
-  phenotype_term:
-    preferred_term: Popcorn epiphyses
-    term:
-      id: HP:0010580
-      label: Enlarged epiphyses
-  evidence:
-  - reference: PMID:18566967
-    reference_title: "CRTAP and LEPRE1 mutations in recessive osteogenesis imperfecta."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Interestingly, "popcorn" epiphyses may reflect underlying cartilaginous
-      and bone dysplasia in this form of OI.
-    explanation: >-
-      This abstract specifically highlights "popcorn" epiphyses as a notable
-      radiographic manifestation in recessive OI due to CRTAP/LEPRE1 defects.
 - name: Wormian Bones
   description: >
     Wormian bones have been reported in severe craniofacial involvement.
@@ -403,8 +383,8 @@ phenotypes:
   phenotype_term:
     preferred_term: High myopia
     term:
-      id: HP:0000545
-      label: Myopia
+      id: HP:0011003
+      label: High myopia
   evidence:
   - reference: PMID:41064055
     reference_title: "CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in CRTAP."

--- a/kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type VII
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-07T16:13:00Z'
+updated_date: '2026-04-19T07:26:23Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type VII is a severe autosomal recessive form of OI
@@ -8,8 +8,9 @@ description: >
   forms a complex with P3H1 (LEPRE1) and cyclophilin B (PPIB) that catalyzes
   3-hydroxylation of a specific proline residue in type I collagen, essential
   for proper collagen folding and stability. Loss of CRTAP function impairs
-  collagen modification, leading to severe bone fragility resembling types II/III
-  OI but with distinctive features including rhizomelia and white sclerae.
+  collagen modification, leading to a bone-fragility spectrum that overlaps
+  severe OI types II/III and is often accompanied by rhizomelia, coxa vara,
+  and growth impairment.
 disease_term:
   preferred_term: Osteogenesis imperfecta type VII
   term:
@@ -133,16 +134,26 @@ genetic:
       Original paper identifying CRTAP mutations as cause of recessive OI types,
       establishing a new mechanism for OI distinct from collagen structural mutations.
 phenotypes:
-- name: Severe Bone Fragility
+- name: Recurrent Fractures
   description: >
-    Multiple fractures at birth or in early infancy, with ongoing fracture
-    susceptibility throughout life.
+    Bone fragility typically manifests with recurrent fractures beginning
+    prenatally, at birth, or in early childhood.
   phenotype_term:
     preferred_term: Recurrent fractures
     term:
       id: HP:0002757
       label: Recurrent fractures
   evidence:
+  - reference: PMID:38214665
+    reference_title: "Genetic Analysis, Phenotypic Spectrum and Functional Study of Rare Osteogenesis Imperfecta Caused by CRTAP Variants."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with OI type VII had early-onset recurrent fractures, severe
+      osteoporosis, and bone deformities.
+    explanation: >-
+      The 2024 CRTAP cohort directly identifies early-onset recurrent fractures
+      as a prominent phenotype.
   - reference: PMID:12110406
     reference_title: "Osteogenesis imperfecta type VII: an autosomal recessive form of brittle bone disease."
     supports: SUPPORT
@@ -152,8 +163,20 @@ phenotypes:
       bluish sclerae, early deformity of the lower extremities, coxa vara, and
       osteopenia.
     explanation: >-
-      The original OI type VII paper describes fractures at birth as a defining
-      feature of the phenotype.
+      The founding OI type VII cohort describes fractures at birth as part of
+      the defining phenotype.
+  - reference: PMID:41064055
+    reference_title: "CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in CRTAP."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The phenotype varied extensively in terms of severity and clinical
+      features, ranging from moderate (type IV) to severe (type III) and
+      including cases with prenatal fractures as well as one case with a low
+      number of fractures and no prenatal fractures.
+    explanation: >-
+      This 2025 series shows that fracture onset is variable, including prenatal
+      presentation as well as milder postnatal cases.
 - name: Rhizomelia
   description: >
     Characteristic shortening of the proximal limb segments (humerus, femur),
@@ -173,14 +196,15 @@ phenotypes:
     explanation: >-
       The original OI type VII paper identifies rhizomelia as a prominent and
       distinguishing clinical feature.
-- name: Severe Short Stature
+- name: Growth Delay
   description: >
-    Profound growth deficiency with adult height significantly below normal.
+    Impaired growth is reported in childhood survivors and contributes to short
+    stature in more severely affected individuals.
   phenotype_term:
-    preferred_term: Severe short stature
+    preferred_term: Growth delay
     term:
-      id: HP:0003510
-      label: Severe short stature
+      id: HP:0001510
+      label: Growth delay
   evidence:
   - reference: PMID:19895918
     reference_title: "CRTAP deficiency leads to abnormally high bone matrix mineralization in a murine model and in children with osteogenesis imperfecta type VII."
@@ -190,8 +214,8 @@ phenotypes:
       patients have fractures at birth, deformities of the lower extremities
       and impaired growth
     explanation: >-
-      Fratzl-Zelman et al. describe impaired growth as a key feature of OI type
-      VII patients with CRTAP deficiency.
+      This human cohort supports impaired growth, but not a uniform claim of
+      severe short stature across all OI type VII patients.
 - name: Blue Sclerae
   description: >
     Bluish sclerae are part of the original clinical description of OI type VII.
@@ -232,11 +256,12 @@ phenotypes:
     explanation: >-
       Coxa vara is listed as a defining phenotypic feature of OI type VII in
       the original characterization of the disorder.
-- name: Osteopenia
+- name: Low Bone Mineral Density
   description: >
-    Severely reduced bone mineral density on imaging.
+    Reduced bone mineral density ranges from osteopenia in the founding cohort
+    to extremely low bone mineral density in more severe cases.
   phenotype_term:
-    preferred_term: Osteopenia
+    preferred_term: Low bone mineral density
     term:
       id: HP:0000938
       label: Osteopenia
@@ -250,8 +275,167 @@ phenotypes:
       bluish sclerae, early deformity of the lower extremities, coxa vara, and
       osteopenia.
     explanation: >-
-      Osteopenia is listed as a defining feature of OI type VII in the original
-      description of the disorder.
+      Osteopenia is listed as a defining feature in the founding OI type VII
+      cohort.
+  - reference: PMID:18566967
+    reference_title: "CRTAP and LEPRE1 mutations in recessive osteogenesis imperfecta."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Infants in both groups had multiple fractures, decreased bone modeling
+      (affecting especially the femurs), and extremely low bone mineral density.
+    explanation: >-
+      This expands the low-BMD phenotype to the severe neonatal presentation of
+      CRTAP-related recessive OI.
+- name: Osteoporosis
+  description: >
+    Severe osteoporosis is part of the more severe CRTAP-related OI type VII
+    phenotype spectrum.
+  phenotype_term:
+    preferred_term: Osteoporosis
+    term:
+      id: HP:0000939
+      label: Osteoporosis
+  evidence:
+  - reference: PMID:38214665
+    reference_title: "Genetic Analysis, Phenotypic Spectrum and Functional Study of Rare Osteogenesis Imperfecta Caused by CRTAP Variants."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with OI type VII had early-onset recurrent fractures, severe
+      osteoporosis, and bone deformities.
+    explanation: >-
+      The 2024 CRTAP case series explicitly reports severe osteoporosis.
+- name: Skeletal Deformities
+  description: >
+    Long-bone and other skeletal deformities arise early and contribute to
+    clinical severity.
+  phenotype_term:
+    preferred_term: Skeletal deformity
+    term:
+      id: HP:0000924
+      label: Abnormality of the skeletal system
+  evidence:
+  - reference: PMID:38214665
+    reference_title: "Genetic Analysis, Phenotypic Spectrum and Functional Study of Rare Osteogenesis Imperfecta Caused by CRTAP Variants."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with OI type VII had early-onset recurrent fractures, severe
+      osteoporosis, and bone deformities.
+    explanation: >-
+      The 2024 CRTAP cohort directly identifies bone deformities as a prominent
+      phenotype.
+  - reference: PMID:12110406
+    reference_title: "Osteogenesis imperfecta type VII: an autosomal recessive form of brittle bone disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The phenotype is moderate to severe, characterized by fractures at birth,
+      bluish sclerae, early deformity of the lower extremities, coxa vara, and
+      osteopenia.
+    explanation: >-
+      The founding cohort documents early lower-extremity deformity as part of
+      the phenotype.
+- name: Popcorn Epiphyses
+  description: >
+    Bulbous irregular "popcorn" epiphyses have been reported in surviving
+    severe cases, supporting associated growth-plate dysplasia.
+  phenotype_term:
+    preferred_term: Popcorn epiphyses
+    term:
+      id: HP:0010580
+      label: Enlarged epiphyses
+  evidence:
+  - reference: PMID:18566967
+    reference_title: "CRTAP and LEPRE1 mutations in recessive osteogenesis imperfecta."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Interestingly, "popcorn" epiphyses may reflect underlying cartilaginous
+      and bone dysplasia in this form of OI.
+    explanation: >-
+      This abstract specifically highlights "popcorn" epiphyses as a notable
+      radiographic manifestation in recessive OI due to CRTAP/LEPRE1 defects.
+- name: Wormian Bones
+  description: >
+    Wormian bones have been reported in severe craniofacial involvement.
+  phenotype_term:
+    preferred_term: Wormian bones
+    term:
+      id: HP:0002645
+      label: Wormian bones
+  evidence:
+  - reference: PMID:35970273
+    reference_title: "Craniofacial and dental phenotype of two girls with osteogenesis imperfecta due to mutations in CRTAP."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cone-beam computed tomography showed occipital bossing, platybasia and
+      wormian bones.
+    explanation: >-
+      Wormian bones were documented on craniofacial imaging in the more severe
+      of two 11-year-old girls with CRTAP-related OI.
+- name: Platybasia
+  description: >
+    Platybasia has been reported as part of the craniofacial phenotype in severe
+    childhood OI type VII.
+  phenotype_term:
+    preferred_term: Platybasia
+    term:
+      id: HP:0002691
+      label: Platybasia
+  evidence:
+  - reference: PMID:35970273
+    reference_title: "Craniofacial and dental phenotype of two girls with osteogenesis imperfecta due to mutations in CRTAP."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cone-beam computed tomography showed occipital bossing, platybasia and
+      wormian bones.
+    explanation: >-
+      Platybasia was documented on craniofacial imaging in the more severe of
+      two 11-year-old girls with CRTAP-related OI.
+- name: High Myopia
+  description: >
+    High myopia has been reported in an adult with CRTAP-related OI, suggesting
+    that ocular involvement can occur outside the skeleton.
+  phenotype_term:
+    preferred_term: High myopia
+    term:
+      id: HP:0000545
+      label: Myopia
+  evidence:
+  - reference: PMID:41064055
+    reference_title: "CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in CRTAP."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Interestingly, 1 patient presented with high myopia and bilateral retinal
+      detachment, which have not been previously reported in OI type VII.
+    explanation: >-
+      This should be interpreted cautiously as a single-patient report, but it
+      expands the reported extraskeletal phenotype of CRTAP-related OI.
+- name: Retinal Detachment
+  description: >
+    Bilateral retinal detachment has been reported in an adult with
+    CRTAP-related OI type VII.
+  phenotype_term:
+    preferred_term: Retinal detachment
+    term:
+      id: HP:0000541
+      label: Retinal detachment
+  evidence:
+  - reference: PMID:41064055
+    reference_title: "CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in CRTAP."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Interestingly, 1 patient presented with high myopia and bilateral retinal
+      detachment, which have not been previously reported in OI type VII.
+    explanation: >-
+      This is a single-patient report rather than a core defining feature, but
+      it is a clinically important ocular manifestation when present.
 treatments:
 - name: Bisphosphonate Therapy
   description: >
@@ -399,4 +583,13 @@ references:
   findings: []
 - reference: DOI:10.1210/clinem/dgae025
   title: Genetic Analysis, Phenotypic Spectrum and Functional Study of Rare Osteogenesis Imperfecta Caused by <i>CRTAP</i> Variants
+  findings: []
+- reference: DOI:10.1016/j.bone.2022.116516
+  title: Craniofacial and dental phenotype of two girls with osteogenesis imperfecta due to mutations in <i>CRTAP</i>
+  findings: []
+- reference: DOI:10.1002/humu.20799
+  title: <i>CRTAP</i> and <i>LEPRE1</i> mutations in recessive osteogenesis imperfecta
+  findings: []
+- reference: DOI:10.1159/000547923
+  title: "<i>CRTAP</i>-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in <i>CRTAP</i>"
   findings: []

--- a/references_cache/PMID_35970273.md
+++ b/references_cache/PMID_35970273.md
@@ -1,0 +1,102 @@
+---
+reference_id: "PMID:35970273"
+title: Craniofacial and dental phenotype of two girls with osteogenesis imperfecta due to mutations in CRTAP.
+authors:
+- Marulanda J
+- Ludwig K
+- Glorieux F
+- Lee B
+- Sutton VR
+- Members of the BBD Consortium
+- Retrouvey JM
+- Rauch F
+journal: Bone
+year: '2022'
+doi: 10.1016/j.bone.2022.116516
+keywords:
+- Amino Acids
+- Animals
+- Child
+- Diphosphonates
+- Extracellular Matrix Proteins/metabolism
+- Female
+- Humans
+- Infant
+- Malocclusion/genetics
+- Mice
+- "Molecular Chaperones/genetics, metabolism"
+- Mutation/genetics
+- "Osteogenesis Imperfecta/diagnostic imaging, genetics, metabolism"
+- Phenotype
+- RNA Splice Sites
+- Skull/metabolism
+content_type: abstract_only
+---
+
+# Craniofacial and dental phenotype of two girls with osteogenesis imperfecta due to mutations in CRTAP.
+**Authors:** Marulanda J, Ludwig K, Glorieux F, Lee B, Sutton VR, Members of the BBD Consortium, Retrouvey JM, Rauch F
+**Journal:** Bone (2022)
+**DOI:** [10.1016/j.bone.2022.116516](https://doi.org/10.1016/j.bone.2022.116516)
+
+## Content
+
+1. Bone. 2022 Nov;164:116516. doi: 10.1016/j.bone.2022.116516. Epub 2022 Aug 12.
+
+Craniofacial and dental phenotype of two girls with osteogenesis imperfecta due 
+to mutations in CRTAP.
+
+Marulanda J(1), Ludwig K(1), Glorieux F(2), Lee B(3), Sutton VR(3); Members of 
+the BBD Consortium; Retrouvey JM(4), Rauch F(5).
+
+Author information:
+(1)Shriners Hospital for Children - Canada, Montreal, QC, Canada; Department of 
+Pediatrics, McGill University, Montreal, QC, Canada.
+(2)Shriners Hospital for Children - Canada, Montreal, QC, Canada.
+(3)Department of Molecular and Human Genetics, Baylor College of Medicine, 
+Houston, TX, USA.
+(4)University of Missouri-Kansas City, Kansas City, MO, USA.
+(5)Shriners Hospital for Children - Canada, Montreal, QC, Canada; Department of 
+Pediatrics, McGill University, Montreal, QC, Canada. Electronic address: 
+frank.rauch@mcgill.ca.
+
+Mutations in CRTAP lead to an extremely rare form of recessive osteogenesis 
+imperfecta (OI). CRTAP deficient mice have a brachycephalic skull, fusion of 
+facial bones, midface retrusion and class III dental malocclusion, but in 
+humans, the craniofacial and dental phenotype has not been reported in detail. 
+Here, we describe craniofacial and dental findings in two 11-year-old girls with 
+biallelic CRTAP mutations. Patient 1 has a homozygous c.472-1021C>G variant in 
+CRTAP intron 1 and a moderately severe OI phenotype. The variant is known to 
+create a cryptic splice site, leading to a frameshift and nonsense-mediated RNA 
+decay. Patient 1 started intravenous bisphosphonate treatment at 2 years of age. 
+At age 11 years, height Z-score was +0.6. She had a short and wide face, concave 
+profile and class III malocclusion, with a prognathic mandible and an 
+antero-posterior crossbite. A panoramic radiograph showed a poor angulation of 
+the second upper right premolar, and no dentinogenesis imperfecta or dental 
+agenesis. Cone-beam computed tomography confirmed these findings and did not 
+reveal any other abnormalities. Patient 2 has a homozygous CRTAP deletion of two 
+amino acids (c.804_809del, p.Glu269_Val270del) and a severe OI phenotype. As 
+previously established, the variant leads to instability of CRTAP protein. 
+Intravenous bisphosphonate treatment was started at the age of 15 months. At 
+11 years of age her height Z-score was -9.7. She had a long and narrow face and 
+convex profile, maxillary retrusion leading to a class III malocclusion, an 
+edge-to-edge overjet and lateral open bite. Panoramic radiographs showed no 
+dental abnormalities. Cone-beam computed tomography showed occipital bossing, 
+platybasia and wormian bones. In these two girls with CRTAP mutations, the 
+severity of the skeletal phenotype was mirrored in the severity of the 
+craniofacial phenotype. Class III malocclusion and antero-posterior crossbite 
+were a common trait, while dental agenesis or dentinogenesis imperfecta were not 
+detected.
+
+Copyright © 2022 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.bone.2022.116516
+PMCID: PMC10408670
+PMID: 35970273 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest Juliana 
+Marulanda: None. Karissa Ludwig: None. Francis Glorieux: Novartis, Amgen and 
+Mereo Biopharma: consulting fees and research grants. Brendan Lee: Sanofi 
+research grant; Biomarin consulting fees. Reid Sutton: Ultragenyx research 
+funding. Jean-Marc Retrouvey: Ultragenyx consulting fees. Frank Rauch: Mereo 
+Biopharma, Ultragenyx, Sanofi, Ibsen: consulting fees; Catabasis: Study grant to 
+institution.

--- a/references_cache/PMID_41064055.md
+++ b/references_cache/PMID_41064055.md
@@ -1,0 +1,93 @@
+---
+reference_id: "PMID:41064055"
+title: "CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in CRTAP."
+authors:
+- Travessa AM
+- Romeu JC
+- Mirco T
+- Vaz-de-Macedo C
+- Palma MJ
+- Modamio-Høybjør S
+- Barreiros C
+- Magalhães A
+- Barão RC
+- Heath KE
+- Sousa AB
+journal: Mol Syndromol
+year: '2025'
+doi: 10.1159/000547923
+content_type: abstract_only
+---
+
+# CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential Founder Variant in CRTAP.
+**Authors:** Travessa AM, Romeu JC, Mirco T, Vaz-de-Macedo C, Palma MJ, Modamio-Høybjør S, Barreiros C, Magalhães A, Barão RC, Heath KE, Sousa AB
+**Journal:** Mol Syndromol (2025)
+**DOI:** [10.1159/000547923](https://doi.org/10.1159/000547923)
+
+## Content
+
+1. Mol Syndromol. 2025 Aug 20. doi: 10.1159/000547923. Online ahead of print.
+
+CRTAP-Related Osteogenesis Imperfecta: Clinical Variability and a Potential 
+Founder Variant in CRTAP.
+
+Travessa AM(1)(2)(3), Romeu JC(4), Mirco T(5), Vaz-de-Macedo C(6), Palma MJ(6), 
+Modamio-Høybjør S(7)(8)(9), Barreiros C(10)(11)(12), Magalhães A(11)(12), Barão 
+RC(13), Heath KE(7)(8)(9), Sousa AB(1)(2).
+
+Author information:
+(1)Department of Medical Genetics and ERN-BOND, Hospital de Santa Maria, Centro 
+Hospitalar Universitário Lisboa Norte, Lisbon, Portugal.
+(2)Faculdade de Medicina, Universidade de Lisboa, Lisbon, Portugal.
+(3)Medical Genetics Consultation, Hospital Professor Doutor Fernando Fonseca, 
+Amadora, Portugal.
+(4)Department of Rheumathology and Metabolic Bone Disorders and ERN-BOND, 
+Hospital de Santa Maria, Centro Hospitalar Universitário Lisboa Norte, Lisbon, 
+Portugal.
+(5)Department of Physical Medicine & Rehabilitation and ERN-BOND, Hospital de 
+Santa Maria, Centro Hospitalar Universitário Lisboa Norte, Lisbon, Portugal.
+(6)Department of Obstetrics, Hospital Garcia de Orta, Almada, Portugal.
+(7)Skeletal Dysplasia Multidisciplinary Unit (UMDE) and ERN-BOND, Hospital 
+Universitario la Paz, Madrid, Spain.
+(8)Institute of Medical and Molecular Genetics (INGEMM), Hospital Universitario 
+la Paz, IdiPAZ, Universidad Autónoma de Madrid, Madrid, Spain.
+(9)CIBERER (Centro de Investigación Biomédica en Red de Enfermedades Raras), 
+ISCIII, Madrid, Spain.
+(10)Associação Portuguesa de Osteogénese Imperfeita (APOI), Lisbon, Portugal.
+(11)Cardiology Department and ERN-BOND, Hospital de Santa Maria, Centro 
+Hospitalar Universitário Lisboa Norte, Lisbon, Portugal.
+(12)Cardiovascular Centre of the University of Lisbon (CCUL@RISE), Faculdade de 
+Medicina, Universidade de Lisboa, Lisbon, Portugal.
+(13)Department of Ophthalmology, Hospital de Santa Maria, Centro Hospitalar 
+Universitário Lisboa Norte, Lisbon, Portugal.
+
+INTRODUCTION: CRTAP-related osteogenesis imperfecta (OI) is a form of OI that 
+ranges from moderate (type IV) to extremely severe (type II) and is caused by 
+biallelic variants in the CRTAP gene. To date, only about 30 cases have been 
+reported in the literature.
+METHODS: We describe two adults and one fetus with molecularly confirmed 
+CRTAP-related OI.
+RESULTS: The phenotype varied extensively in terms of severity and clinical 
+features, ranging from moderate (type IV) to severe (type III) and including 
+cases with prenatal fractures as well as one case with a low number of fractures 
+and no prenatal fractures. Interestingly, 1 patient presented with high myopia 
+and bilateral retinal detachment, which have not been previously reported in OI 
+type VII. Regarding molecular results, we identified three CRTAP variants that 
+have not been previously reported in the literature. One of the variants was 
+found in both a woman and an unrelated fetus of Cape Verdean descent, suggesting 
+that the carrier frequency of this variant in the Cape Verde population may be 
+relatively high.
+CONCLUSION: We expand the clinical spectrum of patients with CRTAP variants and 
+highlight the clinical variability of this extremely rare type of OI, which may 
+present with either prenatal or postnatal onset. Our findings also underscore 
+the importance of investigating the role of CRTAP in extra-skeletal tissues and 
+assessing potential founder effects in underrepresented populations.
+
+© 2025 S. Karger AG, Basel.
+
+DOI: 10.1159/000547923
+PMCID: PMC12503711
+PMID: 41064055
+
+Conflict of interest statement: The authors have no conflicts of interest to 
+declare.

--- a/research/Osteogenesis_Imperfecta_Type_VII-phenotype-curation-manual.md
+++ b/research/Osteogenesis_Imperfecta_Type_VII-phenotype-curation-manual.md
@@ -1,0 +1,46 @@
+## Osteogenesis Imperfecta Type VII phenotype curation notes
+
+Date: 2026-04-19
+Target file: `kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml`
+Scope: phenotype section only
+
+### Primary phenotype sources reviewed
+
+- PMID:12110406 - founding eight-person Quebec cohort; strongest source for
+  fractures at birth, bluish sclerae, lower-extremity deformity, coxa vara,
+  osteopenia, and rhizomelia.
+- PMID:19895918 - human OI type VII childhood cohort; supports impaired growth.
+- PMID:18566967 - recessive CRTAP/LEPRE1 OI cohort; supports extremely low bone
+  mineral density and "popcorn" epiphyses in the severe neonatal/surviving
+  spectrum.
+- PMID:38214665 - 2024 CRTAP paper; strongest recent source for early-onset
+  recurrent fractures, severe osteoporosis, and bone deformities.
+- PMID:35970273 - focused craniofacial study in two girls with CRTAP-related OI;
+  supports platybasia and wormian bones.
+- PMID:41064055 - 2025 clinical-variability paper; supports prenatal-vs-postnatal
+  fracture variability and a cautious ocular expansion (high myopia with
+  bilateral retinal detachment in one patient).
+
+### Key phenotype decisions
+
+- Softened `Severe short stature` to `Growth Delay` because the cited evidence
+  supported impaired growth, not a uniform severe-short-stature claim.
+- Removed unsupported `white sclerae` wording from the top description; retained
+  `Blue sclerae` only because the founding abstract explicitly reports bluish
+  sclerae.
+- Added phenotype entries for osteoporosis, skeletal deformities, popcorn
+  epiphyses, wormian bones, platybasia, high myopia, and retinal detachment.
+- Kept ocular findings explicitly cautious because the 2025 paper reports them
+  in one patient rather than as a core defining feature.
+
+### Claims deliberately not added
+
+- Dentinogenesis imperfecta exclusion: the 2022 craniofacial abstract reports
+  absence in two girls only, which is too narrow to encode as a disorder-level
+  excluded phenotype.
+- Class III malocclusion / crossbite: clinically real in the 2022 abstract, but
+  I did not add them because I could not quickly establish a clean, specific HPO
+  mapping with the same confidence as the retained terms.
+- Narrow chest, crumpled long bones, white/light-blue sclerae, and similar
+  lethal-neonatal details from figures/full text were left out because this pass
+  was constrained to abstract-validated PMID evidence.


### PR DESCRIPTION
## Summary
Enhance the phenotype section for `kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml` with tighter PMID-backed clinical evidence.

## What changed
- softened unsupported growth and scleral wording instead of overstating uniform features
- added PMID-backed phenotype evidence for recurrent fractures, low bone mineral density/osteoporosis, skeletal deformities, popcorn epiphyses, wormian bones, platybasia, and cautiously framed ocular findings
- added a focused manual research note and the new PubMed cache files required for deterministic reference validation

## Why
Issue #1525 asked for the phenotype section to be as complete and evidence-backed as possible without broadening the rest of the page.

## Validation
- `just validate kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml`
- `just validate-references kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml`
- `just validate-terms kb/disorders/Osteogenesis_Imperfecta_Type_VII.yaml`

All three commands passed locally.