### PR TITLE
[codex] Handle dragon assignment triggers

### DIFF
--- a/.github/workflows/dragon-ai.yml
+++ b/.github/workflows/dragon-ai.yml
@@ -6,11 +6,11 @@ env:
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened, edited, assigned]
   issue_comment:
     types: [created, edited]
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, assigned]
   pull_request_review_comment:
     types: [created, edited]
 
@@ -26,7 +26,7 @@ jobs:
         # https://github.com/actions/checkout/issues/439
         with:
           ref: ${{ github.ref }}
-        
+
       - name: Check for qualifying mention
         id: check
         uses: actions/github-script@v8
@@ -43,21 +43,25 @@ jobs:
               console.log('Error loading allowed users:', error);
               allowedUsers = ['cmungall']; // Fallback
             }
-            
+
             // Get content and user from event payload directly to avoid API calls when possible
             let content = '';
             let userLogin = '';
             let itemType = '';
             let itemNumber = 0;
-            
+
             if (context.eventName === 'issues') {
               content = context.payload.issue.body || '';
-              userLogin = context.payload.issue.user.login;
+              userLogin = context.payload.action === 'assigned'
+                ? (context.payload.sender?.login || context.payload.issue.user.login)
+                : context.payload.issue.user.login;
               itemType = 'issue';
               itemNumber = context.payload.issue.number;
             } else if (context.eventName === 'pull_request') {
               content = context.payload.pull_request.body || '';
-              userLogin = context.payload.pull_request.user.login;
+              userLogin = context.payload.action === 'assigned'
+                ? (context.payload.sender?.login || context.payload.pull_request.user.login)
+                : context.payload.pull_request.user.login;
               itemType = 'pull_request';
               itemNumber = context.payload.pull_request.number;
             } else if (context.eventName === 'issue_comment') {
@@ -71,17 +75,28 @@ jobs:
               itemType = 'pull_request';
               itemNumber = context.payload.pull_request.number;
             }
-            
+
             // Check if user is allowed and mention exists
             const isAllowed = allowedUsers.includes(userLogin);
             const mentionRegex = /@dragon-ai-agent\s+please\s+(.*)/i;
             const mentionMatch = content.match(mentionRegex);
-            
-            const qualifiedMention = isAllowed && mentionMatch !== null;
-            const prompt = qualifiedMention ? mentionMatch[1].trim() : '';
-            
-            console.log(`User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}`);
-            
+            const isDragonAssignment =
+              (context.eventName === 'issues' || context.eventName === 'pull_request') &&
+              context.payload.action === 'assigned' &&
+              context.payload.assignee?.login === 'dragon-ai-agent';
+
+            const qualifiedMention = (isAllowed && mentionMatch !== null) || isDragonAssignment;
+            const prompt = mentionMatch !== null
+              ? mentionMatch[1].trim()
+              : (isDragonAssignment
+                ? 'You were assigned to this item. Read the full GitHub context, identify the next concrete action, and carry it through.'
+                : '');
+
+            console.log(
+              `User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}, ` +
+              `Dragon assignment: ${isDragonAssignment}`
+            );
+
             return {
               qualifiedMention,
               itemType,
@@ -110,7 +125,7 @@ jobs:
         run: |
           git config --global user.name "Dragon-AI Agent"
           git config --global user.email "dragon-ai-agent[bot]@users.noreply.github.com"
-      
+
       - name: Create tools directory
         run: mkdir -p ${{ env.TOOLS_DIR }}
 
@@ -123,7 +138,6 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
 
-      
       - name: Add tools to PATH
         run: |
           echo "${{ env.TOOLS_DIR }}" >> $GITHUB_PATH
@@ -132,7 +146,7 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-          
+
       - name: Install python tools
         run: |
           uv venv
@@ -148,7 +162,7 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.PAT_FOR_PR }} 
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
         run: |
           cat > /tmp/claude-input/claude_prompt.txt << EOL
           You are @dragon-ai-agent.
@@ -161,7 +175,7 @@ jobs:
 
           Always end by informing the user what you did (or were not able to do) with a message, either on an issue or a PR,
           as appropriate.
-          
+
           The request is below, enclosed in triple backticks:
           \`\`\`
           $(cat /tmp/claude-input/prompt.txt)
@@ -171,8 +185,7 @@ jobs:
           that provide additional context.
 
           EOL
-      
-      
+
       - name: Run Claude Code in headless mode
         id: claude-response
         env:
@@ -186,5 +199,4 @@ jobs:
           claude -p "$(cat /tmp/claude-input/claude_prompt.txt)" \
             --permission-mode bypassPermissions \
             --output-format stream-json \
-            --verbose 
-          
+            --verbose

--- a/.github/workflows/dragon-ai.yml
+++ b/.github/workflows/dragon-ai.yml
@@ -5,6 +5,9 @@ env:
   TOOLS_DIR: ${{ github.workspace }}/tools
 
 on:
+  # `assigned` lets authorized controllers dispatch work by assigning
+  # `dragon-ai-agent` directly. Context: PR #1614
+  # https://github.com/monarch-initiative/dismech/pull/1614
   issues:
     types: [opened, edited, assigned]
   issue_comment:
@@ -80,6 +83,10 @@ jobs:
             const isAllowed = allowedUsers.includes(userLogin);
             const mentionRegex = /@dragon-ai-agent\s+please\s+(.*)/i;
             const mentionMatch = content.match(mentionRegex);
+            // Assignment is a valid trigger, but it must preserve the same
+            // allowlist boundary as explicit `@dragon-ai-agent please ...`
+            // requests. Context: PR #1614
+            // https://github.com/monarch-initiative/dismech/pull/1614
             const isDragonAssignment =
               (context.eventName === 'issues' || context.eventName === 'pull_request') &&
               context.payload.action === 'assigned' &&

--- a/.github/workflows/dragon-ai.yml
+++ b/.github/workflows/dragon-ai.yml
@@ -85,7 +85,8 @@ jobs:
               context.payload.action === 'assigned' &&
               context.payload.assignee?.login === 'dragon-ai-agent';
 
-            const qualifiedMention = (isAllowed && mentionMatch !== null) || isDragonAssignment;
+            const qualifiedMention =
+              (isAllowed && mentionMatch !== null) || (isDragonAssignment && isAllowed);
             const prompt = mentionMatch !== null
               ? mentionMatch[1].trim()
               : (isDragonAssignment


### PR DESCRIPTION
## Summary
This updates `.github/workflows/dragon-ai.yml` so the Dragon AI workflow can start when the bot is assigned directly to an issue or pull request, not only when an authorized user leaves an explicit `@dragon-ai-agent please ...` mention.

## What Changed
- added `assigned` to both `issues.types` and `pull_request.types`
- treated assignment to `dragon-ai-agent` as a qualifying trigger in the `check-mention` script
- used the assigning user as the request context for assigned issue/PR events
- provided a default prompt for assignment-triggered runs so the downstream agent gets actionable instructions even without an inline mention

## Why
The workflow previously ignored direct assignment events for issues and pull requests, so assigning work to `dragon-ai-agent` did not trigger the automation path that handles the request.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dragon-ai.yml"); puts "YAML_OK"'`
- pre-commit hooks during `git commit`:
  - `check yaml`
  - `fix end of files`
  - `trim trailing whitespace`
  - `yamllint`
  - `codespell`