### PR TITLE
[codex] Use full MONDO priority candidate export

### DIFF
--- a/.github/workflows/generate-pages.yaml
+++ b/.github/workflows/generate-pages.yaml
@@ -89,6 +89,9 @@ jobs:
       - name: Generate compliance dashboard
         run: just gen-dashboard
 
+      - name: Generate priority dashboard
+        run: just gen-priority-dashboard
+
       - name: Generate schema docs site
         run: just gen-schema-docs
 

--- a/project.justfile
+++ b/project.justfile
@@ -372,8 +372,15 @@ gen-dashboard:
 
 # Generate MONDO curation priority dashboard
 [group('QC')]
-gen-priority-dashboard candidates='examples/mondo_prioritizer_candidates.tsv' config='conf/mondo_prioritizer.yaml':
-    uv run python scripts/generate_priority_dashboard.py --candidates {{candidates}} --kb-dir {{kb_dir}} --config {{config}} --dashboard-dir dashboard/ --dashboard-index dashboard/index.html
+gen-priority-dashboard candidates='tmp/mondo_priority_candidates_full.tsv' config='conf/mondo_prioritizer.yaml':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    candidates="{{candidates}}"
+    if [ "$candidates" = "tmp/mondo_priority_candidates_full.tsv" ] || [ ! -f "$candidates" ]; then
+        mkdir -p "$(dirname "$candidates")"
+        uv run python scripts/export_mondo_priority_candidates.py --mondo-db {{mondo_db}} --output "$candidates" --kb-dir {{kb_dir}}
+    fi
+    uv run python scripts/generate_priority_dashboard.py --candidates "$candidates" --kb-dir {{kb_dir}} --config {{config}} --dashboard-dir dashboard/ --dashboard-index dashboard/index.html
     echo "Priority dashboard generated in dashboard/"
 
 # Generate a local-only all-MONDO priority dashboard under tmp/ (gitignored)


### PR DESCRIPTION
## Summary

The MONDO priority dashboard defaulted to the 7-row toy candidate file, so both local `just gen-priority-dashboard` runs and the Pages workflow only surfaced a tiny example set instead of the full MONDO candidate universe.

This change switches the default priority dashboard behavior to the full MONDO candidate export without committing a large generated TSV. The `gen-priority-dashboard` target now writes the full candidate list to `tmp/mondo_priority_candidates_full.tsv` on demand, and the Pages workflow runs that target alongside the existing compliance dashboard step.

## Changes

- updated `project.justfile` so `gen-priority-dashboard` defaults to `tmp/mondo_priority_candidates_full.tsv`
- added on-demand MONDO export to `gen-priority-dashboard` before rendering the priority dashboard
- added a `Generate priority dashboard` step to `.github/workflows/generate-pages.yaml`

## Not Changed

- no `examples/mondo_priority_candidates_full.tsv` is committed
- no `dashboard/*.html` or `dashboard/*.json` outputs were committed; those remain pipeline-derived artifacts

## Validation

- `uv run python scripts/export_mondo_priority_candidates.py --mondo-db /Users/cjm/.data/oaklib/mondo.db --output tmp/mondo_priority_candidates_full.tsv --kb-dir kb/disorders`
  - exported `25238` candidates
  - excluded `716` curated roots from `25954` disease descendants
- `uv run python scripts/generate_priority_dashboard.py --candidates tmp/mondo_priority_candidates_full.tsv --kb-dir kb/disorders --config conf/mondo_prioritizer.yaml --dashboard-dir tmp/priority-dashboard-validation --dashboard-index tmp/priority-dashboard-validation/index.html`
- pre-commit hooks passed on the amended commit