### PR TITLE
[codex] Allow github-actions in claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.ai4c-token.outputs.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
-          allowed_bots: claude
+          allowed_bots: 'claude,github-actions'
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(just:*),Bash(uv run:*)"
 


### PR DESCRIPTION
## Summary
This updates the Claude Code review workflow to allow review runs on pull requests opened by the `github-actions` bot.

## Why
The workflow currently restricts `allowed_bots` to `claude`, which causes the review job to fail on PRs authored by `github-actions`.

## Impact
PRs created by `github-actions` can now pass through the same review workflow without failing the bot allowlist check.

## Validation
- `git diff --check`
- repository pre-commit hooks during `git commit` (`check yaml`, `yamllint`, `codespell`, and related configured hooks)
