### PR TITLE
[codex] Enhance SCTSS phenotype evidence

### DIFF
--- a/kb/disorders/Spondylocarpotarsal_Synostosis_Syndrome.yaml
+++ b/kb/disorders/Spondylocarpotarsal_Synostosis_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Spondylocarpotarsal Synostosis Syndrome
 creation_date: '2026-03-04T20:22:00Z'
-updated_date: '2026-03-04T20:48:00Z'
+updated_date: '2026-04-19T07:27:31Z'
 category: Mendelian
 description: >
   Spondylocarpotarsal synostosis syndrome is a rare autosomal recessive FLNB-related
@@ -209,7 +209,7 @@ genetic:
 phenotypes:
 - name: Short Stature
   description: >
-    Disproportionate short stature with short trunk is a core growth phenotype in SCTSS.
+    Disproportionate short stature is a core growth phenotype in SCTSS.
   phenotype_term:
     preferred_term: Short stature
     term:
@@ -224,26 +224,61 @@ phenotypes:
       Spondylocarpotarsal synostosis syndrome is characterized by disproportionate short stature, vertebral anomalies and fusion of carpal and tarsal bones.
     explanation: >-
       This directly supports disproportionate short stature.
+- name: Short Neck
+  description: >
+    A short neck has been reported in some affected individuals with FLNB-related
+    SCTSS.
+  phenotype_term:
+    preferred_term: Short neck
+    term:
+      id: HP:0000470
+      label: Short neck
+  evidence:
+  - reference: PMID:37781000
+    reference_title: "A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three of the four affected siblings evaluated had severe short stature, short trunk, short neck, kyphoscoliosis, pectus carinatum, and winged scapula.
+    explanation: >-
+      This supports short neck as part of the variable axial skeletal phenotype.
 - name: Vertebral Fusion
   description: >
-    Progressive vertebral fusion is a defining axial skeletal abnormality.
+    Vertebral fusion is a defining axial skeletal abnormality in SCTSS.
   phenotype_term:
     preferred_term: Vertebral fusion
     term:
       id: HP:0002948
       label: Vertebral fusion
   evidence:
-  - reference: PMID:17635842
-    reference_title: "Disruption of the Flnb gene in mice phenocopies the human disease spondylocarpotarsal synostosis syndrome."
+  - reference: PMID:18470895
+    reference_title: "Autosomal dominant spondylocarpotarsal synostosis syndrome: phenotypic homogeneity and genetic heterogeneity."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Spondylocarpotarsal synostosis syndrome (SCT) is an autosomal recessive disease that is characterized by short stature, and fusions of the vertebrae and carpal and tarsal bones.
+      Spondylocarpotarsal synostosis syndrome (SCT) (OMIM 272460), originally thought to be a failure of normal spine segmentation, is characterized by progressive fusion of vertebras and associates unsegmented bars, scoliosis, short stature, carpal and tarsal synostosis.
     explanation: >-
-      This directly supports vertebral fusion in the human disease phenotype.
+      This review directly supports vertebral fusion as a defining human phenotype.
+- name: Block Vertebrae
+  description: >
+    Block vertebrae are part of the radiographic spinal involvement in SCTSS.
+  phenotype_term:
+    preferred_term: Block vertebrae
+    term:
+      id: HP:0003305
+      label: Block vertebrae
+  evidence:
+  - reference: PMID:10766994
+    reference_title: "Spondylocarpotarsal synostosis syndrome and cervical instability."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Spondylocarpotarsal synostosis syndrome is a recently delineated autosomal recessive condition comprising short stature with short trunk, failure of normal spine segmentation resulting in block vertebrae and fusion of posterior elements, carpal and/or tarsal coalition, scoliosis, lordosis, pes planus, dental enamel hypoplasia, decreased range of motion or dislocation of the elbow, renal anomalies, and hearing loss.
+    explanation: >-
+      This directly supports block vertebrae as part of the characteristic spinal phenotype.
 - name: Carpal Synostosis
   description: >
-    Carpal coalition/synostosis is a hallmark appendicular imaging finding.
+    Carpal coalition or synostosis is a characteristic appendicular imaging finding.
   phenotype_term:
     preferred_term: Carpal synostosis
     term:
@@ -258,9 +293,35 @@ phenotypes:
       Spondylocarpotarsal synostosis syndrome is characterized by disproportionate short stature, vertebral anomalies and fusion of carpal and tarsal bones.
     explanation: >-
       This supports carpal fusion/synostosis as a core phenotype.
+- name: Delayed Ossification of Carpal Bones
+  description: >
+    Delayed carpal ossification has been reported in some molecularly confirmed
+    cases.
+  phenotype_term:
+    preferred_term: Delayed ossification of carpal bones
+    term:
+      id: HP:0001216
+      label: Delayed ossification of carpal bones
+  evidence:
+  - reference: PMID:39086440
+    reference_title: "Novel FLNB Variants in Seven Argentinian Cases with Spondylocarpotarsal Synostosis Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All cases presented with spinal fusion with variable severity and location, carpal bones coalition, and also delay in carpal ossification.
+    explanation: >-
+      This cohort directly supports delayed ossification of the carpal bones.
+  - reference: PMID:18257094
+    reference_title: "Expanded clinical spectrum of spondylocarpotarsal synostosis syndrome and possible manifestation in a heterozygous father."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In addition to the typical phenotype of SCT syndrome, he showed pronounced delay of carpal bone age and bilateral epiphyseal dysplasia of the proximal femora.
+    explanation: >-
+      This independently supports delayed carpal ossification in a molecularly confirmed case.
 - name: Tarsal Synostosis
   description: >
-    Tarsal coalition/synostosis is a recurrent lower-limb skeletal feature.
+    Tarsal coalition or synostosis is a recurrent lower-limb skeletal feature.
   phenotype_term:
     preferred_term: Tarsal synostosis
     term:
@@ -277,7 +338,7 @@ phenotypes:
       This directly supports tarsal synostosis.
 - name: Scoliosis
   description: >
-    Progressive scoliosis is common in SCTSS and contributes substantially to morbidity.
+    Scoliosis is part of the characteristic vertebral deformity pattern in SCTSS.
   phenotype_term:
     preferred_term: Scoliosis
     term:
@@ -309,15 +370,49 @@ phenotypes:
       Spondylocarpotarsal synostosis syndrome (SCT) is a distinct group of disorders characterized by short stature, disrupted vertebral segmentation with vertebral fusion, scoliosis, lordosis, carpal/tarsal synostosis, and lack of rib anomalies.
     explanation: >-
       This supports lordotic spinal deformity in SCTSS.
-- name: Sensorineural Hearing Impairment
+- name: Hearing Impairment
   description: >
-    Sensorineural hearing loss is a variable extra-axial feature in some cohorts.
+    Hearing loss is variably reported and may be conductive, mixed, or sensorineural.
   phenotype_term:
-    preferred_term: Sensorineural hearing impairment
+    preferred_term: Hearing impairment
     term:
-      id: HP:0000407
-      label: Sensorineural hearing impairment
+      id: HP:0000365
+      label: Hearing impairment
   evidence:
+  - reference: PMID:18470895
+    reference_title: "Autosomal dominant spondylocarpotarsal synostosis syndrome: phenotypic homogeneity and genetic heterogeneity."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cleft palate, sensorineural or mixed hearing loss, joint limitation, clinodactyly, and dental enamel hypoplasia are variable manifestations.
+    explanation: >-
+      This review supports hearing impairment as a variable manifestation and shows that both sensorineural and mixed forms occur.
+  - reference: PMID:18257094
+    reference_title: "Expanded clinical spectrum of spondylocarpotarsal synostosis syndrome and possible manifestation in a heterozygous father."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We report on a 5-year-old boy with spondylocarpotarsal synostosis (SCT) syndrome who presents with disproportionate short stature, thoracic scoliosis, pes planus, dental enamel hypoplasia, unilateral conductive hearing loss and mild facial dysmorphisms.
+    explanation: >-
+      This adds direct evidence that conductive hearing loss can also occur in SCTSS.
+- name: Joint Stiffness
+  description: >
+    Joint stiffness or limitation without bone fusion is a variable musculoskeletal
+    feature.
+  phenotype_term:
+    preferred_term: Joint stiffness
+    term:
+      id: HP:0001387
+      label: Joint stiffness
+  evidence:
+  - reference: PMID:37781000
+    reference_title: "A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other common manifestations are cleft palate, conductive and sensorineural hearing loss, joint stiffness, and dental enamel hypoplasia.
+    explanation: >-
+      This supports joint stiffness as a recurrent but variable phenotype.
   - reference: PMID:39086440
     reference_title: "Novel FLNB Variants in Seven Argentinian Cases with Spondylocarpotarsal Synostosis Syndrome."
     supports: SUPPORT
@@ -325,7 +420,116 @@ phenotypes:
     snippet: >-
       Other findings included clinodactyly, joint limitation without bone fusion, neurosensorial hearing loss, and ophthalmological compromise.
     explanation: >-
-      This supports variable sensorineural hearing involvement in SCTSS.
+      This independently supports joint limitation in the SCTSS phenotype spectrum.
+- name: Clinodactyly
+  description: >
+    Clinodactyly is a variable appendicular skeletal feature in SCTSS.
+  phenotype_term:
+    preferred_term: Clinodactyly
+    term:
+      id: HP:0030084
+      label: Clinodactyly
+  evidence:
+  - reference: PMID:18470895
+    reference_title: "Autosomal dominant spondylocarpotarsal synostosis syndrome: phenotypic homogeneity and genetic heterogeneity."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cleft palate, sensorineural or mixed hearing loss, joint limitation, clinodactyly, and dental enamel hypoplasia are variable manifestations.
+    explanation: >-
+      This review supports clinodactyly as a variable manifestation of SCTSS.
+  - reference: PMID:39086440
+    reference_title: "Novel FLNB Variants in Seven Argentinian Cases with Spondylocarpotarsal Synostosis Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other findings included clinodactyly, joint limitation without bone fusion, neurosensorial hearing loss, and ophthalmological compromise.
+    explanation: >-
+      This independently supports clinodactyly in a modern molecular cohort.
+- name: Pes Planus
+  description: >
+    Pes planus has been reported in some affected individuals with SCTSS.
+  phenotype_term:
+    preferred_term: Pes planus
+    term:
+      id: HP:0001763
+      label: Pes planus
+  evidence:
+  - reference: PMID:18257094
+    reference_title: "Expanded clinical spectrum of spondylocarpotarsal synostosis syndrome and possible manifestation in a heterozygous father."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We report on a 5-year-old boy with spondylocarpotarsal synostosis (SCT) syndrome who presents with disproportionate short stature, thoracic scoliosis, pes planus, dental enamel hypoplasia, unilateral conductive hearing loss and mild facial dysmorphisms.
+    explanation: >-
+      This supports pes planus as part of the variable skeletal phenotype.
+- name: Enamel Hypoplasia
+  description: >
+    Dental enamel hypoplasia is a recurrent but variable extra-axial feature.
+  phenotype_term:
+    preferred_term: Dental enamel hypoplasia
+    term:
+      id: HP:0006297
+      label: Enamel hypoplasia
+  evidence:
+  - reference: PMID:18470895
+    reference_title: "Autosomal dominant spondylocarpotarsal synostosis syndrome: phenotypic homogeneity and genetic heterogeneity."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cleft palate, sensorineural or mixed hearing loss, joint limitation, clinodactyly, and dental enamel hypoplasia are variable manifestations.
+    explanation: >-
+      This review supports dental enamel hypoplasia as a variable manifestation of SCTSS.
+  - reference: PMID:37781000
+    reference_title: "A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other common manifestations are cleft palate, conductive and sensorineural hearing loss, joint stiffness, and dental enamel hypoplasia.
+    explanation: >-
+      This independently supports enamel hypoplasia as part of the SCTSS phenotype spectrum.
+- name: Cleft Palate
+  description: >
+    Cleft palate is reported in a subset of SCTSS cases.
+  phenotype_term:
+    preferred_term: Cleft palate
+    term:
+      id: HP:0000175
+      label: Cleft palate
+  evidence:
+  - reference: PMID:18470895
+    reference_title: "Autosomal dominant spondylocarpotarsal synostosis syndrome: phenotypic homogeneity and genetic heterogeneity."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cleft palate, sensorineural or mixed hearing loss, joint limitation, clinodactyly, and dental enamel hypoplasia are variable manifestations.
+    explanation: >-
+      This review supports cleft palate as a variable manifestation of SCTSS.
+  - reference: PMID:37781000
+    reference_title: "A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other common manifestations are cleft palate, conductive and sensorineural hearing loss, joint stiffness, and dental enamel hypoplasia.
+    explanation: >-
+      This independently supports cleft palate in the reported phenotype spectrum.
+- name: Round Face
+  description: >
+    Round face has been reported as a mild craniofacial feature in some cohorts.
+  phenotype_term:
+    preferred_term: Round face
+    term:
+      id: HP:0000311
+      label: Round face
+  evidence:
+  - reference: PMID:39086440
+    reference_title: "Novel FLNB Variants in Seven Argentinian Cases with Spondylocarpotarsal Synostosis Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The seven cases share previously described facial characteristics: round facies, large eyes, and wide based nose; all of them had variable height deficit, in one case noted early in life.
+    explanation: >-
+      This supports round face as a recurring mild facial feature in a pediatric SCTSS cohort.
 diagnosis:
 - name: Clinical-Radiographic Pattern with FLNB Exome Confirmation
   description: >

--- a/references_cache/PMID_10766994.md
+++ b/references_cache/PMID_10766994.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:10766994"
+title: Spondylocarpotarsal synostosis syndrome and cervical instability.
+authors:
+- Seaver LH
+- Boyd E
+journal: Am J Med Genet
+year: '2000'
+doi: "10.1002/(sici)1096-8628(20000424)91:5<340::aid-ajmg3>3.0.co;2-n"
+keywords:
+- "Abnormalities, Multiple/diagnostic imaging"
+- "Carpal Bones/abnormalities, diagnostic imaging"
+- "Cervical Vertebrae/abnormalities, diagnostic imaging"
+- "Child, Preschool"
+- Female
+- Humans
+- Radiography
+- "Spine/abnormalities, diagnostic imaging"
+- Syndrome
+- Synostosis/diagnostic imaging
+- "Tarsal Bones/abnormalities, diagnostic imaging"
+content_type: abstract_only
+---
+
+# Spondylocarpotarsal synostosis syndrome and cervical instability.
+**Authors:** Seaver LH, Boyd E
+**Journal:** Am J Med Genet (2000)
+**DOI:** [10.1002/(sici)1096-8628(20000424)91:5<340::aid-ajmg3>3.0.co;2-n](https://doi.org/10.1002/(sici)1096-8628(20000424)91:5<340::aid-ajmg3>3.0.co;2-n)
+
+## Content
+
+1. Am J Med Genet. 2000 Apr 24;91(5):340-4. doi: 
+10.1002/(sici)1096-8628(20000424)91:5<340::aid-ajmg3>3.0.co;2-n.
+
+Spondylocarpotarsal synostosis syndrome and cervical instability.
+
+Seaver LH(1), Boyd E.
+
+Author information:
+(1)Greenwood Genetic Center, Greenwood, South Carolina 29646, USA. 
+lseaver@ggc.org
+
+Spondylocarpotarsal synostosis syndrome is a recently delineated autosomal 
+recessive condition comprising short stature with short trunk, failure of normal 
+spine segmentation resulting in block vertebrae and fusion of posterior 
+elements, carpal and/or tarsal coalition, scoliosis, lordosis, pes planus, 
+dental enamel hypoplasia, decreased range of motion or dislocation of the elbow, 
+renal anomalies, and hearing loss. The vertebral segmentation defects may 
+involve noncontiguous areas of the cervical, thoracic, and lumbar spine. 
+Odontoid hypoplasia was noted in two cases. We report on a sporadic case of 
+spondylocarpotarsal synostosis in a 5-year-old girl with hypoplasia of C1 and 
+odontoid and subluxation of C2 upon C3. This brings the number of 
+well-documented cases of spondylocar- potarsal synostosis to 19, and is the 
+first documenting cervical spine instability. Careful evaluation for this 
+complication should be considered in other cases.
+
+Copyright 2000 Wiley-Liss, Inc.
+
+DOI: 10.1002/(sici)1096-8628(20000424)91:5<340::aid-ajmg3>3.0.co;2-n
+PMID: 10766994 [Indexed for MEDLINE]

--- a/references_cache/PMID_37781000.md
+++ b/references_cache/PMID_37781000.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:37781000"
+title: "A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family."
+authors:
+- Shahid H
+- Shakoor N
+- Bibi A
+- Qazi AS
+- Saeed RF
+- Nawaz A
+- Malik S
+- Mumtaz S
+journal: Yale J Biol Med
+year: '2023'
+doi: 10.59249/UTCP9818
+keywords:
+- Filamins/genetics
+- Cleft Palate
+- Consanguinity
+- Phenotype
+- Humans
+- "Scoliosis/diagnostic imaging, genetics, congenital"
+- Animals
+- Dental Enamel Hypoplasia
+- "Abnormalities, Multiple"
+- Lumbar Vertebrae/abnormalities
+- Musculoskeletal Diseases
+- Synostosis
+- Thoracic Vertebrae/abnormalities
+content_type: abstract_only
+---
+
+# A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family.
+**Authors:** Shahid H, Shakoor N, Bibi A, Qazi AS, Saeed RF, Nawaz A, Malik S, Mumtaz S
+**Journal:** Yale J Biol Med (2023)
+**DOI:** [10.59249/UTCP9818](https://doi.org/10.59249/UTCP9818)
+
+## Content
+
+1. Yale J Biol Med. 2023 Sep 29;96(3):383-396. doi: 10.59249/UTCP9818.
+eCollection  2023 Sep.
+
+A Stop-gain Variant c.220C>T (p.(Gln74*)) in FLNB Segregates with 
+Spondylocarpotarsal Synostosis Syndrome in a Consanguineous Family.
+
+Shahid H(1), Shakoor N(2), Bibi A(2), Qazi AS(1), Saeed RF(1), Nawaz A(2), Malik 
+S(2), Mumtaz S(1).
+
+Author information:
+(1)Department of Biological Sciences, National University of Medical Sciences, 
+Rawalpindi, Pakistan.
+(2)Human Genetics Program, Department of Zoology, Faculty of Biological 
+Sciences, Quaid-i-Azam University, Islamabad, Pakistan.
+
+Spondylocarpotarsal synostosis (SCT) syndrome is a very rare and severe form of 
+skeletal dysplasia. The hallmark features of SCT are disproportionate short 
+stature, scoliosis, fusion of carpal and tarsal bones, and clubfoot. Other 
+common manifestations are cleft palate, conductive and sensorineural hearing 
+loss, joint stiffness, and dental enamel hypoplasia. Homozygous variants in FLNB 
+are known to cause SCT. This study was aimed to investigate the phenotypic and 
+genetic basis of unique presentation of SCT syndrome segregating in a 
+consanguineous Pakistani family. Three of the four affected siblings evaluated 
+had severe short stature, short trunk, short neck, kyphoscoliosis, pectus 
+carinatum, and winged scapula. The subjects had difficulty in walking and gait 
+problems and complained of knee pain and backache. Roentgenographic examination 
+of the eldest patient revealed gross anomalies in the axial skeleton including 
+thoracolumbar and cervical fusion of ribs, severe kyphoscoliosis, thoracic and 
+lumbar lordosis, coxa valga, fusion of certain carpals and tarsals, and 
+clinodactyly. The patients had normal faces and lacked other typical features of 
+SCT like cleft palate, conductive and sensorineural hearing loss, joint 
+stiffness, and dental enamel hypoplasia. Whole exome sequencing (WES) of two 
+affected siblings led to the discovery of a rare stop-gain variant c.220C>T 
+(p.(Gln74*)) in exon 1 of the FLNB gene. The variant was homozygous and 
+segregated with the malformation in this family. This study reports extensive 
+phenotypic variability in SCT and expands the mutation spectrum of FLNB.
+
+Copyright ©2023, Yale Journal of Biology and Medicine.
+
+DOI: 10.59249/UTCP9818
+PMCID: PMC10524816
+PMID: 37781000 [Indexed for MEDLINE]

--- a/research/Spondylocarpotarsal_Synostosis_Syndrome-phenotype-refresh-manual.md
+++ b/research/Spondylocarpotarsal_Synostosis_Syndrome-phenotype-refresh-manual.md
@@ -1,0 +1,72 @@
+---
+provider: manual_pubmed_review
+model: n/a
+cached: false
+start_time: '2026-04-19T07:05:00Z'
+end_time: '2026-04-19T07:27:31Z'
+duration_seconds: 1351.0
+citation_count: 8
+notes: >
+  Focused phenotype curation review for issue #1527. The goal was to tighten the
+  SCTSS phenotype section to abstract-supported, HPO-grounded manifestations only,
+  adding clinically important missing findings and softening unsupported strength
+  claims.
+---
+
+## Question
+
+What phenotype manifestations of spondylocarpotarsal synostosis syndrome are directly
+supported by PubMed abstracts and should be represented in the phenotype section of
+`kb/disorders/Spondylocarpotarsal_Synostosis_Syndrome.yaml`?
+
+## Output
+
+# SCTSS phenotype curation summary
+
+## Core axial and appendicular skeletal findings retained
+
+- Disproportionate short stature
+- Vertebral fusion
+- Block vertebrae
+- Carpal synostosis / coalition
+- Tarsal synostosis / coalition
+- Scoliosis
+- Lordosis / hyperlordosis
+
+## Clinically important additional phenotypes supported by abstracts
+
+- Short neck
+- Delayed ossification of carpal bones
+- Hearing impairment
+- Joint stiffness / joint limitation
+- Clinodactyly
+- Pes planus
+- Enamel hypoplasia
+- Cleft palate
+- Round face
+
+## Claims intentionally softened or avoided
+
+- Frequency qualifiers were omitted because the available abstracts mostly support
+  disease-phenotype association rather than whole-disease frequency bands.
+- Onset qualifiers were omitted because age-of-onset detail was generally in full text
+  rather than the abstract.
+- Sensorineural hearing loss was broadened to hearing impairment because the abstract
+  literature supports conductive, mixed, and sensorineural forms across different
+  reports.
+- Short trunk, clubfoot, pectus carinatum, winged scapula, rib anomalies, coxa valga,
+  gait difficulty, and ophthalmologic compromise were reviewed but not promoted into the
+  final phenotype list because they were either difficult to ground cleanly to HPO with
+  the available abstract evidence or appeared too family-specific for the narrow
+  phenotype refresh requested here.
+
+## References
+
+- PMID:10766994
+- PMID:17635842
+- PMID:18257094
+- PMID:18470895
+- PMID:28145000
+- PMID:29566257
+- PMID:37781000
+- PMID:39086440

--- a/research/Spondylocarpotarsal_Synostosis_Syndrome-phenotype-refresh-manual.md.citations.md
+++ b/research/Spondylocarpotarsal_Synostosis_Syndrome-phenotype-refresh-manual.md.citations.md
@@ -1,0 +1,10 @@
+# Citations for Manual Phenotype Review
+
+1. PMID:10766994 - https://pubmed.ncbi.nlm.nih.gov/10766994/
+2. PMID:17635842 - https://pubmed.ncbi.nlm.nih.gov/17635842/
+3. PMID:18257094 - https://pubmed.ncbi.nlm.nih.gov/18257094/
+4. PMID:18470895 - https://pubmed.ncbi.nlm.nih.gov/18470895/
+5. PMID:28145000 - https://pubmed.ncbi.nlm.nih.gov/28145000/
+6. PMID:29566257 - https://pubmed.ncbi.nlm.nih.gov/29566257/
+7. PMID:37781000 - https://pubmed.ncbi.nlm.nih.gov/37781000/
+8. PMID:39086440 - https://pubmed.ncbi.nlm.nih.gov/39086440/


### PR DESCRIPTION
## Summary
- enrich the SCTSS phenotype section with abstract-backed skeletal, craniofacial, and extra-skeletal manifestations
- replace overly strong or overly narrow phenotype claims with more defensible wording and a broader hearing phenotype
- add the two newly cited PubMed cache files and a phenotype-focused research note for auditability

## Validation
- `just validate kb/disorders/Spondylocarpotarsal_Synostosis_Syndrome.yaml`
- `just validate-references kb/disorders/Spondylocarpotarsal_Synostosis_Syndrome.yaml`
- `just validate-terms kb/disorders/Spondylocarpotarsal_Synostosis_Syndrome.yaml`

Refs #1527