### PR TITLE
[codex] Add FAS-related autoimmune lymphoproliferative syndrome

### DIFF
--- a/kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml
+++ b/kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml
@@ -1,0 +1,638 @@
+name: FAS-related Autoimmune Lymphoproliferative Syndrome
+creation_date: "2026-04-16T00:00:00Z"
+updated_date: "2026-04-16T00:00:00Z"
+category: Mendelian
+synonyms:
+- ALPS-Ia
+- autoimmune lymphoproliferative syndrome type IA
+- autoimmune lymphoproliferative syndrome type 1A
+description: >-
+  FAS-related autoimmune lymphoproliferative syndrome is an inborn error of
+  immunity caused by pathogenic FAS variants that impair Fas-mediated apoptosis
+  and disrupt lymphocyte homeostasis. The classical phenotype corresponds to
+  the dominant historical ALPS-Ia form, the most common molecular subtype of
+  ALPS, and is characterized by chronic non-malignant lymphadenopathy or
+  hepatosplenomegaly, autoimmune cytopenias, expansion of alpha-beta
+  double-negative T cells, and lifelong lymphoma predisposition.
+disease_term:
+  preferred_term: FAS-related autoimmune lymphoproliferative syndrome
+  term:
+    id: MONDO:1060194
+    label: FAS-related autoimmune lymphoproliferative syndrome
+parents:
+- Primary Immunodeficiency
+- Autoimmune Disorder
+- Lymphoproliferative Disorder
+tracked_issues:
+- url: https://github.com/monarch-initiative/mondo/issues/9749
+  title: FAS-related autoimmune lymphoproliferative syndrome
+  tracked_issue_role: ontology_term_request
+  tracked_issue_status: OPEN
+  notes: >-
+    ClinGen/MONDO term request that introduced the current gene-related disease
+    label used here.
+inheritance:
+- name: Autosomal dominant
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  penetrance: INCOMPLETE
+  description: >-
+    The classical FAS-related ALPS phenotype is usually inherited in an
+    autosomal dominant manner with incomplete penetrance. Many affected
+    families segregate heterozygous FAS death-domain variants, but clinically
+    unaffected carriers can occur.
+  evidence:
+  - reference: PMID:21447005
+    reference_title: "Advances in autoimmune lymphoproliferative syndromes."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Majority of patients with ALPS harbor heterozygous germline mutations in
+      the gene for the TNF receptor-family member Fas (CD 95, Apo-1) which are
+      inherited in an autosomal dominant fashion.
+    explanation: >-
+      Review evidence that the predominant FAS-related ALPS form is due to
+      heterozygous germline FAS variants with dominant transmission.
+  - reference: PMID:12732128
+    reference_title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The molecular study of these families confirms a diagnosis of ALPS and
+      suggests that the causing defect of this syndrome is compatible with an
+      autosomal dominant inheritance with incomplete penetrance.
+    explanation: >-
+      Family-based human genetic evidence directly supports autosomal dominant
+      inheritance with incomplete penetrance.
+genetic:
+- name: FAS
+  gene_term:
+    preferred_term: FAS
+    term:
+      id: hgnc:11920
+      label: FAS
+  association: CAUSATIVE
+  features: >-
+    Classical disease is usually caused by heterozygous germline FAS variants,
+    especially lesions affecting the intracellular death domain, which impair
+    receptor-mediated apoptosis of activated lymphocytes. Somatic FAS variants
+    also occur, but the dominant germline form remains the canonical
+    presentation of historical ALPS-Ia.
+  inheritance:
+  - name: Autosomal dominant
+  evidence:
+  - reference: PMID:23850805
+    reference_title: "Sequential decisions on FAS sequencing guided by biomarkers in patients with lymphoproliferation and autoimmune cytopenia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinical and genetic heterogeneity renders confirmation or exclusion of
+      autoimmune lymphoproliferative syndrome difficult. To re-evaluate and
+      improve the currently suggested diagnostic approach to patients with
+      suspected FAS mutation, the most frequent cause of autoimmune
+      lymphoproliferative syndrome, we prospectively determined 11 biomarkers in
+      163 patients with splenomegaly or lymphadenopathy and presumed or proven
+      autoimmune cytopenia(s).
+    explanation: >-
+      Prospective diagnostic study identifies FAS mutation as the most frequent
+      molecular cause of ALPS.
+  - reference: PMID:12732128
+    reference_title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both mutations are located in exon 9 of TNFRSF6 gene, affecting the death
+      domain of the Fas protein.
+    explanation: >-
+      Human family study shows that pathogenic variants in the FAS death domain
+      are a core mutational mechanism in classical ALPS-Ia.
+  - reference: PMID:22157362
+    reference_title: "New advances in the diagnosis and treatment of autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      A number of key observations have been made recently that better define
+      the pathophysiology of ALPS, including the characterization of somatic FAS
+      variant ALPS, the identification of haploinsufficiency as a mechanism of
+      decreased Fas expression, and the description of multiple genetic hits in
+      FAS in some families that may explain the variable penetrance of the
+      disease.
+    explanation: >-
+      Review evidence refines the allelic spectrum to include haploinsufficient
+      and somatic FAS-driven disease mechanisms.
+pathophysiology:
+- name: Defective Fas-mediated apoptosis of activated lymphocytes
+  description: >-
+    Pathogenic FAS variants impair signaling through the Fas death receptor and
+    blunt activation-induced cell death of mature lymphocytes. This failure of
+    peripheral deletion is the core molecular lesion underlying FAS-related
+    ALPS.
+  gene:
+    preferred_term: FAS
+    term:
+      id: hgnc:11920
+      label: FAS
+  cell_types:
+  - preferred_term: T cell
+    term:
+      id: CL:0000084
+      label: T cell
+  - preferred_term: alpha-beta T cell
+    term:
+      id: CL:0000789
+      label: alpha-beta T cell
+  biological_processes:
+  - preferred_term: activation-induced cell death of T cells
+    term:
+      id: GO:0006924
+      label: activation-induced cell death of T cells
+    modifier: DECREASED
+  - preferred_term: extrinsic apoptotic signaling pathway via death domain receptors
+    term:
+      id: GO:0008625
+      label: extrinsic apoptotic signaling pathway via death domain receptors
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:12732128
+    reference_title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In family A, in vitro Fas-mediated apoptosis was absent in the patient
+      and markedly reduced in his father.
+    explanation: >-
+      Human functional testing directly shows defective Fas-mediated apoptosis
+      in mutation carriers.
+  - reference: PMID:22157362
+    reference_title: "New advances in the diagnosis and treatment of autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Autoimmune lymphoproliferative syndrome (ALPS) is a disorder of disrupted
+      lymphocyte homeostasis, resulting from mutations in the Fas apoptotic
+      pathway.
+    explanation: >-
+      Review evidence frames the disease as a primary failure of the Fas
+      apoptotic pathway.
+  downstream:
+  - target: Chronic lymphocyte accumulation and double-negative T-cell expansion
+  - target: Persistence of autoreactive lymphocytes and autoimmune cytopenias
+  - target: Lymphoma predisposition
+- name: Chronic lymphocyte accumulation and double-negative T-cell expansion
+  description: >-
+    Because activated lymphocytes are not efficiently deleted, lymphoid mass
+    accumulates and the characteristic circulating alpha-beta double-negative T
+    cell population expands. Clinically this drives chronic, non-infectious,
+    non-malignant lymphadenopathy and hepatosplenomegaly.
+  cell_types:
+  - preferred_term: lymphocyte
+    term:
+      id: CL:0000542
+      label: lymphocyte
+  - preferred_term: alpha-beta T cell
+    term:
+      id: CL:0000789
+      label: alpha-beta T cell
+  biological_processes:
+  - preferred_term: lymphocyte homeostasis
+    term:
+      id: GO:0002260
+      label: lymphocyte homeostasis
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Autoimmune lymphoproliferative syndrome (ALPS) represents a failure of
+      apoptotic mechanisms to maintain lymphocyte homeostasis, permitting
+      accumulation of lymphoid mass and persistence of autoreactive cells that
+      often manifest in childhood with chronic nonmalignant lymphadenopathy,
+      hepatosplenomegaly, and recurring multilineage cytopenias.
+    explanation: >-
+      Review evidence directly links failed apoptotic homeostasis to lymphoid
+      accumulation, lymphadenopathy, and hepatosplenomegaly.
+  - reference: PMID:23850805
+    reference_title: "Sequential decisions on FAS sequencing guided by biomarkers in patients with lymphoproliferation and autoimmune cytopenia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Among 98 patients sequenced for FAS mutations in
+      CD3(+)TCRα/β(+)CD4(-)CD8(-) "double negative" T cells, 32 had germline and
+      six had somatic FAS mutations.
+    explanation: >-
+      Prospective cohort evidence anchors expanded alpha-beta double-negative T
+      cells as a characteristic cellular feature of FAS-mutant ALPS.
+- name: Persistence of autoreactive lymphocytes and autoimmune cytopenias
+  description: >-
+    Failed deletion of activated lymphocytes allows autoreactive clones to
+    persist, breaking peripheral tolerance and producing immune-mediated
+    destruction of multiple hematopoietic lineages.
+  cell_types:
+  - preferred_term: T cell
+    term:
+      id: CL:0000084
+      label: T cell
+  biological_processes:
+  - preferred_term: tolerance induction dependent upon immune response
+    term:
+      id: GO:0002461
+      label: tolerance induction dependent upon immune response
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Cytopenias in these patients can be the result of splenic sequestration
+      as well as autoimmune complications manifesting as autoimmune hemolytic
+      anemia, immune-mediated thrombocytopenia, and autoimmune neutropenia.
+    explanation: >-
+      Review evidence identifies the canonical autoimmune cytopenias that arise
+      downstream of failed lymphocyte tolerance.
+  - reference: PMID:20170754
+    reference_title: "The autoimmune lymphoproliferative syndrome: A rare disorder providing clues about normal tolerance."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      While ALPS is one of the few autoimmune diseases with a known genetic
+      defect, there remain unanswered questions regarding how a defect in
+      apoptosis results in the observed phenotype.
+    explanation: >-
+      Review evidence supports the central concept that defective apoptosis
+      drives autoimmune manifestations in ALPS.
+- name: Lymphoma predisposition
+  description: >-
+    Defective Fas-mediated apoptosis also weakens deletion of transformed or
+    transformation-prone lymphocytes, creating a lifelong predisposition to
+    lymphoma, especially B-cell and Hodgkin-type malignancies.
+  cell_types:
+  - preferred_term: B cell
+    term:
+      id: CL:0000236
+      label: B cell
+  biological_processes:
+  - preferred_term: extrinsic apoptotic signaling pathway via death domain receptors
+    term:
+      id: GO:0008625
+      label: extrinsic apoptotic signaling pathway via death domain receptors
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:15160902
+    reference_title: "Development of lymphoma in Autoimmune Lymphoproliferative Syndrome (ALPS) and its relationship to Fas gene mutations."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Individuals with germline mutations in the Fas gene have a high risk to
+      develop non Hodgkin lymphomas (x 14) as well as Hodgkin lymphomas (x 51),
+      in particular NLP Hodgkin lymphoma.
+    explanation: >-
+      Review evidence quantifies the marked lymphoma predisposition associated
+      with germline FAS mutations.
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Some of these patients with FAS mutations affecting the intracellular
+      portion of the FAS protein also have an increased risk of B-cell
+      lymphoma.
+    explanation: >-
+      Review evidence further links intracellular FAS mutations to B-cell
+      lymphoma risk.
+phenotypes:
+- name: Lymphadenopathy
+  description: >-
+    Chronic, non-malignant lymph node enlargement is a defining clinical
+    manifestation of FAS-related ALPS.
+  phenotype_term:
+    preferred_term: lymphadenopathy
+    term:
+      id: HP:0002716
+      label: Lymphadenopathy
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Autoimmune lymphoproliferative syndrome (ALPS) represents a failure of
+      apoptotic mechanisms to maintain lymphocyte homeostasis, permitting
+      accumulation of lymphoid mass and persistence of autoreactive cells that
+      often manifest in childhood with chronic nonmalignant lymphadenopathy,
+      hepatosplenomegaly, and recurring multilineage cytopenias.
+    explanation: >-
+      Review evidence directly supports chronic non-malignant lymphadenopathy
+      as a hallmark manifestation.
+- name: Hepatosplenomegaly
+  description: >-
+    Persistent enlargement of the liver and spleen reflects chronic benign
+    lymphoid accumulation.
+  phenotype_term:
+    preferred_term: hepatosplenomegaly
+    term:
+      id: HP:0001433
+      label: Hepatosplenomegaly
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Autoimmune lymphoproliferative syndrome (ALPS) represents a failure of
+      apoptotic mechanisms to maintain lymphocyte homeostasis, permitting
+      accumulation of lymphoid mass and persistence of autoreactive cells that
+      often manifest in childhood with chronic nonmalignant lymphadenopathy,
+      hepatosplenomegaly, and recurring multilineage cytopenias.
+    explanation: >-
+      The same review abstract directly supports hepatosplenomegaly as part of
+      the core lymphoproliferative phenotype.
+- name: Autoimmune hemolytic anemia
+  description: >-
+    Immune-mediated red-cell destruction is one of the most common autoimmune
+    cytopenias in ALPS.
+  phenotype_term:
+    preferred_term: autoimmune hemolytic anemia
+    term:
+      id: HP:0001890
+      label: Autoimmune hemolytic anemia
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Cytopenias in these patients can be the result of splenic sequestration
+      as well as autoimmune complications manifesting as autoimmune hemolytic
+      anemia, immune-mediated thrombocytopenia, and autoimmune neutropenia.
+    explanation: >-
+      Review evidence explicitly lists autoimmune hemolytic anemia among the
+      canonical autoimmune cytopenias of ALPS.
+- name: Autoimmune thrombocytopenia
+  description: >-
+    Immune-mediated platelet destruction is a recurrent hematologic
+    complication of FAS-related ALPS.
+  phenotype_term:
+    preferred_term: autoimmune thrombocytopenia
+    term:
+      id: HP:0001973
+      label: Autoimmune thrombocytopenia
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Cytopenias in these patients can be the result of splenic sequestration
+      as well as autoimmune complications manifesting as autoimmune hemolytic
+      anemia, immune-mediated thrombocytopenia, and autoimmune neutropenia.
+    explanation: >-
+      Review evidence explicitly lists immune-mediated thrombocytopenia as a
+      core autoimmune cytopenia in ALPS.
+- name: Autoimmune neutropenia
+  description: >-
+    Autoimmune neutropenia occurs as part of the multilineage cytopenia
+    spectrum.
+  phenotype_term:
+    preferred_term: autoimmune neutropenia
+    term:
+      id: HP:0001904
+      label: Autoimmune neutropenia
+  evidence:
+  - reference: PMID:21885601
+    reference_title: "How I treat autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Cytopenias in these patients can be the result of splenic sequestration
+      as well as autoimmune complications manifesting as autoimmune hemolytic
+      anemia, immune-mediated thrombocytopenia, and autoimmune neutropenia.
+    explanation: >-
+      Review evidence explicitly lists autoimmune neutropenia among the
+      multilineage cytopenias seen in ALPS.
+- name: Abnormal double-negative T cell proportion
+  description: >-
+    Elevated circulating alpha-beta double-negative T cells are a characteristic
+    immunophenotypic marker of FAS-related ALPS.
+  phenotype_term:
+    preferred_term: abnormal double-negative T cell proportion
+    term:
+      id: HP:0031399
+      label: Abnormal double-negative T cell proportion
+  evidence:
+  - reference: PMID:23993982
+    reference_title: "Investigation of common variable immunodeficiency patients and healthy individuals using autoimmune lymphoproliferative syndrome biomarkers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Biomarkers including elevated CD3+TCRαβ+CD4-CD8- double negative T cells
+      (TCRαβ+ DNT), IL-10, sCD95L and vitamin B12 can be used to differentiate
+      between ALPS and common variable immunodeficiency (CVID) patients with an
+      overlapping clinical phenotype.
+    explanation: >-
+      Biomarker study supports elevated alpha-beta double-negative T cells as a
+      distinguishing immunophenotypic feature of ALPS.
+- name: Lymphoma
+  description: >-
+    FAS-related ALPS confers increased lifetime risk of both Hodgkin and
+    non-Hodgkin lymphoma.
+  phenotype_term:
+    preferred_term: lymphoma
+    term:
+      id: HP:0002665
+      label: Lymphoma
+  evidence:
+  - reference: PMID:15160902
+    reference_title: "Development of lymphoma in Autoimmune Lymphoproliferative Syndrome (ALPS) and its relationship to Fas gene mutations."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Individuals with germline mutations in the Fas gene have a high risk to
+      develop non Hodgkin lymphomas (x 14) as well as Hodgkin lymphomas (x 51),
+      in particular NLP Hodgkin lymphoma.
+    explanation: >-
+      Review evidence directly supports lymphoma as a major malignant
+      complication of germline FAS-mutant ALPS.
+diagnosis:
+- name: Flow-cytometric double-negative T-cell quantification
+  description: >-
+    Flow cytometry is used to quantify circulating CD3-positive
+    TCR-alpha-beta-positive CD4-negative CD8-negative T cells, the hallmark
+    immunophenotypic abnormality of ALPS.
+  diagnosis_term:
+    preferred_term: flow cytometry procedure
+    term:
+      id: MAXO:0035055
+      label: flow cytometry procedure
+  evidence:
+  - reference: PMID:12732128
+    reference_title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      To confirm such a diagnosis, immunoglobulin quantification, cellular
+      phenotypic analysis by flow cytometry, IL-10 quantification, an apoptosis
+      study, and molecular analysis were performed.
+    explanation: >-
+      Family study directly supports flow-cytometric immunophenotyping in the
+      diagnostic workup.
+  - reference: PMID:23993982
+    reference_title: "Investigation of common variable immunodeficiency patients and healthy individuals using autoimmune lymphoproliferative syndrome biomarkers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The 95th percentile for TCRαβ+ DNT in healthy controls was used to define
+      a normal range up to 2.3% of total lymphocytes or 3.4% of T cells.
+    explanation: >-
+      Biomarker study provides practical flow-cytometric thresholds for the
+      abnormal DNT-cell phenotype.
+- name: Serum biomarker analysis
+  description: >-
+    Serum vitamin B12, soluble Fas ligand, and IL-10 help prioritize FAS
+    sequencing in patients with lymphoproliferation and autoimmune cytopenias.
+  diagnosis_term:
+    preferred_term: biomarker analysis
+    term:
+      id: MAXO:0000018
+      label: biomarker analysis
+  evidence:
+  - reference: PMID:23850805
+    reference_title: "Sequential decisions on FAS sequencing guided by biomarkers in patients with lymphoproliferation and autoimmune cytopenia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The best a priori predictor of FAS mutations was the combination of
+      vitamin B12 and soluble FAS ligand (cut-offs 1255 pg/mL and 559 pg/mL,
+      respectively), which had a positive predictive value of 92% and a
+      negative predictive value of 97%.
+    explanation: >-
+      Prospective cohort evidence supports vitamin B12 and soluble Fas ligand as
+      high-yield biomarkers for selecting patients for FAS testing.
+  - reference: PMID:23993982
+    reference_title: "Investigation of common variable immunodeficiency patients and healthy individuals using autoimmune lymphoproliferative syndrome biomarkers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Biomarkers including elevated CD3+TCRαβ+CD4-CD8- double negative T cells
+      (TCRαβ+ DNT), IL-10, sCD95L and vitamin B12 can be used to differentiate
+      between ALPS and common variable immunodeficiency (CVID) patients with an
+      overlapping clinical phenotype.
+    explanation: >-
+      Independent biomarker study supports the same laboratory panel for
+      differential diagnosis.
+- name: Fas-mediated apoptosis assay
+  description: >-
+    Functional apoptosis testing can confirm impaired Fas signaling in
+    suspected cases.
+  diagnosis_term:
+    preferred_term: apoptosis assay
+    term:
+      id: MAXO:0035080
+      label: apoptosis assay
+  evidence:
+  - reference: PMID:12732128
+    reference_title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In family A, in vitro Fas-mediated apoptosis was absent in the patient
+      and markedly reduced in his father.
+    explanation: >-
+      Human family study supports apoptosis assays as a functional confirmation
+      of defective Fas signaling.
+- name: FAS molecular genetic testing
+  description: >-
+    Molecular testing of FAS confirms the diagnosis and distinguishes germline
+    from somatic disease mechanisms.
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+  evidence:
+  - reference: PMID:12732128
+    reference_title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The molecular study of these families confirms a diagnosis of ALPS and
+      suggests that the causing defect of this syndrome is compatible with an
+      autosomal dominant inheritance with incomplete penetrance.
+    explanation: >-
+      Molecular confirmation of familial FAS variants anchors gene-level testing
+      as a core diagnostic modality.
+treatments:
+- name: Sirolimus
+  description: >-
+    mTOR inhibition with sirolimus is an effective steroid-sparing therapy for
+    refractory autoimmune cytopenias and benign lymphoproliferation in ALPS,
+    and can normalize the double-negative T-cell compartment.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: sirolimus
+      term:
+        id: CHEBI:9168
+        label: sirolimus
+  target_phenotypes:
+  - preferred_term: lymphadenopathy
+    term:
+      id: HP:0002716
+      label: Lymphadenopathy
+  - preferred_term: autoimmune thrombocytopenia
+    term:
+      id: HP:0001973
+      label: Autoimmune thrombocytopenia
+  - preferred_term: hepatosplenomegaly
+    term:
+      id: HP:0001433
+      label: Hepatosplenomegaly
+  evidence:
+  - reference: PMID:19208097
+    reference_title: "Treatment with sirolimus results in complete responses in patients with autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Four patients were treated for autoimmune cytopenias; all had a rapid
+      complete or near complete response.
+    explanation: >-
+      Initial clinical series supports sirolimus efficacy against ALPS
+      autoimmune cytopenias.
+  - reference: PMID:19208097
+    reference_title: "Treatment with sirolimus results in complete responses in patients with autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three patients had complete resolution of lymphadenopathy and
+      splenomegaly and all patients had a reduction in double negative T cells,
+      a population hallmark of the disease.
+    explanation: >-
+      The same series shows that sirolimus improves lymphoproliferation and the
+      characteristic DNT-cell abnormality.
+  - reference: PMID:26504182
+    reference_title: "Sirolimus is effective in relapsed/refractory autoimmune cytopenias: results of a prospective multi-institutional trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All children (N = 12) with autoimmune lymphoproliferative syndrome (ALPS)
+      achieved a durable complete response (CR), including rapid improvement in
+      autoimmune disease, lymphadenopathy, and splenomegaly within 1 to 3
+      months of starting sirolimus.
+    explanation: >-
+      Prospective trial evidence supports sirolimus as a highly active
+      treatment for ALPS requiring chronic therapy.
+notes: >-
+  This entry follows the current MONDO gene-related label for
+  FAS-related autoimmune lymphoproliferative syndrome while preserving the
+  historical ALPS-Ia synonym set. Rare biallelic or fetal-onset FAS phenotypes
+  are part of the broader FAS disease spectrum, but this curation emphasizes
+  the classical dominant apoptosis-defect syndrome requested in MONDO NTR
+  # 9749.

--- a/kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml
+++ b/kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: FAS-related Autoimmune Lymphoproliferative Syndrome
 creation_date: "2026-04-16T00:00:00Z"
-updated_date: "2026-04-16T00:00:00Z"
+updated_date: "2026-04-19T00:00:00Z"
 category: Mendelian
 synonyms:
 - ALPS-Ia
@@ -629,10 +629,36 @@ treatments:
     explanation: >-
       Prospective trial evidence supports sirolimus as a highly active
       treatment for ALPS requiring chronic therapy.
+- name: Mycophenolate mofetil
+  description: >-
+    Mycophenolate mofetil is an established steroid-sparing immunosuppressive
+    therapy for chronic autoimmune disease manifestations in ALPS, particularly
+    when long-term corticosteroids should be avoided.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: mycophenolate mofetil
+      term:
+        id: CHEBI:8764
+        label: mycophenolate mofetil
+  evidence:
+  - reference: PMID:22157362
+    reference_title: "New advances in the diagnosis and treatment of autoimmune lymphoproliferative syndrome."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      mycophenolate mofetil and sirolimus have been demonstrated to have marked
+      activity against the disease.
+    explanation: >-
+      Review evidence identifies mycophenolate mofetil as one of the two
+      established steroid-sparing agents with marked activity in ALPS.
 notes: >-
   This entry follows the current MONDO gene-related label for
   FAS-related autoimmune lymphoproliferative syndrome while preserving the
   historical ALPS-Ia synonym set. Rare biallelic or fetal-onset FAS phenotypes
   are part of the broader FAS disease spectrum, but this curation emphasizes
   the classical dominant apoptosis-defect syndrome requested in MONDO NTR
-  # 9749.
+  9749.

--- a/references_cache/PMID_12732128.md
+++ b/references_cache/PMID_12732128.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:12732128"
+title: "[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families]."
+authors:
+- Cambronero R
+- Cámara C
+- López-Granados E
+- Ferreira A
+- Fontán G
+- García Rodríguez MC
+journal: Med Clin (Barc)
+year: '2003'
+doi: 10.1016/s0025-7753(03)73790-7
+keywords:
+- "Autoimmune Diseases/diagnosis, genetics, immunology"
+- Base Sequence
+- Child
+- "Child, Preschool"
+- Family Health
+- Female
+- "Genes, T-Cell Receptor alpha/genetics"
+- Humans
+- Immunoglobulin E/metabolism
+- Immunoglobulin G/metabolism
+- Immunohistochemistry
+- "Lymphocytes/immunology, pathology"
+- "Lymphoma, Non-Hodgkin/diagnosis, genetics"
+- "Lymphoproliferative Disorders/diagnosis, genetics, immunology"
+- Male
+- Molecular Sequence Data
+- Mutation
+- Pedigree
+- "Sequence Homology, Nucleic Acid"
+- "Splenomegaly/diagnosis, genetics"
+- Syndrome
+content_type: abstract_only
+---
+
+# [Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families].
+**Authors:** Cambronero R, Cámara C, López-Granados E, Ferreira A, Fontán G, García Rodríguez MC
+**Journal:** Med Clin (Barc) (2003)
+**DOI:** [10.1016/s0025-7753(03)73790-7](https://doi.org/10.1016/s0025-7753(03)73790-7)
+
+## Content
+
+1. Med Clin (Barc). 2003 May 3;120(16):622-5. doi: 10.1016/s0025-7753(03)73790-7.
+
+[Autoimmune lymphoproliferative syndrome: molecular diagnosis in two families].
+
+[Article in Spanish]
+
+Cambronero R(1), Cámara C, López-Granados E, Ferreira A, Fontán G, García
+Rodríguez MC.
+
+Author information:
+(1)Unidad de Inmunología. Hospital La Paz. Madrid. Spain.
+mcruzgracia.hulp@salud.madrid.org
+
+BACKGROUND AND OBJECTIVE: The autoimmune lymphoproliferative syndrome (ALPS) is
+a disorder caused by a defect in lymphocytes' apoptosis and characterized by non
+malignant lymphoproliferation, autoimmune features and increased TCR alpha +
+CD4CD8 cells. Most patients have a mutation in the TNFRSF6 gene, which encodes
+the Fas protein. Our aim was to identify mutations in this gene in two families
+with possible ALPS cases.
+PATIENTS AND METHOD: Two patients with suspicion of ALPS, belonging to two
+unrelated families, were studied. To confirm such a diagnosis, immunoglobulin
+quantification, cellular phenotypic analysis by flow cytometry, IL-10
+quantification, an apoptosis study, and molecular analysis were performed.
+RESULTS: Both patients showed hypergammaglobulinemia and an increased percentage
+of TCR alpha + CD4CD8 cells (family A patient: 14%; family B patient: 4.25%). In
+family A, in vitro Fas-mediated apoptosis was absent in the patient and markedly
+reduced in his father. In this family, both the patient and his father were
+heterozygous for the Fas mutation T1045C (Leu 268 Pro). The family B patient and
+her mother showed the Fas mutation G943T (Arg 234 Leu), both being heterozygous
+for it too. Both mutations are located in exon 9 of TNFRSF6 gene, affecting the
+death domain of the Fas protein.
+CONCLUSIONS: The molecular study of these families confirms a diagnosis of ALPS
+and suggests that the causing defect of this syndrome is compatible with an
+autosomal dominant inheritance with incomplete penetrance.
+
+DOI: 10.1016/s0025-7753(03)73790-7
+PMID: 12732128 [Indexed for MEDLINE]

--- a/references_cache/PMID_15160902.md
+++ b/references_cache/PMID_15160902.md
@@ -1,0 +1,63 @@
+---
+reference_id: "PMID:15160902"
+title: Development of lymphoma in Autoimmune Lymphoproliferative Syndrome (ALPS) and its relationship to Fas gene mutations.
+authors:
+- Poppema S
+- Maggio E
+- van den Berg A
+journal: Leuk Lymphoma
+year: '2004'
+doi: 10.1080/10428190310001593166
+keywords:
+- Apoptosis/genetics
+- "Autoimmune Diseases/complications, genetics"
+- Caspases/genetics
+- Family Health
+- Humans
+- "Lymphoma/etiology, genetics"
+- "Lymphoproliferative Disorders/complications, genetics"
+- T-Lymphocytes/immunology
+- fas Receptor/genetics
+content_type: abstract_only
+---
+
+# Development of lymphoma in Autoimmune Lymphoproliferative Syndrome (ALPS) and its relationship to Fas gene mutations.
+**Authors:** Poppema S, Maggio E, van den Berg A
+**Journal:** Leuk Lymphoma (2004)
+**DOI:** [10.1080/10428190310001593166](https://doi.org/10.1080/10428190310001593166)
+
+## Content
+
+1. Leuk Lymphoma. 2004 Mar;45(3):423-31. doi: 10.1080/10428190310001593166.
+
+Development of lymphoma in Autoimmune Lymphoproliferative Syndrome (ALPS) and
+its relationship to Fas gene mutations.
+
+Poppema S(1), Maggio E, van den Berg A.
+
+Author information:
+(1)Department of Pathology & Laboratory Medicine, University Medical Center
+Groningen, Hanzeplein 1, 9700RB Groningen, The Netherlands. s.poppema@med.rug.nl
+
+Autoimmune Lymphoproliferative Syndrome (ALPS) is generally the result of a
+mutation in genes associated with apoptosis, like Fas, Fas ligand, Casp 8 and
+Casp 10. As a result, the normal homeostasis of T- and B-lymphocytes is
+disturbed and a proliferation of polyclonal T lymphocytes occurs. This leads to
+hepatosplenomegaly and lymphadenopathy and in most patients also to autoimmune
+phenomena like anemia and thrombocytopenia. The proliferating T cells are
+TCRalphabeta and/or TCRgammadelta positive but lack both CD4 and CD8. Hence they
+are termed double negative (DN) T cells. In addition, there is an increase of
+CD5 positive B cells. Individuals with germline mutations in the Fas gene have a
+high risk to develop non Hodgkin lymphomas (x 14) as well as Hodgkin lymphomas
+(x 51), in particular NLP Hodgkin lymphoma. Somatic mutations of Fas are
+frequently acquired during the normal germinal center reaction. Non Hodgkin
+lymphomas carry somatic mutations of the Fas gene in 11% and of the Casp 10 gene
+in 14.5% of the patients. In Hodgkin lymphomas, Fas mutations can be
+demonstrated in Reed-Sternberg cells in 10-20% of the patients. These data
+implicate a role for Fas-mediated apoptosis in preventing lymphomas. Inherited
+defects in receptor-mediated lymphocyte apoptosis represent a risk factor for
+lymphomas and somatic mutations of these genes may also play a role in the
+development and/or progression of lymphomas.
+
+DOI: 10.1080/10428190310001593166
+PMID: 15160902 [Indexed for MEDLINE]

--- a/references_cache/PMID_19208097.md
+++ b/references_cache/PMID_19208097.md
@@ -1,0 +1,99 @@
+---
+reference_id: "PMID:19208097"
+title: Treatment with sirolimus results in complete responses in patients with autoimmune lymphoproliferative syndrome.
+authors:
+- Teachey DT
+- Greiner R
+- Seif A
+- Attiyeh E
+- Bleesing J
+- Choi J
+- Manno C
+- Rappaport E
+- Schwabe D
+- Sheen C
+- Sullivan KE
+- Zhuang H
+- Wechsler DS
+- Grupp SA
+journal: Br J Haematol
+year: '2009'
+doi: 10.1111/j.1365-2141.2009.07595.x
+keywords:
+- "Anemia, Hemolytic, Autoimmune/diagnostic imaging, drug therapy"
+- Child
+- "Child, Preschool"
+- Drug Administration Schedule
+- Follow-Up Studies
+- Humans
+- Immunosuppressive Agents/therapeutic use
+- Infant
+- Male
+- Positron-Emission Tomography
+- Radiography
+- Sirolimus/therapeutic use
+content_type: full_text_xml
+---
+
+# Treatment with sirolimus results in complete responses in patients with autoimmune lymphoproliferative syndrome.
+**Authors:** Teachey DT, Greiner R, Seif A, Attiyeh E, Bleesing J, Choi J, Manno C, Rappaport E, Schwabe D, Sheen C, Sullivan KE, Zhuang H, Wechsler DS, Grupp SA
+**Journal:** Br J Haematol (2009)
+**DOI:** [10.1111/j.1365-2141.2009.07595.x](https://doi.org/10.1111/j.1365-2141.2009.07595.x)
+
+## Content
+
+1. Br J Haematol. 2009 Apr;145(1):101-6. doi: 10.1111/j.1365-2141.2009.07595.x.
+Epub 2009 Feb 4.
+
+Treatment with sirolimus results in complete responses in patients with
+autoimmune lymphoproliferative syndrome.
+
+Teachey DT(1), Greiner R, Seif A, Attiyeh E, Bleesing J, Choi J, Manno C,
+Rappaport E, Schwabe D, Sheen C, Sullivan KE, Zhuang H, Wechsler DS, Grupp SA.
+
+Author information:
+(1)Pediatric Hematology and Oncology, Children's Hospital of Philadelphia,
+University of Pennsylvania School of Medicine, Philadelphia PA 19104, USA.
+teacheyd@email.chop.edu
+
+We hypothesized that sirolimus, an mTOR inhibitor, may be effective in patients
+with autoimmune lymphoproliferative syndrome (ALPS) and treated patients who
+were intolerant to or failed other therapies. Four patients were treated for
+autoimmune cytopenias; all had a rapid complete or near complete response. Two
+patients were treated for autoimmune arthritis and colitis, demonstrating marked
+improvement. Three patients had complete resolution of lymphadenopathy and
+splenomegaly and all patients had a reduction in double negative T cells, a
+population hallmark of the disease. Based on these significant responses, we
+recommend that sirolimus be considered as second-line therapy for patients with
+steroid-refractory disease.
+
+DOI: 10.1111/j.1365-2141.2009.07595.x
+PMCID: PMC2819393
+PMID: 19208097 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of interest No author has competing
+financial interests to declare.
+
+Autoimmune lymphoproliferative syndrome (ALPS) is a disorder of disrupted lymphocyte homeostasis caused by defective Fas-mediated apoptosis. As part of the down-regulation of the immune response, activated B lymphocytes normally up-regulate Fas expression and activated B and T lymphocytes up-regulate expression of Fas-ligand (Nagata & Golstein, 1995). The binding of Fas to Fas-ligand triggers the caspase cascade, leading to cellular apoptosis. Patients with ALPS have a defect in this extrinsic apoptotic pathway, leading to chronic lymphoproliferation, autoimmune manifestations and a propensity to develop secondary malignancies (Bleesing et al, 2000).
+
+Currently, a patient must meet three diagnostic criteria for ALPS: (i) clinically identifiable chronic non-malignant lymphoproliferation; (ii) an increased number of double-negative T cells (DNTs; cell phenotype CD4−/CD8−, CD3+, TCRαβ+) and (iii) in vitro evidence of defective Fas-mediated apoptosis (Bleesing et al, 2000). Supporting evidence for the diagnosis includes genetic mutations in the Fas pathway (FAS, FAS LG, CASP8, or CASP10), systemic autoimmunity, elevated serum levels of interleukin-10 (IL-10), elevated serum vitamin B12 and hypergammaglobulinaemia; however, these latter findings are not diagnostic (Rieux-Laucat et al, 2003).
+
+Most patients with ALPS develop autoimmunity, usually manifested as autoimmune cytopenias. Other autoimmune manifestations are seen less frequently, including autoimmune nephritis, hepatitis, arthritis, colitis, uveitis and urticaria (Sneller et al, 1997). Some patients with ALPS require no treatment; however, many other patients require medications directed toward autoimmune manifestations, particularly autoimmune cytopenias. Patients usually respond to short bursts of immunosuppressive medications, including corticosteroids (Bleesing et al, 2000). Occasionally patients with severe cytopenias need more aggressive immunosuppression. Anecdotal reports and small series have described responses to a number of medications, including cyclosporine, mycophenolate mofetil (MMF), vincristine and rituximab (Ferrer et al, 2007). Nevertheless, these agents are often ineffective, have significant side effects and are non-specific for ALPS.
+
+Sirolimus (rapamycin) is an immunosuppressive agent that targets the mammalian target of rapamycin (mTOR) and has been shown to induce apoptosis in both normal and abnormal lymphocytes. We hypothesized that targeting the mTOR pathway might be effective in patients with ALPS by inducing apoptosis in the abnormal lymphocytes underlying this condition. We previously tested this hypothesis using two murine models of ALPS (CBA-lprcg and MRL-lpr) and found sirolimus was more effective than conventional therapies, including MMF (Teachey et al, 2006). Based on these results, we began treating children with refractory ALPS with sirolimus, targeting a serum trough level of 4–15 ng/ml. We have treated six patients and found marked improvement in autoimmune disease markers in all of these patients.
+
+Patients with ALPS were followed under an Institutional Review Board-approved classification protocol that allowed data collection, including medication response. We treated six male ALPS patients with sirolimus. Patients were started on sirolimus at 2–3 mg/m2/d, rounding to the nearest 0·5 mg with maximum initial dose of 4 mg. Doses were adjusted to achieve a steady-state serum trough of 4–15 ng/ml. Three of these patients were type Ia because they have a documented mutation in FAS. The other three were classified as type III because no genetic mutation was found. Four corticosteroid-refractory or intolerant patients were treated for severe chronic autoimmune cytopenias. Three of the four patients had complete resolution of autoimmune cytopenias (Table I and Fig 1). The fourth patient had near complete resolution with a residual mild thrombocytopenia (platelet count >100 × 109/l). All four patients were able to completely taper off steroids within 4 weeks of initiating sirolimus. These patients have been treated for 5, 7, 17 and 27 months. Many of these patients had failed other immunosuppressive medications, including MMF (Table I). Two of the six patients were treated with sirolimus for autoimmune arthritis and colitis for 6 and 36 months respectively. Both of these patients had marked improvement in their symptoms on sirolimus after failing multiple other immunosuppressant medications. One of these patients remains on low dose every other day steroids (Patient 5) without toxicity. Prior to sirolimus he required high dose steroids (1–2 mg/kg/d) with significant side effects. The other patient (Patient 6) required re-initiation of steroids after one year and other more aggressive immunosuppressive regimens were tried, including systemic chemotherapy (mercaptopurine, cyclophosphamide and methotrexate) and biological agents (anakindra, etanercept, rituximab and MMF) with and without sirolimus. No regimen controlled his disease as well as a combination of sirolimus and steroids and whenever his sirolimus was held for alternative regimens his disease would flare significantly. Thus, he has been continued on chronic sirolimus.
+
+Five patients had significant lymphoproliferation (lymphadenopathy and/or splenomegaly) at the initiation of sirolimus therapy. One patient’s lymphoproliferation was controlled with steroids and thus he had no measurable lymphadenopathy or splenomegaly when sirolimus was initiated; he has not developed lymphoproliferation on sirolimus after stopping steroids. Of the five patients with lymphoproliferation at the time of sirolimus initiation, one patient had minimal response (no change in lymphadenopathy and mild improvement in splenomegaly), three patients had a complete response and one patient had a near-complete response with one 0·5-cm residual cervical lymph node. One patient had positive disease on a positron emission tomography (PET)/computed tomography (CT) scan immediately prior to initiating sirolimus; a follow-up scan after 3 months of treatment demonstrated resolution of PET-avid disease (Fig 1). We know of no other reported therapy producing such a dramatic response in refractory ALPS patients. As a biological marker of disease response, we compared peripheral blood DNTs prior to and after starting therapy with sirolimus. The percentage of DNTs was reduced by >50% in five of six patients (Fig 1) with an average decrease of 60% (P = 0·02) (range 41–74%). Of note, despite the reduction in DNTs, no patient had a reduction in total absolute lymphocyte count (ALC). Three patients were mildly lymphopenic at the initiation of sirolimus and two of these (Patients 1 and 3) had improvement of ALC to the normal range. No grade 3 or 4 toxicities were observed in any patient.
+
+Sirolimus (rapamycin) is a Federal Drug Administration-approved immunosuppressant that targets mTOR. Sirolimus has been in clinical use for over 20 years and its toxicities are well-described (Abdel-Karim & Giles, 2008). We hypothesized that mTOR inhibitors would be effective in patients with ALPS for three compelling reasons: (i) mTOR inhibitors induce cell death and apoptosis in abnormal lymphocytes; (ii) mTOR inhibitors, unlike most other immunosuppressive medications, increase peripheral blood regulatory T cells (Tregs) and (iii) mTOR inhibitors are safe and well-tolerated.
+
+Common toxicities found in patients taking sirolimus include hypercholesterolemia, hypertension and mucositis (Abdel-Karim & Giles, 2008). An increased risk of infections is very rare when used as a single agent; however, when combined with other immunosuppressive agents the risk increases. Sirolimus requires therapeutic drug monitoring to maximize effect and avoid toxicity.
+
+Treatment for patients with refractory ALPS is challenging. Many patients do not require chronic treatment, but for those patients who do there are only a few effective and tolerable agents. Currently a number of more targeted therapies are undergoing preclinical testing and clinical trials. Pyrimethamine and sulphadoxine were shown to reduce lymphoproliferation and autoimmune cytopenias significantly in a small series of patients with ALPS; however, this combination failed to show any response in a different larger clinical trial (Ferrer et al, 2007). We have also recently shown that targeting the Notch signaling pathway may be beneficial in preclinical models of ALPS (Teachey et al, 2008), while other groups have shown that arsenic and histone deacetylase-inhibitors may be effective in preclinical models of ALPS (Ferrer et al, 2007). As with many autoimmune diseases, rituximab has been shown to be effective in a subset of ALPS patients; however, 5–10% of ALPS patients eventually develop common variable immunodeficiency (CVID) and our group (unpublished observations) and others have seen an association between rituximab use and the development of CVID in ALPS patients (Dale et al, 2007). Moreover, the effects of rituximab are generally relatively transient; patients that do respond will probably relapse and with the potential risk of CVID, we recommend avoiding use of rituximab in ALPS patients. MMF was found to be effective in another series (Koneti Rao et al, 2005). While we have had less success overall with this drug, we have also seen good responses in a few children with ALPS treated with MMF (unpublished data).
+
+MMF inhibits lymphocyte proliferation but does not cause lymphocyte death and does not appear to increase Tregs (Noris et al, 2007). Tregs are a subset of T lymphocytes that suppress the activation of the immune system and increasing Treg numbers may improve autoimmune diseases (Brusko et al, 2008). Interestingly, some evidence suggests that peripheral blood DNTs may be dysregulated Tregs, while other evidence suggests they are cytotoxic T lymphocytes that have lost CD8 expression (Bleesing et al, 2001; Fischer et al, 2005). We have found mTOR inhibition decreases these abnormal DNTs in ALPS patients. Sirolimus has been shown to increase Tregs in healthy volunteers and patients with other autoimmune diseases (Battaglia et al, 2006). These observations, taken together, suggest the possibility that the improved responses with sirolimus seen here compared to other immunosuppressive agents, both in preclinical models and in patients, may be attributable to both induction of apoptosis in the abnormal lymphocytes and increases in normal Tregs. In subsequent patients, we plan to measure Tregs before and after initiating treatment with sirolimus. Unfortunately, as DNTs do not survive in culture, we could not directly test the in-vitro sensitivity of ALPS-patient’s DNTs to sirolimus.
+
+As sirolimus can cause lymphocyte apoptosis and increase Tregs, it may also have activity in non-ALPS patients with autoimmune cytopenias, including patients with immune thrombocytopenia purpura (ITP), autoimmune hemolytic anemia (AIHA) and autoimmune neutropenia, either as isolated idiopathic conditions or when associated with other autoimmune syndromes, including lupus or Evans syndrome. Our findings suggest that sirolimus may be superior to other agents currently used for or being investigated in these syndromes, including mercaptopurine, MMF, cyclosporine and tacrolimus. None of these agents are both lymphotoxic to both B and T cells while simultaneously increasing Tregs. Accordingly, we plan to open a clinical trial investigating the efficacy of sirolimus in patients with chronic ITP and chronic AIHA.
+
+We found sirolimus was very effective in ameliorating autoimmune disease and lymphoproliferation in patients with ALPS, corroborating our previous preclinical work. Based on these results, we plan to continue to treat patients with ALPS and either steroid-refractory disease or who are steroid-intolerant with sirolimus and we have initiated a phase II efficacy trial of sirolimus in ALPS. Based on this trial, we anticipate that sirolimus may move to the frontline of therapy for patients with ALPS.

--- a/references_cache/PMID_20170754.md
+++ b/references_cache/PMID_20170754.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:20170754"
+title: "The autoimmune lymphoproliferative syndrome: A rare disorder providing clues about normal tolerance."
+authors:
+- Turbyville JC
+- Rao VK
+journal: Autoimmun Rev
+year: '2010'
+doi: 10.1016/j.autrev.2010.02.007
+keywords:
+- Animals
+- "Autoimmune Lymphoproliferative Syndrome/diagnosis, epidemiology, immunology, physiopathology"
+- Autoimmunity
+- "Diagnosis, Differential"
+- Endothelium/immunology
+- Humans
+- Immune Tolerance
+- Inflammation
+- Lymphatic Diseases
+- National Institutes of Health (U.S.)
+- "Rare Diseases/diagnosis, epidemiology, immunology, physiopathology"
+- Splenomegaly
+- United States
+content_type: abstract_only
+---
+
+# The autoimmune lymphoproliferative syndrome: A rare disorder providing clues about normal tolerance.
+**Authors:** Turbyville JC, Rao VK
+**Journal:** Autoimmun Rev (2010)
+**DOI:** [10.1016/j.autrev.2010.02.007](https://doi.org/10.1016/j.autrev.2010.02.007)
+
+## Content
+
+1. Autoimmun Rev. 2010 May;9(7):488-93. doi: 10.1016/j.autrev.2010.02.007. Epub
+2010 Feb 17.
+
+The autoimmune lymphoproliferative syndrome: A rare disorder providing clues
+about normal tolerance.
+
+Turbyville JC(1), Rao VK.
+
+Author information:
+(1)Department of Allergy-Immunology, Walter Reed Army Medical Center,
+Washington, DC 20307, USA. joseph.c.turbyville@us.army.mil
+<joseph.c.turbyville@us.army.mil>
+
+The autoimmune lymphoproliferative syndrome (ALPS) is characterized by chronic,
+non-malignant lymphoproliferation, autoimmunity often manifesting as
+multilineage cytopenias, and an increased risk of lymphoma. While considered a
+rare disease, there are currently over 250 patients with ALPS being followed at
+the National Institutes of Health in Bethesda, Maryland. Most of these patients
+have a mutation in the gene for the TNF receptor-family member Fas (CD 95,
+Apo-1), and about one-third have an unknown defect or mutations affecting
+function of other signaling proteins involved in the apoptotic pathway. While
+ALPS is one of the few autoimmune diseases with a known genetic defect, there
+remain unanswered questions regarding how a defect in apoptosis results in the
+observed phenotype. In addition to shedding light on the pathophysiology of this
+rare and fascinating condition, studying ALPS may improve our understanding of
+normal tolerance and more common, sporadic autoimmune disorders.
+
+Published by Elsevier B.V.
+
+DOI: 10.1016/j.autrev.2010.02.007
+PMID: 20170754 [Indexed for MEDLINE]

--- a/references_cache/PMID_21447005.md
+++ b/references_cache/PMID_21447005.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:21447005"
+title: Advances in autoimmune lymphoproliferative syndromes.
+authors:
+- Madkaikar M
+- Mhatre S
+- Gupta M
+- Ghosh K
+journal: Eur J Haematol
+year: '2011'
+doi: 10.1111/j.1600-0609.2011.01617.x
+keywords:
+- Apoptosis
+- "Autoimmune Lymphoproliferative Syndrome/classification, diagnosis, genetics, therapy"
+- Autoimmunity
+- Cell Proliferation
+- Humans
+- "Models, Biological"
+- Mutation
+- Neoplasms/etiology
+- Prognosis
+- Risk Factors
+- Signal Transduction
+- fas Receptor/genetics
+content_type: abstract_only
+---
+
+# Advances in autoimmune lymphoproliferative syndromes.
+**Authors:** Madkaikar M, Mhatre S, Gupta M, Ghosh K
+**Journal:** Eur J Haematol (2011)
+**DOI:** [10.1111/j.1600-0609.2011.01617.x](https://doi.org/10.1111/j.1600-0609.2011.01617.x)
+
+## Content
+
+1. Eur J Haematol. 2011 Jul;87(1):1-9. doi: 10.1111/j.1600-0609.2011.01617.x.
+
+Advances in autoimmune lymphoproliferative syndromes.
+
+Madkaikar M(1), Mhatre S, Gupta M, Ghosh K.
+
+Author information:
+(1)National Institute of Immunohaematology, KEM Hospital, Parel, Mumbai, India.
+madkaikarm@icmr.org.in
+
+Autoimmune lymphoproliferative syndrome (ALPS) is a disorder of lymphocyte
+homeostasis. It is characterized by non-malignant lymphoproliferation
+autoimmunity mostly directed toward blood cells and increased risk of lymphoma.
+Majority of patients with ALPS harbor heterozygous germline mutations in the
+gene for the TNF receptor-family member Fas (CD 95, Apo-1) which are inherited
+in an autosomal dominant fashion. Somatic Fas mutations are the second most
+common genetic etiology of ALPS. Additionally mutations in the genes encoding
+Fas-ligand (FASLG), caspase 10 (CASP10) and caspase 8 (CASP8), NRAS and KRAS
+have been identified in a small number of patients with ALPS and related
+disorders. Approximately one-third of patients with ALPS have yet unidentified
+defect. ALPS was initially thought to be a very rare disease, but recent studies
+have shown that it may be more common than previously thought. Testing for ALPS
+should therefore be considered in patients with unexplained lymphadenopathy,
+cytopenias, and hepatosplenomegaly. There have been significant advances in the
+understanding of the pathophysiology of ALPS in last few years which has
+resulted in the development of new diagnostic criteria and a number of targeted
+therapies. This review describes the clinical and laboratory manifestations
+found in patients with ALPS, as well as the molecular basis for the disease and
+new advances in treatment.
+
+© 2011 John Wiley & Sons A/S.
+
+DOI: 10.1111/j.1600-0609.2011.01617.x
+PMID: 21447005 [Indexed for MEDLINE]

--- a/references_cache/PMID_21885601.md
+++ b/references_cache/PMID_21885601.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:21885601"
+title: How I treat autoimmune lymphoproliferative syndrome.
+authors:
+- Rao VK
+- Oliveira JB
+journal: Blood
+year: '2011'
+doi: 10.1182/blood-2011-07-325217
+keywords:
+- Animals
+- "Apoptosis/genetics, physiology"
+- "Autoimmune Lymphoproliferative Syndrome/classification, diagnosis, genetics, therapy"
+- "Autoimmunity/genetics, physiology"
+- "Cell Transformation, Neoplastic/genetics, pathology"
+- Humans
+- "Lymphoma/etiology, genetics"
+- "Models, Biological"
+- Risk Factors
+- Signal Transduction/genetics
+content_type: abstract_only
+---
+
+# How I treat autoimmune lymphoproliferative syndrome.
+**Authors:** Rao VK, Oliveira JB
+**Journal:** Blood (2011)
+**DOI:** [10.1182/blood-2011-07-325217](https://doi.org/10.1182/blood-2011-07-325217)
+
+## Content
+
+1. Blood. 2011 Nov 24;118(22):5741-51. doi: 10.1182/blood-2011-07-325217. Epub
+2011  Sep 1.
+
+How I treat autoimmune lymphoproliferative syndrome.
+
+Rao VK(1), Oliveira JB.
+
+Author information:
+(1)ALPS Unit, Laboratory of Clinical and Infectious Diseases, National Institute
+of Allergy and Infectious Diseases, National Institutes of Health (NIH),
+Bethesda, MD 20892, USA. korao@niaid.nih.gov
+
+Autoimmune lymphoproliferative syndrome (ALPS) represents a failure of apoptotic
+mechanisms to maintain lymphocyte homeostasis, permitting accumulation of
+lymphoid mass and persistence of autoreactive cells that often manifest in
+childhood with chronic nonmalignant lymphadenopathy, hepatosplenomegaly, and
+recurring multilineage cytopenias. Cytopenias in these patients can be the
+result of splenic sequestration as well as autoimmune complications manifesting
+as autoimmune hemolytic anemia, immune-mediated thrombocytopenia, and autoimmune
+neutropenia. More than 300 families with hereditary ALPS have now been
+described; nearly 500 patients from these families have been studied and
+followed worldwide over the last 20 years by our colleagues and ourselves. Some
+of these patients with FAS mutations affecting the intracellular portion of the
+FAS protein also have an increased risk of B-cell lymphoma. The best approaches
+to diagnosis, follow-up, and management of ALPS, its associated cytopenias, and
+other complications resulting from infiltrative lymphoproliferation and
+autoimmunity are presented.
+
+DOI: 10.1182/blood-2011-07-325217
+PMCID: PMC3228494
+PMID: 21885601 [Indexed for MEDLINE]

--- a/references_cache/PMID_22157362.md
+++ b/references_cache/PMID_22157362.md
@@ -1,0 +1,113 @@
+---
+reference_id: "PMID:22157362"
+title: New advances in the diagnosis and treatment of autoimmune lymphoproliferative syndrome.
+authors:
+- Teachey DT
+journal: Curr Opin Pediatr
+year: '2012'
+doi: 10.1097/MOP.0b013e32834ea739
+keywords:
+- "Autoimmune Lymphoproliferative Syndrome/diagnosis, drug therapy, genetics"
+- Female
+- "Germ-Line Mutation/drug effects, genetics"
+- Humans
+- Immunosuppressive Agents/therapeutic use
+- "Lymphatic Diseases/diagnosis, drug therapy, genetics"
+- Male
+- "Mycophenolic Acid/analogs & derivatives, therapeutic use"
+- Signal Transduction
+- Sirolimus/therapeutic use
+- "Splenomegaly/diagnosis, drug therapy, genetics"
+- "fas Receptor/drug effects, genetics"
+content_type: full_text_xml
+---
+
+# New advances in the diagnosis and treatment of autoimmune lymphoproliferative syndrome.
+**Authors:** Teachey DT
+**Journal:** Curr Opin Pediatr (2012)
+**DOI:** [10.1097/MOP.0b013e32834ea739](https://doi.org/10.1097/MOP.0b013e32834ea739)
+
+## Content
+
+1. Curr Opin Pediatr. 2012 Feb;24(1):1-8. doi: 10.1097/MOP.0b013e32834ea739.
+
+New advances in the diagnosis and treatment of autoimmune lymphoproliferative
+syndrome.
+
+Teachey DT(1).
+
+Author information:
+(1)Division of Pediatric Hematology, Children's Hospital of Philadelphia,
+University of Pennsylvania, School of Medicine, Philadelphia, Pennsylvania, USA.
+teacheyd@E-Mail.chop.edu
+
+PURPOSE OF REVIEW: Autoimmune lymphoproliferative syndrome (ALPS) is a disorder
+of disrupted lymphocyte homeostasis, resulting from mutations in the Fas
+apoptotic pathway. Clinical manifestations include lymphadenopathy,
+splenomegaly, and autoimmune cytopenias. A number of new insights have improved
+the understanding of the genetics and biology of ALPS. These will be discussed
+in this review.
+RECENT FINDINGS: A number of key observations have been made recently that
+better define the pathophysiology of ALPS, including the characterization of
+somatic FAS variant ALPS, the identification of haploinsufficiency as a
+mechanism of decreased Fas expression, and the description of multiple genetic
+hits in FAS in some families that may explain the variable penetrance of the
+disease. In addition, ALPS has been shown to be a more common condition, as
+patients diagnosed with other disorders, including Evans syndrome and common
+variable immune deficiency, have been found to have ALPS. Finally, the treatment
+of the disease has changed as splenectomy and rituximab have been shown to have
+unexpected ALPS-specific toxicities, and mycophenolate mofetil and sirolimus
+have been demonstrated to have marked activity against the disease.
+SUMMARY: On the basis of novel advances, the diagnostic algorithm and
+recommended treatment for ALPS have changed significantly, improving quality of
+life for many patients.
+
+DOI: 10.1097/MOP.0b013e32834ea739
+PMCID: PMC3673763
+PMID: 22157362 [Indexed for MEDLINE]
+
+Autoimmune Lymphoproliferative Syndrome (ALPS) is a disorder of abnormal lymphocyte survival caused by dysregulation of the FAS apoptotic pathway. Patients with ALPS develop chronic non-malignant lymphoproliferation, autoimmune disease, and secondary malignancies. ALPS was first described in the 1990s, and since its discovery a number of significant advances have been made that have changed diagnosis and treatment of ALPS and have better defined its pathophysiology. ALPS was originally thought to be extremely rare but may be more common as more cases are being diagnosed with increasing clinician awareness. This article reviews the diagnosis and treatment of ALPS, focusing on recent scientific advances.
+
+ALPS is a syndrome defined by a defect in the Fas apoptotic pathway (Figure 1).[1] In order to downregulate the normal immune response, activated B and T lymphocytes increase Fas expression, and activated T lymphocytes increase expression of Fas-ligand.[2] Fas and Fas-ligand interact through the Fas-activating death domain (FADD), triggering the caspase cascade, culminating in DNA degradation, proteolysis and apoptosis.[3] Defective apoptosis can lead to lymphoproliferation, autoimmunity, and cancer.[4,5] Over 70% of patients with ALPS have identifiable mutations in Fas pathway genes. Most patients have germline (60–70% of patients) or somatic mutations (10% of patients) in FAS (TNFRSF6). Rarely, patients have mutations in FASL (TNFSF6, <1% of patients) and CASP10 (2–3% of patients).[6] Twenty to 30% of patients have no identifiable mutation.[6] Recently, an international consensus conference at the NIH redefined ALPS nomenclature, using a gene-based classification (Table 1).[7]
+
+Germline mutations in FAS are usually inherited in an autosomal dominant fashion.[8] Most often FAS defects are dominant negative heterozygous missense mutations in the intracellular death domain (exons 7–9), with the mutated allele inhibiting the function of the wild-type allele. Approximately 30% of ALPS causative mutations affect the extracellular domain. Recently, Keuhn and colleagues established these are mostly nonsense or frameshift mutations resulting in haploinsufficiency.[9] Dominant negative mutations typically lead to absence of FAS activity, whereas haploinsufficient mutations usually lead to decreased activity. As such, disease penetrance appears to be much higher in families with dominant negative intracellular mutations compared with haploinsufficient extracellular mutations.[9–11] ALPS mutations have highly variable expressivity, and mutation type is not predictive of disease manifestations or laboratory biomarkers. The only reported association is a higher incidence of secondary lymphomas in patients with dominant negative intracellular mutations.[9] Of note, the total number of reported patients with ALPS-associated lymphoma is small, and this observed difference may result from selection bias.
+
+A significant subset of ALPS patients have somatic FAS mutations, primarily limited to the non-thymic double negative T cell (DNT) compartment. DNTs (phenotype, CD3+, CD4−, CD8−, TCRα/β+) are a subset of T cells normally found at small percentages in the peripheral blood that are markedly elevated in patients with ALPS. The elevated DNTs in ALPS were originally considered an epiphenomenon; however, they may drive abnormal B cell activity and subsequent autoimmunity.[12] The recent description of somatic ALPS is a strong argument that DNTs play a role in ALPS pathogenesis. ALPS patients with germline and somatic-variant FAS mutations are phenotypically similar in both disease manifestations and laboratory abnormalities.[13,14] Predictably, the primary difference is that patients with germline FAS mutations typically present at a younger age than their somatic counterparts. Causative somatic mutations in CASP10 and FASL have not been described.
+
+FAS mutations have variable penetrance, as ALPS patients often have family members with the same genetic alterations and an absent or very mild clinical phenotype [15,16]. This suggests a second “hit” is required for disease, such as additional genetic mutations and/or environmental triggers. Recently, Magerus-Chatinet and colleagues observed that disease penetrance can be explained in some families as a consequence of multiple FAS mutations.[17] They identified seven ALPS patients who inherited heterozygous FAS mutations and also acquired a somatic alteration in the second FAS allele. Family members with only germline FAS mutations were asymptomatic. Multiple abnormalities in FAS may explain the variable penetrance in some families; however, patients may acquire mutations in other cooperating genes as the second event.
+
+Lymphoproliferation is the most common clinical manifestation in ALPS, presenting as lymphadenopathy, splenomegaly, and/or hepatomegaly.[6,18–20] Most patients develop lymphoproliferation at a young age (median 11.5 months) that varies from mild to severe enough to compromise vital organs. [21] Autoimmunity is the second most common finding and is the most likely to require medical intervention. Over 70% of patients develop autoimmune disease, most commonly immune-mediated cytopenias, which can affect erythrocytes (autoimmune hemolytic anemia), platelets (immune thrombocytopenia) or neutrophils (autoimmune neutropenia).[15] Severity ranges from asymptomatic laboratory abnormalities to severe, chronic, and debilitating destruction of multiple cell lineages.[6] Other autoimmune manifestations are less frequent, although ALPS autoimmunity can affect virtually any organ, and patients can develop nephritis, gastritis, hepatitis, urticaria, arthritis, colitis, and pulmonary fibrosis, similar to systemic lupus erythematosis.[10,22,23] While autoimmune neurologic disease is a rare manifestation of ALPS, we have diagnosed severe autoimmune neurologic complications in three patients, including autoantibody-positive autoimmune cerebellar ataxia, transverse myelitis, and Guillain-Barre syndrome (unpublished observation). All three patients responded to systemic immune suppression.
+
+ALPS patients have an increased risk of secondary malignancies, most commonly EBER+ non-Hodgkin lymphoma.[10,15] The risk is estimated to be 10–20% and is most prevalent in FAS-mutant ALPS.[16] Unaffected family members with FAS mutations are also predisposed to malignancy, consistent with observations that somatic mutations in FAS family genes are highly prevalent in lymphomas in the general population.[24] Identifying malignancy can be difficult as clinical manifestations of ALPS mirror lymphoma. No imaging modality, including FDG-PET, can accurately distinguish benign from malignant lymphoproliferation because rapidly proliferating cells in ALPS have high FDG uptake.[25] Unlike carcinomas and other solid tumors, early diagnosis of lymphoma does not change clinical outcome. Accordingly, based on the very high false-positive rate, our group does not perform routine serial imaging of ALPS patients. Rather, we investigate for malignancy if patients develop constitutional symptoms or have a significant change in disease pattern. ALPS lymphadenopathy consists primarily of polyclonal expansion of abnormal cells. Progression to lymphoma is associated with monoclonal expansion of malignant lymphocytes. Testing for clonality in lymphocyte subsets can sometimes help distinguish benign from malignant disease.
+
+Until 2010, diagnosis of ALPS required meeting three mandatory criteria: (1) chronic (> 6 months) non-malignant lymphoproliferation; (2) elevated peripheral blood DNTs; and (3) defective in vitro Fas-mediated apoptosis (Table 2). The first two criteria remain mandatory for diagnosis. DNTs are assessed by flow cytometry of peripheral blood or lymphoid tissue. DNTs should only be tested in an experienced clinical laboratory and must include testing for the TCRα/β receptor, as other non-pathogenic lymphocyte subsets are CD3+/CD4−/CD8−. DNT test results must be interpreted carefully, as the normal range can vary between laboratories. Finally, lymphopenic patients and those on high dose steroids or sirolimus should not undergo DNT testing due to risks of false positives or negatives, respectively.
+
+In order to test for defective in vitro Fas-mediated apoptosis, a patient’s peripheral blood mononuclear cells are isolated, activated with mitogen, and expanded with interleukin-2 (IL-2) in culture for 10–28 days.[4] Normally, mitogen activation and T cell expansion upregulate the Fas pathway. Subsequent exposure of normal T cells to anti-Fas immunoglobulin M (IgM) monoclonal antibody in vitro leads to rapid apoptosis.[26] ALPS patients’ T cells do not die after exposure.[27] This is an elegant but expensive and labor-intensive assay, requiring samples from patients and unaffected controls. DNTs do not survive in routine culture; this assay only identifies Fas defects in non-DNT T cells. Patients with somatic-variant ALPS or FASL mutations usually have normal apoptosis assays.
+
+A number of recent studies have identified reliable biomarkers for ALPS, including elevated serum vitamin B12, soluble Fas ligand, IL-10, and IL-18.[13,28] These biomarkers are very specific for ALPS in patients with lymphoproliferation and elevated DNTs and are most predictive for FAS-variant (germline or somatic) ALPS. Our group established that a combination of autoimmune cytopenias and hypergammaglobulinemia are very predictive of ALPS in patients with lymphoproliferation and elevated DNTs.[29]
+
+The recent international consensus conference led to a new diagnostic algorithm that includes the three previously mandatory criteria but also allows for the diagnosis of ALPS with genetic testing, biomarkers, family history, and/or histopathology (Table 2).[7] The new algorithm makes a nomenclature distinction between definitive versus probable diagnoses; however, the published consensus statement recommends that patients with definitive and probable ALPS be treated the same clinically. A number of clinical laboratories can perform specialized testing for DNTs, FAS and other gene mutations, and biomarkers, including IL-10 and sFASL. The Diagnostic Immunology and Molecular Genetics laboratories at Cincinnati Children’s Hospital (Cincinnati, OH) provide the most comprehensive assortment of testing. Other laboratories that offer a number of specialized tests, include the Children’s Hospital of Philadelphia (Philadelphia, PA), and GeneDX (Gaithersburg, MD).
+
+ALPS patients have highly heterogeneous phenotypes with clinical findings that overlap with malignant, infectious, autoimmune, and rheumatologic conditions. Several lymphoproliferative disorders, including Castleman disease, Rosai-Dorfman disease, X-linked lymphoproliferative disease (XLP), Dianzani Autoimmune Lymphoproliferative Disease (DALD), Kikuchi-Fujimoto disease, Caspase 8 deficiency syndrome (CEDS), and Ras-associated leukoproliferative disorder (RALD) can present with clinical features similar to ALPS. As these disorders are often distinguishable by histopathology, most patients should undergo tissue biopsy (bone marrow and/or lymph node) at initial presentation.
+
+Patients with mutations in CASP8 were originally classified as having ALPS because caspase 8 and caspase 10 have similar functions, and CASP8 mutant patients present with lymphadenopathy and defective Fas-mediated apoptosis [30]. While patients with ALPS primarily have apoptotic defects in T lymphocytes, patients with CASP8 mutations have profound apoptotic defects in B, T, and NK lymphocytes [30]. Patients with CASP8 mutations are predisposed to significant mucocutaneous infections with herpes virus [30]. Thus, patients with CASP8 mutations are now considered to have a distinct disease termed CEDS.
+
+Rosai-Dorfman (RD) disease is a histiocytic disorder with considerable phenotypic overlap with ALPS. RD is diagnosed by histopathology. Emperipolesis (lymphophagocytosis) was thought to be pathognomonic for RD; however, lymph node biopsies from ALPS patients can demonstrate emperipolesis, as well as other RD features.[31] Accordingly, testing for ALPS should be considered in any child diagnosed with RD.
+
+X-linked lymphoproliferative disorder (XLP) is a rare disorder characterized by a dysregulated T and NK cell-mediated immune response to EBV infection, most commonly as a consequence loss of SLAM-associated protein (SAP) because of mutations in SH2D1A. Patients with XLP can present with fulminant mononucleosis, hematophagocytic syndrome, aplastic anemia and/or aggressive lymphoproliferative disease. Recently, SAP-deficient T cells collected from XLP patients were demonstrated to have defective restimulation-induced apoptosis.[32] Thus, XLP can be classified as an ALPS-like disorder of abnormal lymphocyte apoptosis.
+
+Ras-associated leukoproliferative disorder (RALD) is a newly described lymphoproliferative disorder characterized by impaired cytokine withdrawal-induced apoptosis in T cells due to gain of function somatic mutations in RAS family genes (KRAS and NRAS).[33–35] Fewer than 10 patients with RALD have been reported, resulting in limited knowledge of the clinical manifestations of the disease. Common features include lymphoproliferation, autoimmune cytopenias, and hypergammaglobulinemia. DNTs may be mildly elevated in RALD but are usually normal. As in juvenile myelomonocytic leukemia (JMML; a myeloproliferative disorder characterized by RAS mutations), myeloid cells from these patients may demonstrate hypersensitivity to GM-CSF. Recent literature suggests RALD is a non-malignant disease based on its indolent nature; however, no published studies have described whether the abnormal cells in RALD are clonal. Secondary cancers and unexplained sudden death have been described in RALD and somatic gain-of-function mutations in RAS family genes are extremely common in cancer. Thus, more studies are needed to determine if RALD is a benign lymphoproliferative disorder, a pre-malignant condition, or a malignant state.
+
+Patients with common variable immunodeficiency (CVID) can present with lymphadenopathy and autoimmune disease mirroring ALPS.[36] In addition, a small subset of ALPS patients have co-morbid CVID. Specific testing for ALPS, including DNT analysis, apoptosis assays, and genetic testing, may aid in distinguishing the conditions. Arguably, any patient with CVID and secondary autoimmune cytopenias should be tested for ALPS.
+
+Evans syndrome (ES), defined by autoimmune destruction of at least two hematologic cell types, can also have a similar presentation to ALPS [37]. Recently, our group demonstrated in an multi-institutional trial that a significant percentage of children diagnosed with ES have ALPS.[26,29] There was likely selection bias, as not all ES patients were captured at each participating institution, and a similar prevalence of ALPS may not be found among ES patients in other populations. A recent comprehensive analysis of children with autoimmune hemolytic anemia in France, including a large cohort of ES patients, did not find a high incidence of ALPS.[38] ALPS patients were identified in the study but at a lower rate than in US studies. Of note, not all patients were tested for ALPS, and only ES patients with autoimmune hemolytic anemia were included.
+
+While some ALPS patients require no treatment, many require immunosuppression, particularly to treat cytopenias. Some patients develop organ compromise from lymphoproliferation, requiring medical intervention. Most patients respond to short corticosteroid pulses. [39] While appropriate for periodic disease flares, corticosteroids are too toxic for use in chronic disease. As recently as five years ago, medication choices for ALPS autoimmunity did not differ from other autoimmune conditions. Recent studies have established that some therapies commonly used in other conditions are relatively contraindicated, while other less common therapies are very effective in ALPS.
+
+Rituximab and splenectomy are often the treatments of choice in refractory autoimmune cytopenias in children. Rituximab can lead to prolonged, clinically significant hypogammaglobulinemia when used in ALPS. Thus, alternative immune suppressants should be tried before using rituximab, if possible.[40,41] Rituximab is active in many ALPS patients, and can be used when other agents are ineffective or not tolerated. Patients should be advised that they may require prolonged IVIgG replacement therapy. Patients with ALPS have a very high risk of developing post-splenectomy sepsis, even with antibiotic prophylaxis and vaccination.[42,43] Accordingly, splenectomy should be avoided except in the case of uncontrolled hypersplenism that fails other medical management.
+
+The two best-studied and most effective non-steroid agents used in children with ALPS are mycophenolate mofetil (Cellcept, MMF) and sirolimus (rapamycin). MMF inactivates inosine monophosphate, a key enzyme in purine synthesis required for lymphocyte proliferation [44,45]. Over thirty patients treated with MMF have been reported, and over 80% of these patients demonstrated measurable improvements in autoimmune disease [44,46,47]. MMF does not improve lymphoproliferation or reduce DNTs. Many of these patients had only partial responses, and some relapsed. MMF is a well-tolerated medication with side effects including neutropenia and diarrhea. In Europe, another purine synthesis inhibitor, mercaptopurine, is commonly used instead of MMF.
+
+Sirolimus (rapamycin), a mammalian target of rapamycin (mTOR) inhibitor, has also been studied extensively in ALPS. We hypothesized that targeting the PI3K/mTOR/Akt signaling pathway may be effective in ALPS (Figure 2). In support, the mTOR signaling pathway is upregulated in murine ALPS (our unpublished results), and sirolimus is very active in this disease model, demonstrating superior efficacy than other therapies including MMF.[48] We subsequently opened a clinical trial that has examined 13 patients thus far, and continues to enroll (NCT00392951).[49,50] Our early results indicate that sirolimus is uniquely active in ALPS with most patients showing rapid, complete responses (unpublished data).[49] The majority of patients had failed other treatments, often involving multiple agents, including corticosteroids and MMF. In these patients, sirolimus inhibited both autoimmune disease and lymphoproliferation, and in most patients, eliminated the abnormal DNTs. These results have been confirmed in independent studies.[51,52] Based on our observation that the mTOR signaling pathway is abnormally activated in ALPS, treating ALPS patients with sirolimus is a form of targeted therapy that is well tolerated with little toxicity. Side effects include hypercholesterolemia, hypertension, and mucositis.[53] Of note, we continue to offer MMF as a first line for chronic treatment, as sirolimus requires therapeutic drug monitoring. For patients with more aggressive disease or in those with symptomatic lymphoproliferation, we use sirolimus as first line.
+
+In summary, over the past decade a number of remarkable insights have been made that improve understanding of the underlying pathogenesis of ALPS. Through international collaborations, the diagnosis and treatment of ALPS has changed significantly in a short time, making it easier for physicians to diagnosis the disease and improving quality of life for patients.

--- a/references_cache/PMID_23850805.md
+++ b/references_cache/PMID_23850805.md
@@ -1,0 +1,107 @@
+---
+reference_id: "PMID:23850805"
+title: Sequential decisions on FAS sequencing guided by biomarkers in patients with lymphoproliferation and autoimmune cytopenia.
+authors:
+- Rensing-Ehl A
+- Janda A
+- Lorenz MR
+- Gladstone BP
+- Fuchs I
+- Abinun M
+- Albert M
+- Butler K
+- Cant A
+- Cseh AM
+- Ebinger M
+- Goldacker S
+- Hambleton S
+- Hebart H
+- Houet L
+- Kentouche K
+- Kühnle I
+- Lehmberg K
+- Mejstrikova E
+- Niemeyer C
+- Minkov M
+- Neth O
+- Dückers G
+- Owens S
+- Rösler J
+- Schilling FH
+- Schuster V
+- Seidel MG
+- Smisek P
+- Sukova M
+- Svec P
+- Wiesel T
+- Gathmann B
+- Schwarz K
+- Vach W
+- Ehl S
+- Speckmann C
+journal: Haematologica
+year: '2013'
+doi: 10.3324/haematol.2012.081901
+keywords:
+- Adolescent
+- "Autoimmune Diseases/blood, diagnosis, genetics"
+- Biomarkers/blood
+- Cohort Studies
+- "Fas Ligand Protein/blood, genetics"
+- Female
+- Humans
+- "Lymphoproliferative Disorders/blood, diagnosis, genetics"
+- Male
+- Vitamin B 12/blood
+content_type: abstract_only
+---
+
+# Sequential decisions on FAS sequencing guided by biomarkers in patients with lymphoproliferation and autoimmune cytopenia.
+**Authors:** Rensing-Ehl A, Janda A, Lorenz MR, Gladstone BP, Fuchs I, Abinun M, Albert M, Butler K, Cant A, Cseh AM, Ebinger M, Goldacker S, Hambleton S, Hebart H, Houet L, Kentouche K, Kühnle I, Lehmberg K, Mejstrikova E, Niemeyer C, Minkov M, Neth O, Dückers G, Owens S, Rösler J, Schilling FH, Schuster V, Seidel MG, Smisek P, Sukova M, Svec P, Wiesel T, Gathmann B, Schwarz K, Vach W, Ehl S, Speckmann C
+**Journal:** Haematologica (2013)
+**DOI:** [10.3324/haematol.2012.081901](https://doi.org/10.3324/haematol.2012.081901)
+
+## Content
+
+1. Haematologica. 2013 Dec;98(12):1948-55. doi: 10.3324/haematol.2012.081901.
+Epub  2013 Jul 12.
+
+Sequential decisions on FAS sequencing guided by biomarkers in patients with
+lymphoproliferation and autoimmune cytopenia.
+
+Rensing-Ehl A(1), Janda A, Lorenz MR, Gladstone BP, Fuchs I, Abinun M, Albert M,
+Butler K, Cant A, Cseh AM, Ebinger M, Goldacker S, Hambleton S, Hebart H, Houet
+L, Kentouche K, Kühnle I, Lehmberg K, Mejstrikova E, Niemeyer C, Minkov M, Neth
+O, Dückers G, Owens S, Rösler J, Schilling FH, Schuster V, Seidel MG, Smisek P,
+Sukova M, Svec P, Wiesel T, Gathmann B, Schwarz K, Vach W, Ehl S, Speckmann C.
+
+Author information:
+(1)stephan.ehl@uniklinik-freiburg.de.
+
+Clinical and genetic heterogeneity renders confirmation or exclusion of
+autoimmune lymphoproliferative syndrome difficult. To re-evaluate and improve
+the currently suggested diagnostic approach to patients with suspected FAS
+mutation, the most frequent cause of autoimmune lymphoproliferative syndrome, we
+prospectively determined 11 biomarkers in 163 patients with splenomegaly or
+lymphadenopathy and presumed or proven autoimmune cytopenia(s). Among 98
+patients sequenced for FAS mutations in CD3(+)TCRα/β(+)CD4(-)CD8(-) "double
+negative" T cells, 32 had germline and six had somatic FAS mutations. The best a
+priori predictor of FAS mutations was the combination of vitamin B12 and soluble
+FAS ligand (cut-offs 1255 pg/mL and 559 pg/mL, respectively), which had a
+positive predictive value of 92% and a negative predictive value of 97%. We used
+these data to develop a web-based probability calculator for FAS mutations using
+the three most discriminatory biomarkers (vitamin B12, soluble FAS ligand,
+interleukin-10) of the 11 tested. Since more than 60% of patients with
+lymphoproliferation and autoimmune cytopenia(s) in our cohort did not harbor FAS
+mutations, 15% had somatic FAS mutations, and the predictive value of
+double-negative T-cell values was rather low (positive and negative predictive
+values of 61% and 77%, respectively), we argue that the previously suggested
+diagnostic algorithm based on determination of double-negative T cells and
+germline FAS sequencing, followed by biomarker analysis, is not efficient. We
+propose vitamin B12 and soluble FAS ligand assessment as the initial diagnostic
+step with subsequent decision on FAS sequencing supported by a
+probability-calculating tool.
+
+DOI: 10.3324/haematol.2012.081901
+PMCID: PMC3856970
+PMID: 23850805 [Indexed for MEDLINE]

--- a/references_cache/PMID_23993982.md
+++ b/references_cache/PMID_23993982.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:23993982"
+title: Investigation of common variable immunodeficiency patients and healthy individuals using autoimmune lymphoproliferative syndrome biomarkers.
+authors:
+- Roberts CA
+- Ayers L
+- Bateman EA
+- Sadler R
+- Magerus-Chatinet A
+- Rieux-Laucat F
+- Misbah SA
+- Ferry BL
+journal: Hum Immunol
+year: '2013'
+doi: 10.1016/j.humimm.2013.08.266
+keywords:
+- Adult
+- Aged
+- "Autoimmune Lymphoproliferative Syndrome/diagnosis, drug therapy, metabolism"
+- "Biomarkers/blood, metabolism"
+- Case-Control Studies
+- "Common Variable Immunodeficiency/diagnosis, drug therapy, metabolism"
+- "Diagnosis, Differential"
+- Female
+- Humans
+- Immunophenotyping
+- Lymphocyte Count
+- Male
+- Middle Aged
+- Mutation
+- "Receptors, Antigen, T-Cell, alpha-beta/metabolism"
+- "T-Lymphocyte Subsets/immunology, metabolism"
+- Young Adult
+- "fas Receptor/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Investigation of common variable immunodeficiency patients and healthy individuals using autoimmune lymphoproliferative syndrome biomarkers.
+**Authors:** Roberts CA, Ayers L, Bateman EA, Sadler R, Magerus-Chatinet A, Rieux-Laucat F, Misbah SA, Ferry BL
+**Journal:** Hum Immunol (2013)
+**DOI:** [10.1016/j.humimm.2013.08.266](https://doi.org/10.1016/j.humimm.2013.08.266)
+
+## Content
+
+1. Hum Immunol. 2013 Dec;74(12):1531-5. doi: 10.1016/j.humimm.2013.08.266. Epub
+2013 Aug 28.
+
+Investigation of common variable immunodeficiency patients and healthy
+individuals using autoimmune lymphoproliferative syndrome biomarkers.
+
+Roberts CA(1), Ayers L, Bateman EA, Sadler R, Magerus-Chatinet A, Rieux-Laucat
+F, Misbah SA, Ferry BL.
+
+Author information:
+(1)Department of Clinical Laboratory Immunology, Churchill Hospital, Oxford, UK.
+
+Autoimmune lymphoproliferative syndrome (ALPS) is a disorder of dysregulated
+lymphocyte homeostasis. Biomarkers including elevated CD3+TCRαβ+CD4-CD8- double
+negative T cells (TCRαβ+ DNT), IL-10, sCD95L and vitamin B12 can be used to
+differentiate between ALPS and common variable immunodeficiency (CVID) patients
+with an overlapping clinical phenotype. We investigated the utility of ALPS
+biomarkers in 13 CVID patients with lymphoproliferation and/or autoimmune
+cytopaenia with comparison to 33 healthy controls. Vitamin B12 (P < 0.01) and
+IL-10 (P < 0.0001), but not sCD95L or TCRαβ+ DNT, were increased in CVID
+compared to controls. The 95th percentile for TCRαβ+ DNT in healthy controls was
+used to define a normal range up to 2.3% of total lymphocytes or 3.4% of T
+cells. These frequencies lie markedly beyond the cut offs used in current ALPS
+diagnostic criteria (≥ 1.5% of total lymphocytes or 2.5% of CD3+ lymphocytes),
+suggesting these limits may have poor specificity for ALPS.
+
+Copyright © 2013 American Society for Histocompatibility and Immunogenetics.
+Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.humimm.2013.08.266
+PMID: 23993982 [Indexed for MEDLINE]

--- a/references_cache/PMID_26504182.md
+++ b/references_cache/PMID_26504182.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:26504182"
+title: "Sirolimus is effective in relapsed/refractory autoimmune cytopenias: results of a prospective multi-institutional trial."
+authors:
+- Bride KL
+- Vincent T
+- Smith-Whitley K
+- Lambert MP
+- Bleesing JJ
+- Seif AE
+- Manno CS
+- Casper J
+- Grupp SA
+- Teachey DT
+journal: Blood
+year: '2016'
+doi: 10.1182/blood-2015-07-657981
+keywords:
+- Adolescent
+- Adult
+- "Autoimmune Diseases/drug therapy, mortality, pathology"
+- Child
+- "Child, Preschool"
+- "Drug Resistance, Neoplasm/drug effects"
+- Female
+- Follow-Up Studies
+- "Hematologic Diseases/drug therapy, mortality, pathology"
+- Humans
+- "Immunosuppressive Agents/pharmacokinetics, therapeutic use"
+- Infant
+- Male
+- "Neoplasm Recurrence, Local/drug therapy, mortality, pathology"
+- Neoplasm Staging
+- Prognosis
+- Prospective Studies
+- Salvage Therapy
+- "Sirolimus/pharmacokinetics, therapeutic use"
+- Survival Rate
+- Tissue Distribution
+- Young Adult
+content_type: abstract_only
+---
+
+# Sirolimus is effective in relapsed/refractory autoimmune cytopenias: results of a prospective multi-institutional trial.
+**Authors:** Bride KL, Vincent T, Smith-Whitley K, Lambert MP, Bleesing JJ, Seif AE, Manno CS, Casper J, Grupp SA, Teachey DT
+**Journal:** Blood (2016)
+**DOI:** [10.1182/blood-2015-07-657981](https://doi.org/10.1182/blood-2015-07-657981)
+
+## Content
+
+1. Blood. 2016 Jan 7;127(1):17-28. doi: 10.1182/blood-2015-07-657981. Epub 2015
+Oct  26.
+
+Sirolimus is effective in relapsed/refractory autoimmune cytopenias: results of
+a prospective multi-institutional trial.
+
+Bride KL(1), Vincent T(1), Smith-Whitley K(2), Lambert MP(2), Bleesing JJ(3),
+Seif AE(1), Manno CS(4), Casper J(5), Grupp SA(1), Teachey DT(1).
+
+Author information:
+(1)Division of Oncology, The Children's Hospital of Philadelphia, Philadelphia,
+PA; Department of Pediatrics, Perelman School of Medicine at the University of
+Pennsylvania, Philadelphia, PA;
+(2)Department of Pediatrics, Perelman School of Medicine at the University of
+Pennsylvania, Philadelphia, PA; Division of Hematology, The Children's Hospital
+of Philadelphia, Philadelphia, PA;
+(3)Division of Bone Marrow Transplantation and Immune Deficiency, Department of
+Pediatrics, Cincinnati Children's Hospital Medical Center, University of
+Cincinnati, Cincinnati, OH;
+(4)Department of Pediatrics, New York University Langone Medical Center, New
+York, NY; and.
+(5)Division of Pediatric Hematology, Oncology and Bone Marrow Transplant,
+Medical College of Wisconsin, Children's Hospital of Wisconsin, Milwaukee, WI.
+
+Comment in
+    Blood. 2016 Jan 7;127(1):5-6. doi: 10.1182/blood-2015-11-679829.
+
+Patients with autoimmune multilineage cytopenias are often refractory to
+standard therapies requiring chronic immunosuppression with medications with
+limited efficacy and high toxicity. We present data on 30 patients treated on a
+multicenter prospective clinical trial using sirolimus as monotherapy. All
+children (N = 12) with autoimmune lymphoproliferative syndrome (ALPS) achieved a
+durable complete response (CR), including rapid improvement in autoimmune
+disease, lymphadenopathy, and splenomegaly within 1 to 3 months of starting
+sirolimus. Double-negative T cells were no longer detectable in most, yet other
+lymphocyte populations were spared, suggesting a targeted effect of sirolimus.
+We also treated 12 patients with multilineage cytopenias secondary to common
+variable immunodeficiency (CVID), Evans syndrome (ES), or systemic lupus
+erythematosus (SLE), and most achieved a CR (N = 8), although the time to CR was
+often slower than was seen in ALPS. Six children with single-lineage autoimmune
+cytopenias were treated and only 2 responded. Sirolimus was well tolerated with
+very few side effects. All of the responding patients have remained on therapy
+for over 1 year (median, 2 years; range, 1 to 4.5 years). In summary, sirolimus
+led to CR and durable responses in a majority of children with refractory
+multilineage autoimmune cytopenias. The responses seen in ALPS patients were
+profound, suggesting that sirolimus should be considered as a first-line,
+steroid-sparing treatment of patients needing chronic therapy. The results in
+other multilineage autoimmune cytopenia cohorts were encouraging, and sirolimus
+should be considered in children with SLE, ES, and CVID. This trial was
+registered at www.clinicaltrials.gov as #NCT00392951.
+
+© 2016 by The American Society of Hematology.
+
+DOI: 10.1182/blood-2015-07-657981
+PMCID: PMC4705607
+PMID: 26504182 [Indexed for MEDLINE]

--- a/research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-falcon.md
+++ b/research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-falcon.md
@@ -1,0 +1,1266 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-04-16T12:24:54.773318'
+end_time: '2026-04-16T12:37:47.669853'
+duration_seconds: 772.9
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: FAS-related Autoimmune Lymphoproliferative Syndrome
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 39
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** FAS-related Autoimmune Lymphoproliferative Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **FAS-related Autoimmune Lymphoproliferative Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** FAS-related Autoimmune Lymphoproliferative Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **FAS-related Autoimmune Lymphoproliferative Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Comprehensive Research Report: FAS-related Autoimmune Lymphoproliferative Syndrome (ALPS-FAS)
+
+## Executive summary
+FAS-related autoimmune lymphoproliferative syndrome (ALPS-FAS) is an inborn error of immunity (primary immune regulatory disorder) caused by impaired FAS-mediated apoptosis (extrinsic apoptotic pathway), leading to chronic nonmalignant lymphoproliferation, autoimmune cytopenias, characteristic expansion of TCRαβ+ CD4−CD8− double-negative T cells (DNTs), and elevated risk of lymphoma. Recent (2023–2024) work emphasizes (i) biomarker-driven case finding (especially sFASL with vitamin B12 and DNTs), (ii) practical NGS panel yields in large referral cohorts, and (iii) recognition of complex genetic architectures including somatic “second hits” (e.g., somatic loss of heterozygosity) that can be missed by standard exome sequencing. (rao2024beyondfascinatingadvances pages 1-3, fernandez2024lookingforalps pages 1-2, xu2024genetictestingin pages 1-2)
+
+**Key evidence statistics from recent/major cohorts**
+- **NGS panel yield (Cincinnati Children’s, 2014–2023 submissions):** 62/802 (7.7%) definite molecular diagnoses; 52/802 (6.5%) with pathogenic/likely pathogenic **germline FAS** variants; 17/37 (46%) diagnostic FAS variants were novel. Diagnostic yield increased to **30%** among those meeting abnormal ALPS immunology criteria. (xu2024genetictestingin pages 1-2, xu2024genetictestingin pages 4-6)
+- **Rapamycin/sirolimus outcomes (28 ALPS-FAS patients):** 79% complete remission and 21% partial remission at 6–9 months; relapse occurred rapidly upon stopping therapy. (klemann2017evolutionofdisease pages 6-10)
+
+## Target disease
+- **Disease name:** FAS-related Autoimmune Lymphoproliferative Syndrome
+- **Category:** Mendelian (inborn error of immunity / primary immune regulatory disorder)
+- **MONDO ID:** Not available from retrieved sources in this run.
+
+---
+
+## 1. Disease information
+### 1.1 What is the disease?
+ALPS is a rare immune dysregulation disorder characterized by defective FAS signaling and consequent failure of FAS-mediated lymphocyte apoptosis, producing chronic, nonmalignant lymphoproliferation with autoimmunity (often autoimmune cytopenias) and expansion of αβ DNT cells, with increased risk of malignancy (notably lymphoma). (elgharbawy2023casereportneonatal pages 1-2, fernandez2024lookingforalps pages 1-2, rao2024beyondfascinatingadvances pages 1-3)
+
+**Direct abstract quote (definition):** “Autoimmune lymphoproliferative syndrome (ALPS) is a rare primary immune disorder caused by defect of the extrinsic apoptotic pathway.” (Pediatric Allergy and Immunology; May 2024; https://doi.org/10.1111/pai.14135) (fernandez2024lookingforalps pages 1-2)
+
+### 1.2 Key identifiers
+Curated disease identifiers were not directly retrievable from OMIM/Orphanet/MeSH/ICD/MONDO within the documents available to this run.
+
+### 1.3 Synonyms / alternative names
+- Autoimmune lymphoproliferative syndrome (ALPS) (elgharbawy2023casereportneonatal pages 1-2, fernandez2024lookingforalps pages 1-2)
+- ALPS-FAS (germline FAS pathogenic variants) (fernandez2024lookingforalps pages 1-2, xu2024genetictestingin pages 1-2)
+- ALPS-sFAS (somatic FAS pathogenic variants) (fernandez2024lookingforalps pages 1-2, rao2024beyondfascinatingadvances pages 1-3)
+- “FAS deficiency” / “FAS-pathway apoptosis defect” (rao2011howitreat pages 2-3, rao2024beyondfascinatingadvances pages 1-3)
+
+### 1.4 Evidence sources
+Most information summarized here comes from **aggregated disease-level resources** (cohorts, consensus criteria papers, expert reviews) rather than single EHR-derived observations, though illustrative case reports are included for severe biallelic disease and sirolimus response. (price2014naturalhistoryof pages 3-4, klemann2017evolutionofdisease pages 6-10, elgharbawy2023casereportneonatal pages 1-2)
+
+---
+
+## 2. Etiology
+### 2.1 Disease causal factors
+**Primary cause:** Pathogenic variants affecting the FAS-mediated extrinsic apoptotic pathway, most commonly **FAS** (TNFRSF6) variants that abrogate FAS expression or function, resulting in impaired activation-induced cell death and defective termination of immune responses. (rao2024beyondfascinatingadvances pages 1-3, rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2, casamayorpolo2021immunologicevaluationand pages 3-5)
+
+### 2.2 Risk factors
+#### Genetic risk factors
+- **Germline FAS variants** (typically autosomal dominant with incomplete penetrance). In the NIH natural history cohort, penetrance among mutation-positive individuals was variable and **sex-dependent** (69% males vs 46% females among mutation carriers reported in the excerpt). (price2014naturalhistoryof pages 3-4)
+- **Somatic FAS defects** (ALPS-sFAS) and **second-hit mechanisms** in monoallelic disease, including somatic loss of heterozygosity (sLOH) reported as common in expert synthesis. (rao2024beyondfascinatingadvances pages 1-3)
+
+**Recent diagnostic-yield data:** In a 2024 NGS panel study of 802 referrals, 52/802 (6.5%) had diagnostic germline FAS pathogenic/likely pathogenic variants; 46% of diagnostic FAS variants were novel. (xu2024genetictestingin pages 1-2, xu2024genetictestingin pages 4-6)
+
+#### Environmental/infectious risk factors
+No specific environmental toxin/lifestyle risk factors were identified in the retrieved ALPS-FAS sources. Infection risk is clinically relevant as a complication/modifier, especially post-splenectomy, but not a primary etiologic trigger in available evidence. (price2014naturalhistoryof pages 1-3, rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6)
+
+### 2.3 Protective factors
+Not specifically identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+Not well characterized in the retrieved ALPS-FAS sources; contemporary reviews of inborn errors of immunity emphasize that penetrance/expressivity can reflect multiple factors over time, including somatic events and environmental exposures, but ALPS-FAS-specific quantitative GxE data were not retrieved here. (rao2024beyondfascinatingadvances pages 1-3)
+
+---
+
+## 3. Phenotypes
+### 3.1 Core clinical phenotypes (with frequency when available)
+Key phenotypes (HPO suggestions in parentheses):
+- **Chronic lymphadenopathy** (~96%) (HP:0002716) (rao2011howitreat pages 2-3)
+- **Splenomegaly** (~95%) (HP:0001744) (rao2011howitreat pages 2-3)
+- **Hepatomegaly** (~72%) (HP:0002240) (rao2011howitreat pages 2-3)
+- **Autoimmune cytopenias** (HP:0001871)
+  - Autoimmune hemolytic anemia ~29% (HP:0001890) (rao2011howitreat pages 2-3)
+  - Immune thrombocytopenia ~23% (HP:0001873) (rao2011howitreat pages 2-3)
+  - Neutropenia ~19% (HP:0001875) (rao2011howitreat pages 2-3)
+- **Polyclonal hypergammaglobulinemia** (HP:0004315); in NIH cohort, IgG elevated in 58%, IgA in 45%, IgM in 10% (HP:0004313/HP:0004312 patterns) (price2014naturalhistoryof pages 6-7)
+
+Additional lab/immune abnormalities reported in the NIH cohort include DAT positivity (40%), RF positivity (32%), eosinophilia (24%), and elevated monocyte count (38%). (price2014naturalhistoryof pages 6-7)
+
+### 3.2 Age of onset and course
+- Usually **early childhood onset**; one review excerpt reports a **median age of onset of ~3 years**. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6)
+- Rare severe cases can present **neonatally** with biallelic loss-of-function FAS variants. (elgharbawy2023casereportneonatal pages 1-2)
+- Disease course is typically **chronic** (>6 months) with fluctuating activity and risk of autoimmune relapses; stopping mTOR inhibition can lead to rapid relapse in treated patients. (klemann2017evolutionofdisease pages 6-10, price2014naturalhistoryof pages 3-4)
+
+### 3.3 Quality of life impact / complications
+Formal QoL instruments were not retrieved. Clinically impactful complications include refractory cytopenias requiring immunosuppression, organomegaly, infection risk, and malignancy surveillance burden. Reviews emphasize avoidance of splenectomy when possible due to septicemia risk and loss of anti-polysaccharide responses. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6, price2014naturalhistoryof pages 1-3)
+
+---
+
+## 4. Genetic / molecular information
+### 4.1 Causal genes
+- **FAS (TNFRSF6)** is the principal causal gene for ALPS-FAS. (fernandez2024lookingforalps pages 1-2, xu2024genetictestingin pages 1-2)
+- Other extrinsic apoptosis pathway genes associated with ALPS spectrum (not FAS-related subtype specifically) include **FASLG, FADD, CASP10**, though they are much less frequent. (fernandez2024lookingforalps pages 1-2, price2014naturalhistoryof pages 3-4)
+
+### 4.2 Pathogenic variants (classes and examples)
+- In a 2024 referral cohort, most diagnostic FAS variants were truncating or missense variants located in the intracellular domain, often the death domain. (xu2024genetictestingin pages 4-6)
+- Severe early-onset disease can be caused by **biallelic loss-of-function** variants: e.g., a neonatal case with **FAS exon 9 c.775del leading to p.(Ile259*)**. (elgharbawy2023casereportneonatal pages 1-2)
+
+### 4.3 Germline vs somatic origin
+- Germline FAS variants are common; **somatic FAS variants** also occur and may require analysis of sorted DNTs or sensitive sequencing approaches. (rieuxlaucat2018theautoimmunelymphoproliferative pages 7-8, rao2024beyondfascinatingadvances pages 1-3)
+- In expert synthesis, **somatic second hits** such as **sLOH** (often via uniparental disomy) are highlighted and can be missed by exome sequencing. (rao2024beyondfascinatingadvances pages 1-3)
+
+### 4.4 Modifier genes and debated genes
+A 2024 Cell Death & Disease study challenges the role of common CASP10 variants in ALPS pathogenesis, concluding caspase-10 is dispensable for FAS-mediated apoptosis and CASP10 defects are unlikely to contribute to ALPS when they do not impair apoptosis. (consonni2024studyofthe pages 1-2)
+
+---
+
+## 5. Environmental information
+No ALPS-FAS-specific environmental toxin/lifestyle/infectious causal triggers were identified in the retrieved evidence. The key clinically relevant “environmental” dimension is **infectious risk** under immunosuppression and after splenectomy. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6, price2014naturalhistoryof pages 1-3)
+
+---
+
+## 6. Mechanism / pathophysiology
+### 6.1 Causal chain (from trigger to manifestations)
+1. **FAS ligation and signaling failure:** Normally, FAS–FASL interaction triggers receptor trimerization and recruitment of **FADD** and initiator **procaspase-8/10** into the **DISC**, leading to initiator caspase activation and effector caspase cascade. (rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2, casamayorpolo2021immunologicevaluationand pages 3-5)
+2. **Defective activation-induced cell death (AICD):** Failure to eliminate activated lymphocytes impairs immune contraction and tolerance. (lambert2021presentationanddiagnosis pages 3-4, casamayorpolo2021immunologicevaluationand pages 3-5)
+3. **Accumulation/expansion of DNT cells and autoreactive lymphocytes:** This manifests as lymphadenopathy/splenomegaly and autoimmune cytopenias. (bride2017autoimmunelymphoproliferativesyndrome pages 1-3, rao2011howitreat pages 2-3)
+4. **Downstream proliferative signaling:** DNT subsets show evidence of proliferative/survival pathway engagement (mTOR, STAT3), supporting targeted mTOR inhibition as therapy. (lambert2021presentationanddiagnosis pages 3-4, klemann2017evolutionofdisease pages 6-10)
+
+### 6.2 Pathways and processes (ontology suggestions)
+- GO: **extrinsic apoptotic signaling pathway** (GO:0097191)
+- GO: **activation-induced cell death of T cells** (concept supported; see AICD discussion) (lambert2021presentationanddiagnosis pages 3-4)
+- GO: **regulation of lymphocyte apoptosis** / **immune tolerance** (mechanistic basis) (casamayorpolo2021immunologicevaluationand pages 3-5)
+- CL: **double negative T cell** (TCRαβ+ CD4−CD8−; pathogenic expansion) (xu2024genetictestingin pages 1-2, price2014naturalhistoryof pages 3-4)
+
+### 6.3 Model organisms / experimental systems
+Murine Fas/FasL-deficient models recapitulate key ALPS-like features (lymphoproliferation, autoimmunity, DNT accumulation), including **MRL/lpr** (Fas-deficient) and **MRL/gld** (FasL-deficient) models. (bride2017autoimmunelymphoproliferativesyndrome pages 1-3, rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2)
+
+A 2024 modifier study in **Faslpr** mice (iScience, Nov 2024) shows that altering B-cell apoptosis/activation regulators (EAF2) can modulate lymphoproliferation and nephritis, illustrating potential modifier pathways (Akt/survival genes) in a Fas-deficient background. (luan2024eaf2deficiencyattenuates pages 1-2)
+
+---
+
+## 7. Anatomical structures affected
+### 7.1 Organ/system level (UBERON suggestions)
+Primary:
+- **Spleen** (UBERON:0002106) – splenomegaly/hypersplenism, sequestration cytopenias (rao2011howitreat pages 2-3)
+- **Lymph nodes** (UBERON:0000029) – chronic lymphadenopathy (rao2011howitreat pages 2-3)
+Secondary/variable:
+- **Liver** (UBERON:0002107) – hepatomegaly; occasional liver dysfunction (rao2011howitreat pages 2-3)
+- **Bone marrow / hematologic system** – autoimmune cytopenias (rao2011howitreat pages 2-3)
+
+### 7.2 Tissue/cell level (CL suggestions)
+- **TCRαβ DNT cells** (CL: T cell subset concept) (xu2024genetictestingin pages 1-2, price2014naturalhistoryof pages 3-4)
+- Activated T cells undergoing (failed) AICD; B cell activation/plasma cells in models (luan2024eaf2deficiencyattenuates pages 1-2)
+
+### 7.3 Subcellular level (GO-CC suggestions)
+- **Death-inducing signaling complex (DISC)** (complex; DISC discussed mechanistically) (rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2)
+
+---
+
+## 8. Temporal development
+- **Onset:** most often pediatric with chronic course; median onset ~3 years in one review excerpt; severe biallelic disease can present neonatally. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6, elgharbawy2023casereportneonatal pages 1-2)
+- **Progression/course:** chronic lymphoproliferation and episodic/relapsing autoimmune cytopenias; long-term malignancy surveillance required. (price2014naturalhistoryof pages 3-4, rao2011howitreat pages 2-3)
+
+---
+
+## 9. Inheritance and population
+### 9.1 Inheritance pattern
+- Typical ALPS-FAS: **autosomal dominant** with incomplete penetrance (price2014naturalhistoryof pages 3-4)
+- Rare severe biallelic FAS loss-of-function can follow **autosomal recessive** inheritance (as in the neonatal homozygous truncating case report). (elgharbawy2023casereportneonatal pages 1-2)
+
+### 9.2 Penetrance/expressivity
+- NIH cohort data indicate **variable penetrance** with sex differences among mutation carriers (69% males vs 46% females in excerpt). (price2014naturalhistoryof pages 3-4)
+- 2024 expert review emphasizes somatic second hits (including sLOH) and complex variants that may explain variable expression and diagnostic gaps. (rao2024beyondfascinatingadvances pages 1-3)
+
+### 9.3 Epidemiology (incidence/prevalence)
+No population incidence/prevalence estimates were identified in the retrieved sources for this run.
+
+---
+
+## 10. Diagnostics
+### 10.1 Standardized diagnostic criteria (NIH 2009 revised)
+NIH 2009 revised criteria (as reproduced in the ALPS-FAS natural history study) define:
+- **Required criteria:** chronic (>6 months) nonmalignant, noninfectious lymphadenopathy and/or splenomegaly; plus elevated TCRαβ DNT cells (>1.5% of total lymphocytes or >2.5% of CD3+ lymphocytes) with normal/elevated lymphocyte count. (price2014naturalhistoryof pages 3-4)
+- **Primary accessory:** defective FAS-induced apoptosis or pathogenic germline/somatic mutation in FAS/FASL/FADD/CASP10. (price2014naturalhistoryof pages 3-4)
+- **Secondary accessory:** elevated biomarkers including sFASL (>200 pg/mL), IL-10 (>20 pg/mL), vitamin B12 (>1500 pg/mL), typical histopathology, autoimmune cytopenias, hypergammaglobulinemia, family history. (price2014naturalhistoryof pages 3-4)
+
+**Visual evidence:** Table 1 (cropped) in Price et al. 2014 reproduces these thresholds and criteria components. (price2014naturalhistoryof media e08f037f)
+
+### 10.2 Biomarkers and real-world screening strategies (recent)
+A 2024 pediatric study screened 398 patients with autoimmune cytopenia/lymphoproliferation using DNT cells plus sFASL; sFASL correlated strongly with vitamin B12, and sFASL with vitamin B12 were “the most discriminating biomarkers” among confirmed cases in their cohort. (fernandez2024lookingforalps pages 1-2)
+
+### 10.3 Genetic testing approaches
+A 15-gene ALPS NGS panel experience (802 cases) showed a 7.7% definite diagnostic yield overall, increasing to 30% when abnormal ALPS immunology criteria were met; it also identified non-FAS ALPID diagnoses (ADA2, CTLA4, KRAS, MAGT1, NRAS) in 1.2%. (xu2024genetictestingin pages 1-2)
+
+### 10.4 Differential diagnosis
+Differentials include ALPS-like/autoimmune lymphoproliferative immunodeficiency (ALPID) conditions with overlapping lymphoproliferation and cytopenias, including RAS pathway disorders and CTLA4/LRBA-related immune dysregulation (highlighted in the 2024 NGS panel cohort). (xu2024genetictestingin pages 1-2)
+
+---
+
+## 11. Outcome / prognosis
+### 11.1 Morbidity and mortality drivers
+In the NIH natural history study, major morbidity/mortality drivers include **overwhelming postsplenectomy sepsis** and development of **lymphoma**; thus, avoiding splenectomy when possible and using steroid-sparing approaches is emphasized. (price2014naturalhistoryof pages 1-3)
+
+### 11.2 Malignancy risk
+ALPS-FAS carries increased lymphoma risk; clinical warning features include systemic symptoms and sudden focal lymph node enlargement in established lymphadenopathy. (price2014naturalhistoryof pages 6-7)
+
+No specific numeric lifetime lymphoma incidence was extracted from the retrieved excerpts (the full paper contains SEER O/E analyses but exact values were not captured in the evidence snippets). (price2014naturalhistoryof pages 3-4)
+
+---
+
+## 12. Treatment
+### 12.1 Pharmacotherapy (current practice and evidence)
+**mTOR inhibition (sirolimus/rapamycin)**
+- In a 28-patient ALPS-FAS cohort, rapamycin achieved **complete remission in 79%** and **partial remission in 21%** at 6–9 months; all who stopped relapsed rapidly; biomarker normalization was incomplete in many (e.g., DNT normalized in 33%). (klemann2017evolutionofdisease pages 6-10)
+- A 2024 ASH Hematology review notes rapamycin (sirolimus) and mycophenolate mofetil as long-term steroid-sparing measures used successfully over two decades. (rao2024beyondfascinatingadvances pages 1-3)
+
+**Mycophenolate mofetil (MMF)**
+Used as a steroid-sparing agent in ALPS management in expert review summaries. (rao2024beyondfascinatingadvances pages 1-3)
+
+**Supportive / avoidance strategies**
+Avoid splenectomy when possible due to infection risk; management includes surveillance for malignancy. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6, price2014naturalhistoryof pages 1-3)
+
+### 12.2 Real-world implementations (recent case reports)
+A 2023 neonatal severe ALPS-FAS case with homozygous truncating FAS variant improved clinically with sirolimus with “obvious reduction” in DNT percentage. (elgharbawy2023casereportneonatal pages 1-2)
+
+### 12.3 Clinical trials (registered)
+- **NCT00392951** (CHOP; started Dec 2006; completed Feb 2016; results posted Dec 6, 2017): Phase 1/2 pilot of oral sirolimus for refractory autoimmune cytopenias including ALPS; targeted trough 5–15 ng/mL; primary outcome grade 3–4 toxicities over 6 months; secondary outcomes included CR/PR response and lymphoproliferation response. https://clinicaltrials.gov/study/NCT00392951 (NCT00392951 chunk 1)
+- **NCT02579967** (NCI; started Nov 19, 2015; recruiting): Phase 2 allo-BMT trial for primary immunodeficiencies listing “Autoimmune Lymphoproliferative” among conditions; primary endpoint aGVHD-free, graft-failure–free survival at day +180. https://clinicaltrials.gov/study/NCT02579967 (NCT02579967 chunk 1, NCT02579967 chunk 2)
+
+**Emerging targeted therapy direction:** PI3Kδ inhibition is highlighted as a successful paradigm in related IEIs (leniolisib FDA-licensed in 2023 for APDS), and preclinical work supports evaluation in ALPS (NCT06549114 referenced in murine work; not retrievable as a full CT record in this run). (rao2024beyondfascinatingadvances pages 1-3)
+
+### 12.4 MAXO suggestions (treatment/action ontology)
+- mTOR inhibitor therapy (sirolimus/rapamycin) (supported by rapamycin cohort and trial) (klemann2017evolutionofdisease pages 6-10, NCT00392951 chunk 1)
+- Immunosuppressive therapy (MMF; steroids) (rao2024beyondfascinatingadvances pages 1-3)
+- Hematopoietic stem cell transplantation / allo-BMT (for severe PID/immune dysregulation in selected cases) (NCT02579967 chunk 1)
+
+---
+
+## 13. Prevention
+Primary prevention is not generally applicable for Mendelian ALPS-FAS beyond reproductive options. Secondary/tertiary prevention includes:
+- **Genetic counseling** and cascade testing of relatives; family studies can identify at-risk family members and assist variant classification. (xu2024genetictestingin pages 1-2)
+- Avoidance of splenectomy when possible and infection prophylaxis strategies as clinically indicated. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6, price2014naturalhistoryof pages 1-3)
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring veterinary ALPS-FAS cases were retrieved in obtainable texts in this run.
+
+---
+
+## 15. Model organisms
+### 15.1 Core models
+- **MRL/lpr** (Fas-deficient) and **MRL/gld** (FasL-deficient) mice recapitulate lymphoproliferation, autoimmunity, DNT expansion, and organ pathology (e.g., glomerulonephritis) relevant to ALPS mechanisms. (bride2017autoimmunelymphoproliferativesyndrome pages 1-3, rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2)
+
+### 15.2 Recent model-organism development (2024)
+A 2024 iScience study used Faslpr mice to demonstrate that EAF2 deficiency can attenuate autoimmune disease features by modulating B-cell activation and apoptosis, providing a modifier pathway example in a Fas-deficient background. (luan2024eaf2deficiencyattenuates pages 1-2)
+
+---
+
+## Recent developments (2023–2024 focus) and expert analysis
+1. **Biomarker strategy refinement:** A 2024 study argues that existing ALPS criteria are sensitive but have low PPV and supports combined biochemical marker screening, particularly sFASL with vitamin B12 (plus DNTs). (fernandez2024lookingforalps pages 1-2)
+2. **Large-scale NGS diagnostic yield:** The 2024 802-patient NGS panel experience quantifies real-world yields and highlights that adding immunology pre-screening increases molecular diagnostic efficiency (30% yield in immunology-abnormal subgroup). (xu2024genetictestingin pages 1-2)
+3. **Complex genetics and “missed” variants:** 2024 ASH Hematology review emphasizes that promoter/deep intronic variants, deletions/duplications, and somatic second hits (including sLOH) can be missed by exome sequencing, motivating extended testing strategies. (rao2024beyondfascinatingadvances pages 1-3)
+
+---
+
+## Structured reference table (diagnostics/genetics)
+The following table compacts the core naming, NIH criteria, key biomarkers, and genetics for ALPS-FAS.
+
+| Domain | Summary | Key thresholds/details | Supporting citations |
+|---|---|---|---|
+| Disease name / synonyms | **FAS-related Autoimmune Lymphoproliferative Syndrome**; commonly referred to as **ALPS-FAS** or **autoimmune lymphoproliferative syndrome due to FAS defect/deficiency**. Core disease concept: inborn error of immunity with defective Fas-mediated apoptosis causing chronic nonmalignant lymphoproliferation, autoimmune cytopenias, expanded αβ double-negative T cells, and increased lymphoma risk. | Usually childhood-onset, but presentation can occur at any age. | (rao2024beyondfascinatingadvances pages 1-3, xu2024genetictestingin pages 1-2, fernandez2024lookingforalps pages 1-2) |
+| NIH 2009 required criteria | Both are required for ALPS diagnosis framework. | 1) Chronic >6 months, nonmalignant, noninfectious lymphadenopathy and/or splenomegaly. 2) Elevated **CD3+ TCRαβ+ CD4− CD8− DNT cells** with normal/elevated lymphocyte counts: **>1.5% of total lymphocytes or >2.5% of CD3+ lymphocytes**. | (price2014naturalhistoryof pages 3-4, rao2011howitreat pages 2-3) |
+| NIH 2009 primary accessory criteria | Supports **definitive** diagnosis when combined with both required criteria. | 1) Defective Fas-mediated apoptosis in 2 separate assays; **or** 2) pathogenic **somatic or germline** mutation in **FAS, FASLG, FADD, or CASP10**. | (price2014naturalhistoryof pages 3-4, rao2011howitreat pages 2-3) |
+| NIH 2009 secondary accessory criteria | Supports **probable** diagnosis when combined with both required criteria. | Elevated **sFASL >200 pg/mL**, **IL-10 >20 pg/mL**, **vitamin B12 >1500 pg/mL/ng/L**; typical immunohistopathology; autoimmune cytopenias with elevated IgG/polyclonal hypergammaglobulinemia; family history of nonmalignant/noninfectious lymphoproliferation. IL-18 >500 pg/mL is also noted in later diagnostic summaries. | (price2014naturalhistoryof pages 3-4, rao2011howitreat pages 2-3, fernandez2024lookingforalps pages 1-2) |
+| Key biomarker: DNT cells | Hallmark immunophenotypic marker of ALPS-FAS; reflects expansion of apoptosis-resistant αβ T cells and is central to screening/diagnosis. | Often markedly elevated in ALPS-FAS; in one molecularly defined cohort median **7.5%** in ALPS-FAS vs **2.7%** in ALPS-U. Flow panel cutoffs used clinically include **TCRαβ DNT >2% or >68 cells/µL**. | (xu2024genetictestingin pages 1-2, molnar2020keydiagnosticmarkers pages 17-19) |
+| Key biomarker: soluble Fas ligand (sFASL) | Indicates Fas-pathway dysregulation; especially useful for predicting **FAS-mutated** disease when paired with apoptosis testing. | NIH threshold **>200 pg/mL**; ALPS-FAS can show very high values, with molecular cohort median **>1000 pg/mL** versus **152 pg/mL** in ALPS-U. | (fernandez2024lookingforalps pages 1-2, molnar2020keydiagnosticmarkers pages 17-19) |
+| Key biomarker: IL-10 | Reflects immune activation/lymphoproliferative dysregulation; useful supportive biomarker but less specific than sFASL for FAS-mutant disease. | NIH threshold **>20 pg/mL**. Elevated in ALPS generally; in one comparison it was less discriminatory between ALPS-FAS and ALPS-U than sFASL or apoptosis testing. | (fernandez2024lookingforalps pages 1-2, rao2011howitreat pages 2-3, molnar2020keydiagnosticmarkers pages 17-19) |
+| Key biomarker: vitamin B12 | Readily measurable supportive biomarker; often persistently elevated in ALPS-FAS and useful in biomarker-based triage for FAS testing. | NIH threshold **>1500 pg/mL/ng/L**. Price et al. identified elevated vitamin B12 as a reliable biomarker of ALPS-FAS. | (price2014naturalhistoryof pages 3-4, price2014naturalhistoryof pages 1-3, fernandez2024lookingforalps pages 1-2) |
+| Genetics summary: germline FAS | Major genetic cause of ALPS. Most diagnosed molecular cases are due to **germline FAS pathogenic/likely pathogenic variants**, often affecting the intracellular death domain; inheritance usually **autosomal dominant with incomplete penetrance**, though recessive severe early-onset cases occur. | In a 2024 cohort of **802** referred patients, **62/802 (7.7%)** had definite molecular diagnoses; **52/62 (84%)** had germline **FAS** variants, including **37 unique variants**, **46% novel**. Penetrance in an NIH natural-history cohort was **<60%** overall; sex difference reported **69% males vs 46% females**. | (xu2024genetictestingin pages 1-2, xu2024genetictestingin pages 4-6, price2014naturalhistoryof pages 1-3, price2014naturalhistoryof pages 3-4) |
+| Genetics summary: somatic FAS / ALPS-sFAS | A clinically important subset has **somatic FAS** variants, often enriched in sorted DNT cells, explaining apparently mutation-negative blood testing and delayed diagnosis. | Somatic **FAS** changes reported in about **15–20%** of ALPS patients in recent summaries; testing sorted DNT cells may be required when whole blood is negative or variant allele fraction is low. | (rao2024beyondfascinatingadvances pages 1-3, fernandez2024lookingforalps pages 1-2) |
+| Genetics summary: second hits / sLOH | Additional somatic events can worsen penetrance and disease expression in monoallelic FAS disease. | **Somatic loss of heterozygosity (sLOH)**, often due to uniparental disomy duplicating the mutated allele, is reported in roughly **80%** of relevant somatic-event cases in recent expert review summaries. | (rao2024beyondfascinatingadvances pages 1-3) |
+
+
+*Table: This table compacts the core disease labels, NIH 2009 diagnostic framework, biomarker interpretation, and genetics of FAS-related autoimmune lymphoproliferative syndrome. It is useful as a quick reference for case curation and knowledge-base population.*
+
+---
+
+## Evidence gaps / not available in retrieved sources
+- Curated cross-ontology identifiers (OMIM/Orphanet/MeSH/ICD/MONDO) were not directly extractable in this run.
+- Population-level prevalence/incidence estimates were not present in retrieved excerpts.
+- QoL statistics (EQ-5D/SF-36/PROMIS) were not identified in retrieved ALPS-FAS sources.
+
+---
+
+## Key primary literature and authoritative sources (with dates/URLs)
+- Price et al. **Blood** (Mar 2014): Natural history of ALPS-FAS; includes NIH 2009 criteria table and cohort lab frequencies. https://doi.org/10.1182/blood-2013-10-535393 (price2014naturalhistoryof pages 3-4, price2014naturalhistoryof pages 6-7)
+- Xu et al. **Journal of Clinical Immunology** (Jul 2024): 802-patient ALPS NGS panel diagnostic yield. https://doi.org/10.1007/s10875-024-01772-z (xu2024genetictestingin pages 1-2)
+- Rao et al. **ASH Hematology** (Dec 2024): Expert review on advances in diagnosis/management; emphasizes complex genetics and sLOH. https://doi.org/10.1182/hematology.2024000537 (rao2024beyondfascinatingadvances pages 1-3)
+- Fernandez & Touzot **Pediatric Allergy and Immunology** (May 2024): Combined biomarker assessment (DNT+sFASL) in a screened pediatric cohort. https://doi.org/10.1111/pai.14135 (fernandez2024lookingforalps pages 1-2)
+- Klemann et al. **Haematologica** (Feb 2017): Rapamycin outcomes and biomarker evolution in 28 ALPS-FAS patients. https://doi.org/10.3324/haematol.2016.153411 (klemann2017evolutionofdisease pages 6-10)
+- ClinicalTrials.gov **NCT00392951** (results posted Dec 6, 2017; last update Nov 19, 2019): Sirolimus for autoimmune disease of blood cells including ALPS. https://clinicaltrials.gov/study/NCT00392951 (NCT00392951 chunk 1)
+
+
+References
+
+1. (rao2024beyondfascinatingadvances pages 1-3): V. Koneti Rao, Stefania Pittaluga, and Gulbu Uzel. Beyond fascinating: advances in diagnosis and management of autoimmune lymphoproliferative syndrome and activated pi3 kinase δ syndrome. Hematology, 2024:126-136, Dec 2024. URL: https://doi.org/10.1182/hematology.2024000537, doi:10.1182/hematology.2024000537. This article has 9 citations and is from a peer-reviewed journal.
+
+2. (fernandez2024lookingforalps pages 1-2): Isabel Fernandez and Fabien Touzot. Looking for alps: the value of a combined assessment of biochemical markers. Pediatric Allergy and Immunology, May 2024. URL: https://doi.org/10.1111/pai.14135, doi:10.1111/pai.14135. This article has 0 citations and is from a domain leading peer-reviewed journal.
+
+3. (xu2024genetictestingin pages 1-2): Xinxiu Xu, James Denton, Yaning Wu, Jie Liu, Qiaoning Guan, D. Brian Dawson, Jack Bleesing, and Wenying Zhang. Genetic testing in patients with autoimmune lymphoproliferative syndrome: experience of 802 patients at cincinnati children’s hospital medical center. Journal of Clinical Immunology, Jul 2024. URL: https://doi.org/10.1007/s10875-024-01772-z, doi:10.1007/s10875-024-01772-z. This article has 4 citations and is from a domain leading peer-reviewed journal.
+
+4. (xu2024genetictestingin pages 4-6): Xinxiu Xu, James Denton, Yaning Wu, Jie Liu, Qiaoning Guan, D. Brian Dawson, Jack Bleesing, and Wenying Zhang. Genetic testing in patients with autoimmune lymphoproliferative syndrome: experience of 802 patients at cincinnati children’s hospital medical center. Journal of Clinical Immunology, Jul 2024. URL: https://doi.org/10.1007/s10875-024-01772-z, doi:10.1007/s10875-024-01772-z. This article has 4 citations and is from a domain leading peer-reviewed journal.
+
+5. (klemann2017evolutionofdisease pages 6-10): Christian Klemann, Myrian Esquivel, Aude Magerus-Chatinet, Myriam R. Lorenz, Ilka Fuchs, Nathalie Neveux, Martin Castelle, Jan Rohr, Claudia Bettoni da Cunha, Martin Ebinger, Robin Kobbe, Bernhard Kremens, Florian Kollert, Eleonora Gambineri, Kai Lehmberg, Markus G. Seidel, Kathrin Siepermann, Thomas Voelker, Volker Schuster, Sigune Goldacker, Klaus Schwarz, Carsten Speckmann, Capucine Picard, Alain Fischer, Frederic Rieux-Laucat, Stephan Ehl, Anne Rensing-Ehl, and Benedicte Neven. Evolution of disease activity and biomarkers on and off rapamycin in 28 patients with autoimmune lymphoproliferative syndrome. Haematologica, 102:e52-e56, Feb 2017. URL: https://doi.org/10.3324/haematol.2016.153411, doi:10.3324/haematol.2016.153411. This article has 68 citations.
+
+6. (elgharbawy2023casereportneonatal pages 1-2): Fawzia M. Elgharbawy, Mohammed Yousuf Karim, Dina Sameh Soliman, Amel Siddik Hassan, Anoop Sudarsanan, and Ashraf Gad. Case report: neonatal autoimmune lymphoproliferative syndrome with a novel pathogenic homozygous fas variant effectively treated with sirolimus. Frontiers in Pediatrics, Apr 2023. URL: https://doi.org/10.3389/fped.2023.1150179, doi:10.3389/fped.2023.1150179. This article has 4 citations.
+
+7. (rao2011howitreat pages 2-3): V. Koneti Rao and João Bosco Oliveira. How i treat autoimmune lymphoproliferative syndrome. Blood, 118 22:5741-51, Nov 2011. URL: https://doi.org/10.1182/blood-2011-07-325217, doi:10.1182/blood-2011-07-325217. This article has 240 citations and is from a highest quality peer-reviewed journal.
+
+8. (price2014naturalhistoryof pages 3-4): Susan Price, Pamela A. Shaw, Amy Seitz, Gyan Joshi, Joie Davis, Julie E. Niemela, Katie Perkins, Ronald L. Hornung, Les Folio, Philip S. Rosenberg, Jennifer M. Puck, Amy P. Hsu, Bernice Lo, Stefania Pittaluga, Elaine S. Jaffe, Thomas A. Fleisher, V. Koneti Rao, and Michael J. Lenardo. Natural history of autoimmune lymphoproliferative syndrome associated with fas gene mutations. Blood, 123 13:1989-99, Mar 2014. URL: https://doi.org/10.1182/blood-2013-10-535393, doi:10.1182/blood-2013-10-535393. This article has 270 citations and is from a highest quality peer-reviewed journal.
+
+9. (rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2): Frédéric Rieux-Laucat, Aude Magérus-Chatinet, and Bénédicte Neven. The autoimmune lymphoproliferative syndrome with defective fas or fas-ligand functions. Journal of Clinical Immunology, 38:558-568, Jun 2018. URL: https://doi.org/10.1007/s10875-018-0523-x, doi:10.1007/s10875-018-0523-x. This article has 100 citations and is from a domain leading peer-reviewed journal.
+
+10. (casamayorpolo2021immunologicevaluationand pages 3-5): Laura Casamayor-Polo, Marta López-Nevado, Estela Paz-Artal, Alberto Anel, Frederic Rieux-Laucat, and Luis M. Allende. Immunologic evaluation and genetic defects of apoptosis in patients with autoimmune lymphoproliferative syndrome (alps). Critical Reviews in Clinical Laboratory Sciences, 58:253-274, Dec 2021. URL: https://doi.org/10.1080/10408363.2020.1855623, doi:10.1080/10408363.2020.1855623. This article has 29 citations and is from a peer-reviewed journal.
+
+11. (price2014naturalhistoryof pages 1-3): Susan Price, Pamela A. Shaw, Amy Seitz, Gyan Joshi, Joie Davis, Julie E. Niemela, Katie Perkins, Ronald L. Hornung, Les Folio, Philip S. Rosenberg, Jennifer M. Puck, Amy P. Hsu, Bernice Lo, Stefania Pittaluga, Elaine S. Jaffe, Thomas A. Fleisher, V. Koneti Rao, and Michael J. Lenardo. Natural history of autoimmune lymphoproliferative syndrome associated with fas gene mutations. Blood, 123 13:1989-99, Mar 2014. URL: https://doi.org/10.1182/blood-2013-10-535393, doi:10.1182/blood-2013-10-535393. This article has 270 citations and is from a highest quality peer-reviewed journal.
+
+12. (rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6): Frédéric Rieux-Laucat, Aude Magérus-Chatinet, and Bénédicte Neven. The autoimmune lymphoproliferative syndrome with defective fas or fas-ligand functions. Journal of Clinical Immunology, 38:558-568, Jun 2018. URL: https://doi.org/10.1007/s10875-018-0523-x, doi:10.1007/s10875-018-0523-x. This article has 100 citations and is from a domain leading peer-reviewed journal.
+
+13. (price2014naturalhistoryof pages 6-7): Susan Price, Pamela A. Shaw, Amy Seitz, Gyan Joshi, Joie Davis, Julie E. Niemela, Katie Perkins, Ronald L. Hornung, Les Folio, Philip S. Rosenberg, Jennifer M. Puck, Amy P. Hsu, Bernice Lo, Stefania Pittaluga, Elaine S. Jaffe, Thomas A. Fleisher, V. Koneti Rao, and Michael J. Lenardo. Natural history of autoimmune lymphoproliferative syndrome associated with fas gene mutations. Blood, 123 13:1989-99, Mar 2014. URL: https://doi.org/10.1182/blood-2013-10-535393, doi:10.1182/blood-2013-10-535393. This article has 270 citations and is from a highest quality peer-reviewed journal.
+
+14. (rieuxlaucat2018theautoimmunelymphoproliferative pages 7-8): Frédéric Rieux-Laucat, Aude Magérus-Chatinet, and Bénédicte Neven. The autoimmune lymphoproliferative syndrome with defective fas or fas-ligand functions. Journal of Clinical Immunology, 38:558-568, Jun 2018. URL: https://doi.org/10.1007/s10875-018-0523-x, doi:10.1007/s10875-018-0523-x. This article has 100 citations and is from a domain leading peer-reviewed journal.
+
+15. (consonni2024studyofthe pages 1-2): Filippo Consonni, Solange Moreno, Blanca Vinuales Colell, Marie-Claude Stolzenberg, Alicia Fernandes, Mélanie Parisot, Cécile Masson, Nathalie Neveux, Jérémie Rosain, Sarah Bamberger, Marie-Gabrielle Vigue, Marion Malphettes, Pierre Quartier, Capucine Picard, Frédéric Rieux-Laucat, and Aude Magerus. Study of the potential role of caspase-10 mutations in the development of autoimmune lymphoproliferative syndrome. Cell Death &amp; Disease, May 2024. URL: https://doi.org/10.1038/s41419-024-06679-6, doi:10.1038/s41419-024-06679-6. This article has 7 citations and is from a peer-reviewed journal.
+
+16. (lambert2021presentationanddiagnosis pages 3-4): Michele P. Lambert. Presentation and diagnosis of autoimmune lymphoproliferative syndrome (alps). Expert Review of Clinical Immunology, 17:1163-1173, Sep 2021. URL: https://doi.org/10.1080/1744666x.2021.1978842, doi:10.1080/1744666x.2021.1978842. This article has 27 citations and is from a peer-reviewed journal.
+
+17. (bride2017autoimmunelymphoproliferativesyndrome pages 1-3): Karen Bride and David Teachey. Autoimmune lymphoproliferative syndrome: more than a fascinating disease. F1000Research, 6:1928, Nov 2017. URL: https://doi.org/10.12688/f1000research.11545.1, doi:10.12688/f1000research.11545.1. This article has 129 citations and is from a peer-reviewed journal.
+
+18. (luan2024eaf2deficiencyattenuates pages 1-2): Yingying Luan, Qing Min, Runyun Zhang, Zichao Wen, Xin Meng, Ziying Hu, Xiaoqian Feng, Meiping Yu, Lulu Dong, and Ji-Yang Wang. Eaf2 deficiency attenuates autoimmune disease in faslpr mice by modulating b cell activation and apoptosis. iScience, 27:111220, Nov 2024. URL: https://doi.org/10.1016/j.isci.2024.111220, doi:10.1016/j.isci.2024.111220. This article has 1 citations and is from a peer-reviewed journal.
+
+19. (price2014naturalhistoryof media e08f037f): Susan Price, Pamela A. Shaw, Amy Seitz, Gyan Joshi, Joie Davis, Julie E. Niemela, Katie Perkins, Ronald L. Hornung, Les Folio, Philip S. Rosenberg, Jennifer M. Puck, Amy P. Hsu, Bernice Lo, Stefania Pittaluga, Elaine S. Jaffe, Thomas A. Fleisher, V. Koneti Rao, and Michael J. Lenardo. Natural history of autoimmune lymphoproliferative syndrome associated with fas gene mutations. Blood, 123 13:1989-99, Mar 2014. URL: https://doi.org/10.1182/blood-2013-10-535393, doi:10.1182/blood-2013-10-535393. This article has 270 citations and is from a highest quality peer-reviewed journal.
+
+20. (NCT00392951 chunk 1):  Sirolimus for Autoimmune Disease of Blood Cells. Children's Hospital of Philadelphia. 2006. ClinicalTrials.gov Identifier: NCT00392951
+
+21. (NCT02579967 chunk 1):  Pilot Trial of Allogeneic Blood or Marrow Transplantation for Primary Immunodeficiencies. National Cancer Institute (NCI). 2015. ClinicalTrials.gov Identifier: NCT02579967
+
+22. (NCT02579967 chunk 2):  Pilot Trial of Allogeneic Blood or Marrow Transplantation for Primary Immunodeficiencies. National Cancer Institute (NCI). 2015. ClinicalTrials.gov Identifier: NCT02579967
+
+23. (molnar2020keydiagnosticmarkers pages 17-19): Emese Molnár, Nesrine Radwan, Gábor Kovács, Hajnalka Andrikovics, Frances Henriquez, Anton Zarafov, Matthew Hayman, Daniela Linzner, Adrian J. Thrasher, Matthew Buckland, Siobhan O. Burns, and Kimberly C. Gilmour. Key diagnostic markers for autoimmune lymphoproliferative syndrome with molecular genetic diagnosis. Blood, 136:1933-1945, Oct 2020. URL: https://doi.org/10.1182/blood.2020005486, doi:10.1182/blood.2020005486. This article has 44 citations and is from a highest quality peer-reviewed journal.

--- a/research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-falcon.md.citations.md
+++ b/research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-falcon.md.citations.md
@@ -1,0 +1,490 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** FAS-related Autoimmune Lymphoproliferative Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **FAS-related Autoimmune Lymphoproliferative Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-04-16T12:37:47.669853
+
+1. klemann2017evolutionofdisease pages 6-10
+2. fernandez2024lookingforalps pages 1-2
+3. price2014naturalhistoryof pages 3-4
+4. rao2024beyondfascinatingadvances pages 1-3
+5. rao2011howitreat pages 2-3
+6. price2014naturalhistoryof pages 6-7
+7. rieuxlaucat2018theautoimmunelymphoproliferative pages 5-6
+8. elgharbawy2023casereportneonatal pages 1-2
+9. xu2024genetictestingin pages 4-6
+10. consonni2024studyofthe pages 1-2
+11. lambert2021presentationanddiagnosis pages 3-4
+12. casamayorpolo2021immunologicevaluationand pages 3-5
+13. rieuxlaucat2018theautoimmunelymphoproliferative pages 1-2
+14. xu2024genetictestingin pages 1-2
+15. price2014naturalhistoryof pages 1-3
+16. rieuxlaucat2018theautoimmunelymphoproliferative pages 7-8
+17. bride2017autoimmunelymphoproliferativesyndrome pages 1-3
+18. molnar2020keydiagnosticmarkers pages 17-19
+19. https://doi.org/10.1111/pai.14135
+20. https://clinicaltrials.gov/study/NCT00392951
+21. https://clinicaltrials.gov/study/NCT02579967
+22. https://doi.org/10.1182/blood-2013-10-535393
+23. https://doi.org/10.1007/s10875-024-01772-z
+24. https://doi.org/10.1182/hematology.2024000537
+25. https://doi.org/10.3324/haematol.2016.153411
+26. https://doi.org/10.1182/hematology.2024000537,
+27. https://doi.org/10.1111/pai.14135,
+28. https://doi.org/10.1007/s10875-024-01772-z,
+29. https://doi.org/10.3324/haematol.2016.153411,
+30. https://doi.org/10.3389/fped.2023.1150179,
+31. https://doi.org/10.1182/blood-2011-07-325217,
+32. https://doi.org/10.1182/blood-2013-10-535393,
+33. https://doi.org/10.1007/s10875-018-0523-x,
+34. https://doi.org/10.1080/10408363.2020.1855623,
+35. https://doi.org/10.1038/s41419-024-06679-6,
+36. https://doi.org/10.1080/1744666x.2021.1978842,
+37. https://doi.org/10.12688/f1000research.11545.1,
+38. https://doi.org/10.1016/j.isci.2024.111220,
+39. https://doi.org/10.1182/blood.2020005486,

--- a/research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-manual.md
+++ b/research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-manual.md
@@ -1,0 +1,94 @@
+---
+provider: manual_pubmed_review
+model: n/a
+cached: false
+start_time: '2026-04-16T19:23:00Z'
+end_time: '2026-04-16T19:39:00Z'
+duration_seconds: 960.0
+citation_count: 10
+notes: >
+  Automated provider runs via `just research-disorder falcon
+  FAS-related_Autoimmune_Lymphoproliferative_Syndrome` and
+  `just research-disorder openai
+  FAS-related_Autoimmune_Lymphoproliferative_Syndrome` did not return cleanly
+  in this environment during curation. A falcon artifact was later found in the
+  worktree, but manual PubMed-first deep research plus OLS term verification
+  was completed independently and used to support the curated entry.
+---
+
+## Question
+
+Provide a concise mechanistic review of FAS-related autoimmune lymphoproliferative syndrome, emphasizing the classical dominant ALPS-Ia phenotype, core apoptotic mechanism, hallmark cytopenias and lymphoproliferation, lymphoma risk, diagnosis, and treatment.
+
+## Output
+
+# FAS-related Autoimmune Lymphoproliferative Syndrome: Mechanistic Summary
+
+## Disease scope and terminology
+
+FAS-related autoimmune lymphoproliferative syndrome corresponds to the classical
+FAS-driven ALPS spectrum and aligns with the newer MONDO label
+**MONDO:1060194 FAS-related autoimmune lymphoproliferative syndrome**. In
+historical literature, the dominant form is usually called **ALPS-Ia** or
+**autoimmune lymphoproliferative syndrome type 1A**.
+
+## Genetics and inheritance
+
+The dominant clinical form is usually caused by **heterozygous germline FAS
+variants**, especially lesions affecting the intracellular death domain.
+Published family studies support **autosomal dominant inheritance with
+incomplete penetrance**. Reviews consistently describe FAS as the most frequent
+molecular cause of ALPS.
+
+## Core pathophysiology
+
+FAS-related ALPS is fundamentally a disorder of **defective Fas-mediated
+apoptosis**. Failure of activation-induced lymphocyte deletion disrupts
+lymphocyte homeostasis, allowing survival of autoreactive lymphocytes and
+expansion of the characteristic **alpha-beta double-negative T-cell**
+population. This mechanistically explains the triad of:
+
+- chronic benign lymphoproliferation
+- autoimmune cytopenias
+- lymphoma predisposition
+
+## Hallmark clinical phenotype
+
+The core phenotype includes:
+
+- chronic non-malignant **lymphadenopathy**
+- **hepatosplenomegaly**
+- autoimmune cytopenias, especially **autoimmune hemolytic anemia**,
+  **autoimmune thrombocytopenia**, and **autoimmune neutropenia**
+- elevated circulating **alpha-beta double-negative T cells**
+- increased lifetime risk of **Hodgkin and non-Hodgkin lymphoma**
+
+## Diagnosis
+
+Diagnosis is supported by:
+
+- **flow-cytometric quantification** of CD3+TCR-alpha-beta+CD4-CD8- cells
+- serum biomarker assessment including **vitamin B12**, **soluble Fas ligand**,
+  and **IL-10**
+- **functional apoptosis assays** demonstrating impaired Fas-mediated apoptosis
+- confirmatory **FAS molecular genetic testing**
+
+## Treatment
+
+The strongest treatment evidence identified here supports **sirolimus** as a
+highly effective steroid-sparing therapy for refractory autoimmune cytopenias
+and benign lymphoproliferation in ALPS. Reviews also describe **mycophenolate
+mofetil** as active, but sirolimus has the clearest direct response data.
+
+## References
+
+- PMID:12732128
+- PMID:15160902
+- PMID:19208097
+- PMID:20170754
+- PMID:21447005
+- PMID:21885601
+- PMID:22157362
+- PMID:23850805
+- PMID:23993982
+- PMID:26504182


### PR DESCRIPTION
## Summary
Add a new disorder entry for FAS-related autoimmune lymphoproliferative syndrome aligned to MONDO NTR #9749.

## What Changed
- add `kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml`
- model the classical dominant ALPS-Ia phenotype with FAS causality, defective Fas-mediated apoptosis, lymphoproliferation, autoimmune cytopenias, lymphoma risk, diagnosis, and sirolimus treatment
- add fetched PMID reference cache files for the cited evidence
- add research artifacts for this curation, including a manual PubMed-backed note and the falcon-generated report

## Why
This publishes the curated FAS-related ALPS disease concept requested from the prior curation pass and aligns the entry to the current MONDO gene-related label.

## Impact
The knowledge base gains a validated Mendelian disorder entry for the dominant FAS-related ALPS spectrum, including mechanistic and clinical evidence needed for downstream browsing and review.

## Validation
- `just validate kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml`
- `pre-commit run --files kb/disorders/FAS-related_Autoimmune_Lymphoproliferative_Syndrome.yaml research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-falcon.md research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-falcon.md.citations.md research/FAS-related_Autoimmune_Lymphoproliferative_Syndrome-deep-research-manual.md references_cache/PMID_12732128.md references_cache/PMID_15160902.md references_cache/PMID_19208097.md references_cache/PMID_20170754.md references_cache/PMID_21447005.md references_cache/PMID_21885601.md references_cache/PMID_22157362.md references_cache/PMID_23850805.md references_cache/PMID_23993982.md references_cache/PMID_26504182.md`