### PR TITLE
[codex] Enhance ODDD phenotype evidence

### DIFF
--- a/kb/disorders/Oculodentodigital_Dysplasia.yaml
+++ b/kb/disorders/Oculodentodigital_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Oculodentodigital Dysplasia
 creation_date: '2026-04-04T12:00:00Z'
-updated_date: '2026-04-04T18:00:00Z'
+updated_date: '2026-04-19T07:26:55Z'
 category: Mendelian
 description: >
   Oculodentodigital dysplasia (ODDD) is a rare pleiotropic disorder caused by mutations
@@ -9,15 +9,18 @@ description: >
   expressivity; rare autosomal recessive forms with more severe phenotypes have been
   reported. The hallmark features are craniofacial dysmorphism (narrow nose with
   hypoplastic alae nasi), ocular anomalies (microphthalmia, microcornea), dental
-  abnormalities (microdontia, enamel hypoplasia, caries), and digital malformations
-  (type III syndactyly of the fourth and fifth fingers, camptodactyly). Neurological
-  involvement including spastic paraplegia, dysarthria, ataxia, neurogenic bladder,
-  and seizures occurs in a significant minority. Conductive hearing loss, sparse hair,
-  and cardiac defects are additional features. Dominant-negative GJA1 mutations impair
-  gap junction intercellular communication, disrupting coordinated signaling in tissues
-  that depend on Cx43-mediated coupling. Allelic conditions include erythrokeratodermia
-  variabilis et progressiva (MONDO:0033013) and palmoplantar keratoderma with congenital
-  alopecia (MONDO:0007083), reflecting the broad phenotypic spectrum of GJA1 dysfunction.
+  abnormalities (microdontia, enamel hypoplasia, taurodontia), and digital
+  malformations (type III syndactyly of the fourth and fifth fingers,
+  camptodactyly). Neurological involvement including spastic paraplegia,
+  dysarthria, ataxia, neurogenic bladder, and seizures occurs in a significant
+  minority. Conductive hearing impairment, skin/hair/nail anomalies, and rare
+  cardiac defects are additional reported features. Dominant-negative GJA1
+  mutations impair gap junction intercellular communication, disrupting
+  coordinated signaling in tissues that depend on Cx43-mediated coupling.
+  Allelic conditions include erythrokeratodermia variabilis et progressiva
+  (MONDO:0033013) and palmoplantar keratoderma with congenital alopecia
+  (MONDO:0007083), reflecting the broad phenotypic spectrum of GJA1
+  dysfunction.
 disease_term:
   preferred_term: oculodentodigital dysplasia
   term:
@@ -93,198 +96,372 @@ inheritance:
     explanation: Reports a third AR family with a homozygous truncating mutation, confirming recessive inheritance in ODDD.
 phenotypes:
 - category: Craniofacial
-  name: Narrow Nose with Hypoplastic Alae Nasi
+  name: Narrow nose
   description: >
-    The characteristic facial appearance includes a narrow, pinched nose with
-    hypoplastic alae nasi, prominent columella, and thin anteverted nares,
-    along with a narrow nasal bridge. This is considered the most recognizable
-    feature of ODDD.
+    A narrow or pinched nose is part of the characteristic craniofacial gestalt
+    of ODDD.
   phenotype_term:
-    preferred_term: Narrow nose with hypoplastic alae nasi
+    preferred_term: Narrow nose
     term:
       id: HP:0000460
       label: Narrow nose
-  frequency: VERY_FREQUENT
   evidence:
   - reference: PMID:19338053
     reference_title: "GJA1 mutations, variants, and connexin 43 dysfunction as it relates to the oculodentodigital dysplasia phenotype."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Patients present with a characteristic facial appearance, narrow nose, and hypoplastic alae nasi."
-    explanation: Describes the hallmark craniofacial feature of ODDD.
+    explanation: Supports narrow nose as a characteristic craniofacial manifestation of ODDD.
+- category: Craniofacial
+  name: Hypoplastic alae nasi
+  description: >
+    Underdeveloped nasal alae are a recurrent and distinctive part of the nasal
+    phenotype in ODDD.
+  phenotype_term:
+    preferred_term: Hypoplastic alae nasi
+    term:
+      id: HP:0000430
+      label: Underdeveloped nasal alae
+  evidence:
+  - reference: PMID:19338053
+    reference_title: "GJA1 mutations, variants, and connexin 43 dysfunction as it relates to the oculodentodigital dysplasia phenotype."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patients present with a characteristic facial appearance, narrow nose, and hypoplastic alae nasi."
+    explanation: Supports underdeveloped nasal alae as part of the characteristic ODDD facial appearance.
 - category: Ophthalmological
   name: Microphthalmia
   description: >
-    Small eyes (microphthalmia) are a core ocular feature, often accompanied
-    by microcornea. These reflect impaired gap junction communication during
-    eye development.
+    Small eyes are among the most commonly reported ocular manifestations of ODDD.
   phenotype_term:
     preferred_term: Microphthalmia
     term:
       id: HP:0000568
       label: Microphthalmia
-  frequency: FREQUENT
   evidence:
-  - reference: PMID:29902798
-    reference_title: "Autosomal Recessive Oculodentodigital Dysplasia: A Case Report and Review of the Literature."
+  - reference: PMID:32318302
+    reference_title: "Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and Ocular Adnexa Features of 295 Reported Cases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "a 14-year-old boy with microphthalmia, microcornea, narrow nasal bridge, hypoplastic alae nasi"
-    explanation: Microphthalmia documented as a key clinical feature.
+    snippet: "The most common eye features reported among all mutations were microcornea, microphthalmia, short palpebral fissures, and glaucoma."
+    explanation: Supports microphthalmia as one of the core ocular manifestations reported across published ODDD cases.
 - category: Ophthalmological
   name: Microcornea
   description: >
-    Abnormally small cornea is a frequent ocular finding, often co-occurring
-    with microphthalmia.
+    Abnormally small corneas are a recurrent ocular finding in ODDD and often
+    accompany microphthalmia.
   phenotype_term:
     preferred_term: Microcornea
     term:
       id: HP:0000482
       label: Microcornea
-  frequency: FREQUENT
-- category: Dental
-  name: Microdontia and Enamel Hypoplasia
-  description: >
-    Teeth are typically small (microdontia) with defective enamel formation,
-    predisposing to early and severe dental caries. Hypodontia (missing teeth)
-    also occurs.
-  phenotype_term:
-    preferred_term: Microdontia
-    term:
-      id: HP:0000691
-      label: Microdontia
-  frequency: VERY_FREQUENT
   evidence:
-  - reference: PMID:29902798
-    reference_title: "Autosomal Recessive Oculodentodigital Dysplasia: A Case Report and Review of the Literature."
+  - reference: PMID:32318302
+    reference_title: "Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and Ocular Adnexa Features of 295 Reported Cases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "hypodontia, dental caries"
-    explanation: Dental abnormalities are a core feature of ODDD.
-- category: Dental
-  name: Enamel Hypoplasia
+    snippet: "The most common eye features reported among all mutations were microcornea, microphthalmia, short palpebral fissures, and glaucoma."
+    explanation: Supports microcornea as a recurrent ocular phenotype in ODDD.
+- category: Ophthalmological
+  name: Short palpebral fissure
   description: >
-    Defective enamel formation contributes to early caries and poor dental health.
+    Short palpebral fissures are part of the recognized ocular adnexal phenotype
+    in ODDD.
+  phenotype_term:
+    preferred_term: Short palpebral fissure
+    term:
+      id: HP:0012745
+      label: Short palpebral fissure
+  evidence:
+  - reference: PMID:32318302
+    reference_title: "Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and Ocular Adnexa Features of 295 Reported Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most common eye features reported among all mutations were microcornea, microphthalmia, short palpebral fissures, and glaucoma."
+    explanation: Supports short palpebral fissures as a recognized ocular adnexal feature of ODDD.
+- category: Ophthalmological
+  name: Glaucoma
+  description: >
+    Glaucoma is a clinically important ocular complication in ODDD and may
+    threaten vision.
+  phenotype_term:
+    preferred_term: Glaucoma
+    term:
+      id: HP:0000501
+      label: Glaucoma
+  evidence:
+  - reference: PMID:32318302
+    reference_title: "Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and Ocular Adnexa Features of 295 Reported Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most common eye features reported among all mutations were microcornea, microphthalmia, short palpebral fissures, and glaucoma."
+    explanation: Supports glaucoma as one of the major ocular manifestations reported across published ODDD cases.
+  - reference: PMID:34035645
+    reference_title: "Heterozygous GJA1 variants with ocular phenotype: Missense in domain but truncation out of domain."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Of the 116 patients, glaucoma was observed in 26.7% (31/116), among whom 77.4% (24/31) of cases occurred in patients ≥10 years old."
+    explanation: In the literature review subset with ocular signs, glaucoma affected 31/116 patients and usually presented after age 10, underscoring its clinical importance.
+- category: Dental
+  name: Enamel hypoplasia
+  description: >
+    Defective enamel formation is a recurrent dental abnormality in ODDD and
+    contributes to structural tooth fragility.
   phenotype_term:
     preferred_term: Enamel hypoplasia
     term:
       id: HP:0006297
       label: Enamel hypoplasia
   frequency: FREQUENT
-- category: Musculoskeletal
-  name: Finger Syndactyly (Type III)
-  description: >
-    Complete cutaneous syndactyly of the fourth and fifth fingers (syndactyly
-    type III) is the characteristic digital malformation. The third finger may
-    also be involved. Associated camptodactyly is common.
-  phenotype_term:
-    preferred_term: Syndactyly type III (4th-5th fingers)
-    term:
-      id: HP:0006101
-      label: Finger syndactyly
-  frequency: VERY_FREQUENT
   evidence:
-  - reference: PMID:12457340
-    reference_title: "Connexin 43 (GJA1) mutations cause the pleiotropic phenotype of oculodentodigital dysplasia."
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "This autosomal dominant syndrome presents with craniofacial (ocular, nasal, and dental) and limb dysmorphisms, spastic paraplegia, and neurodegeneration. Syndactyly type III and conductive deafness can occur in some cases"
-    explanation: Syndactyly type III is listed as a recognized feature of ODDD.
+    snippet: "Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, and taurodontism were common dental findings in ODDD."
+    explanation: Author wording "common" maps to FREQUENT under the dismech qualitative frequency guideline and directly supports enamel hypoplasia in ODDD.
+- category: Dental
+  name: Enamel hypomineralization
+  description: >
+    Defective mineralization of dental enamel is part of the structural dental
+    phenotype in ODDD.
+  phenotype_term:
+    preferred_term: Enamel hypomineralization
+    term:
+      id: HP:0006285
+      label: Enamel hypomineralization
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, and taurodontism were common dental findings in ODDD."
+    explanation: Author wording "common" maps to FREQUENT under the dismech qualitative frequency guideline and directly supports enamel hypomineralization in ODDD.
+- category: Dental
+  name: Microdontia
+  description: >
+    Small teeth are a recurrent dental manifestation of ODDD.
+  phenotype_term:
+    preferred_term: Microdontia
+    term:
+      id: HP:0000691
+      label: Microdontia
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, and taurodontism were common dental findings in ODDD."
+    explanation: Author wording "common" maps to FREQUENT under the dismech qualitative frequency guideline and directly supports microdontia in ODDD.
+- category: Dental
+  name: Pulp calcification
+  description: >
+    Calcified pulp stones are reported among the recurrent radiographic dental
+    findings in ODDD.
+  phenotype_term:
+    preferred_term: Pulp stone
+    term:
+      id: HP:0003771
+      label: Pulp calcification
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, and taurodontism were common dental findings in ODDD."
+    explanation: Author wording "common" maps to FREQUENT under the dismech qualitative frequency guideline and directly supports pulp calcification in ODDD.
+- category: Dental
+  name: Curved dental root
+  description: >
+    Abnormally curved dental roots are part of the recurrent dental morphology
+    reported in ODDD.
+  phenotype_term:
+    preferred_term: Curved dental root
+    term:
+      id: HP:4000104
+      label: Curved dental root
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, and taurodontism were common dental findings in ODDD."
+    explanation: Author wording "common" maps to FREQUENT under the dismech qualitative frequency guideline and directly supports curved dental roots in ODDD.
+- category: Dental
+  name: Taurodontia
+  description: >
+    Enlarged pulp chambers with apically displaced furcations are part of the
+    structural dental phenotype in ODDD.
+  phenotype_term:
+    preferred_term: Taurodontia
+    term:
+      id: HP:0000679
+      label: Taurodontia
+  frequency: FREQUENT
+  evidence:
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, and taurodontism were common dental findings in ODDD."
+    explanation: Author wording "common" maps to FREQUENT under the dismech qualitative frequency guideline and directly supports taurodontia in ODDD.
+- category: Musculoskeletal
+  name: 4-5 finger cutaneous syndactyly
+  description: >
+    Cutaneous syndactyly of the fourth and fifth fingers is the characteristic
+    digital malformation in ODDD; some patients also have third-finger or foot
+    syndactyly.
+  phenotype_term:
+    preferred_term: 4-5 finger cutaneous syndactyly
+    term:
+      id: HP:0010705
+      label: 4-5 finger cutaneous syndactyly
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: PMID:29927410
+    reference_title: "[Neurological presentations of oculodentodigital dysplasia]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Typical features are syndactyly of IV-V or III-V fingers with/without feet syndactyly, anomalies of eyes, teeth, hair and nose."
+    explanation: Author wording "typical" maps to VERY_FREQUENT under the dismech qualitative frequency guideline and directly supports characteristic 4-5 finger cutaneous syndactyly in ODDD.
 - category: Musculoskeletal
   name: Camptodactyly
   description: >
-    Permanent flexion contracture of the interphalangeal joints, commonly
-    associated with the syndactyly.
+    Permanent flexion contracture of the fingers occurs as part of the digital
+    phenotype in some patients with ODDD.
   phenotype_term:
     preferred_term: Camptodactyly
     term:
       id: HP:0012385
       label: Camptodactyly
-  frequency: FREQUENT
+  evidence:
+  - reference: PMID:36990989
+    reference_title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Examination revealed unusual facial features, i.e., long narrow nose, hypertelorism, prominent epicanthal folds along with syndactyly and camptodactyly."
+    explanation: Supports camptodactyly as part of the digital phenotype described in ODDD.
 - category: Neurological
-  name: Spastic Paraplegia
+  name: Spastic paraparesis
   description: >
-    Progressive spastic paraplegia is the most common neurological complication
-    of ODDD, reflecting impaired gap junction communication in the central
-    nervous system. Dysarthria, ataxia, and neurogenic bladder disturbances
-    also occur.
+    Progressive lower-extremity spasticity is a prominent neurologic
+    manifestation of ODDD and may emerge later in life.
   phenotype_term:
-    preferred_term: Spastic paraplegia
+    preferred_term: Spastic paraparesis
     term:
-      id: HP:0001258
-      label: Spastic paraplegia
-  frequency: OCCASIONAL
+      id: HP:0002313
+      label: Spastic paraparesis
+  evidence:
+  - reference: PMID:29927410
+    reference_title: "[Neurological presentations of oculodentodigital dysplasia]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In about 30% of patients neurological disorders appear later in life: progressive spastic paraparesis, neurogenic bladder/bowel, ataxia, white matter lesions on MRI."
+    explanation: Supports progressive spastic paraparesis as part of the later-onset neurologic spectrum of ODDD.
+- category: Neurological
+  name: Dysarthria
+  description: >
+    Dysarthria is part of the recognized neurologic phenotype in ODDD.
+  phenotype_term:
+    preferred_term: Dysarthria
+    term:
+      id: HP:0001260
+      label: Dysarthria
   evidence:
   - reference: PMID:19338053
     reference_title: "GJA1 mutations, variants, and connexin 43 dysfunction as it relates to the oculodentodigital dysplasia phenotype."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Neurological problems, including dysarthria, neurogenic bladder disturbances, spastic paraparesis, ataxia, anterior tibial muscle weakness, and seizures, are known to occur"
-    explanation: Spastic paraparesis is documented among the neurological complications of ODDD.
-  - reference: PMID:12457340
-    reference_title: "Connexin 43 (GJA1) mutations cause the pleiotropic phenotype of oculodentodigital dysplasia."
+    explanation: Supports dysarthria as part of the neurologic phenotype reported in ODDD.
+- category: Neurological
+  name: Neurogenic bladder
+  description: >
+    Urinary dysfunction due to neurogenic bladder can accompany neurologic
+    involvement in ODDD.
+  phenotype_term:
+    preferred_term: Neurogenic bladder
+    term:
+      id: HP:0000011
+      label: Neurogenic bladder
+  evidence:
+  - reference: PMID:29927410
+    reference_title: "[Neurological presentations of oculodentodigital dysplasia]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "craniofacial (ocular, nasal, and dental) and limb dysmorphisms, spastic paraplegia, and neurodegeneration"
-    explanation: Spastic paraplegia listed as a feature of ODDD in the original genetic characterization.
+    snippet: "In about 30% of patients neurological disorders appear later in life: progressive spastic paraparesis, neurogenic bladder/bowel, ataxia, white matter lesions on MRI."
+    explanation: Supports neurogenic bladder as part of the later-onset neurologic spectrum of ODDD.
 - category: Neurological
-  name: Seizures
+  name: Ataxia
   description: >
-    Seizures have been reported in ODDD patients, part of the broader
-    neurological involvement.
+    Cerebellar-type gait and coordination impairment have been reported within
+    the neurologic spectrum of ODDD.
   phenotype_term:
-    preferred_term: Seizures
+    preferred_term: Ataxia
+    term:
+      id: HP:0001251
+      label: Ataxia
+  evidence:
+  - reference: PMID:29927410
+    reference_title: "[Neurological presentations of oculodentodigital dysplasia]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In about 30% of patients neurological disorders appear later in life: progressive spastic paraparesis, neurogenic bladder/bowel, ataxia, white matter lesions on MRI."
+    explanation: Supports ataxia as part of the later-onset neurologic phenotype of ODDD.
+- category: Neurological
+  name: Seizure
+  description: >
+    Seizures are part of the broader neurologic phenotype reported in ODDD.
+  phenotype_term:
+    preferred_term: Seizure
     term:
       id: HP:0001250
       label: Seizure
-  frequency: OCCASIONAL
   evidence:
   - reference: PMID:19338053
     reference_title: "GJA1 mutations, variants, and connexin 43 dysfunction as it relates to the oculodentodigital dysplasia phenotype."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Neurological problems, including dysarthria, neurogenic bladder disturbances, spastic paraparesis, ataxia, anterior tibial muscle weakness, and seizures, are known to occur"
-    explanation: Seizures listed among the neurological features of ODDD.
-- category: Audiological
-  name: Conductive Hearing Impairment
+    explanation: Supports seizures as part of the neurologic phenotype reported in ODDD.
+- category: Neurological
+  name: CNS hypomyelination
   description: >
-    Conductive hearing loss occurs in some ODDD patients, likely reflecting
-    abnormal development of middle ear structures dependent on gap junction signaling.
+    In neurologically affected individuals, brain MRI can show white matter
+    abnormalities consistent with cerebral hypomyelination.
+  phenotype_term:
+    preferred_term: Cerebral hypomyelination
+    term:
+      id: HP:0003429
+      label: CNS hypomyelination
+  evidence:
+  - reference: PMID:31023660
+    reference_title: "GJA1 Variants Cause Spastic Paraplegia Associated with Cerebral Hypomyelination."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cerebral MR imaging revealed variable white matter abnormalities, consistent with a hypomyelination pattern"
+    explanation: Supports CNS hypomyelination as a neuroimaging manifestation in neurologically affected ODDD patients with GJA1 variants.
+- category: Audiological
+  name: Conductive hearing impairment
+  description: >
+    Conductive hearing impairment is a recognized but non-universal auditory
+    manifestation of ODDD.
   phenotype_term:
     preferred_term: Conductive hearing impairment
     term:
       id: HP:0000405
       label: Conductive hearing impairment
-  frequency: OCCASIONAL
   evidence:
   - reference: PMID:12457340
     reference_title: "Connexin 43 (GJA1) mutations cause the pleiotropic phenotype of oculodentodigital dysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Syndactyly type III and conductive deafness can occur in some cases, and cardiac abnormalities are observed in rare instances."
-    explanation: Conductive deafness documented as a feature of ODDD.
-- category: Dermatological
-  name: Sparse Hair
-  description: >
-    Sparse, slow-growing hair is a common ectodermal feature, reflecting
-    impaired Cx43-dependent signaling in hair follicles.
-  phenotype_term:
-    preferred_term: Sparse hair
-    term:
-      id: HP:0008070
-      label: Sparse hair
-  frequency: FREQUENT
-- category: Dermatological
-  name: Dry Skin
-  description: >
-    Dry skin and other cutaneous anomalies may occur as part of the ectodermal
-    dysplasia spectrum.
-  phenotype_term:
-    preferred_term: Dry skin
-    term:
-      id: HP:0000958
-      label: Dry skin
-  frequency: OCCASIONAL
+    explanation: Supports conductive hearing impairment as an additional but non-universal manifestation of ODDD.
 pathophysiology:
 - name: Dominant-negative GJA1 mutations disrupt gap junction communication
   description: >

--- a/references_cache/PMID_29927410.md
+++ b/references_cache/PMID_29927410.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:29927410"
+title: "[Neurological presentations of oculodentodigital dysplasia]."
+authors:
+- Rudenskaya GE
+- Dyomina NA
+- Bliznetz EA
+- Khlebnikova OV
+- Dadaly EL
+- Polyakov AV
+journal: Zh Nevrol Psikhiatr Im S S Korsakova
+year: '2018'
+doi: 10.17116/jnevro20181185185
+keywords:
+- "Abnormalities, Multiple"
+- Adolescent
+- Adult
+- Child
+- Craniofacial Abnormalities
+- Eye Abnormalities
+- Female
+- "Foot Deformities, Congenital"
+- Humans
+- Middle Aged
+- Mutation
+- Russia
+- Syndactyly
+- Tooth Abnormalities
+- Young Adult
+content_type: abstract_only
+---
+
+# [Neurological presentations of oculodentodigital dysplasia].
+**Authors:** Rudenskaya GE, Dyomina NA, Bliznetz EA, Khlebnikova OV, Dadaly EL, Polyakov AV
+**Journal:** Zh Nevrol Psikhiatr Im S S Korsakova (2018)
+**DOI:** [10.17116/jnevro20181185185](https://doi.org/10.17116/jnevro20181185185)
+
+## Content
+
+1. Zh Nevrol Psikhiatr Im S S Korsakova. 2018;118(5):85-91. doi: 
+10.17116/jnevro20181185185.
+
+[Neurological presentations of oculodentodigital dysplasia].
+
+[Article in Russian; Abstract available in Russian from the publisher]
+
+Rudenskaya GE(1), Dyomina NA(1), Bliznetz EA(1), Khlebnikova OV(1), Dadaly 
+EL(1), Polyakov AV(1).
+
+Author information:
+(1)Research Centre for Medical Genetics, Moscow, Russia.
+
+Oculodentodigital dysplasia (ODDD) is a rare autosomal dominant disorder caused 
+by mutations in connexin 43 gene GJA1. Typical features are syndactyly of IV-V 
+or III-V fingers with/without feet syndactyly, anomalies of eyes, teeth, hair 
+and nose. In about 30% of patients neurological disorders appear later in life: 
+progressive spastic paraparesis, neurogenic bladder/bowel, ataxia, white matter 
+lesions on MRI. First Russian DNA-confirmed ODDD cases are presented: 4 
+unrelated families with 5 affected women age 10-59 yrs. In addition to typical 
+congenital anomalies all patients had neurological symptoms (mainly spastic 
+paraparesis) with different age of onset. In three cases, preliminary diagnoses 
+were hereditary neurodegenerations, only in one patient ODDD was recognized 
+earlier. In GJA1 gene three novel mutations were detected: c.400_402delAAG (in 
+two families), с.461C>T (p.Thr154Ile) and с.94T>G (p.Phe32Val). De novo origin 
+of mutations in three sporadic cases was proved by parent DNA testing; in the 
+familial case, the mutation in elder patient also obviously occurred de novo.
+
+Publisher: Глазо-зубо-пальцевой синдром - редкая аутосомно-доминантная болезнь, 
+обусловленная мутациями гена коннексина 43 GJA1. Типичная картина включает 
+синдактилию IV-V или III-V пальцев кистей, в части случаев в сочетании с 
+синдактилией стоп, аномалии глаз, зубов, волос, носа. У трети больных в разном 
+возрасте присоединяются неврологические симптомы: спастический парапарез, 
+расстройства тазовых функций, атаксия, изменения при нейровизуализации. 
+Представлены первые молекулярно-генетически верифицированные российские 
+наблюдения глазо-зубо-пальцевого синдрома: 4 неродственные семьи с 5 больными 
+женщинами 10-59 лет. Наряду с типичными врожденными аномалиями у всех имелись 
+неврологические расстройства (ведущий - спастический парапарез), возникшие в 
+разном возрасте. В семьях предварительными диагнозами были наследственные 
+нейродегенерации, лишь у 1 больной синдром был клинически диагностирован в 
+раннем возрасте. В гене GJA1 найдены три не описанные ранее мутации в 
+гетерозиготном состоянии: c.400_402delAAG (в 2 семьях), с.461C>T (p.Thr154Ile) и 
+с.94T>G (p.Phe32Val). В 3 спорадических случаях возникновение мутаций de novo 
+доказано анализом ДНК родителей больных; в семейном случае мутация у старшей 
+больной тоже, очевидно, возникла de novo.
+
+DOI: 10.17116/jnevro20181185185
+PMID: 29927410 [Indexed for MEDLINE]

--- a/references_cache/PMID_31023660.md
+++ b/references_cache/PMID_31023660.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:31023660"
+title: GJA1 Variants Cause Spastic Paraplegia Associated with Cerebral Hypomyelination.
+authors:
+- Saint-Val L
+- Courtin T
+- Charles P
+- Verny C
+- Catala M
+- Schiffmann R
+- Boespflug-Tanguy O
+- Mochel F
+journal: AJNR Am J Neuroradiol
+year: '2019'
+doi: 10.3174/ajnr.A6036
+keywords:
+- Adolescent
+- Adult
+- Brain/pathology
+- Connexin 43/genetics
+- "Craniofacial Abnormalities/complications, genetics, pathology"
+- "Eye Abnormalities/complications, genetics, pathology"
+- Female
+- "Foot Deformities, Congenital/complications, genetics, pathology"
+- Humans
+- Magnetic Resonance Imaging
+- Male
+- Middle Aged
+- Neuroimaging
+- "Spastic Paraplegia, Hereditary/genetics, pathology"
+- "Syndactyly/complications, genetics, pathology"
+- "Tooth Abnormalities/complications, genetics, pathology"
+content_type: abstract_only
+---
+
+# GJA1 Variants Cause Spastic Paraplegia Associated with Cerebral Hypomyelination.
+**Authors:** Saint-Val L, Courtin T, Charles P, Verny C, Catala M, Schiffmann R, Boespflug-Tanguy O, Mochel F
+**Journal:** AJNR Am J Neuroradiol (2019)
+**DOI:** [10.3174/ajnr.A6036](https://doi.org/10.3174/ajnr.A6036)
+
+## Content
+
+1. AJNR Am J Neuroradiol. 2019 May;40(5):788-791. doi: 10.3174/ajnr.A6036. Epub 
+2019 Apr 25.
+
+GJA1 Variants Cause Spastic Paraplegia Associated with Cerebral Hypomyelination.
+
+Saint-Val L(1), Courtin T(1), Charles P(1), Verny C(2), Catala M(3)(4), 
+Schiffmann R(5), Boespflug-Tanguy O(6), Mochel F(7)(8)(9)(10).
+
+Author information:
+(1)From the Department of Genetics (L.S.-V., T.C., P.C., F.M.).
+(2)Department of Neurology and Reference Center for Neurogenetic Diseases 
+(C.V.), Angers University Hospital, Angers, France.
+(3)Department of Neurology (M.C.), Assistance Publique-Hôpitaux de Paris, La 
+Pitié-Salpêtrière University Hospital, Paris, France.
+(4)Sorbonne Université (M.C.), Centre National de la Recherche Scientifique UMR 
+7622, Institut National de la Santé et de la Recherche Médicale ERL 1156, 
+Institut de Biologie Paris-Seine, Paris, France.
+(5)Baylor Scott & White Research Institute (R.S.), Dallas, Texas.
+(6)Department of Neuropediatrics and Reference Center for Leukodystrophy and 
+Leukoencephalopathy (O.B.-T.), Assistance Publique-Hôpitaux de Paris, 
+Robert-Debré University Hospital, Paris, France.
+(7)From the Department of Genetics (L.S.-V., T.C., P.C., F.M.) 
+fanny.mochel@upmc.fr.
+(8)Reference Center for Adult Neurometabolic Diseases (F.M.).
+(9)Groupe de Recherche Clinique No. 13, Neurométabolisme (F.M.), Sorbonne 
+Université, Paris, France.
+(10)Sorbonne Université (F.M.), Université Pierre-et-Marie-Curie-Paris 6, UMR S 
+1127 and Institut National de la Santé et de la Recherche Médicale U 1127, and 
+Centre National de la Recherche Scientifique UMR 7225, and Brain and Spine 
+Institute, F-75013, Paris, France.
+
+Oculodentodigital dysplasia is an autosomal dominant disorder due to GJA1 
+variants characterized by dysmorphic features. Neurologic symptoms have been 
+described in some patients but without a clear neuroimaging pattern. To 
+understand the pathophysiology underlying neurologic deficits in 
+oculodentodigital dysplasia, we studied 8 consecutive patients presenting with 
+hereditary spastic paraplegia due to GJA1 variants. Clinical disease severity 
+was highly variable. Cerebral MR imaging revealed variable white matter 
+abnormalities, consistent with a hypomyelination pattern, and bilateral 
+hypointense signal of the basal ganglia on T2-weighted images and/or magnetic 
+susceptibility sequences, as seen in neurodegeneration with brain iron 
+accumulation diseases. Patients with the more prominent basal ganglia 
+abnormalities were the most disabled ones. This study suggests that GJA1-related 
+hereditary spastic paraplegia is a complex neurodegenerative disease affecting 
+both the myelin and the basal ganglia. GJA1 variants should be considered in 
+patients with hereditary spastic paraplegia presenting with brain 
+hypomyelination, especially if associated with neurodegeneration and a brain 
+iron accumulation pattern.
+
+© 2019 by American Journal of Neuroradiology.
+
+DOI: 10.3174/ajnr.A6036
+PMCID: PMC7053899
+PMID: 31023660 [Indexed for MEDLINE]

--- a/references_cache/PMID_32318302.md
+++ b/references_cache/PMID_32318302.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:32318302"
+title: "Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and Ocular Adnexa Features of 295 Reported Cases."
+authors:
+- Kumar V
+- Couser NL
+- Pandya A
+journal: Case Rep Ophthalmol Med
+year: '2020'
+doi: 10.1155/2020/6535974
+content_type: abstract_only
+---
+
+# Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and Ocular Adnexa Features of 295 Reported Cases.
+**Authors:** Kumar V, Couser NL, Pandya A
+**Journal:** Case Rep Ophthalmol Med (2020)
+**DOI:** [10.1155/2020/6535974](https://doi.org/10.1155/2020/6535974)
+
+## Content
+
+1. Case Rep Ophthalmol Med. 2020 Apr 4;2020:6535974. doi: 10.1155/2020/6535974. 
+eCollection 2020.
+
+Oculodentodigital Dysplasia: A Case Report and Major Review of the Eye and 
+Ocular Adnexa Features of 295 Reported Cases.
+
+Kumar V(1), Couser NL(2)(3)(4), Pandya A(5).
+
+Author information:
+(1)Virginia Commonwealth University School of Medicine, Richmond, VA, USA.
+(2)Department of Ophthalmology, Virginia Commonwealth University School of 
+Medicine, Richmond, VA, USA.
+(3)Department of Human and Molecular Genetics, Virginia Commonwealth University 
+School of Medicine, Richmond, VA, USA.
+(4)Department of Pediatrics, Virginia Commonwealth University School of 
+Medicine, Richmond, VA, USA.
+(5)Department of Pediatrics, Division of Genetics and Metabolism, School of 
+Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+
+Oculodentodigital dysplasia (ODDD) is a rare genetic disorder associated with a 
+characteristic craniofacial profile with variable dental, limb, eye, and ocular 
+adnexa abnormalities. We performed an extensive literature review to highlight 
+key eye features in patients with ODDD and report a new case of a female patient 
+with a heterozygous missense GJA1 mutation (c.65G>A, p.G22E) and clinical 
+features consistent with the condition. Our patient presented with multiple 
+congenital anomalies including syndactyly, microphthalmia, microcornea, 
+retrognathia, and a small nose with hypoplastic alae and prominent columella; in 
+addition, an omphalocele defect was present, which has not been reported in 
+previous cases. A systematic review of the published cases to date revealed 91 
+literature reports of 295 individuals with ODDD. There were 73 different GJA1 
+mutations associated with these cases, of which the most common were the 
+following missense mutations: c.605G>A (p.R202H) (11%), c.389T>C (p.I130T) 
+(10%), and c.119C>T (p.A40V) (10%). Mutations most commonly affect the 
+extracellular-1 and cytoplasmic-1 domains of connexin-43 (gene product of GJA1), 
+predominately manifesting in microphthalmia and microcornea. The syndrome 
+appears with an approximately equal sex ratio. The most common eye features 
+reported among all mutations were microcornea, microphthalmia, short palpebral 
+fissures, and glaucoma.
+
+Copyright © 2020 Virang Kumar et al.
+
+DOI: 10.1155/2020/6535974
+PMCID: PMC7165356
+PMID: 32318302
+
+Conflict of interest statement: Virang Kumar and Arti Pandya declare that they 
+have no conflicts of interest. Natario L. Couser, MD, MS, is a principal 
+investigator at the Virginia Commonwealth University site of Retrophin, Inc., 
+and book editor in Elsevier.

--- a/references_cache/PMID_34035645.md
+++ b/references_cache/PMID_34035645.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:34035645"
+title: "Heterozygous GJA1 variants with ocular phenotype: Missense in domain but truncation out of domain."
+authors:
+- Li X
+- Xiao X
+- Li S
+- Ouyang J
+- Sun W
+- Liu X
+- Zhang Q
+journal: Mol Vis
+year: '2021'
+keywords:
+- Adult
+- Child
+- Connexin 43/genetics
+- Craniofacial Abnormalities/genetics
+- Eye Abnormalities/genetics
+- Female
+- "Foot Deformities, Congenital/genetics"
+- Glaucoma/genetics
+- Heterozygote
+- Humans
+- Male
+- Middle Aged
+- "Mutation, Missense/genetics"
+- Pedigree
+- Phenotype
+- Syndactyly/genetics
+- Tooth Abnormalities/genetics
+- Visual Acuity/physiology
+- Exome Sequencing
+content_type: abstract_only
+---
+
+# Heterozygous GJA1 variants with ocular phenotype: Missense in domain but truncation out of domain.
+**Authors:** Li X, Xiao X, Li S, Ouyang J, Sun W, Liu X, Zhang Q
+**Journal:** Mol Vis (2021)
+
+## Content
+
+1. Mol Vis. 2021 May 13;27:309-322. eCollection 2021.
+
+Heterozygous GJA1 variants with ocular phenotype: Missense in domain but 
+truncation out of domain.
+
+Li X(1), Xiao X(1), Li S(1), Ouyang J(1), Sun W(1), Liu X(1), Zhang Q(1).
+
+Author information:
+(1)State Key Laboratory of Ophthalmology, Zhongshan Ophthalmic Center, Sun 
+Yat-sen University, Guangzhou, China.
+
+PURPOSE: Oculodentodigital dysplasia (ODDD) is a group disorder caused by GJA1 
+variants, of which glaucoma leading to blindness is a frequent complication of 
+the ocular phenotype. In this study, the correlation of the GJA1 genotype with 
+the ocular phenotype was analyzed systematically.
+METHODS: GJA1 variants were collected from in-house whole-exome sequencing data 
+of 5,307 individuals. Potentially pathogenic variants (PPVs) were defined based 
+on prediction of multiple in silico tools, related phenotypes, and previously 
+established evidence. The characteristics of GJA1 PPVs were evaluated based on 
+our data, gnomAD, and HGMD.
+RESULTS: In total, 21 rare variants in GJA1 were detected in 32 subjects from 
+the study cohort. Four of the 21 variants were classified as PPVs, including two 
+frameshift, one missense, and one in-frame deletion. The four PPVs were detected 
+in four probands with microcornea or high hyperopia; two developed glaucoma. A 
+systematic review of GJA1 variants in literature suggested that most 
+heterozygous missense PPVs are located inside the connexin domain. All 
+truncations downstream of the connexin domain are associated with autosomal 
+dominant disease, while most truncations within the domain are associated with 
+autosomal recessive ODDD. Ocular signs were present in 80.0% (116/145) of 
+patients with GJA1 PPVs. Of the 116 patients, glaucoma was observed in 26.7% 
+(31/116), among whom 77.4% (24/31) of cases occurred in patients ≥10 years old.
+CONCLUSIONS: Eye abnormalities are the most common signs associated with GJA1 
+PPVs, and they carry a high risk of developing glaucoma. The identification of 
+GJA1 PPVs needs further attention and clarification.
+
+Copyright © 2021 Molecular Vision.
+
+PMCID: PMC8131177
+PMID: 34035645 [Indexed for MEDLINE]

--- a/references_cache/PMID_36990989.md
+++ b/references_cache/PMID_36990989.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:36990989"
+title: "Oculo-dento-digital dysplasia: a systematic analysis of published dental literature."
+authors:
+- Hindu KD
+- Umer F
+journal: BDJ Open
+year: '2023'
+doi: 10.1038/s41405-023-00139-7
+content_type: abstract_only
+---
+
+# Oculo-dento-digital dysplasia: a systematic analysis of published dental literature.
+**Authors:** Hindu KD, Umer F
+**Journal:** BDJ Open (2023)
+**DOI:** [10.1038/s41405-023-00139-7](https://doi.org/10.1038/s41405-023-00139-7)
+
+## Content
+
+1. BDJ Open. 2023 Mar 29;9(1):13. doi: 10.1038/s41405-023-00139-7.
+
+Oculo-dento-digital dysplasia: a systematic analysis of published dental 
+literature.
+
+Hindu KD(1), Umer F(2).
+
+Author information:
+(1)Aga Khan University Hospital, Stadium Road, Karachi, 74800, Pakistan.
+(2)Aga Khan University Hospital, Stadium Road, Karachi, 74800, Pakistan. 
+fahad.umer@aku.edu.
+
+INTRODUCTION: Oculo-dento-digital dysplasia (ODDD, OMIM# 164200) is a rare 
+genetic disorder caused by mutation in Gap junction alpha gene that encodes 
+connexin 43 (Cx43) protein. In this paper, the case of a 16-year-old boy is 
+reported who presented with the complaint of toothache. Examination revealed 
+unusual facial features, i.e., long narrow nose, hypertelorism, prominent 
+epicanthal folds along with syndactyly and camptodactyly. We have also compiled 
+available dental literature on ODDD that will help clinicians in early diagnosis 
+and management of this condition.
+MATERIALS AND METHODS: A literature search was performed in PubMed NLM, EBSCO 
+Dentistry & Oral Sciences Source, and EBSCO CINAHL Plus.
+RESULTS: A total of 309 articles were identified in the literature search. Only 
+17 articles were included based on the predetermined inclusion and exclusion 
+criteria in the review synthesis. The included articles were case reports 
+(n = 15), a case report and review (n = 1), and an original article (n = 1). 
+Enamel hypoplasia, hypomineralization, microdontia, pulp stones, curved roots, 
+and taurodontism were common dental findings in ODDD.
+CONCLUSIONS: After establishing definitive diagnosis, a multidisciplinary team 
+should work in cohesion to improve the quality of life of patients. Immediate 
+treatment should be focused on the correction of current oral condition and 
+symptomatic treatment. In the long term, attention should be diverted to prevent 
+tooth wear and maintaining the occlusal vertical dimension to establish adequate 
+function.
+
+© 2023. The Author(s).
+
+DOI: 10.1038/s41405-023-00139-7
+PMCID: PMC10060216
+PMID: 36990989
+
+Conflict of interest statement: The authors declare no competing interests. The 
+authors have no financial interest or affiliations that would constitute a 
+conflict of interest. Informed written consent was obtained from the patient for 
+participation in this study, who allowed us to use the relevant data and 
+pictures for publication.

--- a/research/Oculodentodigital_Dysplasia-phenotype-research-codex.md
+++ b/research/Oculodentodigital_Dysplasia-phenotype-research-codex.md
@@ -1,0 +1,37 @@
+# Oculodentodigital Dysplasia phenotype curation notes
+
+Date: 2026-04-19
+Curator: Codex
+Scope: Phenotype section only for `kb/disorders/Oculodentodigital_Dysplasia.yaml`
+
+## PMIDs used
+
+- `PMID:19338053`
+  Supports characteristic nasal morphology (`narrow nose`, `hypoplastic alae nasi`) and the broader neurologic spectrum (`dysarthria`, `spastic paraparesis`, `neurogenic bladder disturbances`, `ataxia`, `seizures`), plus conductive hearing loss and generic skin/hair/nail anomalies.
+- `PMID:32318302`
+  Supports the core ocular phenotype and review-level ocular prominence: `microcornea`, `microphthalmia`, `short palpebral fissures`, and `glaucoma`.
+- `PMID:34035645`
+  Adds glaucoma-specific severity context from a literature review subset: glaucoma in `31/116` ocularly affected individuals, with most cases in patients `>=10` years old.
+- `PMID:36990989`
+  Supports the expanded dental phenotype (`enamel hypoplasia`, `enamel hypomineralization`, `microdontia`, `pulp stones`, `curved roots`, `taurodontism`) and provides direct support for `camptodactyly`.
+- `PMID:29927410`
+  Supports the characteristic digital pattern (`IV-V or III-V finger syndactyly`) and later-life neurologic manifestations (`spastic paraparesis`, `neurogenic bladder/bowel`, `ataxia`, `white matter lesions on MRI`).
+- `PMID:31023660`
+  Supports neuroimaging evidence for cerebral white matter abnormalities consistent with hypomyelination in neurologically affected ODDD patients.
+- `PMID:12457340`
+  Retained as phenotype support for non-universal `conductive hearing impairment`.
+
+## Key curation decisions
+
+- Split the previous combined nasal phenotype into separate `Narrow nose` and `Hypoplastic alae nasi` entries to improve HPO specificity.
+- Replaced weak ocular support with review-backed ocular phenotype evidence.
+- Expanded dental phenotypes using the 2023 systematic dental review rather than retaining broad, weakly supported summary claims.
+- Replaced the general finger syndactyly term with `HP:0010705` (`4-5 finger cutaneous syndactyly`) because the published ODDD literature repeatedly emphasizes the fourth/fifth finger pattern.
+- Switched the neurologic motor phenotype from `spastic paraplegia` to `spastic paraparesis` to match the exact wording of the phenotype-focused neurologic literature.
+- Added `CNS hypomyelination` to capture the clinically important MRI phenotype in neurologically affected cases.
+
+## Claims intentionally removed or softened
+
+- Removed phenotype entries for `Sparse hair` and `Dry skin` because the available abstract-level support was too weak or nonspecific for those exact HPO terms.
+- Softened the disease description from specific `sparse hair` to broader `skin/hair/nail anomalies`, which is directly supported by `PMID:19338053`.
+- Removed unsupported frequency claims from ocular, neurologic, auditory, and skin phenotypes unless frequency wording was directly supported in the cited abstract.


### PR DESCRIPTION
## Summary
- replace the ODDD phenotype section with phenotype-specific, PMID-backed entries focused on ocular, dental, digital, neurologic, and auditory manifestations
- add missing clinically important phenotypes including short palpebral fissures, glaucoma, enamel hypomineralization, pulp calcification, curved dental roots, taurodontia, neurogenic bladder, dysarthria, and CNS hypomyelination
- remove unsupported or overly specific phenotype claims such as `Sparse hair` and `Dry skin`, and soften the top-level description accordingly
- add a focused research note documenting the phenotype curation decisions and supporting PMIDs

## Why
Issue #1523 asks for a more complete and evidence-backed phenotype section for `kb/disorders/Oculodentodigital_Dysplasia.yaml`, with exact PMID support, tighter ontology grounding, and removal of unsupported claims.

## Validation
- `just validate kb/disorders/Oculodentodigital_Dysplasia.yaml`
  - passed (`No issues found`; `✓ All validations passed for kb/disorders/Oculodentodigital_Dysplasia.yaml`)
- `just validate-references kb/disorders/Oculodentodigital_Dysplasia.yaml`
  - passed (`Validation Summary: Total checks: 0; All validations passed!`)
- `just validate-terms kb/disorders/Oculodentodigital_Dysplasia.yaml`
  - passed (`✅ Validation passed`)

## Notes
- The worktree contains unrelated dirty files outside the staged ODDD phenotype scope; they were intentionally left out of this PR.
- This PR is opened as a draft because the repository hook flow conflicts with unrelated dirty files in the worktree; the requested validation commands were run successfully before commit.