### PR TITLE
[codex] Clarify BDA1 phenotype evidence source

### DIFF
--- a/kb/disorders/Brachydactyly_Type_A1.yaml
+++ b/kb/disorders/Brachydactyly_Type_A1.yaml
@@ -1,6 +1,6 @@
 name: Brachydactyly Type A1
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-04-19T07:24:02Z'
+updated_date: '2026-04-19T21:33:40Z'
 category: Mendelian
 description: >
   Brachydactyly type A1 (BDA1) is the first recorded Mendelian autosomal dominant
@@ -167,6 +167,7 @@ phenotypes:
   - reference: PMID:30651074
     reference_title: "p.E95K mutation in Indian hedgehog causing brachydactyly type A1 impairs IHH/Gli1 downstream transcriptional regulation."
     supports: SUPPORT
+    evidence_source: IN_VITRO
     snippet: "Brachydactyly type A1 (BDA1, OMIM 112500) is a rare inherited malformation characterized primarily by shortness or absence of middle bones of fingers and toes."
     explanation: "Supports toe middle-phalanx involvement as part of the core BDA1 malformation pattern."
   - reference: PMID:40606564

--- a/kb/disorders/Brachydactyly_Type_A1.yaml
+++ b/kb/disorders/Brachydactyly_Type_A1.yaml
@@ -1,6 +1,6 @@
 name: Brachydactyly Type A1
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-04-19T21:33:40Z'
+updated_date: '2026-04-19T21:46:07Z'
 category: Mendelian
 description: >
   Brachydactyly type A1 (BDA1) is the first recorded Mendelian autosomal dominant
@@ -173,6 +173,7 @@ phenotypes:
   - reference: PMID:40606564
     reference_title: "A Novel Heterozygous IHH c.331_333del Mutation Identified in a Fetus with Brachydactyly Type A1 Causes IHH Protein Maturation Failure in HEK293T Cells."
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "Brachydactyly A1 (BDA1) is a rare disorder characterized by the disproportionate shortening of fingers and/or toes with or without symphalangism."
     explanation: "Recent prenatal case report independently supports toe shortening within the BDA1 phenotype spectrum."
 - name: Short Stature


### PR DESCRIPTION
## Summary
- annotate the `PMID:30651074` toe-phenotype evidence in `kb/disorders/Brachydactyly_Type_A1.yaml` with `evidence_source: IN_VITRO`
- refresh `updated_date` for the disorder entry

## Why
PR #1530 was already merged, but a subsequent review correctly noted that `PMID:30651074` is primarily an in vitro study even though the quoted line in the abstract summarizes the clinical phenotype. This follow-up makes the evidence typing explicit without changing the phenotype assertions.

## Validation
- `just validate kb/disorders/Brachydactyly_Type_A1.yaml` ✅
- `just validate-references kb/disorders/Brachydactyly_Type_A1.yaml` ✅
- `just validate-terms kb/disorders/Brachydactyly_Type_A1.yaml` ✅

Follow-up to #1530