### PR TITLE
[codex] refine curation scanner prioritization

### DIFF
--- a/.github/workflows/curation-scanner.yml
+++ b/.github/workflows/curation-scanner.yml
@@ -59,7 +59,7 @@ jobs:
             --dangerously-skip-permissions
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
             --model ${{ inputs.model || 'claude-opus-4-7' }}
-            --max-turns 20
+            --max-turns 40
           prompt: |
             REPO: ${{ github.repository }}
             TRIGGER: ${{ github.event_name }}
@@ -67,16 +67,31 @@ jobs:
             You are running an automated curation scanner for the dismech repository.
 
             Scan for open issues and pull requests labeled `curation` that are unassigned.
-            Start by using `gh issue list` and `gh pr list` to find candidate items.
-            Use your judgment to choose and process at most 3 total items in this run.
+            Start by gathering candidate items with `gh issue list` and `gh pr list`, including
+            metadata such as labels, assignees, updated time, review state, and reaction counts.
 
-            For each unassigned curation issue:
+            You may scan multiple candidates, but you must choose exactly one issue or pull request
+            to actively work on in this run. Leave all other items untouched.
+
+            Rank candidates before acting. Use judgment, with these signals in mind:
+            - prioritize `high-priority` items when that label is present
+            - prioritize items with stronger positive reaction signals, especially `THUMBS_UP`
+            - prioritize stale items that have not been updated recently
+            - deprioritize `low-priority` items
+            - deprioritize items that were updated very recently, unless they are clearly the best use of this run
+            - prefer the single item where a safe, meaningful next step can be completed in one run
+
+            Avoid repeatedly touching the freshest bottom-of-queue items while older unassigned
+            candidates remain. If signals conflict, explain your choice briefly in the comment or PR
+            you post for the selected item.
+
+            For the single selected unassigned curation issue:
             - Analyze the request.
             - Post a concise assessment comment covering the likely disease or disease area, what work is needed, and the estimated scope/risk.
             - If the first step is straightforward and low-risk, create an initial PR.
             - Otherwise, leave the assessment comment and flag the issue for human review.
 
-            For each unassigned curation PR:
+            For the single selected unassigned curation PR:
             - Inspect its current state, review history, and discussion.
             - Address review comments when the right fix is clear and safe.
             - If the branch is stale or conflicted, refresh it carefully.
@@ -91,4 +106,4 @@ jobs:
             - Follow `CLAUDE.md` and the repository conventions.
             - Never create or hand-edit `references_cache/*.md`; regenerate cache entries with `just fetch-reference <ID>` if needed.
             - Validate any file edits you make with the relevant `just` or `uv run` commands before committing.
-            - Stop after handling at most 3 items even if more remain.
+            - After choosing a target, spend the run on that one item only.


### PR DESCRIPTION
## Summary

- raise the curation scanner turn budget from 20 to 40 after the first live run failed with `Reached maximum number of turns (20)`
- change the prompt so the scanner can inspect multiple unassigned `curation` candidates but must actively work on exactly one item per run
- add explicit ranking guidance: prefer `high-priority` when present, stronger positive reactions (especially thumbs up), and stale items; deprioritize `low-priority` and very recently updated items

## Why

- the failed Actions run spent its budget going deep on one real curation task and exited with `error_max_turns`
- the original prompt encouraged processing up to 3 items, which increases turn pressure and risks repeatedly hitting the newest queue items instead of older stale work

## Notes

- I kept the scanner scoped to unassigned items labeled `curation`
- I did not broaden it to all issues/PRs
- `high-priority` was not visible in the current label list from `gh label list --limit 200`, but the prompt now honors it if present

## Validation

- inspected the failing job log for run `24803920444`, job `72593342439`, and confirmed `error_max_turns` after 21 turns
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/curation-scanner.yml"); puts "YAML OK"'
- repo pre-commit hooks during `git commit` (`check yaml`, `yamllint`, `codespell`, etc.)
