### PR TITLE
feat: update DK1-congenital disorder of glycosylation

### DIFF
--- a/kb/disorders/DK1-congenital_disorder_of_glycosylation.yaml
+++ b/kb/disorders/DK1-congenital_disorder_of_glycosylation.yaml
@@ -1,6 +1,6 @@
 name: DK1-congenital disorder of glycosylation
 creation_date: "2026-04-15T23:36:42Z"
-updated_date: "2026-04-16T01:04:42Z"
+updated_date: "2026-04-21T21:14:34Z"
 description: >-
   DK1-congenital disorder of glycosylation is an autosomal recessive DOLK-
   related congenital disorder of glycosylation characterized by impaired
@@ -133,6 +133,21 @@ pathophysiology:
       explanation: >-
         DOLK mutations produce deficient protein N-glycosylation (the defining
         CDG biochemical signature of defective glycoprotein maturation).
+  - target: Epidermal lipid metabolism defect
+    description: >-
+      Severe cutaneous DOLK-CDG includes epidermal lipid-handling defects that
+      contribute to the ichthyotic skin phenotype.
+    evidence:
+    - reference: PMID:28816422
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Histology of the skin showed lipid droplet accumulation in the stratum
+        corneum and keratinocytes, which suggests defective epidermal lipid
+        metabolism.
+      explanation: >-
+        This directly supports epidermal lipid metabolic disruption as a
+        downstream consequence of DOLK deficiency in the skin.
 - name: Abnormal alpha-dystroglycan O-mannosylation
   description: >-
     DOLK-related glycosylation defects reduce O-mannosylation of
@@ -199,16 +214,56 @@ pathophysiology:
     description: Multisystem metabolic disease contributes to poor growth and feeding difficulty.
   - target: Microcytic anemia
     description: Abnormal glycoprotein biology can accompany chronic microcytic anemia.
+  - target: Leukopenia
+    description: >-
+      Marrow and glycoprotein abnormalities can be accompanied by recurrent
+      leukopenia.
   - target: Renal insufficiency
     description: Severe multisystem involvement can include renal dysfunction.
   - target: Hyperglycemia
     description: Severe neonatal disease may include insulin-resistant hyperglycemia.
+  - target: Hypoglycemia
+    description: >-
+      Some patients with syndromic ichthyotic DOLK-CDG develop neonatal or
+      infantile hypoglycemia.
   - target: Global developmental delay
     description: Neurodevelopmental impairment is part of the broad CDG phenotype.
   - target: Abnormal facial shape
     description: Dysmorphic features can occur in severe multisystem disease.
   - target: Talipes equinovarus
     description: Fetal hypokinesia and muscular dystrophy can contribute to limb contractures.
+- name: Epidermal lipid metabolism defect
+  description: >-
+    DOLK-related glycosylation abnormalities can disrupt epidermal lipid
+    metabolism, producing keratinocyte lipid-droplet accumulation and severe
+    ichthyosis.
+  evidence:
+  - reference: PMID:28816422
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histology of the skin showed lipid droplet accumulation in the stratum
+      corneum and keratinocytes, which suggests defective epidermal lipid
+      metabolism.
+    explanation: >-
+      This provides a direct cutaneous mechanistic correlate for the
+      ichthyosiform phenotype in severe neonatal DOLK-CDG.
+  downstream:
+  - target: Ichthyosis
+    description: >-
+      Defective epidermal lipid metabolism contributes to the congenital
+      ichthyotic skin phenotype.
+    evidence:
+    - reference: PMID:28816422
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Both patients presented in the neonatal period with severe ichthyosis,
+        unusual distal digital constrictions and dilated cardiomyopathy which
+        resulted in death.
+      explanation: >-
+        This links the skin-specific pathophysiology to severe ichthyosis in
+        affected neonates.
 phenotypes:
 - name: Dilated cardiomyopathy
   category: Cardiovascular
@@ -373,6 +428,26 @@ phenotypes:
       episodes of leucopenia without thrombocytopenia.
     explanation: >-
       This supports microcytic anemia as a frequent hematologic feature.
+- name: Leukopenia
+  category: Hematologic
+  description: >-
+    Recurrent leukopenia has been reported alongside chronic microcytic anemia
+    in cohort studies of DK1-CDG.
+  phenotype_term:
+    preferred_term: Leukopenia
+    term:
+      id: HP:0001882
+      label: Decreased total leukocyte count
+  evidence:
+  - reference: PMID:22327749
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Most patients presented with chronic microcytic anemia and recurrent
+      episodes of leucopenia without thrombocytopenia.
+    explanation: >-
+      This directly supports recurrent leukopenia as part of the DK1-CDG
+      hematologic phenotype.
 - name: Hyperglycemia
   category: Endocrine
   description: >-
@@ -397,6 +472,28 @@ phenotypes:
       did not stabilize the glucose.
     explanation: >-
       This directly supports severe neonatal hyperglycemia in DK1-CDG.
+- name: Hypoglycemia
+  category: Endocrine
+  description: >-
+    Hypoglycemia has also been reported within the fatal neonatal syndromic
+    ichthyosis presentation of DOLK-CDG.
+  phenotype_term:
+    preferred_term: Hypoglycemia
+    term:
+      id: HP:0001943
+      label: Hypoglycemia
+  evidence:
+  - reference: PMID:34956305
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the congenital skin phenotype (often ichthyosis) is later associated with
+      variable extracutaneous features such as dilatative cardiomyopathy,
+      epilepsy, microcephaly, visual impairment, and hypoglycemia and may lead
+      to a fatal course.
+    explanation: >-
+      This explicitly supports hypoglycemia as an extracutaneous endocrine
+      manifestation of severe neonatal DOLK-CDG.
 - name: Renal insufficiency
   category: Renal
   description: >-

--- a/research/DK1-congenital_disorder_of_glycosylation-deep-research-asta.md
+++ b/research/DK1-congenital_disorder_of_glycosylation-deep-research-asta.md
@@ -1,10 +1,10 @@
 ---
 provider: asta
 model: Asta Scientific Corpus Retrieval
-cached: false
-start_time: '2026-04-15T19:37:01.489974'
-end_time: '2026-04-15T19:37:05.621715'
-duration_seconds: 4.13
+cached: true
+start_time: '2026-04-21T17:02:46.427211'
+end_time: '2026-04-21T17:02:46.439349'
+duration_seconds: 0.01
 template_file: templates/disease_pathophysiology_research_asta.md
 template_variables:
   disease_name: DK1-congenital disorder of glycosylation

--- a/research/DK1-congenital_disorder_of_glycosylation-deep-research-asta.md.citations.md
+++ b/research/DK1-congenital_disorder_of_glycosylation-deep-research-asta.md.citations.md
@@ -2,7 +2,7 @@
 
 **Query:** Pathophysiology and clinical mechanisms of DK1-congenital disorder of glycosylation. Core disease mechanisms, molecular and cellular pathways, involved genes and proteins, relevant metabolites or drugs, affected cell types and anatomical structures, disease progression, major clinical phenotypes and complications, and treatment-relevant mechanism papers.
 **Provider:** asta
-**Generated:** 2026-04-15T19:37:05.621715
+**Generated:** 2026-04-21T17:02:46.439349
 
 1. I. Muffels, R. Budhraja, R. Shah, S. Radenkovic, E. Morava et al. (2025). Predicting disease-overarching therapeutic approaches for Congenital Disorders of Glycosylation using multi-OMICS. bioRxiv. https://www.semanticscholar.org/paper/8f9edb863a2ede55b3a106e304d7bef842ac19b5
 2. E. Klaver, Lynn Dukes-Rimsky, B. Kumar, Zhi-Jie Xia, Tammie Dang et al. (2021). Protease-dependent defects in N-cadherin processing drive PMM2-CDG pathogenesis. JCI Insight. https://www.semanticscholar.org/paper/1964b8cddfd573cfd6e04b619109ace9f23d48e8


### PR DESCRIPTION
## Summary
- enrich the existing DK1-congenital disorder of glycosylation page with added mechanistic granularity for epidermal lipid metabolism defects
- add supported leukopenia and hypoglycemia phenotypes and refresh the disorder updated timestamp
- keep the refreshed Asta research provenance files with the update PR scope

## Validation
- `just validate kb/disorders/DK1-congenital_disorder_of_glycosylation.yaml`

## Not changed
- no clinical trials or datasets were added because the current evidence in the branch did not justify them
- unrelated validator-generated cache churn in the worktree was intentionally left unstaged