### PR TITLE
[codex] Tighten Kniest hearing phenotype description

### DIFF
--- a/kb/disorders/Kniest_Dysplasia.yaml
+++ b/kb/disorders/Kniest_Dysplasia.yaml
@@ -1,6 +1,6 @@
 name: Kniest Dysplasia
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T00:33:21Z'
+updated_date: '2026-04-19T21:33:56Z'
 category: Mendelian
 description: >
   Kniest dysplasia is a moderately severe type II collagenopathy caused by
@@ -886,8 +886,8 @@ phenotypes:
 - name: Hearing Loss
   category: Otologic
   description: >
-    Hearing loss is common and may include both conductive and sensorineural
-    components.
+    Hearing loss is common and typically involves mixed conductive and
+    sensorineural components.
   phenotype_term:
     preferred_term: Mixed hearing impairment
     term:


### PR DESCRIPTION
## Summary
- address the only relevant follow-up review note from #1471 by tightening the Kniest hearing-loss description
- keep the ontology term and evidence unchanged; this is a wording-only alignment with `HP:0000410` mixed hearing impairment

## Validation
- `just validate kb/disorders/Kniest_Dysplasia.yaml`
- `just validate-references kb/disorders/Kniest_Dysplasia.yaml`
- `just validate-terms kb/disorders/Kniest_Dysplasia.yaml`

Follow-up to #1471 and related to #1453.