### PR TITLE
Document safe branch refresh for PRs

### DIFF
--- a/.claude/skills/boss/SKILL.md
+++ b/.claude/skills/boss/SKILL.md
@@ -59,7 +59,8 @@ Turn the main session into an **orchestrator of external agents running in tmux*
    - Multi-commit work: `--issue N` is required. `tp` pulls the issue title into `@desc` and derives a branch like `fix/N-<slug>`.
    - Single-commit chore: `--issue` optional; `-d "description"` is enough and you pick the slug.
 6. **Every `tp send` after session creation uses `--wait`.** Agents are not always at a sendable prompt; `--wait` blocks until they are.
-7. **If `tp` has friction, talk to Chris** and/or file an issue at `cmungall/tmux-pilot`. **Do not** fall back to raw `tmux send-keys` without explicit permission.
+7. **Refreshing a worker branch with `main` is risky.** For branches the worker owns, prefer `git fetch origin && git rebase origin/main`. If the branch is stale or conflict-heavy, recreate from `origin/main` and cherry-pick only the intended commits. Do not blindly tell a worker to `merge origin/main` and push. After any refresh, the worker must review `git diff --name-status origin/main...HEAD` and `git diff --stat origin/main...HEAD` before commit/push.
+8. **If `tp` has friction, talk to Chris** and/or file an issue at `cmungall/tmux-pilot`. **Do not** fall back to raw `tmux send-keys` without explicit permission.
 
 ## Workflow
 
@@ -233,6 +234,18 @@ Standard prod sequence:
    then report to the user with the PR URL, the specific failing check or review comment, and what the worker tried.
 
 **Never mark `done-ish` on PR-opened alone.** "I opened a PR" is a milestone, not a finish line. If you mark it done-ish and walk away, you've left an un-reviewed draft sitting in the queue.
+
+### 6a. Conflicted PR branches
+
+If the worker reports that the PR branch is in conflict, do **not** send a vague instruction like "merge `origin/main` and push".
+
+Use a specific instruction that treats the refresh as content-changing work:
+
+```bash
+tp send --wait <name> "refresh the branch from origin/main safely: prefer rebase; if too stale or messy, recreate from origin/main and cherry-pick only the intended commits; then review git diff --name-status origin/main...HEAD and git diff --stat origin/main...HEAD before committing or pushing"
+```
+
+If the worker reports merge/rebase/index errors or an unexplained post-refresh diff, stop and escalate to the human instead of pushing through.
 
 Tear down only after `done-ish`:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -651,6 +651,20 @@ If a PR was authored by another contributor, **do not** force-push, rebase, or r
 2. Or create a separate fix commit on top of their work (no force-push)
 3. Only force-push branches that you (or your orchestrator) created
 
+### Refresh your own branch safely
+Refreshing a PR branch with `main` is a content-changing operation, not bookkeeping.
+For branches you own:
+1. Prefer `git fetch origin && git rebase origin/main`
+2. If the branch is stale or conflict-heavy, create a fresh branch from `origin/main` and cherry-pick only the intended commits
+3. Avoid routine `git merge origin/main` into PR branches
+4. After any refresh, review:
+```bash
+git diff --name-status origin/main...HEAD
+git diff --stat origin/main...HEAD
+```
+5. If you see unrelated deletions, stale reversions, or protected-path churn, stop and fix that before commit/push
+6. If merge/rebase/cherry-pick reports conflicts or index errors, do not commit or push until the operation is clean and the post-refresh diff has been reviewed
+
 ### Always use targeted git add
 Never use `git add -A` or `git add .` in worktrees. Only stage files relevant to the task:
 ```bash


### PR DESCRIPTION
## Summary
Document safer branch refresh practices so agents stop treating `sync with main` as harmless bookkeeping.

## Changes
- add a `CLAUDE.md` section that recommends rebase for owned branches, recreation/cherry-pick for stale branches, and post-refresh diff review before push
- update the `boss` skill so orchestrators do not tell workers to blindly `merge origin/main` and push
- add explicit conflicted-PR guidance for orchestrators

## Notes
- this is documentation / skill guidance only
- staged only the guidance files; unrelated local page/KB churn in my checkout was left untouched

Refs #1430