### PR TITLE
[codex] Use ai4c-agent token for claude-review submissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,11 +37,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh pr checkout ${{ env.PR_NUMBER }}
 
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.ai4c-token.outputs.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
           allowed_bots: claude
           claude_args: |


### PR DESCRIPTION
## Summary
- add a `Generate ai4c-agent token` step before `Run Claude Code Review`
- pass the generated token as `github_token` to `anthropics/claude-code-action@v1`
- leave the existing Claude OAuth token path unchanged

## Why
Fixes #1579.

The claude-review workflow currently submits reviews as `app/claude`, which cannot approve compliance PRs authored by the same identity. Supplying a GitHub token from the `ai4c-agent` app makes the review submission come from a different author identity.

## Validation
- verified the workflow diff only adds the requested token-generation step and `github_token` input
- repo YAML hooks passed for the staged workflow before the pre-commit stash restore hit unrelated local edits