### PR TITLE
Expand qualifiers: onset, temporality, clinical course, and severity

### DIFF
--- a/.claude/skills/dismech-pr-review/SKILL.md
+++ b/.claude/skills/dismech-pr-review/SKILL.md
@@ -102,8 +102,15 @@ Split mixed sources into separate evidence items.
 Add qualifiers when needed for precision:
 - Location (`located_in`)
 - Direction (`INCREASED`, `DECREASED`, `ABERRANT`)
-- Temporal (`recurrent`, `chronic`)
+- Temporal (`temporality: RECURRENT`, `temporality: CHRONIC`, `temporality: ACUTE`)
 - Laterality (when applicable)
+- Clinical course (`clinical_course: PROGRESSIVE` / `STABLE`)
+- Descriptor severity (`severity: MILD|MODERATE|SEVERE`)
+- Descriptor onset (`onset.onset_category: CHILDHOOD`, etc.)
+
+Prefer the explicit descriptor slots above over the deprecated generic `qualifiers`
+field for common post-composition. Reserve `qualifiers` for predicate-value cases
+that are not covered by dedicated slots.
 
 7. Section Appropriateness
 Put content in the correct section:

--- a/.claude/skills/dismech-pr-review/SKILL.md
+++ b/.claude/skills/dismech-pr-review/SKILL.md
@@ -102,7 +102,7 @@ Split mixed sources into separate evidence items.
 Add qualifiers when needed for precision:
 - Location (`located_in`)
 - Direction (`INCREASED`, `DECREASED`, `ABERRANT`)
-- Temporal (`temporality: RECURRENT`, `temporality: CHRONIC`, `temporality: ACUTE`)
+- Temporal (`temporality: RECURRENT`, `CHRONIC`, `ACUTE`, `SUBACUTE`, `TRANSIENT`, etc.)
 - Laterality (when applicable)
 - Clinical course (`clinical_course: PROGRESSIVE` / `STABLE`)
 - Descriptor severity (`severity: MILD|MODERATE|SEVERE`)

--- a/.claude/skills/dismech-terms/SKILL.md
+++ b/.claude/skills/dismech-terms/SKILL.md
@@ -155,6 +155,44 @@ for f in glob.glob("kb/disorders/*.yaml"):
    ```
 4. Validate: `just validate-terms`
 
+### Descriptor Qualifiers for Common Clinical Modifiers
+
+When a base ontology term needs common clinical qualification, prefer the explicit
+descriptor slots instead of the deprecated generic `qualifiers` list:
+
+```yaml
+phenotype_term:
+  preferred_term: Diarrhea
+  term:
+    id: HP:0002014
+    label: Diarrhea
+  temporality: CHRONIC
+
+phenotype_term:
+  preferred_term: Muscle weakness
+  term:
+    id: HP:0001324
+    label: Muscle weakness
+  clinical_course: PROGRESSIVE
+
+phenotype_term:
+  preferred_term: Meningitis
+  term:
+    id: HP:0001287
+    label: Meningitis
+  severity: SEVERE
+  onset:
+    onset_category: NEONATAL
+```
+
+Enum values with ontology `meaning` mappings:
+- `temporality`: `ACUTE` = `HP:0011009`, `CHRONIC` = `HP:0011010`, `RECURRENT` = `HP:0031796`
+- `clinical_course`: `PROGRESSIVE` = `HP:0003676`, `STABLE` = `HP:0031915`
+- `severity`: `MILD` = `HP:0012825`, `MODERATE` = `HP:0012826`, `SEVERE` = `HP:0012828`
+
+Prefer a precoordinated ontology term when one already exists; otherwise add the
+qualifier in these dedicated slots.
+
 ### Adding CL to Cell Types
 1. Look up term: `uv run runoak -i sqlite:obo:cl info "l~<cell type>"`
 2. Verify specificity

--- a/.claude/skills/dismech-terms/SKILL.md
+++ b/.claude/skills/dismech-terms/SKILL.md
@@ -186,7 +186,9 @@ phenotype_term:
 ```
 
 Enum values with ontology `meaning` mappings:
-- `temporality`: `ACUTE` = `HP:0011009`, `CHRONIC` = `HP:0011010`, `RECURRENT` = `HP:0031796`
+- `temporality`: `ACUTE` = `HP:0011009`, `TRANSIENT` = `HP:0025153`,
+  `SUBACUTE` = `HP:0011011`, `CHRONIC` = `HP:0011010`, `RECURRENT` = `HP:0031796`,
+  `DIURNAL` = `HP:0025302`, `NOCTURNAL` = `HP:0025301`, `PROLONGED` = `HP:0025297`
 - `clinical_course`: `PROGRESSIVE` = `HP:0003676`, `STABLE` = `HP:0031915`
 - `severity`: `MILD` = `HP:0012825`, `MODERATE` = `HP:0012826`, `SEVERE` = `HP:0012828`
 

--- a/.claude/skills/projman/agents/openai.yaml
+++ b/.claude/skills/projman/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Project Manager"
+  short_description: "Manage markdown projects and GitHub sync"
+  default_prompt: "Use $projman to update a file in `projects/`, record session notes, and sync the project state to GitHub when needed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,8 @@ This prevents AI hallucination of fake or mismatched ontology terms.
 Common clinical qualifiers on ontology-bound descriptors should use explicit slots on
 the descriptor object rather than the deprecated generic `qualifiers` list:
 
-- `temporality`: `ACUTE`, `CHRONIC`, `RECURRENT`
+- `temporality`: `ACUTE`, `TRANSIENT`, `SUBACUTE`, `CHRONIC`, `RECURRENT`,
+  `DIURNAL`, `NOCTURNAL`, `PROLONGED`
 - `clinical_course`: `PROGRESSIVE`, `STABLE`
 - `severity`: prefer enum-backed values (`MILD`, `MODERATE`, `SEVERE`) when the qualifier
   is part of the ontology post-composition; free text is still tolerated for legacy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,38 @@ uv run runoak -i sqlite:obo:hp info HP:0040282 -O obo
 
 This prevents AI hallucination of fake or mismatched ontology terms.
 
+### Descriptor Qualifier Slots
+
+Common clinical qualifiers on ontology-bound descriptors should use explicit slots on
+the descriptor object rather than the deprecated generic `qualifiers` list:
+
+- `temporality`: `ACUTE`, `CHRONIC`, `RECURRENT`
+- `clinical_course`: `PROGRESSIVE`, `STABLE`
+- `severity`: prefer enum-backed values (`MILD`, `MODERATE`, `SEVERE`) when the qualifier
+  is part of the ontology post-composition; free text is still tolerated for legacy
+  phenotype/context summaries
+- `onset`: structured `OnsetDescriptor` with `onset_category` and optional age fields
+
+Pattern:
+```yaml
+phenotype_term:
+  preferred_term: Diarrhea
+  term:
+    id: HP:0002014
+    label: Diarrhea
+  temporality: CHRONIC
+
+phenotype_term:
+  preferred_term: Muscle weakness
+  term:
+    id: HP:0001324
+    label: Muscle weakness
+  clinical_course: PROGRESSIVE
+```
+
+Use these first-class slots for common post-composition. Reserve `qualifiers` for
+more complex predicate-value patterns that are not covered by dedicated slots.
+
 ### `preferred_term` vs Ontology Term Labels
 
 Each descriptor (phenotype, cell type, treatment, etc.) has two distinct label fields with different rules:

--- a/docs/explanation/post-composition.md
+++ b/docs/explanation/post-composition.md
@@ -22,6 +22,11 @@ The Descriptor base class provides explicit slots for post-composition:
 | `modifier` | Directional/qualitative change | `ModifierEnum` | All Descriptors |
 | `located_in` | Anatomical location | `AnatomicalEntityDescriptor` | All Descriptors |
 | `laterality` | Left/right/bilateral | `LateralityEnum` | All Descriptors |
+| `spatial_extent` | Distribution/extent pattern | `SpatialExtentEnum` | All Descriptors |
+| `temporality` | Acute/chronic/recurrent qualifier | `TemporalityEnum` | All Descriptors |
+| `clinical_course` | Progressive/stable course qualifier | `ClinicalCourseEnum` | All Descriptors |
+| `severity` | Mild/moderate/severe qualifier | `SeverityQualifierEnum` (or legacy free text) | All Descriptors |
+| `onset` | Structured onset metadata | `OnsetDescriptor` | All Descriptors |
 | `therapeutic_agent` | Drug/chemical used in treatment | `ChemicalEntityDescriptor` | TreatmentDescriptor |
 
 ### 1. The `modifier` Slot
@@ -134,6 +139,56 @@ This expresses: "pharmacotherapy using zinc acetate"
 - Use NCIT for drug classes when specific CHEBI term unavailable
 - Only available on `TreatmentDescriptor` (used in `treatment_term`)
 
+### 5. Temporal / Course / Severity / Onset Slots
+
+These slots cover common clinical qualifiers that previously required the deprecated
+generic `qualifiers` pattern.
+
+```yaml
+phenotype_term:
+  preferred_term: Diarrhea
+  term:
+    id: HP:0002014
+    label: Diarrhea
+  temporality: CHRONIC
+
+phenotype_term:
+  preferred_term: Muscle weakness
+  term:
+    id: HP:0001324
+    label: Muscle weakness
+  clinical_course: PROGRESSIVE
+
+phenotype_term:
+  preferred_term: Meningitis
+  term:
+    id: HP:0001287
+    label: Meningitis
+  severity: SEVERE
+  onset:
+    onset_category: NEONATAL
+```
+
+**Available temporality values** (`TemporalityEnum`):
+- `ACUTE`
+- `CHRONIC`
+- `RECURRENT`
+
+**Available clinical course values** (`ClinicalCourseEnum`):
+- `PROGRESSIVE`
+- `STABLE`
+
+**Available severity values** (`SeverityQualifierEnum`):
+- `MILD`
+- `MODERATE`
+- `SEVERE`
+
+**Guidance:**
+- Prefer these explicit slots over `qualifiers` for common clinical qualification.
+- Prefer precoordinated ontology terms when the ontology already has the exact term.
+- Use `onset` when onset timing itself is part of the descriptor semantics rather than
+  a cohort-specific phenotype-context statement.
+
 **Example from `Wilsons_Disease.yaml`:**
 ```yaml
 - name: Zinc Acetate
@@ -180,6 +235,10 @@ The generic `qualifiers` slot (predicate-value pairs) is **deprecated**. It prov
 - For anatomical location: use `located_in`
 - For laterality: use `laterality`
 - For directional changes: use `modifier`
+- For temporality: use `temporality`
+- For course: use `clinical_course`
+- For qualifier severity: use descriptor `severity`
+- For onset: use descriptor `onset`
 
 If you encounter a post-composition need not covered by these slots, open an issue to discuss adding a new explicit slot rather than using the deprecated `qualifiers` pattern.
 
@@ -216,6 +275,22 @@ phenotype_term:
 - The condition/finding is unilateral or bilateral
 - Distinguishing left vs right side involvement
 - The laterality is not captured in the base term
+
+### Use `temporality` when:
+- The base term needs an acute/chronic/recurrent qualifier
+- The ontology lacks the exact precoordinated acute/chronic/recurrent term
+
+### Use `clinical_course` when:
+- The manifestation is specifically progressive or stable over time
+- The course qualifier is part of the descriptor semantics rather than a disease-phase label
+
+### Use descriptor `severity` when:
+- You need an ontology-aligned mild/moderate/severe qualifier on a descriptor
+- The severity modifies the bound term itself (for example, severe coma)
+
+### Use descriptor `onset` when:
+- Onset timing qualifies the descriptor itself
+- You want structured onset categories or age summaries on the descriptor
 
 ## The "Below the Shoreline" Problem
 

--- a/docs/explanation/post-composition.md
+++ b/docs/explanation/post-composition.md
@@ -23,7 +23,7 @@ The Descriptor base class provides explicit slots for post-composition:
 | `located_in` | Anatomical location | `AnatomicalEntityDescriptor` | All Descriptors |
 | `laterality` | Left/right/bilateral | `LateralityEnum` | All Descriptors |
 | `spatial_extent` | Distribution/extent pattern | `SpatialExtentEnum` | All Descriptors |
-| `temporality` | Acute/chronic/recurrent qualifier | `TemporalityEnum` | All Descriptors |
+| `temporality` | Acute/chronic/recurrent/subacute/etc. qualifier | `TemporalityEnum` | All Descriptors |
 | `clinical_course` | Progressive/stable course qualifier | `ClinicalCourseEnum` | All Descriptors |
 | `severity` | Mild/moderate/severe qualifier | `SeverityQualifierEnum` (or legacy free text) | All Descriptors |
 | `onset` | Structured onset metadata | `OnsetDescriptor` | All Descriptors |
@@ -171,8 +171,13 @@ phenotype_term:
 
 **Available temporality values** (`TemporalityEnum`):
 - `ACUTE`
+- `TRANSIENT`
+- `SUBACUTE`
 - `CHRONIC`
 - `RECURRENT`
+- `DIURNAL`
+- `NOCTURNAL`
+- `PROLONGED`
 
 **Available clinical course values** (`ClinicalCourseEnum`):
 - `PROGRESSIVE`

--- a/kb/disorders/CINCA_Syndrome.yaml
+++ b/kb/disorders/CINCA_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: CINCA Syndrome
 creation_date: '2026-02-09T17:35:00Z'
-updated_date: '2026-02-17T21:53:14Z'
+updated_date: '2026-04-22T18:49:52Z'
 category: Mendelian
 synonyms:
 - Neonatal-onset multisystem inflammatory disease
@@ -572,14 +572,16 @@ phenotypes:
     Aseptic meningitis is part of the diagnostic triad of NOMID and
     is present in the majority of patients; its chronicity
     distinguishes CINCA from the milder CAPS phenotypes.
-  context: Chronic, from neonatal period
-  severity: Severe
   diagnostic: true
   phenotype_term:
     preferred_term: Meningitis
     term:
       id: HP:0001287
       label: Meningitis
+    temporality: CHRONIC
+    severity: SEVERE
+    onset:
+      onset_category: NEONATAL
   evidence:
   - reference: PMID:16899778
     reference_title: "Neonatal-onset multisystem inflammatory disease responsive to interleukin-1beta inhibition."

--- a/kb/disorders/Malaria.yaml
+++ b/kb/disorders/Malaria.yaml
@@ -1,6 +1,6 @@
 name: Malaria
 creation_date: "2026-02-20T00:00:00Z"
-updated_date: "2026-02-20T16:02:29Z"
+updated_date: "2026-04-22T18:49:52Z"
 description: >-
   Malaria is a mosquito-borne protozoal infection caused by Plasmodium species,
   with major global burden from Plasmodium falciparum and Plasmodium vivax.
@@ -406,6 +406,7 @@ phenotypes:
     term:
       id: HP:0001945
       label: Fever
+    temporality: ACUTE
   frequency: VERY_FREQUENT
   diagnostic: true
   evidence:
@@ -524,12 +525,12 @@ phenotypes:
 - name: Coma
   description: Cerebral malaria can present with coma as a defining severe neurologic manifestation.
   subtype: Cerebral malaria
-  severity: Severe
   phenotype_term:
     preferred_term: Coma
     term:
       id: HP:0001259
       label: Coma
+    severity: SEVERE
   frequency: OCCASIONAL
   diagnostic: true
   evidence:
@@ -542,12 +543,12 @@ phenotypes:
 - name: Seizure
   description: Seizures are a major severe neurologic manifestation in cerebral malaria.
   subtype: Cerebral malaria
-  severity: Severe
   phenotype_term:
     preferred_term: Seizure
     term:
       id: HP:0001250
       label: Seizure
+    severity: SEVERE
   frequency: OCCASIONAL
   diagnostic: true
   evidence:

--- a/kb/disorders/Myotonic_Dystrophy_Type_1.yaml
+++ b/kb/disorders/Myotonic_Dystrophy_Type_1.yaml
@@ -1,6 +1,6 @@
 name: Myotonic Dystrophy Type 1
 creation_date: "2026-03-06T00:00:00Z"
-updated_date: "2026-03-06T06:25:00Z"
+updated_date: "2026-04-22T18:49:52Z"
 description: >
   Myotonic dystrophy type 1 (DM1), also known as Steinert disease, is an autosomal
   dominant multisystem disorder caused by expansion of a CTG trinucleotide repeat
@@ -138,6 +138,7 @@ phenotypes:
     term:
       id: HP:0001324
       label: Muscle weakness
+    clinical_course: PROGRESSIVE
   evidence:
   - reference: PMID:28780071
     reference_title: "Myotonic dystrophy: candidate small molecule therapeutics."

--- a/kb/disorders/Whipple_Disease.yaml
+++ b/kb/disorders/Whipple_Disease.yaml
@@ -1,6 +1,6 @@
 name: Whipple Disease
 creation_date: '2026-01-14T23:44:48Z'
-updated_date: '2026-04-11T01:06:52Z'
+updated_date: '2026-04-22T18:49:52Z'
 category: Infectious
 description: >
   Whipple disease is a chronic, multisystem infection caused by the actinomycete
@@ -107,6 +107,7 @@ phenotypes:
     term:
       id: HP:0002014
       label: Diarrhea
+    temporality: CHRONIC
   evidence:
   - reference: PMID:26288590
     reference_title: "Whipple's Disease."

--- a/src/dismech/export/tabular_export.py
+++ b/src/dismech/export/tabular_export.py
@@ -555,6 +555,14 @@ class TabularExporter:
                 self._append_if_value(aggregated, "postcomp_modifier", value_text or value_literal)
             elif relation_type == "laterality":
                 self._append_if_value(aggregated, "postcomp_laterality", value_text or value_literal)
+            elif relation_type == "temporality":
+                self._append_if_value(aggregated, "postcomp_temporality", value_text or value_literal)
+            elif relation_type == "clinical_course":
+                self._append_if_value(aggregated, "postcomp_clinical_course", value_text or value_literal)
+            elif relation_type == "severity":
+                self._append_if_value(aggregated, "postcomp_severity", value_text or value_literal)
+            elif relation_type == "onset":
+                self._append_if_value(aggregated, "postcomp_onset", value_text or value_literal)
             elif relation_type == "located_in":
                 self._append_if_value(aggregated, "postcomp_located_in", value_text)
                 self._append_if_value(aggregated, "postcomp_located_in_ids", value_id)
@@ -669,6 +677,10 @@ class TabularExporter:
                 "MIN(value_term_label) FILTER (WHERE relation_type = 'located_in') AS located_in_term_label, "
                 "MIN(value_literal) FILTER (WHERE relation_type = 'laterality') AS laterality, "
                 "MIN(value_literal) FILTER (WHERE relation_type = 'modifier') AS modifier, "
+                "MIN(value_literal) FILTER (WHERE relation_type = 'temporality') AS temporality, "
+                "MIN(value_literal) FILTER (WHERE relation_type = 'clinical_course') AS clinical_course, "
+                "MIN(value_literal) FILTER (WHERE relation_type = 'severity') AS severity, "
+                "MIN(value_literal) FILTER (WHERE relation_type = 'onset') AS onset, "
                 "STRING_AGG(value_term_label, '; ' ORDER BY relation_index) FILTER (WHERE relation_type = 'therapeutic_agent') AS therapeutic_agents, "
                 "STRING_AGG(predicate_term_label, '; ' ORDER BY relation_index) FILTER (WHERE relation_type = 'qualifier') AS qualifier_predicates, "
                 "STRING_AGG(value_term_label, '; ' ORDER BY relation_index) FILTER (WHERE relation_type = 'qualifier') AS qualifier_values "
@@ -756,6 +768,65 @@ class TabularExporter:
                 predicate_preferred_term="laterality",
                 value_literal=str(laterality),
                 raw_value=laterality,
+            )
+
+        temporality = descriptor.get("temporality")
+        if temporality not in (None, ""):
+            add_row(
+                relation_type="temporality",
+                relation_index=0,
+                relation_path=f"{descriptor_path}.temporality",
+                predicate_preferred_term="temporality",
+                value_literal=str(temporality),
+                raw_value=temporality,
+            )
+
+        clinical_course = descriptor.get("clinical_course")
+        if clinical_course not in (None, ""):
+            add_row(
+                relation_type="clinical_course",
+                relation_index=0,
+                relation_path=f"{descriptor_path}.clinical_course",
+                predicate_preferred_term="clinical_course",
+                value_literal=str(clinical_course),
+                raw_value=clinical_course,
+            )
+
+        severity = descriptor.get("severity")
+        if severity not in (None, ""):
+            add_row(
+                relation_type="severity",
+                relation_index=0,
+                relation_path=f"{descriptor_path}.severity",
+                predicate_preferred_term="severity",
+                value_literal=str(severity),
+                raw_value=severity,
+            )
+
+        onset = descriptor.get("onset")
+        if isinstance(onset, dict):
+            onset_parts: list[str] = []
+            onset_category = onset.get("onset_category")
+            mean_age_years = onset.get("mean_age_years")
+            min_age_years = onset.get("min_age_years")
+            max_age_years = onset.get("max_age_years")
+            if onset_category not in (None, ""):
+                onset_parts.append(str(onset_category))
+            if mean_age_years is not None:
+                onset_parts.append(f"mean {mean_age_years}y")
+            if min_age_years is not None and max_age_years is not None:
+                onset_parts.append(f"{min_age_years}-{max_age_years}y")
+            elif min_age_years is not None:
+                onset_parts.append(f"from {min_age_years}y")
+            elif max_age_years is not None:
+                onset_parts.append(f"up to {max_age_years}y")
+            add_row(
+                relation_type="onset",
+                relation_index=0,
+                relation_path=f"{descriptor_path}.onset",
+                predicate_preferred_term="onset",
+                value_literal="; ".join(onset_parts),
+                raw_value=onset,
             )
 
         located_in = descriptor.get("located_in")
@@ -873,6 +944,10 @@ class TabularExporter:
                 "modifier",
                 "located_in",
                 "laterality",
+                "temporality",
+                "clinical_course",
+                "severity",
+                "onset",
                 "qualifiers",
                 "therapeutic_agent",
                 "dietary_modifications",

--- a/src/dismech/render.py
+++ b/src/dismech/render.py
@@ -508,7 +508,26 @@ def _collect_unique_descriptors(
             label = _descriptor_display_label(descriptor)
             term_id = str(term.get("id") or "").strip()
             modifier = str(descriptor.get("modifier") or "").strip()
-            key = (term_id or label, modifier)
+            laterality = str(descriptor.get("laterality") or "").strip()
+            spatial_extent = str(descriptor.get("spatial_extent") or "").strip()
+            temporality = str(descriptor.get("temporality") or "").strip()
+            clinical_course = str(descriptor.get("clinical_course") or "").strip()
+            severity = str(descriptor.get("severity") or "").strip()
+            onset = descriptor.get("onset")
+            onset_key = ""
+            if isinstance(onset, dict):
+                onset_key = json.dumps(onset, sort_keys=True)
+
+            key = (
+                term_id or label,
+                modifier,
+                laterality,
+                spatial_extent,
+                temporality,
+                clinical_course,
+                severity,
+                onset_key,
+            )
             if not key[0] or key in seen:
                 continue
 
@@ -518,6 +537,12 @@ def _collect_unique_descriptors(
                     "label": label or term_id,
                     "id": term_id or None,
                     "modifier": modifier or None,
+                    "laterality": laterality or None,
+                    "spatial_extent": spatial_extent or None,
+                    "temporality": temporality or None,
+                    "clinical_course": clinical_course or None,
+                    "severity": severity or None,
+                    "onset": onset if isinstance(onset, dict) else None,
                 }
             )
 

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -478,6 +478,47 @@ enums:
       SEGMENTAL:
         title: Segmental
         description: Affecting a specific segment or dermatome
+  TemporalityEnum:
+    description: Temporal qualifiers for descriptor post-composition
+    permissible_values:
+      ACUTE:
+        title: Acute
+        description: Acute manifestation or episode
+        meaning: HP:0011009
+      CHRONIC:
+        title: Chronic
+        description: Chronic or persistent over time
+        meaning: HP:0011010
+      RECURRENT:
+        title: Recurrent
+        description: Repeated episodes separated by symptom-free intervals
+        meaning: HP:0031796
+  ClinicalCourseEnum:
+    description: Clinical course qualifiers for descriptor post-composition
+    permissible_values:
+      PROGRESSIVE:
+        title: Progressive
+        description: Worsening over time
+        meaning: HP:0003676
+      STABLE:
+        title: Stable
+        description: Not varying in severity or amount over time
+        meaning: HP:0031915
+  SeverityQualifierEnum:
+    description: Severity qualifiers for descriptor post-composition
+    permissible_values:
+      MILD:
+        title: Mild
+        description: Mild severity
+        meaning: HP:0012825
+      MODERATE:
+        title: Moderate
+        description: Moderate severity
+        meaning: HP:0012826
+      SEVERE:
+        title: Severe
+        description: Severe severity
+        meaning: HP:0012828
   AssayTerm:
     description: A term representing an assay
     reachable_from:
@@ -1154,8 +1195,14 @@ slots:
     description: Laterality qualifier (left, right, or bilateral)
     range: LateralityEnum
   spatial_extent:
-    description: The spatial extent or distribution pattern of this phenotype or process (e.g., focal, diffuse, extensive)
+    description: The spatial extent or distribution pattern applicable to this descriptor (e.g., focal, diffuse, extensive)
     range: SpatialExtentEnum
+  temporality:
+    description: Temporal qualifier for this descriptor (e.g., acute, chronic, recurrent)
+    range: TemporalityEnum
+  clinical_course:
+    description: Clinical course qualifier for this descriptor (e.g., progressive, stable)
+    range: ClinicalCourseEnum
   therapeutic_agent:
     description: >-
       The drug, chemical, or therapeutic agent used in a treatment. Use when the MAXO term
@@ -1598,7 +1645,10 @@ slots:
   severity:
     examples:
       - value: Severe
-    range: string
+    range: Any
+    any_of:
+      - range: SeverityQualifierEnum
+      - range: string
   presence:
     examples:
       - value: Positive
@@ -2523,7 +2573,8 @@ classes:
     description: >-
       Base class for structured descriptors that allow a preferred term,
       optional description, optional ontology term binding, and post-composition
-      via modifier, located_in, and laterality slots.
+      via modifier, located_in, laterality, spatial_extent, onset,
+      temporality, clinical_course, and severity slots.
     slots:
       - preferred_term
       - description
@@ -2532,6 +2583,10 @@ classes:
       - located_in
       - laterality
       - spatial_extent
+      - onset
+      - temporality
+      - clinical_course
+      - severity
       - qualifiers
     slot_usage:
       description:

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -485,6 +485,14 @@ enums:
         title: Acute
         description: Acute manifestation or episode
         meaning: HP:0011009
+      TRANSIENT:
+        title: Transient
+        description: Transient manifestation
+        meaning: HP:0025153
+      SUBACUTE:
+        title: Subacute
+        description: Subacute manifestation or episode
+        meaning: HP:0011011
       CHRONIC:
         title: Chronic
         description: Chronic or persistent over time
@@ -493,6 +501,18 @@ enums:
         title: Recurrent
         description: Repeated episodes separated by symptom-free intervals
         meaning: HP:0031796
+      DIURNAL:
+        title: Diurnal
+        description: Manifestation occurring during the day
+        meaning: HP:0025302
+      NOCTURNAL:
+        title: Nocturnal
+        description: Manifestation occurring at night
+        meaning: HP:0025301
+      PROLONGED:
+        title: Prolonged
+        description: Manifestation lasting longer than typical
+        meaning: HP:0025297
   ClinicalCourseEnum:
     description: Clinical course qualifiers for descriptor post-composition
     permissible_values:

--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -2552,6 +2552,56 @@
     {% endif %}
     {% endmacro %}
 
+    {% macro render_onset_badge(onset) %}
+    {% if onset %}
+    {% set onset_category = onset.get('onset_category') %}
+    {% set onset_mean = onset.get('mean_age_years') %}
+    {% set onset_min = onset.get('min_age_years') %}
+    {% set onset_max = onset.get('max_age_years') %}
+    {% if onset_category or onset_mean is not none or onset_min is not none or onset_max is not none %}
+    <span class="tag tag-classification">
+        Onset:
+        {%- if onset_category %} {{ onset_category | replace('_', ' ') }}{% endif -%}
+        {%- if onset_mean is not none and onset_min is not none and onset_max is not none -%}
+          {{ '; ' if onset_category else ' ' }}mean {{ onset_mean }}y (range {{ onset_min }}-{{ onset_max }}y)
+        {%- elif onset_mean is not none -%}
+          {{ '; ' if onset_category else ' ' }}mean {{ onset_mean }}y
+        {%- elif onset_min is not none and onset_max is not none -%}
+          {{ '; ' if onset_category else ' ' }}{{ onset_min }}-{{ onset_max }}y
+        {%- elif onset_min is not none -%}
+          {{ '; ' if onset_category else ' ' }}from {{ onset_min }}y
+        {%- elif onset_max is not none -%}
+          {{ '; ' if onset_category else ' ' }}up to {{ onset_max }}y
+        {%- endif -%}
+    </span>
+    {% endif %}
+    {% endif %}
+    {% endmacro %}
+
+    {% macro render_descriptor_qualifiers(descriptor) %}
+    {% if descriptor %}
+    {{ render_modifier(descriptor.modifier) }}
+    {% if descriptor.laterality %}
+    <span class="tag tag-classification">Laterality: {{ descriptor.laterality | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.spatial_extent %}
+    <span class="tag tag-classification">Extent: {{ descriptor.spatial_extent | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.temporality %}
+    <span class="tag tag-classification">Temporal: {{ descriptor.temporality | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.clinical_course %}
+    <span class="tag tag-classification">Course: {{ descriptor.clinical_course | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.severity %}
+    <span class="tag tag-classification">Severity: {{ descriptor.severity | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.onset %}
+    {{ render_onset_badge(descriptor.onset) }}
+    {% endif %}
+    {% endif %}
+    {% endmacro %}
+
     {% macro render_criteria_list(title, items) %}
     {% if items %}
     <div class="criteria-group">
@@ -3480,7 +3530,7 @@
                         <a href="{{ ct.term.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(ct.modifier) }}
+                    {{ render_descriptor_qualifiers(ct) }}
                     {% endfor %}
                 </div>
                 {% endif %}
@@ -3517,7 +3567,7 @@
                         <a href="{{ bp.term.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(bp.modifier) }}
+                    {{ render_descriptor_qualifiers(bp) }}
                     {% endfor %}
                 </div>
                 {% endif %}
@@ -3530,7 +3580,7 @@
                         <a href="{{ mf.term.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(mf.modifier) }}
+                    {{ render_descriptor_qualifiers(mf) }}
                     {% endfor %}
                 </div>
                 {% endif %}
@@ -3697,15 +3747,20 @@
                         {% if pheno.frequency %}
                         <span class="phenotype-freq">{{ pheno.frequency }}</span>
                         {% endif %}
-                        {% if pheno.phenotype_term and pheno.phenotype_term.term %}
-                        <span class="phenotype-id">
-                            <a href="{{ pheno.phenotype_term.term.id | curie_to_url }}" target="_blank">
-                                {{ pheno.phenotype_term.term.label or pheno.phenotype_term.term.id }}
-                            </a>
+                    {% if pheno.phenotype_term and pheno.phenotype_term.term %}
+                    <span class="phenotype-id">
+                        <a href="{{ pheno.phenotype_term.term.id | curie_to_url }}" target="_blank">
+                            {{ pheno.phenotype_term.term.label or pheno.phenotype_term.term.id }}
+                        </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">({{ pheno.phenotype_term.term.id }})</span>
                         </span>
                         {% endif %}
                     </div>
+                    {% if pheno.phenotype_term and (pheno.phenotype_term.modifier or pheno.phenotype_term.laterality or pheno.phenotype_term.spatial_extent or pheno.phenotype_term.temporality or pheno.phenotype_term.clinical_course or pheno.phenotype_term.severity or pheno.phenotype_term.onset) %}
+                    <div class="item-meta">
+                        {{ render_descriptor_qualifiers(pheno.phenotype_term) }}
+                    </div>
+                    {% endif %}
                     {% if pheno.notes %}
                     <div class="item-desc">{{ pheno.notes }}</div>
                     {% endif %}
@@ -3767,6 +3822,11 @@
                     </span>
                     {% endif %}
                 </div>
+                {% if pheno.phenotype_term and (pheno.phenotype_term.modifier or pheno.phenotype_term.laterality or pheno.phenotype_term.spatial_extent or pheno.phenotype_term.temporality or pheno.phenotype_term.clinical_course or pheno.phenotype_term.severity or pheno.phenotype_term.onset) %}
+                <div class="item-meta">
+                    {{ render_descriptor_qualifiers(pheno.phenotype_term) }}
+                </div>
+                {% endif %}
                 {% if pheno.notes %}
                 <div class="item-desc">{{ pheno.notes }}</div>
                 {% endif %}
@@ -3842,6 +3902,7 @@
                     {% if tx_term_id %}
                     <a href="{{ tx_term_id | curie_to_url }}" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">{{ tx_term_id }}</a>
                     {% endif %}
+                    {{ render_descriptor_qualifiers(tx.treatment_term) }}
                     {% endif %}
                     {% if tx.regimen_term and tx.regimen_term.term %}
                     {% set regimen_id = tx.regimen_term.term.id %}
@@ -3855,6 +3916,7 @@
                     {% if regimen_id %}
                     <a href="{{ regimen_id | curie_to_url }}" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">{{ regimen_id }}</a>
                     {% endif %}
+                    {{ render_descriptor_qualifiers(tx.regimen_term) }}
                     {% endif %}
                 </div>
                 {% endif %}

--- a/src/dismech/templates/module.html.j2
+++ b/src/dismech/templates/module.html.j2
@@ -838,6 +838,56 @@
     {% endif %}
     {%- endmacro %}
 
+    {% macro render_onset_badge(onset) -%}
+    {% if onset %}
+    {% set onset_category = onset.get('onset_category') %}
+    {% set onset_mean = onset.get('mean_age_years') %}
+    {% set onset_min = onset.get('min_age_years') %}
+    {% set onset_max = onset.get('max_age_years') %}
+    {% if onset_category or onset_mean is not none or onset_min is not none or onset_max is not none %}
+    <span class="tag tag-modifier">
+        Onset:
+        {%- if onset_category %} {{ onset_category | replace('_', ' ') }}{% endif -%}
+        {%- if onset_mean is not none and onset_min is not none and onset_max is not none -%}
+          {{ '; ' if onset_category else ' ' }}mean {{ onset_mean }}y (range {{ onset_min }}-{{ onset_max }}y)
+        {%- elif onset_mean is not none -%}
+          {{ '; ' if onset_category else ' ' }}mean {{ onset_mean }}y
+        {%- elif onset_min is not none and onset_max is not none -%}
+          {{ '; ' if onset_category else ' ' }}{{ onset_min }}-{{ onset_max }}y
+        {%- elif onset_min is not none -%}
+          {{ '; ' if onset_category else ' ' }}from {{ onset_min }}y
+        {%- elif onset_max is not none -%}
+          {{ '; ' if onset_category else ' ' }}up to {{ onset_max }}y
+        {%- endif -%}
+    </span>
+    {% endif %}
+    {% endif %}
+    {%- endmacro %}
+
+    {% macro render_descriptor_qualifiers(descriptor) -%}
+    {% if descriptor %}
+    {{ render_modifier(descriptor.modifier) }}
+    {% if descriptor.laterality %}
+    <span class="tag tag-modifier">Laterality: {{ descriptor.laterality | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.spatial_extent %}
+    <span class="tag tag-modifier">Extent: {{ descriptor.spatial_extent | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.temporality %}
+    <span class="tag tag-modifier">Temporal: {{ descriptor.temporality | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.clinical_course %}
+    <span class="tag tag-modifier">Course: {{ descriptor.clinical_course | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.severity %}
+    <span class="tag tag-modifier">Severity: {{ descriptor.severity | replace('_', ' ') }}</span>
+    {% endif %}
+    {% if descriptor.onset %}
+    {{ render_onset_badge(descriptor.onset) }}
+    {% endif %}
+    {% endif %}
+    {%- endmacro %}
+
     <div class="container">
         <div class="breadcrumb">
             <a href="../../app/index.html">Browse All</a>
@@ -889,7 +939,7 @@
                         <a href="{{ cell.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(cell.modifier) }}
+                    {{ render_descriptor_qualifiers(cell) }}
                     {% endfor %}
                 </div>
                 {% else %}
@@ -912,7 +962,7 @@
                         <a href="{{ process.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(process.modifier) }}
+                    {{ render_descriptor_qualifiers(process) }}
                     {% endfor %}
                 </div>
                 {% else %}
@@ -1028,7 +1078,7 @@
                         <a href="{{ ct.term.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(ct.modifier) }}
+                    {{ render_descriptor_qualifiers(ct) }}
                     {% endfor %}
                 </div>
                 {% endif %}
@@ -1042,7 +1092,7 @@
                         <a href="{{ bp.term.id | curie_to_url }}" target="_blank" class="linkout">link</a>
                         {% endif %}
                     </span>
-                    {{ render_modifier(bp.modifier) }}
+                    {{ render_descriptor_qualifiers(bp) }}
                     {% endfor %}
                 </div>
                 {% endif %}

--- a/tests/test_tabular_export.py
+++ b/tests/test_tabular_export.py
@@ -50,6 +50,10 @@ def test_tabular_export_flattens_assertions_descriptors_and_evidence():
                     "phenotype_term": {
                         "preferred_term": "Seizure",
                         "term": {"id": "HP:0001250", "label": "Seizure"},
+                        "temporality": "RECURRENT",
+                        "clinical_course": "PROGRESSIVE",
+                        "severity": "SEVERE",
+                        "onset": {"onset_category": "CHILDHOOD"},
                     },
                     "phenotype_contexts": [
                         {
@@ -140,7 +144,23 @@ def test_tabular_export_flattens_assertions_descriptors_and_evidence():
         assert treatment_term_row["qualifier_therapeutic_agent_ids"] == "NCIT:C258"
         assert treatment_term_row["qualifier_therapeutic_agent_predicate_ids"] == "NCIT:C2259"
 
+        phenotype_term_row = next(row for row in descriptors if row["path"] == "phenotype_term")
+        assert phenotype_term_row["postcomp_temporality"] == "RECURRENT"
+        assert phenotype_term_row["postcomp_clinical_course"] == "PROGRESSIVE"
+        assert phenotype_term_row["postcomp_severity"] == "SEVERE"
+        assert phenotype_term_row["postcomp_onset"] == "CHILDHOOD"
+
         postcomposition = _read_tsv(output_dir / "descriptor_postcomposition.tsv")
+        phenotype_postcomposition = {
+            row["relation_type"]: row
+            for row in postcomposition
+            if row["descriptor_path"] == "phenotype_term"
+        }
+        assert phenotype_postcomposition["temporality"]["value_literal"] == "RECURRENT"
+        assert phenotype_postcomposition["clinical_course"]["value_literal"] == "PROGRESSIVE"
+        assert phenotype_postcomposition["severity"]["value_literal"] == "SEVERE"
+        assert phenotype_postcomposition["onset"]["value_literal"] == "CHILDHOOD"
+
         qualifier_row = next(
             row
             for row in postcomposition


### PR DESCRIPTION
Fix #113 

This pull request implements and documents a new, explicit pattern for handling common clinical qualifiers (temporality, clinical course, severity, onset) as dedicated slots on descriptor objects, further deprecating the previous use of the generic `qualifiers` field. The changes update documentation, data files, and export/rendering logic to consistently use these new slots, improving clarity, ontology alignment, and downstream data handling.

**Key changes:**

### Documentation and Guidance

* Added and updated documentation in `.claude/skills/dismech-terms/SKILL.md`, `CLAUDE.md`, and `docs/explanation/post-composition.md` to describe the new explicit descriptor slots (`temporality`, `clinical_course`, `severity`, `onset`), provide YAML examples, enumerate valid enum values, and give guidance on when to use each slot instead of the deprecated `qualifiers` field. [[1]](diffhunk://#diff-418a8671a94f0d4ab918a0aa2521098a29c37de54cb0ee69ca714e9d88696be9R158-R197) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R195-R227) [[3]](diffhunk://#diff-c0b09a06ee3c244b5fe9efdfddb39ed0ec298dae6209f248ce677e27b61c0f0bR25-R29) [[4]](diffhunk://#diff-c0b09a06ee3c244b5fe9efdfddb39ed0ec298dae6209f248ce677e27b61c0f0bR142-R196) [[5]](diffhunk://#diff-c0b09a06ee3c244b5fe9efdfddb39ed0ec298dae6209f248ce677e27b61c0f0bR243-R246) [[6]](diffhunk://#diff-c0b09a06ee3c244b5fe9efdfddb39ed0ec298dae6209f248ce677e27b61c0f0bR284-R299) [[7]](diffhunk://#diff-92bb596b6d0b0f9e8e73610dbe1b889e44baa3590980bcc06f077fe33b1adac7L105-R113)

### Data Model and Content Updates

* Updated disorder YAML files (e.g., `CINCA_Syndrome.yaml`, `Malaria.yaml`, `Whipple_Disease.yaml`, `Myotonic_Dystrophy_Type_1.yaml`) to move clinical qualifiers from free-text or previous fields into the new dedicated descriptor slots, ensuring data consistency and improved structure. [[1]](diffhunk://#diff-ffddb94863e86773e8b87e72094cabf003d74050a9daba44da6a644cd7cb9a8bL575-R584) [[2]](diffhunk://#diff-54dcc9fdd766c478636d980a6e74d360a3519457ed11b1d26fe94d28ee57780fR409) [[3]](diffhunk://#diff-54dcc9fdd766c478636d980a6e74d360a3519457ed11b1d26fe94d28ee57780fL527-R533) [[4]](diffhunk://#diff-54dcc9fdd766c478636d980a6e74d360a3519457ed11b1d26fe94d28ee57780fL545-R551) [[5]](diffhunk://#diff-7b5511795c9d38aceb5c8a256ace23e9b5941a2eb4e00ac3a0a2d3fa22d976ebR141) [[6]](diffhunk://#diff-bf9c5d4993ae8ac3df1fae48881bcefacadaad753e412f1da7f6ebc0dfa29b1cR110)

### Export and Rendering Logic

* Enhanced the tabular export pipeline (`src/dismech/export/tabular_export.py`) to recognize and output the new descriptor slots, both in row construction and DuckDB export, and to aggregate onset information in a structured way. [[1]](diffhunk://#diff-a76029678ccfa52c08dd6785e08606ba6066d0c7ed69f4cdcf856c9f129ed2cfR558-R565) [[2]](diffhunk://#diff-a76029678ccfa52c08dd6785e08606ba6066d0c7ed69f4cdcf856c9f129ed2cfR680-R683) [[3]](diffhunk://#diff-a76029678ccfa52c08dd6785e08606ba6066d0c7ed69f4cdcf856c9f129ed2cfR773-R831) [[4]](diffhunk://#diff-a76029678ccfa52c08dd6785e08606ba6066d0c7ed69f4cdcf856c9f129ed2cfR947-R950)
* Updated rendering logic (`src/dismech/render.py`) to include the new slots in descriptor uniqueness keys, ensuring correct deduplication and display.

These changes collectively standardize how common clinical qualifiers are represented and processed, leading to more robust, maintainable, and interoperable data.