### PR TITLE
[codex] Enhance Schneckenbecken dysplasia phenotype evidence

### DIFF
--- a/kb/disorders/Schneckenbecken_Dysplasia.yaml
+++ b/kb/disorders/Schneckenbecken_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Schneckenbecken Dysplasia
 creation_date: "2026-04-02T00:00:00Z"
-updated_date: "2026-04-03T12:00:00Z"
+updated_date: "2026-04-19T07:27:12Z"
 category: Mendelian
 description: >
   Schneckenbecken dysplasia is a perinatally lethal autosomal recessive skeletal dysplasia
@@ -174,11 +174,10 @@ pathophysiology:
 phenotypes:
 - category: Skeletal
   name: Severe Platyspondyly
-  frequency: VERY_FREQUENT
   description: >
-    Markedly flattened vertebral bodies, often described as wafer-thin, with absent
-    ossification of posterior vertebral body elements. On lateral view, vertebral bodies
-    appear oval-shaped. This is a cardinal radiographic feature.
+    Marked flattening of the vertebral bodies is a core radiographic feature. In classic
+    lethal cases the vertebral bodies can be wafer-thin, with deficient ossification of the
+    posterior elements and a rounded profile on lateral radiographs.
   phenotype_term:
     preferred_term: Platyspondyly
     term:
@@ -197,9 +196,14 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "severe flattening of the vertebral bodies with absent ossification of the posterior parts of the vertebral bodies"
     explanation: Multi-family study confirms severe platyspondyly with deficient posterior ossification as a hallmark feature.
+  - reference: PMID:1754916
+    reference_title: "Case report 693: Schneckenbecken dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "demonstrating a short-limbed, platyspondylic dwarf with a snail-like configuration of the ilium and vertebral bodies, flat on AP and round on lateral view"
+    explanation: Follow-up case report confirms platyspondyly with the characteristic flattened AP and rounded lateral vertebral contour.
 - category: Skeletal
   name: Hypoplastic Ilia with Snail-Like Configuration
-  frequency: VERY_FREQUENT
   description: >
     The iliac bones are hypoplastic with a distinctive medial bone projection from the
     inner iliac margin, producing the pathognomonic snail-like (Schneckenbecken)
@@ -223,13 +227,17 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "The radiological hallmark of SBD is the snail-like configuration of the hypoplastic iliac bone"
     explanation: Confirms that the snail-like iliac configuration is the radiological hallmark.
+  - reference: PMID:19407457
+    reference_title: "Schneckenbecken dysplasia in fetus: report of four cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "showing especially the small ilia with medial snail-like projection"
+    explanation: Additional fetal series confirms the characteristic medial iliac projection.
 - category: Skeletal
   name: Severe Micromelia
-  frequency: VERY_FREQUENT
   description: >
-    All limbs are severely shortened (micromelia). Long bones are short and broad with a
-    characteristic dumbbell-like appearance due to metaphyseal widening. The fibula is
-    distinctively short and wide.
+    The appendicular skeleton is markedly shortened in the classic lethal phenotype. Long
+    bones are short and broad, and the fibula can also be short and wide.
   phenotype_term:
     preferred_term: Micromelia
     term:
@@ -246,14 +254,13 @@ phenotypes:
     reference_title: "Identification of loss-of-function mutations of SLC35D1 in patients with Schneckenbecken dysplasia, but not with other severe spondylodysplastic dysplasias group diseases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "short thick long bones"
-    explanation: Multi-family study confirms characteristic short thick long bones.
+    snippet: "There was marked micromelia."
+    explanation: Multi-family case descriptions document marked micromelia in the classic prenatal lethal phenotype.
 - category: Skeletal
   name: Dumbbell-Shaped Long Bones
-  frequency: VERY_FREQUENT
   description: >
-    Long bones have a characteristic dumbbell-like or club-shaped appearance with
-    metaphyseal flaring and relative narrowing at the diaphysis.
+    Long bones are short and broad with relative metaphyseal expansion, producing a
+    dumbbell-like contour on radiographs.
   phenotype_term:
     preferred_term: Dumbbell-shaped long bone
     term:
@@ -273,11 +280,10 @@ phenotypes:
     snippet: "short and broad long bones with a dumbbell-like appearance, thoracic hypoplasia"
     explanation: Later report confirms dumbbell-shaped long bones as characteristic even in milder cases.
 - category: Skeletal
-  name: Short Ribs with Narrow Thorax
-  frequency: VERY_FREQUENT
+  name: Short Ribs
   description: >
-    Ribs are short, producing a narrow bell-shaped thorax. Thoracic hypoplasia contributes
-    to lethal pulmonary restriction in the classic form.
+    Short ribs are part of the characteristic lethal skeletal dysplasia pattern and
+    contribute to thoracic restriction.
   phenotype_term:
     preferred_term: Short ribs
     term:
@@ -290,24 +296,40 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "short ribs"
     explanation: Original description identifies short ribs as a cardinal feature.
+  - reference: PMID:25997753
+    reference_title: "A second locus for Schneckenbecken dysplasia identified by a mutation in the gene encoding inositol polyphosphate phosphatase-like 1 (INPPL1)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "included midface hypoplasia, handlebar clavicles, short ribs, hypoplastic vertebrae with rounded anterior ends, short long bones with widened metaphyseal ends and a snail-like medial projection in the ileum"
+    explanation: INPPL1-related Schneckenbecken dysplasia preserves the characteristic short-rib phenotype seen in SLC35D1-related disease.
+- category: Skeletal
+  name: Bell-Shaped Thorax
+  description: >
+    The thorax is narrow and bell shaped in the classic lethal presentation, reflecting
+    severe thoracic constriction.
+  phenotype_term:
+    preferred_term: Bell-shaped thorax
+    term:
+      id: HP:0001591
+      label: Bell-shaped thorax
+  evidence:
   - reference: PMID:19508970
     reference_title: "Identification of loss-of-function mutations of SLC35D1 in patients with Schneckenbecken dysplasia, but not with other severe spondylodysplastic dysplasias group diseases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "The chest was narrow and bell shaped."
-    explanation: Multi-family study describes the narrow bell-shaped thorax caused by short ribs.
+    explanation: Bell-shaped thoracic constriction was documented radiographically in a molecularly supported fetal case.
 - category: Skeletal
-  name: Precocious Tarsal Ossification
-  frequency: FREQUENT
+  name: Advanced Tarsal Ossification
   description: >
     Advanced ossification of the tarsal bones is a distinctive radiographic finding
     that distinguishes Schneckenbecken dysplasia from other severe spondylodysplastic
     dysplasias.
   phenotype_term:
-    preferred_term: Accelerated skeletal maturation
+    preferred_term: Advanced tarsal ossification
     term:
-      id: HP:0005616
-      label: Accelerated skeletal maturation
+      id: HP:0008108
+      label: Advanced tarsal ossification
   evidence:
   - reference: PMID:3799723
     reference_title: "A distinct lethal neonatal chondrodysplasia with snail-like pelvis: Schneckenbecken dysplasia."
@@ -321,9 +343,105 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Tarsal ossification was advanced"
     explanation: Confirmed in subsequent multi-family study.
+- category: Skeletal
+  name: Brachydactyly
+  description: >
+    Short digits have been included among the recurring skeletal findings of classic
+    Schneckenbecken dysplasia.
+  phenotype_term:
+    preferred_term: Brachydactyly
+    term:
+      id: HP:0001156
+      label: Brachydactyly
+  evidence:
+  - reference: PMID:25997753
+    reference_title: "A second locus for Schneckenbecken dysplasia identified by a mutation in the gene encoding inositol polyphosphate phosphatase-like 1 (INPPL1)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical findings include relative macrocephaly, a very flat midface, cleft palate, a short neck, a narrow thorax, brachydactyly, and a high incidence of polyhydramnios."
+    explanation: Review of the published Schneckenbecken dysplasia phenotype spectrum includes brachydactyly among the recurring skeletal findings.
+- category: Skeletal
+  name: Short Neck
+  description: >
+    Prenatal ultrasound may show a short neck, sometimes with associated redundant nuchal
+    skin.
+  phenotype_term:
+    preferred_term: Short neck
+    term:
+      id: HP:0000470
+      label: Short neck
+  evidence:
+  - reference: PMID:19508970
+    reference_title: "Identification of loss-of-function mutations of SLC35D1 in patients with Schneckenbecken dysplasia, but not with other severe spondylodysplastic dysplasias group diseases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "On prenatal ultrasound at 22 weeks gestation, this fetus was identified as having a short neck with redundant nuchal skin, narrow thorax, scoliosis, and short limbs"
+    explanation: Detailed prenatal case description documents short neck as part of the fetal presentation.
+  - reference: PMID:25997753
+    reference_title: "A second locus for Schneckenbecken dysplasia identified by a mutation in the gene encoding inositol polyphosphate phosphatase-like 1 (INPPL1)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical findings include relative macrocephaly, a very flat midface, cleft palate, a short neck, a narrow thorax, brachydactyly, and a high incidence of polyhydramnios."
+    explanation: Published phenotype summaries of classic Schneckenbecken dysplasia include short neck among the recognizable prenatal findings.
+- category: Craniofacial
+  name: Flat Midface
+  description: >
+    A very flat or retrusive midface has been described in classic cases and contributes to
+    the characteristic craniofacial appearance.
+  phenotype_term:
+    preferred_term: Flat midface
+    term:
+      id: HP:0011800
+      label: Midface retrusion
+  evidence:
+  - reference: PMID:25997753
+    reference_title: "A second locus for Schneckenbecken dysplasia identified by a mutation in the gene encoding inositol polyphosphate phosphatase-like 1 (INPPL1)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical findings include relative macrocephaly, a very flat midface, cleft palate, a short neck, a narrow thorax, brachydactyly, and a high incidence of polyhydramnios."
+    explanation: Published phenotype summaries identify a very flat midface as part of the classic craniofacial phenotype.
+- category: Prenatal
+  name: Increased Nuchal Thickness
+  description: >
+    Increased nuchal thickness or redundant nuchal skin can be one of the earliest prenatal
+    clues, sometimes noted together with generalized fetal edema.
+  phenotype_term:
+    preferred_term: Increased nuchal thickness
+    term:
+      id: HP:0000474
+      label: Thickened nuchal skin fold
+  evidence:
+  - reference: PMID:15386610
+    reference_title: "Perinatally lethal, short-limbed dwarfism with distinct features -- Schneckenbecken dysplasia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "presenting antenatally with increased nuchal thickness and severe skeletal dysplasia"
+    explanation: Prenatal case report identifies increased nuchal thickness as an early sonographic clue.
+  - reference: PMID:19508970
+    reference_title: "Identification of loss-of-function mutations of SLC35D1 in patients with Schneckenbecken dysplasia, but not with other severe spondylodysplastic dysplasias group diseases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The fetus was terminated 20 weeks gestation due to detection of short limbs, redundant nuchal skin and scalp oedema on prenatal ultrasound."
+    explanation: Additional fetal case supports redundant nuchal soft tissue swelling within the prenatal phenotype spectrum.
+- category: Prenatal
+  name: Polyhydramnios
+  description: >
+    Polyhydramnios has been reported in affected pregnancies and is part of the prenatal
+    phenotype spectrum.
+  phenotype_term:
+    preferred_term: Polyhydramnios
+    term:
+      id: HP:0001561
+      label: Polyhydramnios
+  evidence:
+  - reference: PMID:25997753
+    reference_title: "A second locus for Schneckenbecken dysplasia identified by a mutation in the gene encoding inositol polyphosphate phosphatase-like 1 (INPPL1)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical findings include relative macrocephaly, a very flat midface, cleft palate, a short neck, a narrow thorax, brachydactyly, and a high incidence of polyhydramnios."
+    explanation: Published phenotype summaries describe polyhydramnios as a recurrent pregnancy finding in Schneckenbecken dysplasia.
 - category: Prenatal
   name: Hydrops Fetalis
-  frequency: FREQUENT
   description: >
     Nonimmune hydrops fetalis has been reported in multiple cases, sometimes developing
     as early as the second trimester. Associated findings include cystic hygroma,
@@ -346,13 +464,28 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "This fetus was identified on 18 weeks ultrasound as having hydrops and short limbs"
     explanation: Additional case with hydrops detected on prenatal ultrasound.
+- category: Abdominal
+  name: Protuberant Abdomen
+  description: >
+    A protuberant abdomen has been described repeatedly in fetuses with the classic lethal
+    phenotype.
+  phenotype_term:
+    preferred_term: Protuberant abdomen
+    term:
+      id: HP:0001538
+      label: Protuberant abdomen
+  evidence:
+  - reference: PMID:19508970
+    reference_title: "Identification of loss-of-function mutations of SLC35D1 in patients with Schneckenbecken dysplasia, but not with other severe spondylodysplastic dysplasias group diseases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The chest was narrow and short with a protuberant abdomen."
+    explanation: Detailed fetal case descriptions document a recurrent protuberant abdominal contour.
 - category: Respiratory
   name: Pulmonary Hypoplasia
-  frequency: VERY_FREQUENT
   description: >
-    Underdevelopment of the lungs secondary to thoracic restriction from short ribs
-    and narrow chest. Pulmonary hypoplasia is the primary cause of death in cases
-    that survive to delivery.
+    Pulmonary hypoplasia has been documented at autopsy in classic cases and likely reflects
+    severe thoracic restriction.
   phenotype_term:
     preferred_term: Pulmonary hypoplasia
     term:
@@ -365,6 +498,62 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "The autopsy revealed placental hydropic changes, pulmonary hypoplasia and accessory spleen"
     explanation: Autopsy confirmation of pulmonary hypoplasia in a classic case.
+- category: Growth
+  name: Short Stature
+  description: >
+    Surviving individuals with hypomorphic SLC35D1 variants can present with nonlethal
+    short stature rather than the classic perinatal lethal phenotype.
+  phenotype_term:
+    preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  evidence:
+  - reference: PMID:35934917
+    reference_title: "A novel SLC35D1 variant causing milder phenotype of Schneckenbecken dysplasia in a large pedigree."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The affected patients have common clinical features such as short stature, mild mesomelia, shortening of the lower extremity, genu valgum, and narrow thorax."
+    explanation: Hypomorphic SLC35D1 variants can cause a surviving phenotype centered on short stature rather than perinatal lethality.
+  - reference: PMID:38058750
+    reference_title: "A Mild Skeletal Dysplasia Caused by a Biallelic Missense Variant in the SLC35D1 Gene."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A 17-year-old male with a coarse face and short stature was referred to our clinic."
+    explanation: Independent report confirms short stature in the nonlethal SLC35D1 phenotypic spectrum.
+- category: Skeletal
+  name: Mesomelia
+  description: >
+    Mild mesomelia has been reported in the nonlethal hypomorphic SLC35D1 spectrum.
+  phenotype_term:
+    preferred_term: Mesomelia
+    term:
+      id: HP:0003027
+      label: Mesomelia
+  evidence:
+  - reference: PMID:35934917
+    reference_title: "A novel SLC35D1 variant causing milder phenotype of Schneckenbecken dysplasia in a large pedigree."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The affected patients have common clinical features such as short stature, mild mesomelia, shortening of the lower extremity, genu valgum, and narrow thorax."
+    explanation: Mild mesomelia is part of the documented nonlethal spectrum caused by hypomorphic SLC35D1 variants.
+- category: Skeletal
+  name: Genu Valgum
+  description: >
+    Genu valgum is part of the limb phenotype in some surviving individuals with
+    hypomorphic SLC35D1 variants.
+  phenotype_term:
+    preferred_term: Genu valgum
+    term:
+      id: HP:0002857
+      label: Genu valgum
+  evidence:
+  - reference: PMID:35934917
+    reference_title: "A novel SLC35D1 variant causing milder phenotype of Schneckenbecken dysplasia in a large pedigree."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The affected patients have common clinical features such as short stature, mild mesomelia, shortening of the lower extremity, genu valgum, and narrow thorax."
+    explanation: Genu valgum is explicitly reported in the surviving hypomorphic SLC35D1 phenotype.
 genetic:
 - name: SLC35D1 Loss-of-Function Mutations
   association: Causative

--- a/references_cache/PMID_15386610.md
+++ b/references_cache/PMID_15386610.md
@@ -1,0 +1,46 @@
+---
+reference_id: "PMID:15386610"
+title: "Perinatally lethal, short-limbed dwarfism with distinct features -- Schneckenbecken dysplasia."
+authors:
+- Varkey JJ
+- Jones RA
+journal: Ultrasound Obstet Gynecol
+year: '2004'
+doi: 10.1002/uog.1115
+keywords:
+- Adult
+- Female
+- Fetal Death
+- Humans
+- Pregnancy
+- "Thanatophoric Dysplasia/diagnostic imaging, pathology"
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Perinatally lethal, short-limbed dwarfism with distinct features -- Schneckenbecken dysplasia.
+**Authors:** Varkey JJ, Jones RA
+**Journal:** Ultrasound Obstet Gynecol (2004)
+**DOI:** [10.1002/uog.1115](https://doi.org/10.1002/uog.1115)
+
+## Content
+
+1. Ultrasound Obstet Gynecol. 2004 Oct;24(5):575-7. doi: 10.1002/uog.1115.
+
+Perinatally lethal, short-limbed dwarfism with distinct features -- 
+Schneckenbecken dysplasia.
+
+Varkey JJ(1), Jones RA.
+
+Author information:
+(1)Department of Paediatrics, Wexham Park Hospital, Slough, Berkshire, United 
+Kingdom.
+
+The clinical, radiographical and histological features are described for a case 
+of Schneckenbecken dysplasia, presenting antenatally with increased nuchal 
+thickness and severe skeletal dysplasia. Intrauterine death occurred in the 
+third trimester and the precise diagnosis was made postmortem. This is the first 
+case reported in the UK.
+
+DOI: 10.1002/uog.1115
+PMID: 15386610 [Indexed for MEDLINE]

--- a/references_cache/PMID_1754916.md
+++ b/references_cache/PMID_1754916.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:1754916"
+title: "Case report 693: Schneckenbecken dysplasia."
+authors:
+- Giedion A
+- Biedermann K
+- Briner J
+- Soler R
+- Spycher M
+journal: Skeletal Radiol
+year: '1991'
+doi: 10.1007/BF00194254
+keywords:
+- "Dwarfism/diagnosis, diagnostic imaging, pathology"
+- Female
+- Fetal Diseases/diagnostic imaging
+- "Fetus/diagnostic imaging, pathology"
+- Humans
+- Pregnancy
+- Prenatal Diagnosis
+- Radiography
+- Syndrome
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Case report 693: Schneckenbecken dysplasia.
+**Authors:** Giedion A, Biedermann K, Briner J, Soler R, Spycher M
+**Journal:** Skeletal Radiol (1991)
+**DOI:** [10.1007/BF00194254](https://doi.org/10.1007/BF00194254)
+
+## Content
+
+1. Skeletal Radiol. 1991;20(7):534-8. doi: 10.1007/BF00194254.
+
+Case report 693: Schneckenbecken dysplasia.
+
+Giedion A(1), Biedermann K, Briner J, Soler R, Spycher M.
+
+Author information:
+(1)Department of Radiology, University Children's Hospital, Zürich, Switzerland.
+
+Three siblings with SBD from consangineous parents are reported. The prenatal 
+diagnosis of a short-limbed form of dwarfism was made by ultrasonography and the 
+final diagnosis in the index case by radiography, demonstrating a short-limbed, 
+platyspondylic dwarf with a snail-like configuration of the ilium and vertebral 
+bodies, flat on AP and round on lateral view. The histological examination 
+showed a generalized, severe disturbance of cartilage formation with marked 
+hypercellularity of proliferating and resting zones, reduction of intercellular 
+matrix, and shortening of the irregular columns of proliferating cartilage. The 
+ultramicroscopic findings were nonspecific. This is the first report of SBD 
+after the original description, bringing the total to 14 cases in 5 families. 
+The correct radiological diagnosis and the differential diagnosis, in particular 
+thanatophoric dysplasia, are essential for genetic counselling and obstetrical 
+guidance of families affected with this autosomal recessive dysplasia.
+
+DOI: 10.1007/BF00194254
+PMID: 1754916 [Indexed for MEDLINE]

--- a/references_cache/PMID_19407457.md
+++ b/references_cache/PMID_19407457.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:19407457"
+title: "Schneckenbecken dysplasia in fetus: report of four cases."
+authors:
+- Lahmar-Boufaroua A
+- Yacoubi MT
+- Belaid L
+- Delezoide AL
+journal: Fetal Diagn Ther
+year: '2009'
+doi: 10.1159/000214860
+keywords:
+- "Aborted Fetus/diagnostic imaging, pathology"
+- Adult
+- Consanguinity
+- Female
+- Humans
+- "Osteochondrodysplasias/diagnostic imaging, pathology"
+- Pregnancy
+- Radiography
+- "Ultrasonography, Prenatal"
+content_type: abstract_only
+---
+
+# Schneckenbecken dysplasia in fetus: report of four cases.
+**Authors:** Lahmar-Boufaroua A, Yacoubi MT, Belaid L, Delezoide AL
+**Journal:** Fetal Diagn Ther (2009)
+**DOI:** [10.1159/000214860](https://doi.org/10.1159/000214860)
+
+## Content
+
+1. Fetal Diagn Ther. 2009;25(2):216-9. doi: 10.1159/000214860. Epub 2009 Apr 29.
+
+Schneckenbecken dysplasia in fetus: report of four cases.
+
+Lahmar-Boufaroua A(1), Yacoubi MT, Belaid L, Delezoide AL.
+
+Author information:
+(1)Department of Pathology, Farhat Hached Hospital, Sousse, Tunisia. 
+aboufaroua@yahoo.fr
+
+Several different types of lethal short-limbed skeletal dysplasia with 
+platyspondylia have been recognized with a different mode of inheritance. 
+Schneckenbecken dysplasia, a very rare lethal osteochondrodysplasia, is included 
+in these entities, with an autosomal recessive mode of inheritance. We describe 
+4 new Tunisian cases with clinical, radiographic and histopathological features. 
+The fetuses were of consanguineous parents. Prenatal diagnostics of short limbs 
+were carried out on ultrasounds at 20, 22, 23 and 28 weeks of gestation. The 
+radiographic findings were typical, showing especially the small ilia with 
+medial snail-like projection. The chondro-osseous histology of the 4 cases was 
+compatible with the diagnostics demonstrating cartilage anomalies characterized 
+by hypercellularity, hypervascularisation and chondrocytes with central large 
+round nucleus. Schneckenbecken dysplasia should be considered when the phenotype 
+of dwarfism and snail feature of iliac bone associated with histological finding 
+are presented. Frozen fetal samples should be taken in order to look for 
+candidate genes.
+
+Copyright (c) 2009 S. Karger AG, Basel.
+
+DOI: 10.1159/000214860
+PMID: 19407457 [Indexed for MEDLINE]


### PR DESCRIPTION
Refs #1526

## Summary
- expand the `Schneckenbecken_Dysplasia.yaml` phenotype section with PMID-backed skeletal, prenatal, craniofacial, respiratory, and mild-spectrum findings
- replace the broad tarsal ossification mapping with the specific HPO term for advanced tarsal ossification
- remove unsupported phenotype frequency assertions and soften over-strong pulmonary hypoplasia wording
- cache the newly cited references for PMID:15386610, PMID:1754916, and PMID:19407457

## Validation
- `just validate kb/disorders/Schneckenbecken_Dysplasia.yaml` — passed (`No issues found`)
- `just validate-references kb/disorders/Schneckenbecken_Dysplasia.yaml` — passed (`All validations passed`)
- `just validate-terms kb/disorders/Schneckenbecken_Dysplasia.yaml` — passed (`✅ Validation passed`)
