### PR TITLE
Update classic Hodgkin lymphoma

### DIFF
--- a/kb/disorders/Classic_Hodgkin_Lymphoma.yaml
+++ b/kb/disorders/Classic_Hodgkin_Lymphoma.yaml
@@ -1,6 +1,6 @@
 name: Classic Hodgkin Lymphoma
 creation_date: "2026-04-12T03:59:32Z"
-updated_date: "2026-04-21T13:35:41Z"
+updated_date: "2026-04-21T14:07:20Z"
 category: Cancer
 categories:
 - Hematologic Malignancy
@@ -216,25 +216,6 @@ histopathology:
     evidence_source: OTHER
     snippet: "HRS cells are scattered within a dense inflammatory infiltrate, and through a network of cytokines and chemokines they shape their microenvironment, evade immune response, survive, and grow."
     explanation: This review directly supports the hallmark microscopic pattern of sparse HRS cells embedded in an inflammatory background.
-- name: Classical Hodgkin Immunophenotype
-  finding_term:
-    preferred_term: CD30-positive, CD15-positive, PAX5-positive immunophenotype
-    term:
-      id: HP:0025461
-      label: Abnormal cell morphology
-  frequency: VERY_FREQUENT
-  diagnostic: true
-  description: >-
-    In most cases, classic Hodgkin lymphoma shows the characteristic
-    immunophenotype of CD30, CD15, and PAX5 expression with absence of CD45 and
-    T-lineage markers.
-  evidence:
-  - reference: PMID:26839195
-    reference_title: "Atypical Phenotypes in Classical Hodgkin Lymphoma."
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "Classical Hodgkin lymphoma has a characteristic immunophenotype in most cases, with expression of CD30, CD15, and PAX-5, and absence of CD45 and T-lineage markers."
-    explanation: This pathology review abstract directly supports the characteristic immunophenotypic profile used in classic Hodgkin lymphoma diagnosis.
 phenotypes:
 - category: Lymphatic
   name: Lymphadenopathy
@@ -312,6 +293,24 @@ diagnosis:
     evidence_source: OTHER
     snippet: "An open lymph node biopsy is preferred for diagnosis."
     explanation: This review explicitly states that open lymph node biopsy is the preferred diagnostic procedure for lymphoma.
+- name: Immunohistochemistry for classical Hodgkin lymphoma markers
+  description: >-
+    Diagnosis of classic Hodgkin lymphoma is supported by the characteristic
+    immunophenotype of CD30, CD15, and PAX5 expression with absence of CD45 and
+    T-lineage markers.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  markers: CD30, CD15, PAX5, CD45
+  evidence:
+  - reference: PMID:26839195
+    reference_title: "Atypical Phenotypes in Classical Hodgkin Lymphoma."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Classical Hodgkin lymphoma has a characteristic immunophenotype in most cases, with expression of CD30, CD15, and PAX-5, and absence of CD45 and T-lineage markers."
+    explanation: This pathology review abstract directly supports the diagnostic immunophenotypic profile used in classic Hodgkin lymphoma.
 - name: PET/CT-Based Lugano Staging
   description: >-
     PET/CT is integrated into Lugano staging to define disease extent and guide

--- a/kb/disorders/Classic_Hodgkin_Lymphoma.yaml
+++ b/kb/disorders/Classic_Hodgkin_Lymphoma.yaml
@@ -1,6 +1,6 @@
 name: Classic Hodgkin Lymphoma
 creation_date: "2026-04-12T03:59:32Z"
-updated_date: "2026-04-21T12:32:22Z"
+updated_date: "2026-04-21T13:35:41Z"
 category: Cancer
 categories:
 - Hematologic Malignancy
@@ -609,7 +609,7 @@ clinical_trials:
     explanation: This supports autologous transplantation as an actively studied salvage strategy in poor-risk recurrent Hodgkin lymphoma.
 datasets:
 - accession: geo:GSE301492
-  title: Transcriptome sequencing of Hodgkin lymphoma Hodgkin and Reed-Stenberg cells reveals escape from NK cell recognition and an unfolded protein response
+  title: Transcriptome sequencing of Hodgkin lymphoma Hodgkin and Reed-Sternberg cells reveals escape from NK cell recognition and an unfolded protein response
   description: >-
     Bulk RNA-seq resource profiling flow-sorted primary Hodgkin/Reed-Sternberg
     cells, matched intratumoral non-neoplastic B cells, and cell lines to define
@@ -629,5 +629,5 @@ datasets:
   - reference: GEO:GSE301492
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Bulk RNA-seq profiling the transcriptome differences between HRS cells and intra-tumoral B cells following flow-cytometry sorting."
+    snippet: "To discover the molecular features that distinguish cHL, we deployed flow cytometric cell sorting and low-input RNA sequencing to generate full transcriptome data from viable, isolated Hodgkin and Red-Sternberg (HRS) cells from eighteen primary tumors, alongside matched intra-tumoral non-neoplastic B cells and four cell lines."
     explanation: This GEO series directly provides a patient-derived transcriptomic resource focused on malignant HRS cells and matched intratumoral B cells in classic Hodgkin lymphoma.

--- a/kb/disorders/Classic_Hodgkin_Lymphoma.yaml
+++ b/kb/disorders/Classic_Hodgkin_Lymphoma.yaml
@@ -1,6 +1,6 @@
 name: Classic Hodgkin Lymphoma
 creation_date: "2026-04-12T03:59:32Z"
-updated_date: "2026-04-12T16:40:38Z"
+updated_date: "2026-04-21T12:32:22Z"
 category: Cancer
 categories:
 - Hematologic Malignancy
@@ -18,33 +18,6 @@ disease_term:
     label: classic Hodgkin lymphoma
 parents:
 - Lymphoma
-has_subtypes:
-- name: Nodular Sclerosis
-  display_name: Nodular Sclerosis Classic Hodgkin Lymphoma
-  description: >-
-    The most common histologic subtype of classic Hodgkin lymphoma, characterized
-    by broad collagen bands that divide involved lymph node tissue into nodules
-    and by lacunar-type Hodgkin/Reed-Sternberg cells.
-  classification: histological
-- name: Mixed Cellularity
-  display_name: Mixed Cellularity Classic Hodgkin Lymphoma
-  description: >-
-    Histologic subtype with diffuse nodal effacement, numerous classic
-    Hodgkin/Reed-Sternberg cells, and a prominent mixed inflammatory background;
-    it is more often associated with Epstein-Barr virus than nodular sclerosis cHL.
-  classification: histological
-- name: Lymphocyte-Rich
-  display_name: Lymphocyte-Rich Classic Hodgkin Lymphoma
-  description: >-
-    Histologic subtype with relatively sparse Hodgkin/Reed-Sternberg cells in a
-    lymphocyte-rich background and comparatively less fibrosis.
-  classification: histological
-- name: Lymphocyte-Depleted
-  display_name: Lymphocyte-Depleted Classic Hodgkin Lymphoma
-  description: >-
-    Rare aggressive histologic subtype with numerous Hodgkin/Reed-Sternberg
-    cells, relative paucity of small lymphocytes, and often advanced-stage disease.
-  classification: histological
 description: >-
   Classic Hodgkin lymphoma is a B-cell lymphoma characterized histologically by
   the presence of Hodgkin cells and multinucleated Reed-Sternberg cells.
@@ -114,6 +87,15 @@ pathophysiology:
   description: >-
     Recurrent mutations in classic Hodgkin lymphoma activate JAK/STAT signaling
     programs that support tumor-cell survival and cytokine-responsive growth.
+  genes:
+  - preferred_term: JAK2
+    term:
+      id: hgnc:6192
+      label: JAK2
+  - preferred_term: STAT6
+    term:
+      id: hgnc:11368
+      label: STAT6
   biological_processes:
   - preferred_term: cell surface receptor signaling pathway via JAK-STAT
     modifier: INCREASED
@@ -193,6 +175,10 @@ pathophysiology:
   downstream:
   - target: PD-1 Ligand-Mediated Immune Evasion
     description: The inflammatory niche is coupled to ineffective anti-tumor immunity.
+  - target: Lymphadenopathy
+    description: The HRS-supported inflammatory niche contributes to bulky nodal enlargement.
+  - target: Fever
+    description: Cytokine-rich tumor inflammation contributes to B symptoms including fever.
 - name: PD-1 Ligand-Mediated Immune Evasion
   conforms_to: "immune_checkpoint_blockade#Adaptive Immune Resistance"
   description: >-
@@ -337,6 +323,47 @@ diagnosis:
     evidence_source: OTHER
     snippet: "The Lugano classification system incorporates symptoms and the extent of the disease as shown on positron emission tomography/computed tomography to stage lymphoma, which is then used to determine treatment."
     explanation: This review supports PET/CT-based Lugano staging as a standard part of lymphoma diagnosis and management.
+differential_diagnoses:
+- name: Nodular lymphocyte predominant Hodgkin lymphoma
+  disease_term:
+    preferred_term: nodular lymphocyte predominant Hodgkin lymphoma
+    term:
+      id: MONDO:0044778
+      label: nodular lymphocyte predominant Hodgkin lymphoma
+  description: >-
+    NLPHL is a major pathologic differential because it can overlap morphologically
+    with classic Hodgkin lymphoma while differing in immunophenotype and clinical
+    behavior.
+  distinguishing_features:
+  - NLPHL retains a B-cell program with LP cells rather than classic Hodgkin/Reed-Sternberg cells.
+  - NLPHL requires careful separation from classic Hodgkin lymphoma because management and biologic behavior differ.
+  evidence:
+  - reference: PMID:34208705
+    reference_title: "Pitfalls in the Diagnosis of Nodular Lymphocyte Predominant Hodgkin Lymphoma: Variant Patterns, Borderlines and Mimics."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "NLPHL also shows overlap with other lymphomas, particularly, classic Hodgkin lymphoma and T-cell lymphomas."
+    explanation: This review explicitly identifies classic Hodgkin lymphoma as a diagnostic overlap and differential consideration for NLPHL.
+- name: Primary mediastinal large B-cell lymphoma
+  disease_term:
+    preferred_term: primary mediastinal large B-cell lymphoma
+    term:
+      id: MONDO:0020323
+      label: primary mediastinal large B-cell lymphoma
+  description: >-
+    PMBCL is a relevant mediastinal differential because it shares B-cell
+    lineage features and overlapping immune-evasion biology with classic
+    Hodgkin lymphoma, especially in mediastinal presentations.
+  distinguishing_features:
+  - PMBCL typically presents as a rapidly enlarging anterior mediastinal mass with preserved B-cell surface marker expression.
+  - Classic Hodgkin lymphoma is defined by Hodgkin/Reed-Sternberg cells in an inflammatory background rather than a diffuse large B-cell phenotype.
+  evidence:
+  - reference: PMID:34590432
+    reference_title: Primary mediastinal large B cell lymphoma.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Primary mediastinal large B cell lymphoma (PMBCL) is an aggressive large B cell lymphoma originating in the mediastinum, that mainly expresses B cell surface molecules, such as CD19, CD20, CD22, andCD79a."
+    explanation: This supports PMBCL as a clinically and pathologically distinct mediastinal B-cell lymphoma that must be separated from classic Hodgkin lymphoma.
 genetic:
 - name: TNFAIP3
   association: Somatic Loss-of-Function Mutation
@@ -522,3 +549,85 @@ treatments:
       evidence_source: HUMAN_CLINICAL
       snippet: "Pembrolizumab was associated with high response rates and an acceptable safety profile in patients with rrHL, offering a new treatment paradigm for this disease."
       explanation: The clinical activity of pembrolizumab supports inhibition of PD-1 ligand-mediated immune evasion as a therapeutically relevant mechanism in relapsed or refractory classic Hodgkin lymphoma.
+- name: Nivolumab
+  description: >-
+    PD-1 blockade with nivolumab is an established treatment option in previously
+    treated classic Hodgkin lymphoma and is tightly aligned to the disease's
+    9p24.1-driven checkpoint biology.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: nivolumab
+      term:
+        id: NCIT:C68814
+        label: Nivolumab
+  evidence:
+  - reference: clinicaltrials:NCT02181738
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: The purpose of this study is to evaluate the efficacy and safety of Nivolumab in previously treated (cohorts, A, B & C) or newly diagnosed (cohort D) classical Hodgkin Lymphoma participants.
+    explanation: This phase II study directly supports nivolumab as an active therapeutic strategy in classical Hodgkin lymphoma.
+  target_mechanisms:
+  - target: PD-1 Ligand-Mediated Immune Evasion
+    treatment_effect: INHIBITS
+    description: >-
+      Nivolumab blocks PD-1 signaling and counteracts checkpoint-mediated immune
+      escape in classic Hodgkin lymphoma.
+    evidence:
+    - reference: clinicaltrials:NCT02181738
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The purpose of this study is to evaluate the efficacy and safety of Nivolumab in previously treated (cohorts, A, B & C) or newly diagnosed (cohort D) classical Hodgkin Lymphoma participants.
+      explanation: The trial objective directly supports nivolumab targeting the PD-1 axis in classical Hodgkin lymphoma.
+clinical_trials:
+- name: NCT02181738
+  phase: PHASE_II
+  status: COMPLETED
+  description: >-
+    Multi-cohort phase II nivolumab study in previously treated or newly diagnosed
+    classical Hodgkin lymphoma.
+  evidence:
+  - reference: clinicaltrials:NCT02181738
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: The purpose of this study is to evaluate the efficacy and safety of Nivolumab in previously treated (cohorts, A, B & C) or newly diagnosed (cohort D) classical Hodgkin Lymphoma participants.
+    explanation: This directly supports active clinical development of nivolumab in classical Hodgkin lymphoma.
+- name: NCT00265889
+  phase: PHASE_II
+  status: COMPLETED
+  description: >-
+    Phase II tandem autologous stem-cell transplantation study for primary
+    progressive or poor-risk recurrent Hodgkin lymphoma.
+  evidence:
+  - reference: clinicaltrials:NCT00265889
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Giving two autologous stem cell transplants (one after the other) may be an effective treatment for Hodgkin's lymphoma.
+    explanation: This supports autologous transplantation as an actively studied salvage strategy in poor-risk recurrent Hodgkin lymphoma.
+datasets:
+- accession: geo:GSE301492
+  title: Transcriptome sequencing of Hodgkin lymphoma Hodgkin and Reed-Stenberg cells reveals escape from NK cell recognition and an unfolded protein response
+  description: >-
+    Bulk RNA-seq resource profiling flow-sorted primary Hodgkin/Reed-Sternberg
+    cells, matched intratumoral non-neoplastic B cells, and cell lines to define
+    malignant-cell transcriptional programs and immune-evasion biology in classic
+    Hodgkin lymphoma.
+  organism:
+    preferred_term: human
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  data_type: BULK_RNA_SEQ
+  sample_count: 18
+  conditions:
+  - classic Hodgkin lymphoma Hodgkin/Reed-Sternberg cells
+  - matched intratumoral non-neoplastic B cells
+  evidence:
+  - reference: GEO:GSE301492
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Bulk RNA-seq profiling the transcriptome differences between HRS cells and intra-tumoral B cells following flow-cytometry sorting."
+    explanation: This GEO series directly provides a patient-derived transcriptomic resource focused on malignant HRS cells and matched intratumoral B cells in classic Hodgkin lymphoma.

--- a/references_cache/GEO_GSE301492.md
+++ b/references_cache/GEO_GSE301492.md
@@ -1,0 +1,11 @@
+---
+reference_id: "GEO:GSE301492"
+title: Transcriptome sequencing of Hodgkin lymphoma Hodgkin and Reed-Stenberg cells reveals escape from NK cell recognition and an unfolded protein response
+content_type: summary
+---
+
+# Transcriptome sequencing of Hodgkin lymphoma Hodgkin and Reed-Stenberg cells reveals escape from NK cell recognition and an unfolded protein response
+
+## Content
+
+The mutational profile of classic Hodgkin lymphoma (cHL) overlaps with that of related B cell lymphomas, including primary mediastinal B cell lymphoma (PMBL), and yet these are different histologically and clinically. To discover the molecular features that distinguish cHL, we deployed flow cytometric cell sorting and low-input RNA sequencing to generate full transcriptome data from viable, isolated Hodgkin and Red-Sternberg (HRS) cells from eighteen primary tumors, alongside matched intra-tumoral non-neoplastic B cells and four cell lines. Comparison of HRS cells to normal cellular subsets revealed evidence of abortive plasma cell differentiation, with an unfolded protein response signature, shared with plasma cell neoplasms, but not other B-cell lymphoma types. Comparison of cHL to PMBL revealed similarities but also key differences in B cell differentiation programs accompanied by upregulation of genes involved in microtubule cytoskeleton organization in cHL, which may be related to the unique multinucleated nature of HRS cells. In HRS cells, we also observed a downregulation of SLAM family receptors, which are crucial for NK cell activation, providing a potential mechanism for immune evasion from NK-mediated killing. New fusion transcripts were seen, including a recurrent transcript predicted to result in an in-frame fusion protein involving TRAF1 and PHF19.

--- a/references_cache/PMID_34208705.md
+++ b/references_cache/PMID_34208705.md
@@ -1,0 +1,57 @@
+---
+reference_id: "PMID:34208705"
+title: "Pitfalls in the Diagnosis of Nodular Lymphocyte Predominant Hodgkin Lymphoma: Variant Patterns, Borderlines and Mimics."
+authors:
+- Younes S
+- Rojansky RB
+- Menke JR
+- Gratzinger D
+- Natkunam Y
+journal: Cancers (Basel)
+year: '2021'
+doi: 10.3390/cancers13123021
+content_type: abstract_only
+---
+
+# Pitfalls in the Diagnosis of Nodular Lymphocyte Predominant Hodgkin Lymphoma: Variant Patterns, Borderlines and Mimics.
+**Authors:** Younes S, Rojansky RB, Menke JR, Gratzinger D, Natkunam Y
+**Journal:** Cancers (Basel) (2021)
+**DOI:** [10.3390/cancers13123021](https://doi.org/10.3390/cancers13123021)
+
+## Content
+
+1. Cancers (Basel). 2021 Jun 16;13(12):3021. doi: 10.3390/cancers13123021.
+
+Pitfalls in the Diagnosis of Nodular Lymphocyte Predominant Hodgkin Lymphoma: 
+Variant Patterns, Borderlines and Mimics.
+
+Younes S(1), Rojansky RB(1), Menke JR(1), Gratzinger D(1), Natkunam Y(1).
+
+Author information:
+(1)Department of Pathology, Stanford University School of Medicine, Stanford, CA 
+94305, USA.
+
+Nodular lymphocyte predominant Hodgkin lymphoma (NLPHL) represents approximately 
+5% of Hodgkin lymphoma and typically affects children and young adults. Although 
+the overall prognosis is favorable, variant growth patterns in NLPHL correlate 
+with disease recurrence and progression to T-cell/histiocyte-rich large B-cell 
+lymphoma or frank diffuse large B-cell lymphoma (DLBCL). The diagnostic boundary 
+between NLPHL and DLBCL can be difficult to discern, especially in the presence 
+of variant histologies. Both diagnoses are established using morphology and 
+immunophenotype and share similarities, including the infrequent large tumor 
+B-cells and the lymphocyte and histiocyte-rich microenvironment. NLPHL also 
+shows overlap with other lymphomas, particularly, classic Hodgkin lymphoma and 
+T-cell lymphomas. Similarly, there is overlap with non-neoplastic conditions, 
+such as the progressive transformation of germinal centers. Given the 
+significant clinical differences among these entities, it is imperative that 
+NLPHL and its variants are carefully separated from other lymphomas and their 
+mimics. In this article, the characteristic features of NLPHL and its diagnostic 
+boundaries and pitfalls are discussed. The current understanding of genetic 
+features and immune microenvironment will be addressed, such that a framework to 
+better understand biological behavior and customize patient care is provided.
+
+DOI: 10.3390/cancers13123021
+PMCID: PMC8234802
+PMID: 34208705
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_34590432.md
+++ b/references_cache/PMID_34590432.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:34590432"
+title: Primary mediastinal large B cell lymphoma.
+authors:
+- Yu Y
+- Dong X
+- Tu M
+- Wang H
+journal: Thorac Cancer
+year: '2021'
+doi: 10.1111/1759-7714.14155
+keywords:
+- "Diagnosis, Differential"
+- Humans
+- "Lymphoma, Large B-Cell, Diffuse/diagnostic imaging, therapy"
+- "Mediastinal Neoplasms/diagnostic imaging, therapy"
+- Positron Emission Tomography Computed Tomography
+content_type: abstract_only
+---
+
+# Primary mediastinal large B cell lymphoma.
+**Authors:** Yu Y, Dong X, Tu M, Wang H
+**Journal:** Thorac Cancer (2021)
+**DOI:** [10.1111/1759-7714.14155](https://doi.org/10.1111/1759-7714.14155)
+
+## Content
+
+1. Thorac Cancer. 2021 Nov;12(21):2831-2837. doi: 10.1111/1759-7714.14155. Epub 
+2021 Sep 29.
+
+Primary mediastinal large B cell lymphoma.
+
+Yu Y(#)(1), Dong X(#)(1), Tu M(2), Wang H(1).
+
+Author information:
+(1)Department of Hematology, General Hospital, Tianjin Medical University, 
+Tianjin, China.
+(2)Department of Lymphoma, Key Laboratory of Carcinogenesis and Translational 
+Research (Ministry of Education/Beijing), Peking University Cancer Hospital & 
+Institute, Beijing, China.
+(#)Contributed equally
+
+Primary mediastinal large B cell lymphoma (PMBCL) is an aggressive large B cell 
+lymphoma originating in the mediastinum, that mainly expresses B cell surface 
+molecules, such as CD19, CD20, CD22, andCD79a. Clinically, they are 
+characterized by rapidly increasing anterior mediastinal masses, which can cause 
+compression of the surrounding tissues. The diagnosis of PMBCL mainly depends on 
+the pathological features, imaging examination and clinical features. Currently, 
+the most commonly used therapeutic regimens are R-CHOP and R-EPOCH. Radiotherapy 
+is beneficial in some patients, but it can also lead to long-term toxicity. The 
+research and development of novel therapies are ongoing, and some studies have 
+achieved encouraging results, including those conducted on chimeric antigen 
+receptor-modified T (CAR-T) cell therapy and anti-PD-1 drugs. However, 
+randomized controlled trials with larger sample sizes are still needed. Positron 
+emission tomography-computed tomography (PET-CT) is mainly used to assess the 
+curative effect after treatment and to guide the subsequent treatment strategy.
+
+© 2021 The Authors. Thoracic Cancer published by China Lung Oncology Group and 
+John Wiley & Sons Australia, Ltd.
+
+DOI: 10.1111/1759-7714.14155
+PMCID: PMC8563158
+PMID: 34590432 [Indexed for MEDLINE]
+
+Conflict of interest statement: All authors declare no conflict of interest.

--- a/references_cache/clinicaltrials_NCT00265889.md
+++ b/references_cache/clinicaltrials_NCT00265889.md
@@ -1,0 +1,13 @@
+---
+reference_id: clinicaltrials:NCT00265889
+title: "Tandem Autologous Stem Cell Transplantation for Patients With Primary Progressive or Poor Risk Recurrent Hodgkin's Disease"
+content_type: summary
+---
+
+# Tandem Autologous Stem Cell Transplantation for Patients With Primary Progressive or Poor Risk Recurrent Hodgkin's Disease
+
+## Content
+
+RATIONALE: Giving two autologous stem cell transplants (one after the other) may be an effective treatment for Hodgkin's lymphoma.
+
+PURPOSE: This phase II trial is studying how well giving two autologous stem cell transplants works in treating patients with progressive or recurrent Hodgkin's lymphoma.

--- a/references_cache/clinicaltrials_NCT02181738.md
+++ b/references_cache/clinicaltrials_NCT02181738.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT02181738
+title: "Non-Comparative, Multi-Cohort, Single Arm, Open-Label, Phase 2 Study of Nivolumab (BMS-936558) in Classical Hodgkin Lymphoma (cHL) Subjects"
+content_type: summary
+---
+
+# Non-Comparative, Multi-Cohort, Single Arm, Open-Label, Phase 2 Study of Nivolumab (BMS-936558) in Classical Hodgkin Lymphoma (cHL) Subjects
+
+## Content
+
+The purpose of this study is to evaluate the efficacy and safety of Nivolumab in previously treated (cohorts, A, B \& C) or newly diagnosed (cohort D) classical Hodgkin Lymphoma participants.

--- a/research/Classic_Hodgkin_Lymphoma-deep-research-asta.md
+++ b/research/Classic_Hodgkin_Lymphoma-deep-research-asta.md
@@ -2,14 +2,14 @@
 provider: asta
 model: Asta Scientific Corpus Retrieval
 cached: false
-start_time: '2026-04-11T21:00:14.704519'
-end_time: '2026-04-11T21:00:18.355347'
-duration_seconds: 3.65
+start_time: '2026-04-21T08:23:33.827479'
+end_time: '2026-04-21T08:23:40.898797'
+duration_seconds: 7.07
 template_file: templates/disease_pathophysiology_research_asta.md
 template_variables:
   disease_name: Classic Hodgkin Lymphoma
   mondo_id: ''
-  category: Complex
+  category: Cancer
 provider_config:
   timeout: null
   max_retries: 3
@@ -50,7 +50,7 @@ This report is retrieval-only and is generated directly from Asta results.
 - DOI: 10.3390/ijms26104701
 - PMID: 40429842
 - PMCID: 12112708
-- Citations: 5
+- Citations: 6
 - Summary: Recent advances in combating P-gp-mediated resistance are examined, including the development of novel P-gp inhibitors, innovative drug delivery systems, and strategies to modulate P-gp expression or activity, including targeting relevant signaling pathways and exploring drug repurposing.
 - Evidence snippets:
   - Snippet 1 (score: 0.478)

--- a/research/Classic_Hodgkin_Lymphoma-deep-research-asta.md.citations.md
+++ b/research/Classic_Hodgkin_Lymphoma-deep-research-asta.md.citations.md
@@ -2,7 +2,7 @@
 
 **Query:** Pathophysiology and clinical mechanisms of Classic Hodgkin Lymphoma. Core disease mechanisms, molecular and cellular pathways, involved genes and proteins, relevant metabolites or drugs, affected cell types and anatomical structures, disease progression, major clinical phenotypes and complications, and treatment-relevant mechanism papers.
 **Provider:** asta
-**Generated:** 2026-04-11T21:00:18.355347
+**Generated:** 2026-04-21T08:23:40.898797
 
 1. Pablo Álvarez-Carrasco, Fernanda Morales-Villamil, C. Maldonado-Bernal (2025). P-Glycoprotein as a Therapeutic Target in Hematological Malignancies: A Challenge to Overcome. International Journal of Molecular Sciences. https://www.semanticscholar.org/paper/e5804b5ab8e1ed680a595670111915afd0be21fd
 2. Marcelo Antônio Oliveira Santos, M. M. Lima (2017). CD20 role in pathophysiology of Hodgkin's disease.. Revista da Associacao Medica Brasileira. https://www.semanticscholar.org/paper/04e73161107ceb5fae03a0e118c8f7dd6c33543c


### PR DESCRIPTION
Issue-driven enhancement of the existing classic Hodgkin lymphoma page using Asta research and additional schema coverage.

Changes include:
- remove histologic subtype split per issue guidance
- add differential diagnoses, clinical trials, and dataset coverage
- add nivolumab coverage and strengthen checkpoint-centered mechanism modeling
- refresh evidence and updated_date

Validation: `just validate kb/disorders/Classic_Hodgkin_Lymphoma.yaml`