### PR TITLE
Remove max-turns argument from curation scanner

### DIFF
--- a/.github/workflows/curation-scanner.yml
+++ b/.github/workflows/curation-scanner.yml
@@ -59,7 +59,6 @@ jobs:
             --dangerously-skip-permissions
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
             --model ${{ inputs.model || 'claude-opus-4-7' }}
-            --max-turns 40
           prompt: |
             REPO: ${{ github.repository }}
             TRIGGER: ${{ github.event_name }}


### PR DESCRIPTION
Removed the max-turns argument from the curation scanner workflow.