### PR TITLE
[codex] Refine ARO phenotype follow-up after review

### DIFF
--- a/kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml
+++ b/kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Recessive Osteopetrosis Type 2
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-04-19T07:25:24Z'
+updated_date: '2026-04-19T21:33:27Z'
 category: Mendelian
 description: >
   Autosomal recessive osteopetrosis type 2 (ARO2) is a severe sclerosing bone
@@ -145,7 +145,7 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Osteopetrosis is characterized by increased bone density and bone marrow cavity stenosis"
-    explanation: "An autosomal recessive osteopetrosis cohort including TCIRG1 cases identified increased bone density with marrow cavity stenosis as a core manifestation."
+    explanation: "An autosomal recessive osteopetrosis cohort that included 3 TCIRG1 cases identified increased bone density with marrow cavity stenosis as a core manifestation."
   - reference: PMID:40462430
     reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
     supports: SUPPORT
@@ -167,7 +167,7 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
-    explanation: "The autosomal recessive osteopetrosis cohort explicitly presented with anemia."
+    explanation: "The autosomal recessive osteopetrosis cohort, including 3 TCIRG1 cases, explicitly presented with anemia."
   - reference: PMID:40462430
     reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
     supports: SUPPORT
@@ -189,7 +189,7 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
-    explanation: "The autosomal recessive osteopetrosis cohort explicitly presented with thrombocytopenia."
+    explanation: "The autosomal recessive osteopetrosis cohort, including 3 TCIRG1 cases, explicitly presented with thrombocytopenia."
   - reference: PMID:40462430
     reference_title: "[Clinical and genetic characteristics of osteopetrosis in children]."
     supports: SUPPORT
@@ -211,7 +211,7 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
-    explanation: "Hepatosplenomegaly was part of the presenting phenotype in an autosomal recessive osteopetrosis cohort that included multiple TCIRG1 cases."
+    explanation: "Hepatosplenomegaly was part of the presenting phenotype in an autosomal recessive osteopetrosis cohort that included 3 TCIRG1 cases."
   - reference: PMID:18946580
     reference_title: "Rare gross deletion in T-cell immune regulator-1 gene in Iranian family with infantile malignant osteopetrosis."
     supports: SUPPORT
@@ -233,7 +233,7 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "five Chinese children who presented with anemia, thrombocytopenia, hepatosplenomegaly, repeated infections, and increased bone density"
-    explanation: "Repeated infections were part of the presenting phenotype in an autosomal recessive osteopetrosis cohort."
+    explanation: "Repeated infections were part of the presenting phenotype in an autosomal recessive osteopetrosis cohort that included 3 TCIRG1 cases."
   - reference: PMID:30898950
     reference_title: "Osteomyelitis of the mandible secondary to malignant infantile osteopetrosis in an adult."
     supports: SUPPORT
@@ -377,7 +377,7 @@ phenotypes:
     Severe disease may be accompanied by delayed neurodevelopment,
     particularly when early neurologic complications occur.
   phenotype_term:
-    preferred_term: developmental delay
+    preferred_term: Neurodevelopmental delay
     term:
       id: HP:0012758
       label: Neurodevelopmental delay


### PR DESCRIPTION
Follow-up to merged PR #1531.

## What changed
- aligned `preferred_term` with the ontology label for `HP:0012758` by changing it to `Neurodevelopmental delay`
- tightened several phenotype evidence explanations to say explicitly that PMID:34545712 included 3 TCIRG1 cases

## Why
These were the only review suggestions that were both in-scope for the phenotype-only curation and safe to address without broadening into unrelated pathophysiology or gene-section edits.

## Validation
- `just validate kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` -> passed
- `just validate-references kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` -> passed (`Total checks: 0; All validations passed!`)
- `just validate-terms kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml` -> passed
