### PR TITLE
[codex] Enhance FOP phenotype evidence

### DIFF
--- a/kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml
+++ b/kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml
@@ -1,6 +1,6 @@
 name: Fibrodysplasia Ossificans Progressiva
 creation_date: '2025-12-19T01:18:09Z'
-updated_date: '2026-02-27T22:30:27Z'
+updated_date: '2026-04-19T07:29:40Z'
 category: Genetic
 parents:
 - Musculoskeletal Disease
@@ -80,11 +80,9 @@ pathophysiology:
         The study demonstrates that the R206H mutation causes BMP signal
         activation in muscle tissue, leading to ectopic bone formation.
   - target: Congenital Great Toe Malformation
-    description: Aberrant ACVR1 signaling during embryonic patterning disrupts
-      first digit development.
+    description: Aberrant ACVR1 signaling during embryonic patterning disrupts first digit development.
   - target: Activin A Neomorphic Signaling
-    description: Mutant receptor acquires abnormal signaling response to Activin
-      A.
+    description: Mutant receptor acquires abnormal signaling response to Activin A.
   evidence:
   - reference: PMID:17572636
     reference_title: "Functional modeling of the ACVR1 (R206H) mutation in FOP."
@@ -119,8 +117,7 @@ pathophysiology:
       Loss of FKBP1A binding is a key mechanism allowing leaky BMP signaling.
   downstream:
   - target: Constitutive BMP Signaling Activation
-    description: Loss of FKBP1A inhibition lowers the activation threshold for
-      mutant ACVR1 signaling.
+    description: Loss of FKBP1A inhibition lowers the activation threshold for mutant ACVR1 signaling.
 - name: Activin A Neomorphic Signaling
   description: >-
     The R206H mutation renders ACVR1 responsive to Activin A ligands, which
@@ -149,11 +146,9 @@ pathophysiology:
     as a targeted therapy for FOP.
   downstream:
   - target: Inflammatory Triggering of Flare-ups
-    description: Injury-related Activin A release aberrantly activates mutant
-      ACVR1 in local tissues.
+    description: Injury-related Activin A release aberrantly activates mutant ACVR1 in local tissues.
   - target: Heterotopic Ossification
-    description: Activin A-driven mutant receptor signaling initiates ectopic
-      chondrogenic and osteogenic programs.
+    description: Activin A-driven mutant receptor signaling initiates ectopic chondrogenic and osteogenic programs.
 - name: Heterotopic Ossification
   description: >-
     Progressive formation of qualitatively normal bone in extraskeletal tissues
@@ -195,11 +190,9 @@ pathophysiology:
   - target: Joint Stiffness
     description: Early periarticular ossification reduces range of motion.
   - target: Scoliosis
-    description: Asymmetric axial heterotopic bone and contractures distort
-      spinal alignment.
+    description: Asymmetric axial heterotopic bone and contractures distort spinal alignment.
   - target: Restrictive Ventilatory Defect
-    description: Thoracic cage ossification limits chest wall expansion and lung
-      mechanics.
+    description: Thoracic cage ossification limits chest wall expansion and lung mechanics.
 - name: Inflammatory Triggering of Flare-ups
   description: >-
     Macrophages, mast cells, and lymphocytes infiltrate affected tissues during
@@ -238,26 +231,38 @@ pathophysiology:
     soft-tissue injury aberrantly signals through mutant ACVR1.
   downstream:
   - target: Heterotopic Ossification
-    description: Cytokine-rich flare environments recruit progenitors and
-      promote endochondral ectopic bone formation.
+    description: Cytokine-rich flare environments recruit progenitors and promote endochondral ectopic bone formation.
 phenotypes:
 - category: Skeletal
   name: Congenital Great Toe Malformation
-  frequency: VERY_FREQUENT
   diagnostic: true
   notes: >-
-    Bilateral hallux valgus with short first metatarsals and monophalangic
-    great toes. Present at birth and pathognomonic for FOP.
+    Classic hallux abnormalities include shortening of the great toe with
+    hallux valgus and first-ray malformation. This is the most important early
+    diagnostic clue in classic FOP.
   evidence:
-  - reference: PMID:17572636
-    reference_title: "Functional modeling of the ACVR1 (R206H) mutation in FOP."
+  - reference: PMID:21116899
+    reference_title: "Deformity of the great toe in fibrodysplasia ossificans progressiva."
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Individuals with fibrodysplasia ossificans progressiva are born with
-      malformations of the great toes
+      A shortened great toe and hallux valgus were frequently found in
+      patients with FOP.
     explanation: >-
-      Congenital toe malformation is described as a cardinal feature present
-      from birth.
+      Supports the characteristic hallux shortening and hallux valgus of FOP.
+  phenotype_contexts:
+  - onset:
+      onset_category: CONGENITAL
+    notes: The great-toe malformation is a congenital skeletal anomaly.
+    evidence:
+    - reference: PMID:21116899
+      reference_title: "Deformity of the great toe in fibrodysplasia ossificans progressiva."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        These findings were thought to exist from birth and may be a key to
+        an early diagnosis.
+      explanation: Supports congenital onset of the great-toe abnormality.
   phenotype_term:
     preferred_term: Abnormal hallux morphology
     term:
@@ -265,105 +270,309 @@ phenotypes:
       label: Abnormal hallux morphology
 - category: Skeletal
   name: Heterotopic Ossification
-  frequency: VERY_FREQUENT
-  diagnostic: true
   notes: >-
-    Progressive formation of ectopic bone in muscles, tendons, and ligaments.
-    Typically begins in childhood and progresses cranially to caudally and
-    axially to appendicularly.
+    Progressive formation of ectopic bone in soft connective tissues including
+    muscles, fascia, tendons, and ligaments. FOP lesions may accumulate even
+    in the absence of a recognized flare-up.
   evidence:
-  - reference: PMID:17572636
-    reference_title: "Functional modeling of the ACVR1 (R206H) mutation in FOP."
+  - reference: PMID:36152026
+    reference_title: "The natural history of fibrodysplasia ossificans progressiva: A prospective, global 36-month study."
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Individuals with fibrodysplasia ossificans progressiva are born with
-      malformations of the great toes and develop a heterotopic skeleton
-      during childhood
+      FOP is characterized by painful, recurrent flare-ups, and disabling,
+      cumulative heterotopic ossification (HO) in soft tissues.
     explanation: >-
-      The development of a second skeleton is the defining feature of the
-      disease.
+      Supports cumulative soft-tissue heterotopic ossification as the defining
+      phenotype of FOP.
+  phenotype_contexts:
+  - onset:
+      onset_category: CHILDHOOD
+    notes: Classic FOP develops a heterotopic skeleton during childhood.
+    evidence:
+    - reference: PMID:17572636
+      reference_title: "Functional modeling of the ACVR1 (R206H) mutation in FOP."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Individuals with fibrodysplasia ossificans progressiva are born with
+        malformations of the great toes and develop a heterotopic skeleton
+        during childhood
+      explanation: Supports childhood onset of classic heterotopic ossification.
   phenotype_term:
-    preferred_term: Ectopic ossification in muscle tissue
+    preferred_term: Progressive heterotopic ossification
     term:
-      id: HP:0011987
-      label: Ectopic ossification in muscle tissue
+      id: HP:0011986
+      label: Ectopic ossification
 - category: Musculoskeletal
-  name: Progressive Joint Immobility
-  frequency: VERY_FREQUENT
+  name: Acute Flare-up Pain
   notes: >-
-    Ankylosis of joints due to heterotopic bone formation crossing joint
-    spaces. Leads to progressive loss of mobility.
+    Acute pain is a common presenting feature of flare-ups and contributes
+    substantially to physical disability.
   evidence:
-  - reference: PMID:26896819
-    reference_title: "Palovarotene Inhibits Heterotopic Ossification and Maintains Limb Mobility and Growth in Mice With the Human ACVR1(R206H) Fibrodysplasia Ossificans Progressiva (FOP) Mutation."
+  - reference: PMID:26564023
+    reference_title: "Quality of life of patients with fibrodysplasia ossificans progressiva."
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      causes skeletal deformities, movement impairment, and premature death
+      Fibrodysplasia ossificans progressiva (FOP) is a rare disorder
+      characterized by episodes of acute pain and heterotopic ossification of
+      soft tissue, and progressively limited physical function and social
+      participation.
     explanation: >-
-      Movement impairment is a direct consequence of progressive ossification.
+      Supports acute pain as a core clinical manifestation during FOP flare-ups.
   phenotype_term:
-    preferred_term: Limitation of joint mobility
+    preferred_term: Acute flare-up pain
     term:
-      id: HP:0001376
-      label: Limitation of joint mobility
+      id: HP:0012531
+      label: Pain
 - category: Musculoskeletal
-  name: Joint Stiffness
-  frequency: VERY_FREQUENT
+  name: Soft Tissue Swelling During Flare-ups
   notes: >-
-    Stiffness precedes complete ankylosis and may be accompanied by soft
-    tissue swelling during flare-ups.
+    Preosseous flare-ups often present as inflammatory soft-tissue swelling and
+    may occur in the back, neck, jaw, or limbs.
   evidence:
-  - reference: PMID:26896819
-    reference_title: "Palovarotene Inhibits Heterotopic Ossification and Maintains Limb Mobility and Growth in Mice With the Human ACVR1(R206H) Fibrodysplasia Ossificans Progressiva (FOP) Mutation."
-    supports: PARTIAL
+  - reference: PMID:27025942
+    reference_title: "The Natural History of Flare-Ups in Fibrodysplasia Ossificans Progressiva (FOP): A Comprehensive Global Assessment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      palovarotene maintained joint, limb, and body motion, providing clear
-      evidence for its encompassing therapeutic potential as a treatment for FOP
+      The most common presenting symptoms of flare-ups were swelling (93%),
+      pain (86%), or decreased mobility (79%).
     explanation: >-
-      The therapeutic goal of maintaining joint motion indicates joint
-      stiffness and loss of motion are key disease features.
+      Supports inflammatory soft-tissue swelling as a hallmark presenting
+      symptom of FOP flare-ups.
   phenotype_term:
-    preferred_term: Joint stiffness
+    preferred_term: Soft tissue swelling during flare-ups
     term:
-      id: HP:0001387
-      label: Joint stiffness
+      id: HP:0000969
+      label: Edema
+- category: Musculoskeletal
+  name: Joint Ankylosis
+  notes: >-
+    Progressive bridging heterotopic bone can ankylize major joints and cause
+    persistent loss of mobility.
+  evidence:
+  - reference: PMID:28390760
+    reference_title: "Restricted Mandibular Movement Attributed to Ossification of Mandibular Depressors and Medial Pterygoid Muscles in Patients With Fibrodysplasia Ossificans Progressiva: A Report of 3 Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      As the condition progresses, HO leads to joint ankylosis, breathing
+      difficulties, and mouth-opening restriction, and it can shorten the
+      patient's lifespan.
+    explanation: >-
+      Directly supports joint ankylosis as a clinical consequence of
+      progressive heterotopic ossification in FOP.
+  phenotype_term:
+    preferred_term: Joint ankylosis
+    term:
+      id: HP:0031013
+      label: Ankylosis
 - category: Skeletal
   name: Scoliosis
   frequency: FREQUENT
   notes: >-
-    Spinal deformity due to asymmetric heterotopic ossification of
-    paraspinal muscles.
+    Thoracolumbar or lumbar curves are common, may become rigid by early
+    adulthood, and can impair sitting or standing balance.
   evidence:
-  - reference: PMID:26896819
-    reference_title: "Palovarotene Inhibits Heterotopic Ossification and Maintains Limb Mobility and Growth in Mice With the Human ACVR1(R206H) Fibrodysplasia Ossificans Progressiva (FOP) Mutation."
-    supports: PARTIAL
+  - reference: PMID:7929490
+    reference_title: "Spinal deformity in patients who have fibrodysplasia ossificans progressiva."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      causes skeletal deformities, movement impairment, and premature death
+      Twenty-six (65 per cent) of the patients had scoliosis, which, according
+      to the clinical records and the recollection of the patients, had been
+      present during childhood.
     explanation: >-
-      Skeletal deformities including scoliosis result from progressive
-      heterotopic ossification.
+      26/40 = 65%, which falls in the FREQUENT band; the same cohort report
+      also indicates childhood onset.
+  phenotype_contexts:
+  - onset:
+      onset_category: CHILDHOOD
+    notes: In the 40-patient series, scoliosis was already present in childhood.
+    evidence:
+    - reference: PMID:7929490
+      reference_title: "Spinal deformity in patients who have fibrodysplasia ossificans progressiva."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Twenty-six (65 per cent) of the patients had scoliosis, which,
+        according to the clinical records and the recollection of the
+        patients, had been present during childhood.
+      explanation: Supports childhood onset of scoliosis in the reported cohort.
   phenotype_term:
     preferred_term: Scoliosis
     term:
       id: HP:0002650
       label: Scoliosis
+- category: Skeletal
+  name: Cervical Spine Malformations
+  notes: >-
+    Characteristic radiographic abnormalities include enlarged posterior
+    elements, tall narrow vertebral bodies, and fusion of cervical facet joints.
+  evidence:
+  - reference: PMID:15959366
+    reference_title: "Developmental anomalies of the cervical spine in patients with fibrodysplasia ossificans progressiva are distinctly different from those in patients with Klippel-Feil syndrome: clues from the BMP signaling pathway."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In the FOP patient group, characteristic anomalies, including large
+      posterior elements, tall narrow vertebral bodies,and fusion of the facet
+      joints between C2 and C7, were observed.
+    explanation: >-
+      Supports characteristic congenital cervical spine malformations,
+      including fusion involving the cervical vertebrae.
+  phenotype_contexts:
+  - onset:
+      onset_category: CONGENITAL
+    notes: These cervical spine abnormalities are congenital skeletal defects.
+    evidence:
+    - reference: PMID:15959366
+      reference_title: "Developmental anomalies of the cervical spine in patients with fibrodysplasia ossificans progressiva are distinctly different from those in patients with Klippel-Feil syndrome: clues from the BMP signaling pathway."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        FOP patients exhibit a characteristic set of congenital spine
+        malformations.
+      explanation: Supports congenital onset of the cervical spine abnormalities.
+  phenotype_term:
+    preferred_term: Congenital cervical spine malformations
+    term:
+      id: HP:0002949
+      label: Fused cervical vertebrae
+- category: Musculoskeletal
+  name: Limitation of Neck Motion
+  notes: >-
+    Neck stiffness and reduced cervical range of motion are often early
+    manifestations of cervical involvement in FOP.
+  evidence:
+  - reference: PMID:15959366
+    reference_title: "Developmental anomalies of the cervical spine in patients with fibrodysplasia ossificans progressiva are distinctly different from those in patients with Klippel-Feil syndrome: clues from the BMP signaling pathway."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Generalized neck stiffness and decreased range of motion were noted in
+      most children with FOP.
+    explanation: >-
+      Supports neck stiffness with limited cervical motion as an early
+      musculoskeletal manifestation.
+  phenotype_term:
+    preferred_term: Limitation of neck motion
+    term:
+      id: HP:0005986
+      label: Limitation of neck motion
+- category: Skeletal
+  name: Short Thumb
+  notes: >-
+    Thumb shortening is an additional skeletal clue that can help identify FOP,
+    including patients whose great toes appear less obviously abnormal.
+  evidence:
+  - reference: PMID:25343126
+    reference_title: "Radiographic characteristics of the hand and cervical spine in fibrodysplasia ossificans progressiva."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The thumb shortening and cervical spine abnormalities are other skeletal
+      features often observed in FOP.
+    explanation: Supports short thumb as part of the congenital skeletal phenotype.
+  phenotype_term:
+    preferred_term: Short thumb
+    term:
+      id: HP:0009778
+      label: Short thumb
+- category: Sensory
+  name: Conductive Hearing Impairment
+  notes: >-
+    Hearing loss in FOP is typically conductive rather than sensorineural.
+  evidence:
+  - reference: PMID:10499116
+    reference_title: "Conductive hearing loss in individuals with fibrodysplasia ossificans progressiva."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The findings of both studies indicate that individuals with FOP are at
+      risk for hearing loss and that the type of loss is predominantly
+      conductive in nature
+    explanation: >-
+      Supports conductive hearing impairment as a recognized non-skeletal
+      manifestation of FOP.
+  phenotype_term:
+    preferred_term: Conductive hearing impairment
+    term:
+      id: HP:0000405
+      label: Conductive hearing impairment
+- category: Musculoskeletal
+  name: Restricted Mouth Opening
+  notes: >-
+    Maxillofacial heterotopic ossification can severely restrict jaw opening and
+    complicate eating, oral care, and airway management.
+  evidence:
+  - reference: PMID:28390760
+    reference_title: "Restricted Mandibular Movement Attributed to Ossification of Mandibular Depressors and Medial Pterygoid Muscles in Patients With Fibrodysplasia Ossificans Progressiva: A Report of 3 Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      As the condition progresses, HO leads to joint ankylosis, breathing
+      difficulties, and mouth-opening restriction, and it can shorten the
+      patient's lifespan.
+    explanation: >-
+      Supports restricted mouth opening as a clinically important manifestation
+      of maxillofacial heterotopic ossification.
+  phenotype_term:
+    preferred_term: Restricted mouth opening
+    term:
+      id: HP:0000211
+      label: Trismus
+- category: Skeletal
+  name: Proximal Tibial Osteochondromas
+  frequency: VERY_FREQUENT
+  notes: >-
+    These lesions are usually asymptomatic, most commonly bilateral, and
+    typically arise near the pes anserinus.
+  evidence:
+  - reference: PMID:18245597
+    reference_title: "Proximal tibial osteochondromas in patients with fibrodysplasia ossificans progressiva."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Ninety percent of all patients had osteochondroma of the proximal part
+      of the tibia.
+    explanation: >-
+      90% falls in the VERY_FREQUENT band and directly supports proximal tibial
+      osteochondromas as a common skeletal manifestation of FOP.
+  phenotype_term:
+    preferred_term: Proximal tibial osteochondromas
+    term:
+      id: HP:0030431
+      label: Osteochondroma
 - category: Respiratory
   name: Restrictive Ventilatory Defect
-  frequency: FREQUENT
   notes: >-
-    Thoracic insufficiency syndrome develops as heterotopic ossification
-    involves the thoracic spine, ribs, and thoracic musculature, severely
-    restricting chest expansion and ventilatory capacity. This is a major
-    cause of mortality with median life expectancy of approximately 40 years.
+    Thoracic heterotopic ossification causes restrictive respiratory mechanics
+    and underlies much of the cardiorespiratory mortality in FOP.
   evidence:
-  - reference: PMID:26896819
-    reference_title: "Palovarotene Inhibits Heterotopic Ossification and Maintains Limb Mobility and Growth in Mice With the Human ACVR1(R206H) Fibrodysplasia Ossificans Progressiva (FOP) Mutation."
-    supports: NO_EVIDENCE
+  - reference: PMID:40597333
+    reference_title: "Respiratory oscillometry in individuals with fibrodysplasia ossificans progressiva."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      causes skeletal deformities, movement impairment, and premature death
+      Spirometry showed a uniform pattern of restrictive physiology in all
+      eight participants with no significant difference amongst the group.
     explanation: >-
-      Snippet does not directly mention thoracic insufficiency or restrictive
-      ventilatory physiology.
+      Supports restrictive ventilatory physiology in a modern FOP cohort.
+  - reference: PMID:20194327
+    reference_title: "Early mortality and cardiorespiratory failure in patients with fibrodysplasia ossificans progressiva."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common causes of death in patients with fibrodysplasia
+      ossificans progressiva were cardiorespiratory failure from thoracic
+      insufficiency syndrome (54%; median age, forty-two years) and pneumonia
+      (15%; median age, forty years).
+    explanation: >-
+      Supports thoracic insufficiency syndrome as a major life-limiting
+      respiratory complication of FOP.
   phenotype_term:
     preferred_term: Restrictive ventilatory defect
     term:
@@ -556,60 +765,47 @@ disease_term:
     label: fibrodysplasia ossificans progressiva
 references:
 - reference: DOI:10.1002/jbm4.10821
-  title: Palovarotene Action Against Heterotopic Ossification Includes a
-    Reduction of Local Participating Activin <scp>A‐Expressing</scp> Cell
-    Populations
+  title: Palovarotene Action Against Heterotopic Ossification Includes a Reduction of Local Participating Activin <scp>A‐Expressing</scp> Cell Populations
   findings: []
 - reference: DOI:10.1073/pnas.1302703111
-  title: Hypertrophic chondrocytes can become osteoblasts and osteocytes in
-    endochondral bone formation
+  title: Hypertrophic chondrocytes can become osteoblasts and osteocytes in endochondral bone formation
   findings: []
 - reference: DOI:10.1073/pnas.2019152118
-  title: SOX9 keeps growth plates and articular cartilage healthy by inhibiting
-    chondrocyte dedifferentiation/osteoblastic redifferentiation
+  title: SOX9 keeps growth plates and articular cartilage healthy by inhibiting chondrocyte dedifferentiation/osteoblastic redifferentiation
   findings: []
 - reference: DOI:10.1186/s12874-023-02080-7
-  title: Study methodology and insights from the palovarotene clinical
-    development program in fibrodysplasia ossificans progressiva
+  title: Study methodology and insights from the palovarotene clinical development program in fibrodysplasia ossificans progressiva
   findings: []
 - reference: DOI:10.1631/jzus.b2300779
-  title: Advancements in mechanisms and drug treatments for fibrodysplasia
-    ossificans progressiva
+  title: Advancements in mechanisms and drug treatments for fibrodysplasia ossificans progressiva
   findings: []
 - reference: DOI:10.3389/fcell.2017.00047
-  title: A Novel Role for the BMP Antagonist Noggin in Sensitizing Cells to
-    Non-canonical Wnt-5a/Ror2/Disheveled Pathway Activation
+  title: A Novel Role for the BMP Antagonist Noggin in Sensitizing Cells to Non-canonical Wnt-5a/Ror2/Disheveled Pathway Activation
   findings: []
 - reference: DOI:10.3389/fcell.2021.637011
-  title: CCDC154 Mutant Caused Abnormal Remodeling of the Otic Capsule and
-    Hearing Loss in Mice
+  title: CCDC154 Mutant Caused Abnormal Remodeling of the Otic Capsule and Hearing Loss in Mice
   findings: []
 - reference: DOI:10.3390/biom14020147
   title: The HIF-1α and mTOR Pathways Amplify Heterotopic Ossification
   findings: []
 - reference: DOI:10.3390/biom14030349
-  title: Intersections of Fibrodysplasia Ossificans Progressiva and Traumatic
-    Heterotopic Ossification
+  title: Intersections of Fibrodysplasia Ossificans Progressiva and Traumatic Heterotopic Ossification
   findings: []
 - reference: DOI:10.3390/biom14030357
   title: Immunologic Aspects in Fibrodysplasia Ossificans Progressiva
   findings: []
 - reference: DOI:10.3390/biomedicines12040779
-  title: Cellular and Molecular Mechanisms of Heterotopic Ossification in
-    Fibrodysplasia Ossificans Progressiva
+  title: Cellular and Molecular Mechanisms of Heterotopic Ossification in Fibrodysplasia Ossificans Progressiva
   findings: []
 - reference: PMID:24677724
   title: Chondrocyte hypertrophy in skeletal development, growth, and disease.
   findings: []
 - reference: PMID:25122769
-  title: Mitogen-activated protein kinase (MAPK)-regulated interactions between
-    Osterix and Runx2 are critical for the transcriptional osteogenic program.
+  title: Mitogen-activated protein kinase (MAPK)-regulated interactions between Osterix and Runx2 are critical for the transcriptional osteogenic program.
   findings: []
 - reference: PMID:28473268
-  title: The congenital great toe malformation of fibrodysplasia ossificans
-    progressiva? - A close call.
+  title: The congenital great toe malformation of fibrodysplasia ossificans progressiva? - A close call.
   findings: []
 - reference: PMID:33572801
-  title: ALK2 Receptor Kinase Association with FKBP12.6 Is Structurally
-    Conserved with the ALK2-FKBP12 Complex.
+  title: ALK2 Receptor Kinase Association with FKBP12.6 Is Structurally Conserved with the ALK2-FKBP12 Complex.
   findings: []

--- a/references_cache/PMID_10499116.md
+++ b/references_cache/PMID_10499116.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:10499116"
+title: Conductive hearing loss in individuals with fibrodysplasia ossificans progressiva.
+authors:
+- Levy CE
+- Lash AT
+- Janoff HB
+- Kaplan FS
+journal: Am J Audiol
+year: '1999'
+doi: 10.1044/1059-0889(1999/011)
+keywords:
+- Adolescent
+- Adult
+- "Audiometry, Pure-Tone"
+- Child
+- "Child, Preschool"
+- Female
+- "Hearing Loss, Conductive/diagnosis, etiology"
+- Humans
+- Infant
+- Male
+- Middle Aged
+- Myositis Ossificans/complications
+- Severity of Illness Index
+- Surveys and Questionnaires
+content_type: abstract_only
+---
+
+# Conductive hearing loss in individuals with fibrodysplasia ossificans progressiva.
+**Authors:** Levy CE, Lash AT, Janoff HB, Kaplan FS
+**Journal:** Am J Audiol (1999)
+**DOI:** [10.1044/1059-0889(1999/011)](https://doi.org/10.1044/1059-0889(1999/011))
+
+## Content
+
+1. Am J Audiol. 1999 Jun;8(1):29-33. doi: 10.1044/1059-0889(1999/011).
+
+Conductive hearing loss in individuals with fibrodysplasia ossificans
+progressiva.
+
+Levy CE(1), Lash AT, Janoff HB, Kaplan FS.
+
+Author information:
+(1)Ohio State University, Columbus, USA. levy.28@osu.edu
+
+Fibrodysplasia ossificans progressiva (FOP) is a very rare genetic disorder that
+is characterized by progressive heterotopic ossification of soft tissues and
+congenital malformation of the great toes. Although previous case studies have
+reported hearing loss in individuals with FOP, there have been no large-scale
+studies regarding the nature or cause of the hearing loss. Here, we report the
+findings of a two-part study. In Part I, we report the findings of a postal
+survey regarding hearing loss that was sent to 102 individuals with FOP. In Part
+II, we report the findings of on-site hearing evaluations of eight individuals
+with FOP. The findings of both studies indicate that individuals with FOP are at
+risk for hearing loss and that the type of loss is predominantly conductive in
+nature, similar to that seen in individuals who have otosclerosis.
+
+DOI: 10.1044/1059-0889(1999/011)
+PMID: 10499116 [Indexed for MEDLINE]

--- a/references_cache/PMID_15959366.md
+++ b/references_cache/PMID_15959366.md
@@ -1,0 +1,91 @@
+---
+reference_id: "PMID:15959366"
+title: "Developmental anomalies of the cervical spine in patients with fibrodysplasia ossificans progressiva are distinctly different from those in patients with Klippel-Feil syndrome: clues from the BMP signaling pathway."
+authors:
+- Schaffer AA
+- Kaplan FS
+- Tracy MR
+- "O'Brien ML"
+- Dormans JP
+- Shore EM
+- Harland RM
+- Kusumi K
+journal: Spine (Phila Pa 1976)
+year: '2005'
+doi: 10.1097/01.brs.0000166619.22832.2c
+keywords:
+- Adolescent
+- Adult
+- Animals
+- "Bone Morphogenetic Proteins/antagonists & inhibitors, genetics, metabolism"
+- Carrier Proteins/genetics
+- Cervical Vertebrae/abnormalities
+- Child
+- "Child, Preschool"
+- "Diagnosis, Differential"
+- Female
+- Humans
+- Infant
+- "Klippel-Feil Syndrome/metabolism, pathology, physiopathology"
+- Male
+- Mice
+- Middle Aged
+- "Muscle Rigidity/etiology, physiopathology"
+- "Myositis Ossificans/metabolism, pathology, physiopathology"
+- "Range of Motion, Articular"
+- Signal Transduction
+- Noggin Protein
+content_type: abstract_only
+---
+
+# Developmental anomalies of the cervical spine in patients with fibrodysplasia ossificans progressiva are distinctly different from those in patients with Klippel-Feil syndrome: clues from the BMP signaling pathway.
+**Authors:** Schaffer AA, Kaplan FS, Tracy MR, O'Brien ML, Dormans JP, Shore EM, Harland RM, Kusumi K
+**Journal:** Spine (Phila Pa 1976) (2005)
+**DOI:** [10.1097/01.brs.0000166619.22832.2c](https://doi.org/10.1097/01.brs.0000166619.22832.2c)
+
+## Content
+
+1. Spine (Phila Pa 1976). 2005 Jun 15;30(12):1379-85. doi:
+10.1097/01.brs.0000166619.22832.2c.
+
+Developmental anomalies of the cervical spine in patients with fibrodysplasia
+ossificans progressiva are distinctly different from those in patients with
+Klippel-Feil syndrome: clues from the BMP signaling pathway.
+
+Schaffer AA(1), Kaplan FS, Tracy MR, O'Brien ML, Dormans JP, Shore EM, Harland
+RM, Kusumi K.
+
+Author information:
+(1)Division of Orthopaedic Surgery, Children's Hospital of Philadelphia,
+Institution B, Philadelphia, PA, USA.
+
+STUDY DESIGN: A radiographic analysis of the cervical spine of 70 patients
+diagnosed with fibrodysplasia ossificans progressiva (FOP) and 33 diagnosed with
+Klippel-Feil (KF) syndrome was conducted.
+OBJECTIVES: The objectives of this study were to describe cervical spine
+abnormalities in patients with FOP, to compare and contrast those findings with
+the malformations in patients with KF syndrome, and to examine the possible
+etiology of these abnormalities.
+SUMMARY OF BACKGROUND DATA: Congenital features of diseases often provide
+seminal clues to underlying etiology and developmental pathways. While
+progressive metamorphosis of connective tissue to heterotopic bone is the most
+dramatic and disabling feature of FOP, less severe congenital anomalies of the
+skeleton are also present. Vertebral fusions observed in KF are consistent with
+defects in embryonic segmentation.
+METHODS: The cervical spine plain films of 70 FOP patients and 33 KF patients
+with documented congenital abnormalities were reviewed.
+RESULTS: Generalized neck stiffness and decreased range of motion were noted in
+most children with FOP. In the FOP patient group, characteristic anomalies,
+including large posterior elements, tall narrow vertebral bodies,and fusion of
+the facet joints between C2 and C7, were observed. Most notably, these
+characteristic anomalies of the cervical spine in patients with FOP were
+distinctly different from those of 33 patients with KF that were examined but
+were strikingly similar to those seen in mice with homozygous deletions of the
+gene-encoding noggin, a bone morphogenetic protein (BMP) antagonist.
+CONCLUSIONS: FOP patients exhibit a characteristic set of congenital spine
+malformations. While the noggin gene (NOG) is not mutated in patients who have
+FOP, these findings extend a growing body of evidence implicating overactivity
+of the BMP signaling pathway in the molecular pathogenesis of FOP.
+
+DOI: 10.1097/01.brs.0000166619.22832.2c
+PMID: 15959366 [Indexed for MEDLINE]

--- a/references_cache/PMID_18245597.md
+++ b/references_cache/PMID_18245597.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:18245597"
+title: Proximal tibial osteochondromas in patients with fibrodysplasia ossificans progressiva.
+authors:
+- Deirmengian GK
+- Hebela NM
+- "O'Connell M"
+- Glaser DL
+- Shore EM
+- Kaplan FS
+journal: J Bone Joint Surg Am
+year: '2008'
+doi: 10.2106/JBJS.G.00774
+keywords:
+- Adolescent
+- Adult
+- "Bone Neoplasms/epidemiology, etiology"
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- Male
+- Middle Aged
+- Myositis Ossificans/complications
+- "Osteochondroma/epidemiology, etiology"
+- Prevalence
+- Tibia
+content_type: abstract_only
+---
+
+# Proximal tibial osteochondromas in patients with fibrodysplasia ossificans progressiva.
+**Authors:** Deirmengian GK, Hebela NM, O'Connell M, Glaser DL, Shore EM, Kaplan FS
+**Journal:** J Bone Joint Surg Am (2008)
+**DOI:** [10.2106/JBJS.G.00774](https://doi.org/10.2106/JBJS.G.00774)
+
+## Content
+
+1. J Bone Joint Surg Am. 2008 Feb;90(2):366-74. doi: 10.2106/JBJS.G.00774.
+
+Proximal tibial osteochondromas in patients with fibrodysplasia ossificans
+progressiva.
+
+Deirmengian GK(1), Hebela NM, O'Connell M, Glaser DL, Shore EM, Kaplan FS.
+
+Author information:
+(1)Department of Orthopaedic Surgery, The University of Pennsylvania School of
+Medicine, Silverstein-2, Hospital of the University of Pennsylvania, 3400 Spruce
+Street, Philadelphia, PA 19104, USA.
+
+BACKGROUND: Fibrodysplasia ossificans progressiva is a rare autosomal dominant
+disorder characterized by congenital malformation of the great toes and by
+progressive heterotopic ossification of skeletal muscle and soft connective
+tissues. The disorder is caused by a recurrent missense mutation in the
+glycine-serine activation domain of activin A receptor type I, a bone
+morphogenetic protein (BMP) type-I receptor, in all classically affected
+individuals. Osteochondromas of the proximal part of the tibia are benign
+osteochondral neoplasms or orthotopic lesions of skeletal remodeling associated
+with dysregulated BMP signaling and have been considered an atypical feature of
+fibrodysplasia ossificans progressiva, but they may be underdiagnosed because of
+their often asymptomatic nature. The purpose of the present study was to
+determine the prevalence and characteristics of proximal tibial osteochondromas
+in individuals who have fibrodysplasia ossificans progressiva.
+METHODS: Over a period of thirty months, we evaluated all patients with new and
+established fibrodysplasia ossificans progressiva for the presence of proximal
+tibial osteochondromas on the basis of medical history, physical examination,
+and radiographic studies. We quantified the prevalence of osteochondromas and
+characterized the types of osteochondromas to identify relevant trends.
+RESULTS: Ninety-six patients (including fifty-two female patients and forty-four
+male patients) with fibrodysplasia ossificans progressiva were evaluated on the
+basis of a history and physical examination. Plain radiographs were available
+for sixty-seven patients. Ninety percent of all patients had osteochondroma of
+the proximal part of the tibia. These lesions usually were asymptomatic, most
+commonly were bilateral, and typically were located at the pes anserinus.
+Seventy-five percent of the lesions were pedunculated, and 25% were sessile.
+CONCLUSIONS: Proximal tibial osteochondromas are a common phenotypic feature of
+fibrodysplasia ossificans progressiva, a finding that expands the recognized
+consequences of recurrent activating mutations in activin A receptor type I to
+include not only congenital skeletal malformations and heterotopic
+skeletogenesis but also benign osteochondral neoplasms or orthotopic lesions of
+skeletal modeling. The present study provides insight into the genetic basis of
+osteochondroma formation in patients with fibrodysplasia ossificans progressiva
+and possibly into that of more common conditions in which these lesions occur.
+
+DOI: 10.2106/JBJS.G.00774
+PMCID: PMC3516450
+PMID: 18245597 [Indexed for MEDLINE]

--- a/references_cache/PMID_20194327.md
+++ b/references_cache/PMID_20194327.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:20194327"
+title: Early mortality and cardiorespiratory failure in patients with fibrodysplasia ossificans progressiva.
+authors:
+- Kaplan FS
+- Zasloff MA
+- Kitterman JA
+- Shore EM
+- Hong CC
+- Rocke DM
+journal: J Bone Joint Surg Am
+year: '2010'
+doi: 10.2106/JBJS.I.00705
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Cause of Death
+- Child
+- "Child, Preschool"
+- Female
+- Heart Failure/mortality
+- Humans
+- Male
+- Middle Aged
+- Myositis Ossificans/mortality
+- Pneumonia/mortality
+- Registries
+- Survival Rate
+content_type: abstract_only
+---
+
+# Early mortality and cardiorespiratory failure in patients with fibrodysplasia ossificans progressiva.
+**Authors:** Kaplan FS, Zasloff MA, Kitterman JA, Shore EM, Hong CC, Rocke DM
+**Journal:** J Bone Joint Surg Am (2010)
+**DOI:** [10.2106/JBJS.I.00705](https://doi.org/10.2106/JBJS.I.00705)
+
+## Content
+
+1. J Bone Joint Surg Am. 2010 Mar;92(3):686-91. doi: 10.2106/JBJS.I.00705.
+
+Early mortality and cardiorespiratory failure in patients with fibrodysplasia
+ossificans progressiva.
+
+Kaplan FS(1), Zasloff MA, Kitterman JA, Shore EM, Hong CC, Rocke DM.
+
+Author information:
+(1)Department of Orthopaedic Surgery, Hospital of the University of
+Pennsylvania, Silverstein-2, 3400 Spruce Street, Philadelphia, PA 19104, USA.
+Frederick.Kaplan@uphs.upenn.edu
+
+BACKGROUND: Fibrodysplasia ossificans progressiva, a rare genetic disorder of
+progressive extraskeletal ossification, is the most disabling form of
+heterotopic ossification in humans. However, little is known about the lifespan
+or causes of mortality in these patients. We undertook this study to determine
+the lifespan and causes of mortality in individuals who had fibrodysplasia
+ossificans progressiva.
+METHODS: We reviewed comprehensive mortality reports from two large registries
+of patients with fibrodysplasia ossificans progressiva. Together, these
+registries comprise >90% of all known patients with this condition in the world.
+We noted the sex, dates of birth and death, and the cause of death for each
+individual. We verified the cause of death with extensive medical records, when
+available. We also collected date of birth, current age, and sex information for
+each living patient member of the International Fibrodysplasia Ossificans
+Progressiva Association.
+RESULTS: Sixty deaths (thirty male and thirty female patients) were reported in
+the fibrodysplasia ossificans progressiva community during a
+thirty-three-year-period. For all sixty patients, the median age at the time of
+death was forty years (range, three to seventy-seven years). Data were
+sufficient to establish the cause of death in forty-eight (80%) of the sixty
+individuals. The median age at the time of death for the forty-eight patients
+(twenty-four male and twenty-four female patients) with an established cause of
+death was also forty years. The median lifespan estimated from the 371
+individuals in the international fibrodysplasia ossificans progressiva community
+who were alive and the sixty who had died was fifty-six years (95% confidence
+interval, fifty-one to sixty years). The most common causes of death in patients
+with fibrodysplasia ossificans progressiva were cardiorespiratory failure from
+thoracic insufficiency syndrome (54%; median age, forty-two years) and pneumonia
+(15%; median age, forty years).
+CONCLUSIONS: Fibrodysplasia ossificans progressiva is not only an extremely
+disabling disease but also a condition of considerably shortened lifespan. The
+most common cause of death in patients with fibrodysplasia ossificans
+progressiva is cardiorespiratory failure from thoracic insufficiency syndrome.
+
+DOI: 10.2106/JBJS.I.00705
+PMCID: PMC2827822
+PMID: 20194327 [Indexed for MEDLINE]

--- a/references_cache/PMID_21116899.md
+++ b/references_cache/PMID_21116899.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:21116899"
+title: Deformity of the great toe in fibrodysplasia ossificans progressiva.
+authors:
+- Nakashima Y
+- Haga N
+- Kitoh H
+- Kamizono J
+- Tozawa K
+- Katagiri T
+- Susami T
+- Fukushi J
+- Iwamoto Y
+journal: J Orthop Sci
+year: '2010'
+doi: 10.1007/s00776-010-1542-5
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- Cohort Studies
+- Cross-Sectional Studies
+- Early Diagnosis
+- Female
+- "Foot Deformities, Acquired/diagnostic imaging, etiology"
+- "Hallux/diagnostic imaging, pathology"
+- Humans
+- Infant
+- Male
+- "Metatarsophalangeal Joint/diagnostic imaging, pathology"
+- Middle Aged
+- "Myositis Ossificans/complications, diagnostic imaging, pathology"
+- Radiography
+- Young Adult
+content_type: abstract_only
+---
+
+# Deformity of the great toe in fibrodysplasia ossificans progressiva.
+**Authors:** Nakashima Y, Haga N, Kitoh H, Kamizono J, Tozawa K, Katagiri T, Susami T, Fukushi J, Iwamoto Y
+**Journal:** J Orthop Sci (2010)
+**DOI:** [10.1007/s00776-010-1542-5](https://doi.org/10.1007/s00776-010-1542-5)
+
+## Content
+
+1. J Orthop Sci. 2010 Nov;15(6):804-9. doi: 10.1007/s00776-010-1542-5. Epub 2010
+Nov 30.
+
+Deformity of the great toe in fibrodysplasia ossificans progressiva.
+
+Nakashima Y(1), Haga N, Kitoh H, Kamizono J, Tozawa K, Katagiri T, Susami T,
+Fukushi J, Iwamoto Y.
+
+Author information:
+(1)Department of Orthopaedic Surgery, Kyushu University, 1-3-3 Maidashi,
+Higashi-ku, Fukuoka 812-8582, Japan.
+
+BACKGROUND: As invasive medical procedures can induce permanent heterotopic
+ossification in fibrodysplasia ossificans progressiva (FOP), caution should be
+exercised in clinical practice. The present study was conducted to examine the
+characteristics of the great toe deformity in patients with FOP, which may lead
+to an early diagnosis of this condition.
+METHODS: The subjects consisted of 31 feet from 16 FOP patients (8 males, 8
+females) with an average age of 17.3 years (range 1-47 years) at the time of
+this study. Gross and radiographic findings, including the hallux valgus angles
+(HVA), intermetatarsal angles (IMA), and the deformity of the proximal phalanx
+and metatarsal bone, were examined.
+RESULTS: Of the 31 feet, 29 (93.5%) showed several degrees of great toe
+deformity. A shortened great toe was the typical gross finding and was observed
+in 20 feet (64.5%). The mean HVA and IMA were 19.7° and 8.5°, respectively; and
+22 (71.0%) feet satisfied the radiographic definition of hallux valgus (HVA ≥
+20° or IMA ≥ 10°). The proximal phalanx was consistently shortened but
+morphologically dissimilar from case to case. The metatarsal bone was also
+shortened and sharpened to the medial side, deviating the proximal phalanx
+laterally from the metatarsal axis. Fusion between the distal and proximal
+phalanx occurred with advancing age. Only two feet in one patient showed no
+obvious deformity of the great toe.
+CONCLUSIONS: A shortened great toe and hallux valgus were frequently found in
+patients with FOP. Shortening and sharpening of the proximal phalanx and
+metatarsal bone consistently existed and contributed to the great toe deformity.
+These findings were thought to exist from birth and may be a key to an early
+diagnosis.
+
+DOI: 10.1007/s00776-010-1542-5
+PMID: 21116899 [Indexed for MEDLINE]

--- a/references_cache/PMID_25343126.md
+++ b/references_cache/PMID_25343126.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:25343126"
+title: Radiographic characteristics of the hand and cervical spine in fibrodysplasia ossificans progressiva.
+authors:
+- Mishima K
+- Kitoh H
+- Haga N
+- Nakashima Y
+- Kamizono J
+- Katagiri T
+- Susami T
+- Matsushita M
+- Ishiguro N
+journal: Intractable Rare Dis Res
+year: '2014'
+doi: 10.5582/irdr.2014.01009
+content_type: abstract_only
+---
+
+# Radiographic characteristics of the hand and cervical spine in fibrodysplasia ossificans progressiva.
+**Authors:** Mishima K, Kitoh H, Haga N, Nakashima Y, Kamizono J, Katagiri T, Susami T, Matsushita M, Ishiguro N
+**Journal:** Intractable Rare Dis Res (2014)
+**DOI:** [10.5582/irdr.2014.01009](https://doi.org/10.5582/irdr.2014.01009)
+
+## Content
+
+1. Intractable Rare Dis Res. 2014 May;3(2):46-51. doi: 10.5582/irdr.2014.01009.
+
+Radiographic characteristics of the hand and cervical spine in fibrodysplasia
+ossificans progressiva.
+
+Mishima K(1), Kitoh H(2), Haga N(3), Nakashima Y(3), Kamizono J(3), Katagiri
+T(3), Susami T(3), Matsushita M(1), Ishiguro N(1).
+
+Author information:
+(1)Department of Orthopaedic Surgery, Nagoya University Graduate School of
+Medicine, Nagoya, Aichi, Japan;
+(2)Department of Orthopaedic Surgery, Nagoya University Graduate School of
+Medicine, Nagoya, Aichi, Japan; ; The Research Committee on Fibrodysplasia
+Ossificans Progressiva, Tokyo, Japan.
+(3)The Research Committee on Fibrodysplasia Ossificans Progressiva, Tokyo,
+Japan.
+
+Fibrodysplasia ossificans progressiva (FOP) is a disabling heritable disorder of
+connective tissue characterized by progressive heterotopic ossification in
+various extraskeletal sites. Early correct diagnosis of FOP is important to
+prevent additional iatrogenic harm or trauma. Congenital malformation of the
+great toes is a well-known diagnostic clue, but some patients show
+normal-appearing great toes. The thumb shortening and cervical spine
+abnormalities are other skeletal features often observed in FOP. This study
+aimed to address the quantitative assessment of these features in a cohort of
+patients with FOP, which potentially helps early diagnosis of FOP. Radiographs
+of the hand and cervical spine were retrospectively analyzed from a total of 18
+FOP patients (9 males and 9 females) with an average age of 13.9 years (range
+0.7-39.3 years). The elevated ratio of the second metacarpal bone to the distal
+phalanx of the thumb (> +1SD) was a consistent finding irrespective of the
+patient's age and gender. Infant FOP patients, in addition, exhibited an
+extremely high ratio of the second metacarpal bone to the first metacarpal bone
+(> +3SD). The height/depth ratio of the C5 vertebra increased in patients over 4
+years of age (> +2SD). Additionally, the ratio of (height+depth) of the C5
+spinous process to the C5 vertebral depth was markedly elevated in young
+patients (> +2SD). We quantitatively demonstrated the hand and cervical spine
+characteristics of FOP. These findings, which can be seen from early infancy,
+could be useful for early diagnosis of FOP even in patients without great toe
+abnormalities.
+
+DOI: 10.5582/irdr.2014.01009
+PMCID: PMC4204539
+PMID: 25343126

--- a/references_cache/PMID_26564023.md
+++ b/references_cache/PMID_26564023.md
@@ -1,0 +1,55 @@
+---
+reference_id: PMID:26564023
+title: Quality of life of patients with fibrodysplasia ossificans progressiva.
+authors:
+- Ortiz-Agapito F
+- Colmenares-Bonilla D
+journal: J Child Orthop
+year: '2015'
+doi: 10.1007/s11832-015-0704-6
+content_type: abstract_only
+---
+
+# Quality of life of patients with fibrodysplasia ossificans progressiva.
+**Authors:** Ortiz-Agapito F, Colmenares-Bonilla D
+**Journal:** J Child Orthop (2015)
+**DOI:** [10.1007/s11832-015-0704-6](https://doi.org/10.1007/s11832-015-0704-6)
+
+## Content
+
+1. J Child Orthop. 2015 Dec;9(6):489-93. doi: 10.1007/s11832-015-0704-6. Epub
+2015  Nov 13.
+
+Quality of life of patients with fibrodysplasia ossificans progressiva.
+
+Ortiz-Agapito F(1), Colmenares-Bonilla D(2).
+
+Author information:
+(1)Hospital Regional de Alta Especialidad del Bajio, Boulevard Milenio No. 130,
+Col. San Carlos la Roncha, C.P. 37660, León, Guanajuato, Mexico.
+(2)Hospital Regional de Alta Especialidad del Bajio, Boulevard Milenio No. 130,
+Col. San Carlos la Roncha, C.P. 37660, León, Guanajuato, Mexico.
+douglas_cb@yahoo.com.
+
+INTRODUCTION: Fibrodysplasia ossificans progressiva (FOP) is a rare disorder
+characterized by episodes of acute pain and heterotopic ossification of soft
+tissue, and progressively limited physical function and social participation.
+OBJECTIVE: We aimed to determine the impact of FOP on quality of life,
+specifying areas or dimensions most affected.
+MATERIALS AND METHODS: This was a transverse observational study; patients with
+FOP were assessed using the Short Form 36. Questionnaire results were obtained
+using Quality Metric software and analyzed using frequency distribution,
+percentages and measures of central tendency.
+RESULTS: Eight patients, mean age 30.2 years, were included. The physical
+dimension was the most affected, with an average of 25.5 points. The most
+representative items were impaired function and physical role. Physical pain was
+found with an average of 44.5 points. The best scores were reported in the areas
+of emotional role and mental health, with an average of 79 and 76 respectively.
+CONCLUSIONS: FOP is a severely disabling disease, generating a significant
+deterioration in quality of life secondary to progressive deterioration in
+physical abilities. The findings of this study demonstrate good self-rated
+health of participants.
+
+DOI: 10.1007/s11832-015-0704-6
+PMCID: PMC4661157
+PMID: 26564023

--- a/references_cache/PMID_27025942.md
+++ b/references_cache/PMID_27025942.md
@@ -1,0 +1,102 @@
+---
+reference_id: "PMID:27025942"
+title: "The Natural History of Flare-Ups in Fibrodysplasia Ossificans Progressiva (FOP): A Comprehensive Global Assessment."
+authors:
+- Pignolo RJ
+- Bedford-Gay C
+- Liljesthröm M
+- Durbin-Johnson BP
+- Shore EM
+- Rocke DM
+- Kaplan FS
+journal: J Bone Miner Res
+year: '2016'
+doi: 10.1002/jbmr.2728
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Child
+- "Child, Preschool"
+- Demography
+- Disability Evaluation
+- Disease Progression
+- Female
+- "Health Knowledge, Attitudes, Practice"
+- Humans
+- Infant
+- Internationality
+- Male
+- Middle Aged
+- Myositis Ossificans/pathology
+- Symptom Flare Up
+- Young Adult
+content_type: abstract_only
+---
+
+# The Natural History of Flare-Ups in Fibrodysplasia Ossificans Progressiva (FOP): A Comprehensive Global Assessment.
+**Authors:** Pignolo RJ, Bedford-Gay C, Liljesthröm M, Durbin-Johnson BP, Shore EM, Rocke DM, Kaplan FS
+**Journal:** J Bone Miner Res (2016)
+**DOI:** [10.1002/jbmr.2728](https://doi.org/10.1002/jbmr.2728)
+
+## Content
+
+1. J Bone Miner Res. 2016 Mar;31(3):650-6. doi: 10.1002/jbmr.2728. Epub 2015 Nov
+14.
+
+The Natural History of Flare-Ups in Fibrodysplasia Ossificans Progressiva (FOP):
+A Comprehensive Global Assessment.
+
+Pignolo RJ(1)(2)(3), Bedford-Gay C(4), Liljesthröm M(4), Durbin-Johnson
+BP(5)(6), Shore EM(2)(3)(7), Rocke DM(5)(6), Kaplan FS(1)(2)(3).
+
+Author information:
+(1)Department of Medicine, Perelman School of Medicine, University of
+Pennsylvania, Philadelphia, PA, USA.
+(2)Department of Orthopaedic Surgery, Perelman School of Medicine, University of
+Pennsylvania, Philadelphia, PA, USA.
+(3)The Center for Research in FOP and Related Disorders, Perelman School of
+Medicine, University of Pennsylvania, Philadelphia, PA, USA.
+(4)International FOP Association, Winter Springs, FL, USA.
+(5)Department of Public Health Sciences, School of Medicine, University of
+California, Davis, Davis, CA, USA.
+(6)Department of Biomedical Engineering, University of California, Davis, Davis,
+CA, USA.
+(7)Department of Genetics, Perelman School of Medicine, University of
+Pennsylvania, Philadelphia, PA, USA.
+
+Fibrodysplasia ossificans progressiva (FOP) leads to disabling heterotopic
+ossification (HO) from episodic flare-ups. However, the natural history of FOP
+flare-ups is poorly understood. A 78-question survey on FOP flare-ups,
+translated into 15 languages, was sent to 685 classically-affected patients in
+45 countries (six continents). Five hundred patients or knowledgeable informants
+responded (73%; 44% males, 56% females; ages: 1 to 71 years; median: 23 years).
+The most common presenting symptoms of flare-ups were swelling (93%), pain
+(86%), or decreased mobility (79%). Seventy-one percent experienced a flare-up
+within the preceding 12 months (52% spontaneous; 48% trauma-related).
+Twenty-five percent of those who had received an intramuscular injection
+reported an immediate flare-up at the injection site, 84% of whom developed HO.
+Axial flare-ups most frequently involved the back (41.6%), neck (26.4%), or jaw
+(19.4%). Flare-ups occurred more frequently in the upper limbs before 8 years of
+age, but more frequently in the lower limbs thereafter. Appendicular flare-ups
+occurred more frequently at proximal than at distal sites without preferential
+sidedness. Seventy percent of patients reported functional loss from a flare-up.
+Thirty-two percent reported complete resolution of at least one flare-up and 12%
+without any functional loss (mostly in the head or back). The most disabling
+flare-ups occurred at the shoulders or hips. Surprisingly, 47% reported
+progression of FOP without obvious flare-ups. Worldwide, 198 treatments were
+reported; anti-inflammatory agents were most common. Seventy-five percent used
+short-term glucocorticoids as a treatment for flare-ups at appendicular sites.
+Fifty-five percent reported that glucocorticoids improved symptoms occasionally
+whereas 31% reported that they always did. Only 12% reported complete resolution
+of a flare-up with glucocorticoids. Forty-three percent reported rebound
+symptoms within 1 to 7 days after completing a course of glucocorticoids. This
+study is the first comprehensive global assessment of FOP flare-ups and
+establishes a critical foundation for the design and evaluation of future
+clinical trials.
+
+© 2015 American Society for Bone and Mineral Research.
+
+DOI: 10.1002/jbmr.2728
+PMCID: PMC4829946
+PMID: 27025942 [Indexed for MEDLINE]

--- a/references_cache/PMID_28390760.md
+++ b/references_cache/PMID_28390760.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:28390760"
+title: "Restricted Mandibular Movement Attributed to Ossification of Mandibular Depressors and Medial Pterygoid Muscles in Patients With Fibrodysplasia Ossificans Progressiva: A Report of 3 Cases."
+authors:
+- Okuno T
+- Suzuki H
+- Inoue A
+- Kusukawa J
+journal: J Oral Maxillofac Surg
+year: '2017'
+doi: 10.1016/j.joms.2017.03.005
+keywords:
+- Adult
+- Disease Progression
+- Female
+- Humans
+- "Imaging, Three-Dimensional"
+- Male
+- "Mandibular Diseases/diagnostic imaging, physiopathology"
+- Middle Aged
+- "Myositis Ossificans/diagnostic imaging, physiopathology"
+- "Pterygoid Muscles/diagnostic imaging, physiopathology"
+- "Tomography, X-Ray Computed"
+- "Trismus/diagnostic imaging, physiopathology"
+content_type: abstract_only
+---
+
+# Restricted Mandibular Movement Attributed to Ossification of Mandibular Depressors and Medial Pterygoid Muscles in Patients With Fibrodysplasia Ossificans Progressiva: A Report of 3 Cases.
+**Authors:** Okuno T, Suzuki H, Inoue A, Kusukawa J
+**Journal:** J Oral Maxillofac Surg (2017)
+**DOI:** [10.1016/j.joms.2017.03.005](https://doi.org/10.1016/j.joms.2017.03.005)
+
+## Content
+
+1. J Oral Maxillofac Surg. 2017 Sep;75(9):1891-1898. doi:
+10.1016/j.joms.2017.03.005. Epub 2017 Mar 16.
+
+Restricted Mandibular Movement Attributed to Ossification of Mandibular
+Depressors and Medial Pterygoid Muscles in Patients With Fibrodysplasia
+Ossificans Progressiva: A Report of 3 Cases.
+
+Okuno T(1), Suzuki H(2), Inoue A(3), Kusukawa J(4).
+
+Author information:
+(1)Special Advisor, Department of Orthopedic Surgery, Yanagawa Rehabilitation
+Hospital, Yanagawa, Japan. Electronic address: okuno@kouhoukai.org.
+(2)Assistant Professor, Department of Orthopedic Surgery, School of Medicine,
+University of Occupational and Environmental Health, Kitakyushu, Japan.
+(3)Honorary Director, Department of Orthopedic Surgery, Yanagawa Rehabilitation
+Hospital, Yanagawa, Japan.
+(4)Professor, Dental and Oral Medical Center, Kurume University School of
+Medicine, Kurume, Japan.
+
+Fibrodysplasia ossificans progressiva (FOP) is an extremely rare genetic
+condition characterized by congenital malformation and progressive heterotopic
+ossification (HO) caused by a recurrent single nucleotide substitution at
+position 617 in the ACVR1 gene. As the condition progresses, HO leads to joint
+ankylosis, breathing difficulties, and mouth-opening restriction, and it can
+shorten the patient's lifespan. This report describes 3 cases of FOP confirmed
+by genetic testing in patients with restricted mouth opening. Each patient
+presented a different onset and degree of jaw movement restriction. The anatomic
+ossification site of the mandibular joint was examined in each patient using
+reconstructed computed tomographic (CT) images and 3-dimensional reconstructed
+CT (3D-CT) images. A 29-year-old woman complained of jaw movement restriction
+since 13 years of age. 3D-CT image of the mandibular joint showed an osseous
+bridge, formed by the mandibular depressors that open the mouth, between the
+hyoid bone and the mentum of the mandible. A 39-year-old man presented with jaw
+movement restriction that developed at 3 years of age after a mouth injury.
+3D-CT image of the jaw showed ankylosis of the jaw from ossification of the
+mandibular depressors that was worse than in patient 1. CT images showed no HO
+findings of the masticatory muscles. To the authors' knowledge, these are the
+first 2 case descriptions of the anatomic site of ankylosis involving HO of the
+mandibular depressors in the jaw resulting from FOP. In contrast, a 62-year-old
+bedridden woman with an interincisal distance longer than 10 mm (onset, 39 years
+of age) had no HO of the mandibular depressors and slight HO of the medial
+pterygoid muscle on the right and left sides. These findings suggest that
+restricted mouth opening varies according to the presence or absence of HO of
+the mandibular depressors.
+
+Copyright © 2017. Published by Elsevier Inc.
+
+DOI: 10.1016/j.joms.2017.03.005
+PMID: 28390760 [Indexed for MEDLINE]

--- a/references_cache/PMID_36152026.md
+++ b/references_cache/PMID_36152026.md
@@ -1,0 +1,141 @@
+---
+reference_id: "PMID:36152026"
+title: "The natural history of fibrodysplasia ossificans progressiva: A prospective, global 36-month study."
+authors:
+- Pignolo RJ
+- Baujat G
+- Brown MA
+- De Cunto C
+- Hsiao EC
+- Keen R
+- Al Mukaddam M
+- Le Quan Sang KH
+- Wilson A
+- Marino R
+- Strahs A
+- Kaplan FS
+journal: Genet Med
+year: '2022'
+doi: 10.1016/j.gim.2022.08.013
+keywords:
+- Adolescent
+- Adult
+- Female
+- Humans
+- Male
+- "Myositis Ossificans/diagnostic imaging, epidemiology"
+- "Ossification, Heterotopic/diagnostic imaging, genetics"
+- Pain
+- Prospective Studies
+- "Child, Preschool"
+- Child
+- Young Adult
+- Middle Aged
+content_type: abstract_only
+---
+
+# The natural history of fibrodysplasia ossificans progressiva: A prospective, global 36-month study.
+**Authors:** Pignolo RJ, Baujat G, Brown MA, De Cunto C, Hsiao EC, Keen R, Al Mukaddam M, Le Quan Sang KH, Wilson A, Marino R, Strahs A, Kaplan FS
+**Journal:** Genet Med (2022)
+**DOI:** [10.1016/j.gim.2022.08.013](https://doi.org/10.1016/j.gim.2022.08.013)
+
+## Content
+
+1. Genet Med. 2022 Dec;24(12):2422-2433. doi: 10.1016/j.gim.2022.08.013. Epub
+2022  Sep 24.
+
+The natural history of fibrodysplasia ossificans progressiva: A prospective,
+global 36-month study.
+
+Pignolo RJ(1), Baujat G(2), Brown MA(3), De Cunto C(4), Hsiao EC(5), Keen R(6),
+Al Mukaddam M(7), Le Quan Sang KH(2), Wilson A(8), Marino R(8), Strahs A(8),
+Kaplan FS(9).
+
+Author information:
+(1)Department of Medicine, Mayo Clinic, Rochester, MN. Electronic address:
+pignolo.robert@mayo.edu.
+(2)Département de Génétique, Hôpital Universitaire Necker-Enfants Malades,
+Institut Imagine, Université Paris Cité, Paris, France.
+(3)Department of Medicine and Molecular Genetics, Faculty of Life Sciences and
+Medicine, School of Basic and Medical Biosciences, King's College London,
+London, United Kingdom; Genomics England, London, United Kingdom.
+(4)Pediatric Rheumatology Section, Department of Pediatrics, Hospital Italiano
+de Buenos Aires, Buenos Aires, Argentina.
+(5)Division of Endocrinology and Metabolism, the UCSF Metabolic Bone Clinic, the
+Eli and Edyth Broad Institute for Regeneration Medicine, and the Institute of
+Human Genetics, Department of Medicine, and the UCSF Program in Craniofacial
+Biology, University of California San Francisco, San Francisco, CA.
+(6)Centre for Metabolic Bone Disease, Royal National Orthopaedic Hospital,
+Stanmore, United Kingdom.
+(7)Departments of Orthopaedic Surgery and Medicine, Center for Research in FOP
+and Related Disorders, Perelman School of Medicine, University of Pennsylvania,
+Philadelphia, PA.
+(8)Ipsen, Cambridge, MA.
+(9)Departments of Orthopaedic Surgery and Medicine, Center for Research in FOP
+and Related Disorders, Perelman School of Medicine, University of Pennsylvania,
+Philadelphia, PA. Electronic address: Frederick.Kaplan@pennmedicine.upenn.edu.
+
+PURPOSE: We report the first prospective, international, natural history study
+of the ultra-rare genetic disorder fibrodysplasia ossificans progressiva (FOP).
+FOP is characterized by painful, recurrent flare-ups, and disabling, cumulative
+heterotopic ossification (HO) in soft tissues.
+METHODS: Individuals aged ≤65 years with classical FOP (ACVR1R206H variant) were
+assessed at baseline and over 36 months.
+RESULTS: In total, 114 individuals participated; 33 completed the study (mean
+follow up: 26.8 months). Median age was 15.0 (range: 4-56) years; 54.4% were
+male. During the study, 82 (71.9%) individuals reported 229 flare-ups (upper
+back: 17.9%, hip: 14.8%, shoulder: 10.9%). After 84 days, 14 of 52 (26.9%)
+imaged flare-ups had new HO at the flare-up site (mean new HO volume: 28.8 × 103
+mm3). Mean baseline low-dose whole-body computed tomography (excluding head) HO
+volume was 314.4 × 103 mm3; lowest at 2 to <8 years (68.8 × 103 mm3) and
+increasing by age (25-65 years: 575.2 × 103 mm3). The mean annualized volume of
+new HO was 23.6 × 103 mm3/year; highest at 8 to <15 and 15 to <25 years (21.9 ×
+103 and 41.5 × 103 mm3/year, respectively) and lowest at 25 to 65 years (4.6 ×
+103 mm3/year).
+CONCLUSION: Results from individuals receiving standard care for up to 3 years
+in this natural history study show the debilitating effect and progressive
+nature of FOP cross-sectionally and longitudinally, with greatest progression
+during childhood and early adulthood.
+
+Copyright © 2022 The Authors. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.gim.2022.08.013
+PMID: 36152026 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of Interest R.J.P. is a research
+investigator at Clementia Pharmaceuticals/Ipsen and Regeneron Pharmaceuticals,
+Inc and is part of the advisory board as President of the International Clinical
+Council on Fibrodysplasia Ossificans Progressiva. G.B. is part of the advisory
+boards of Clementia Pharmaceuticals/Ipsen, FOP European Consortium, and
+International Clinical Council on FOP and is a speaker at Clementia
+Pharmaceuticals/Ipsen. M.A.B. is part of the advisory boards of AbbVie, Janssen,
+Pfizer, UCB Pharma, and Novartis; receives grant support from AbbVie; is a
+research investigator at AbbVie, Clementia Pharmaceuticals/Ipsen, Janssen,
+Novartis, Pathios Therapeutics Ltd, and Regeneron Pharmaceuticals, Inc; and is a
+speaker at AbbVie, United States, Janssen, Novartis, Switzerland, Pfizer, United
+States, Regeneron Pharmaceuticals, Inc, United States, and UCB Pharma, United
+Kingdom. C.D.C. is a research investigator at Clementia Pharmaceuticals/Ipsen
+and is a speaker at Novartis. E.C.H. is part (all voluntary) of the Fibrous
+Dysplasia Foundation Advisory Board, International Fibrodysplasia Ossificans
+Progressiva Association (IFOPA), United States Registry Medical Advisory Board,
+and International Clinical Council on FOP Advisory Board; receives clinical
+research support from Clementia Pharmaceuticals/Ipsen, France, Neurocrine
+Biosciences Inc, United States, and Regeneron Pharmaceuticals, Inc; and is a
+research investigator at Clementia Pharmaceuticals/Ipsen. R.K. is a research
+investigator at Clementia Pharmaceuticals/Ipsen, Kyowa Kirin, and Regeneron
+Pharmaceuticals, Inc and is part of the IFOPA Fibrodysplasia Ossificans
+Progressiva Registry Medical Advisory Board and International Clinical Council
+on Fibrodysplasia Ossificans Progressiva Advisory Board. M.A.M. receives
+research support from Clementia Pharmaceuticals/Ipsen and Regeneron
+Pharmaceuticals, Inc; is a non-paid consultant for BioCryst Pharmaceuticals,
+Inc, United States, Blueprint Medicines, Daiichi Sankyo, Incyte, and Keros
+Therapeutics; is part (all voluntary) of the IFOPA Registry Medical Advisory
+Board, Incyte Advisory Board, and International Clinical Council on FOP Advisory
+Board; and receives non-restricted educational fund from Excel and Catalyst
+sponsored by Ipsen. K.-H.L.Q.S. is a coordinator of Ipsen FOP-program and
+multiple osteochondromas-trial. A.W., R.M., and A.S. are employees of Ipsen.
+F.S.K. is a research investigator at Clementia/Ipsen and Regeneron
+Pharmaceuticals, Inc, is part of the IFOPA Medical Advisory Board, is a Founder
+and immediate past President of the International Clinical Council on FOP, and
+is the Chair of the Publications Committee of the International Clinical
+Council. In April 2019, Ipsen acquired Clementia Pharmaceuticals.

--- a/references_cache/PMID_40597333.md
+++ b/references_cache/PMID_40597333.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:40597333"
+title: Respiratory oscillometry in individuals with fibrodysplasia ossificans progressiva.
+authors:
+- Vasileva A
+- Wu JKY
+- Valaee M
+- Ortiz E
+- Hantos Z
+- Tile L
+- Ho I
+- Cheung AM
+- Chow CW
+journal: Orphanet J Rare Dis
+year: '2025'
+doi: 10.1186/s13023-025-03846-6
+keywords:
+- Humans
+- Male
+- Female
+- Oscillometry/methods
+- Adult
+- "Myositis Ossificans/physiopathology, diagnosis"
+- Spirometry
+- Respiratory Function Tests/methods
+- Middle Aged
+- Young Adult
+content_type: abstract_only
+---
+
+# Respiratory oscillometry in individuals with fibrodysplasia ossificans progressiva.
+**Authors:** Vasileva A, Wu JKY, Valaee M, Ortiz E, Hantos Z, Tile L, Ho I, Cheung AM, Chow CW
+**Journal:** Orphanet J Rare Dis (2025)
+**DOI:** [10.1186/s13023-025-03846-6](https://doi.org/10.1186/s13023-025-03846-6)
+
+## Content
+
+1. Orphanet J Rare Dis. 2025 Jul 1;20(1):323. doi: 10.1186/s13023-025-03846-6.
+
+Respiratory oscillometry in individuals with fibrodysplasia ossificans
+progressiva.
+
+Vasileva A(1), Wu JKY(1)(2), Valaee M(1), Ortiz E(1), Hantos Z(3), Tile
+L(4)(5)(6)(7), Ho I(4)(5), Cheung AM(4)(5)(6)(7), Chow CW(8)(9).
+
+Author information:
+(1)Division of Respirology, Department of Medicine, University Health Network,
+585 University Avenue, 11 PMB 130, Toronto, ON, M5G 2N2, Canada.
+(2)Toronto General-Pulmonary Function Laboratory, University Health Network,
+Toronto, Canada.
+(3)Department of Anesthesiology and Intensive Therapy, Semmelweis University,
+Budapest, Hungary.
+(4)Division of General Internal Medicine, Department of Medicine, University
+Health Network, Toronto, Canada.
+(5)Osteoporosis Program, University Health Network and Sinai Health System,
+Toronto, Canada.
+(6)Temerty Faculty of Medicine, Centre of Excellence in Skeletal Health
+Assessment, University of Toronto, Toronto, Canada.
+(7)Department of Medicine, Temerty Faculty of Medicine, University of Toronto,
+Toronto, Canada.
+(8)Division of Respirology, Department of Medicine, University Health Network,
+585 University Avenue, 11 PMB 130, Toronto, ON, M5G 2N2, Canada.
+chung-wai.chow@uhn.ca.
+(9)Department of Medicine, Temerty Faculty of Medicine, University of Toronto,
+Toronto, Canada. chung-wai.chow@uhn.ca.
+
+BACKGROUND: Fibrodysplasia ossificans progressiva (FOP) is an ultra-rare genetic
+bone disease that is characterized by progressive heterotopic ossification of
+the thoracic cavity. Prognosis is poor with cardiopulmonary complications being
+the main cause of death. Spirometry is a well-established metric of functional
+exercise capacity and prognosis in lung diseases but its use is limited in this
+population. Accuracy and validity of spirometry is dependent on forced
+expiratory maneuvers which are difficult to perform for individuals with FOP.
+Oscillometry is an effort-independent pulmonary function test that is highly
+sensitive to changes in respiratory mechanics. Little is known about
+oscillometry in individuals with FOP. The purpose of this paper is to
+characterize FOP using oscillometry.
+RESULTS: Eight participants with FOP were recruited for oscillometry prior to
+spirometry. Cumulative Analogue Joint Involvement Scale (CAJIS) scores were used
+to evaluate total body and regional FOP burden. Spirometry showed a uniform
+pattern of restrictive physiology in all eight participants with no significant
+difference amongst the group. Oscillometry revealed significant diversity in
+respiratory mechanics and chest wall involvement from normal, airway obstruction
+and ventilatory inhomogeneity to extra-thoracic airflow obstruction. We compared
+individuals with normal and abnormal oscillometry and found no statistically
+significant differences in functional status and clinical parameters. However,
+there is a tendency for lower CAJIS scores and fewer recent flare-ups in those
+with more normal respiratory mechanics. The tidal volumes were significantly
+higher in the group with more normal respiratory mechanics. Two
+wheelchair-dependent participants exhibited a pattern of high respiratory
+resistance that increased during both inspiration and expiration, to suggest
+presence of a fixed extra-thoracic defect.
+CONCLUSIONS: Oscillometry provides additional, more detailed information beyond
+spirometry in individuals with FOP. It is far easier than spirometry to complete
+and may be useful to help track disease progression and response to therapies in
+individuals with FOP.
+
+© 2025. The Author(s).
+
+DOI: 10.1186/s13023-025-03846-6
+PMCID: PMC12211171
+PMID: 40597333 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Ethics approval and consent to
+participate: This study was approved by the University Health Network (UHN)
+Research Ethics Board (#19–5582 and 17–5652). The participants provided their
+written informed consent to participate in this study. Consent for publication:
+Not applicable. Competing interests: AMC: consultant fees Ipsen, grants to UHN
+from Ipsen and Incyte for the clinical trials in FOP; CWC: speaker honoraria
+from AstraZeneca Canada and Covis Pharma, investigator-initiated research grant
+from Thorasys Thoracic Medical Devices Corp. (held at UHN); JW: speaker
+honoraria from Covis Pharma; consultant fees from Thorasys Thoracic Medical
+Devices Corp; ZH: consultant fees from Thorasys Thoracic Medical Devices Corp
+and Piston Medical Ltd.

--- a/references_cache/PMID_7929490.md
+++ b/references_cache/PMID_7929490.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:7929490"
+title: Spinal deformity in patients who have fibrodysplasia ossificans progressiva.
+authors:
+- Shah PB
+- Zasloff MA
+- Drummond D
+- Kaplan FS
+journal: J Bone Joint Surg Am
+year: '1994'
+doi: 10.2106/00004623-199410000-00002
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- Contraindications
+- Female
+- Follow-Up Studies
+- Humans
+- Male
+- "Myositis Ossificans/complications, epidemiology"
+- Orthotic Devices
+- Radiography
+- "Scoliosis/diagnostic imaging, epidemiology, etiology, therapy"
+- Spinal Fusion
+- Spine/diagnostic imaging
+content_type: abstract_only
+---
+
+# Spinal deformity in patients who have fibrodysplasia ossificans progressiva.
+**Authors:** Shah PB, Zasloff MA, Drummond D, Kaplan FS
+**Journal:** J Bone Joint Surg Am (1994)
+**DOI:** [10.2106/00004623-199410000-00002](https://doi.org/10.2106/00004623-199410000-00002)
+
+## Content
+
+1. J Bone Joint Surg Am. 1994 Oct;76(10):1442-50. doi:
+10.2106/00004623-199410000-00002.
+
+Spinal deformity in patients who have fibrodysplasia ossificans progressiva.
+
+Shah PB(1), Zasloff MA, Drummond D, Kaplan FS.
+
+Author information:
+(1)Department of Orthopaedic Surgery, University of Pennsylvania School of
+Medicine, Philadelphia.
+
+We reviewed roentgenograms and clinical records in order to characterize the
+spinal deformity in forty patients who had an established diagnosis of
+fibrodysplasia ossificans progressiva. Twenty-six (65 per cent) of the patients
+had scoliosis, which, according to the clinical records and the recollection of
+the patients, had been present during childhood. Twenty-three (88 per cent) of
+the twenty-six curves were unbalanced c-shaped curves, while the remaining three
+(12 per cent) were balanced s-shaped curves. Twenty-one (91 per cent) of the
+twenty-three c-shaped curves involved the thoraco-lumbar or lumbar spine. The
+c-shaped curves ranged in magnitude from 15 to more than 80 degrees. Curves
+became rigid by early adulthood and many resulted in severe pelvic obliquity
+with impaired sitting or standing balance. An osseous bridge developed between
+the posterolateral aspect of the iliac crest and the posterolateral aspect of
+the rib cage in twenty-two (55 per cent) of the forty patients. Nineteen (86 per
+cent) of these twenty-two patients had scoliosis; there was a significant
+association between the development of scoliosis and the presence of the osseous
+bridge (p < 0.005). Ossification of the paravertebral muscles and fascia during
+the first decade of life limited the development of a normal thoracic kyphosis
+in ten (42 per cent) of twenty-four patients for whom lateral roentgenograms of
+the spine were available. A spinal orthosis was used to treat the scoliosis in
+two patients, but this method resulted in breakdown of the skin and failed to
+halt progression of the curve.(ABSTRACT TRUNCATED AT 250 WORDS)
+
+DOI: 10.2106/00004623-199410000-00002
+PMID: 7929490 [Indexed for MEDLINE]

--- a/research/Fibrodysplasia_Ossificans_Progressiva-phenotype-curation-2026-04-19.md
+++ b/research/Fibrodysplasia_Ossificans_Progressiva-phenotype-curation-2026-04-19.md
@@ -1,0 +1,111 @@
+---
+provider: manual_pubmed_review
+model: n/a
+cached: false
+start_time: '2026-04-19T06:45:00Z'
+end_time: '2026-04-19T07:35:00Z'
+duration_seconds: 3000.0
+citation_count: 12
+notes: >
+  Manual phenotype-focused curation review for Fibrodysplasia Ossificans
+  Progressiva. Scope was limited to the phenotype section of
+  `kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml`. Primary PubMed
+  abstracts were fetched with `just fetch-reference`; ontology mappings were
+  checked against HPO labels and refined to favor phenotype specificity without
+  overclaiming unsupported frequency or onset.
+---
+
+## Question
+
+Enhance the phenotype section for Fibrodysplasia Ossificans Progressiva with
+clinically important, PMID-backed manifestations only; add onset/frequency only
+when directly supported; remove or soften unsupported phenotype claims.
+
+## Output
+
+# FOP Phenotype Curation Note
+
+## Scope decisions
+
+- Kept the edit phenotype-only; no unrelated mechanism, treatment, or prevalence
+  rewrites were performed.
+- Replaced weak phenotype evidence that had been anchored to a mouse palovarotene
+  paper with human clinical abstracts that directly describe the phenotype.
+- Added missing but clinically important manifestations that recur across FOP
+  case series and natural-history studies: flare-up pain/swelling, cervical
+  spine anomalies, neck motion limitation, short thumb, conductive hearing loss,
+  restricted mouth opening, and proximal tibial osteochondromas.
+- Used structured `phenotype_contexts` only where onset was directly stated in
+  the abstract.
+- Kept frequency qualifiers only where an abstract gave a clear count or
+  percentage that could be mapped directly to the HPO-aligned frequency bands.
+
+## Key phenotype evidence used
+
+### Hallux malformation
+
+- PMID:21116899
+  > A shortened great toe and hallux valgus were frequently found in patients with FOP.
+- PMID:21116899
+  > These findings were thought to exist from birth and may be a key to an early diagnosis.
+
+### Heterotopic ossification
+
+- PMID:36152026
+  > FOP is characterized by painful, recurrent flare-ups, and disabling, cumulative heterotopic ossification (HO) in soft tissues.
+- PMID:17572636
+  > Individuals with fibrodysplasia ossificans progressiva are born with malformations of the great toes and develop a heterotopic skeleton during childhood
+
+### Flare-up manifestations
+
+- PMID:26564023
+  > Fibrodysplasia ossificans progressiva (FOP) is a rare disorder characterized by episodes of acute pain and heterotopic ossification of soft tissue, and progressively limited physical function and social participation.
+- PMID:27025942
+  > The most common presenting symptoms of flare-ups were swelling (93%), pain (86%), or decreased mobility (79%).
+
+### Axial skeletal and mobility manifestations
+
+- PMID:7929490
+  > Twenty-six (65 per cent) of the patients had scoliosis, which, according to the clinical records and the recollection of the patients, had been present during childhood.
+- PMID:15959366
+  > In the FOP patient group, characteristic anomalies, including large posterior elements, tall narrow vertebral bodies,and fusion of the facet joints between C2 and C7, were observed.
+- PMID:15959366
+  > Generalized neck stiffness and decreased range of motion were noted in most children with FOP.
+- PMID:15959366
+  > FOP patients exhibit a characteristic set of congenital spine malformations.
+
+### Additional skeletal manifestations
+
+- PMID:25343126
+  > The thumb shortening and cervical spine abnormalities are other skeletal features often observed in FOP.
+- PMID:18245597
+  > Ninety percent of all patients had osteochondroma of the proximal part of the tibia.
+
+### Craniofacial, auditory, and respiratory manifestations
+
+- PMID:28390760
+  > As the condition progresses, HO leads to joint ankylosis, breathing difficulties, and mouth-opening restriction, and it can shorten the patient's lifespan.
+- PMID:10499116
+  > The findings of both studies indicate that individuals with FOP are at risk for hearing loss and that the type of loss is predominantly conductive in nature
+- PMID:40597333
+  > Spirometry showed a uniform pattern of restrictive physiology in all eight participants with no significant difference amongst the group.
+- PMID:20194327
+  > The most common causes of death in patients with fibrodysplasia ossificans progressiva were cardiorespiratory failure from thoracic insufficiency syndrome (54%; median age, forty-two years) and pneumonia (15%; median age, forty years).
+
+## Modeling decisions
+
+- `HP:0011986` `Ectopic ossification` was used instead of the narrower
+  muscle-only term because FOP affects fascia, tendons, and ligaments as well
+  as muscle.
+- `HP:0002949` `Fused cervical vertebrae` was used as the best HPO anchor for
+  the congenital cervical fusion phenotype, while the `preferred_term`
+  preserves the broader clinical description of the cervical anomaly pattern.
+- `HP:0012531` `Pain` and `HP:0000969` `Edema` were used with more specific
+  `preferred_term` labels for flare-up pain and swelling because HPO does not
+  offer an FOP-specific flare-up term.
+- Frequency was retained only for:
+  - `Scoliosis` from 26/40 patients = 65% (`FREQUENT`)
+  - `Proximal Tibial Osteochondromas` from 90% of patients (`VERY_FREQUENT`)
+- Earlier blanket frequency claims for joint immobility, joint stiffness, and
+  restrictive ventilatory defect were removed because the prior citations did
+  not directly support those bands.


### PR DESCRIPTION
## Summary

Enhances the phenotype section for `kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml` with phenotype-specific, PMID-backed human clinical evidence.

## What changed

- replaced weak or indirect phenotype citations with direct human clinical abstracts
- added major missing manifestations: flare-up pain, soft-tissue swelling during flare-ups, cervical spine malformations, limitation of neck motion, short thumb, conductive hearing impairment, restricted mouth opening, and proximal tibial osteochondromas
- added onset context only where explicitly supported in abstracts
- retained frequency qualifiers only where the abstract reported direct counts or percentages
- added a concise phenotype-focused research note in `research/`
- fetched and committed the required PubMed reference caches for the new phenotype evidence

## Intentionally not changed

- no unrelated rewrite of pathophysiology, treatment, prevalence, or other sections
- no unrelated dirty files in the worktree were staged

## Validation

- `just validate kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml`
  - passed
- `just validate-references kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml`
  - passed
- `just validate-terms kb/disorders/Fibrodysplasia_Ossificans_Progressiva.yaml`
  - passed

Closes #1522