### PR TITLE
[codex] review Wilson disease evidence

### DIFF
--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-06T22:37:07Z'
+updated_date: '2026-04-23T00:34:30Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -10,7 +10,7 @@ description: >
   muscles, and bones. Clinical presentations range from asymptomatic liver disease to fulminant
   hepatic failure, chronic hepatitis, cirrhosis, and diverse neuropsychiatric manifestations
   including dystonia, tremor, dysarthria, depression, and psychosis. Kayser-Fleischer corneal
-  rings and Coombs-negative hemolytic anemia are characteristic features. Diagnosis relies on
+  rings are characteristic, and hemolytic anemia can accompany acute hepatic presentations. Diagnosis relies on
   the modified Leipzig Scoring System integrating serum ceruloplasmin, urinary copper, hepatic
   copper content, and genetic testing. Treatment with copper chelators (D-penicillamine, trientine)
   and zinc salts can prevent disease progression when initiated early; liver transplantation is
@@ -120,9 +120,9 @@ mechanistic_hypotheses:
   evidence:
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: "Many interesting disease details were published on the mechanistic steps, such as the generation of reactive oxygen species (ROS) and cuproptosis causing a copper dependent cell death."
-    explanation: Supports cuproptosis as an emerging mechanistic layer in Wilson disease.
+    explanation: Supports cuproptosis as a proposed emerging mechanistic layer in Wilson disease rather than a definitively established dominant pathway.
 - hypothesis_group_id: ferroptosis_superimposition_model
   hypothesis_label: Iron-Related Ferroptosis Superimposition Model
   status: EMERGING
@@ -130,11 +130,16 @@ mechanistic_hypotheses:
     Secondary hepatic iron deposition may superimpose iron-driven ferroptotic
     injury on copper-mediated pathology.
   evidence:
+  - reference: PMID:39733327
+    reference_title: "Iron and Copper Liver Concentrations in Wilson Disease."
+    supports: PARTIAL
+    snippet: "13 (8%) patients aged 13 or older had a hepatic iron index >1.0 which may indicate secondary iron overload."
+    explanation: Directly supports that a subset of Wilson disease patients has secondary hepatic iron overload, which is a prerequisite for the ferroptosis hypothesis.
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: "In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles"
-    explanation: Supports a superimposed ferroptosis hypothesis in hepatic Wilson disease.
+    explanation: Supports ferroptosis as an inferred downstream consequence of secondary hepatic iron deposition rather than a fully established mechanism in Wilson disease.
 pathophysiology:
 - name: Impaired Biliary Copper Excretion
   description: >
@@ -328,9 +333,9 @@ pathophysiology:
       label: mitophagy
   downstream:
   - target: Cuproptosis
-    description: Copper-dependent cell death amplifies hepatocyte injury.
+    description: Proposed copper-dependent cell death pathways may amplify hepatocyte injury.
   - target: Ferroptosis
-    description: Secondary iron deposition may superimpose ferroptotic injury.
+    description: Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.
 
 - name: Neurodegeneration
   description: >
@@ -380,20 +385,20 @@ pathophysiology:
       label: neuron apoptotic process
 - name: Cuproptosis
   description: >
-    Copper-dependent cell death involving binding of copper to lipoylated
-    enzymes in the tricarboxylic acid (TCA) cycle, leading to proteotoxic
-    stress and mitochondrial dysfunction.
+    Copper-dependent cell death has been proposed in Wilson disease, involving
+    binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA)
+    cycle and leading to proteotoxic stress and mitochondrial dysfunction.
   evidence:
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
     supports: PARTIAL
     snippet: "Many interesting disease details were published on the mechanistic steps, such as the generation of reactive oxygen species (ROS) and cuproptosis causing a copper dependent cell death"
-    explanation: Establishes cuproptosis as a copper-dependent cell death mechanism in Wilson disease.
+    explanation: Supports cuproptosis as a proposed mechanistic contributor in Wilson disease, but not yet as a definitively established pathway in patients.
   - reference: PMID:41006805
     reference_title: "The pathogenesis of liver fibrosis in Wilson's disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation."
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: "Moreover, abnormal lipoylation of the copper-dependent proteins metal-binding domain of ferredoxin 1 and dihydrolipoamide transacetylase causes mitochondrial protein oligomer buildup and tricarboxylic acid cycle dysfunction, reinforcing an \"oxidative damage-inflammation-fibrosis\" vicious cycle."
-    explanation: Supports lipoylation-related mitochondrial proteotoxic stress and TCA cycle dysfunction consistent with cuproptosis.
+    explanation: A recent mechanistic review links abnormal lipoylation and TCA-cycle dysfunction to Wilson disease liver injury, providing hypothesis-level support for cuproptosis-related biology.
   biological_processes:
   - preferred_term: cuproptosis
     term:
@@ -402,14 +407,20 @@ pathophysiology:
 - name: Ferroptosis
   description: >
     Iron-related cell death pathway involving phospholipid peroxidation.
-    Increased iron deposits in Wilson disease liver may contribute to
-    ferroptosis alongside copper-mediated injury.
+    Secondary hepatic iron overload has been documented in a subset of Wilson
+    disease patients, raising the possibility of ferroptotic injury alongside
+    copper-mediated toxicity.
   evidence:
+  - reference: PMID:39733327
+    reference_title: "Iron and Copper Liver Concentrations in Wilson Disease."
+    supports: PARTIAL
+    snippet: "13 (8%) patients aged 13 or older had a hepatic iron index >1.0 which may indicate secondary iron overload."
+    explanation: Supports that secondary hepatic iron overload can occur in Wilson disease, which provides biologic plausibility for ferroptosis but does not directly prove it.
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: "In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles"
-    explanation: Demonstrates that ferroptosis may contribute to liver injury in Wilson disease due to iron accumulation.
+    explanation: Supports ferroptosis as an emerging inference from observed hepatic iron deposition rather than a directly proven disease mechanism.
   biological_processes:
   - preferred_term: ferroptosis
     term:
@@ -460,6 +471,11 @@ phenotypes:
     supports: SUPPORT
     snippet: "Four patients (17%) presented with acute liver failure and fifteen (63%) individuals had cirrhosis at diagnosis."
     explanation: Supports acute hepatic failure as a recognized presenting hepatic manifestation in Wilson disease.
+  - reference: PMID:32520831
+    reference_title: "Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis."
+    supports: SUPPORT
+    snippet: "Of the total 256 subjects, 87% underwent LT, 11% achieved spontaneous recovery and 2% died before LT."
+    explanation: Supports that Wilson disease-associated acute liver failure is a severe presentation that frequently requires transplantation.
   phenotype_term:
     preferred_term: Acute hepatic failure
     term:
@@ -659,31 +675,16 @@ phenotypes:
     term:
       id: HP:0002015
       label: Dysphagia
-- name: Dysgraphia
-  category: Neurological
-  frequency: OCCASIONAL
-  notes: Writing problems are reported as part of neurologic involvement
-  evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
-    snippet: "Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia"
-    explanation: Supports writing impairment as part of the neurologic Wilson disease phenotype.
-  phenotype_term:
-    preferred_term: Dysgraphia
-    term:
-      id: HP:0010526
-      label: Dysgraphia
 - name: Depression
   category: Psychiatric
   frequency: FREQUENT
   notes: One of the most common psychiatric manifestations of Wilson disease
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:1821256
+    reference_title: "The psychiatric presentations of Wilson's disease."
     supports: SUPPORT
-    snippet: "Among these are depression, psychosis, dysarthria, ataxia, writing problems"
-    explanation: Depression is explicitly listed as a neuropsychiatric manifestation of Wilson disease.
+    snippet: "Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%)."
+    explanation: Cohort data directly support depression as a common psychiatric manifestation in symptomatic Wilson disease.
   phenotype_term:
     preferred_term: Depression
     term:
@@ -693,11 +694,11 @@ phenotypes:
   category: Psychiatric
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:1821256
+    reference_title: "The psychiatric presentations of Wilson's disease."
     supports: SUPPORT
-    snippet: "Among these are depression, psychosis, dysarthria, ataxia, writing problems"
-    explanation: Psychosis is explicitly listed as a neuropsychiatric manifestation of Wilson disease.
+    snippet: "Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred."
+    explanation: Supports psychosis as a recognized, less frequent psychiatric presentation of Wilson disease.
   phenotype_term:
     preferred_term: Psychosis
     term:
@@ -708,11 +709,11 @@ phenotypes:
   frequency: OCCASIONAL
   notes: Personality changes may be an early psychiatric manifestation
   evidence:
-  - reference: PMID:28433113
-    reference_title: "Wilson disease: brain pathology."
-    supports: PARTIAL
-    snippet: "the cerebral copper content is not correlated with the severity of the neuropathologic abnormalities or with the neuropsychiatric symptomatology."
-    explanation: Reference to neuropsychiatric symptomatology in Wilson disease indirectly supports personality changes as a recognized psychiatric feature, though personality changes are not individually named in this abstract.
+  - reference: PMID:1821256
+    reference_title: "The psychiatric presentations of Wilson's disease."
+    supports: SUPPORT
+    snippet: "Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%)."
+    explanation: Directly supports personality change as a common psychiatric presentation in symptomatic Wilson disease.
   phenotype_term:
     preferred_term: Personality changes
     term:
@@ -722,11 +723,11 @@ phenotypes:
   category: Cardiac
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:27176875
+    reference_title: "Strain and strain rate echocardiography in children with Wilson's disease."
     supports: SUPPORT
-    snippet: "This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias"
-    explanation: Cardiomyopathy is explicitly listed as a cardiac manifestation of Wilson disease due to copper deposition.
+    snippet: "Cardiac arrhythmias, cardiomyopathy and sudden cardiac death are rare complications but may be seen in children with Wilson's disease due to copper accumulation in the heart tissue."
+    explanation: Supports cardiomyopathy as a recognized but uncommon cardiac complication of Wilson disease.
   phenotype_term:
     preferred_term: Cardiomyopathy
     term:
@@ -736,11 +737,11 @@ phenotypes:
   category: Cardiac
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:28947309
+    reference_title: "Wilson's Disease and Cardiac Myopathy."
     supports: SUPPORT
-    snippet: "This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias"
-    explanation: Cardiac arrhythmias are explicitly listed as a cardiac manifestation of Wilson disease.
+    snippet: "Patients with Wilson's disease exhibited a 29% higher risk of AF after adjusting for age, gender, race, income, hypertension, diabetes, renal disease, hyperlipidemia, obesity, coronary disease, and obstructive sleep apnea (HR 1.29, 95% CI 1.15 to 1.45, p <0.0001)."
+    explanation: Supports arrhythmia risk as a clinically relevant cardiac manifestation in Wilson disease.
   phenotype_term:
     preferred_term: Arrhythmia
     term:
@@ -749,12 +750,13 @@ phenotypes:
 - name: Renal Tubular Dysfunction
   category: Renal
   frequency: OCCASIONAL
+  notes: Renal tubular acidosis is one documented form of renal tubular involvement
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:31317233
+    reference_title: "Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A Cross-Sectional Study from India."
     supports: SUPPORT
-    snippet: "This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction"
-    explanation: Renal tubular dysfunction is explicitly listed as a renal manifestation of Wilson disease.
+    snippet: "Fifty-six percent (14/25) of patients with WD had renal tubular acidosis (RTA)."
+    explanation: Supports renal tubular dysfunction in Wilson disease through direct evidence of a high prevalence of renal tubular acidosis.
   phenotype_term:
     preferred_term: Renal tubular dysfunction
     term:
@@ -763,32 +765,23 @@ phenotypes:
 - name: Hemolytic Anemia
   category: Hematologic
   frequency: OCCASIONAL
-  notes: Coombs-negative hemolytic anemia is a key feature
+  notes: May accompany acute hepatic decompensation with marked copper release
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:24577547
+    reference_title: "Acute hemolytic anemia as an initial presentation of Wilson disease in children."
     supports: SUPPORT
-    snippet: "In addition, Coombs-negative hemolytic anemia is a key feature of Wilson disease with undetectable serum haptoglobin"
-    explanation: Coombs-negative hemolytic anemia is described as a key feature of Wilson disease.
+    snippet: "Hemolytic anemia in WD occurs in up to 17% of patients at some point during their illness."
+    explanation: Supports hemolytic anemia as a recognized hematologic manifestation of Wilson disease.
+  - reference: PMID:7234865
+    reference_title: "Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms."
+    supports: SUPPORT
+    snippet: "Two patients with Wilson disease who presented with severe hemolytic anemia are described."
+    explanation: Provides direct case-based evidence of severe hemolytic anemia in Wilson disease.
   phenotype_term:
     preferred_term: Hemolytic anemia
     term:
       id: HP:0001878
       label: Hemolytic anemia
-- name: Rhabdomyolysis
-  category: Muscular
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
-    snippet: "This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis"
-    explanation: Rhabdomyolysis is explicitly listed as a muscle manifestation in Wilson disease.
-  phenotype_term:
-    preferred_term: Rhabdomyolysis
-    term:
-      id: HP:0003201
-      label: Rhabdomyolysis
 - name: Osteoporosis
   category: Skeletal
   frequency: OCCASIONAL
@@ -798,11 +791,11 @@ phenotypes:
     supports: SUPPORT
     snippet: "The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%"
     explanation: Meta-analysis supports frequent low bone density and osteoporosis in Wilson disease populations.
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:31317233
+    reference_title: "Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A Cross-Sectional Study from India."
     supports: SUPPORT
-    snippet: "This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis"
-    explanation: Osteoporosis is explicitly listed as a skeletal manifestation of Wilson disease.
+    snippet: "Patients with WD had significantly lower BMD as compared to control subjects (p < 0.05)."
+    explanation: Supports reduced bone mineral density as a real skeletal manifestation in Wilson disease cohorts.
   phenotype_term:
     preferred_term: Osteoporosis
     term:
@@ -817,53 +810,16 @@ phenotypes:
     supports: SUPPORT
     snippet: "The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%"
     explanation: Meta-analysis supports osteopenia as a common bone phenotype in Wilson disease.
+  - reference: PMID:31317233
+    reference_title: "Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A Cross-Sectional Study from India."
+    supports: SUPPORT
+    snippet: "Patients with WD had significantly lower BMD as compared to control subjects (p < 0.05)."
+    explanation: Independent cohort data support low bone mass in Wilson disease.
   phenotype_term:
     preferred_term: Osteopenia
     term:
       id: HP:0000938
       label: Osteopenia
-- name: Osteomalacia
-  category: Skeletal
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
-    snippet: "osteoporosis, osteomalacia, arthritis, and arthralgia"
-    explanation: Osteomalacia is explicitly listed among musculoskeletal manifestations in Wilson disease.
-  phenotype_term:
-    preferred_term: Osteomalacia
-    term:
-      id: HP:0002749
-      label: Osteomalacia
-- name: Arthritis
-  category: Skeletal
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
-    snippet: "osteoporosis, osteomalacia, arthritis, and arthralgia"
-    explanation: Arthritis is listed as a musculoskeletal manifestation of Wilson disease.
-  phenotype_term:
-    preferred_term: Arthritis
-    term:
-      id: HP:0001369
-      label: Arthritis
-- name: Arthralgia
-  category: Skeletal
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
-    supports: SUPPORT
-    snippet: "osteoporosis, osteomalacia, arthritis, and arthralgia"
-    explanation: Arthralgia is explicitly listed among musculoskeletal manifestations in Wilson disease.
-  phenotype_term:
-    preferred_term: Arthralgia
-    term:
-      id: HP:0002829
-      label: Arthralgia
 biochemical:
 - name: Ceruloplasmin
   presence: Decreased
@@ -876,27 +832,32 @@ biochemical:
     explanation: Directly supports low serum ceruloplasmin as a diagnostic biochemical feature.
 - name: Non-Ceruloplasmin-Bound Serum Copper
   presence: Elevated
-  context: Free copper fraction is elevated; a key diagnostic biomarker criterion met in 86.6% of patients
+  context: Free copper fraction is elevated and used both diagnostically and for treatment monitoring
   evidence:
   - reference: PMID:16709660
     reference_title: "Clinical presentation, diagnosis and long-term outcome of Wilson's disease: a cohort study."
     supports: SUPPORT
     snippet: "Diagnostic criteria for non-caeruloplasmin-bound serum copper, serum caeruloplasmin, 24-h urinary copper excretion, liver copper content, presence of Kayser-Fleischer rings and histological signs of chronic liver damage were reached in 86.6%, 88.2%, 87.1%, 92.7%, 66.3% and 73% of patients, respectively."
     explanation: Supports non-ceruloplasmin-bound copper as a commonly met diagnostic biomarker criterion.
-  - reference: PMID:37741465
-    reference_title: "Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson's disease."
-    supports: PARTIAL
-    snippet: "The goal of these strategies is to reduce free copper, redox stress, and cellular toxicity"
-    explanation: Elevated free copper is the therapeutic target in Wilson disease, confirming its pathological elevation.
+  - reference: PMID:39139457
+    reference_title: "Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets."
+    supports: SUPPORT
+    snippet: "Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited."
+    explanation: Supports NCC as an established Wilson disease monitoring biomarker during chelation therapy.
 - name: 24-Hour Urinary Copper
   presence: Elevated
-  context: Elevated urinary copper is diagnostic
+  context: Elevated urinary copper is diagnostic and is also followed during chelation therapy
   evidence:
   - reference: PMID:15205951
     reference_title: "Wilson disease."
     supports: SUPPORT
     snippet: "The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content."
     explanation: Directly supports increased urinary copper excretion as a diagnostic biochemical feature.
+  - reference: PMID:39139457
+    reference_title: "Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets."
+    supports: SUPPORT
+    snippet: "Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited."
+    explanation: Supports 24-hour urinary copper excretion as a standard biomarker used to monitor Wilson disease therapy.
 - name: Hepatic Copper
   presence: Elevated
   context: Liver biopsy with elevated copper is diagnostic
@@ -930,13 +891,13 @@ genetic:
     explanation: Confirms large number of ATP7B mutations causing Wilson disease.
 environmental:
 - name: Dietary Copper
-  notes: High copper foods may accelerate accumulation
+  notes: Dietary copper contributes to exposure, but strict long-term restriction beyond very high-copper foods is not well supported
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:36010023
+    reference_title: "Low Copper Diet-A Therapeutic Option for Wilson Disease?"
     supports: PARTIAL
-    snippet: "copper, which is found ubiquitously on earth and normally enters the human body in small amounts via the food chain"
-    explanation: Dietary copper intake contributes to body copper load, making dietary restriction an important adjunctive measure.
+    snippet: "A lower copper intake only prevents the re-accumulation of copper."
+    explanation: Supports dietary copper reduction as an adjunctive measure, while implying that diet alone is not the main determinant of disease control.
 treatments:
 - name: D-Penicillamine
   description: Copper chelator, first-line therapy, promotes urinary copper excretion.
@@ -988,26 +949,26 @@ treatments:
         id: CHEBI:62984
         label: zinc acetate
 - name: Low Copper Diet
-  description: Avoid liver, shellfish, chocolate, nuts, mushrooms.
+  description: Adjunctive dietary measure; liver and shellfish are the foods most consistently recommended for avoidance.
   evidence:
-  - reference: PMID:38731973
-    reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+  - reference: PMID:36010023
+    reference_title: "Low Copper Diet-A Therapeutic Option for Wilson Disease?"
     supports: PARTIAL
-    snippet: "copper, which is found ubiquitously on earth and normally enters the human body in small amounts via the food chain"
-    explanation: Establishes that dietary intake is a source of copper, supporting dietary restriction as an adjunctive treatment approach.
+    snippet: "In summary, consistent adherence to drug therapy is more important than a strict diet. Only two foods should be consistently avoided: Liver and Shellfish."
+    explanation: Supports a limited adjunctive low-copper diet while explicitly cautioning against overstating the value of strict dietary restriction.
   treatment_term:
     preferred_term: dietary intervention
     term:
       id: MAXO:0000088
       label: dietary intervention
 - name: Tetrathiomolybdate
-  description: Emerging copper chelator that rapidly complexes free copper, reducing bioavailable copper.
+  description: Investigational copper chelator that markedly reduces intestinal copper uptake and lowers hepatic and brain copper exposure.
   evidence:
-  - reference: PMID:37741465
-    reference_title: "Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson's disease."
-    supports: PARTIAL
-    snippet: "Current treatment protocols are limited to either sequestration of copper via chelation or reduction of copper absorption in the gut"
-    explanation: Tetrathiomolybdate represents an emerging chelation approach that tightly complexes copper.
+  - reference: PMID:38081365
+    reference_title: "Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease."
+    supports: SUPPORT
+    snippet: "TTM effectively inhibited most intestinal 64Cu uptake and retained 64Cu in the blood stream, limiting the exposure of organs like the liver and brain to 64Cu."
+    explanation: Human tracer studies support tetrathiomolybdate as an investigational therapy that reduces organ copper exposure primarily by blocking intestinal uptake.
   treatment_term:
     preferred_term: copper chelator agent therapy
     term:
@@ -1021,6 +982,11 @@ treatments:
 - name: Liver Transplantation
   description: Curative for hepatic Wilson disease, reverses copper metabolism defect.
   evidence:
+  - reference: PMID:32520831
+    reference_title: "Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis."
+    supports: SUPPORT
+    snippet: "Of the total 256 subjects, 87% underwent LT, 11% achieved spontaneous recovery and 2% died before LT."
+    explanation: Supports liver transplantation as the predominant life-saving therapy for Wilson disease presenting with acute liver failure.
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
     supports: SUPPORT
@@ -1143,4 +1109,40 @@ references:
   findings: []
 - reference: DOI:10.1016/j.jhep.2023.04.007
   title: 'Neurological worsening in Wilson disease - clinical classification and outcome'
+  findings: []
+- reference: DOI:10.1016/j.jhepr.2024.101115
+  title: 'Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets.'
+  findings: []
+- reference: DOI:10.1016/j.amjcard.2017.08.025
+  title: "Wilson's Disease and Cardiac Myopathy."
+  findings: []
+- reference: DOI:10.1016/j.jhep.2023.11.023
+  title: Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease.
+  findings: []
+- reference: DOI:10.1007/s00223-019-00588-z
+  title: "Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A Cross-Sectional Study from India."
+  findings: []
+- reference: DOI:10.1176/jnp.3.4.377
+  title: "The psychiatric presentations of Wilson's disease."
+  findings: []
+- reference: DOI:10.1002/ajh.2830090305
+  title: 'Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms.'
+  findings: []
+- reference: DOI:10.3390/children9081132
+  title: Low Copper Diet-A Therapeutic Option for Wilson Disease?
+  findings: []
+- reference: DOI:10.1097/MPG.0000000000002777
+  title: 'Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis.'
+  findings: []
+- reference: DOI:10.15403/jgld-5662
+  title: Iron and Copper Liver Concentrations in Wilson Disease.
+  findings: []
+- reference: DOI:10.5830/CVJA-2016-028
+  title: "Strain and strain rate echocardiography in children with Wilson's disease."
+  findings: []
+- reference: DOI:10.1097/MPH.0000000000000127
+  title: Acute hemolytic anemia as an initial presentation of Wilson disease in children.
+  findings: []
+- reference: DOI:10.1007/s10534-025-00748-9
+  title: 'The pathogenesis of liver fibrosis in Wilson''s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.'
   findings: []

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-23T00:34:30Z'
+updated_date: '2026-04-23T01:49:27Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -219,6 +219,9 @@ pathophysiology:
     term:
       id: GO:0055070
       label: copper ion homeostasis
+  downstream:
+  - target: Ceruloplasmin
+    description: Failure to load copper into apoceruloplasmin leads to low circulating ceruloplasmin.
 
 - name: Hepatic Copper Accumulation
   description: >
@@ -251,6 +254,8 @@ pathophysiology:
     description: Copper overload in hepatocytes drives oxidative stress and cell death.
   - target: Systemic Copper Distribution
     description: Overflow of copper from the liver enters the circulation and deposits in extrahepatic organs.
+  - target: Hepatic Copper
+    description: Retained hepatic copper becomes measurably increased on liver biopsy.
 
 - name: Systemic Copper Distribution
   description: >
@@ -271,13 +276,34 @@ pathophysiology:
   downstream:
   - target: Neurodegeneration
     description: Copper deposition in the basal ganglia and other brain regions causes neuronal injury.
+  - target: Non-Ceruloplasmin-Bound Serum Copper
+    description: Overflow of hepatocellular copper raises the circulating free copper fraction.
+  - target: 24-Hour Urinary Copper
+    description: Increased circulating free copper drives elevated urinary copper excretion.
+  - target: Kayser-Fleischer Rings
+    description: Copper deposition in Descemet membrane produces Kayser-Fleischer corneal rings.
+  - target: Renal Tubular Dysfunction
+    description: Copper deposition in the kidneys contributes to renal tubular injury and dysfunction.
+  - target: Cardiomyopathy
+    description: Cardiac copper deposition contributes to myocardial injury and cardiomyopathy.
+  - target: Heart Failure
+    description: Copper-mediated cardiac injury can progress to clinical heart failure.
+  - target: Cardiac Arrhythmia
+    description: Copper-mediated cardiac involvement increases the risk of clinically significant arrhythmias.
+  - target: Osteopenia
+    description: Extrahepatic copper toxicity contributes to reduced bone mineral density.
+  - target: Osteoporosis
+    description: Chronic extrahepatic copper toxicity contributes to pathologic bone loss in a subset of patients.
+  - target: Arthralgia
+    description: Musculoskeletal copper deposition and bone disease contribute to arthralgia.
 
 - name: Hepatocyte Injury
   description: >
     Copper accumulation in hepatocytes causes oxidative stress, mitochondrial
-    dysfunction, and cell death. Progressive liver damage leads to fibrosis
-    and cirrhosis. Copper overload activates autophagy and mitophagy-based
-    mitochondrial quality control responses.
+    dysfunction, and cell death. Severe injury can manifest as hepatitis,
+    jaundice, hepatomegaly, and acute liver failure. Copper overload also
+    activates autophagy and mitophagy-based mitochondrial quality control
+    responses.
   evidence:
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
@@ -332,10 +358,98 @@ pathophysiology:
       id: GO:0000423
       label: mitophagy
   downstream:
+  - target: Hepatic Stellate Cell Activation
+    description: Injured hepatocytes activate pro-fibrotic stellate-cell responses in the liver.
+  - target: Hepatitis
+    description: Hepatocellular oxidative injury and inflammation manifest clinically as hepatitis.
+  - target: Hepatomegaly
+    description: Hepatocyte swelling and inflammatory liver injury can produce hepatomegaly.
+  - target: Jaundice
+    description: Acute hepatocellular dysfunction impairs bilirubin handling and can produce jaundice.
+  - target: Acute Hepatic Failure
+    description: Severe hepatocyte death can precipitate fulminant hepatic failure.
+  - target: Hemolytic Anemia
+    description: Abrupt copper release from injured liver can trigger oxidant hemolysis.
+  - target: Vomiting
+    description: Acute hepatic decompensation can present with vomiting as part of the hepatic illness syndrome.
   - target: Cuproptosis
     description: Proposed copper-dependent cell death pathways may amplify hepatocyte injury.
   - target: Ferroptosis
     description: Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.
+
+- name: Hepatic Stellate Cell Activation
+  conforms_to: fibrotic_response#Mesenchymal Cell Activation
+  description: >
+    Copper-injured liver tissue activates pro-fibrotic signaling, including
+    TGF-beta and NF-kappaB pathways, which stimulate hepatic stellate cells to
+    transdifferentiate toward collagen-secreting myofibroblasts.
+  evidence:
+  - reference: PMID:41006805
+    reference_title: "The pathogenesis of liver fibrosis in Wilson's disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Copper ions also activate signaling pathways such as the TGF-β1/Smad and NF-κB pathways, which stimulate hepatic stellate cells and promote their transdifferentiation into collagen-secreting myofibroblasts"
+    explanation: Supports a distinct fibrogenic step in which copper-triggered signaling activates hepatic stellate cells and drives myofibroblast conversion.
+  cell_types:
+  - preferred_term: hepatic stellate cell
+    term:
+      id: CL:0000632
+      label: hepatic stellate cell
+  - preferred_term: myofibroblast cell
+    term:
+      id: CL:0000186
+      label: myofibroblast cell
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  biological_processes:
+  - preferred_term: transforming growth factor beta receptor signaling pathway
+    term:
+      id: GO:0007179
+      label: transforming growth factor beta receptor signaling pathway
+    modifier: INCREASED
+  downstream:
+  - target: Excessive Hepatic ECM Deposition
+    description: Activated stellate cells and myofibroblasts drive excess extracellular matrix deposition.
+
+- name: Excessive Hepatic ECM Deposition
+  conforms_to: fibrotic_response#Excessive ECM Deposition
+  description: >
+    Collagen-secreting myofibroblasts deposit excessive extracellular matrix in
+    the liver, progressively distorting architecture and promoting cirrhosis.
+  evidence:
+  - reference: PMID:41006805
+    reference_title: "The pathogenesis of liver fibrosis in Wilson's disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "collagen-secreting myofibroblasts, which then accelerate extracellular matrix deposition."
+    explanation: Supports extracellular matrix accumulation as the immediate downstream consequence of hepatic stellate-cell activation in Wilson disease liver fibrosis.
+  cell_types:
+  - preferred_term: myofibroblast cell
+    term:
+      id: CL:0000186
+      label: myofibroblast cell
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+    modifier: INCREASED
+  - preferred_term: collagen biosynthetic process
+    term:
+      id: GO:0032964
+      label: collagen biosynthetic process
+    modifier: INCREASED
+  downstream:
+  - target: Cirrhosis
+    description: Progressive matrix deposition and architectural distortion manifest clinically as cirrhosis.
 
 - name: Neurodegeneration
   description: >
@@ -379,10 +493,39 @@ pathophysiology:
       id: UBERON:0001874
       label: putamen
   biological_processes:
-  - preferred_term: neuron death
+  - preferred_term: neuron apoptotic process
     term:
       id: GO:0051402
       label: neuron apoptotic process
+  downstream:
+  - target: Tremor
+    description: Basal ganglia and cerebellar circuit injury contributes to tremor.
+  - target: Dystonia
+    description: Striatal injury disrupts motor circuit output and contributes to dystonia.
+  - target: Parkinsonism
+    description: Basal ganglia dysfunction can manifest clinically as parkinsonism.
+  - target: Bradykinesia
+    description: Extrapyramidal circuit dysfunction contributes to bradykinesia.
+  - target: Rigidity
+    description: Extrapyramidal circuit dysfunction contributes to rigidity.
+  - target: Chorea
+    description: Basal ganglia injury can produce choreiform hyperkinesia.
+  - target: Dysarthria
+    description: Motor network injury affecting bulbar and extrapyramidal function contributes to dysarthria.
+  - target: Ataxia
+    description: Cerebellar and brainstem involvement contributes to ataxia.
+  - target: Dysphagia
+    description: Bulbar motor dysfunction contributes to dysphagia.
+  - target: Drooling
+    description: Bulbar dysfunction and impaired swallowing contribute to drooling.
+  - target: Anxiety
+    description: Copper-mediated brain injury can contribute to neuropsychiatric symptoms including anxiety.
+  - target: Depression
+    description: Neuropsychiatric brain involvement contributes to depressive symptoms.
+  - target: Psychosis
+    description: Severe neuropsychiatric involvement can manifest as psychosis.
+  - target: Personality Changes
+    description: Fronto-striatal and related network dysfunction can manifest as personality change.
 - name: Cuproptosis
   description: >
     Copper-dependent cell death has been proposed in Wilson disease, involving
@@ -516,7 +659,7 @@ phenotypes:
       label: Hepatitis
 - name: Kayser-Fleischer Rings
   category: Ocular
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   diagnostic: true
   notes: Copper deposits in Descemet membrane, pathognomonic
   evidence:
@@ -794,7 +937,7 @@ phenotypes:
     snippet: "patients with Wilson's disease had a 55% higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p <0.0001)"
     explanation: Population-level claims data support heart failure as an important cardiac complication of Wilson disease.
   phenotype_term:
-    preferred_term: Heart failure
+    preferred_term: Congestive heart failure
     term:
       id: HP:0001635
       label: Congestive heart failure
@@ -849,7 +992,6 @@ phenotypes:
       label: Hemolytic anemia
 - name: Osteoporosis
   category: Skeletal
-  frequency: OCCASIONAL
   evidence:
   - reference: PMID:29110062
     reference_title: "Osteoporosis and bone mineral density in patients with Wilson's disease: a systematic review and meta-analysis."
@@ -868,7 +1010,6 @@ phenotypes:
       label: Osteoporosis
 - name: Osteopenia
   category: Skeletal
-  frequency: OCCASIONAL
   evidence:
   - reference: PMID:29110062
     reference_title: "Osteoporosis and bone mineral density in patients with Wilson's disease: a systematic review and meta-analysis."

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -429,18 +429,31 @@ pathophysiology:
 phenotypes:
 - name: Hepatomegaly
   category: Hepatic
-  frequency: VERY_FREQUENT
+  frequency: OCCASIONAL
   evidence:
-  - reference: PMID:15205951
-    reference_title: "Wilson disease."
-    supports: PARTIAL
-    snippet: "Resultant liver damage leads to steatosis, inflammation, cirrhosis, and, occasionally, fulminant liver failure."
-    explanation: Hepatic copper accumulation causes progressive liver damage including steatosis and inflammation, which manifest as hepatomegaly. Direct frequency data for hepatomegaly not available in this abstract.
+  - reference: PMID:22473403
+    reference_title: "Wilson's disease: an analysis of 28 Brazilian children."
+    supports: SUPPORT
+    snippet: "three had hepatomegaly associated with neurological disorders"
+    explanation: Pediatric cohort data directly support hepatomegaly as an occasional presenting phenotype in Wilson disease.
   phenotype_term:
     preferred_term: Hepatomegaly
     term:
       id: HP:0002240
       label: Hepatomegaly
+- name: Jaundice
+  category: Hepatic
+  evidence:
+  - reference: PMID:3595645
+    reference_title: "Presenting symptoms and natural history of Wilson disease."
+    supports: SUPPORT
+    snippet: "the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"
+    explanation: Large case-series data identify jaundice among the common presenting symptoms of Wilson disease.
+  phenotype_term:
+    preferred_term: Jaundice
+    term:
+      id: HP:0000952
+      label: Jaundice
 - name: Cirrhosis
   category: Hepatic
   frequency: FREQUENT
@@ -675,9 +688,48 @@ phenotypes:
     term:
       id: HP:0002015
       label: Dysphagia
+- name: Drooling
+  category: Neurological
+  evidence:
+  - reference: PMID:3595645
+    reference_title: "Presenting symptoms and natural history of Wilson disease."
+    supports: SUPPORT
+    snippet: "the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"
+    explanation: Large case-series data identify drooling as one of the more common presenting symptoms of Wilson disease.
+  phenotype_term:
+    preferred_term: Drooling
+    term:
+      id: HP:0002307
+      label: Drooling
+- name: Vomiting
+  category: Gastrointestinal
+  evidence:
+  - reference: PMID:29914392
+    reference_title: "Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease."
+    supports: SUPPORT
+    snippet: "These patients had clinical features such as numbness of hands and feet, vomiting, insomnia, palsy, liver failure and Kayser-Fleischer (K-F) rings"
+    explanation: HPOA-linked case-series evidence supports vomiting as a gastrointestinal manifestation reported in Wilson disease.
+  phenotype_term:
+    preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
+- name: Anxiety
+  category: Psychiatric
+  evidence:
+  - reference: PMID:1821256
+    reference_title: "The psychiatric presentations of Wilson's disease."
+    supports: SUPPORT
+    snippet: "Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred."
+    explanation: Supports anxiety as a recognized psychiatric manifestation of Wilson disease.
+  phenotype_term:
+    preferred_term: Anxiety
+    term:
+      id: HP:0000739
+      label: Anxiety
 - name: Depression
   category: Psychiatric
-  frequency: FREQUENT
+  frequency: OCCASIONAL
   notes: One of the most common psychiatric manifestations of Wilson disease
   evidence:
   - reference: PMID:1821256
@@ -706,7 +758,7 @@ phenotypes:
       label: Psychosis
 - name: Personality Changes
   category: Psychiatric
-  frequency: OCCASIONAL
+  frequency: FREQUENT
   notes: Personality changes may be an early psychiatric manifestation
   evidence:
   - reference: PMID:1821256
@@ -733,6 +785,19 @@ phenotypes:
     term:
       id: HP:0001638
       label: Cardiomyopathy
+- name: Heart Failure
+  category: Cardiac
+  evidence:
+  - reference: PMID:28947309
+    reference_title: "Wilson's Disease and Cardiac Myopathy."
+    supports: SUPPORT
+    snippet: "patients with Wilson's disease had a 55% higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p <0.0001)"
+    explanation: Population-level claims data support heart failure as an important cardiac complication of Wilson disease.
+  phenotype_term:
+    preferred_term: Heart failure
+    term:
+      id: HP:0001635
+      label: Congestive heart failure
 - name: Cardiac Arrhythmia
   category: Cardiac
   frequency: OCCASIONAL
@@ -820,6 +885,19 @@ phenotypes:
     term:
       id: HP:0000938
       label: Osteopenia
+- name: Arthralgia
+  category: Skeletal
+  evidence:
+  - reference: PMID:3595645
+    reference_title: "Presenting symptoms and natural history of Wilson disease."
+    supports: SUPPORT
+    snippet: "the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"
+    explanation: Large case-series data identify arthralgia among the more common presenting symptoms of Wilson disease.
+  phenotype_term:
+    preferred_term: Arthralgia
+    term:
+      id: HP:0002829
+      label: Arthralgia
 biochemical:
 - name: Ceruloplasmin
   presence: Decreased
@@ -1145,4 +1223,13 @@ references:
   findings: []
 - reference: DOI:10.1007/s10534-025-00748-9
   title: 'The pathogenesis of liver fibrosis in Wilson''s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.'
+  findings: []
+- reference: DOI:10.6061/clinics/2012(03)05
+  title: "Wilson's disease: an analysis of 28 Brazilian children."
+  findings: []
+- reference: DOI:10.1007/BF00716470
+  title: Presenting symptoms and natural history of Wilson disease.
+  findings: []
+- reference: DOI:10.1186/s12881-018-0619-4
+  title: Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease.
   findings: []

--- a/pages/disorders/Wilson_Disease.html
+++ b/pages/disorders/Wilson_Disease.html
@@ -2413,7 +2413,7 @@
                 </span>
 
 
-                <a class="badge badge-pathograph" href="#pathograph">Pathograph 9</a>
+                <a class="badge badge-pathograph" href="#pathograph">Pathograph 44</a>
 
 
                 <span class="badge badge-category" style="background: rgba(255,255,255,0.1);">Metabolic Disease</span>
@@ -2553,7 +2553,7 @@
 
             <a class="stat-link" href="#pathophysiology">
             <div class="stat-item">
-                <div class="stat-value">8</div>
+                <div class="stat-value">10</div>
                 <div class="stat-label">Pathophysiology</div>
             </div>
             </a>
@@ -2575,7 +2575,7 @@
 
             <a class="stat-link" href="#pathograph">
             <div class="stat-item">
-                <div class="stat-value">9</div>
+                <div class="stat-value">44</div>
                 <div class="stat-label">Pathograph</div>
             </div>
             </a>
@@ -2764,7 +2764,7 @@
             <div class="card-header">
                 <div class="card-icon" style="background: #fef3c7; color: #d97706;">⚙</div>
                 <h2 class="card-title">Pathophysiology</h2>
-                <span class="card-count">8</span>
+                <span class="card-count">10</span>
             </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-impaired-biliary-copper-excretion">
@@ -2836,6 +2836,21 @@
 
 
 
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hepatic Copper Accumulation</span>
+
+	                            <span class="crosslink-desc">Loss of biliary copper excretion leads to progressive copper retention in hepatocytes.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
+
+
 
     <details class="evidence-details">
         <summary class="evidence-toggle">
@@ -2902,7 +2917,7 @@
     </details>
 
 
-            </div>
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-impaired-ceruloplasmin-loading">
                 <div class="item-name">Impaired Ceruloplasmin Loading</div>
@@ -2948,6 +2963,21 @@
 
 
 
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Ceruloplasmin</span>
+
+	                            <span class="crosslink-desc">Failure to load copper into apoceruloplasmin leads to low circulating ceruloplasmin.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
+
+
 
     <details class="evidence-details">
         <summary class="evidence-toggle">
@@ -2978,7 +3008,7 @@
     </details>
 
 
-            </div>
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-hepatic-copper-accumulation">
                 <div class="item-name">Hepatic Copper Accumulation</div>
@@ -3019,6 +3049,35 @@
                 </div>
 
 
+
+
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hepatocyte Injury</span>
+
+	                            <span class="crosslink-desc">Copper overload in hepatocytes drives oxidative stress and cell death.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Systemic Copper Distribution</span>
+
+	                            <span class="crosslink-desc">Overflow of copper from the liver enters the circulation and deposits in extrahepatic organs.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hepatic Copper</span>
+
+	                            <span class="crosslink-desc">Retained hepatic copper becomes measurably increased on liver biopsy.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
 
 
 
@@ -3069,7 +3128,7 @@
     </details>
 
 
-            </div>
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-systemic-copper-distribution">
                 <div class="item-name">Systemic Copper Distribution</div>
@@ -3085,6 +3144,91 @@
 
 
 
+
+
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Neurodegeneration</span>
+
+	                            <span class="crosslink-desc">Copper deposition in the basal ganglia and other brain regions causes neuronal injury.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Non-Ceruloplasmin-Bound Serum Copper</span>
+
+	                            <span class="crosslink-desc">Overflow of hepatocellular copper raises the circulating free copper fraction.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">24-Hour Urinary Copper</span>
+
+	                            <span class="crosslink-desc">Increased circulating free copper drives elevated urinary copper excretion.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Kayser-Fleischer Rings</span>
+
+	                            <span class="crosslink-desc">Copper deposition in Descemet membrane produces Kayser-Fleischer corneal rings.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Renal Tubular Dysfunction</span>
+
+	                            <span class="crosslink-desc">Copper deposition in the kidneys contributes to renal tubular injury and dysfunction.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Cardiomyopathy</span>
+
+	                            <span class="crosslink-desc">Cardiac copper deposition contributes to myocardial injury and cardiomyopathy.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Heart Failure</span>
+
+	                            <span class="crosslink-desc">Copper-mediated cardiac injury can progress to clinical heart failure.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Cardiac Arrhythmia</span>
+
+	                            <span class="crosslink-desc">Copper-mediated cardiac involvement increases the risk of clinically significant arrhythmias.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Osteopenia</span>
+
+	                            <span class="crosslink-desc">Extrahepatic copper toxicity contributes to reduced bone mineral density.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Osteoporosis</span>
+
+	                            <span class="crosslink-desc">Chronic extrahepatic copper toxicity contributes to pathologic bone loss in a subset of patients.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Arthralgia</span>
+
+	                            <span class="crosslink-desc">Musculoskeletal copper deposition and bone disease contribute to arthralgia.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
 
 
 
@@ -3135,12 +3279,12 @@
     </details>
 
 
-            </div>
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-hepatocyte-injury">
                 <div class="item-name">Hepatocyte Injury</div>
 
-                <div class="item-desc">Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Progressive liver damage leads to fibrosis and cirrhosis. Copper overload activates autophagy and mitophagy-based mitochondrial quality control responses.
+                <div class="item-desc">Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Severe injury can manifest as hepatitis, jaundice, hepatomegaly, and acute liver failure. Copper overload also activates autophagy and mitophagy-based mitochondrial quality control responses.
 </div>
 
 
@@ -3200,6 +3344,77 @@
                 </div>
 
 
+
+
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hepatic Stellate Cell Activation</span>
+
+	                            <span class="crosslink-desc">Injured hepatocytes activate pro-fibrotic stellate-cell responses in the liver.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hepatitis</span>
+
+	                            <span class="crosslink-desc">Hepatocellular oxidative injury and inflammation manifest clinically as hepatitis.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hepatomegaly</span>
+
+	                            <span class="crosslink-desc">Hepatocyte swelling and inflammatory liver injury can produce hepatomegaly.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Jaundice</span>
+
+	                            <span class="crosslink-desc">Acute hepatocellular dysfunction impairs bilirubin handling and can produce jaundice.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Acute Hepatic Failure</span>
+
+	                            <span class="crosslink-desc">Severe hepatocyte death can precipitate fulminant hepatic failure.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Hemolytic Anemia</span>
+
+	                            <span class="crosslink-desc">Abrupt copper release from injured liver can trigger oxidant hemolysis.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Vomiting</span>
+
+	                            <span class="crosslink-desc">Acute hepatic decompensation can present with vomiting as part of the hepatic illness syndrome.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Cuproptosis</span>
+
+	                            <span class="crosslink-desc">Proposed copper-dependent cell death pathways may amplify hepatocyte injury.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Ferroptosis</span>
+
+	                            <span class="crosslink-desc">Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
 
 
 
@@ -3270,7 +3485,247 @@
     </details>
 
 
+	            </div>
+
+            <div class="item-box pathophys-box anchor-target" id="pathophysiology-hepatic-stellate-cell-activation">
+                <div class="item-name">Hepatic Stellate Cell Activation</div>
+
+                <div class="item-desc">Copper-injured liver tissue activates pro-fibrotic signaling, including TGF-beta and NF-kappaB pathways, which stimulate hepatic stellate cells to transdifferentiate toward collagen-secreting myofibroblasts.
+</div>
+
+
+                <div class="item-meta">
+
+                    <span class="tag tag-cell">
+                        hepatic stellate cell
+
+                        <a href="http://purl.obolibrary.org/obo/CL_0000632" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+
+
+
+                    <span class="tag tag-cell">
+                        myofibroblast cell
+
+                        <a href="http://purl.obolibrary.org/obo/CL_0000186" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+
+
+
+                </div>
+
+
+
+
+                <div class="item-meta">
+
+                    <span class="tag tag-bio">
+                        transforming growth factor beta receptor signaling pathway
+
+                        <a href="http://purl.obolibrary.org/obo/GO_0007179" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+
+    <span class="tag tag-modifier">
+        ↑ INCREASED
+    </span>
+
+
+
+                </div>
+
+
+
+
+                <div class="item-meta">
+
+                    <span class="tag tag-location">
+                        liver
+
+                        <a href="http://purl.obolibrary.org/obo/UBERON_0002107" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+                </div>
+
+
+
+
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Excessive Hepatic ECM Deposition</span>
+
+	                            <span class="crosslink-desc">Activated stellate cells and myofibroblasts drive excess extracellular matrix deposition.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/41006805" target="_blank">PMID:41006805</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                    <span class="evidence-source source-OTHER">Other</span>
+
+                </div>
+
+                <div class="evidence-snippet">"Copper ions also activate signaling pathways such as the TGF-β1/Smad and NF-κB pathways, which stimulate hepatic stellate cells and promote their transdifferentiation into collagen-secreting myofibroblasts"</div>
+
+
+                <div class="evidence-explanation">Supports a distinct fibrogenic step in which copper-triggered signaling activates hepatic stellate cells and drives myofibroblast conversion.</div>
+
             </div>
+
+
+        </div>
+    </details>
+
+
+	            </div>
+
+            <div class="item-box pathophys-box anchor-target" id="pathophysiology-excessive-hepatic-ecm-deposition">
+                <div class="item-name">Excessive Hepatic ECM Deposition</div>
+
+                <div class="item-desc">Collagen-secreting myofibroblasts deposit excessive extracellular matrix in the liver, progressively distorting architecture and promoting cirrhosis.
+</div>
+
+
+                <div class="item-meta">
+
+                    <span class="tag tag-cell">
+                        myofibroblast cell
+
+                        <a href="http://purl.obolibrary.org/obo/CL_0000186" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+
+
+
+                </div>
+
+
+
+
+                <div class="item-meta">
+
+                    <span class="tag tag-bio">
+                        extracellular matrix organization
+
+                        <a href="http://purl.obolibrary.org/obo/GO_0030198" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+
+    <span class="tag tag-modifier">
+        ↑ INCREASED
+    </span>
+
+
+
+                    <span class="tag tag-bio">
+                        collagen biosynthetic process
+
+                        <a href="http://purl.obolibrary.org/obo/GO_0032964" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+
+    <span class="tag tag-modifier">
+        ↑ INCREASED
+    </span>
+
+
+
+                </div>
+
+
+
+
+                <div class="item-meta">
+
+                    <span class="tag tag-location">
+                        liver
+
+                        <a href="http://purl.obolibrary.org/obo/UBERON_0002107" target="_blank" class="linkout">link</a>
+
+                    </span>
+
+                </div>
+
+
+
+
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Cirrhosis</span>
+
+	                            <span class="crosslink-desc">Progressive matrix deposition and architectural distortion manifest clinically as cirrhosis.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/41006805" target="_blank">PMID:41006805</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                    <span class="evidence-source source-OTHER">Other</span>
+
+                </div>
+
+                <div class="evidence-snippet">"collagen-secreting myofibroblasts, which then accelerate extracellular matrix deposition."</div>
+
+
+                <div class="evidence-explanation">Supports extracellular matrix accumulation as the immediate downstream consequence of hepatic stellate-cell activation in Wilson disease liver fibrosis.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-neurodegeneration">
                 <div class="item-name">Neurodegeneration</div>
@@ -3309,7 +3764,7 @@
                 <div class="item-meta">
 
                     <span class="tag tag-bio">
-                        neuron death
+                        neuron apoptotic process
 
                         <a href="http://purl.obolibrary.org/obo/GO_0051402" target="_blank" class="linkout">link</a>
 
@@ -3342,6 +3797,112 @@
                 </div>
 
 
+
+
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Tremor</span>
+
+	                            <span class="crosslink-desc">Basal ganglia and cerebellar circuit injury contributes to tremor.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Dystonia</span>
+
+	                            <span class="crosslink-desc">Striatal injury disrupts motor circuit output and contributes to dystonia.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Parkinsonism</span>
+
+	                            <span class="crosslink-desc">Basal ganglia dysfunction can manifest clinically as parkinsonism.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Bradykinesia</span>
+
+	                            <span class="crosslink-desc">Extrapyramidal circuit dysfunction contributes to bradykinesia.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Rigidity</span>
+
+	                            <span class="crosslink-desc">Extrapyramidal circuit dysfunction contributes to rigidity.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Chorea</span>
+
+	                            <span class="crosslink-desc">Basal ganglia injury can produce choreiform hyperkinesia.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Dysarthria</span>
+
+	                            <span class="crosslink-desc">Motor network injury affecting bulbar and extrapyramidal function contributes to dysarthria.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Ataxia</span>
+
+	                            <span class="crosslink-desc">Cerebellar and brainstem involvement contributes to ataxia.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Dysphagia</span>
+
+	                            <span class="crosslink-desc">Bulbar motor dysfunction contributes to dysphagia.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Drooling</span>
+
+	                            <span class="crosslink-desc">Bulbar dysfunction and impaired swallowing contribute to drooling.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Anxiety</span>
+
+	                            <span class="crosslink-desc">Copper-mediated brain injury can contribute to neuropsychiatric symptoms including anxiety.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Depression</span>
+
+	                            <span class="crosslink-desc">Neuropsychiatric brain involvement contributes to depressive symptoms.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Psychosis</span>
+
+	                            <span class="crosslink-desc">Severe neuropsychiatric involvement can manifest as psychosis.</span>
+
+	                        </div>
+
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">Personality Changes</span>
+
+	                            <span class="crosslink-desc">Fronto-striatal and related network dysfunction can manifest as personality change.</span>
+
+	                        </div>
+
+	                    </div>
+	                </div>
 
 
 
@@ -3412,7 +3973,7 @@
     </details>
 
 
-            </div>
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-cuproptosis">
                 <div class="item-name">Cuproptosis</div>
@@ -3437,6 +3998,7 @@
 
 
                 </div>
+
 
 
 
@@ -3492,7 +4054,7 @@
     </details>
 
 
-            </div>
+	            </div>
 
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-ferroptosis">
                 <div class="item-name">Ferroptosis</div>
@@ -3517,6 +4079,7 @@
 
 
                 </div>
+
 
 
 
@@ -3572,7 +4135,7 @@
     </details>
 
 
-            </div>
+	            </div>
 
         </div>
 
@@ -3599,7 +4162,7 @@
             </div>
             <script>
             (function() {
-                var graphData = JSON.parse("{\"nodes\": [{\"id\": \"ATP7B\", \"node_type\": \"genetic\", \"color\": \"#f3e8ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"genes\": [\"ATP7B\"], \"association\": \"Causative\"}}, {\"id\": \"Cuproptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper-dependent cell death has been proposed in Wilson disease, involving binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA) cycle and leading to proteotoxic stress and mitochondrial dysfunction.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"cuproptosis\"]}}, {\"id\": \"Ferroptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Iron-related cell death pathway involving phospholipid peroxidation. Secondary hepatic iron overload has been documented in a subset of Wilson disease patients, raising the possibility of ferroptotic injury alongside copper-mediated toxicity.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"ferroptosis\"]}}, {\"id\": \"Hepatic Copper Accumulation\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Impaired biliary excretion causes progressive copper retention in hepatocytes. When hepatic storage capacity is exceeded, copper is released into the circulation.\\n\", \"meta\": {\"evidence_count\": 2, \"cell_types\": [\"hepatocyte\"], \"locations\": [\"liver\"]}}, {\"id\": \"Hepatocyte Injury\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Progressive liver damage leads to fibrosis and cirrhosis. Copper overload activates autophagy and mitophagy-based mitochondrial quality control responses.\\n\", \"meta\": {\"evidence_count\": 6, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"response to oxidative stress\", \"mitophagy\"], \"locations\": [\"liver\"]}}, {\"id\": \"Impaired Biliary Copper Excretion\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B mutations impair copper excretion into bile. ATP7B normally resides in the trans-Golgi network and traffics to the bile canalicular membrane when intracellular copper is elevated. Loss of ATP7B function prevents this copper export pathway.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"copper ion transport\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Impaired Ceruloplasmin Loading\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B normally loads copper into apoceruloplasmin in the trans-Golgi network. Loss of ATP7B function results in secretion of copper-free apoceruloplasmin, which is rapidly degraded, leading to the characteristic low serum ceruloplasmin levels.\\n\", \"meta\": {\"evidence_count\": 1, \"biological_processes\": [\"copper ion homeostasis\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Neurodegeneration\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper deposition is thought to drive brain cellular damage with characteristic striatal/basal ganglia lesions. Reactive astrogliosis and microglial activation with increased CNS inflammatory cytokines indicate neuroinflammation contributing to movement and psychiatric symptoms.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"astrocyte\", \"microglial cell\"], \"biological_processes\": [\"neuron death\"], \"locations\": [\"collection of basal ganglia\", \"putamen\"]}}, {\"id\": \"Systemic Copper Distribution\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"When hepatic copper storage capacity is exceeded, free copper enters the circulation and deposits in the brain, kidneys, eyes, heart, muscles, and bones, causing multi-organ injury.\\n\", \"meta\": {\"evidence_count\": 2}}], \"edges\": [{\"source\": \"Impaired Biliary Copper Excretion\", \"target\": \"Hepatic Copper Accumulation\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Hepatocyte Injury\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Systemic Copper Distribution\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Neurodegeneration\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Cuproptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Ferroptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Biliary Copper Excretion\", \"predicate\": \"contributes_to\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Ceruloplasmin Loading\", \"predicate\": \"contributes_to\", \"is_orphan\": false}], \"orphan_targets\": []}");
+                var graphData = JSON.parse("{\"nodes\": [{\"id\": \"24-Hour Urinary Copper\", \"node_type\": \"biochemical\", \"color\": \"#e0e7ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2}}, {\"id\": \"ATP7B\", \"node_type\": \"genetic\", \"color\": \"#f3e8ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"genes\": [\"ATP7B\"], \"association\": \"Causative\"}}, {\"id\": \"Acute Hepatic Failure\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0006554\"}}, {\"id\": \"Anxiety\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"term_id\": \"HP:0000739\"}}, {\"id\": \"Arthralgia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"term_id\": \"HP:0002829\"}}, {\"id\": \"Ataxia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0001251\"}}, {\"id\": \"Bradykinesia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0002067\"}}, {\"id\": \"Cardiac Arrhythmia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0011675\"}}, {\"id\": \"Cardiomyopathy\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0001638\"}}, {\"id\": \"Ceruloplasmin\", \"node_type\": \"biochemical\", \"color\": \"#e0e7ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1}}, {\"id\": \"Chorea\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0002072\"}}, {\"id\": \"Cirrhosis\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0001394\"}}, {\"id\": \"Cuproptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper-dependent cell death has been proposed in Wilson disease, involving binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA) cycle and leading to proteotoxic stress and mitochondrial dysfunction.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"cuproptosis\"]}}, {\"id\": \"Depression\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0000716\"}}, {\"id\": \"Drooling\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"term_id\": \"HP:0002307\"}}, {\"id\": \"Dysarthria\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0001260\"}}, {\"id\": \"Dysphagia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0002015\"}}, {\"id\": \"Dystonia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0001332\"}}, {\"id\": \"Excessive Hepatic ECM Deposition\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Collagen-secreting myofibroblasts deposit excessive extracellular matrix in the liver, progressively distorting architecture and promoting cirrhosis.\\n\", \"meta\": {\"evidence_count\": 1, \"cell_types\": [\"myofibroblast cell\"], \"biological_processes\": [\"extracellular matrix organization\", \"collagen biosynthetic process\"], \"locations\": [\"liver\"]}}, {\"id\": \"Ferroptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Iron-related cell death pathway involving phospholipid peroxidation. Secondary hepatic iron overload has been documented in a subset of Wilson disease patients, raising the possibility of ferroptotic injury alongside copper-mediated toxicity.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"ferroptosis\"]}}, {\"id\": \"Heart Failure\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"term_id\": \"HP:0001635\"}}, {\"id\": \"Hemolytic Anemia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0001878\"}}, {\"id\": \"Hepatic Copper\", \"node_type\": \"biochemical\", \"color\": \"#e0e7ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1}}, {\"id\": \"Hepatic Copper Accumulation\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Impaired biliary excretion causes progressive copper retention in hepatocytes. When hepatic storage capacity is exceeded, copper is released into the circulation.\\n\", \"meta\": {\"evidence_count\": 2, \"cell_types\": [\"hepatocyte\"], \"locations\": [\"liver\"]}}, {\"id\": \"Hepatic Stellate Cell Activation\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper-injured liver tissue activates pro-fibrotic signaling, including TGF-beta and NF-kappaB pathways, which stimulate hepatic stellate cells to transdifferentiate toward collagen-secreting myofibroblasts.\\n\", \"meta\": {\"evidence_count\": 1, \"cell_types\": [\"hepatic stellate cell\", \"myofibroblast cell\"], \"biological_processes\": [\"transforming growth factor beta receptor signaling pathway\"], \"locations\": [\"liver\"]}}, {\"id\": \"Hepatitis\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"VERY_FREQUENT\", \"term_id\": \"HP:0012115\"}}, {\"id\": \"Hepatocyte Injury\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Severe injury can manifest as hepatitis, jaundice, hepatomegaly, and acute liver failure. Copper overload also activates autophagy and mitophagy-based mitochondrial quality control responses.\\n\", \"meta\": {\"evidence_count\": 6, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"response to oxidative stress\", \"mitophagy\"], \"locations\": [\"liver\"]}}, {\"id\": \"Hepatomegaly\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0002240\"}}, {\"id\": \"Impaired Biliary Copper Excretion\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B mutations impair copper excretion into bile. ATP7B normally resides in the trans-Golgi network and traffics to the bile canalicular membrane when intracellular copper is elevated. Loss of ATP7B function prevents this copper export pathway.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"copper ion transport\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Impaired Ceruloplasmin Loading\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B normally loads copper into apoceruloplasmin in the trans-Golgi network. Loss of ATP7B function results in secretion of copper-free apoceruloplasmin, which is rapidly degraded, leading to the characteristic low serum ceruloplasmin levels.\\n\", \"meta\": {\"evidence_count\": 1, \"biological_processes\": [\"copper ion homeostasis\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Jaundice\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"term_id\": \"HP:0000952\"}}, {\"id\": \"Kayser-Fleischer Rings\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0200032\"}}, {\"id\": \"Neurodegeneration\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper deposition is thought to drive brain cellular damage with characteristic striatal/basal ganglia lesions. Reactive astrogliosis and microglial activation with increased CNS inflammatory cytokines indicate neuroinflammation contributing to movement and psychiatric symptoms.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"astrocyte\", \"microglial cell\"], \"biological_processes\": [\"neuron apoptotic process\"], \"locations\": [\"collection of basal ganglia\", \"putamen\"]}}, {\"id\": \"Non-Ceruloplasmin-Bound Serum Copper\", \"node_type\": \"biochemical\", \"color\": \"#e0e7ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2}}, {\"id\": \"Osteopenia\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"term_id\": \"HP:0000938\"}}, {\"id\": \"Osteoporosis\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"term_id\": \"HP:0000939\"}}, {\"id\": \"Parkinsonism\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0001300\"}}, {\"id\": \"Personality Changes\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0000751\"}}, {\"id\": \"Psychosis\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0000709\"}}, {\"id\": \"Renal Tubular Dysfunction\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0000124\"}}, {\"id\": \"Rigidity\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"frequency\": \"OCCASIONAL\", \"term_id\": \"HP:0002063\"}}, {\"id\": \"Systemic Copper Distribution\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"When hepatic copper storage capacity is exceeded, free copper enters the circulation and deposits in the brain, kidneys, eyes, heart, muscles, and bones, causing multi-organ injury.\\n\", \"meta\": {\"evidence_count\": 2}}, {\"id\": \"Tremor\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"frequency\": \"FREQUENT\", \"term_id\": \"HP:0001337\"}}, {\"id\": \"Vomiting\", \"node_type\": \"phenotype\", \"color\": \"#fef3c7\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 1, \"term_id\": \"HP:0002013\"}}], \"edges\": [{\"source\": \"Impaired Biliary Copper Excretion\", \"target\": \"Hepatic Copper Accumulation\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Impaired Ceruloplasmin Loading\", \"target\": \"Ceruloplasmin\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Hepatocyte Injury\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Systemic Copper Distribution\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Hepatic Copper\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Neurodegeneration\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Non-Ceruloplasmin-Bound Serum Copper\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"24-Hour Urinary Copper\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Kayser-Fleischer Rings\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Renal Tubular Dysfunction\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Cardiomyopathy\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Heart Failure\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Cardiac Arrhythmia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Osteopenia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Osteoporosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Arthralgia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Hepatic Stellate Cell Activation\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Hepatitis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Hepatomegaly\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Jaundice\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Acute Hepatic Failure\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Hemolytic Anemia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Vomiting\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Cuproptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Ferroptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Stellate Cell Activation\", \"target\": \"Excessive Hepatic ECM Deposition\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Excessive Hepatic ECM Deposition\", \"target\": \"Cirrhosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Tremor\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Dystonia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Parkinsonism\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Bradykinesia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Rigidity\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Chorea\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Dysarthria\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Ataxia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Dysphagia\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Drooling\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Anxiety\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Depression\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Psychosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Neurodegeneration\", \"target\": \"Personality Changes\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Biliary Copper Excretion\", \"predicate\": \"contributes_to\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Ceruloplasmin Loading\", \"predicate\": \"contributes_to\", \"is_orphan\": false}], \"orphan_targets\": []}");
                 renderPathograph("pathograph", graphData);
             })();
             </script>
@@ -4353,7 +4916,7 @@
                     <div class="item-name">
                         Kayser-Fleischer Rings
 
-                        <span class="phenotype-freq">VERY_FREQUENT</span>
+                        <span class="phenotype-freq">FREQUENT</span>
 
 
                         <span class="phenotype-id">
@@ -4612,8 +5175,6 @@
                     <div class="item-name">
                         Osteoporosis
 
-                        <span class="phenotype-freq">OCCASIONAL</span>
-
 
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000939" target="_blank">
@@ -4682,8 +5243,6 @@
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Osteopenia
-
-                        <span class="phenotype-freq">OCCASIONAL</span>
 
 
                         <span class="phenotype-id">
@@ -6539,7 +7098,7 @@
             <div class="yaml-content" id="yamlContent">
                 <pre class="yaml-preview">name: Wilson Disease
 creation_date: &#39;2025-12-19T14:27:56Z&#39;
-updated_date: &#39;2026-04-23T00:34:30Z&#39;
+updated_date: &#39;2026-04-23T01:49:27Z&#39;
 category: Genetic
 description: &gt;
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -6758,6 +7317,9 @@ pathophysiology:
     term:
       id: GO:0055070
       label: copper ion homeostasis
+  downstream:
+  - target: Ceruloplasmin
+    description: Failure to load copper into apoceruloplasmin leads to low circulating ceruloplasmin.
 
 - name: Hepatic Copper Accumulation
   description: &gt;
@@ -6790,6 +7352,8 @@ pathophysiology:
     description: Copper overload in hepatocytes drives oxidative stress and cell death.
   - target: Systemic Copper Distribution
     description: Overflow of copper from the liver enters the circulation and deposits in extrahepatic organs.
+  - target: Hepatic Copper
+    description: Retained hepatic copper becomes measurably increased on liver biopsy.
 
 - name: Systemic Copper Distribution
   description: &gt;
@@ -6810,13 +7374,34 @@ pathophysiology:
   downstream:
   - target: Neurodegeneration
     description: Copper deposition in the basal ganglia and other brain regions causes neuronal injury.
+  - target: Non-Ceruloplasmin-Bound Serum Copper
+    description: Overflow of hepatocellular copper raises the circulating free copper fraction.
+  - target: 24-Hour Urinary Copper
+    description: Increased circulating free copper drives elevated urinary copper excretion.
+  - target: Kayser-Fleischer Rings
+    description: Copper deposition in Descemet membrane produces Kayser-Fleischer corneal rings.
+  - target: Renal Tubular Dysfunction
+    description: Copper deposition in the kidneys contributes to renal tubular injury and dysfunction.
+  - target: Cardiomyopathy
+    description: Cardiac copper deposition contributes to myocardial injury and cardiomyopathy.
+  - target: Heart Failure
+    description: Copper-mediated cardiac injury can progress to clinical heart failure.
+  - target: Cardiac Arrhythmia
+    description: Copper-mediated cardiac involvement increases the risk of clinically significant arrhythmias.
+  - target: Osteopenia
+    description: Extrahepatic copper toxicity contributes to reduced bone mineral density.
+  - target: Osteoporosis
+    description: Chronic extrahepatic copper toxicity contributes to pathologic bone loss in a subset of patients.
+  - target: Arthralgia
+    description: Musculoskeletal copper deposition and bone disease contribute to arthralgia.
 
 - name: Hepatocyte Injury
   description: &gt;
     Copper accumulation in hepatocytes causes oxidative stress, mitochondrial
-    dysfunction, and cell death. Progressive liver damage leads to fibrosis
-    and cirrhosis. Copper overload activates autophagy and mitophagy-based
-    mitochondrial quality control responses.
+    dysfunction, and cell death. Severe injury can manifest as hepatitis,
+    jaundice, hepatomegaly, and acute liver failure. Copper overload also
+    activates autophagy and mitophagy-based mitochondrial quality control
+    responses.
   evidence:
   - reference: PMID:38731973
     reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
@@ -6871,10 +7456,98 @@ pathophysiology:
       id: GO:0000423
       label: mitophagy
   downstream:
+  - target: Hepatic Stellate Cell Activation
+    description: Injured hepatocytes activate pro-fibrotic stellate-cell responses in the liver.
+  - target: Hepatitis
+    description: Hepatocellular oxidative injury and inflammation manifest clinically as hepatitis.
+  - target: Hepatomegaly
+    description: Hepatocyte swelling and inflammatory liver injury can produce hepatomegaly.
+  - target: Jaundice
+    description: Acute hepatocellular dysfunction impairs bilirubin handling and can produce jaundice.
+  - target: Acute Hepatic Failure
+    description: Severe hepatocyte death can precipitate fulminant hepatic failure.
+  - target: Hemolytic Anemia
+    description: Abrupt copper release from injured liver can trigger oxidant hemolysis.
+  - target: Vomiting
+    description: Acute hepatic decompensation can present with vomiting as part of the hepatic illness syndrome.
   - target: Cuproptosis
     description: Proposed copper-dependent cell death pathways may amplify hepatocyte injury.
   - target: Ferroptosis
     description: Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.
+
+- name: Hepatic Stellate Cell Activation
+  conforms_to: fibrotic_response#Mesenchymal Cell Activation
+  description: &gt;
+    Copper-injured liver tissue activates pro-fibrotic signaling, including
+    TGF-beta and NF-kappaB pathways, which stimulate hepatic stellate cells to
+    transdifferentiate toward collagen-secreting myofibroblasts.
+  evidence:
+  - reference: PMID:41006805
+    reference_title: &#34;The pathogenesis of liver fibrosis in Wilson&#39;s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.&#34;
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: &#34;Copper ions also activate signaling pathways such as the TGF-β1/Smad and NF-κB pathways, which stimulate hepatic stellate cells and promote their transdifferentiation into collagen-secreting myofibroblasts&#34;
+    explanation: Supports a distinct fibrogenic step in which copper-triggered signaling activates hepatic stellate cells and drives myofibroblast conversion.
+  cell_types:
+  - preferred_term: hepatic stellate cell
+    term:
+      id: CL:0000632
+      label: hepatic stellate cell
+  - preferred_term: myofibroblast cell
+    term:
+      id: CL:0000186
+      label: myofibroblast cell
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  biological_processes:
+  - preferred_term: transforming growth factor beta receptor signaling pathway
+    term:
+      id: GO:0007179
+      label: transforming growth factor beta receptor signaling pathway
+    modifier: INCREASED
+  downstream:
+  - target: Excessive Hepatic ECM Deposition
+    description: Activated stellate cells and myofibroblasts drive excess extracellular matrix deposition.
+
+- name: Excessive Hepatic ECM Deposition
+  conforms_to: fibrotic_response#Excessive ECM Deposition
+  description: &gt;
+    Collagen-secreting myofibroblasts deposit excessive extracellular matrix in
+    the liver, progressively distorting architecture and promoting cirrhosis.
+  evidence:
+  - reference: PMID:41006805
+    reference_title: &#34;The pathogenesis of liver fibrosis in Wilson&#39;s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.&#34;
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: &#34;collagen-secreting myofibroblasts, which then accelerate extracellular matrix deposition.&#34;
+    explanation: Supports extracellular matrix accumulation as the immediate downstream consequence of hepatic stellate-cell activation in Wilson disease liver fibrosis.
+  cell_types:
+  - preferred_term: myofibroblast cell
+    term:
+      id: CL:0000186
+      label: myofibroblast cell
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+    modifier: INCREASED
+  - preferred_term: collagen biosynthetic process
+    term:
+      id: GO:0032964
+      label: collagen biosynthetic process
+    modifier: INCREASED
+  downstream:
+  - target: Cirrhosis
+    description: Progressive matrix deposition and architectural distortion manifest clinically as cirrhosis.
 
 - name: Neurodegeneration
   description: &gt;
@@ -6918,10 +7591,39 @@ pathophysiology:
       id: UBERON:0001874
       label: putamen
   biological_processes:
-  - preferred_term: neuron death
+  - preferred_term: neuron apoptotic process
     term:
       id: GO:0051402
       label: neuron apoptotic process
+  downstream:
+  - target: Tremor
+    description: Basal ganglia and cerebellar circuit injury contributes to tremor.
+  - target: Dystonia
+    description: Striatal injury disrupts motor circuit output and contributes to dystonia.
+  - target: Parkinsonism
+    description: Basal ganglia dysfunction can manifest clinically as parkinsonism.
+  - target: Bradykinesia
+    description: Extrapyramidal circuit dysfunction contributes to bradykinesia.
+  - target: Rigidity
+    description: Extrapyramidal circuit dysfunction contributes to rigidity.
+  - target: Chorea
+    description: Basal ganglia injury can produce choreiform hyperkinesia.
+  - target: Dysarthria
+    description: Motor network injury affecting bulbar and extrapyramidal function contributes to dysarthria.
+  - target: Ataxia
+    description: Cerebellar and brainstem involvement contributes to ataxia.
+  - target: Dysphagia
+    description: Bulbar motor dysfunction contributes to dysphagia.
+  - target: Drooling
+    description: Bulbar dysfunction and impaired swallowing contribute to drooling.
+  - target: Anxiety
+    description: Copper-mediated brain injury can contribute to neuropsychiatric symptoms including anxiety.
+  - target: Depression
+    description: Neuropsychiatric brain involvement contributes to depressive symptoms.
+  - target: Psychosis
+    description: Severe neuropsychiatric involvement can manifest as psychosis.
+  - target: Personality Changes
+    description: Fronto-striatal and related network dysfunction can manifest as personality change.
 - name: Cuproptosis
   description: &gt;
     Copper-dependent cell death has been proposed in Wilson disease, involving
@@ -7055,7 +7757,7 @@ phenotypes:
       label: Hepatitis
 - name: Kayser-Fleischer Rings
   category: Ocular
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   diagnostic: true
   notes: Copper deposits in Descemet membrane, pathognomonic
   evidence:
@@ -7333,7 +8035,7 @@ phenotypes:
     snippet: &#34;patients with Wilson&#39;s disease had a 55% higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p &lt;0.0001)&#34;
     explanation: Population-level claims data support heart failure as an important cardiac complication of Wilson disease.
   phenotype_term:
-    preferred_term: Heart failure
+    preferred_term: Congestive heart failure
     term:
       id: HP:0001635
       label: Congestive heart failure
@@ -7388,7 +8090,6 @@ phenotypes:
       label: Hemolytic anemia
 - name: Osteoporosis
   category: Skeletal
-  frequency: OCCASIONAL
   evidence:
   - reference: PMID:29110062
     reference_title: &#34;Osteoporosis and bone mineral density in patients with Wilson&#39;s disease: a systematic review and meta-analysis.&#34;
@@ -7407,7 +8108,6 @@ phenotypes:
       label: Osteoporosis
 - name: Osteopenia
   category: Skeletal
-  frequency: OCCASIONAL
   evidence:
   - reference: PMID:29110062
     reference_title: &#34;Osteoporosis and bone mineral density in patients with Wilson&#39;s disease: a systematic review and meta-analysis.&#34;
@@ -8439,7 +9139,7 @@ references:
         'use strict';
 
         // Config injected by Jinja2
-        const OS_CONFIG = {"diseaseName": "Wilson Disease", "mondoId": "MONDO:0010200", "proxyUrl": "https://dismech-openscientist.bbop.workers.dev", "slug": "Wilson_Disease", "yamlRevision": "90a78da0a13c"};
+        const OS_CONFIG = {"diseaseName": "Wilson Disease", "mondoId": "MONDO:0010200", "proxyUrl": "https://dismech-openscientist.bbop.workers.dev", "slug": "Wilson_Disease", "yamlRevision": "ca492b5e5537"};
 
         // --- DOM refs ---
         const questionInput = document.getElementById('os-question');

--- a/pages/disorders/Wilson_Disease.html
+++ b/pages/disorders/Wilson_Disease.html
@@ -2567,7 +2567,7 @@
 
             <a class="stat-link" href="#phenotypes">
             <div class="stat-item">
-                <div class="stat-value">23</div>
+                <div class="stat-value">29</div>
                 <div class="stat-label">Phenotypes</div>
             </div>
             </a>
@@ -2634,7 +2634,7 @@
 
             <a class="stat-link" href="#references">
             <div class="stat-item">
-                <div class="stat-value">32</div>
+                <div class="stat-value">35</div>
                 <div class="stat-label">References</div>
             </div>
             </a>
@@ -3612,7 +3612,7 @@
             <div class="card-header">
                 <div class="card-icon" style="background: #dcfce7; color: #16a34a;">●</div>
                 <h2 class="card-title">Phenotypes</h2>
-                <span class="card-count">23</span>
+                <span class="card-count">29</span>
             </div>
 
 
@@ -3620,17 +3620,21 @@
 
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-1">Blood<span class="pill-count">(1)</span></button>
 
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-2">Cardiovascular<span class="pill-count">(2)</span></button>
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-2">Cardiovascular<span class="pill-count">(3)</span></button>
 
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-3">Digestive<span class="pill-count">(5)</span></button>
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-3">Digestive<span class="pill-count">(7)</span></button>
 
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-4">Eye<span class="pill-count">(1)</span></button>
 
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-5">Genitourinary<span class="pill-count">(1)</span></button>
 
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-6">Musculoskeletal<span class="pill-count">(3)</span></button>
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-6">Head and Neck<span class="pill-count">(1)</span></button>
 
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-7">Nervous System<span class="pill-count">(10)</span></button>
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-7">Musculoskeletal<span class="pill-count">(3)</span></button>
+
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-8">Nervous System<span class="pill-count">(11)</span></button>
+
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-9">Constitutional<span class="pill-count">(1)</span></button>
 
                 <button class="pheno-toggle-all" id="phenoToggleAll">Expand all</button>
             </div>
@@ -3722,7 +3726,7 @@
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Cardiovascular
-                    <span class="cat-count">2</span>
+                    <span class="cat-count">3</span>
                 </summary>
 
                 <div class="item-box phenotype-box">
@@ -3765,6 +3769,57 @@
 
 
                 <div class="evidence-explanation">Supports cardiomyopathy as a recognized but uncommon cardiac complication of Wilson disease.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+
+
+
+                </div>
+
+                <div class="item-box phenotype-box">
+                    <div class="item-name">
+                        Heart Failure
+
+
+                        <span class="phenotype-id">
+                            <a href="http://purl.obolibrary.org/obo/HP_0001635" target="_blank">
+                                Congestive heart failure
+                            </a>
+                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001635)</span>
+                        </span>
+
+                    </div>
+
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/28947309" target="_blank">PMID:28947309</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"patients with Wilson&#39;s disease had a 55% higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p &lt;0.0001)"</div>
+
+
+                <div class="evidence-explanation">Population-level claims data support heart failure as an important cardiac complication of Wilson disease.</div>
 
             </div>
 
@@ -3837,14 +3892,14 @@
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Digestive
-                    <span class="cat-count">5</span>
+                    <span class="cat-count">7</span>
                 </summary>
 
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Hepatomegaly
 
-                        <span class="phenotype-freq">VERY_FREQUENT</span>
+                        <span class="phenotype-freq">OCCASIONAL</span>
 
 
                         <span class="phenotype-id">
@@ -3868,18 +3923,69 @@
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/15205951" target="_blank">PMID:15205951</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/22473403" target="_blank">PMID:22473403</a>
                     </span>
 
-                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
 
 
                 </div>
 
-                <div class="evidence-snippet">"Resultant liver damage leads to steatosis, inflammation, cirrhosis, and, occasionally, fulminant liver failure."</div>
+                <div class="evidence-snippet">"three had hepatomegaly associated with neurological disorders"</div>
 
 
-                <div class="evidence-explanation">Hepatic copper accumulation causes progressive liver damage including steatosis and inflammation, which manifest as hepatomegaly. Direct frequency data for hepatomegaly not available in this abstract.</div>
+                <div class="evidence-explanation">Pediatric cohort data directly support hepatomegaly as an occasional presenting phenotype in Wilson disease.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+
+
+
+                </div>
+
+                <div class="item-box phenotype-box">
+                    <div class="item-name">
+                        Jaundice
+
+
+                        <span class="phenotype-id">
+                            <a href="http://purl.obolibrary.org/obo/HP_0000952" target="_blank">
+                                Jaundice
+                            </a>
+                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000952)</span>
+                        </span>
+
+                    </div>
+
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/3595645" target="_blank">PMID:3595645</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"</div>
+
+
+                <div class="evidence-explanation">Large case-series data identify jaundice among the common presenting symptoms of Wilson disease.</div>
 
             </div>
 
@@ -4183,6 +4289,57 @@
 
                 </div>
 
+                <div class="item-box phenotype-box">
+                    <div class="item-name">
+                        Vomiting
+
+
+                        <span class="phenotype-id">
+                            <a href="http://purl.obolibrary.org/obo/HP_0002013" target="_blank">
+                                Vomiting
+                            </a>
+                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002013)</span>
+                        </span>
+
+                    </div>
+
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/29914392" target="_blank">PMID:29914392</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"These patients had clinical features such as numbness of hands and feet, vomiting, insomnia, palsy, liver failure and Kayser-Fleischer (K-F) rings"</div>
+
+
+                <div class="evidence-explanation">HPOA-linked case-series evidence supports vomiting as a gastrointestinal manifestation reported in Wilson disease.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+
+
+
+                </div>
+
             </details>
 
             <details class="phenotype-category-group" id="pheno-cat-4">
@@ -4332,6 +4489,66 @@
             </details>
 
             <details class="phenotype-category-group" id="pheno-cat-6">
+                <summary>
+                    <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
+                    Head and Neck
+                    <span class="cat-count">1</span>
+                </summary>
+
+                <div class="item-box phenotype-box">
+                    <div class="item-name">
+                        Drooling
+
+
+                        <span class="phenotype-id">
+                            <a href="http://purl.obolibrary.org/obo/HP_0002307" target="_blank">
+                                Drooling
+                            </a>
+                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002307)</span>
+                        </span>
+
+                    </div>
+
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/3595645" target="_blank">PMID:3595645</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"</div>
+
+
+                <div class="evidence-explanation">Large case-series data identify drooling as one of the more common presenting symptoms of Wilson disease.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+
+
+
+                </div>
+
+            </details>
+
+            <details class="phenotype-category-group" id="pheno-cat-7">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Musculoskeletal
@@ -4535,11 +4752,11 @@
 
             </details>
 
-            <details class="phenotype-category-group" id="pheno-cat-7">
+            <details class="phenotype-category-group" id="pheno-cat-8">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Nervous System
-                    <span class="cat-count">10</span>
+                    <span class="cat-count">11</span>
                 </summary>
 
                 <div class="item-box phenotype-box">
@@ -4991,9 +5208,60 @@
 
                 <div class="item-box phenotype-box">
                     <div class="item-name">
+                        Anxiety
+
+
+                        <span class="phenotype-id">
+                            <a href="http://purl.obolibrary.org/obo/HP_0000739" target="_blank">
+                                Anxiety
+                            </a>
+                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000739)</span>
+                        </span>
+
+                    </div>
+
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/1821256" target="_blank">PMID:1821256</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred."</div>
+
+
+                <div class="evidence-explanation">Supports anxiety as a recognized psychiatric manifestation of Wilson disease.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+
+
+
+                </div>
+
+                <div class="item-box phenotype-box">
+                    <div class="item-name">
                         Depression
 
-                        <span class="phenotype-freq">FREQUENT</span>
+                        <span class="phenotype-freq">OCCASIONAL</span>
 
 
                         <span class="phenotype-id">
@@ -5101,7 +5369,7 @@
                     <div class="item-name">
                         Personality Changes
 
-                        <span class="phenotype-freq">OCCASIONAL</span>
+                        <span class="phenotype-freq">FREQUENT</span>
 
 
                         <span class="phenotype-id">
@@ -5139,6 +5407,66 @@
 
 
                 <div class="evidence-explanation">Directly supports personality change as a common psychiatric presentation in symptomatic Wilson disease.</div>
+
+            </div>
+
+
+        </div>
+    </details>
+
+
+
+
+
+                </div>
+
+            </details>
+
+            <details class="phenotype-category-group" id="pheno-cat-9">
+                <summary>
+                    <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
+                    Constitutional
+                    <span class="cat-count">1</span>
+                </summary>
+
+                <div class="item-box phenotype-box">
+                    <div class="item-name">
+                        Arthralgia
+
+
+                        <span class="phenotype-id">
+                            <a href="http://purl.obolibrary.org/obo/HP_0002829" target="_blank">
+                                Arthralgia
+                            </a>
+                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002829)</span>
+                        </span>
+
+                    </div>
+
+
+
+
+    <details class="evidence-details">
+        <summary class="evidence-toggle">
+            Show evidence (1 reference)
+        </summary>
+        <div class="evidence-list">
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/3595645" target="_blank">PMID:3595645</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"</div>
+
+
+                <div class="evidence-explanation">Large case-series data identify arthralgia among the more common presenting symptoms of Wilson disease.</div>
 
             </div>
 
@@ -6640,18 +6968,31 @@ pathophysiology:
 phenotypes:
 - name: Hepatomegaly
   category: Hepatic
-  frequency: VERY_FREQUENT
+  frequency: OCCASIONAL
   evidence:
-  - reference: PMID:15205951
-    reference_title: &#34;Wilson disease.&#34;
-    supports: PARTIAL
-    snippet: &#34;Resultant liver damage leads to steatosis, inflammation, cirrhosis, and, occasionally, fulminant liver failure.&#34;
-    explanation: Hepatic copper accumulation causes progressive liver damage including steatosis and inflammation, which manifest as hepatomegaly. Direct frequency data for hepatomegaly not available in this abstract.
+  - reference: PMID:22473403
+    reference_title: &#34;Wilson&#39;s disease: an analysis of 28 Brazilian children.&#34;
+    supports: SUPPORT
+    snippet: &#34;three had hepatomegaly associated with neurological disorders&#34;
+    explanation: Pediatric cohort data directly support hepatomegaly as an occasional presenting phenotype in Wilson disease.
   phenotype_term:
     preferred_term: Hepatomegaly
     term:
       id: HP:0002240
       label: Hepatomegaly
+- name: Jaundice
+  category: Hepatic
+  evidence:
+  - reference: PMID:3595645
+    reference_title: &#34;Presenting symptoms and natural history of Wilson disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia&#34;
+    explanation: Large case-series data identify jaundice among the common presenting symptoms of Wilson disease.
+  phenotype_term:
+    preferred_term: Jaundice
+    term:
+      id: HP:0000952
+      label: Jaundice
 - name: Cirrhosis
   category: Hepatic
   frequency: FREQUENT
@@ -6886,9 +7227,48 @@ phenotypes:
     term:
       id: HP:0002015
       label: Dysphagia
+- name: Drooling
+  category: Neurological
+  evidence:
+  - reference: PMID:3595645
+    reference_title: &#34;Presenting symptoms and natural history of Wilson disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia&#34;
+    explanation: Large case-series data identify drooling as one of the more common presenting symptoms of Wilson disease.
+  phenotype_term:
+    preferred_term: Drooling
+    term:
+      id: HP:0002307
+      label: Drooling
+- name: Vomiting
+  category: Gastrointestinal
+  evidence:
+  - reference: PMID:29914392
+    reference_title: &#34;Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;These patients had clinical features such as numbness of hands and feet, vomiting, insomnia, palsy, liver failure and Kayser-Fleischer (K-F) rings&#34;
+    explanation: HPOA-linked case-series evidence supports vomiting as a gastrointestinal manifestation reported in Wilson disease.
+  phenotype_term:
+    preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
+- name: Anxiety
+  category: Psychiatric
+  evidence:
+  - reference: PMID:1821256
+    reference_title: &#34;The psychiatric presentations of Wilson&#39;s disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.&#34;
+    explanation: Supports anxiety as a recognized psychiatric manifestation of Wilson disease.
+  phenotype_term:
+    preferred_term: Anxiety
+    term:
+      id: HP:0000739
+      label: Anxiety
 - name: Depression
   category: Psychiatric
-  frequency: FREQUENT
+  frequency: OCCASIONAL
   notes: One of the most common psychiatric manifestations of Wilson disease
   evidence:
   - reference: PMID:1821256
@@ -6917,7 +7297,7 @@ phenotypes:
       label: Psychosis
 - name: Personality Changes
   category: Psychiatric
-  frequency: OCCASIONAL
+  frequency: FREQUENT
   notes: Personality changes may be an early psychiatric manifestation
   evidence:
   - reference: PMID:1821256
@@ -6944,6 +7324,19 @@ phenotypes:
     term:
       id: HP:0001638
       label: Cardiomyopathy
+- name: Heart Failure
+  category: Cardiac
+  evidence:
+  - reference: PMID:28947309
+    reference_title: &#34;Wilson&#39;s Disease and Cardiac Myopathy.&#34;
+    supports: SUPPORT
+    snippet: &#34;patients with Wilson&#39;s disease had a 55% higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p &lt;0.0001)&#34;
+    explanation: Population-level claims data support heart failure as an important cardiac complication of Wilson disease.
+  phenotype_term:
+    preferred_term: Heart failure
+    term:
+      id: HP:0001635
+      label: Congestive heart failure
 - name: Cardiac Arrhythmia
   category: Cardiac
   frequency: OCCASIONAL
@@ -7031,6 +7424,19 @@ phenotypes:
     term:
       id: HP:0000938
       label: Osteopenia
+- name: Arthralgia
+  category: Skeletal
+  evidence:
+  - reference: PMID:3595645
+    reference_title: &#34;Presenting symptoms and natural history of Wilson disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia&#34;
+    explanation: Large case-series data identify arthralgia among the more common presenting symptoms of Wilson disease.
+  phenotype_term:
+    preferred_term: Arthralgia
+    term:
+      id: HP:0002829
+      label: Arthralgia
 biochemical:
 - name: Ceruloplasmin
   presence: Decreased
@@ -7357,6 +7763,15 @@ references:
 - reference: DOI:10.1007/s10534-025-00748-9
   title: &#39;The pathogenesis of liver fibrosis in Wilson&#39;&#39;s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.&#39;
   findings: []
+- reference: DOI:10.6061/clinics/2012(03)05
+  title: &#34;Wilson&#39;s disease: an analysis of 28 Brazilian children.&#34;
+  findings: []
+- reference: DOI:10.1007/BF00716470
+  title: Presenting symptoms and natural history of Wilson disease.
+  findings: []
+- reference: DOI:10.1186/s12881-018-0619-4
+  title: Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease.
+  findings: []
 </pre>
             </div>
         </div>
@@ -7372,7 +7787,7 @@ references:
             <div class="grouped-section anchor-target" id="references">
                 <div class="grouped-section-header">
                     <h3 class="grouped-section-title">References</h3>
-                    <span class="card-count">32</span>
+                    <span class="card-count">35</span>
                 </div>
 
                 <div class="reference-entry">
@@ -7919,6 +8334,57 @@ references:
 
                 </div>
 
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.6061/clinics/2012(03)05" target="_blank">DOI:10.6061/clinics/2012(03)05</a>
+                            </div>
+
+                            <div class="reference-title">Wilson&#39;s disease: an analysis of 28 Brazilian children.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1007/BF00716470" target="_blank">DOI:10.1007/BF00716470</a>
+                            </div>
+
+                            <div class="reference-title">Presenting symptoms and natural history of Wilson disease.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1186/s12881-018-0619-4" target="_blank">DOI:10.1186/s12881-018-0619-4</a>
+                            </div>
+
+                            <div class="reference-title">Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
             </div>
 
 
@@ -7973,7 +8439,7 @@ references:
         'use strict';
 
         // Config injected by Jinja2
-        const OS_CONFIG = {"diseaseName": "Wilson Disease", "mondoId": "MONDO:0010200", "proxyUrl": "https://dismech-openscientist.bbop.workers.dev", "slug": "Wilson_Disease", "yamlRevision": "e49b650698ec"};
+        const OS_CONFIG = {"diseaseName": "Wilson Disease", "mondoId": "MONDO:0010200", "proxyUrl": "https://dismech-openscientist.bbop.workers.dev", "slug": "Wilson_Disease", "yamlRevision": "90a78da0a13c"};
 
         // --- DOM refs ---
         const questionInput = document.getElementById('os-question');

--- a/pages/disorders/Wilson_Disease.html
+++ b/pages/disorders/Wilson_Disease.html
@@ -2370,27 +2370,27 @@
 </head>
 <body>
     <button type="button" class="notice-banner">This resource is in its pre-alpha development stage. Content is actively being curated and may be incomplete or subject to change.</button>
-    
 
-    
 
-    
-    
 
-    
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 
     <div class="container">
         <nav class="breadcrumb">
@@ -2402,24 +2402,24 @@
         <header class="page-header">
             <h1>Wilson Disease</h1>
             <div class="header-meta">
-                
+
                 <span class="badge badge-category">Genetic</span>
-                
-                
+
+
                 <span class="badge badge-mondo">
                     <a href="http://purl.obolibrary.org/obo/MONDO_0010200" target="_blank">
                         MONDO:0010200
                     </a>
                 </span>
-                
-                
+
+
                 <a class="badge badge-pathograph" href="#pathograph">Pathograph 9</a>
-                
-                
+
+
                 <span class="badge badge-category" style="background: rgba(255,255,255,0.1);">Metabolic Disease</span>
-                
+
                 <span class="badge badge-category" style="background: rgba(255,255,255,0.1);">Liver Disease</span>
-                
+
                 <button class="badge badge-openscientist" id="os-ask-btn"
                         onclick="toggleOpenScientist()">
                     <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" style="width: 18px; height: 18px; margin-right: 5px; vertical-align: middle;">
@@ -2432,12 +2432,12 @@
                     Ask OpenScientist
                 </button>
             </div>
-            
+
             <p style="margin-top: 16px; font-size: 1rem; line-height: 1.6; opacity: 0.95; position: relative;">
-                Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations in the ATP7B gene encoding a copper-transporting P-type ATPase. ATP7B dysfunction impairs biliary copper excretion and ceruloplasmin biosynthesis, leading to toxic copper accumulation primarily in the liver and brain, with secondary involvement of the kidneys, eyes, heart, muscles, and bones. Clinical presentations range from asymptomatic liver disease to fulminant hepatic failure, chronic hepatitis, cirrhosis, and diverse neuropsychiatric manifestations including dystonia, tremor, dysarthria, depression, and psychosis. Kayser-Fleischer corneal rings and Coombs-negative hemolytic anemia are characteristic features. Diagnosis relies on the modified Leipzig Scoring System integrating serum ceruloplasmin, urinary copper, hepatic copper content, and genetic testing. Treatment with copper chelators (D-penicillamine, trientine) and zinc salts can prevent disease progression when initiated early; liver transplantation is curative for end-stage hepatic disease.
+                Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations in the ATP7B gene encoding a copper-transporting P-type ATPase. ATP7B dysfunction impairs biliary copper excretion and ceruloplasmin biosynthesis, leading to toxic copper accumulation primarily in the liver and brain, with secondary involvement of the kidneys, eyes, heart, muscles, and bones. Clinical presentations range from asymptomatic liver disease to fulminant hepatic failure, chronic hepatitis, cirrhosis, and diverse neuropsychiatric manifestations including dystonia, tremor, dysarthria, depression, and psychosis. Kayser-Fleischer corneal rings are characteristic, and hemolytic anemia can accompany acute hepatic presentations. Diagnosis relies on the modified Leipzig Scoring System integrating serum ceruloplasmin, urinary copper, hepatic copper content, and genetic testing. Treatment with copper chelators (D-penicillamine, trientine) and zinc salts can prevent disease progression when initiated early; liver transplantation is curative for end-stage hepatic disease.
 
             </p>
-            
+
         </header>
 
         <!-- OpenScientist panel -->
@@ -2507,1070 +2507,1088 @@
         </div>
 
         <!-- Stats bar -->
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
         <div class="stats-bar">
-            
+
             <div class="stat-item">
                 <div class="stat-value">0</div>
                 <div class="stat-label">Mappings</div>
             </div>
-            
-            
+
+
             <div class="stat-item">
                 <div class="stat-value">0</div>
                 <div class="stat-label">Definitions</div>
             </div>
-            
-            
+
+
             <a class="stat-link" href="#inheritance">
             <div class="stat-item">
                 <div class="stat-value">1</div>
                 <div class="stat-label">Inheritance</div>
             </div>
             </a>
-            
-            
+
+
             <a class="stat-link" href="#pathophysiology">
             <div class="stat-item">
                 <div class="stat-value">8</div>
                 <div class="stat-label">Pathophysiology</div>
             </div>
             </a>
-            
-            
+
+
             <div class="stat-item">
                 <div class="stat-value">0</div>
                 <div class="stat-label">Histopathology</div>
             </div>
-            
-            
+
+
             <a class="stat-link" href="#phenotypes">
             <div class="stat-item">
-                <div class="stat-value">28</div>
+                <div class="stat-value">23</div>
                 <div class="stat-label">Phenotypes</div>
             </div>
             </a>
-            
-            
+
+
             <a class="stat-link" href="#pathograph">
             <div class="stat-item">
                 <div class="stat-value">9</div>
                 <div class="stat-label">Pathograph</div>
             </div>
             </a>
-            
-            
+
+
             <a class="stat-link" href="#genetic">
             <div class="stat-item">
                 <div class="stat-value">1</div>
                 <div class="stat-label">Genes</div>
             </div>
             </a>
-            
-            
+
+
             <a class="stat-link" href="#treatments">
             <div class="stat-item">
                 <div class="stat-value">6</div>
                 <div class="stat-label">Treatments</div>
             </div>
             </a>
-            
-            
+
+
             <div class="stat-item">
                 <div class="stat-value">0</div>
                 <div class="stat-label">Subtypes</div>
             </div>
-            
-            
+
+
             <a class="stat-link" href="#differentials">
             <div class="stat-item">
                 <div class="stat-value">2</div>
                 <div class="stat-label">Differentials</div>
             </div>
             </a>
-            
-            
+
+
             <a class="stat-link" href="#datasets">
             <div class="stat-item">
                 <div class="stat-value">1</div>
                 <div class="stat-label">Datasets</div>
             </div>
             </a>
-            
-            
+
+
             <div class="stat-item">
                 <div class="stat-value">0</div>
                 <div class="stat-label">Trials</div>
             </div>
-            
-            
+
+
             <div class="stat-item">
                 <div class="stat-value">0</div>
                 <div class="stat-label">Models</div>
             </div>
-            
-            
-            
+
+
+
             <a class="stat-link" href="#references">
             <div class="stat-item">
-                <div class="stat-value">20</div>
+                <div class="stat-value">32</div>
                 <div class="stat-label">References</div>
             </div>
             </a>
-            
-            
+
+
         </div>
 
         <!-- Classifications -->
-        
+
 
         <!-- Mappings -->
-        
+
 
         <!-- Definitions -->
-        
+
 
         <!-- Inheritance -->
-        
+
         <div class="card" id="inheritance">
             <div class="card-header">
                 <div class="card-icon" style="background: #fef3c7; color: #92400e;">👪</div>
                 <h2 class="card-title">Inheritance</h2>
                 <span class="card-count">1</span>
             </div>
-            
+
             <div class="item-box inheritance-box">
                 <div class="item-name">
                     Autosomal Recessive
-                    
+
                     <span class="phenotype-id">
                         <a href="http://purl.obolibrary.org/obo/HP_0000007" target="_blank">
                             HP:0000007
                         </a>
                     </span>
-                    
+
                 </div>
-                
-                
-    
-    
+
+
+
+
     <div class="item-meta">
-        
+
         <span class="tag tag-classification">
             Autosomal recessive inheritance
         </span>
-        
-        
-        
-        
-        
+
+
+
+
+
     </div>
-    
-    
-    
-                
-    
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/37741465" target="_blank">PMID:37741465</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Inactivating mutations of the copper-transporting P-type ATPase, ATP7B, result in Wilson&#39;s disease, an autosomal recessive disorder"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Directly states autosomal recessive inheritance for Wilson disease.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Subtypes -->
-        
+
 
         <!-- Comorbidities -->
-        
+
         <div class="card" id="comorbidities">
             <div class="card-header">
                 <div class="card-icon" style="background: #ede9fe; color: #6d28d9;">C</div>
                 <h2 class="card-title">Comorbidities</h2>
             </div>
             <div class="mapping-section">
-                
+
                 <div class="mapping-item">
                     <div class="mapping-title">
                         <a href="../comorbidities/com_Wilsons_Disease__Osteoporosis.html">Wilsons Disease &lt;-&gt; Osteoporosis</a>
                     </div>
                     <div class="tag-list">
-                        
+
                         <span class="tag tag-parent">Disease A</span>
-                        
-                        
+
+
                         <span class="tag tag-classification">UNKNOWN</span>
-                        
-                        
+
+
                         <span class="tag tag-mechanistic">CANDIDATE</span>
-                        
+
                     </div>
                 </div>
-                
+
             </div>
         </div>
-        
+
 
         <!-- Pathophysiology -->
-        
+
         <div class="card" id="pathophysiology">
             <div class="card-header">
                 <div class="card-icon" style="background: #fef3c7; color: #d97706;">⚙</div>
                 <h2 class="card-title">Pathophysiology</h2>
                 <span class="card-count">8</span>
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-impaired-biliary-copper-excretion">
                 <div class="item-name">Impaired Biliary Copper Excretion</div>
-                
+
                 <div class="item-desc">ATP7B mutations impair copper excretion into bile. ATP7B normally resides in the trans-Golgi network and traffics to the bile canalicular membrane when intracellular copper is elevated. Loss of ATP7B function prevents this copper export pathway.
 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-cell">
                         hepatocyte
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CL_0000182" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         copper ion transport
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0006825" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         P-type monovalent copper transporter activity
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0140581" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-component">
                         Golgi apparatus
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0005794" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (3 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Copper accumulation in the liver is due to impaired biliary excretion of copper caused by the inheritable malfunctioning or missing ATP7B protein."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms that impaired biliary copper excretion is the primary defect caused by ATP7B dysfunction.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/16382340" target="_blank">PMID:16382340</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"ATP7B is the gene product of the WD gene located on chromosome 13 and resides in hepatocytes in the trans-Golgi network, transporting copper into the secretory pathway for incorporation into apoceruloplasmin and excretion into the bile."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports ATP7B localization to the trans-Golgi network with biliary excretion function.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/18395099" target="_blank">PMID:18395099</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Copper excess provokes a massive download of the ATP7B retained in the trans-Golgi network into the bile canalicular membrane."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Demonstrates copper-stimulated ATP7B trafficking to the canalicular membrane.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-impaired-ceruloplasmin-loading">
                 <div class="item-name">Impaired Ceruloplasmin Loading</div>
-                
+
                 <div class="item-desc">ATP7B normally loads copper into apoceruloplasmin in the trans-Golgi network. Loss of ATP7B function results in secretion of copper-free apoceruloplasmin, which is rapidly degraded, leading to the characteristic low serum ceruloplasmin levels.
 </div>
-                
-                
-                
-                
-                
+
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         copper ion homeostasis
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0055070" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         P-type monovalent copper transporter activity
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0140581" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/16382340" target="_blank">PMID:16382340</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"ATP7B is the gene product of the WD gene located on chromosome 13 and resides in hepatocytes in the trans-Golgi network, transporting copper into the secretory pathway for incorporation into apoceruloplasmin and excretion into the bile."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports that ATP7B loads copper into apoceruloplasmin in the secretory pathway.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-hepatic-copper-accumulation">
                 <div class="item-name">Hepatic Copper Accumulation</div>
-                
+
                 <div class="item-desc">Impaired biliary excretion causes progressive copper retention in hepatocytes. When hepatic storage capacity is exceeded, copper is released into the circulation.
 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-cell">
                         hepatocyte
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CL_0000182" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-location">
                         liver
-                        
+
                         <a href="http://purl.obolibrary.org/obo/UBERON_0002107" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
-                
-                
-    
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/16382340" target="_blank">PMID:16382340</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Wilson disease (WD) is an autosomal recessive inherited disorder of copper metabolism, resulting in pathological accumulation of copper in many organs and tissues."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports multi-organ copper accumulation in Wilson disease.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms hepatic copper overflow into systemic circulation.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-systemic-copper-distribution">
                 <div class="item-name">Systemic Copper Distribution</div>
-                
+
                 <div class="item-desc">When hepatic copper storage capacity is exceeded, free copper enters the circulation and deposits in the brain, kidneys, eyes, heart, muscles, and bones, causing multi-organ injury.
 </div>
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Explains the pathophysiology of systemic copper distribution from hepatic overflow.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/25002079" target="_blank">PMID:25002079</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Free copper in Wilson disease (WD) is toxic and may reduce antioxidant, increase oxidative stress marker and thereby cytokine release and excitotoxic injury, but there is paucity of studies in humans."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports toxic effects of circulating free copper causing oxidative stress and excitotoxic injury.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-hepatocyte-injury">
                 <div class="item-name">Hepatocyte Injury</div>
-                
+
                 <div class="item-desc">Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Progressive liver damage leads to fibrosis and cirrhosis. Copper overload activates autophagy and mitophagy-based mitochondrial quality control responses.
 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-cell">
                         hepatocyte
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CL_0000182" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         response to oxidative stress
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0006979" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                     <span class="tag tag-bio">
                         mitophagy
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0000423" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-location">
                         liver
-                        
+
                         <a href="http://purl.obolibrary.org/obo/UBERON_0002107" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
-                
-                
-    
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (6 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Excess Cu2+ primarily leads to the generation of reactive oxygen species (ROS), as evidenced by early experimental studies exemplified with the detection of hydroxyl radical formation"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Demonstrates that excess copper generates ROS leading to oxidative stress and cellular injury.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/24517326" target="_blank">PMID:24517326</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"On the contrary, however, when copper is massively deposited in mitochondria, severe structural and respiratory impairments are observed upon disease progression. This provokes reactive oxygen species and consequently causes the mitochondrial membranes to disintegrate, which triggers hepatocyte death."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports mitochondrial dysfunction, ROS generation, and hepatocyte death with copper overload.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433112" target="_blank">PMID:28433112</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports progression from hepatic injury to fibrosis and cirrhosis.</div>
-                
+
             </div>
-            
-            
+
+
             <div class="evidence-more">+ 3 more references</div>
-            
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-neurodegeneration">
                 <div class="item-name">Neurodegeneration</div>
-                
+
                 <div class="item-desc">Copper deposition is thought to drive brain cellular damage with characteristic striatal/basal ganglia lesions. Reactive astrogliosis and microglial activation with increased CNS inflammatory cytokines indicate neuroinflammation contributing to movement and psychiatric symptoms.
 </div>
-                
-                
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-cell">
                         astrocyte
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CL_0000127" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                     <span class="tag tag-cell">
                         microglial cell
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CL_0000129" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         neuron death
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0051402" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-location">
                         collection of basal ganglia
-                        
+
                         <a href="http://purl.obolibrary.org/obo/UBERON_0010011" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
+
                     <span class="tag tag-location">
                         putamen
-                        
+
                         <a href="http://purl.obolibrary.org/obo/UBERON_0001874" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
-                
-                
-    
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (3 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433113" target="_blank">PMID:28433113</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"In Wilson disease (WD), brain cellular damage is thought to be due to copper deposition. Striatal lesions are the most characteristic lesions found in the brain of patients with neurologic symptoms, as emphasized in the initial reports of S.A.K. Wilson."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports copper deposition driving brain damage with characteristic striatal lesions.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/31179301" target="_blank">PMID:31179301</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Most severe neuropathologic abnormalities, including tissue rarefaction, reactive astrogliosis, myelin palor, and presence of iron-laden macrophages, are typically present in the putamen while other basal ganglia, thalami, and brainstem are usually less affected."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports reactive astrogliosis and basal ganglia/putamen involvement.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/39334421" target="_blank">PMID:39334421</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                     <span class="evidence-source source-MODEL_ORGANISM">Model Organism</span>
-                    
+
                 </div>
-                
+
                 <div class="evidence-snippet">"At 3-5 months of age, these mice started to display neurological deficits in motor coordination and cognitive dysfunction, accompanied by increased expression of inflammatory cytokines in the central nervous system. Microglia in the striatum and cortex exhibit significant activation, shorter..."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Demonstrates CNS inflammatory cytokines and microglial activation in a Wilson disease mouse model.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-cuproptosis">
                 <div class="item-name">Cuproptosis</div>
-                
-                <div class="item-desc">Copper-dependent cell death involving binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA) cycle, leading to proteotoxic stress and mitochondrial dysfunction.
+
+                <div class="item-desc">Copper-dependent cell death has been proposed in Wilson disease, involving binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA) cycle and leading to proteotoxic stress and mitochondrial dysfunction.
 </div>
-                
-                
-                
-                
-                
+
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         cuproptosis
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0160119" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Many interesting disease details were published on the mechanistic steps, such as the generation of reactive oxygen species (ROS) and cuproptosis causing a copper dependent cell death"</div>
-                
-                
-                <div class="evidence-explanation">Establishes cuproptosis as a copper-dependent cell death mechanism in Wilson disease.</div>
-                
+
+
+                <div class="evidence-explanation">Supports cuproptosis as a proposed mechanistic contributor in Wilson disease, but not yet as a definitively established pathway in patients.</div>
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/41006805" target="_blank">PMID:41006805</a>
                     </span>
-                    
-                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Moreover, abnormal lipoylation of the copper-dependent proteins metal-binding domain of ferredoxin 1 and dihydrolipoamide transacetylase causes mitochondrial protein oligomer buildup and tricarboxylic acid cycle dysfunction, reinforcing an &#34;oxidative damage-inflammation-fibrosis&#34; vicious cycle."</div>
-                
-                
-                <div class="evidence-explanation">Supports lipoylation-related mitochondrial proteotoxic stress and TCA cycle dysfunction consistent with cuproptosis.</div>
-                
+
+
+                <div class="evidence-explanation">A recent mechanistic review links abnormal lipoylation and TCA-cycle dysfunction to Wilson disease liver injury, providing hypothesis-level support for cuproptosis-related biology.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box pathophys-box anchor-target" id="pathophysiology-ferroptosis">
                 <div class="item-name">Ferroptosis</div>
-                
-                <div class="item-desc">Iron-related cell death pathway involving phospholipid peroxidation. Increased iron deposits in Wilson disease liver may contribute to ferroptosis alongside copper-mediated injury.
+
+                <div class="item-desc">Iron-related cell death pathway involving phospholipid peroxidation. Secondary hepatic iron overload has been documented in a subset of Wilson disease patients, raising the possibility of ferroptotic injury alongside copper-mediated toxicity.
 </div>
-                
-                
-                
-                
-                
+
+
+
+
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-bio">
                         ferroptosis
-                        
+
                         <a href="http://purl.obolibrary.org/obo/GO_0097707" target="_blank" class="linkout">link</a>
-                        
+
                     </span>
-                    
-    
-    
-                    
+
+
+
+
                 </div>
-                
-                
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
-            Show evidence (1 reference)
+            Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/39733327" target="_blank">PMID:39733327</a>
+                    </span>
+
+                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"13 (8%) patients aged 13 or older had a hepatic iron index &gt;1.0 which may indicate secondary iron overload."</div>
+
+
+                <div class="evidence-explanation">Supports that secondary hepatic iron overload can occur in Wilson disease, which provides biologic plausibility for ferroptosis but does not directly prove it.</div>
+
+            </div>
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
-                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles"</div>
-                
-                
-                <div class="evidence-explanation">Demonstrates that ferroptosis may contribute to liver injury in Wilson disease due to iron accumulation.</div>
-                
+
+
+                <div class="evidence-explanation">Supports ferroptosis as an emerging inference from observed hepatic iron deposition rather than a directly proven disease mechanism.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Histopathology -->
-        
+
 
         <!-- Causal Graph (Pathograph) -->
-        
+
         <div class="card">
             <div class="card-header">
                 <div class="card-icon" style="background: #e0e7ff; color: #4f46e5;">⬡</div>
                 <h2 class="card-title">Pathograph</h2>
             </div>
             <div class="graph-note">Use the checkboxes to hide or show graph categories. Hover nodes for evidence and cross-linked metadata.</div>
-            
+
             <div class="pathograph-container" id="pathograph">
                 <div class="pathograph-legend" id="pathograph-legend"></div>
                 <svg id="pathograph-svg" role="img">
@@ -3581,1783 +3599,1561 @@
             </div>
             <script>
             (function() {
-                var graphData = JSON.parse("{\"nodes\": [{\"id\": \"ATP7B\", \"node_type\": \"genetic\", \"color\": \"#f3e8ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"genes\": [\"ATP7B\"], \"association\": \"Causative\"}}, {\"id\": \"Cuproptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper-dependent cell death involving binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA) cycle, leading to proteotoxic stress and mitochondrial dysfunction.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"cuproptosis\"]}}, {\"id\": \"Ferroptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Iron-related cell death pathway involving phospholipid peroxidation. Increased iron deposits in Wilson disease liver may contribute to ferroptosis alongside copper-mediated injury.\\n\", \"meta\": {\"evidence_count\": 1, \"biological_processes\": [\"ferroptosis\"]}}, {\"id\": \"Hepatic Copper Accumulation\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Impaired biliary excretion causes progressive copper retention in hepatocytes. When hepatic storage capacity is exceeded, copper is released into the circulation.\\n\", \"meta\": {\"evidence_count\": 2, \"cell_types\": [\"hepatocyte\"], \"locations\": [\"liver\"]}}, {\"id\": \"Hepatocyte Injury\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Progressive liver damage leads to fibrosis and cirrhosis. Copper overload activates autophagy and mitophagy-based mitochondrial quality control responses.\\n\", \"meta\": {\"evidence_count\": 6, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"response to oxidative stress\", \"mitophagy\"], \"locations\": [\"liver\"]}}, {\"id\": \"Impaired Biliary Copper Excretion\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B mutations impair copper excretion into bile. ATP7B normally resides in the trans-Golgi network and traffics to the bile canalicular membrane when intracellular copper is elevated. Loss of ATP7B function prevents this copper export pathway.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"copper ion transport\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Impaired Ceruloplasmin Loading\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B normally loads copper into apoceruloplasmin in the trans-Golgi network. Loss of ATP7B function results in secretion of copper-free apoceruloplasmin, which is rapidly degraded, leading to the characteristic low serum ceruloplasmin levels.\\n\", \"meta\": {\"evidence_count\": 1, \"biological_processes\": [\"copper ion homeostasis\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Neurodegeneration\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper deposition is thought to drive brain cellular damage with characteristic striatal/basal ganglia lesions. Reactive astrogliosis and microglial activation with increased CNS inflammatory cytokines indicate neuroinflammation contributing to movement and psychiatric symptoms.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"astrocyte\", \"microglial cell\"], \"biological_processes\": [\"neuron death\"], \"locations\": [\"collection of basal ganglia\", \"putamen\"]}}, {\"id\": \"Systemic Copper Distribution\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"When hepatic copper storage capacity is exceeded, free copper enters the circulation and deposits in the brain, kidneys, eyes, heart, muscles, and bones, causing multi-organ injury.\\n\", \"meta\": {\"evidence_count\": 2}}], \"edges\": [{\"source\": \"Impaired Biliary Copper Excretion\", \"target\": \"Hepatic Copper Accumulation\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Hepatocyte Injury\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Systemic Copper Distribution\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Neurodegeneration\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Cuproptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Ferroptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Biliary Copper Excretion\", \"predicate\": \"contributes_to\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Ceruloplasmin Loading\", \"predicate\": \"contributes_to\", \"is_orphan\": false}], \"orphan_targets\": []}");
+                var graphData = JSON.parse("{\"nodes\": [{\"id\": \"ATP7B\", \"node_type\": \"genetic\", \"color\": \"#f3e8ff\", \"is_orphan\": false, \"meta\": {\"evidence_count\": 2, \"genes\": [\"ATP7B\"], \"association\": \"Causative\"}}, {\"id\": \"Cuproptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper-dependent cell death has been proposed in Wilson disease, involving binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA) cycle and leading to proteotoxic stress and mitochondrial dysfunction.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"cuproptosis\"]}}, {\"id\": \"Ferroptosis\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Iron-related cell death pathway involving phospholipid peroxidation. Secondary hepatic iron overload has been documented in a subset of Wilson disease patients, raising the possibility of ferroptotic injury alongside copper-mediated toxicity.\\n\", \"meta\": {\"evidence_count\": 2, \"biological_processes\": [\"ferroptosis\"]}}, {\"id\": \"Hepatic Copper Accumulation\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Impaired biliary excretion causes progressive copper retention in hepatocytes. When hepatic storage capacity is exceeded, copper is released into the circulation.\\n\", \"meta\": {\"evidence_count\": 2, \"cell_types\": [\"hepatocyte\"], \"locations\": [\"liver\"]}}, {\"id\": \"Hepatocyte Injury\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper accumulation in hepatocytes causes oxidative stress, mitochondrial dysfunction, and cell death. Progressive liver damage leads to fibrosis and cirrhosis. Copper overload activates autophagy and mitophagy-based mitochondrial quality control responses.\\n\", \"meta\": {\"evidence_count\": 6, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"response to oxidative stress\", \"mitophagy\"], \"locations\": [\"liver\"]}}, {\"id\": \"Impaired Biliary Copper Excretion\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B mutations impair copper excretion into bile. ATP7B normally resides in the trans-Golgi network and traffics to the bile canalicular membrane when intracellular copper is elevated. Loss of ATP7B function prevents this copper export pathway.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"hepatocyte\"], \"biological_processes\": [\"copper ion transport\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Impaired Ceruloplasmin Loading\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"ATP7B normally loads copper into apoceruloplasmin in the trans-Golgi network. Loss of ATP7B function results in secretion of copper-free apoceruloplasmin, which is rapidly degraded, leading to the characteristic low serum ceruloplasmin levels.\\n\", \"meta\": {\"evidence_count\": 1, \"biological_processes\": [\"copper ion homeostasis\"], \"molecular_functions\": [\"P-type monovalent copper transporter activity\"], \"genes\": [\"ATP7B\"]}}, {\"id\": \"Neurodegeneration\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"Copper deposition is thought to drive brain cellular damage with characteristic striatal/basal ganglia lesions. Reactive astrogliosis and microglial activation with increased CNS inflammatory cytokines indicate neuroinflammation contributing to movement and psychiatric symptoms.\\n\", \"meta\": {\"evidence_count\": 3, \"cell_types\": [\"astrocyte\", \"microglial cell\"], \"biological_processes\": [\"neuron death\"], \"locations\": [\"collection of basal ganglia\", \"putamen\"]}}, {\"id\": \"Systemic Copper Distribution\", \"node_type\": \"pathophysiology\", \"color\": \"#dbeafe\", \"is_orphan\": false, \"description\": \"When hepatic copper storage capacity is exceeded, free copper enters the circulation and deposits in the brain, kidneys, eyes, heart, muscles, and bones, causing multi-organ injury.\\n\", \"meta\": {\"evidence_count\": 2}}], \"edges\": [{\"source\": \"Impaired Biliary Copper Excretion\", \"target\": \"Hepatic Copper Accumulation\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Hepatocyte Injury\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatic Copper Accumulation\", \"target\": \"Systemic Copper Distribution\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Systemic Copper Distribution\", \"target\": \"Neurodegeneration\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Cuproptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"Hepatocyte Injury\", \"target\": \"Ferroptosis\", \"predicate\": \"causes\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Biliary Copper Excretion\", \"predicate\": \"contributes_to\", \"is_orphan\": false}, {\"source\": \"ATP7B\", \"target\": \"Impaired Ceruloplasmin Loading\", \"predicate\": \"contributes_to\", \"is_orphan\": false}], \"orphan_targets\": []}");
                 renderPathograph("pathograph", graphData);
             })();
             </script>
         </div>
-        
+
 
         <!-- Phenotypes -->
-        
+
         <div class="card" id="phenotypes">
             <div class="card-header">
                 <div class="card-icon" style="background: #dcfce7; color: #16a34a;">●</div>
                 <h2 class="card-title">Phenotypes</h2>
-                <span class="card-count">28</span>
+                <span class="card-count">23</span>
             </div>
-            
-            
+
+
             <div class="pheno-toc">
-                
+
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-1">Blood<span class="pill-count">(1)</span></button>
-                
+
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-2">Cardiovascular<span class="pill-count">(2)</span></button>
-                
+
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-3">Digestive<span class="pill-count">(5)</span></button>
-                
+
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-4">Eye<span class="pill-count">(1)</span></button>
-                
+
                 <button type="button" class="pheno-toc-pill" data-target="pheno-cat-5">Genitourinary<span class="pill-count">(1)</span></button>
-                
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-6">Musculoskeletal<span class="pill-count">(6)</span></button>
-                
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-7">Nervous System<span class="pill-count">(11)</span></button>
-                
-                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-8">Constitutional<span class="pill-count">(1)</span></button>
-                
+
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-6">Musculoskeletal<span class="pill-count">(3)</span></button>
+
+                <button type="button" class="pheno-toc-pill" data-target="pheno-cat-7">Nervous System<span class="pill-count">(10)</span></button>
+
                 <button class="pheno-toggle-all" id="phenoToggleAll">Expand all</button>
             </div>
-            
-            
+
+
             <details class="phenotype-category-group" id="pheno-cat-1">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Blood
                     <span class="cat-count">1</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Hemolytic Anemia
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001878" target="_blank">
                                 Hemolytic anemia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001878)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    <div class="item-desc">Coombs-negative hemolytic anemia is a key feature</div>
-                    
-                    
-                    
-    
+
+                    <div class="item-desc">May accompany acute hepatic decompensation with marked copper release</div>
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
-            Show evidence (1 reference)
+            Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/24577547" target="_blank">PMID:24577547</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"In addition, Coombs-negative hemolytic anemia is a key feature of Wilson disease with undetectable serum haptoglobin"</div>
-                
-                
-                <div class="evidence-explanation">Coombs-negative hemolytic anemia is described as a key feature of Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Hemolytic anemia in WD occurs in up to 17% of patients at some point during their illness."</div>
+
+
+                <div class="evidence-explanation">Supports hemolytic anemia as a recognized hematologic manifestation of Wilson disease.</div>
+
             </div>
-            
-            
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/7234865" target="_blank">PMID:7234865</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"Two patients with Wilson disease who presented with severe hemolytic anemia are described."</div>
+
+
+                <div class="evidence-explanation">Provides direct case-based evidence of severe hemolytic anemia in Wilson disease.</div>
+
+            </div>
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
             </details>
-            
+
             <details class="phenotype-category-group" id="pheno-cat-2">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Cardiovascular
                     <span class="cat-count">2</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Cardiomyopathy
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001638" target="_blank">
                                 Cardiomyopathy
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001638)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/27176875" target="_blank">PMID:27176875</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction,..."</div>
-                
-                
-                <div class="evidence-explanation">Cardiomyopathy is explicitly listed as a cardiac manifestation of Wilson disease due to copper deposition.</div>
-                
+
+                <div class="evidence-snippet">"Cardiac arrhythmias, cardiomyopathy and sudden cardiac death are rare complications but may be seen in children with Wilson&#39;s disease due to copper accumulation in the heart tissue."</div>
+
+
+                <div class="evidence-explanation">Supports cardiomyopathy as a recognized but uncommon cardiac complication of Wilson disease.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Cardiac Arrhythmia
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0011675" target="_blank">
                                 Arrhythmia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0011675)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/28947309" target="_blank">PMID:28947309</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction,..."</div>
-                
-                
-                <div class="evidence-explanation">Cardiac arrhythmias are explicitly listed as a cardiac manifestation of Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Patients with Wilson&#39;s disease exhibited a 29% higher risk of AF after adjusting for age, gender, race, income, hypertension, diabetes, renal disease, hyperlipidemia, obesity, coronary disease, and obstructive sleep apnea (HR 1.29, 95% CI 1.15 to 1.45, p &lt;0.0001)."</div>
+
+
+                <div class="evidence-explanation">Supports arrhythmia risk as a clinically relevant cardiac manifestation in Wilson disease.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
             </details>
-            
+
             <details class="phenotype-category-group" id="pheno-cat-3">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Digestive
                     <span class="cat-count">5</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Hepatomegaly
-                        
+
                         <span class="phenotype-freq">VERY_FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0002240" target="_blank">
                                 Hepatomegaly
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002240)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/15205951" target="_blank">PMID:15205951</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Resultant liver damage leads to steatosis, inflammation, cirrhosis, and, occasionally, fulminant liver failure."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Hepatic copper accumulation causes progressive liver damage including steatosis and inflammation, which manifest as hepatomegaly. Direct frequency data for hepatomegaly not available in this abstract.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Cirrhosis
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001394" target="_blank">
                                 Cirrhosis
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001394)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">Can be presenting feature or develop over time</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/35197085" target="_blank">PMID:35197085</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Four patients (17%) presented with acute liver failure and fifteen (63%) individuals had cirrhosis at diagnosis."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Cohort data support cirrhosis as a common presenting hepatic phenotype in Wilson disease.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Liver transplantation is an option viewed as ultima ratio in end-stage liver disease with untreatable complications or acute liver failure."</div>
-                
-                
+
+
                 <div class="evidence-explanation">End-stage liver disease including cirrhosis is a major complication requiring transplantation.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Acute Hepatic Failure
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0006554" target="_blank">
                                 Acute hepatic failure
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0006554)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">May be a presenting event that requires urgent transplant evaluation</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
-            Show evidence (1 reference)
+            Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/35197085" target="_blank">PMID:35197085</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Four patients (17%) presented with acute liver failure and fifteen (63%) individuals had cirrhosis at diagnosis."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports acute hepatic failure as a recognized presenting hepatic manifestation in Wilson disease.</div>
-                
+
             </div>
-            
-            
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/32520831" target="_blank">PMID:32520831</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"Of the total 256 subjects, 87% underwent LT, 11% achieved spontaneous recovery and 2% died before LT."</div>
+
+
+                <div class="evidence-explanation">Supports that Wilson disease-associated acute liver failure is a severe presentation that frequently requires transplantation.</div>
+
+            </div>
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Hepatitis
-                        
+
                         <span class="phenotype-freq">VERY_FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0012115" target="_blank">
                                 Hepatitis
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0012115)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">May present as chronic hepatitis or acute hepatitis</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433112" target="_blank">PMID:28433112</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Liver biopsy findings of portal and lobular inflammation are consistent with hepatitis as a very frequent hepatic presentation.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433112" target="_blank">PMID:28433112</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Wilson disease may be microscopically misinterpreted as many other liver diseases, including viral or autoimmune hepatitis, alcoholic/nonalcoholic steatohepatitis, toxic liver injury, cryptogenic cirrhosis"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Wilson disease liver pathology frequently mimics hepatitis patterns, confirming hepatitis-like presentation.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Dysphagia
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0002015" target="_blank">
                                 Dysphagia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002015)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Dysphagia is explicitly listed as a neurological manifestation of Wilson disease.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms dysphagia among the core neurologic manifestations.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
             </details>
-            
+
             <details class="phenotype-category-group" id="pheno-cat-4">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Eye
                     <span class="cat-count">1</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Kayser-Fleischer Rings
-                        
+
                         <span class="phenotype-freq">VERY_FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0200032" target="_blank">
                                 Kayser-Fleischer ring
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0200032)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">Copper deposits in Descemet membrane, pathognomonic</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/16709660" target="_blank">PMID:16709660</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Diagnostic criteria for non-caeruloplasmin-bound serum copper, serum caeruloplasmin, 24-h urinary copper excretion, liver copper content, presence of Kayser-Fleischer rings and histological signs of chronic liver damage were reached in 86.6%, 88.2%, 87.1%, 92.7%, 66.3% and 73% of patients, respectively."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Large-cohort data confirm frequent Kayser-Fleischer ring detection in diagnosed Wilson disease.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer..."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms Kayser-Fleischer rings as a key clinical feature of Wilson&#39;s disease due to copper deposition in the eyes.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
             </details>
-            
+
             <details class="phenotype-category-group" id="pheno-cat-5">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Genitourinary
                     <span class="cat-count">1</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Renal Tubular Dysfunction
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000124" target="_blank">
                                 Renal tubular dysfunction
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000124)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+                    <div class="item-desc">Renal tubular acidosis is one documented form of renal tubular involvement</div>
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/31317233" target="_blank">PMID:31317233</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction"</div>
-                
-                
-                <div class="evidence-explanation">Renal tubular dysfunction is explicitly listed as a renal manifestation of Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Fifty-six percent (14/25) of patients with WD had renal tubular acidosis (RTA)."</div>
+
+
+                <div class="evidence-explanation">Supports renal tubular dysfunction in Wilson disease through direct evidence of a high prevalence of renal tubular acidosis.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
             </details>
-            
+
             <details class="phenotype-category-group" id="pheno-cat-6">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Musculoskeletal
-                    <span class="cat-count">6</span>
+                    <span class="cat-count">3</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Rigidity
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0002063" target="_blank">
                                 Rigidity
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002063)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports rigidity as part of the neurologic movement phenotype spectrum.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
-                <div class="item-box phenotype-box">
-                    <div class="item-name">
-                        Rhabdomyolysis
-                        
-                        <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
-                        <span class="phenotype-id">
-                            <a href="http://purl.obolibrary.org/obo/HP_0003201" target="_blank">
-                                Rhabdomyolysis
-                            </a>
-                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0003201)</span>
-                        </span>
-                        
-                    </div>
-                    
-                    
-                    
-    
-    <details class="evidence-details">
-        <summary class="evidence-toggle">
-            Show evidence (1 reference)
-        </summary>
-        <div class="evidence-list">
-            
-            <div class="evidence-item">
-                <div class="evidence-header">
-                    <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
-                    </span>
-                    
-                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
-                </div>
-                
-                <div class="evidence-snippet">"This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction,..."</div>
-                
-                
-                <div class="evidence-explanation">Rhabdomyolysis is explicitly listed as a muscle manifestation in Wilson disease.</div>
-                
-            </div>
-            
-            
-        </div>
-    </details>
-    
-    
-                    
-    
-    
-                </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Osteoporosis
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000939" target="_blank">
                                 Osteoporosis
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000939)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/29110062" target="_blank">PMID:29110062</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Meta-analysis supports frequent low bone density and osteoporosis in Wilson disease populations.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/31317233" target="_blank">PMID:31317233</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction,..."</div>
-                
-                
-                <div class="evidence-explanation">Osteoporosis is explicitly listed as a skeletal manifestation of Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Patients with WD had significantly lower BMD as compared to control subjects (p &lt; 0.05)."</div>
+
+
+                <div class="evidence-explanation">Supports reduced bone mineral density as a real skeletal manifestation in Wilson disease cohorts.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Osteopenia
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000938" target="_blank">
                                 Osteopenia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000938)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
-            Show evidence (1 reference)
+            Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/29110062" target="_blank">PMID:29110062</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Meta-analysis supports osteopenia as a common bone phenotype in Wilson disease.</div>
-                
+
             </div>
-            
-            
-        </div>
-    </details>
-    
-    
-                    
-    
-    
-                </div>
-                
-                <div class="item-box phenotype-box">
-                    <div class="item-name">
-                        Osteomalacia
-                        
-                        <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
-                        <span class="phenotype-id">
-                            <a href="http://purl.obolibrary.org/obo/HP_0002749" target="_blank">
-                                Osteomalacia
-                            </a>
-                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002749)</span>
-                        </span>
-                        
-                    </div>
-                    
-                    
-                    
-    
-    <details class="evidence-details">
-        <summary class="evidence-toggle">
-            Show evidence (1 reference)
-        </summary>
-        <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/31317233" target="_blank">PMID:31317233</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"osteoporosis, osteomalacia, arthritis, and arthralgia"</div>
-                
-                
-                <div class="evidence-explanation">Osteomalacia is explicitly listed among musculoskeletal manifestations in Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Patients with WD had significantly lower BMD as compared to control subjects (p &lt; 0.05)."</div>
+
+
+                <div class="evidence-explanation">Independent cohort data support low bone mass in Wilson disease.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
-                <div class="item-box phenotype-box">
-                    <div class="item-name">
-                        Arthritis
-                        
-                        <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
-                        <span class="phenotype-id">
-                            <a href="http://purl.obolibrary.org/obo/HP_0001369" target="_blank">
-                                Arthritis
-                            </a>
-                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001369)</span>
-                        </span>
-                        
-                    </div>
-                    
-                    
-                    
-    
-    <details class="evidence-details">
-        <summary class="evidence-toggle">
-            Show evidence (1 reference)
-        </summary>
-        <div class="evidence-list">
-            
-            <div class="evidence-item">
-                <div class="evidence-header">
-                    <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
-                    </span>
-                    
-                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
-                </div>
-                
-                <div class="evidence-snippet">"osteoporosis, osteomalacia, arthritis, and arthralgia"</div>
-                
-                
-                <div class="evidence-explanation">Arthritis is listed as a musculoskeletal manifestation of Wilson disease.</div>
-                
-            </div>
-            
-            
-        </div>
-    </details>
-    
-    
-                    
-    
-    
-                </div>
-                
+
             </details>
-            
+
             <details class="phenotype-category-group" id="pheno-cat-7">
                 <summary>
                     <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
                     Nervous System
-                    <span class="cat-count">11</span>
+                    <span class="cat-count">10</span>
                 </summary>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Tremor
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001337" target="_blank">
                                 Tremor
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001337)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">Often wing-beating tremor</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/33474589" target="_blank">PMID:33474589</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"most common neurological manifestation was dystonia, followed by tremor and parkinsonism."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Cohort data directly identify tremor as a common neurologic manifestation.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports tremor as part of the core neurologic phenotype spectrum.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Dystonia
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001332" target="_blank">
                                 Dystonia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001332)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/33474589" target="_blank">PMID:33474589</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"most common neurological manifestation was dystonia, followed by tremor and parkinsonism."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Cohort data support dystonia as the most common neurologic manifestation in this series.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports dystonia as a core feature of neurologic Wilson disease.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Parkinsonism
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001300" target="_blank">
                                 Parkinsonism
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001300)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">May include bradykinesia, rigidity, and tremor</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/33474589" target="_blank">PMID:33474589</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"most common neurological manifestation was dystonia, followed by tremor and parkinsonism."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Cohort data directly report parkinsonism among predominant neurologic presentations.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports parkinsonian-spectrum motor features in neurologic Wilson disease.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Bradykinesia
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0002067" target="_blank">
                                 Bradykinesia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002067)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports bradykinesia as part of the neurologic movement phenotype spectrum.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Chorea
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0002072" target="_blank">
                                 Chorea
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002072)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports chorea as part of the neurologic movement phenotype spectrum.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Dysarthria
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001260" target="_blank">
                                 Dysarthria
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001260)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Dysarthria is explicitly listed as a neurological manifestation of Wilson disease.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433096" target="_blank">PMID:28433096</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms dysarthria among core neurologic Wilson disease features.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Ataxia
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0001251" target="_blank">
                                 Ataxia
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0001251)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Ataxia is explicitly listed as a neurological manifestation of Wilson disease.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
-                <div class="item-box phenotype-box">
-                    <div class="item-name">
-                        Dysgraphia
-                        
-                        <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
-                        <span class="phenotype-id">
-                            <a href="http://purl.obolibrary.org/obo/HP_0010526" target="_blank">
-                                Dysgraphia
-                            </a>
-                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0010526)</span>
-                        </span>
-                        
-                    </div>
-                    
-                    <div class="item-desc">Writing problems are reported as part of neurologic involvement</div>
-                    
-                    
-                    
-    
-    <details class="evidence-details">
-        <summary class="evidence-toggle">
-            Show evidence (1 reference)
-        </summary>
-        <div class="evidence-list">
-            
-            <div class="evidence-item">
-                <div class="evidence-header">
-                    <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
-                    </span>
-                    
-                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
-                </div>
-                
-                <div class="evidence-snippet">"Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia"</div>
-                
-                
-                <div class="evidence-explanation">Supports writing impairment as part of the neurologic Wilson disease phenotype.</div>
-                
-            </div>
-            
-            
-        </div>
-    </details>
-    
-    
-                    
-    
-    
-                </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Depression
-                        
+
                         <span class="phenotype-freq">FREQUENT</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000716" target="_blank">
                                 Depression
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000716)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">One of the most common psychiatric manifestations of Wilson disease</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/1821256" target="_blank">PMID:1821256</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"Among these are depression, psychosis, dysarthria, ataxia, writing problems"</div>
-                
-                
-                <div class="evidence-explanation">Depression is explicitly listed as a neuropsychiatric manifestation of Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%)."</div>
+
+
+                <div class="evidence-explanation">Cohort data directly support depression as a common psychiatric manifestation in symptomatic Wilson disease.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Psychosis
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000709" target="_blank">
                                 Psychosis
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000709)</span>
                         </span>
-                        
+
                     </div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/1821256" target="_blank">PMID:1821256</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"Among these are depression, psychosis, dysarthria, ataxia, writing problems"</div>
-                
-                
-                <div class="evidence-explanation">Psychosis is explicitly listed as a neuropsychiatric manifestation of Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred."</div>
+
+
+                <div class="evidence-explanation">Supports psychosis as a recognized, less frequent psychiatric presentation of Wilson disease.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
                 <div class="item-box phenotype-box">
                     <div class="item-name">
                         Personality Changes
-                        
+
                         <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
+
+
                         <span class="phenotype-id">
                             <a href="http://purl.obolibrary.org/obo/HP_0000751" target="_blank">
                                 Personality changes
                             </a>
                             <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0000751)</span>
                         </span>
-                        
+
                     </div>
-                    
+
                     <div class="item-desc">Personality changes may be an early psychiatric manifestation</div>
-                    
-                    
-                    
-    
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433113" target="_blank">PMID:28433113</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/1821256" target="_blank">PMID:1821256</a>
                     </span>
-                    
-                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
-                </div>
-                
-                <div class="evidence-snippet">"the cerebral copper content is not correlated with the severity of the neuropathologic abnormalities or with the neuropsychiatric symptomatology."</div>
-                
-                
-                <div class="evidence-explanation">Reference to neuropsychiatric symptomatology in Wilson disease indirectly supports personality changes as a recognized psychiatric feature, though personality changes are not individually named in this abstract.</div>
-                
-            </div>
-            
-            
-        </div>
-    </details>
-    
-    
-                    
-    
-    
-                </div>
-                
-            </details>
-            
-            <details class="phenotype-category-group" id="pheno-cat-8">
-                <summary>
-                    <svg class="chevron" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l5 5-5 5V3z"/></svg>
-                    Constitutional
-                    <span class="cat-count">1</span>
-                </summary>
-                
-                <div class="item-box phenotype-box">
-                    <div class="item-name">
-                        Arthralgia
-                        
-                        <span class="phenotype-freq">OCCASIONAL</span>
-                        
-                        
-                        <span class="phenotype-id">
-                            <a href="http://purl.obolibrary.org/obo/HP_0002829" target="_blank">
-                                Arthralgia
-                            </a>
-                            <span style="font-size: 0.72rem; color: var(--text-muted);">(HP:0002829)</span>
-                        </span>
-                        
-                    </div>
-                    
-                    
-                    
-    
-    <details class="evidence-details">
-        <summary class="evidence-toggle">
-            Show evidence (1 reference)
-        </summary>
-        <div class="evidence-list">
-            
-            <div class="evidence-item">
-                <div class="evidence-header">
-                    <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
-                    </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"osteoporosis, osteomalacia, arthritis, and arthralgia"</div>
-                
-                
-                <div class="evidence-explanation">Arthralgia is explicitly listed among musculoskeletal manifestations in Wilson disease.</div>
-                
+
+                <div class="evidence-snippet">"Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%)."</div>
+
+
+                <div class="evidence-explanation">Directly supports personality change as a common psychiatric presentation in symptomatic Wilson disease.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
-                    
-    
-    
+
+
+
+
+
                 </div>
-                
+
             </details>
-            
+
             <script>
             (function() {
                 // TOC pill click: expand target group and scroll to it
@@ -5382,769 +5178,805 @@
                 }
             })();
             </script>
-            
+
         </div>
-        
+
 
         <!-- Genetic Associations -->
-        
+
         <div class="card" id="genetic">
             <div class="card-header">
                 <div class="card-icon" style="background: #dbeafe; color: #2563eb;">🧬</div>
                 <h2 class="card-title">Genetic Associations</h2>
                 <span class="card-count">1</span>
             </div>
-            
+
             <div class="item-box genetic-box">
                 <div class="item-name">
                     ATP7B
-                    
+
                     <span style="font-size: 0.8rem; font-weight: normal; opacity: 0.8;">(Causative)</span>
-                    
+
                 </div>
-                
+
                 <div class="item-meta">
-                    
+
                     <span class="tag" style="background: #bfdbfe; color: #1e40af;">Autosomal Recessive</span>
-                    
+
                 </div>
-                
-                
-    
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/37741465" target="_blank">PMID:37741465</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Inactivating mutations of the copper-transporting P-type ATPase, ATP7B, result in Wilson&#39;s disease, an autosomal recessive disorder"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Establishes ATP7B mutations as the causative genetic defect in Wilson&#39;s disease with autosomal recessive inheritance.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/15205951" target="_blank">PMID:15205951</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Thus far, more than 200 mutations of the WD gene have been detected, causing impairment of ATP7B function and, ultimately, copper accumulation."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms large number of ATP7B mutations causing Wilson disease.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Treatments -->
-        
+
         <div class="card" id="treatments">
             <div class="card-header">
                 <div class="card-icon" style="background: #ede9fe; color: #7c3aed;">💊</div>
                 <h2 class="card-title">Treatments</h2>
                 <span class="card-count">6</span>
             </div>
-            
+
             <div class="item-box treatment-box">
                 <div class="item-name">
                     D-Penicillamine
                 </div>
-                
+
                 <div class="item-meta">
-                    
-                    
-                    
-                    
+
+
+
+
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Action:</strong>
                     <span class="tag tag-treatment">copper chelator agent therapy</span>
-                    
-                    
+
+
                     <a href="https://bioregistry.io/MAXO:0001224" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">MAXO:0001224</a>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
-                
-                
-                
+
+
+
+
+
                 <div class="item-desc">Copper chelator, first-line therapy, promotes urinary copper excretion.</div>
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Patients with Wilson disease are well-treated first-line with copper chelators like D-penicillamine that facilitate the removal of circulating copper bound to albumin and increase in urinary copper excretion. Early chelation therapy improves prognosis."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Establishes D-penicillamine as first-line chelation therapy with evidence for improved prognosis.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/37116715" target="_blank">PMID:37116715</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"NW was observed with D-penicillamine, trientine and zinc therapy and was reversible in 15/30 (50%) with early NW and in 29/36 (81%) with late NW."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Large cohort data show treatment-associated neurological worsening can occur, supporting close neurologic monitoring during chelation.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box treatment-box">
                 <div class="item-name">
                     Trientine
                 </div>
-                
+
                 <div class="item-meta">
-                    
-                    
-                    
-                    
+
+
+
+
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Action:</strong>
                     <span class="tag tag-treatment">copper chelator agent therapy</span>
-                    
-                    
+
+
                     <a href="https://bioregistry.io/MAXO:0001224" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">MAXO:0001224</a>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
-                
-                
-                
+
+
+
+
+
                 <div class="item-desc">Alternative copper chelator, better tolerated than penicillamine.</div>
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/35887738" target="_blank">PMID:35887738</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"The two salts of trientine were effective in treating patients with WD."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Directly supports trientine efficacy in treated Wilson disease cohorts.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box treatment-box">
                 <div class="item-name">
                     Zinc Acetate
                 </div>
-                
+
                 <div class="item-meta">
-                    
-                    
-                    
-                    
+
+
+
+
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Action:</strong>
                     <span class="tag tag-treatment">pharmacotherapy</span>
-                    
-                    
+
+
                     <a href="https://bioregistry.io/MAXO:0000058" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">MAXO:0000058</a>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
-                
+
+
+
                 <div class="item-meta">
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Agent:</strong>
-                    
+
                     <span class="tag tag-treatment">
                         zinc acetate
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CHEBI_62984" target="_blank" style="color: inherit; margin-left: 4px;">↗</a>
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
-                
+
+
+
                 <div class="item-desc">Blocks intestinal copper absorption, maintenance therapy.</div>
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/37741465" target="_blank">PMID:37741465</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"reduction of copper absorption in the gut (zinc therapy)"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms zinc therapy works by reducing intestinal copper absorption.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box treatment-box">
                 <div class="item-name">
                     Low Copper Diet
                 </div>
-                
+
                 <div class="item-meta">
-                    
-                    
-                    
-                    
+
+
+
+
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Action:</strong>
                     <span class="tag tag-treatment">dietary intervention</span>
-                    
-                    
+
+
                     <a href="https://bioregistry.io/MAXO:0000088" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">MAXO:0000088</a>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
-                
-                
-                
-                <div class="item-desc">Avoid liver, shellfish, chocolate, nuts, mushrooms.</div>
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+                <div class="item-desc">Adjunctive dietary measure; liver and shellfish are the foods most consistently recommended for avoidance.</div>
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/36010023" target="_blank">PMID:36010023</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"copper, which is found ubiquitously on earth and normally enters the human body in small amounts via the food chain"</div>
-                
-                
-                <div class="evidence-explanation">Establishes that dietary intake is a source of copper, supporting dietary restriction as an adjunctive treatment approach.</div>
-                
+
+                <div class="evidence-snippet">"In summary, consistent adherence to drug therapy is more important than a strict diet. Only two foods should be consistently avoided: Liver and Shellfish."</div>
+
+
+                <div class="evidence-explanation">Supports a limited adjunctive low-copper diet while explicitly cautioning against overstating the value of strict dietary restriction.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box treatment-box">
                 <div class="item-name">
                     Tetrathiomolybdate
                 </div>
-                
+
                 <div class="item-meta">
-                    
-                    
-                    
-                    
+
+
+
+
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Action:</strong>
                     <span class="tag tag-treatment">copper chelator agent therapy</span>
-                    
-                    
+
+
                     <a href="https://bioregistry.io/MAXO:0001224" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">MAXO:0001224</a>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
-                
+
+
+
                 <div class="item-meta">
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Agent:</strong>
-                    
+
                     <span class="tag tag-treatment">
                         tetrathiomolybdate
-                        
+
                         <a href="http://purl.obolibrary.org/obo/CHEBI_30703" target="_blank" style="color: inherit; margin-left: 4px;">↗</a>
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
-                
-                <div class="item-desc">Emerging copper chelator that rapidly complexes free copper, reducing bioavailable copper.</div>
-                
-                
-                
-                
-                
-    
+
+
+
+                <div class="item-desc">Investigational copper chelator that markedly reduces intestinal copper uptake and lowers hepatic and brain copper exposure.</div>
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/37741465" target="_blank">PMID:37741465</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38081365" target="_blank">PMID:38081365</a>
                     </span>
-                    
-                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
                 </div>
-                
-                <div class="evidence-snippet">"Current treatment protocols are limited to either sequestration of copper via chelation or reduction of copper absorption in the gut"</div>
-                
-                
-                <div class="evidence-explanation">Tetrathiomolybdate represents an emerging chelation approach that tightly complexes copper.</div>
-                
+
+                <div class="evidence-snippet">"TTM effectively inhibited most intestinal 64Cu uptake and retained 64Cu in the blood stream, limiting the exposure of organs like the liver and brain to 64Cu."</div>
+
+
+                <div class="evidence-explanation">Human tracer studies support tetrathiomolybdate as an investigational therapy that reduces organ copper exposure primarily by blocking intestinal uptake.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box treatment-box">
                 <div class="item-name">
                     Liver Transplantation
                 </div>
-                
+
                 <div class="item-meta">
-                    
-                    
-                    
-                    
+
+
+
+
                     <strong style="font-size: 0.8rem; color: #5b21b6;">Action:</strong>
                     <span class="tag tag-treatment">liver transplantation</span>
-                    
-                    
+
+
                     <a href="https://bioregistry.io/MAXO:0001175" target="_blank" style="font-size: 0.82rem; color: #6d28d9; margin-left: 6px;">MAXO:0001175</a>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
-                
-                
-                
+
+
+
+
+
                 <div class="item-desc">Curative for hepatic Wilson disease, reverses copper metabolism defect.</div>
-                
-                
-                
-                
-                
-    
+
+
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
-            Show evidence (1 reference)
+            Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/32520831" target="_blank">PMID:32520831</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"Of the total 256 subjects, 87% underwent LT, 11% achieved spontaneous recovery and 2% died before LT."</div>
+
+
+                <div class="evidence-explanation">Supports liver transplantation as the predominant life-saving therapy for Wilson disease presenting with acute liver failure.</div>
+
+            </div>
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Liver transplantation is an option viewed as ultima ratio in end-stage liver disease with untreatable complications or acute liver failure. Liver transplantation finally may thus be a life-saving approach and curative treatment of the disease by replacing the hepatic gene mutation."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms liver transplantation as curative treatment that replaces the defective gene.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Environmental Factors -->
-        
+
         <div class="card">
             <div class="card-header">
                 <div class="card-icon" style="background: #ccfbf1; color: #0d9488;">🌍</div>
                 <h2 class="card-title">Environmental Factors</h2>
                 <span class="card-count">1</span>
             </div>
-            
+
             <div class="item-box environmental-box">
                 <div class="item-name">Dietary Copper</div>
-                
-                
-                <div class="item-desc">High copper foods may accelerate accumulation</div>
-                
-                
-                
-    
+
+
+                <div class="item-desc">Dietary copper contributes to exposure, but strict long-term restriction beyond very high-copper foods is not well supported</div>
+
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/38731973" target="_blank">PMID:38731973</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/36010023" target="_blank">PMID:36010023</a>
                     </span>
-                    
+
                     <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+
                 </div>
-                
-                <div class="evidence-snippet">"copper, which is found ubiquitously on earth and normally enters the human body in small amounts via the food chain"</div>
-                
-                
-                <div class="evidence-explanation">Dietary copper intake contributes to body copper load, making dietary restriction an important adjunctive measure.</div>
-                
+
+                <div class="evidence-snippet">"A lower copper intake only prevents the re-accumulation of copper."</div>
+
+
+                <div class="evidence-explanation">Supports dietary copper reduction as an adjunctive measure, while implying that diet alone is not the main determinant of disease control.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Biochemical Markers -->
-        
+
         <div class="card">
             <div class="card-header">
                 <div class="card-icon" style="background: #fef3c7; color: #d97706;">🔬</div>
                 <h2 class="card-title">Biochemical Markers</h2>
                 <span class="card-count">4</span>
             </div>
-            
+
             <div class="item-box biochemical-box">
                 <div class="item-name">
                     Ceruloplasmin
-                    
+
                     <span style="font-size: 0.8rem; font-weight: normal; opacity: 0.8;">(Decreased)</span>
-                    
+
                 </div>
-                
+
                 <div class="item-desc">Context: Low in over 90 percent of patients (less than 20 mg/dL)</div>
-                
-                
-    
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/15205951" target="_blank">PMID:15205951</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Directly supports low serum ceruloplasmin as a diagnostic biochemical feature.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box biochemical-box">
                 <div class="item-name">
                     Non-Ceruloplasmin-Bound Serum Copper
-                    
+
                     <span style="font-size: 0.8rem; font-weight: normal; opacity: 0.8;">(Elevated)</span>
-                    
+
                 </div>
-                
-                <div class="item-desc">Context: Free copper fraction is elevated; a key diagnostic biomarker criterion met in 86.6% of patients</div>
-                
-                
-    
+
+                <div class="item-desc">Context: Free copper fraction is elevated and used both diagnostically and for treatment monitoring</div>
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/16709660" target="_blank">PMID:16709660</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Diagnostic criteria for non-caeruloplasmin-bound serum copper, serum caeruloplasmin, 24-h urinary copper excretion, liver copper content, presence of Kayser-Fleischer rings and histological signs of chronic liver damage were reached in 86.6%, 88.2%, 87.1%, 92.7%, 66.3% and 73% of patients, respectively."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Supports non-ceruloplasmin-bound copper as a commonly met diagnostic biomarker criterion.</div>
-                
+
             </div>
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
-                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/37741465" target="_blank">PMID:37741465</a>
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/39139457" target="_blank">PMID:39139457</a>
                     </span>
-                    
-                    <span class="evidence-support support-PARTIAL">PARTIAL</span>
-                    
-                    
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
                 </div>
-                
-                <div class="evidence-snippet">"The goal of these strategies is to reduce free copper, redox stress, and cellular toxicity"</div>
-                
-                
-                <div class="evidence-explanation">Elevated free copper is the therapeutic target in Wilson disease, confirming its pathological elevation.</div>
-                
+
+                <div class="evidence-snippet">"Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited."</div>
+
+
+                <div class="evidence-explanation">Supports NCC as an established Wilson disease monitoring biomarker during chelation therapy.</div>
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box biochemical-box">
                 <div class="item-name">
                     24-Hour Urinary Copper
-                    
+
                     <span style="font-size: 0.8rem; font-weight: normal; opacity: 0.8;">(Elevated)</span>
-                    
+
                 </div>
-                
-                <div class="item-desc">Context: Elevated urinary copper is diagnostic</div>
-                
-                
-    
+
+                <div class="item-desc">Context: Elevated urinary copper is diagnostic and is also followed during chelation therapy</div>
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
-            Show evidence (1 reference)
+            Show evidence (2 references)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/15205951" target="_blank">PMID:15205951</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Directly supports increased urinary copper excretion as a diagnostic biochemical feature.</div>
-                
+
             </div>
-            
-            
+
+            <div class="evidence-item">
+                <div class="evidence-header">
+                    <span class="evidence-ref">
+                        <a href="http://www.ncbi.nlm.nih.gov/pubmed/39139457" target="_blank">PMID:39139457</a>
+                    </span>
+
+                    <span class="evidence-support support-SUPPORT">SUPPORT</span>
+
+
+                </div>
+
+                <div class="evidence-snippet">"Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited."</div>
+
+
+                <div class="evidence-explanation">Supports 24-hour urinary copper excretion as a standard biomarker used to monitor Wilson disease therapy.</div>
+
+            </div>
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
             <div class="item-box biochemical-box">
                 <div class="item-name">
                     Hepatic Copper
-                    
+
                     <span style="font-size: 0.8rem; font-weight: normal; opacity: 0.8;">(Elevated)</span>
-                    
+
                 </div>
-                
+
                 <div class="item-desc">Context: Liver biopsy with elevated copper is diagnostic</div>
-                
-                
-    
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/15205951" target="_blank">PMID:15205951</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content."</div>
-                
-                
+
+
                 <div class="evidence-explanation">Directly supports increased hepatic copper content as a key diagnostic criterion.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Differential Diagnoses -->
-        
+
         <div class="card" id="differentials">
             <div class="card-header">
                 <div class="card-icon" style="background: #fef2f2; color: #dc2626;">🔀</div>
@@ -6154,220 +5986,220 @@
             <p style="margin-bottom: 16px; font-size: 0.95rem; color: var(--text-muted);">
                 Conditions with similar clinical presentations that must be differentiated from Wilson Disease:
             </p>
-            
-            
-            
+
+
+
             <div class="item-box differential-box">
                 <div class="item-name">
-                    
+
                     <a class="item-name-link" href="Autoimmune_Hepatitis.html">Autoimmune Hepatitis</a>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="differential-similarities">
                     <strong>Overlapping Features</strong>
                     Autoimmune hepatitis can present with similar hepatic inflammation, elevated transaminases, and cirrhosis. Wilson disease liver pathology is frequently misinterpreted as autoimmune hepatitis.
 
                 </div>
-                
-                
+
+
                 <div class="differential-distinctions">
                     <strong>Distinguishing Features</strong>
-                    
+
                     <ul>
-                        
+
                         <li>Positive autoimmune markers (ANA, anti-SMA) in autoimmune hepatitis</li>
-                        
+
                         <li>Low ceruloplasmin and elevated urinary copper distinguish Wilson disease</li>
-                        
+
                         <li>Kayser-Fleischer rings absent in autoimmune hepatitis</li>
-                        
+
                     </ul>
-                    
+
                 </div>
-                
-                
-    
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433112" target="_blank">PMID:28433112</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Wilson disease may be microscopically misinterpreted as many other liver diseases, including viral or autoimmune hepatitis, alcoholic/nonalcoholic steatohepatitis, toxic liver injury, cryptogenic cirrhosis"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Directly states that Wilson disease liver pathology can mimic autoimmune hepatitis.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
-            
-            
+
+
+
             <div class="item-box differential-box">
                 <div class="item-name">
-                    
+
                     Non-Alcoholic Steatohepatitis
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="differential-similarities">
                     <strong>Overlapping Features</strong>
                     NASH shares histological features with Wilson disease including steatosis, inflammation, and fibrosis.
 
                 </div>
-                
-                
+
+
                 <div class="differential-distinctions">
                     <strong>Distinguishing Features</strong>
-                    
+
                     <ul>
-                        
+
                         <li>Metabolic syndrome features (obesity, insulin resistance) in NASH</li>
-                        
+
                         <li>Normal ceruloplasmin and urinary copper in NASH</li>
-                        
+
                         <li>Copper quantification on liver biopsy differentiates</li>
-                        
+
                     </ul>
-                    
+
                 </div>
-                
-                
-    
+
+
+
     <details class="evidence-details">
         <summary class="evidence-toggle">
             Show evidence (1 reference)
         </summary>
         <div class="evidence-list">
-            
+
             <div class="evidence-item">
                 <div class="evidence-header">
                     <span class="evidence-ref">
                         <a href="http://www.ncbi.nlm.nih.gov/pubmed/28433112" target="_blank">PMID:28433112</a>
                     </span>
-                    
+
                     <span class="evidence-support support-SUPPORT">SUPPORT</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="evidence-snippet">"Wilson disease may be microscopically misinterpreted as many other liver diseases, including viral or autoimmune hepatitis, alcoholic/nonalcoholic steatohepatitis, toxic liver injury, cryptogenic cirrhosis"</div>
-                
-                
+
+
                 <div class="evidence-explanation">Confirms histological overlap between Wilson disease and steatohepatitis.</div>
-                
+
             </div>
-            
-            
+
+
         </div>
     </details>
-    
-    
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Datasets -->
-        
+
         <div class="card" id="datasets">
             <div class="card-header">
                 <div class="card-icon" style="background: #e0f2fe; color: #0284c7;">📊</div>
                 <h2 class="card-title">Related Datasets</h2>
                 <span class="card-count">1</span>
             </div>
-            
+
             <div class="item-box dataset-box">
                 <div class="item-name">
                     Expression data from Wilson disease patients liver
-                    
+
                     <span class="dataset-accession">
                         <a href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE197406" target="_blank">geo:GSE197406</a>
                     </span>
-                    
+
                 </div>
-                
+
                 <div class="item-desc">Microarray expression profiling of liver tissue from Wilson disease patients and controls.</div>
-                
+
                 <div class="item-meta">
-                    
+
                     <span class="tag tag-organism">human</span>
-                    
-                    
+
+
                     <span class="tag tag-datatype">MICROARRAY</span>
-                    
-                    
+
+
                     <span class="tag tag-dataset">n=15</span>
-                    
-                    
+
+
                 </div>
-                
+
                 <div class="item-meta" style="margin-top: 6px;">
-                    
+
                     <span class="tag tag-cell">
                         liver tissue
-                        
+
                     </span>
-                    
+
                 </div>
-                
-                
+
+
                 <div class="item-meta" style="margin-top: 6px;">
                     <strong style="font-size: 0.8rem; color: #0369a1;">Conditions:</strong>
-                    
+
                     <span class="tag" style="background: #f0f9ff; color: #0369a1; font-size: 0.8rem;">Wilson disease</span>
-                    
+
                     <span class="tag" style="background: #f0f9ff; color: #0369a1; font-size: 0.8rem;">control liver tissue</span>
-                    
+
                 </div>
-                
-                
-                
-    
-    
-                
-                
+
+
+
+
+
+
+
                 <div class="item-desc" style="margin-top: 8px; font-style: italic;">Includes 7 Wilson disease and 8 control liver samples.</div>
-                
-                
-    
-    
+
+
+
+
             </div>
-            
+
         </div>
-        
+
 
         <!-- Clinical Trials -->
-        
+
 
         <!-- Experimental Models -->
-        
+
 
         <!-- Computational Models -->
-        
+
 
         <!-- Reports -->
-        
+
 
         <!-- YAML Source -->
         <div class="card">
@@ -6379,7 +6211,7 @@
             <div class="yaml-content" id="yamlContent">
                 <pre class="yaml-preview">name: Wilson Disease
 creation_date: &#39;2025-12-19T14:27:56Z&#39;
-updated_date: &#39;2026-04-06T22:37:07Z&#39;
+updated_date: &#39;2026-04-23T00:34:30Z&#39;
 category: Genetic
 description: &gt;
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -6389,7 +6221,7 @@ description: &gt;
   muscles, and bones. Clinical presentations range from asymptomatic liver disease to fulminant
   hepatic failure, chronic hepatitis, cirrhosis, and diverse neuropsychiatric manifestations
   including dystonia, tremor, dysarthria, depression, and psychosis. Kayser-Fleischer corneal
-  rings and Coombs-negative hemolytic anemia are characteristic features. Diagnosis relies on
+  rings are characteristic, and hemolytic anemia can accompany acute hepatic presentations. Diagnosis relies on
   the modified Leipzig Scoring System integrating serum ceruloplasmin, urinary copper, hepatic
   copper content, and genetic testing. Treatment with copper chelators (D-penicillamine, trientine)
   and zinc salts can prevent disease progression when initiated early; liver transplantation is
@@ -6499,9 +6331,9 @@ mechanistic_hypotheses:
   evidence:
   - reference: PMID:38731973
     reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: &#34;Many interesting disease details were published on the mechanistic steps, such as the generation of reactive oxygen species (ROS) and cuproptosis causing a copper dependent cell death.&#34;
-    explanation: Supports cuproptosis as an emerging mechanistic layer in Wilson disease.
+    explanation: Supports cuproptosis as a proposed emerging mechanistic layer in Wilson disease rather than a definitively established dominant pathway.
 - hypothesis_group_id: ferroptosis_superimposition_model
   hypothesis_label: Iron-Related Ferroptosis Superimposition Model
   status: EMERGING
@@ -6509,11 +6341,16 @@ mechanistic_hypotheses:
     Secondary hepatic iron deposition may superimpose iron-driven ferroptotic
     injury on copper-mediated pathology.
   evidence:
+  - reference: PMID:39733327
+    reference_title: &#34;Iron and Copper Liver Concentrations in Wilson Disease.&#34;
+    supports: PARTIAL
+    snippet: &#34;13 (8%) patients aged 13 or older had a hepatic iron index &gt;1.0 which may indicate secondary iron overload.&#34;
+    explanation: Directly supports that a subset of Wilson disease patients has secondary hepatic iron overload, which is a prerequisite for the ferroptosis hypothesis.
   - reference: PMID:38731973
     reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: &#34;In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles&#34;
-    explanation: Supports a superimposed ferroptosis hypothesis in hepatic Wilson disease.
+    explanation: Supports ferroptosis as an inferred downstream consequence of secondary hepatic iron deposition rather than a fully established mechanism in Wilson disease.
 pathophysiology:
 - name: Impaired Biliary Copper Excretion
   description: &gt;
@@ -6707,9 +6544,9 @@ pathophysiology:
       label: mitophagy
   downstream:
   - target: Cuproptosis
-    description: Copper-dependent cell death amplifies hepatocyte injury.
+    description: Proposed copper-dependent cell death pathways may amplify hepatocyte injury.
   - target: Ferroptosis
-    description: Secondary iron deposition may superimpose ferroptotic injury.
+    description: Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.
 
 - name: Neurodegeneration
   description: &gt;
@@ -6759,20 +6596,20 @@ pathophysiology:
       label: neuron apoptotic process
 - name: Cuproptosis
   description: &gt;
-    Copper-dependent cell death involving binding of copper to lipoylated
-    enzymes in the tricarboxylic acid (TCA) cycle, leading to proteotoxic
-    stress and mitochondrial dysfunction.
+    Copper-dependent cell death has been proposed in Wilson disease, involving
+    binding of copper to lipoylated enzymes in the tricarboxylic acid (TCA)
+    cycle and leading to proteotoxic stress and mitochondrial dysfunction.
   evidence:
   - reference: PMID:38731973
     reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
     supports: PARTIAL
     snippet: &#34;Many interesting disease details were published on the mechanistic steps, such as the generation of reactive oxygen species (ROS) and cuproptosis causing a copper dependent cell death&#34;
-    explanation: Establishes cuproptosis as a copper-dependent cell death mechanism in Wilson disease.
+    explanation: Supports cuproptosis as a proposed mechanistic contributor in Wilson disease, but not yet as a definitively established pathway in patients.
   - reference: PMID:41006805
     reference_title: &#34;The pathogenesis of liver fibrosis in Wilson&#39;s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.&#34;
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: &#34;Moreover, abnormal lipoylation of the copper-dependent proteins metal-binding domain of ferredoxin 1 and dihydrolipoamide transacetylase causes mitochondrial protein oligomer buildup and tricarboxylic acid cycle dysfunction, reinforcing an \&#34;oxidative damage-inflammation-fibrosis\&#34; vicious cycle.&#34;
-    explanation: Supports lipoylation-related mitochondrial proteotoxic stress and TCA cycle dysfunction consistent with cuproptosis.
+    explanation: A recent mechanistic review links abnormal lipoylation and TCA-cycle dysfunction to Wilson disease liver injury, providing hypothesis-level support for cuproptosis-related biology.
   biological_processes:
   - preferred_term: cuproptosis
     term:
@@ -6781,14 +6618,20 @@ pathophysiology:
 - name: Ferroptosis
   description: &gt;
     Iron-related cell death pathway involving phospholipid peroxidation.
-    Increased iron deposits in Wilson disease liver may contribute to
-    ferroptosis alongside copper-mediated injury.
+    Secondary hepatic iron overload has been documented in a subset of Wilson
+    disease patients, raising the possibility of ferroptotic injury alongside
+    copper-mediated toxicity.
   evidence:
+  - reference: PMID:39733327
+    reference_title: &#34;Iron and Copper Liver Concentrations in Wilson Disease.&#34;
+    supports: PARTIAL
+    snippet: &#34;13 (8%) patients aged 13 or older had a hepatic iron index &gt;1.0 which may indicate secondary iron overload.&#34;
+    explanation: Supports that secondary hepatic iron overload can occur in Wilson disease, which provides biologic plausibility for ferroptosis but does not directly prove it.
   - reference: PMID:38731973
     reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
+    supports: PARTIAL
     snippet: &#34;In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles&#34;
-    explanation: Demonstrates that ferroptosis may contribute to liver injury in Wilson disease due to iron accumulation.
+    explanation: Supports ferroptosis as an emerging inference from observed hepatic iron deposition rather than a directly proven disease mechanism.
   biological_processes:
   - preferred_term: ferroptosis
     term:
@@ -6839,6 +6682,11 @@ phenotypes:
     supports: SUPPORT
     snippet: &#34;Four patients (17%) presented with acute liver failure and fifteen (63%) individuals had cirrhosis at diagnosis.&#34;
     explanation: Supports acute hepatic failure as a recognized presenting hepatic manifestation in Wilson disease.
+  - reference: PMID:32520831
+    reference_title: &#34;Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis.&#34;
+    supports: SUPPORT
+    snippet: &#34;Of the total 256 subjects, 87% underwent LT, 11% achieved spontaneous recovery and 2% died before LT.&#34;
+    explanation: Supports that Wilson disease-associated acute liver failure is a severe presentation that frequently requires transplantation.
   phenotype_term:
     preferred_term: Acute hepatic failure
     term:
@@ -7038,31 +6886,16 @@ phenotypes:
     term:
       id: HP:0002015
       label: Dysphagia
-- name: Dysgraphia
-  category: Neurological
-  frequency: OCCASIONAL
-  notes: Writing problems are reported as part of neurologic involvement
-  evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
-    snippet: &#34;Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia&#34;
-    explanation: Supports writing impairment as part of the neurologic Wilson disease phenotype.
-  phenotype_term:
-    preferred_term: Dysgraphia
-    term:
-      id: HP:0010526
-      label: Dysgraphia
 - name: Depression
   category: Psychiatric
   frequency: FREQUENT
   notes: One of the most common psychiatric manifestations of Wilson disease
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:1821256
+    reference_title: &#34;The psychiatric presentations of Wilson&#39;s disease.&#34;
     supports: SUPPORT
-    snippet: &#34;Among these are depression, psychosis, dysarthria, ataxia, writing problems&#34;
-    explanation: Depression is explicitly listed as a neuropsychiatric manifestation of Wilson disease.
+    snippet: &#34;Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%).&#34;
+    explanation: Cohort data directly support depression as a common psychiatric manifestation in symptomatic Wilson disease.
   phenotype_term:
     preferred_term: Depression
     term:
@@ -7072,11 +6905,11 @@ phenotypes:
   category: Psychiatric
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:1821256
+    reference_title: &#34;The psychiatric presentations of Wilson&#39;s disease.&#34;
     supports: SUPPORT
-    snippet: &#34;Among these are depression, psychosis, dysarthria, ataxia, writing problems&#34;
-    explanation: Psychosis is explicitly listed as a neuropsychiatric manifestation of Wilson disease.
+    snippet: &#34;Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.&#34;
+    explanation: Supports psychosis as a recognized, less frequent psychiatric presentation of Wilson disease.
   phenotype_term:
     preferred_term: Psychosis
     term:
@@ -7087,11 +6920,11 @@ phenotypes:
   frequency: OCCASIONAL
   notes: Personality changes may be an early psychiatric manifestation
   evidence:
-  - reference: PMID:28433113
-    reference_title: &#34;Wilson disease: brain pathology.&#34;
-    supports: PARTIAL
-    snippet: &#34;the cerebral copper content is not correlated with the severity of the neuropathologic abnormalities or with the neuropsychiatric symptomatology.&#34;
-    explanation: Reference to neuropsychiatric symptomatology in Wilson disease indirectly supports personality changes as a recognized psychiatric feature, though personality changes are not individually named in this abstract.
+  - reference: PMID:1821256
+    reference_title: &#34;The psychiatric presentations of Wilson&#39;s disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%).&#34;
+    explanation: Directly supports personality change as a common psychiatric presentation in symptomatic Wilson disease.
   phenotype_term:
     preferred_term: Personality changes
     term:
@@ -7101,11 +6934,11 @@ phenotypes:
   category: Cardiac
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:27176875
+    reference_title: &#34;Strain and strain rate echocardiography in children with Wilson&#39;s disease.&#34;
     supports: SUPPORT
-    snippet: &#34;This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias&#34;
-    explanation: Cardiomyopathy is explicitly listed as a cardiac manifestation of Wilson disease due to copper deposition.
+    snippet: &#34;Cardiac arrhythmias, cardiomyopathy and sudden cardiac death are rare complications but may be seen in children with Wilson&#39;s disease due to copper accumulation in the heart tissue.&#34;
+    explanation: Supports cardiomyopathy as a recognized but uncommon cardiac complication of Wilson disease.
   phenotype_term:
     preferred_term: Cardiomyopathy
     term:
@@ -7115,11 +6948,11 @@ phenotypes:
   category: Cardiac
   frequency: OCCASIONAL
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:28947309
+    reference_title: &#34;Wilson&#39;s Disease and Cardiac Myopathy.&#34;
     supports: SUPPORT
-    snippet: &#34;This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias&#34;
-    explanation: Cardiac arrhythmias are explicitly listed as a cardiac manifestation of Wilson disease.
+    snippet: &#34;Patients with Wilson&#39;s disease exhibited a 29% higher risk of AF after adjusting for age, gender, race, income, hypertension, diabetes, renal disease, hyperlipidemia, obesity, coronary disease, and obstructive sleep apnea (HR 1.29, 95% CI 1.15 to 1.45, p &lt;0.0001).&#34;
+    explanation: Supports arrhythmia risk as a clinically relevant cardiac manifestation in Wilson disease.
   phenotype_term:
     preferred_term: Arrhythmia
     term:
@@ -7128,12 +6961,13 @@ phenotypes:
 - name: Renal Tubular Dysfunction
   category: Renal
   frequency: OCCASIONAL
+  notes: Renal tubular acidosis is one documented form of renal tubular involvement
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:31317233
+    reference_title: &#34;Renal Tubular Function, Bone Health and Body Composition in Wilson&#39;s Disease: A Cross-Sectional Study from India.&#34;
     supports: SUPPORT
-    snippet: &#34;This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction&#34;
-    explanation: Renal tubular dysfunction is explicitly listed as a renal manifestation of Wilson disease.
+    snippet: &#34;Fifty-six percent (14/25) of patients with WD had renal tubular acidosis (RTA).&#34;
+    explanation: Supports renal tubular dysfunction in Wilson disease through direct evidence of a high prevalence of renal tubular acidosis.
   phenotype_term:
     preferred_term: Renal tubular dysfunction
     term:
@@ -7142,32 +6976,23 @@ phenotypes:
 - name: Hemolytic Anemia
   category: Hematologic
   frequency: OCCASIONAL
-  notes: Coombs-negative hemolytic anemia is a key feature
+  notes: May accompany acute hepatic decompensation with marked copper release
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:24577547
+    reference_title: &#34;Acute hemolytic anemia as an initial presentation of Wilson disease in children.&#34;
     supports: SUPPORT
-    snippet: &#34;In addition, Coombs-negative hemolytic anemia is a key feature of Wilson disease with undetectable serum haptoglobin&#34;
-    explanation: Coombs-negative hemolytic anemia is described as a key feature of Wilson disease.
+    snippet: &#34;Hemolytic anemia in WD occurs in up to 17% of patients at some point during their illness.&#34;
+    explanation: Supports hemolytic anemia as a recognized hematologic manifestation of Wilson disease.
+  - reference: PMID:7234865
+    reference_title: &#34;Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms.&#34;
+    supports: SUPPORT
+    snippet: &#34;Two patients with Wilson disease who presented with severe hemolytic anemia are described.&#34;
+    explanation: Provides direct case-based evidence of severe hemolytic anemia in Wilson disease.
   phenotype_term:
     preferred_term: Hemolytic anemia
     term:
       id: HP:0001878
       label: Hemolytic anemia
-- name: Rhabdomyolysis
-  category: Muscular
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
-    snippet: &#34;This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis&#34;
-    explanation: Rhabdomyolysis is explicitly listed as a muscle manifestation in Wilson disease.
-  phenotype_term:
-    preferred_term: Rhabdomyolysis
-    term:
-      id: HP:0003201
-      label: Rhabdomyolysis
 - name: Osteoporosis
   category: Skeletal
   frequency: OCCASIONAL
@@ -7177,11 +7002,11 @@ phenotypes:
     supports: SUPPORT
     snippet: &#34;The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%&#34;
     explanation: Meta-analysis supports frequent low bone density and osteoporosis in Wilson disease populations.
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:31317233
+    reference_title: &#34;Renal Tubular Function, Bone Health and Body Composition in Wilson&#39;s Disease: A Cross-Sectional Study from India.&#34;
     supports: SUPPORT
-    snippet: &#34;This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis&#34;
-    explanation: Osteoporosis is explicitly listed as a skeletal manifestation of Wilson disease.
+    snippet: &#34;Patients with WD had significantly lower BMD as compared to control subjects (p &lt; 0.05).&#34;
+    explanation: Supports reduced bone mineral density as a real skeletal manifestation in Wilson disease cohorts.
   phenotype_term:
     preferred_term: Osteoporosis
     term:
@@ -7196,53 +7021,16 @@ phenotypes:
     supports: SUPPORT
     snippet: &#34;The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%&#34;
     explanation: Meta-analysis supports osteopenia as a common bone phenotype in Wilson disease.
+  - reference: PMID:31317233
+    reference_title: &#34;Renal Tubular Function, Bone Health and Body Composition in Wilson&#39;s Disease: A Cross-Sectional Study from India.&#34;
+    supports: SUPPORT
+    snippet: &#34;Patients with WD had significantly lower BMD as compared to control subjects (p &lt; 0.05).&#34;
+    explanation: Independent cohort data support low bone mass in Wilson disease.
   phenotype_term:
     preferred_term: Osteopenia
     term:
       id: HP:0000938
       label: Osteopenia
-- name: Osteomalacia
-  category: Skeletal
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
-    snippet: &#34;osteoporosis, osteomalacia, arthritis, and arthralgia&#34;
-    explanation: Osteomalacia is explicitly listed among musculoskeletal manifestations in Wilson disease.
-  phenotype_term:
-    preferred_term: Osteomalacia
-    term:
-      id: HP:0002749
-      label: Osteomalacia
-- name: Arthritis
-  category: Skeletal
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
-    snippet: &#34;osteoporosis, osteomalacia, arthritis, and arthralgia&#34;
-    explanation: Arthritis is listed as a musculoskeletal manifestation of Wilson disease.
-  phenotype_term:
-    preferred_term: Arthritis
-    term:
-      id: HP:0001369
-      label: Arthritis
-- name: Arthralgia
-  category: Skeletal
-  frequency: OCCASIONAL
-  evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
-    supports: SUPPORT
-    snippet: &#34;osteoporosis, osteomalacia, arthritis, and arthralgia&#34;
-    explanation: Arthralgia is explicitly listed among musculoskeletal manifestations in Wilson disease.
-  phenotype_term:
-    preferred_term: Arthralgia
-    term:
-      id: HP:0002829
-      label: Arthralgia
 biochemical:
 - name: Ceruloplasmin
   presence: Decreased
@@ -7255,27 +7043,32 @@ biochemical:
     explanation: Directly supports low serum ceruloplasmin as a diagnostic biochemical feature.
 - name: Non-Ceruloplasmin-Bound Serum Copper
   presence: Elevated
-  context: Free copper fraction is elevated; a key diagnostic biomarker criterion met in 86.6% of patients
+  context: Free copper fraction is elevated and used both diagnostically and for treatment monitoring
   evidence:
   - reference: PMID:16709660
     reference_title: &#34;Clinical presentation, diagnosis and long-term outcome of Wilson&#39;s disease: a cohort study.&#34;
     supports: SUPPORT
     snippet: &#34;Diagnostic criteria for non-caeruloplasmin-bound serum copper, serum caeruloplasmin, 24-h urinary copper excretion, liver copper content, presence of Kayser-Fleischer rings and histological signs of chronic liver damage were reached in 86.6%, 88.2%, 87.1%, 92.7%, 66.3% and 73% of patients, respectively.&#34;
     explanation: Supports non-ceruloplasmin-bound copper as a commonly met diagnostic biomarker criterion.
-  - reference: PMID:37741465
-    reference_title: &#34;Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson&#39;s disease.&#34;
-    supports: PARTIAL
-    snippet: &#34;The goal of these strategies is to reduce free copper, redox stress, and cellular toxicity&#34;
-    explanation: Elevated free copper is the therapeutic target in Wilson disease, confirming its pathological elevation.
+  - reference: PMID:39139457
+    reference_title: &#34;Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets.&#34;
+    supports: SUPPORT
+    snippet: &#34;Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited.&#34;
+    explanation: Supports NCC as an established Wilson disease monitoring biomarker during chelation therapy.
 - name: 24-Hour Urinary Copper
   presence: Elevated
-  context: Elevated urinary copper is diagnostic
+  context: Elevated urinary copper is diagnostic and is also followed during chelation therapy
   evidence:
   - reference: PMID:15205951
     reference_title: &#34;Wilson disease.&#34;
     supports: SUPPORT
     snippet: &#34;The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content.&#34;
     explanation: Directly supports increased urinary copper excretion as a diagnostic biochemical feature.
+  - reference: PMID:39139457
+    reference_title: &#34;Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets.&#34;
+    supports: SUPPORT
+    snippet: &#34;Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited.&#34;
+    explanation: Supports 24-hour urinary copper excretion as a standard biomarker used to monitor Wilson disease therapy.
 - name: Hepatic Copper
   presence: Elevated
   context: Liver biopsy with elevated copper is diagnostic
@@ -7309,13 +7102,13 @@ genetic:
     explanation: Confirms large number of ATP7B mutations causing Wilson disease.
 environmental:
 - name: Dietary Copper
-  notes: High copper foods may accelerate accumulation
+  notes: Dietary copper contributes to exposure, but strict long-term restriction beyond very high-copper foods is not well supported
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:36010023
+    reference_title: &#34;Low Copper Diet-A Therapeutic Option for Wilson Disease?&#34;
     supports: PARTIAL
-    snippet: &#34;copper, which is found ubiquitously on earth and normally enters the human body in small amounts via the food chain&#34;
-    explanation: Dietary copper intake contributes to body copper load, making dietary restriction an important adjunctive measure.
+    snippet: &#34;A lower copper intake only prevents the re-accumulation of copper.&#34;
+    explanation: Supports dietary copper reduction as an adjunctive measure, while implying that diet alone is not the main determinant of disease control.
 treatments:
 - name: D-Penicillamine
   description: Copper chelator, first-line therapy, promotes urinary copper excretion.
@@ -7367,26 +7160,26 @@ treatments:
         id: CHEBI:62984
         label: zinc acetate
 - name: Low Copper Diet
-  description: Avoid liver, shellfish, chocolate, nuts, mushrooms.
+  description: Adjunctive dietary measure; liver and shellfish are the foods most consistently recommended for avoidance.
   evidence:
-  - reference: PMID:38731973
-    reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
+  - reference: PMID:36010023
+    reference_title: &#34;Low Copper Diet-A Therapeutic Option for Wilson Disease?&#34;
     supports: PARTIAL
-    snippet: &#34;copper, which is found ubiquitously on earth and normally enters the human body in small amounts via the food chain&#34;
-    explanation: Establishes that dietary intake is a source of copper, supporting dietary restriction as an adjunctive treatment approach.
+    snippet: &#34;In summary, consistent adherence to drug therapy is more important than a strict diet. Only two foods should be consistently avoided: Liver and Shellfish.&#34;
+    explanation: Supports a limited adjunctive low-copper diet while explicitly cautioning against overstating the value of strict dietary restriction.
   treatment_term:
     preferred_term: dietary intervention
     term:
       id: MAXO:0000088
       label: dietary intervention
 - name: Tetrathiomolybdate
-  description: Emerging copper chelator that rapidly complexes free copper, reducing bioavailable copper.
+  description: Investigational copper chelator that markedly reduces intestinal copper uptake and lowers hepatic and brain copper exposure.
   evidence:
-  - reference: PMID:37741465
-    reference_title: &#34;Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson&#39;s disease.&#34;
-    supports: PARTIAL
-    snippet: &#34;Current treatment protocols are limited to either sequestration of copper via chelation or reduction of copper absorption in the gut&#34;
-    explanation: Tetrathiomolybdate represents an emerging chelation approach that tightly complexes copper.
+  - reference: PMID:38081365
+    reference_title: &#34;Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease.&#34;
+    supports: SUPPORT
+    snippet: &#34;TTM effectively inhibited most intestinal 64Cu uptake and retained 64Cu in the blood stream, limiting the exposure of organs like the liver and brain to 64Cu.&#34;
+    explanation: Human tracer studies support tetrathiomolybdate as an investigational therapy that reduces organ copper exposure primarily by blocking intestinal uptake.
   treatment_term:
     preferred_term: copper chelator agent therapy
     term:
@@ -7400,6 +7193,11 @@ treatments:
 - name: Liver Transplantation
   description: Curative for hepatic Wilson disease, reverses copper metabolism defect.
   evidence:
+  - reference: PMID:32520831
+    reference_title: &#34;Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis.&#34;
+    supports: SUPPORT
+    snippet: &#34;Of the total 256 subjects, 87% underwent LT, 11% achieved spontaneous recovery and 2% died before LT.&#34;
+    explanation: Supports liver transplantation as the predominant life-saving therapy for Wilson disease presenting with acute liver failure.
   - reference: PMID:38731973
     reference_title: &#34;Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.&#34;
     supports: SUPPORT
@@ -7523,369 +7321,609 @@ references:
 - reference: DOI:10.1016/j.jhep.2023.04.007
   title: &#39;Neurological worsening in Wilson disease - clinical classification and outcome&#39;
   findings: []
+- reference: DOI:10.1016/j.jhepr.2024.101115
+  title: &#39;Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets.&#39;
+  findings: []
+- reference: DOI:10.1016/j.amjcard.2017.08.025
+  title: &#34;Wilson&#39;s Disease and Cardiac Myopathy.&#34;
+  findings: []
+- reference: DOI:10.1016/j.jhep.2023.11.023
+  title: Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease.
+  findings: []
+- reference: DOI:10.1007/s00223-019-00588-z
+  title: &#34;Renal Tubular Function, Bone Health and Body Composition in Wilson&#39;s Disease: A Cross-Sectional Study from India.&#34;
+  findings: []
+- reference: DOI:10.1176/jnp.3.4.377
+  title: &#34;The psychiatric presentations of Wilson&#39;s disease.&#34;
+  findings: []
+- reference: DOI:10.1002/ajh.2830090305
+  title: &#39;Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms.&#39;
+  findings: []
+- reference: DOI:10.3390/children9081132
+  title: Low Copper Diet-A Therapeutic Option for Wilson Disease?
+  findings: []
+- reference: DOI:10.1097/MPG.0000000000002777
+  title: &#39;Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis.&#39;
+  findings: []
+- reference: DOI:10.15403/jgld-5662
+  title: Iron and Copper Liver Concentrations in Wilson Disease.
+  findings: []
+- reference: DOI:10.5830/CVJA-2016-028
+  title: &#34;Strain and strain rate echocardiography in children with Wilson&#39;s disease.&#34;
+  findings: []
+- reference: DOI:10.1097/MPH.0000000000000127
+  title: Acute hemolytic anemia as an initial presentation of Wilson disease in children.
+  findings: []
+- reference: DOI:10.1007/s10534-025-00748-9
+  title: &#39;The pathogenesis of liver fibrosis in Wilson&#39;&#39;s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.&#39;
+  findings: []
 </pre>
             </div>
         </div>
 
         <!-- References & Deep Research -->
-        
+
         <div class="card reference-card" id="references-deep-research">
             <div class="card-header">
                 <div class="card-icon" style="background: #eef2ff; color: #4f46e5;">📚</div>
                 <h2 class="card-title">References &amp; Deep Research</h2>
             </div>
-            
+
             <div class="grouped-section anchor-target" id="references">
                 <div class="grouped-section-header">
                     <h3 class="grouped-section-title">References</h3>
-                    <span class="card-count">20</span>
+                    <span class="card-count">32</span>
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1016/j.pharmthera.2023.108529" target="_blank">DOI:10.1016/j.pharmthera.2023.108529</a>
                             </div>
-                            
+
                             <div class="reference-title">Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson&#39;s disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1038/s41467-024-47001-4" target="_blank">DOI:10.1038/s41467-024-47001-4</a>
                             </div>
-                            
+
                             <div class="reference-title">Diverse roles of the metal binding domains and transport mechanism of copper transporting P-type ATPases</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1093/braincomms/fcae329" target="_blank">DOI:10.1093/braincomms/fcae329</a>
                             </div>
-                            
+
                             <div class="reference-title">Structural lesions and transcriptomic specializations shape gradient perturbations in Wilson disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1152/physiol.00032.2025" target="_blank">DOI:10.1152/physiol.00032.2025</a>
                             </div>
-                            
+
                             <div class="reference-title">Copper in Human Health and Disease: Insights from Inherited Disorders</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1186/s12974-024-03178-5" target="_blank">DOI:10.1186/s12974-024-03178-5</a>
                             </div>
-                            
+
                             <div class="reference-title">Aberrant copper metabolism and hepatic inflammation cause neurological manifestations in a mouse model of Wilson&#39;s disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.3389/fmed.2025.1673283" target="_blank">DOI:10.3389/fmed.2025.1673283</a>
                             </div>
-                            
+
                             <div class="reference-title">The role of copper dysregulation in Wilson disease: an expert opinion</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.3390/cells13141214" target="_blank">DOI:10.3390/cells13141214</a>
                             </div>
-                            
+
                             <div class="reference-title">Navigating the CRISPR/Cas Landscape for Enhanced Diagnosis and Treatment of Wilson&#39;s Disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.3390/ijms25094753" target="_blank">DOI:10.3390/ijms25094753</a>
                             </div>
-                            
+
                             <div class="reference-title">Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.3390/ijms25126487" target="_blank">DOI:10.3390/ijms25126487</a>
                             </div>
-                            
+
                             <div class="reference-title">The Role of Copper Overload in Modulating Neuropsychiatric Symptoms</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.3390/ijms25147545" target="_blank">DOI:10.3390/ijms25147545</a>
                             </div>
-                            
+
                             <div class="reference-title">The Role of Glia in Wilson&#39;s Disease: Clinical, Neuroimaging, Neuropathological and Molecular Perspectives</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1289/ehp.02110s5695" target="_blank">DOI:10.1289/ehp.02110s5695</a>
                             </div>
-                            
+
                             <div class="reference-title">Molecular mechanism of copper transport in Wilson disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1007/s00428-004-1047-8" target="_blank">DOI:10.1007/s00428-004-1047-8</a>
                             </div>
-                            
+
                             <div class="reference-title">Wilson disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1136/gut.2005.087262" target="_blank">DOI:10.1136/gut.2005.087262</a>
                             </div>
-                            
+
                             <div class="reference-title">Clinical presentation, diagnosis and long-term outcome of Wilson&#39;s disease: a cohort study</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1016/B978-0-444-63625-6.00010-0" target="_blank">DOI:10.1016/B978-0-444-63625-6.00010-0</a>
                             </div>
-                            
+
                             <div class="reference-title">Wilson disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1007/s10072-020-05013-0" target="_blank">DOI:10.1007/s10072-020-05013-0</a>
                             </div>
-                            
+
                             <div class="reference-title">Neurological features and outcomes of Wilson&#39;s disease: a single-center experience</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1097/MPG.0000000000003196" target="_blank">DOI:10.1097/MPG.0000000000003196</a>
                             </div>
-                            
+
                             <div class="reference-title">Pediatric Wilson&#39;s Disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1186/s13023-022-02245-5" target="_blank">DOI:10.1186/s13023-022-02245-5</a>
                             </div>
-                            
+
                             <div class="reference-title">Wilson disease in Northern Portugal: a long-term follow-up study</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1007/s00198-017-4295-6" target="_blank">DOI:10.1007/s00198-017-4295-6</a>
                             </div>
-                            
+
                             <div class="reference-title">Osteoporosis and bone mineral density in patients with Wilson&#39;s disease: a systematic review and meta-analysis</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.3390/jcm11143975" target="_blank">DOI:10.3390/jcm11143975</a>
                             </div>
-                            
+
                             <div class="reference-title">Efficacy and Safety of Two Salts of Trientine in the Treatment of Wilson&#39;s Disease</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
                 <div class="reference-entry">
                     <div class="reference-entry-header">
                         <div>
                             <div class="reference-curie">
                                 <a href="https://bioregistry.io/DOI:10.1016/j.jhep.2023.04.007" target="_blank">DOI:10.1016/j.jhep.2023.04.007</a>
                             </div>
-                            
+
                             <div class="reference-title">Neurological worsening in Wilson disease - clinical classification and outcome</div>
-                            
+
                         </div>
-                        
+
                     </div>
-                    
+
                     <div class="reference-empty">No top-level findings curated for this source.</div>
-                    
+
                 </div>
-                
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1016/j.jhepr.2024.101115" target="_blank">DOI:10.1016/j.jhepr.2024.101115</a>
+                            </div>
+
+                            <div class="reference-title">Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1016/j.amjcard.2017.08.025" target="_blank">DOI:10.1016/j.amjcard.2017.08.025</a>
+                            </div>
+
+                            <div class="reference-title">Wilson&#39;s Disease and Cardiac Myopathy.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1016/j.jhep.2023.11.023" target="_blank">DOI:10.1016/j.jhep.2023.11.023</a>
+                            </div>
+
+                            <div class="reference-title">Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1007/s00223-019-00588-z" target="_blank">DOI:10.1007/s00223-019-00588-z</a>
+                            </div>
+
+                            <div class="reference-title">Renal Tubular Function, Bone Health and Body Composition in Wilson&#39;s Disease: A Cross-Sectional Study from India.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1176/jnp.3.4.377" target="_blank">DOI:10.1176/jnp.3.4.377</a>
+                            </div>
+
+                            <div class="reference-title">The psychiatric presentations of Wilson&#39;s disease.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1002/ajh.2830090305" target="_blank">DOI:10.1002/ajh.2830090305</a>
+                            </div>
+
+                            <div class="reference-title">Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.3390/children9081132" target="_blank">DOI:10.3390/children9081132</a>
+                            </div>
+
+                            <div class="reference-title">Low Copper Diet-A Therapeutic Option for Wilson Disease?</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1097/MPG.0000000000002777" target="_blank">DOI:10.1097/MPG.0000000000002777</a>
+                            </div>
+
+                            <div class="reference-title">Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.15403/jgld-5662" target="_blank">DOI:10.15403/jgld-5662</a>
+                            </div>
+
+                            <div class="reference-title">Iron and Copper Liver Concentrations in Wilson Disease.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.5830/CVJA-2016-028" target="_blank">DOI:10.5830/CVJA-2016-028</a>
+                            </div>
+
+                            <div class="reference-title">Strain and strain rate echocardiography in children with Wilson&#39;s disease.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1097/MPH.0000000000000127" target="_blank">DOI:10.1097/MPH.0000000000000127</a>
+                            </div>
+
+                            <div class="reference-title">Acute hemolytic anemia as an initial presentation of Wilson disease in children.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
+                <div class="reference-entry">
+                    <div class="reference-entry-header">
+                        <div>
+                            <div class="reference-curie">
+                                <a href="https://bioregistry.io/DOI:10.1007/s10534-025-00748-9" target="_blank">DOI:10.1007/s10534-025-00748-9</a>
+                            </div>
+
+                            <div class="reference-title">The pathogenesis of liver fibrosis in Wilson&#39;s disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation.</div>
+
+                        </div>
+
+                    </div>
+
+                    <div class="reference-empty">No top-level findings curated for this source.</div>
+
+                </div>
+
             </div>
-            
-            
+
+
         </div>
-        
+
 
         <footer class="page-footer">
             <p>
@@ -7935,7 +7973,7 @@ references:
         'use strict';
 
         // Config injected by Jinja2
-        const OS_CONFIG = {"diseaseName": "Wilson Disease", "mondoId": "MONDO:0010200", "proxyUrl": "https://dismech-openscientist.bbop.workers.dev", "slug": "Wilson_Disease", "yamlRevision": "b0733f511fc1"};
+        const OS_CONFIG = {"diseaseName": "Wilson Disease", "mondoId": "MONDO:0010200", "proxyUrl": "https://dismech-openscientist.bbop.workers.dev", "slug": "Wilson_Disease", "yamlRevision": "e49b650698ec"};
 
         // --- DOM refs ---
         const questionInput = document.getElementById('os-question');

--- a/references_cache/PMID_1821256.md
+++ b/references_cache/PMID_1821256.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:1821256"
+title: "The psychiatric presentations of Wilson's disease."
+authors:
+- Akil M
+- Schwartz JA
+- Dutchak D
+- Yuzbasiyan-Gurkan V
+- Brewer GJ
+journal: J Neuropsychiatry Clin Neurosci
+year: '1991'
+doi: 10.1176/jnp.3.4.377
+keywords:
+- Acetates/therapeutic use
+- Acetic Acid
+- Adult
+- "Depressive Disorder/diagnosis, drug therapy, psychology"
+- Female
+- "Hepatolenticular Degeneration/diagnosis, drug therapy, psychology"
+- Humans
+- Magnetic Resonance Imaging
+- Male
+- "Neurocognitive Disorders/diagnosis, drug therapy, psychology"
+- Neurologic Examination
+- Neuropsychological Tests
+- "Personality Disorders/diagnosis, drug therapy, psychology"
+content_type: abstract_only
+---
+
+# The psychiatric presentations of Wilson's disease.
+**Authors:** Akil M, Schwartz JA, Dutchak D, Yuzbasiyan-Gurkan V, Brewer GJ
+**Journal:** J Neuropsychiatry Clin Neurosci (1991)
+**DOI:** [10.1176/jnp.3.4.377](https://doi.org/10.1176/jnp.3.4.377)
+
+## Content
+
+1. J Neuropsychiatry Clin Neurosci. 1991 Fall;3(4):377-82. doi:
+10.1176/jnp.3.4.377.
+
+The psychiatric presentations of Wilson's disease.
+
+Akil M(1), Schwartz JA, Dutchak D, Yuzbasiyan-Gurkan V, Brewer GJ.
+
+Author information:
+(1)Department of Psychiatry, University of Michigan, Ann Arbor.
+
+Comment in
+    J Neuropsychiatry Clin Neurosci. 1992 Summer;4(3):349-50. doi:
+10.1176/jnp.4.3.349.
+
+We reviewed the records of 42 patients with Wilson's disease participating in a
+zinc acetate treatment protocol and interviewed 17 of them. Five of the patients
+studied were asymptomatic. A significant number of symptomatic patients (64.8%)
+reported psychiatric symptoms at the time of initial presentation. These
+symptoms were severe enough to warrant psychiatric intervention in almost half
+of all symptomatic patients before the diagnosis of Wilson's disease was made.
+Personality changes, particularly irritability and aggression, were most
+commonly described (45.9%), followed by depression (27%). Cognitive changes,
+anxiety, psychosis, and catatonia, while less frequent, also occurred. These
+data underscore the need to include Wilson's disease in the differential
+diagnosis of psychiatric disorders.
+
+DOI: 10.1176/jnp.3.4.377
+PMID: 1821256 [Indexed for MEDLINE]

--- a/references_cache/PMID_22473403.md
+++ b/references_cache/PMID_22473403.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:22473403"
+title: "Wilson's disease: an analysis of 28 Brazilian children."
+authors:
+- Kleine RT
+- Mendes R
+- Pugliese R
+- Miura I
+- Danesi V
+- Porta G
+journal: Clinics (Sao Paulo)
+year: '2012'
+doi: 10.6061/clinics/2012(03)05
+keywords:
+- Adolescent
+- Aspartate Aminotransferases/blood
+- Biomarkers/blood
+- Brazil
+- Chelating Agents/therapeutic use
+- Child
+- "Child, Preschool"
+- Copper/therapeutic use
+- Early Diagnosis
+- Family
+- Female
+- Follow-Up Studies
+- "Hepatolenticular Degeneration/diagnosis, drug therapy, prevention & control"
+- Humans
+- Male
+- Mass Screening/methods
+- Retrospective Studies
+- Zinc Sulfate/therapeutic use
+content_type: abstract_only
+---
+
+# Wilson's disease: an analysis of 28 Brazilian children.
+**Authors:** Kleine RT, Mendes R, Pugliese R, Miura I, Danesi V, Porta G
+**Journal:** Clinics (Sao Paulo) (2012)
+**DOI:** [10.6061/clinics/2012(03)05](https://doi.org/10.6061/clinics/2012(03)05)
+
+## Content
+
+1. Clinics (Sao Paulo). 2012;67(3):231-5. doi: 10.6061/clinics/2012(03)05.
+
+Wilson's disease: an analysis of 28 Brazilian children.
+
+Kleine RT(1), Mendes R, Pugliese R, Miura I, Danesi V, Porta G.
+
+Author information:
+(1)Universidade de São Paulo, São Paulo, SP, Brazil. rtkleine@hotmail.com
+
+OBJECTIVES: Clinical-laboratory and evolutionary analysis of twenty-eight
+patients with Wilson's disease.
+METHODS: Twenty-eight children (twelve females and sixteen males) with Wilson's
+disease were evaluated retrospectively between 1987 and 2009, with a follow-up
+of 72 months (1 - 240 months). The clinical, laboratory, and histologic features
+at diagnosis were recorded at the end of the study.
+RESULTS: The median age at diagnosis was 11 years (2 - 18 years). Twelve
+patients were asymptomatic, seven had hepatitis symptoms, five had raised
+aminotransferase levels, three had hepatomegaly associated with neurological
+disorders, one had fulminant hepatitis with hemolytic anemia, and six patients
+presented with a Kayser-Fleischer ring. A histological analysis revealed that
+six children had chronic hepatitis, seven had cirrhosis, two had steatosis, one
+had portal fibrosis, and one had massive necrosis. The treatment consisted of
+D-penicillamine associated with pyridoxine for 26 patients. Adverse effects were
+observed in the other two patients: one presented with uncontrollable vomiting
+and the other demonstrated elastosis perforans serpiginosa. At the end of the
+study, all 26 treated patients were asymptomatic. Twenty-four of the patients
+were treated with D-penicillamine and pyridoxine, and two were treated with
+trientine and zinc sulfate. A liver transplant was performed in one patient with
+fulminant hepatitis, but the final patient died 48 hours after admission to the
+intensive care unit.
+CONCLUSIONS: Family screenings associated with early treatment are important in
+preventing Wilson's disease symptoms and potentially fatal disease progression.
+The study suggests that Wilson's disease must be ruled out in children older
+than two years presenting with abnormal levels of hepatic enzymes because of the
+heterogeneity of symptoms and the encouraging treatment results obtained so far.
+
+DOI: 10.6061/clinics/2012(03)05
+PMCID: PMC3297031
+PMID: 22473403 [Indexed for MEDLINE]
+
+Conflict of interest statement: No potential conflict of interest was reported.

--- a/references_cache/PMID_24577547.md
+++ b/references_cache/PMID_24577547.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:24577547"
+title: Acute hemolytic anemia as an initial presentation of Wilson disease in children.
+authors:
+- El Raziky MS
+- Ali A
+- El Shahawy A
+- Hamdy MM
+journal: J Pediatr Hematol Oncol
+year: '2014'
+doi: 10.1097/MPH.0000000000000127
+keywords:
+- Acute Disease
+- Adolescent
+- "Anemia, Hemolytic/diagnosis, metabolism"
+- Ceruloplasmin/metabolism
+- Chelating Agents/metabolism
+- Child
+- "Child, Preschool"
+- Cohort Studies
+- "Diagnosis, Differential"
+- Female
+- Follow-Up Studies
+- "Hepatolenticular Degeneration/diagnosis, metabolism"
+- Humans
+- Liver Function Tests
+- Male
+- Penicillamine/metabolism
+- Prognosis
+content_type: abstract_only
+---
+
+# Acute hemolytic anemia as an initial presentation of Wilson disease in children.
+**Authors:** El Raziky MS, Ali A, El Shahawy A, Hamdy MM
+**Journal:** J Pediatr Hematol Oncol (2014)
+**DOI:** [10.1097/MPH.0000000000000127](https://doi.org/10.1097/MPH.0000000000000127)
+
+## Content
+
+1. J Pediatr Hematol Oncol. 2014 Apr;36(3):173-8. doi:
+10.1097/MPH.0000000000000127.
+
+Acute hemolytic anemia as an initial presentation of Wilson disease in children.
+
+El Raziky MS(1), Ali A, El Shahawy A, Hamdy MM.
+
+Author information:
+(1)*Pediatric Department, Cairo University †Pediatric Department, National
+Hepatology and Tropical Medicine Institute, Cairo, Egypt.
+
+BACKGROUND: Wilson disease (WD) is an inherited disorder of copper metabolism.
+Hemolytic anemia in WD occurs in up to 17% of patients at some point during
+their illness.
+AIM: To screen for WD among children presenting with hemolytic anemia.
+METHODOLOGY: Twenty cases (mean age, 8.8 ± 3.9 y) with Coombs-negative hemolytic
+anemia, attending the hematology clinic of children hospital, Cairo University,
+were screened for WD by serum ceruloplasmin level, 24 hours urinary copper
+before and after D-penicillamine challenge test, and slit-lamp examination for
+detecting Kayser-Fleischer rings.
+RESULTS: No case had low ceruloplasmin, whereas bilateral Kayser-Fleischer rings
+was detected in 5% of our cases. Urinary copper was elevated in 5% before and in
+40% after D-penicillamine challenge test. According to the scoring system used,
+1 case had definite WD and 7 cases were likely to have WD. These 8 (40%) cases
+were referred to as group B. Group B had a significantly lower hemoglobin, mean
+corpuscular volume, mean corpuscular hemoglobin, and reticulocytes (P=0.04,
+0.001, 0.04, and 0.04, respectively) and a significantly higher urinary copper
+after penicillamine (P=0.000) when compared with group A (unlikely WD).
+CONCLUSION: WD is not uncommon in children with hemolytic anemia after exclusion
+of other common causes.
+
+DOI: 10.1097/MPH.0000000000000127
+PMID: 24577547 [Indexed for MEDLINE]

--- a/references_cache/PMID_27176875.md
+++ b/references_cache/PMID_27176875.md
@@ -1,0 +1,111 @@
+---
+reference_id: "PMID:27176875"
+title: "Strain and strain rate echocardiography in children with Wilson's disease."
+authors:
+- Karakurt C
+- Çelik S
+- Selimoğlu A
+- Varol I
+- Karabiber H
+- Yoloğlu S
+journal: Cardiovasc J Afr
+year: '2016'
+doi: 10.5830/CVJA-2016-028
+keywords:
+- Adolescent
+- Age Factors
+- Case-Control Studies
+- Child
+- "Child, Preschool"
+- Early Diagnosis
+- Echocardiography/methods
+- Electrocardiography
+- Female
+- "Hepatolenticular Degeneration/complications, diagnosis"
+- Humans
+- Male
+- Myocardial Contraction
+- Patient Positioning
+- Predictive Value of Tests
+- Prognosis
+- "Stress, Mechanical"
+- "Ventricular Dysfunction, Left/diagnostic imaging, etiology, physiopathology"
+- "Ventricular Function, Left"
+content_type: abstract_only
+---
+
+# Strain and strain rate echocardiography in children with Wilson's disease.
+**Authors:** Karakurt C, Çelik S, Selimoğlu A, Varol I, Karabiber H, Yoloğlu S
+**Journal:** Cardiovasc J Afr (2016)
+**DOI:** [10.5830/CVJA-2016-028](https://doi.org/10.5830/CVJA-2016-028)
+
+## Content
+
+1. Cardiovasc J Afr. 2016 Sep/Oct 23;27(5):307-314. doi: 10.5830/CVJA-2016-028.
+Epub 2016 May 13.
+
+Strain and strain rate echocardiography in children with Wilson's disease.
+
+Karakurt C(1), Çelik S(1), Selimoğlu A(2), Varol I(2), Karabiber H(2), Yoloğlu
+S(3).
+
+Author information:
+(1)Department of Pediatric Cardiology, Faculty of Medicine, Inonu University,
+Malatya, Turkey.
+(2)Department of Pediatric Gastroenterology, Faculty of Medicine, Inonu
+University, Malatya, Turkey.
+(3)Department of Biostatistics, Faculty of Medicine, Inonu University, Malatya,
+Turkey.
+
+OBJECTIVE: This study aimed to evaluate strain and strain rate echocardiography
+in children with Wilson's disease to detect early cardiac dysfunction.
+METHODS: In this study, 21 patients with Wilson's disease and a control group of
+20 age- and gender-matched healthy children were included. All the patients and
+the control group were evaluated with two-dimensional (2D) and colour-coded
+conventional transthoracic echocardiography by the same paediatric cardiologist
+using the same echocardiography machine (Vivid E9, GE Healthcare, Norway) in
+standard precordial positions, according to the American Society of
+Echocardiography recommendations. 2D strain and strain rate echocardiography
+were performed after the ECG probes of the echocardiography machine were
+adjusted for ECG monitoring. Longitudinal, transverse and radial strain, and
+strain rate were assessed from six basal and six mid-ventricular segments of the
+left ventricle, as recommended by the American Society of Echocardiography.
+RESULTS: Left ventricular wall thickness, systolic and diastolic diameters, left
+ventricular diameters normalised to body surface area, end-systolic and
+end-diastolic volumes, cardiac output and cardiac index values were within
+normal limits and statistically similar in the patient and control groups (p >
+0.05). Global strain and strain rate: the patient group had a statistically
+significant lower peak A longitudinal velocity of the left basal point and peak
+E longitudinal velocity of the left basal (VAbasR) point, and higher global peak
+A longitudinal/circumferential strain rate (GSRa) compared to the corresponding
+values of the control group (p < 0.05). Radial strain and strain rate:
+end-systolic rotation [ROT (ES)] was statistically significantly lower in the
+patient group (p < 0.05). Longitudinal strain and strain rate: end-systolic
+longitudinal strain [SLSC (ES)] and positive peak transverse strain (STSR peak
+P) were statistically significantly lower in the patient group (p < 0.05).
+Segmental analysis showed that rotational strain measurement of the anterior and
+lateral segments of the patient group were statistically significantly lower
+than the corresponding values of the control group (p < 0.05). Segmental
+analysis showed statistically significantly lower values of endsystolic
+longitudinal strain [STSR (ES)] of the basal lateral (p < 0.05) and end-systolic
+longitudinal strain [SLSC (ES)] of the basal septal segment (p < 0.05) in the
+patient group. End-systolic longitudinal strain [SLSC (ES)] and positive peak
+transverse strain (STSR peak P) were statistically significantly lower in the
+patient group (p < 0.05). Segmental analysis showed statistically significantly
+lower values of endsystolic longitudinal strain [SLSC (ES)] of the mid-anterior
+and basal anterior segments (p < 0.05), end-systolic longitudinal strain [STSR
+(ES)] measurements of the posterior and mid-posterior segments, end-systolic
+longitudinal displacement [DLDC (ES)] of the basal posterior, mid-posterior and
+mid-antero-septal segments in the patient group.
+CONCLUSION: Cardiac arrhythmias, cardiomyopathy and sudden cardiac death are
+rare complications but may be seen in children with Wilson's disease due to
+copper accumulation in the heart tissue. Strain and strain rate echocardiography
+is a relatively new and useful echocardiographic technique to evaluate cardiac
+function and cardiac deformation abnormalities. Our study showed that despite
+normal systolic function, patients with Wilson's disease showed diastolic
+dysfunction and regional deformation abnormalities, especially rotational strain
+and strain rate abnormalities.
+
+DOI: 10.5830/CVJA-2016-028
+PMCID: PMC5378936
+PMID: 27176875 [Indexed for MEDLINE]

--- a/references_cache/PMID_28947309.md
+++ b/references_cache/PMID_28947309.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:28947309"
+title: "Wilson's Disease and Cardiac Myopathy."
+authors:
+- Grandis DJ
+- Nah G
+- Whitman IR
+- Vittinghoff E
+- Dewland TA
+- Olgin JE
+- Marcus GM
+journal: Am J Cardiol
+year: '2017'
+doi: 10.1016/j.amjcard.2017.08.025
+keywords:
+- California/epidemiology
+- Cardiomyopathies/complications
+- "Child, Preschool"
+- Disease Progression
+- Female
+- Follow-Up Studies
+- "Heart Failure/epidemiology, etiology"
+- Hepatolenticular Degeneration/complications
+- Humans
+- Incidence
+- Infant
+- Male
+- Prognosis
+- Retrospective Studies
+- Risk Factors
+- Survival Rate/trends
+- Time Factors
+content_type: abstract_only
+---
+
+# Wilson's Disease and Cardiac Myopathy.
+**Authors:** Grandis DJ, Nah G, Whitman IR, Vittinghoff E, Dewland TA, Olgin JE, Marcus GM
+**Journal:** Am J Cardiol (2017)
+**DOI:** [10.1016/j.amjcard.2017.08.025](https://doi.org/10.1016/j.amjcard.2017.08.025)
+
+## Content
+
+1. Am J Cardiol. 2017 Dec 1;120(11):2056-2060. doi:
+10.1016/j.amjcard.2017.08.025.  Epub 2017 Aug 30.
+
+Wilson's Disease and Cardiac Myopathy.
+
+Grandis DJ(1), Nah G(1), Whitman IR(1), Vittinghoff E(2), Dewland TA(3), Olgin
+JE(1), Marcus GM(4).
+
+Author information:
+(1)Division of Cardiology, University of California, San Francisco, San
+Francisco, California.
+(2)Department of Epidemiology and Biostatistics, University of California, San
+Francisco, San Francisco, California.
+(3)Knight Cardiovascular Institute, Oregon Health & Science University,
+Portland, Oregon.
+(4)Division of Cardiology, University of California, San Francisco, San
+Francisco, California. Electronic address: marcusg@medicine.ucsf.edu.
+
+Wilson's disease is a well-characterized disorder known to cause liver and brain
+disease due to abnormal copper deposition. Data regarding copper infiltration of
+the heart is conflicting, and the risk of heart disease has not been well
+described. We aimed to determine whether Wilson's disease is associated with
+cardiac myopathy, clinically evident in the atria as atrial fibrillation (AF)
+and in the ventricles as heart failure (HF). We longitudinally assessed 14.3
+million patients in the California Healthcare Cost and Utilization Project
+database from 2005 through 2009 for diagnoses of Wilson's disease, AF, HF, and
+covariates using International Classification of Diseases-9th Edition codes.
+Cirrhosis and appendicitis diagnoses were assessed for positive and negative
+validation, respectively. We identified 463 patients with Wilson's disease. As
+expected in validation analyses, patients with Wilson's disease had a threefold
+greater risk of cirrhosis (hazard ratio [HR] 2.85, 95% confidence interval [CI]
+2.81 to 2.90, p <0.0001) and no increased risk of appendicitis (HR 0.24, 95% CI
+0.04 to 1.71, p = 0.16). Patients with Wilson's disease exhibited a 29% higher
+risk of AF after adjusting for age, gender, race, income, hypertension,
+diabetes, renal disease, hyperlipidemia, obesity, coronary disease, and
+obstructive sleep apnea (HR 1.29, 95% CI 1.15 to 1.45, p <0.0001). After
+adjusting for the same covariates, patients with Wilson's disease had a 55%
+higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p <0.0001). Patients
+with Wilson's disease have an increased risk of AF and HF, supporting the need
+for careful surveillance for heart disease. These findings also suggest that the
+role of copper metabolism in heart disease should be more broadly investigated.
+
+Copyright © 2017 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.amjcard.2017.08.025
+PMID: 28947309 [Indexed for MEDLINE]

--- a/references_cache/PMID_29914392.md
+++ b/references_cache/PMID_29914392.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:29914392"
+title: Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease.
+authors:
+- Huong NTM
+- Lien NTK
+- Ngoc ND
+- Mai NTP
+- Hoa NPA
+- Hai LT
+- Van Chi P
+- Van TT
+- Van Khanh T
+- Hoang NH
+journal: BMC Med Genet
+year: '2018'
+doi: 10.1186/s12881-018-0619-4
+keywords:
+- Child
+- Copper-Transporting ATPases/genetics
+- Exons/genetics
+- Female
+- Hepatolenticular Degeneration/genetics
+- Humans
+- Male
+- Mutation/genetics
+content_type: abstract_only
+---
+
+# Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease.
+**Authors:** Huong NTM, Lien NTK, Ngoc ND, Mai NTP, Hoa NPA, Hai LT, Van Chi P, Van TT, Van Khanh T, Hoang NH
+**Journal:** BMC Med Genet (2018)
+**DOI:** [10.1186/s12881-018-0619-4](https://doi.org/10.1186/s12881-018-0619-4)
+
+## Content
+
+1. BMC Med Genet. 2018 Jun 18;19(1):104. doi: 10.1186/s12881-018-0619-4.
+
+Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with
+Wilson disease.
+
+Huong NTM(1), Lien NTK(2), Ngoc ND(1), Mai NTP(1), Hoa NPA(3), Hai LT(4), Van
+Chi P(5), Van TT(6), Van Khanh T(6), Hoang NH(7).
+
+Author information:
+(1)Human Genetics Department, Vietnam National Children's Hospital, Ministry of
+Health, 18/879 La Thanh str., Dongda, Hanoi, Vietnam.
+(2)Institute of Genome Research, Vietnam Academy of Science and Technology, 18 -
+Hoang Quoc Viet str., Caugiay, Hanoi, Vietnam.
+(3)Hepatology Department, Vietnam National Children's Hospital, Ministry of
+Health, 18/879 La Thanh str., Dongda, Hanoi, Vietnam.
+(4)Vietnam National Children's Hospital, Ministry of Health, 18/879 La Thanh
+str., Dongda, Hanoi, Vietnam.
+(5)Institute of Biotechnology, Vietnam Academy of Science and Technology, 18 -
+Hoang Quoc Viet str., Caugiay, Hanoi, Vietnam.
+(6)Hanoi Medical University, Ministry of Education and Training, 1 - Ton That
+Tung str., Dongda, Hanoi, Vietnam.
+(7)Institute of Genome Research, Vietnam Academy of Science and Technology, 18 -
+Hoang Quoc Viet str., Caugiay, Hanoi, Vietnam. nhhoang@igr.ac.vn.
+
+BACKGROUND: Wilson disease (OMIM # 277900) is a autosomal recessive disorder
+characterized by accumulation of copper in liver and brain. The accumulation of
+copper resulting in oxidative stress and eventually cell death. The disease has
+an onset in a childhood and result in a significant neurological impairment or
+require lifelong treatment. Another serious consequence of the disease is the
+development of liver damage and acute liver failure leading to liver transplant.
+The disorder is caused by mutations in the ATP7B gene, encoding a P-type copper
+transporting ATPase.
+CASE PRESENTATION: We performed genetic analysis of three unrelated patients
+from three different Vietnamese families. These patients had clinical features
+such as numbness of hands and feet, vomiting, insomnia, palsy, liver failure and
+Kayser-Fleischer (K-F) rings and were diagnosed with Wilson disease in the Human
+Genetics Department, Vietnam National Children's Hospital. The entire coding
+region and adjacent splice sites of ATP7B gene were amplified and sequenced by
+Sanger method. Sequencing data were analyzed and compared with the ATP7B gene
+sequence published in Ensembl (ENSG00000123191) by using BioEdit software to
+detect mutations.
+CONCLUSIONS: In this study, five mutations in the ATP7B gene were found. Among
+of these, three mutations were novel: c.750_751insG (p.His251Alafs*19) in exon
+2, c.2604delC (p.Pro868Profs*5) in exon 11, and c.3077 T > A (p.Phe1026Tyr) in
+exon 14. Our results of the mutations associated with Wilson disease might
+facilitate the development of effective treatment plans.
+
+DOI: 10.1186/s12881-018-0619-4
+PMCID: PMC6006946
+PMID: 29914392 [Indexed for MEDLINE]
+
+Conflict of interest statement: ETHICS APPROVAL AND CONSENT TO PARTICIPATE: The
+study was approved by the Scientific Committee of Institute of Genome Research
+under reference number 12/QD-NCHG. CONSENT FOR PUBLICATION: Written informed
+consent for the publication of the patient’s medical data was obtained from the
+parents before collecting samples. A copy of the written consent is available
+for review by the editor of this journal. COMPETING INTERESTS: The authors
+declare that they have no competing interests. PUBLISHER’S NOTE: Springer Nature
+remains neutral with regard to jurisdictional claims in published maps and
+institutional affiliations.

--- a/references_cache/PMID_31317233.md
+++ b/references_cache/PMID_31317233.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:31317233"
+title: "Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A Cross-Sectional Study from India."
+authors:
+- Kapoor N
+- Cherian KE
+- Sajith KG
+- Thomas M
+- Eapen CE
+- Thomas N
+- Paul TV
+journal: Calcif Tissue Int
+year: '2019'
+doi: 10.1007/s00223-019-00588-z
+keywords:
+- "Acidosis, Renal Tubular/epidemiology, etiology"
+- Adolescent
+- Adult
+- Body Composition/physiology
+- Bone Density/physiology
+- "Bone Diseases, Metabolic/epidemiology, etiology"
+- Bone and Bones/physiopathology
+- Case-Control Studies
+- Child
+- Cross-Sectional Studies
+- Female
+- "Hepatolenticular Degeneration/epidemiology, metabolism, physiopathology"
+- Humans
+- India/epidemiology
+- Kidney Function Tests
+- Kidney Tubules/physiology
+- Male
+- Prevalence
+- Young Adult
+content_type: abstract_only
+---
+
+# Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A Cross-Sectional Study from India.
+**Authors:** Kapoor N, Cherian KE, Sajith KG, Thomas M, Eapen CE, Thomas N, Paul TV
+**Journal:** Calcif Tissue Int (2019)
+**DOI:** [10.1007/s00223-019-00588-z](https://doi.org/10.1007/s00223-019-00588-z)
+
+## Content
+
+1. Calcif Tissue Int. 2019 Nov;105(5):459-465. doi: 10.1007/s00223-019-00588-z.
+Epub 2019 Jul 17.
+
+Renal Tubular Function, Bone Health and Body Composition in Wilson's Disease: A
+Cross-Sectional Study from India.
+
+Kapoor N(1), Cherian KE(1), Sajith KG(2), Thomas M(3), Eapen CE(2), Thomas N(1),
+Paul TV(4).
+
+Author information:
+(1)Department of Endocrinology, Diabetes and Metabolism, Christian Medical
+College, Vellore, Tamil Nadu, 632004, India.
+(2)Department of Hepatology, Christian Medical College, Vellore, India.
+(3)Department of Neurology, Christian Medical College, Vellore, India.
+(4)Department of Endocrinology, Diabetes and Metabolism, Christian Medical
+College, Vellore, Tamil Nadu, 632004, India. thomasvpaul@yahoo.com.
+
+There is limited literature from India with regard to the prevalence and
+magnitude of renal tubular and bone manifestations in Wilson's disease (WD).
+Thus, we studied the prevalence of renal tubular acidosis among Indian patients
+with WD and also evaluated bone health and body composition in them. It was a
+cross-sectional study conducted at a south Indian tertiary care center.
+Twenty-five consecutive patients with WD aged more than 12 years attending the
+hepatology and neurology departments and 50 age, sex and BMI-matched controls
+were recruited. After clinical assessment, they underwent biochemical testing to
+assess renal tubular dysfunction. Bone mineral density (BMD) and body
+composition were assessed using a dual energy X-ray absorptiometry (DXA)
+scanner. Fifty-six percent (14/25) of patients with WD had renal tubular
+acidosis (RTA). Of them, 24% were diagnosed to have distal RTA. RTA was more
+common in hepatic WD patients who had prolonged duration of illness. Patients
+with WD had significantly lower BMD as compared to control subjects (p < 0.05).
+Low BMI, low IGF-1 and a shorter duration of therapy were key determinants of
+low bone mass in them (p < 0.05). Patients with WD had significantly more body
+fat (p = 0.01) and lower lean muscle mass (p = 0.03) when compared to age, sex
+and BMI-matched controls. In conclusion, renal tubular acidosis was common in
+patients with Wilson's disease. These patients had a lower bone mineral density,
+higher body fat percentage and lower lean muscle mass as compared to controls.
+
+DOI: 10.1007/s00223-019-00588-z
+PMID: 31317233 [Indexed for MEDLINE]

--- a/references_cache/PMID_32520831.md
+++ b/references_cache/PMID_32520831.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:32520831"
+title: "Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis."
+authors:
+- Vandriel SM
+- Ayoub MD
+- Ricciuto A
+- Hansen BE
+- Ling SC
+- Ng VL
+- Roberts EA
+- Kamath BM
+journal: J Pediatr Gastroenterol Nutr
+year: '2020'
+doi: 10.1097/MPG.0000000000002777
+keywords:
+- Adolescent
+- Adult
+- Child
+- Female
+- Hepatic Encephalopathy
+- "Hepatolenticular Degeneration/complications, diagnosis"
+- Humans
+- "Liver Failure, Acute/diagnosis, etiology"
+- Liver Transplantation
+- Prospective Studies
+content_type: abstract_only
+---
+
+# Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual Patient Data Meta-analysis.
+**Authors:** Vandriel SM, Ayoub MD, Ricciuto A, Hansen BE, Ling SC, Ng VL, Roberts EA, Kamath BM
+**Journal:** J Pediatr Gastroenterol Nutr (2020)
+**DOI:** [10.1097/MPG.0000000000002777](https://doi.org/10.1097/MPG.0000000000002777)
+
+## Content
+
+1. J Pediatr Gastroenterol Nutr. 2020 Sep;71(3):e90-e96. doi:
+10.1097/MPG.0000000000002777.
+
+Pediatric Wilson Disease Presenting as Acute Liver Failure: An Individual
+Patient Data Meta-analysis.
+
+Vandriel SM(1), Ayoub MD(1)(2), Ricciuto A(1), Hansen BE(3), Ling SC(1)(2), Ng
+VL(1), Roberts EA(1), Kamath BM(1).
+
+Author information:
+(1)Division of Gastroenterology, Hepatology, and Nutrition, Hospital for Sick
+Children, University of Toronto, Toronto, Canada.
+(2)Department of Pediatrics, Faculty of Medicine, Rabigh, King Abdulaziz
+University, Jeddah, Saudi Arabia.
+(3)Institute of Health Policy, Management and Evaluation, University of Toronto,
+Toronto, Ontario, Canada.
+
+OBJECTIVES: Wilson disease (WD) presenting as acute liver failure (ALF) is rare
+and typically fatal without liver transplantation (LT). Its rarity has hindered
+comprehensive studies. We undertook an individual patient data meta-analysis to
+characterize a cohort of pediatric patients presenting with ALF whose final
+diagnosis was WD to examine outcomes and identify predictors of poor outcomes.
+METHODS: Database searches were conducted in PubMed, ScienceDirect, and Google
+Scholar, restricted to English-language articles published between January 1984
+and May 2018. Articles were excluded if pediatric (<18 years old) data were not
+extractable or if LT was not readily available at reporting institutions.
+Extracted data included clinical and biochemical characteristics, genotype,
+treatment, and outcome.
+RESULTS: Data were available on 249 subjects from 52 articles, plus 7 additional
+subjects identified from our institution's WD database (N = 256). Females
+represented 69% (n = 170/245). Median age at presentation was 13.4 years
+(n = 204, range 4.0-17.9). Of the total 256 subjects, 87% underwent LT, 11%
+achieved spontaneous recovery and 2% died before LT. International normalized
+ratio >2.0 at presentation was a predictor of LT/death (odds ratio 7.6, 95%
+confidence interval 1.5-28), with a trend observed for hepatic encephalopathy
+(HE) (odds ratio 4.18, 95% confidence interval 0.99-18). Arithmetic diagnostic
+scores proved inferior in the pediatric age-bracket compared to adults.
+CONCLUSIONS: This large international pediatric cohort has permitted an
+individual patient data analysis of WD presenting as ALF. Notably, 11% of
+subjects achieved spontaneous survival; the rest required LT. Coagulopathy
+(international normalized ratio >2:0) and HE at presentation heralded poor
+outcomes. Further prospective studies may identify additional early predictors
+of outcomes.
+
+DOI: 10.1097/MPG.0000000000002777
+PMID: 32520831 [Indexed for MEDLINE]

--- a/references_cache/PMID_3595645.md
+++ b/references_cache/PMID_3595645.md
@@ -1,0 +1,51 @@
+---
+reference_id: "PMID:3595645"
+title: Presenting symptoms and natural history of Wilson disease.
+authors:
+- Saito T
+journal: Eur J Pediatr
+year: '1987'
+doi: 10.1007/BF00716470
+keywords:
+- Adolescent
+- Adult
+- Age Factors
+- Child
+- Female
+- "Hepatolenticular Degeneration/diagnosis, epidemiology"
+- Humans
+- Japan
+- Male
+- Neurologic Manifestations
+- Prognosis
+content_type: abstract_only
+---
+
+# Presenting symptoms and natural history of Wilson disease.
+**Authors:** Saito T
+**Journal:** Eur J Pediatr (1987)
+**DOI:** [10.1007/BF00716470](https://doi.org/10.1007/BF00716470)
+
+## Content
+
+1. Eur J Pediatr. 1987 May;146(3):261-5. doi: 10.1007/BF00716470.
+
+Presenting symptoms and natural history of Wilson disease.
+
+Saito T.
+
+The presenting symptoms of Wilson disease and its natural history as related to
+age are described based on 283 cases collected in Japan. The disease presented
+with a variety of signs and symptoms; the most frequent were in order of
+frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance,
+malaise and arthralgia. The mean age at onset of the disease was 12.0 years.
+Hepatic and osteoarthral symptoms developed early and neurological symptoms
+late. Fifty-eight cases developed neurological symptoms only, 28 cases had
+hepatic symptoms only, and in 26 cases hepatic symptoms were followed by
+neurological symptoms. A higher mortality rate was observed in hepatic,
+hepato-haematological and hepato-renal cases mainly due to acute hepatic failure
+resulting in death only a few weeks after onset. Cases having only neurological
+symptoms showed a more favourable prognosis with a longer survival.
+
+DOI: 10.1007/BF00716470
+PMID: 3595645 [Indexed for MEDLINE]

--- a/references_cache/PMID_36010023.md
+++ b/references_cache/PMID_36010023.md
@@ -1,0 +1,49 @@
+---
+reference_id: "PMID:36010023"
+title: "Low Copper Diet-A Therapeutic Option for Wilson Disease?"
+authors:
+- Teufel-Schäfer U
+- Forster C
+- Schaefer N
+journal: Children (Basel)
+year: '2022'
+doi: 10.3390/children9081132
+content_type: abstract_only
+---
+
+# Low Copper Diet-A Therapeutic Option for Wilson Disease?
+**Authors:** Teufel-Schäfer U, Forster C, Schaefer N
+**Journal:** Children (Basel) (2022)
+**DOI:** [10.3390/children9081132](https://doi.org/10.3390/children9081132)
+
+## Content
+
+1. Children (Basel). 2022 Jul 28;9(8):1132. doi: 10.3390/children9081132.
+
+Low Copper Diet-A Therapeutic Option for Wilson Disease?
+
+Teufel-Schäfer U(1), Forster C(1), Schaefer N(1).
+
+Author information:
+(1)Department of General Pediatrics, Adolescent Medicine and Neonatology,
+Medical Center-University of Freiburg, Faculty of Medicine, University of
+Freiburg, Mathildenstr. 1, 79106 Freiburg, Germany.
+
+Wilson's disease (WD) is an autosomal recessive inherited disease in which a
+pathological storage of copper in various organs is the mean pathophysiological
+mechanism. The therapy consists of drug therapy with chelating agents or zinc.
+For patients, nutrition is always an important issue. The aim of this review was
+to determine whether there are clear recommendations for a low copper diet for
+WD patients, or whether the essential trace element zinc plays a role? We were
+able to show that some of the foods with high copper content would have to be
+consumed in such large quantities that this is regularly not the case.
+Furthermore, there are also different absorption rates depending on the copper
+content. A lower copper intake only prevents the re-accumulation of copper. In
+summary, consistent adherence to drug therapy is more important than a strict
+diet. Only two foods should be consistently avoided: Liver and Shellfish.
+
+DOI: 10.3390/children9081132
+PMCID: PMC9406399
+PMID: 36010023
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_38081365.md
+++ b/references_cache/PMID_38081365.md
@@ -1,0 +1,95 @@
+---
+reference_id: "PMID:38081365"
+title: Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease.
+authors:
+- Kirk FT
+- Munk DE
+- Swenson ES
+- Quicquaro AM
+- Vendelbo MH
+- Larsen A
+- Schilsky ML
+- Ott P
+- Sandahl TD
+journal: J Hepatol
+year: '2024'
+doi: 10.1016/j.jhep.2023.11.023
+keywords:
+- Animals
+- Humans
+- "Hepatolenticular Degeneration/drug therapy, metabolism"
+- Copper/metabolism
+- Positron Emission Tomography Computed Tomography
+- Healthy Volunteers
+- Chelating Agents/pharmacology
+- Choline
+- Molybdenum
+content_type: abstract_only
+---
+
+# Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease.
+**Authors:** Kirk FT, Munk DE, Swenson ES, Quicquaro AM, Vendelbo MH, Larsen A, Schilsky ML, Ott P, Sandahl TD
+**Journal:** J Hepatol (2024)
+**DOI:** [10.1016/j.jhep.2023.11.023](https://doi.org/10.1016/j.jhep.2023.11.023)
+
+## Content
+
+1. J Hepatol. 2024 Apr;80(4):586-595. doi: 10.1016/j.jhep.2023.11.023. Epub 2023
+Dec 10.
+
+Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in
+patients with Wilson disease.
+
+Kirk FT(1), Munk DE(2), Swenson ES(3), Quicquaro AM(3), Vendelbo MH(4), Larsen
+A(5), Schilsky ML(6), Ott P(2), Sandahl TD(2).
+
+Author information:
+(1)Department of Hepatology and Gastroenterology, Aarhus University Hospital,
+Aarhus, Denmark. Electronic address: frkirk@rm.dk.
+(2)Department of Hepatology and Gastroenterology, Aarhus University Hospital,
+Aarhus, Denmark.
+(3)Alexion, AstraZeneca Rare Disease, Boston, MA, USA.
+(4)Department of Nuclear Medicine & PET-center, Aarhus University Hospital,
+Aarhus, Denmark; Department of Biomedicine, Aarhus University, Aarhus, Denmark.
+(5)Department of Biomedicine, Aarhus University, Aarhus, Denmark.
+(6)Department of Medicine, Section of Digestive Diseases, and Department of
+Surgery, Section of Transplant and Immunology, Yale School of Medicine, New
+Haven, CT, USA.
+
+BACKGROUND & AIMS: In Wilson disease (WD), copper accumulates in the liver and
+brain causing disease. Bis-choline tetrathiomolybdate (TTM) is a potent copper
+chelator that may be associated with a lower risk of inducing paradoxical
+neurological worsening than conventional therapy for neurologic WD. To better
+understand the mode of action of TTM, we investigated its effects on copper
+absorption and biliary excretion.
+METHODS: In a double-blind randomized setting, hepatic 64Cu activity was
+examined after orally administered 64Cu by PET/CT in 16 healthy volunteers
+before and after seven days of TTM treatment (15 mg/d) or placebo. Oral 64Cu was
+administered one hour after the final TTM dose. Changes in hepatic 64Cu activity
+reflected changes in intestinal 64Cu uptake. Additionally, in four patients with
+WD, the distribution of 64Cu in venous blood, liver, gallbladder, kidney, and
+brain was followed after i.v. 64Cu dosing for up to 68 hours before and after
+seven days of TTM (15 mg/day), using PET/MRI. Increased gallbladder 64Cu
+activity was taken as evidence of increased biliary 64Cu excretion.
+RESULTS: In healthy volunteers, TTM reduced intestinal 64Cu uptake by 82% 15
+hours after the oral 64Cu dose. In patients with WD, gallbladder 64Cu activity
+was negligible before and after TTM, while TTM effectively retained 64Cu in the
+blood, significantly reduced hepatic 64Cu activity at all time-points and
+significantly reduced cerebral 64Cu activity two hours after the intravenous
+64Cu dose.
+CONCLUSIONS: While we did not show an increase in biliary excretion of 64Cu
+following TTM administration, we demonstrated that TTM effectively inhibited
+most intestinal 64Cu uptake and retained 64Cu in the blood stream, limiting the
+exposure of organs like the liver and brain to 64Cu.
+IMPACT AND IMPLICATIONS: Bis-choline tetrathiomolybdate (TTM) is an
+investigational copper chelator being developed for the treatment of Wilson
+disease. In animal models of Wilson disease, TTM has been shown to facilitate
+biliary copper excretion. In the present human study, TTM surprisingly did not
+facilitate biliary copper excretion but instead reduced intestinal copper uptake
+to a clinically significant degree. Our study builds on our understanding of
+human copper metabolism and the mechanism of action of TTM.
+
+Copyright © 2023 The Author(s). Published by Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.jhep.2023.11.023
+PMID: 38081365 [Indexed for MEDLINE]

--- a/references_cache/PMID_39139457.md
+++ b/references_cache/PMID_39139457.md
@@ -1,0 +1,128 @@
+---
+reference_id: "PMID:39139457"
+title: "Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets."
+authors:
+- Ott P
+- Sandahl T
+- Ala A
+- Cassiman D
+- Couchonnal-Bedoya E
+- Cury RG
+- Czlonkowska A
+- Denk G
+- "D'Inca R"
+- de Assis Aquino Gondim F
+- Moore J
+- Poujois A
+- Twardowschy CA
+- Weiss KH
+- Zuin M
+- Kamlin COF
+- Schilsky ML
+journal: JHEP Rep
+year: '2024'
+doi: 10.1016/j.jhepr.2024.101115
+content_type: abstract_only
+---
+
+# Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets.
+**Authors:** Ott P, Sandahl T, Ala A, Cassiman D, Couchonnal-Bedoya E, Cury RG, Czlonkowska A, Denk G, D'Inca R, de Assis Aquino Gondim F, Moore J, Poujois A, Twardowschy CA, Weiss KH, Zuin M, Kamlin COF, Schilsky ML
+**Journal:** JHEP Rep (2024)
+**DOI:** [10.1016/j.jhepr.2024.101115](https://doi.org/10.1016/j.jhepr.2024.101115)
+
+## Content
+
+1. JHEP Rep. 2024 May 6;6(8):101115. doi: 10.1016/j.jhepr.2024.101115.
+eCollection  2024 Aug.
+
+Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease:
+Alignment with recommended targets.
+
+Ott P(1), Sandahl T(1), Ala A(2), Cassiman D(3), Couchonnal-Bedoya E(4), Cury
+RG(5), Czlonkowska A(6), Denk G(7), D'Inca R(8), de Assis Aquino Gondim F(9),
+Moore J(10), Poujois A(11), Twardowschy CA(12), Weiss KH(13), Zuin M(14), Kamlin
+COF(15), Schilsky ML(16).
+
+Author information:
+(1)Dept. of Hepatology and Gastroenterology, Aarhus University Hospital,8200
+Aarhus C, Denmark.
+(2)Institute of Liver Studies King's College Hospital NHS Foundation Trust,
+London, UK.
+(3)University Hospitals, Leuven - Department of Gastroenterology-Hepatology and
+Dept. of Chronic Diseases and Metabolism, Herestraat 49, 3000 Leuven, Belgium.
+(4)Hospices Civils de Lyon- Hôpital Femme Mère Enfant - Hépatologie,
+Gastroentérologie et Nutrition pédiatrique, Centre de Référence de la maladie de
+Wilson, 59 boulevard Pinel, 69677 BRON, France.
+(5)Hospital das Clínicas da Faculdade de Medicina da Universidade de São Paulo,
+R. Dr. Eneas de Carvalho Aguiar, 255- Cerqueira César, Sao Paulo, Brazil.
+(6)2 Depatment of Neurology, Institute of Psychiatry and Neurology, 02 957
+Warsaw, Poland.
+(7)Medizinische Klinik und Poliklinik II/Transplantation Center, LMU Klinikum,
+LMU Munich, Germany.
+(8)Department of Surgical, Oncological and Gastroenterological Sciences,
+University of Padova, Padova, Italy.
+(9)Nucleo de Pesquisa e Desenvolvimento de Medicamentos - Universidade Federal
+do Ceará - Rodolfo Teófilo R. Coronel Nunes de Melo 1000, Fortaleza CE60430-275,
+Brazil.
+(10)Leeds Teaching Hospitals NHS Trust Merville Building, LS9 7TF Leeds, UK.
+(11)Département de Neurologie, Centre de Reference de la Maladie de Wilson,
+Hopital Fondation Adolphe de Rothschild, Paris, France.
+(12)Hospital Nossa Senhora das Graças (HNSG), R. Alcides Munhoz, 433,
+Curitiba-PR 80810, Brazil.
+(13)Salem Medical Center, Dept. Of Internal Medicine, Zeppelinstr. 11-33,
+Heidelberg 69121, Germany.
+(14)U.O. Medicina Generale Epatologia e Gastroenterologia Medica ASST Santi
+Paolo e Carlo. Via A. Di Rudinì, 8, Milano, Italy.
+(15)Orphalan, 226 Boulevard Voltaire, Paris 75011, France.
+(16)Departments of Medicine and Surgery, Sections of Digestive Diseases and
+Transplant and Immunology, Yale School of Medicine, 333 Cedar St, LMP 1080, New
+Haven - Connecticut 06510, USA.
+
+BACKGROUND & AIMS: Wilson disease (WD) is caused by accumulation of copper
+primarily in the liver and brain. During maintenance therapy of WD with
+D-penicillamine, current guidelines recommend on-treatment ranges of urinary
+copper excretion (UCE) of 200-500 μg/24 h and serum non-ceruloplasmin-bound
+copper (NCC) of 50-150 μg/L. We compared NCC (measured by two novel assays) and
+UCE from patients with clinically stable WD on D-penicillamine therapy with
+these recommendations.
+METHODS: This is a secondary analysis of data from the Chelate trial
+(NCT03539952) that enrolled physician-selected patients with clinically stable
+WD on D-penicillamine maintenance therapy (at an unaltered dose for at least 4
+months). We analyzed laboratory samples from the first screening visit, prior to
+interventions. NCC was measured by either protein speciation (NCC-Sp) using
+anion exchange high-performance liquid chromatography protein speciation
+followed by copper determination with inductively coupled plasma mass
+spectroscopy or as exchangeable copper (NCC-Ex). NCC-Sp was also analyzed in
+healthy controls (n = 75).
+RESULTS: In 76 patients with WD with 21.3±14.3 average treatment-years, NCC-Sp
+(mean±SD: 56.6±26.2 μg/L) and NCC-Ex (mean±SD: 57.9±24.7 μg/L) were within the
+50-150 μg/L target in 61% and 54% of patients, respectively. In addition, 36%
+and 31%, respectively, were even below the normal ranges (NCC-Sp: 46-213 μg/L,
+NCC-Ex: 41-71 μg/L). NCC-Ex positively correlated with NCC-Sp (r2 = 0.66, p
+<0.001) but with systematic deviation. UCE was outside the 200-500 μg/24 h
+target range in 58%. Only 14/69 (20%) fulfilled both the NCC-Sp and UCE targets.
+Clinical or biochemical signs of copper deficiency were not detected.
+CONCLUSION: Clinically stable patients with WD on maintenance D-penicillamine
+therapy frequently have lower NCC-Sp or higher UCE than current recommendations
+without signs of overtreatment. Further studies are warranted to identify
+appropriate target ranges of NCC-Sp, NCC-Ex and UCE in treated WD.
+IMPACT AND IMPLICATIONS: Chelator treatment of patients with Wilson disease (WD)
+is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and
+24 h urinary copper excretion (UCE) but validation is limited. In 76 adults with
+≈21 years history of treated WD and clinically stable disease on D-penicillamine
+therapy, NCC was commonly found to be below normal values and recommended target
+ranges whether measured by protein speciation (NCC-Sp) or as exchangeable copper
+(NCC-Ex), while UCE values were above the recommended target range in 49%.
+Common wisdom would suggest overtreatment in these cases, but no clinical or
+biochemical signs of copper deficiency were observed. Exploratory analysis of
+liver enzymes suggested that NCC below levels seen in controls may be
+beneficial, while the relation to UCE was less clear. The data calls for
+critical re-evaluation of target ranges for treatment of WD, specific for drug
+and laboratory methodology.
+CLINICAL TRIAL NUMBER: (NCT03539952).
+
+© 2024 The Authors.
+
+DOI: 10.1016/j.jhepr.2024.101115
+PMCID: PMC11321293
+PMID: 39139457

--- a/references_cache/PMID_39733327.md
+++ b/references_cache/PMID_39733327.md
@@ -1,0 +1,101 @@
+---
+reference_id: "PMID:39733327"
+title: Iron and Copper Liver Concentrations in Wilson Disease.
+authors:
+- Day PL
+- Fyffe-Freil R
+- Vanderboom P
+- Spears G
+- Wangensteen K
+- Bornhorst J
+- Hassan S
+- Jannetto PJ
+journal: J Gastrointestin Liver Dis
+year: '2024'
+doi: 10.15403/jgld-5662
+keywords:
+- "Liver/metabolism, surgery"
+- Copper/analysis
+- Iron/analysis
+- "Iron Overload/diagnosis, etiology"
+- "Hepatolenticular Degeneration/complications, metabolism"
+- Liver Transplantation
+- Biopsy
+- Humans
+- Male
+- Female
+- Infant
+- "Child, Preschool"
+- Child
+- Adolescent
+- Young Adult
+- Adult
+- Middle Aged
+- Aged
+- Hematocrit
+- Hemoglobins/analysis
+content_type: abstract_only
+---
+
+# Iron and Copper Liver Concentrations in Wilson Disease.
+**Authors:** Day PL, Fyffe-Freil R, Vanderboom P, Spears G, Wangensteen K, Bornhorst J, Hassan S, Jannetto PJ
+**Journal:** J Gastrointestin Liver Dis (2024)
+**DOI:** [10.15403/jgld-5662](https://doi.org/10.15403/jgld-5662)
+
+## Content
+
+1. J Gastrointestin Liver Dis. 2024 Dec 28;33(4):517-523. doi:
+10.15403/jgld-5662.
+
+Iron and Copper Liver Concentrations in Wilson Disease.
+
+Day PL(1), Fyffe-Freil R(2), Vanderboom P(3), Spears G(4), Wangensteen K(5),
+Bornhorst J(6), Hassan S(7), Jannetto PJ(8).
+
+Author information:
+(1)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN,
+USA. day.patrick@mayo.edu.
+(2)Department of Pathology, Microbiology and Immunology, University of Nebraska
+Medical Center, Omaha NE, USA. rfyffefreil@unmc.edu.
+(3)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN,
+USA. vanderboom.patrick@mayo.edu.
+(4)Department of Quantitative Health Sciences, Mayo Clinic, Rochester, MN, USA.
+Spears.Grant@mayo.edu.
+(5)Division of Gastroenterology and Hepatology, Department of Medicine, Mayo
+Clinic, Rochester, MN, USA. Wangensteen.Kirk@mayo.edu.
+(6)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN,
+USA. Bornhorst.Joshua@mayo.edu.
+(7)Division of Pediatric Gastroenterology, Hepatology and Nutrition, Mayo
+Clinic, Rochester, MN, USA. Hassan.Sara@mayo.edu.
+(8)Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, MN,
+USA. jannetto.paul@mayo.edu.
+
+BACKGROUND AND AIMS: Wilson disease (WD) results in the defective incorporation
+of copper into ceruloplasmin as well as decreased biliary copper excretion.
+Secondary iron overload has also been associated with WD; however, the
+prevalence is currently unknown. This study aims to determine the prevalence of
+potential secondary iron overload in patients suspected to have WD. The
+secondary aim was to determine whether common laboratory tests were associated
+with liver copper concentrations or the need for liver transplantation in a
+subset of patients with confirmed WD.
+METHODS: Using our institution's laboratory information system, 197 patients
+with liver copper concentrations > 250 mcg/g were identified who also had a
+concurrent liver iron concentration available. Correlations between copper,
+iron, and hepatic iron index were performed by log-transforming the data and
+then using the Pearson method. Furthermore, in a subpopulation of ten patients
+clinically confirmed to have WD, various laboratory test values were evaluated
+to determine associations with liver copper concentration or liver
+transplantation.
+RESULTS: There was no significant association between copper and iron liver
+tissue concentrations (p=0.84). However, 13 (8%) patients aged 13 or older had a
+hepatic iron index >1.0 which may indicate secondary iron overload. Furthermore,
+in clinically confirmed WD patients, hemoglobin and hematocrit were inversely
+associated with liver copper concentrations (p=0.036).
+CONCLUSIONS: Iron overload can be detected in liver tissues with elevated copper
+concentrations characteristic of WD Furthermore, in WD, low hemoglobin and
+hematocrit values were associated with elevated liver copper concentration.
+Clinicians should consider the possibility of secondary iron overload and/or
+anemia in patients with WD.
+
+DOI: 10.15403/jgld-5662
+PMID: 39733327 [Indexed for MEDLINE]

--- a/references_cache/PMID_7234865.md
+++ b/references_cache/PMID_7234865.md
@@ -1,0 +1,54 @@
+---
+reference_id: "PMID:7234865"
+title: "Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms."
+authors:
+- Forman SJ
+- Kumar KS
+- Redeker AG
+- Hochstein P
+journal: Am J Hematol
+year: '1980'
+doi: 10.1002/ajh.2830090305
+keywords:
+- Adult
+- "Anemia, Hemolytic/blood, complications, physiopathology"
+- Copper/pharmacology
+- "Erythrocytes/enzymology, metabolism"
+- "Hepatolenticular Degeneration/blood, complications, physiopathology"
+- Humans
+- Male
+content_type: abstract_only
+---
+
+# Hemolytic anemia in Wilson disease: clinical findings and biochemical mechanisms.
+**Authors:** Forman SJ, Kumar KS, Redeker AG, Hochstein P
+**Journal:** Am J Hematol (1980)
+**DOI:** [10.1002/ajh.2830090305](https://doi.org/10.1002/ajh.2830090305)
+
+## Content
+
+1. Am J Hematol. 1980;9(3):269-75. doi: 10.1002/ajh.2830090305.
+
+Hemolytic anemia in Wilson disease: clinical findings and biochemical
+mechanisms.
+
+Forman SJ, Kumar KS, Redeker AG, Hochstein P.
+
+Two patients with Wilson disease who presented with severe hemolytic anemia are
+described. One was noted to have unusually high serum copper levels (369
+micrograms/100 ml). A review of similar such patients in the literature suggests
+that, rather than having a low serum copper, patients with hemolysis
+accompanying Wilson disease have very high serum copper levels. For this reason,
+in vitro studies of the toxic effects of copper on erythrocytes were undertaken.
+It was found that, although copper does not have a major direct inhibitory
+effect on glycolytic enzymes such as hexokinase, the metal does inhibit
+hexokinase as a consequence of its interaction with oxyhemoglobin. However, such
+inhibition does not appear to be a major factor in copper-induced hemolysis. On
+the other hand, the addition of the lipid antioxidant butylated hydroxyanisole
+(BHA) suppresses hemolysis in copper-treated cells. These experiments suggest
+that the primary toxic effect of copper is mediated through its oxidant actions
+on membrane phospholipids rather than through its potential inhibitory effects
+on intracellular enzymes.
+
+DOI: 10.1002/ajh.2830090305
+PMID: 7234865 [Indexed for MEDLINE]

--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -3576,9 +3576,9 @@
                     </div>
                 </div>
                 {% endif %}
-                {% if patho._computational_model_links %}
-                <div class="crosslink-block">
-                    <div class="crosslink-title">Computational models</div>
+	                {% if patho._computational_model_links %}
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Computational models</div>
                     <div class="crosslink-list">
                         {% for link in patho._computational_model_links %}
                         <div class="crosslink-item">
@@ -3594,12 +3594,27 @@
                             {% endif %}
                         </div>
                         {% endfor %}
-                    </div>
-                </div>
-                {% endif %}
-                {{ render_evidence(patho.evidence) }}
-            </div>
-            {% endfor %}
+	                    </div>
+	                </div>
+	                {% endif %}
+	                {% if patho.downstream %}
+	                <div class="crosslink-block">
+	                    <div class="crosslink-title">Downstream</div>
+	                    <div class="crosslink-list">
+	                        {% for edge in patho.downstream %}
+	                        <div class="crosslink-item">
+	                            <span class="crosslink-meta">{{ edge.target }}</span>
+	                            {% if edge.description %}
+	                            <span class="crosslink-desc">{{ edge.description }}</span>
+	                            {% endif %}
+	                        </div>
+	                        {% endfor %}
+	                    </div>
+	                </div>
+	                {% endif %}
+	                {{ render_evidence(patho.evidence) }}
+	            </div>
+	            {% endfor %}
         </div>
         {% endif %}
 


### PR DESCRIPTION
## What changed
This PR performs a substantive evidence review of the Wilson disease entry and regenerates the rendered page.

Key changes:
- tightened the emerging `cuproptosis` and `ferroptosis` sections so the language matches the current level of evidence
- replaced several review-only or indirect claims with primary/supporting studies for psychiatric, cardiac, renal, hematologic, bone, biomarker, diet, tetrathiomolybdate, and acute liver failure/transplant content
- removed weakly supported phenotype claims that did not hold up well enough for this entry
- added the PubMed cache files for newly cited PMIDs and re-rendered the Wilson disease HTML page

## Why it changed
The previous entry was broadly valid but leaned too heavily on a single recent review for multiple extrahepatic phenotypes and some emerging mechanistic claims were phrased more strongly than the evidence warranted.

## Impact
The Wilson disease page is now more conservative where the literature is hypothesis-level, better grounded in primary evidence for non-hepatic manifestations, and easier to defend in downstream curation/review.

## Notes
- `PMID:40245863` was validated during review but not incorporated because it is not a Wilson disease paper. It is an American Journal of Human Genetics article on computational natural history using Noonan syndrome as the use case.

## Validation
- `just validate kb/disorders/Wilsons_Disease.yaml`
- `just validate-references kb/disorders/Wilsons_Disease.yaml`
- `uv run python -m dismech.render kb/disorders/Wilsons_Disease.yaml`
- attempted `just qc`; this surfaced an unrelated existing term-label issue in `kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml` (`hgnc:17806` expected `ZFTRAF1`, got `HIBCH`), so that repo-wide failure is not introduced by this PR