### PR TITLE
fix: restore OpenScientist Worker URL and BBOP deploy config (#1567)

### DIFF
--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -1,19 +1,18 @@
 name = "dismech-openscientist"
 main = "src/index.ts"
 compatibility_date = "2024-12-30"
+account_id = "c338d00dd595f30a8124701d99a729b5"
 
 [vars]
 GITHUB_RAW_BASE = "https://raw.githubusercontent.com/monarch-initiative/dismech/main/kb/disorders"
 GITHUB_RELEASE_KB_ZIP = "https://github.com/monarch-initiative/dismech/releases/latest/download/dismech_kb.zip"
 
 # KV namespace for rate limiting and job tracking.
-# These are placeholder IDs that work for local dev (`wrangler dev --local`).
-# For production, create a real namespace: `wrangler kv:namespace create "KV"`
-# and replace the IDs below.
+# Created via `wrangler kv namespace create "KV"` on the BBOP account.
 [[kv_namespaces]]
 binding = "KV"
-id = "0000000000000000000000000000000000"
-preview_id = "0000000000000000000000000000000000"
+id = "b23357fc10d143b080d14b1889f82c53"
+preview_id = "6f30d73283894c5e83d8db65ea8f3689"
 
 # Secrets (set via `wrangler secret put`):
 # - OPENSCIENTIST_API_KEY: Bearer token in "name:secret" format

--- a/src/dismech/render.py
+++ b/src/dismech/render.py
@@ -1016,7 +1016,7 @@ def render_disorder(
     disease_term_term = disease_term.get("term") or {}
     openscientist_proxy_url = os.environ.get(
         "OPENSCIENTIST_PROXY_URL",
-        "https://dismech-openscientist.workers.dev",
+        "https://dismech-openscientist.bbop.workers.dev",
     )
 
     html = template.render(


### PR DESCRIPTION
## Summary

Fixes #1567. The "Ask OpenScientist" feature on every disorder page fails with `ERR_NAME_NOT_RESOLVED` because the hardcoded proxy URL points at `dismech-openscientist.workers.dev`, which was never deployed. The live Worker is at `dismech-openscientist.bbop.workers.dev` (BBOP Cloudflare account).

## Root cause

PR #1442 (commit `efc9299b7`, merged 2026-04-17) deployed the Worker to the BBOP account and updated two files to match:
- `src/dismech/render.py` — default `OPENSCIENTIST_PROXY_URL` = `.bbop.workers.dev`
- `proxy/wrangler.toml` — BBOP `account_id` + real KV namespace IDs

PR #1425 (commit `4e99ccbae`, merged 2026-04-18, titled *"curate congenital insensitivity to pain umbrella"*) accidentally reverted **both** files. The revert was almost certainly an unintended side-effect of a bad merge/rebase conflict resolution — the PR's stated scope was a disease-curation change, not proxy config.

## Verification

- `curl https://dismech-openscientist.workers.dev/api/jobs` → `Could not resolve host` (confirmed DNS failure matches the bug report).
- `curl https://dismech-openscientist.bbop.workers.dev/api/jobs` → HTTP 404 (Worker is live; GET isn't the right verb for this endpoint).
- Codex subagent confirmed: setting `OPENSCIENTIST_PROXY_URL=https://dismech-openscientist.bbop.workers.dev` and running `uv run python -m dismech.render kb/disorders/Shigellosis.yaml` produces a page whose `OS_CONFIG.proxyUrl` is the correct URL.
- 742 `pages/disorders/*.html` currently embed the broken URL; they will be regenerated by the next `generate-pages.yaml` workflow run (no manual re-render is shipped in this PR).

## Changes

- `src/dismech/render.py:1019` — revert to `https://dismech-openscientist.bbop.workers.dev`.
- `proxy/wrangler.toml` — restore `account_id` and BBOP KV namespace IDs (so `wrangler deploy` from main keeps targeting the live Worker).

## Test plan

- [x] Confirm `curl https://dismech-openscientist.bbop.workers.dev/` is reachable.
- [ ] After merge, confirm the next auto-regenerated `pages/disorders/*.html` contain `"proxyUrl": "https://dismech-openscientist.bbop.workers.dev"` and that the "Ask OpenScientist" dialog succeeds on dismech.monarchinitiative.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
