### PR TITLE
[codex] Enhance ADO2 phenotype evidence

### DIFF
--- a/kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml
+++ b/kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Dominant Osteopetrosis Type II
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-04-19T07:26:32Z'
+updated_date: '2026-04-19T15:07:22Z'
 category: Mendelian
 description: >
   Autosomal dominant osteopetrosis type II (ADO2), also known as Albers-Schonberg
@@ -9,9 +9,10 @@ description: >
   negative mechanism since chloride channels function as dimers. The disease has
   incomplete penetrance (66%) and variable expressivity. Clinical features include
   increased skeletal density, recurrent fractures, osteomyelitis (particularly
-  mandibular), and cranial nerve compression causing visual loss. CLCN7 mutations
-  also cause autosomal recessive osteopetrosis when homozygous, establishing
-  ADO2 as allelic with a subset of infantile malignant osteopetrosis.
+  mandibular), and cranial nerve complications including visual impairment,
+  hearing loss, and facial palsy. CLCN7 mutations also cause autosomal recessive
+  osteopetrosis when homozygous, establishing ADO2 as allelic with a subset of
+  infantile malignant osteopetrosis.
 disease_term:
   preferred_term: autosomal dominant osteopetrosis 2
   term:
@@ -33,24 +34,19 @@ inheritance:
     snippet: "disease penetrance was 66% (62 clinically affected individuals/94 subjects with the gene mutation)"
     explanation: "Demonstrates incomplete penetrance of 66% in the largest ADO2 cohort."
 prevalence:
-- population: Dominant osteopetrosis
+- population: Autosomal dominant osteopetrosis overall
   percentage: 1 in 20,000 births
   notes: >-
-    Exact ADO2-specific prevalence is rarely reported separately. This estimate
-    reflects autosomal dominant osteopetrosis overall; ADO2 is described as the
-    most common form of osteopetrosis and therefore likely accounts for most
-    dominant cases.
+    Exact ADO2-specific prevalence is rarely reported separately. This value is
+    retained only as background epidemiology for autosomal dominant
+    osteopetrosis overall and should not be interpreted as an ADO2-specific
+    prevalence estimate.
   evidence:
   - reference: PMID:37465191
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Autosomal dominant osteopetrosis has an incidence of 1 in 20,000 newborns and autosomal recessive one has 1 in 250,000."
-    explanation: Review-level epidemiology provides the standard incidence estimate for dominant osteopetrosis overall.
-  - reference: PMID:27990310
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Type II autosomal dominant osteopetrosis (ADO2), which is the most common form of osteopetrosis, is caused by heterozygous mutations in the chloride channel 7 (CLCN7) gene."
-    explanation: This human ADO2 study supports the inference that overall dominant osteopetrosis incidence is a reasonable proxy for the commonest dominant subtype, ADO2.
+    explanation: Review-level epidemiology provides the standard incidence estimate for autosomal dominant osteopetrosis overall, not specifically for ADO2.
 pathophysiology:
 - name: CLCN7 Dominant Negative Chloride Channel Dysfunction
   description: >
@@ -125,6 +121,7 @@ phenotypes:
   description: >
     Generalized osteosclerosis with increased skeletal density, especially in
     the spine and pelvis, is the hallmark radiographic abnormality of ADO2.
+    Classic radiographs may also show bone-within-bone appearance.
   phenotype_term:
     preferred_term: Osteopetrosis
     term:
@@ -141,6 +138,11 @@ phenotypes:
     supports: SUPPORT
     snippet: "Type II autosomal dominant osteopetrosis (ADO II, Albers-Schonberg disease) is a genetic condition characterized by generalized osteosclerosis predominating in some skeletal sites such as the spine and pelvis."
     explanation: "Supports generalized osteosclerosis with spine and pelvis predominance as a characteristic ADO2 radiographic phenotype."
+  - reference: PMID:24260721
+    reference_title: "Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II: A Case Report."
+    supports: SUPPORT
+    snippet: "the radiographs revealed generalised osteosclerosis and hallmark radiographic features of ADO type II, that is, \"bone-within-bone appearance\" and \"Erlenmeyer-flask deformity.\""
+    explanation: "Adds exact PMID-backed support that bone-within-bone appearance is a hallmark ADO2 radiographic manifestation."
 - name: Recurrent Fractures
   description: >
     Fractures are the most prevalent clinical consequence of ADO2, and severe
@@ -176,8 +178,8 @@ phenotypes:
   - reference: PMID:17164308
     reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
     supports: SUPPORT
-    snippet: "osteomyelitis typically occurred in the maxilla or mandible in older adults"
-    explanation: "The same cohort reported osteomyelitis in 16% of ADO subjects, which falls in the OCCASIONAL band (5-29%), with jaw predominance in older adults."
+    snippet: "subjects with ADO had a significantly increased prevalence of fracture (84 vs. 36%; P < 0.0001) and osteomyelitis (16 vs. 0.9%; P < 0.0001)"
+    explanation: "16% osteomyelitis prevalence in ADO subjects falls in the OCCASIONAL band (5-29%)."
   - reference: PMID:10617161
     reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
     supports: SUPPORT
@@ -209,6 +211,36 @@ phenotypes:
       supports: SUPPORT
       snippet: "Visual loss, which typically had its onset in childhood, and bone marrow failure occurred in 19 and 3% of ADO subjects, respectively"
       explanation: "Directly supports childhood onset of visual impairment in ADO2."
+- name: Hearing impairment
+  description: >
+    Cranial nerve involvement in ADO2 can include hearing loss, although the
+    available abstract evidence does not quantify hearing impairment separately
+    from other cranial neuropathies.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Cranial nerve involvement responsible for hearing loss, bilateral optic atrophy, and/or facial palsy was present in 14 patients but was clearly attributable to ADO II in only 6 cases (16%)."
+    explanation: "Directly supports hearing loss as part of the ADO2 cranial nerve phenotype, but the abstract does not provide a hearing-specific frequency."
+- name: Facial palsy
+  description: >
+    Facial palsy is part of the cranial nerve complication spectrum of ADO2.
+  phenotype_term:
+    preferred_term: Facial palsy
+    term:
+      id: HP:0010628
+      label: Facial palsy
+  evidence:
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Cranial nerve involvement responsible for hearing loss, bilateral optic atrophy, and/or facial palsy was present in 14 patients but was clearly attributable to ADO II in only 6 cases (16%)."
+    explanation: "Directly supports facial palsy as part of the ADO2 cranial nerve phenotype, but the abstract does not provide a facial-palsy-specific frequency."
 - name: Bone marrow failure
   description: >
     Bone marrow failure is a rare but clinically important hematologic
@@ -310,8 +342,8 @@ genetic:
 treatments:
 - name: Supportive Care
   description: >
-    Management of fractures, monitoring for osteomyelitis and cranial
-    nerve complications. No targeted therapy available.
+    Supportive management is directed at complications such as fractures,
+    osteomyelitis, and cranial nerve deficits.
   treatment_term:
     preferred_term: supportive care
     term:

--- a/kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml
+++ b/kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Dominant Osteopetrosis Type II
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-02-16T20:19:38Z'
+updated_date: '2026-04-19T07:26:32Z'
 category: Mendelian
 description: >
   Autosomal dominant osteopetrosis type II (ADO2), also known as Albers-Schonberg
@@ -123,8 +123,8 @@ pathophysiology:
 phenotypes:
 - name: Osteopetrosis
   description: >
-    Generalized increase in skeletal density due to impaired osteoclast-mediated
-    bone resorption. This is the hallmark radiographic finding.
+    Generalized osteosclerosis with increased skeletal density, especially in
+    the spine and pelvis, is the hallmark radiographic abnormality of ADO2.
   phenotype_term:
     preferred_term: Osteopetrosis
     term:
@@ -136,12 +136,16 @@ phenotypes:
     supports: SUPPORT
     snippet: "the most common form of osteopetrosis, a group of conditions characterized by an increased skeletal mass due to impaired bone and cartilage resorption"
     explanation: "Defines ADO2 as the most common osteopetrosis form with increased skeletal mass."
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Type II autosomal dominant osteopetrosis (ADO II, Albers-Schonberg disease) is a genetic condition characterized by generalized osteosclerosis predominating in some skeletal sites such as the spine and pelvis."
+    explanation: "Supports generalized osteosclerosis with spine and pelvis predominance as a characteristic ADO2 radiographic phenotype."
 - name: Recurrent Fractures
   description: >
-    Paradoxically increased fracture rate despite increased bone density,
-    affecting 84% of ADO subjects. Bones are dense but brittle due to
-    disrupted microarchitecture from impaired remodeling.
-  frequency: "84%"
+    Fractures are the most prevalent clinical consequence of ADO2, and severe
+    fracture patterns are seen only in affected subjects.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Recurrent fractures
     term:
@@ -152,13 +156,17 @@ phenotypes:
     reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
     supports: SUPPORT
     snippet: "subjects with ADO had a significantly increased prevalence of fracture (84 vs. 36%; P < 0.0001)"
-    explanation: "84% fracture prevalence in ADO subjects versus 36% in controls."
+    explanation: "84% fracture prevalence falls in the VERY_FREQUENT band (80-99%)."
+  - reference: PMID:17164308
+    reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
+    supports: SUPPORT
+    snippet: "Severe fractures (defined as > or =10 fractures of any type and/or greater than one hip/femur fracture) were identified only in ADO subjects"
+    explanation: "Supports that ADO2 can include clinically important severe fracture burden, not just incidental fractures."
 - name: Osteomyelitis
   description: >
-    Infection of bone, particularly the mandible, occurring in 16% of
-    ADO subjects. Poor vascular supply in sclerotic bone predisposes
-    to infection, especially after dental procedures.
-  frequency: "16%"
+    Osteomyelitis is an occasional complication of ADO2 and most often affects
+    the jaws, particularly the mandible.
+  frequency: OCCASIONAL
   phenotype_term:
     preferred_term: Osteomyelitis
     term:
@@ -169,24 +177,115 @@ phenotypes:
     reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
     supports: SUPPORT
     snippet: "osteomyelitis typically occurred in the maxilla or mandible in older adults"
-    explanation: "16% osteomyelitis rate, predominantly mandibular in older adults."
-- name: Visual Loss
+    explanation: "The same cohort reported osteomyelitis in 16% of ADO subjects, which falls in the OCCASIONAL band (5-29%), with jaw predominance in older adults."
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Nearly two-thirds of patients (64%) had stomatologic manifestations, including mandibular osteomyelitis in 4 patients (11%)."
+    explanation: "Adds disease-specific support for mandibular predilection of osteomyelitis in ADO2."
+- name: Visual impairment
   description: >
-    Progressive visual loss due to cranial nerve compression from
-    thickened cranial bone, with onset typically in childhood.
-    Affects 19% of ADO subjects.
-  frequency: "19%"
+    Visual impairment or vision loss is an occasional but clinically important
+    complication of ADO2.
+  frequency: OCCASIONAL
   phenotype_term:
-    preferred_term: Optic atrophy
+    preferred_term: Visual impairment
     term:
-      id: HP:0000648
-      label: Optic atrophy
+      id: HP:0000505
+      label: Visual impairment
   evidence:
   - reference: PMID:17164308
     reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
     supports: SUPPORT
     snippet: "Visual loss, which typically had its onset in childhood, and bone marrow failure occurred in 19 and 3% of ADO subjects, respectively"
-    explanation: "19% visual loss with childhood onset in the largest ADO2 cohort."
+    explanation: "19% visual loss falls in the OCCASIONAL band (5-29%)."
+  phenotype_contexts:
+  - onset:
+      onset_category: CHILDHOOD
+      notes: Visual loss was reported as typically beginning in childhood.
+    evidence:
+    - reference: PMID:17164308
+      reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
+      supports: SUPPORT
+      snippet: "Visual loss, which typically had its onset in childhood, and bone marrow failure occurred in 19 and 3% of ADO subjects, respectively"
+      explanation: "Directly supports childhood onset of visual impairment in ADO2."
+- name: Bone marrow failure
+  description: >
+    Bone marrow failure is a rare but clinically important hematologic
+    complication of ADO2.
+  frequency: VERY_RARE
+  phenotype_term:
+    preferred_term: Bone marrow failure
+    term:
+      id: HP:0005528
+      label: Bone marrow hypocellularity
+  evidence:
+  - reference: PMID:17164308
+    reference_title: "Autosomal dominant osteopetrosis: clinical severity and natural history of 94 subjects with a chloride channel 7 gene mutation."
+    supports: SUPPORT
+    snippet: "Visual loss, which typically had its onset in childhood, and bone marrow failure occurred in 19 and 3% of ADO subjects, respectively"
+    explanation: "Bone marrow failure affected 3% of ADO subjects, which falls in the VERY_RARE band (<5%)."
+- name: Osteoarthritis
+  description: >
+    Hip-predominant osteoarthritis can complicate ADO2 and may require
+    arthroplasty.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: Osteoarthritis
+    term:
+      id: HP:0002758
+      label: Osteoarthritis
+  evidence:
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Hip osteoarthritis developed in 27% of patients and required arthroplasty in 9 of the 16 affected hips."
+    explanation: "27% falls in the OCCASIONAL band (5-29%) and shows that hip osteoarthritis is a clinically relevant complication."
+- name: Scoliosis
+  description: >
+    Thoracic or lumbar scoliosis occurs in a minority of patients with ADO2.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  evidence:
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Twenty-four percent of patients had thoracic or lumbar scoliosis."
+    explanation: "24% falls in the OCCASIONAL band (5-29%)."
+- name: Sandwich appearance of vertebral bodies
+  description: >
+    Vertebral endplate thickening producing a sandwich vertebra appearance is a
+    classic radiographic sign of ADO2.
+  phenotype_term:
+    preferred_term: Sandwich vertebrae
+    term:
+      id: HP:0004618
+      label: Sandwich appearance of vertebral bodies
+  evidence:
+  - reference: PMID:10617161
+    reference_title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+    supports: SUPPORT
+    snippet: "Our inclusion criterion was presence on radiographs of the spine of vertebral endplate thickening, producing the classic sandwich vertebra appearance."
+    explanation: "Directly supports sandwich vertebrae as a hallmark radiographic manifestation of ADO2."
+- name: Erlenmeyer flask deformity
+  description: >
+    Erlenmeyer-flask deformity is part of the hallmark radiographic phenotype of
+    ADO2.
+  phenotype_term:
+    preferred_term: Erlenmeyer flask deformity
+    term:
+      id: HP:0004975
+      label: Erlenmeyer flask deformity of the femurs
+  evidence:
+  - reference: PMID:24260721
+    reference_title: "Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II: A Case Report."
+    supports: SUPPORT
+    snippet: "the radiographs revealed generalised osteosclerosis and hallmark radiographic features of ADO type II, that is, \"bone-within-bone appearance\" and \"Erlenmeyer-flask deformity.\""
+    explanation: "Supports Erlenmeyer-flask deformity as a characteristic ADO2 radiographic finding."
 genetic:
 - name: CLCN7 Mutations
   association: Causative

--- a/references_cache/PMID_10617161.md
+++ b/references_cache/PMID_10617161.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:10617161"
+title: "Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients."
+authors:
+- Bénichou OD
+- Laredo JD
+- de Vernejoul MC
+journal: Bone
+year: '2000'
+doi: 10.1016/s8756-3282(99)00244-6
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Arthroplasty, Replacement, Hip"
+- Child
+- Female
+- "Genes, Dominant"
+- "Genetic Diseases, Inborn/diagnostic imaging, genetics, pathology"
+- Humans
+- Male
+- Middle Aged
+- "Osteopetrosis/diagnostic imaging, genetics, pathology"
+- Pedigree
+- Radiography
+content_type: abstract_only
+---
+
+# Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical and radiological manifestations in 42 patients.
+**Authors:** Bénichou OD, Laredo JD, de Vernejoul MC
+**Journal:** Bone (2000)
+**DOI:** [10.1016/s8756-3282(99)00244-6](https://doi.org/10.1016/s8756-3282(99)00244-6)
+
+## Content
+
+1. Bone. 2000 Jan;26(1):87-93. doi: 10.1016/s8756-3282(99)00244-6.
+
+Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical 
+and radiological manifestations in 42 patients.
+
+Bénichou OD(1), Laredo JD, de Vernejoul MC.
+
+Author information:
+(1)INSERM U 349, Hôpital Lariboisière, Paris, France. 
+olivier.benichou@inserm.lrb.ap-hop-paris.fr
+
+Type II autosomal dominant osteopetrosis (ADO II, Albers-Schonberg disease) is a 
+genetic condition characterized by generalized osteosclerosis predominating in 
+some skeletal sites such as the spine and pelvis. ADO II is rare, and most 
+available clinical descriptions are based on small numbers of patients. We 
+report the clinical and radiological manifestations in 42 ADO II patients. To 
+our knowledge, this is the largest series reported so far. Our inclusion 
+criterion was presence on radiographs of the spine of vertebral endplate 
+thickening, producing the classic sandwich vertebra appearance. We found various 
+patterns of sandwich vertebra, of which we provide a description to assist 
+physicians in diagnosing ADO II. The classic bone-within-bone appearance was 
+present in most but not all skeletal sites. The radiological penetrance of the 
+disease was high (90%) and increased after 20 years of age. As many as 81% of 
+our patients experienced clinical manifestations. Fractures were common (78% of 
+patients) and healed slowly. Hip osteoarthritis developed in 27% of patients and 
+required arthroplasty in 9 of the 16 affected hips. Nonmandibular osteomyelitis 
+occurred in 4 cases (11%). Twenty-four percent of patients had thoracic or 
+lumbar scoliosis. Orthopedic surgery was performed in 52.8% of patients, of whom 
+half had at least three surgical procedures for internal fracture fixation, 
+arthroplasty, limb deformity correction, or treatment of surgical complications. 
+There was a high rate of surgical complications including nonunion, infection, 
+prosthesis loosening, and intraoperative fractures. Nearly two-thirds of 
+patients (64%) had stomatologic manifestations, including mandibular 
+osteomyelitis in 4 patients (11%). Cranial nerve involvement responsible for 
+hearing loss, bilateral optic atrophy, and/or facial palsy was present in 14 
+patients but was clearly attributable to ADO II in only 6 cases (16%). This 
+large series sheds new light on several aspects of ADO II, most notably the 
+possibility of severe clinical complications. Although other forms of 
+osteopetrosis are considerably more severe, the name "benign osteopetrosis" 
+previously used for ADO II is probably a misnomer.
+
+DOI: 10.1016/s8756-3282(99)00244-6
+PMID: 10617161 [Indexed for MEDLINE]

--- a/references_cache/PMID_10617161.md
+++ b/references_cache/PMID_10617161.md
@@ -35,43 +35,43 @@ content_type: abstract_only
 
 1. Bone. 2000 Jan;26(1):87-93. doi: 10.1016/s8756-3282(99)00244-6.
 
-Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical 
+Type II autosomal dominant osteopetrosis (Albers-Schönberg disease): clinical
 and radiological manifestations in 42 patients.
 
 Bénichou OD(1), Laredo JD, de Vernejoul MC.
 
 Author information:
-(1)INSERM U 349, Hôpital Lariboisière, Paris, France. 
+(1)INSERM U 349, Hôpital Lariboisière, Paris, France.
 olivier.benichou@inserm.lrb.ap-hop-paris.fr
 
-Type II autosomal dominant osteopetrosis (ADO II, Albers-Schonberg disease) is a 
-genetic condition characterized by generalized osteosclerosis predominating in 
-some skeletal sites such as the spine and pelvis. ADO II is rare, and most 
-available clinical descriptions are based on small numbers of patients. We 
-report the clinical and radiological manifestations in 42 ADO II patients. To 
-our knowledge, this is the largest series reported so far. Our inclusion 
-criterion was presence on radiographs of the spine of vertebral endplate 
-thickening, producing the classic sandwich vertebra appearance. We found various 
-patterns of sandwich vertebra, of which we provide a description to assist 
-physicians in diagnosing ADO II. The classic bone-within-bone appearance was 
-present in most but not all skeletal sites. The radiological penetrance of the 
-disease was high (90%) and increased after 20 years of age. As many as 81% of 
-our patients experienced clinical manifestations. Fractures were common (78% of 
-patients) and healed slowly. Hip osteoarthritis developed in 27% of patients and 
-required arthroplasty in 9 of the 16 affected hips. Nonmandibular osteomyelitis 
-occurred in 4 cases (11%). Twenty-four percent of patients had thoracic or 
-lumbar scoliosis. Orthopedic surgery was performed in 52.8% of patients, of whom 
-half had at least three surgical procedures for internal fracture fixation, 
-arthroplasty, limb deformity correction, or treatment of surgical complications. 
-There was a high rate of surgical complications including nonunion, infection, 
-prosthesis loosening, and intraoperative fractures. Nearly two-thirds of 
-patients (64%) had stomatologic manifestations, including mandibular 
-osteomyelitis in 4 patients (11%). Cranial nerve involvement responsible for 
-hearing loss, bilateral optic atrophy, and/or facial palsy was present in 14 
-patients but was clearly attributable to ADO II in only 6 cases (16%). This 
-large series sheds new light on several aspects of ADO II, most notably the 
-possibility of severe clinical complications. Although other forms of 
-osteopetrosis are considerably more severe, the name "benign osteopetrosis" 
+Type II autosomal dominant osteopetrosis (ADO II, Albers-Schonberg disease) is a
+genetic condition characterized by generalized osteosclerosis predominating in
+some skeletal sites such as the spine and pelvis. ADO II is rare, and most
+available clinical descriptions are based on small numbers of patients. We
+report the clinical and radiological manifestations in 42 ADO II patients. To
+our knowledge, this is the largest series reported so far. Our inclusion
+criterion was presence on radiographs of the spine of vertebral endplate
+thickening, producing the classic sandwich vertebra appearance. We found various
+patterns of sandwich vertebra, of which we provide a description to assist
+physicians in diagnosing ADO II. The classic bone-within-bone appearance was
+present in most but not all skeletal sites. The radiological penetrance of the
+disease was high (90%) and increased after 20 years of age. As many as 81% of
+our patients experienced clinical manifestations. Fractures were common (78% of
+patients) and healed slowly. Hip osteoarthritis developed in 27% of patients and
+required arthroplasty in 9 of the 16 affected hips. Nonmandibular osteomyelitis
+occurred in 4 cases (11%). Twenty-four percent of patients had thoracic or
+lumbar scoliosis. Orthopedic surgery was performed in 52.8% of patients, of whom
+half had at least three surgical procedures for internal fracture fixation,
+arthroplasty, limb deformity correction, or treatment of surgical complications.
+There was a high rate of surgical complications including nonunion, infection,
+prosthesis loosening, and intraoperative fractures. Nearly two-thirds of
+patients (64%) had stomatologic manifestations, including mandibular
+osteomyelitis in 4 patients (11%). Cranial nerve involvement responsible for
+hearing loss, bilateral optic atrophy, and/or facial palsy was present in 14
+patients but was clearly attributable to ADO II in only 6 cases (16%). This
+large series sheds new light on several aspects of ADO II, most notably the
+possibility of severe clinical complications. Although other forms of
+osteopetrosis are considerably more severe, the name "benign osteopetrosis"
 previously used for ADO II is probably a misnomer.
 
 DOI: 10.1016/s8756-3282(99)00244-6

--- a/references_cache/PMID_24260721.md
+++ b/references_cache/PMID_24260721.md
@@ -20,26 +20,26 @@ content_type: abstract_only
 
 1. Case Rep Dent. 2013;2013:707343. doi: 10.1155/2013/707343. Epub 2013 Oct 24.
 
-Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II: 
+Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II:
 A Case Report.
 
 Kant P(1), Sharda N, Bhowate RR.
 
 Author information:
-(1)Department of Oral Medicine and Radiology, Manav Rachna Dental College, 
-Sector 43, Aravalli Hills, Delhi-Surajkund Road, Faridabad, Haryana 121001, 
+(1)Department of Oral Medicine and Radiology, Manav Rachna Dental College,
+Sector 43, Aravalli Hills, Delhi-Surajkund Road, Faridabad, Haryana 121001,
 India.
 
-Osteopetrosis is a rare inherited genetic disease characterized by sclerosis of 
-the skeleton caused by the absence or malfunction of osteoclasts. Three distinct 
-forms of the disease have been recognized, autosomal dominant osteopetrosis 
-being the most common. Autosomal dominant osteopetrosis exhibits a heterogeneous 
-trait with milder symptoms, often at later childhood or adulthood. The aim of 
-this case report is to present the clinical and radiographic features of a 
-35-year-old female patient with autosomal dominant osteopetrosis type II who 
-exhibited features of chronic generalised periodontitis, and the radiographs 
-revealed generalised osteosclerosis and hallmark radiographic features of ADO 
-type II, that is, "bone-within-bone appearance" and "Erlenmeyer-flask 
+Osteopetrosis is a rare inherited genetic disease characterized by sclerosis of
+the skeleton caused by the absence or malfunction of osteoclasts. Three distinct
+forms of the disease have been recognized, autosomal dominant osteopetrosis
+being the most common. Autosomal dominant osteopetrosis exhibits a heterogeneous
+trait with milder symptoms, often at later childhood or adulthood. The aim of
+this case report is to present the clinical and radiographic features of a
+35-year-old female patient with autosomal dominant osteopetrosis type II who
+exhibited features of chronic generalised periodontitis, and the radiographs
+revealed generalised osteosclerosis and hallmark radiographic features of ADO
+type II, that is, "bone-within-bone appearance" and "Erlenmeyer-flask
 deformity."
 
 DOI: 10.1155/2013/707343

--- a/references_cache/PMID_24260721.md
+++ b/references_cache/PMID_24260721.md
@@ -1,0 +1,47 @@
+---
+reference_id: "PMID:24260721"
+title: "Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II: A Case Report."
+authors:
+- Kant P
+- Sharda N
+- Bhowate RR
+journal: Case Rep Dent
+year: '2013'
+doi: 10.1155/2013/707343
+content_type: abstract_only
+---
+
+# Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II: A Case Report.
+**Authors:** Kant P, Sharda N, Bhowate RR
+**Journal:** Case Rep Dent (2013)
+**DOI:** [10.1155/2013/707343](https://doi.org/10.1155/2013/707343)
+
+## Content
+
+1. Case Rep Dent. 2013;2013:707343. doi: 10.1155/2013/707343. Epub 2013 Oct 24.
+
+Clinical and Radiological Findings of Autosomal Dominant Osteopetrosis Type II: 
+A Case Report.
+
+Kant P(1), Sharda N, Bhowate RR.
+
+Author information:
+(1)Department of Oral Medicine and Radiology, Manav Rachna Dental College, 
+Sector 43, Aravalli Hills, Delhi-Surajkund Road, Faridabad, Haryana 121001, 
+India.
+
+Osteopetrosis is a rare inherited genetic disease characterized by sclerosis of 
+the skeleton caused by the absence or malfunction of osteoclasts. Three distinct 
+forms of the disease have been recognized, autosomal dominant osteopetrosis 
+being the most common. Autosomal dominant osteopetrosis exhibits a heterogeneous 
+trait with milder symptoms, often at later childhood or adulthood. The aim of 
+this case report is to present the clinical and radiographic features of a 
+35-year-old female patient with autosomal dominant osteopetrosis type II who 
+exhibited features of chronic generalised periodontitis, and the radiographs 
+revealed generalised osteosclerosis and hallmark radiographic features of ADO 
+type II, that is, "bone-within-bone appearance" and "Erlenmeyer-flask 
+deformity."
+
+DOI: 10.1155/2013/707343
+PMCID: PMC3821930
+PMID: 24260721


### PR DESCRIPTION
## Summary
This PR strengthens the phenotype section for `kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml` with disease-specific PMID-backed evidence.

Changes made:
- converted unsupported raw percentage strings to schema-compliant frequency bands where the cohorts directly supported them
- replaced the over-specific `optic atrophy` mapping with `Visual impairment` and added childhood onset only where directly supported
- added missing clinically important phenotypes supported by ADO2-specific abstracts, including osteoarthritis, scoliosis, bone marrow failure, sandwich vertebrae, and Erlenmeyer flask deformity
- tightened jaw-predominant osteomyelitis wording and removed unsupported mechanistic phrasing

## Why
Issue #1519 requested a phenotype-only, evidence-backed enrichment pass on the ADO2 entry, with exact PMID support and removal or softening of unsupported phenotype claims.

## Validation
- `just validate kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml` -> passed
- `just validate-references kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml` -> passed
- `just validate-terms kb/disorders/Autosomal_Dominant_Osteopetrosis_Type_II.yaml` -> passed

Closes #1519