### PR TITLE
fix: address claude-review feedback on PR #1564 new disorder entries

### DIFF
--- a/kb/disorders/15q11q13_Microduplication_Syndrome.yaml
+++ b/kb/disorders/15q11q13_Microduplication_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: 15q11q13 Microduplication Syndrome
 creation_date: "2026-04-15T23:46:24Z"
-updated_date: "2026-04-16T01:15:00Z"
+updated_date: "2026-04-20T00:00:00Z"
 synonyms:
 - Dup15q syndrome
 - Duplication 15q11q13 syndrome
@@ -19,6 +19,24 @@ disease_term:
   term:
     id: MONDO:0012081
     label: 15q11q13 microduplication syndrome
+has_subtypes:
+- name: int15
+  display_name: Interstitial 15q11-q13 duplication (int15)
+  description: >-
+    Interstitial tandem duplication of 15q11-q13 on the maternal chromosome.
+    Typically milder than idic15, with developmental and behavioral features
+    but lower burden of refractory epilepsy and SUDEP.
+- name: idic15
+  display_name: Isodicentric 15 (idic15)
+  description: >-
+    Supernumerary isodicentric marker chromosome containing an extra copy of
+    15q11-q13. More strongly associated with severe, refractory epilepsy and
+    elevated risk of sudden unexpected death in epilepsy (SUDEP).
+- name: Mosaic idic15
+  description: >-
+    Mosaic form of idic15 in which only a subset of cells carry the
+    supernumerary isodicentric 15 chromosome, producing variable and often
+    attenuated clinical severity relative to non-mosaic idic15.
 pathophysiology:
 - name: Maternal 15q11-q13 dosage increase
   description: >-

--- a/kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 3-hydroxyisobutyryl-CoA hydrolase deficiency
 creation_date: "2026-04-15T00:00:00Z"
-updated_date: "2026-04-16T02:19:46Z"
+updated_date: "2026-04-20T00:00:00Z"
 category: Mendelian
 description: >-
   3-hydroxyisobutyryl-CoA hydrolase deficiency is an inborn error of valine
@@ -21,6 +21,23 @@ mappings:
 parents:
 - hereditary disease
 - inborn error of metabolism
+has_subtypes:
+- name: Neonatal onset
+  description: >-
+    Least frequent subtype. Presents at birth with hypotonia, seizures, and
+    feeding difficulties, with high risk of death in childhood; survivors
+    develop developmental delay, poor weight gain, and a movement disorder.
+- name: Infantile onset
+  description: >-
+    Most common subtype. Presents in the first two years of life with feeding
+    difficulties, vomiting, developmental delay with regression, hypotonia,
+    seizures, movement disorder, microcephaly, vision impairment, and
+    episodes of neurologic deterioration.
+- name: Late onset
+  description: >-
+    Second most common subtype. Presents in childhood as a slowly progressive
+    disease with significant movement disorder with or without paroxysmal
+    dystonia, variable cognitive impairment, and high survivability.
 pathophysiology:
 - name: HIBCH enzyme deficiency
   description: >-
@@ -43,7 +60,10 @@ pathophysiology:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      HIBCH deficiency, a disorder of valine catabolism, is a novel cause
+      HIBCH deficiency, a disorder of valine catabolism, is a novel cause of
+      the multiple mitochondrial dysfunctions syndrome, and should be considered
+      in the differential diagnosis of patients presenting with multiple RC
+      deficiencies and/or pyruvate dehydrogenase deficiency.
     explanation: >-
       This directly supports the initiating enzymatic defect in HIBCH
       deficiency.
@@ -85,7 +105,9 @@ pathophysiology:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      multiple RC enzymes and PDHc in skeletal muscle and fibroblasts respectively,
+      The index case had deficiencies of multiple RC enzymes and PDHc in
+      skeletal muscle and fibroblasts respectively, but these were normal in
+      his younger brother.
     explanation: >-
       This directly supports the combined mitochondrial dysfunction that can
       occur in HIBCH deficiency.
@@ -498,6 +520,30 @@ differential_diagnoses:
       in the valine/isoleucine degradation disorders with overlapping biochemical
       context.
 treatments:
+- name: Valine-Restricted Diet
+  description: >-
+    Dietary restriction of valine is the primary targeted therapy for HIBCH
+    deficiency, addressing the block in valine catabolism. Special medical
+    food formulas can be delivered orally or by gastrostomy tube, with total
+    protein restriction as an alternative when formula adherence is poor.
+  treatment_term:
+    preferred_term: dietary intervention
+    term:
+      id: MAXO:0000088
+      label: dietary intervention
+  evidence:
+  - reference: PMID:41264763
+    reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      MANAGEMENT: Targeted therapy: Valine-restricted diet. As seen in other
+      metabolic disorders, treatment using special formulas (medical food) can
+      be implemented successfully via oral route in individuals diagnosed
+      within the first few months of life.
+    explanation: >-
+      GeneReviews explicitly identifies valine-restricted diet as the primary
+      targeted therapy for HIBCH deficiency.
 - name: Supportive metabolic and dietary management
   description: >-
     HIBCH deficiency has no established curative therapy, but reported patients

--- a/kb/disorders/Acrodysostosis.yaml
+++ b/kb/disorders/Acrodysostosis.yaml
@@ -1,6 +1,6 @@
 name: Acrodysostosis
 creation_date: "2026-04-16T00:00:00Z"
-updated_date: "2026-04-16T22:40:00Z"
+updated_date: "2026-04-20T00:00:00Z"
 description: >-
   Acrodysostosis is a rare skeletal dysplasia with severe brachydactyly,
   cone-shaped epiphyses, midface and nasal hypoplasia, short stature, and
@@ -28,6 +28,39 @@ disease_term:
   term:
     id: MONDO:0019797
     label: acrodysostosis
+inheritance:
+- name: Autosomal dominant
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  description: >-
+    Acrodysostosis is inherited in an autosomal dominant manner. Most reported
+    cases arise from de novo heterozygous pathogenic variants in PRKAR1A
+    (acrodysostosis type 1) or PDE4D (acrodysostosis type 2).
+  evidence:
+  - reference: PMID:33858404
+    reference_title: "A novel de novo PDE4D gene mutation identified in a Chinese patient with acrodysostosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Acrodysostosis is inherited in an autosomal dominant manner. In the
+      literature, most of the patients who have been reported on have de novo
+      pathogenic variants.
+    explanation: >-
+      This explicitly establishes autosomal dominant inheritance with a
+      predominance of de novo pathogenic variants in acrodysostosis.
+  - reference: PMID:30006632
+    reference_title: "PRKAR1A and PDE4D Mutations Cause Acrodysostosis but Two Distinct Syndromes with or without GPCR-Signaling Hormone Resistance."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the acrodysostosis cases, we identified 9 heterozygous de novo PRKAR1A
+      variants
+    explanation: >-
+      This supports de novo heterozygous PRKAR1A variants as a recurrent
+      mechanism in acrodysostosis type 1.
 pathophysiology:
 - name: PRKAR1A-mediated PKA hypoactivation
   description: >-

--- a/kb/disorders/Acrodysostosis.yaml
+++ b/kb/disorders/Acrodysostosis.yaml
@@ -41,7 +41,7 @@ inheritance:
     (acrodysostosis type 1) or PDE4D (acrodysostosis type 2).
   evidence:
   - reference: PMID:33858404
-    reference_title: "A novel de novo PDE4D gene mutation identified in a Chinese patient with acrodysostosis."
+    reference_title: "A novel variant in the PDE4D gene is the cause of Acrodysostosis type 2 in a Lithuanian patient: a case report."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
@@ -52,7 +52,7 @@ inheritance:
       This explicitly establishes autosomal dominant inheritance with a
       predominance of de novo pathogenic variants in acrodysostosis.
   - reference: PMID:30006632
-    reference_title: "PRKAR1A and PDE4D Mutations Cause Acrodysostosis but Two Distinct Syndromes with or without GPCR-Signaling Hormone Resistance."
+    reference_title: "Expanding the phenotypic spectrum of variants in PDE4D/PRKAR1A: from acrodysostosis to acroscyphodysplasia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-


### PR DESCRIPTION
## Summary

Addresses review feedback from claude[bot] on #1564 covering three of the five new disorder entries that triggered the page regeneration.

### HIBCH deficiency (`kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml`) — IMPORTANT
- Added **Valine-Restricted Diet** treatment (MAXO:0000088 dietary intervention, PMID:41264763 — GeneReviews explicitly identifies this as "Targeted therapy").
- Added three onset **subtypes** from GeneReviews: Neonatal onset, Infantile onset, Late onset.
- Expanded the two **truncated pathophysiology snippets** (PMID:24299452) to complete quotes; both still match the cached abstract.

### 15q11q13 Microduplication Syndrome — SUGGESTION
- Added `has_subtypes` for `int15`, `idic15`, and `Mosaic idic15`, capturing their distinct severity and SUDEP risk profiles.

### Acrodysostosis — SUGGESTION
- Added a formal `inheritance` block (Autosomal dominant, HP:0000006) with evidence from PMID:33858404 and PMID:30006632 covering the predominant de novo mechanism across both PRKAR1A- and PDE4D-related subtypes.

### Not addressed
- **2q37 Microdeletion Syndrome** retired GeneReviews caveat — the suggestion was to supplement with current literature; defer to a dedicated reference-hunting PR.
- **Adenosine Kinase Deficiency** had no review asks.
- The failing `test_render_pathograph_payload` is unrelated (Atelosteogenesis Type I node rename) and is already fixed by #1561.

## Test plan
- [x] `just validate kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml`
- [x] `just validate kb/disorders/15q11q13_Microduplication_Syndrome.yaml`
- [x] `just validate kb/disorders/Acrodysostosis.yaml`
- [x] `pytest tests/test_data.py -k subtype` (746 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)