### PR TITLE
[codex] Enhance OI type V phenotype evidence

### DIFF
--- a/kb/disorders/Osteogenesis_Imperfecta_Type_V.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_V.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type V
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-07T16:08:48Z'
+updated_date: '2026-04-19T07:28:20Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type V is a distinct form of OI caused by a specific
@@ -110,34 +110,34 @@ genetic:
 phenotypes:
 - name: Hyperplastic Callus Formation
   description: >
-    Exuberant callus formation after fractures or surgery, sometimes
-    mimicking osteosarcoma. This is a hallmark feature of type V OI.
+    Exuberant callus formation after fracture is a characteristic complication
+    of osteogenesis imperfecta type V.
   phenotype_term:
     preferred_term: Hyperplastic callus formation
     term:
       id: HP:0030268
       label: Hyperplastic callus formation
+  frequency: FREQUENT
   evidence:
-  - reference: PMID:22863190
-    reference_title: "A single recurrent mutation in the 5'-UTR of IFITM5 causes osteogenesis imperfecta type V."
+  - reference: PMID:23804581
+    reference_title: "Osteogenesis imperfecta type V: clinical and radiographic manifestations in mutation confirmed patients."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      OI type V is an autosomal-dominant disease characterized by calcification of
-      the forearm interosseous membrane, radial head dislocation, a subphyseal
-      metaphyseal radiodense line, and hyperplastic callus formation.
+      Hyperplastic callus was detected in 75% of patients and was commonly
+      encountered at the femur.
     explanation: >-
-      Defines hyperplastic callus formation as one of the cardinal features of OI
-      type V.
-- name: Radioulnar Synostosis
+      This mutation-confirmed cohort quantifies hyperplastic callus formation as
+      a frequent feature of OI type V (75%, within the FREQUENT 30-79% band).
+- name: Limited Forearm Pronation/Supination
   description: >
-    Progressive calcification of the interosseous membrane between radius
-    and ulna, restricting forearm rotation (pronation/supination).
+    Forearm rotation is limited because of calcification of the interosseous
+    membrane between the radius and ulna.
   phenotype_term:
-    preferred_term: Radioulnar synostosis
+    preferred_term: Limited pronation/supination of forearm
     term:
-      id: HP:0002974
-      label: Radioulnar synostosis
+      id: HP:0006394
+      label: Limited pronation/supination of forearm
   evidence:
   - reference: PMID:10976985
     reference_title: "Type V osteogenesis imperfecta: a new form of brittle bone disease."
@@ -152,26 +152,60 @@ phenotypes:
       interosseous membrane calcification limiting forearm rotation.
 - name: Radial Head Dislocation
   description: >
-    Congenital or acquired dislocation of the radial head, contributing
-    to forearm limitation.
+    Radial head dislocation is a very common forearm abnormality in
+    mutation-confirmed OI type V cohorts.
   phenotype_term:
     preferred_term: Radial head dislocation
     term:
       id: HP:0003083
       label: Dislocated radial head
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: PMID:23408678
+    reference_title: "Phenotypic variability of osteogenesis imperfecta type V caused by an IFITM5 mutation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thirteen had calcification of interosseous membranes, 14 had radial head
+      dislocations, 10 had HPC, 9 had long bone bowing, 11 could ambulate
+      without assistance, and 1 had mild unilateral mixed hearing loss.
+    explanation: >-
+      In this cohort, radial head dislocation occurred in 14 of 17 individuals
+      (82%), which supports a VERY_FREQUENT classification.
+- name: Dense Metaphyseal Bands
+  description: >
+    Radiodense metaphyseal bands adjacent to the growth plate are a
+    characteristic radiographic feature in growing patients with OI type V.
+  phenotype_term:
+    preferred_term: Dense metaphyseal bands
+    term:
+      id: HP:0100959
+      label: Dense metaphyseal bands
   evidence:
   - reference: PMID:10976985
     reference_title: "Type V osteogenesis imperfecta: a new form of brittle bone disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Three patients had anterior dislocation of the radial head.
+      A radiodense metaphyseal band immediately adjacent to the growth plate
+      was a constant feature in growing patients.
     explanation: >-
-      The original OI type V description identified radial head dislocation
-      in 3 of 7 patients.
+      The original clinical description identifies dense metaphyseal bands as a
+      defining radiographic feature of OI type V in growing children.
+  - reference: PMID:20872883
+    reference_title: "Evolution of the radiographic appearance of the metaphyses over the first year of life in type V osteogenesis imperfecta: clues to pathogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We show the evolution of metaphyseal abnormalities from a rickets-like
+      appearance to the classically described dense metaphyseal bands.
+    explanation: >-
+      This infant case report independently confirms dense metaphyseal bands as
+      part of the OI type V radiographic phenotype.
 - name: Recurrent Fractures
   description: >
-    Bone fragility with recurrent fractures, typically of moderate severity.
+    Moderate to severe bone fragility causes recurrent long-bone and vertebral
+    fractures.
   phenotype_term:
     preferred_term: Recurrent fractures
     term:
@@ -188,9 +222,86 @@ phenotypes:
     explanation: >-
       The original OI type V description documented moderate to severe bone
       fragility affecting long bones and vertebral bodies.
-- name: Normal Sclerae
+- name: Bowing of the Long Bones
   description: >
-    Scleral hue is normal (white), distinguishing type V from type I.
+    Long-bone bowing occurs in a substantial subset of individuals with OI
+    type V.
+  phenotype_term:
+    preferred_term: Bowing of the long bones
+    term:
+      id: HP:0006487
+      label: Bowing of the long bones
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:23408678
+    reference_title: "Phenotypic variability of osteogenesis imperfecta type V caused by an IFITM5 mutation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thirteen had calcification of interosseous membranes, 14 had radial head
+      dislocations, 10 had HPC, 9 had long bone bowing, 11 could ambulate
+      without assistance, and 1 had mild unilateral mixed hearing loss.
+    explanation: >-
+      Long-bone bowing was reported in 9 of 17 individuals (53%), which falls
+      in the FREQUENT range.
+- name: Hypodontia
+  description: >
+    Missing permanent teeth are a common extra-skeletal manifestation and may
+    occur with ectopic eruption or short molar roots.
+  phenotype_term:
+    preferred_term: Hypodontia
+    term:
+      id: HP:0000668
+      label: Hypodontia
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:23804581
+    reference_title: "Osteogenesis imperfecta type V: clinical and radiographic manifestations in mutation confirmed patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      However, hypodontia in the permanent teeth, ectopic eruption, and short
+      roots in molars were additionally observed in 11 patients.
+    explanation: >-
+      Hypodontia was reported in 11 of 16 mutation-confirmed patients (69%),
+      which supports a FREQUENT classification.
+- name: Ectopic Ossification
+  description: >
+    Heterotopic ossification of muscles and tendon insertion sites can occur
+    and may lead to ankylosis or joint contractures.
+  phenotype_term:
+    preferred_term: Heterotopic ossification
+    term:
+      id: HP:0011986
+      label: Ectopic ossification
+  frequency: OCCASIONAL
+  evidence:
+  - reference: PMID:23804581
+    reference_title: "Osteogenesis imperfecta type V: clinical and radiographic manifestations in mutation confirmed patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Heterotopic ossification in the muscles and tendon insertion sites were
+      noted in four patients, which resulted in bony ankylosis or contracture
+      of joints.
+    explanation: >-
+      Ectopic ossification was documented in 4 of 16 patients (25%), supporting
+      an OCCASIONAL classification and showing clinical consequences on joint
+      mobility.
+  - reference: PMID:31099171
+    reference_title: "Expanding the phenotypic spectrum of osteogenesis imperfecta type V including heterotopic ossification of muscle origins and attachments."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSION: Ossification of the origin and attachment of muscles seems to
+      be part of the phenotype in patients with OI type V.
+    explanation: >-
+      This independent case report supports heterotopic ossification as part of
+      the OI type V phenotype.
+- name: Blue Sclerae
+  description: >
+    Blue sclerae are typically absent, helping distinguish OI type V from
+    classical mild OI.
   phenotype_term:
     preferred_term: Blue sclerae
     term:
@@ -198,19 +309,19 @@ phenotypes:
       label: Blue sclerae
   frequency: EXCLUDED
   evidence:
-  - reference: PMID:10976985
-    reference_title: "Type V osteogenesis imperfecta: a new form of brittle bone disease."
+  - reference: PMID:23804581
+    reference_title: "Osteogenesis imperfecta type V: clinical and radiographic manifestations in mutation confirmed patients."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      None of the type V patients presented blue sclerae or dentinogenesis
-      imperfecta
+      Blue sclera and dentinogenesis imperfecta were not evident in any patient.
     explanation: >-
-      The original OI type V description confirmed absence of blue sclerae
-      in all patients, distinguishing type V from other OI types.
-- name: Absence of Dentinogenesis Imperfecta
+      In this mutation-confirmed cohort, blue sclerae were absent in all 16
+      patients.
+- name: Dentinogenesis Imperfecta
   description: >
-    Teeth are normal, unlike many other OI types.
+    Dentinogenesis imperfecta is typically absent in OI type V, despite other
+    dental abnormalities such as hypodontia.
   phenotype_term:
     preferred_term: Dentinogenesis imperfecta
     term:
@@ -218,24 +329,15 @@ phenotypes:
       label: Dentinogenesis imperfecta
   frequency: EXCLUDED
   evidence:
-  - reference: PMID:10976985
-    reference_title: "Type V osteogenesis imperfecta: a new form of brittle bone disease."
+  - reference: PMID:30593885
+    reference_title: "Oro-dental and cranio-facial characteristics of osteogenesis imperfecta type V."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      None of the type V patients presented blue sclerae or dentinogenesis
-      imperfecta
+      None of the individuals had dentinogenesis imperfecta.
     explanation: >-
-      The original OI type V description confirmed absence of dentinogenesis
-      imperfecta in all patients.
-- name: Moderate Short Stature
-  description: >
-    Variable short stature, typically mild to moderate.
-  phenotype_term:
-    preferred_term: Short stature
-    term:
-      id: HP:0004322
-      label: Short stature
+      This dedicated dental cohort confirms that dentinogenesis imperfecta is
+      absent in OI type V.
 treatments:
 - name: Bisphosphonate Therapy
   description: >

--- a/references_cache/PMID_20872883.md
+++ b/references_cache/PMID_20872883.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:20872883"
+title: "Evolution of the radiographic appearance of the metaphyses over the first year of life in type V osteogenesis imperfecta: clues to pathogenesis."
+authors:
+- Arundel P
+- Offiah A
+- Bishop NJ
+journal: J Bone Miner Res
+year: '2011'
+doi: 10.1002/jbmr.258
+keywords:
+- "Arm Bones/abnormalities, diagnostic imaging, pathology"
+- Bone Density Conservation Agents/therapeutic use
+- "Bone Diseases, Metabolic/diagnostic imaging, pathology"
+- "Cranial Fontanelles/abnormalities, pathology"
+- Diphosphonates/therapeutic use
+- Female
+- Femoral Fractures/pathology
+- "Fetus/abnormalities, pathology"
+- "Fibula/abnormalities, pathology"
+- "Fractures, Bone/diagnostic imaging, pathology"
+- "Growth Plate/abnormalities, diagnostic imaging, pathology"
+- Humans
+- "Infant, Newborn"
+- "Leg Bones/abnormalities, diagnostic imaging, pathology"
+- Longitudinal Studies
+- "Osteogenesis Imperfecta/diagnostic imaging, drug therapy, etiology, pathology"
+- Pamidronate
+- Plagiocephaly/pathology
+- Radiography
+- "Rib Fractures/diagnostic imaging, pathology"
+- "Ribs/abnormalities, diagnostic imaging, pathology"
+- "Skull/abnormalities, diagnostic imaging, pathology"
+- "Spine/abnormalities, diagnostic imaging, pathology"
+- "Tibia/abnormalities, diagnostic imaging, pathology"
+- "Ulna/abnormalities, diagnostic imaging, pathology"
+- "Ultrasonography, Prenatal"
+- Vitamin D/therapeutic use
+content_type: abstract_only
+---
+
+# Evolution of the radiographic appearance of the metaphyses over the first year of life in type V osteogenesis imperfecta: clues to pathogenesis.
+**Authors:** Arundel P, Offiah A, Bishop NJ
+**Journal:** J Bone Miner Res (2011)
+**DOI:** [10.1002/jbmr.258](https://doi.org/10.1002/jbmr.258)
+
+## Content
+
+1. J Bone Miner Res. 2011 Apr;26(4):894-8. doi: 10.1002/jbmr.258.
+
+Evolution of the radiographic appearance of the metaphyses over the first year
+of life in type V osteogenesis imperfecta: clues to pathogenesis.
+
+Arundel P(1), Offiah A, Bishop NJ.
+
+Author information:
+(1)Academic Unit of Child Health, University of Sheffield, and Sheffield
+Children's Hospital NHS Foundation Trust, Sheffield, United Kingdom.
+P.Arundel@sheffield.ac.uk
+
+We present the first report of the development of characteristic radiologic
+appearances of long bones during the first year of life in an infant with type V
+osteogenesis imperfecta (OI). We show the evolution of metaphyseal abnormalities
+from a rickets-like appearance to the classically described dense metaphyseal
+bands. These abnormalities suggest that the underlying defect in type V OI may
+involve a molecule common to both bone and cartilage that is involved in the
+regulation of growth plate development and metadiaphyseal ossification. Our
+findings provide new insights into skeletal development in type V OI and
+potentially yield useful clues to the identity of the defect underpinning the
+condition.
+
+Copyright © 2011 American Society for Bone and Mineral Research.
+
+DOI: 10.1002/jbmr.258
+PMID: 20872883 [Indexed for MEDLINE]

--- a/references_cache/PMID_23408678.md
+++ b/references_cache/PMID_23408678.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:23408678"
+title: Phenotypic variability of osteogenesis imperfecta type V caused by an IFITM5 mutation.
+authors:
+- Shapiro JR
+- Lietman C
+- Grover M
+- Lu JT
+- Nagamani SC
+- Dawson BC
+- Baldridge DM
+- Bainbridge MN
+- Cohn DH
+- Blazo M
+- Roberts TT
+- Brennen FS
+- Wu Y
+- Gibbs RA
+- Melvin P
+- Campeau PM
+- Lee BH
+journal: J Bone Miner Res
+year: '2013'
+doi: 10.1002/jbmr.1891
+keywords:
+- "5' Untranslated Regions/genetics"
+- Adult
+- Bone Density
+- Child
+- "Child, Preschool"
+- "Codon, Initiator/genetics"
+- Family
+- Female
+- Humans
+- Infant
+- Male
+- Membrane Proteins
+- Middle Aged
+- "Osteogenesis Imperfecta/diagnostic imaging, genetics, physiopathology"
+- Point Mutation
+- Radiography
+- Retrospective Studies
+content_type: abstract_only
+---
+
+# Phenotypic variability of osteogenesis imperfecta type V caused by an IFITM5 mutation.
+**Authors:** Shapiro JR, Lietman C, Grover M, Lu JT, Nagamani SC, Dawson BC, Baldridge DM, Bainbridge MN, Cohn DH, Blazo M, Roberts TT, Brennen FS, Wu Y, Gibbs RA, Melvin P, Campeau PM, Lee BH
+**Journal:** J Bone Miner Res (2013)
+**DOI:** [10.1002/jbmr.1891](https://doi.org/10.1002/jbmr.1891)
+
+## Content
+
+1. J Bone Miner Res. 2013 Jul;28(7):1523-30. doi: 10.1002/jbmr.1891.
+
+Phenotypic variability of osteogenesis imperfecta type V caused by an IFITM5
+mutation.
+
+Shapiro JR(1), Lietman C, Grover M, Lu JT, Nagamani SC, Dawson BC, Baldridge DM,
+Bainbridge MN, Cohn DH, Blazo M, Roberts TT, Brennen FS, Wu Y, Gibbs RA, Melvin
+P, Campeau PM, Lee BH.
+
+Author information:
+(1)Department of Bone and Osteogenesis Imperfecta, Kennedy Krieger Institution,
+Johns Hopkins University, Baltimore, MD, USA.
+
+Comment in
+    J Bone Miner Res. 2013 Jul;28(7):1519-22. doi: 10.1002/jbmr.1982.
+
+In a large cohort of osteogenesis imperfecta type V (OI type V) patients (17
+individuals from 12 families), we identified the same mutation in the 5'
+untranslated region (5'UTR) of the interferon-induced transmembrane protein 5
+(IFITM5) gene by whole exome and Sanger sequencing (IFITM5 c.-14C > T) and
+provide a detailed description of their phenotype. This mutation leads to the
+creation of a novel start codon adding five residues to IFITM5 and was recently
+reported in several other OI type V families. The variability of the phenotype
+was quite large even within families. Whereas some patients presented with the
+typical calcification of the forearm interosseous membrane, radial head
+dislocation and hyperplastic callus (HPC) formation following fractures, others
+had only some of the typical OI type V findings. Thirteen had calcification of
+interosseous membranes, 14 had radial head dislocations, 10 had HPC, 9 had long
+bone bowing, 11 could ambulate without assistance, and 1 had mild unilateral
+mixed hearing loss. The bone mineral density varied greatly, even within
+families. Our study thus highlights the phenotypic variability of OI type V
+caused by the IFITM5 mutation.
+
+Copyright © 2013 American Society for Bone and Mineral Research.
+
+DOI: 10.1002/jbmr.1891
+PMCID: PMC3688672
+PMID: 23408678 [Indexed for MEDLINE]

--- a/references_cache/PMID_23804581.md
+++ b/references_cache/PMID_23804581.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:23804581"
+title: "Osteogenesis imperfecta type V: clinical and radiographic manifestations in mutation confirmed patients."
+authors:
+- Kim OH
+- Jin DK
+- Kosaki K
+- Kim JW
+- Cho SY
+- Yoo WJ
+- Choi IH
+- Nishimura G
+- Ikegawa S
+- Cho TJ
+journal: Am J Med Genet A
+year: '2013'
+doi: 10.1002/ajmg.a.36024
+keywords:
+- Adult
+- "Bone and Bones/diagnostic imaging, pathology"
+- Child
+- "Child, Preschool"
+- "DNA/analysis, genetics"
+- Female
+- Humans
+- Infant
+- Male
+- Membrane Proteins/genetics
+- Middle Aged
+- Mutation/genetics
+- "Osteogenesis Imperfecta/classification, diagnostic imaging, genetics"
+- Phenotype
+- Polymerase Chain Reaction
+- Radiography
+content_type: abstract_only
+---
+
+# Osteogenesis imperfecta type V: clinical and radiographic manifestations in mutation confirmed patients.
+**Authors:** Kim OH, Jin DK, Kosaki K, Kim JW, Cho SY, Yoo WJ, Choi IH, Nishimura G, Ikegawa S, Cho TJ
+**Journal:** Am J Med Genet A (2013)
+**DOI:** [10.1002/ajmg.a.36024](https://doi.org/10.1002/ajmg.a.36024)
+
+## Content
+
+1. Am J Med Genet A. 2013 Aug;161A(8):1972-9. doi: 10.1002/ajmg.a.36024. Epub
+2013  Jun 26.
+
+Osteogenesis imperfecta type V: clinical and radiographic manifestations in
+mutation confirmed patients.
+
+Kim OH(1), Jin DK, Kosaki K, Kim JW, Cho SY, Yoo WJ, Choi IH, Nishimura G,
+Ikegawa S, Cho TJ.
+
+Author information:
+(1)Department of Radiology, Ajou University Medical School, Suwon, Republic of
+Korea.
+
+Osteogenesis imperfecta (OI) type V is a specific OI phenotype with interosseous
+membrane calcification of the forearm and hyperplastic callus formation as
+typical features. The causative gene mutation for OI type V has been recently
+discovered. The purpose of this report is to review the clinical and
+radiographic characteristics of mutation confirmed OI type V in detail. Sixteen
+(nine familial and seven sporadic) patients were enrolled in the study. Blue
+sclera and dentinogenesis imperfecta were not evident in any patient. However,
+hypodontia in the permanent teeth, ectopic eruption, and short roots in molars
+were additionally observed in 11 patients. Of the radiographic abnormalities,
+cortical thickening and bony excrescence of interosseous margin of the ulna was
+the most common finding, followed by overgrowth of the olecranon and/or coronoid
+process of the ulna. Slender ribs and sloping of the posterior ribs with or
+without fractures were also a consistent finding. Hyperplastic callus was
+detected in 75% of patients and was commonly encountered at the femur.
+Heterotopic ossification in the muscles and tendon insertion sites were noted in
+four patients, which resulted in bony ankylosis or contracture of joints. The
+current study confirms common clinical and radiographic findings of OI type V
+and reports additional phenotypic information. These observations provide clues
+to recognize OI type V more promptly and guide to direct targeted molecular
+study. © 2013 Wiley Periodicals, Inc.
+
+Copyright © 2013 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.a.36024
+PMID: 23804581 [Indexed for MEDLINE]

--- a/references_cache/PMID_30593885.md
+++ b/references_cache/PMID_30593885.md
@@ -1,0 +1,103 @@
+---
+reference_id: "PMID:30593885"
+title: Oro-dental and cranio-facial characteristics of osteogenesis imperfecta type V.
+authors:
+- Retrouvey JM
+- Taqi D
+- Tamimi F
+- Dagdeviren D
+- Glorieux FH
+- Lee B
+- Hazboun R
+- Krakow D
+- Sutton VR
+- Members of the BBD Consortium
+journal: Eur J Med Genet
+year: '2019'
+doi: 10.1016/j.ejmg.2018.12.011
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Male
+- Middle Aged
+- "Osteogenesis Imperfecta/diagnostic imaging, genetics, pathology"
+- Phenotype
+content_type: abstract_only
+---
+
+# Oro-dental and cranio-facial characteristics of osteogenesis imperfecta type V.
+**Authors:** Retrouvey JM, Taqi D, Tamimi F, Dagdeviren D, Glorieux FH, Lee B, Hazboun R, Krakow D, Sutton VR, Members of the BBD Consortium
+**Journal:** Eur J Med Genet (2019)
+**DOI:** [10.1016/j.ejmg.2018.12.011](https://doi.org/10.1016/j.ejmg.2018.12.011)
+
+## Content
+
+1. Eur J Med Genet. 2019 Dec;62(12):103606. doi: 10.1016/j.ejmg.2018.12.011. Epub
+ 2018 Dec 26.
+
+Oro-dental and cranio-facial characteristics of osteogenesis imperfecta type V.
+
+Retrouvey JM(1), Taqi D(2), Tamimi F(2), Dagdeviren D(2), Glorieux FH(3), Lee
+B(4), Hazboun R(5), Krakow D(6), Sutton VR(4); Members of the BBD Consortium.
+
+Collaborators: Bober M(7), Esposito P(8), Eyre DR(9), Gomez D(10), Harris G(11),
+Hart T(12), Jain M(3), Krisher J(13), Nagamani SC(3), Orwoll ES(14), Raggio
+CL(15), Rush E(8), Smith P(11), Tosi L(16), Rauch F(3).
+
+Author information:
+(1)Faculty of Dentistry, McGill University, Montreal, Quebec, Canada. Electronic
+address: jean-marc.retrouvey@mcgill.ca.
+(2)Faculty of Dentistry, McGill University, Montreal, Quebec, Canada.
+(3)Shriners Hospital for Children and McGill University, Montreal, Quebec,
+Canada.
+(4)Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, TX, USA.
+(5)UCLA School of Dentistry, Los Angeles, CA, USA.
+(6)Department of Orthopedic Surgery, David Geffen School of Medicine, University
+of California, Los Angeles, Los Angeles, CA, USA.
+(7)Division of Medical Genetics, Nemours/Alfred I. duPont Hospital for Children,
+Wilmington, DE, USA.
+(8)University of Nebraska Medical Center, Omaha, NE, USA.
+(9)Department of Orthopedic and Sports Medicine, University of Washington,
+Seattle, WA, USA.
+(10)Shriners Hospital for Children - Tampa, Tampa, FL, USA.
+(11)Shriners Hospital for Children - Chicago, Chicago, IL, USA.
+(12)Osteogenesis Imperfecta Foundation, Gaithersburg, MD, USA.
+(13)Health Informatics Institute, Morsani College of Medicine, University of
+South Florida, Tampa, FL, USA.
+(14)Department of Medicine, Division of Endocrinology, Oregon Health Sciences
+University, Portland, OR, USA.
+(15)Hospital for Special Surgery, New York, NY, USA.
+(16)Bone Health Program, Children's National Health System, Washington, DC, USA.
+
+Osteogenesis imperfecta (OI) type V is an ultrarare heritable bone disorder
+caused by the heterozygous c.-14C > T mutation in IFITM5. The oro-dental and
+craniofacial phenotype has not been described in detail, which we therefore
+undertook to evaluate in a multicenter study (Brittle Bone Disease Consortium).
+Fourteen individuals with OI type V (age 3-50 years; 10 females, 4 males)
+underwent dental and craniofacial assessment. None of the individuals had
+dentinogenesis imperfecta. Six of the 9 study participants (66%) for whom
+panoramic radiographs were obtained had at least one missing tooth (range 1-9).
+Class II molar occlusion was present in 8 (57%) of the 14 study participants.
+The facial profile was retrusive and lower face height was decreased in 8 (57%)
+individuals. Cephalometry, performed in three study participants, revealed a
+severely retrusive maxilla and mandible, and moderately to severly retroclined
+incisors in a 14-year old girl, a protrusive maxilla and a retrusive mandible in
+a 14-year old boy. Cone beam computed tomograpy scans were obtained from two
+study participants and demonstrated intervertebral disc calcification at the
+C2-C3 level in one individual. Our study observed that OI type V is associated
+with missing permanent teeth, especially permanent premolar, but not with
+dentinogenesis imperfecta. The pattern of craniofacial abnormalities in OI type
+V thus differs from that in other severe OI types, such as OI type III and IV,
+and could be described as a bimaxillary retrusive malocclusion with reduced
+lower face height and multiple missing teeth.
+
+Copyright © 2018 Elsevier Masson SAS. All rights reserved.
+
+DOI: 10.1016/j.ejmg.2018.12.011
+PMCID: PMC6594916
+PMID: 30593885 [Indexed for MEDLINE]

--- a/references_cache/PMID_31099171.md
+++ b/references_cache/PMID_31099171.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:31099171"
+title: Expanding the phenotypic spectrum of osteogenesis imperfecta type V including heterotopic ossification of muscle origins and attachments.
+authors:
+- Clewemar P
+- Hailer NP
+- Hailer Y
+- Klar J
+- Kindmark A
+- Ljunggren Ö
+- Stattin EL
+journal: Mol Genet Genomic Med
+year: '2019'
+doi: 10.1002/mgg3.723
+keywords:
+- Adult
+- Female
+- "Fractures, Bone/etiology"
+- Humans
+- Membrane Proteins/genetics
+- Middle Aged
+- Muscles/physiology
+- "Ossification, Heterotopic/pathology"
+- "Osteogenesis Imperfecta/genetics, pathology"
+- Phenotype
+- "Polymorphism, Single Nucleotide"
+- "Tomography, X-Ray Computed"
+content_type: abstract_only
+---
+
+# Expanding the phenotypic spectrum of osteogenesis imperfecta type V including heterotopic ossification of muscle origins and attachments.
+**Authors:** Clewemar P, Hailer NP, Hailer Y, Klar J, Kindmark A, Ljunggren Ö, Stattin EL
+**Journal:** Mol Genet Genomic Med (2019)
+**DOI:** [10.1002/mgg3.723](https://doi.org/10.1002/mgg3.723)
+
+## Content
+
+1. Mol Genet Genomic Med. 2019 Jul;7(7):e00723. doi: 10.1002/mgg3.723. Epub 2019
+May 16.
+
+Expanding the phenotypic spectrum of osteogenesis imperfecta type V including
+heterotopic ossification of muscle origins and attachments.
+
+Clewemar P(1), Hailer NP(2), Hailer Y(2), Klar J(3), Kindmark A(1), Ljunggren
+Ö(1), Stattin EL(3).
+
+Author information:
+(1)Department of Medical Sciences, Uppsala University, Uppsala, Sweden.
+(2)Department of Surgical Sciences, Section of Orthopaedics, Uppsala University,
+Uppsala, Sweden.
+(3)Department of Immunology, Genetics and Pathology, Science for Life
+Laboratory, Uppsala University, Uppsala, Sweden.
+
+BACKGROUND: Osteogenesis imperfecta (OI) is a clinical and genetic heterogeneous
+group of connective tissue disorders, characterized by bone fragility and a
+propensity to fracture.
+METHODS: In this report we describe the clinical phenotype of two patients, a
+28-year-old woman and her mother (54 years old), both with a history of short
+stature and multiple fractures.
+RESULTS: Exome sequencing revealed the recurring IFITM5:c.-14 C>T variant
+causing OI type V. Both patients had several fractures during childhood. CT-scan
+and scintigraphy showed ossification of the origin and attachment of muscles and
+hypertrophic callus formation.
+CONCLUSION: Ossification of the origin and attachment of muscles seems to be
+part of the phenotype in patients with OI type V.
+
+© 2019 The Authors. Molecular Genetics & Genomic Medicine published by Wiley
+Periodicals, Inc.
+
+DOI: 10.1002/mgg3.723
+PMCID: PMC6625150
+PMID: 31099171 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that there are no conflicts
+of interest.


### PR DESCRIPTION
## Summary
Enhances the phenotype section for `kb/disorders/Osteogenesis_Imperfecta_Type_V.yaml` with deeper PMID-backed clinical evidence.

## What changed
- replaced the over-broad `Radioulnar synostosis` mapping with `Limited pronation/supination of forearm`
- added specific, evidence-backed OI type V phenotypes including dense metaphyseal bands, bowing of the long bones, hypodontia, and ectopic ossification
- added quantitative frequency qualifiers only where directly supported by cohort data
- strengthened excluded findings for blue sclerae and dentinogenesis imperfecta with mutation-confirmed cohorts
- removed the unsupported short stature phenotype entry rather than leaving an unbacked claim
- cached all newly cited PMIDs under `references_cache/`

## Why
Issue #1524 asks for a phenotype-only curation pass that is as complete and evidence-backed as possible for OI type V without broadening into unrelated sections.

## Validation
- `just validate kb/disorders/Osteogenesis_Imperfecta_Type_V.yaml`
- `just validate-references kb/disorders/Osteogenesis_Imperfecta_Type_V.yaml`
- `just validate-terms kb/disorders/Osteogenesis_Imperfecta_Type_V.yaml`

Refs #1524