### PR TITLE
[codex] enable auto-merge for weekly compliance PRs

### DIFF
--- a/.github/workflows/auto-merge-compliance.yml
+++ b/.github/workflows/auto-merge-compliance.yml
@@ -1,0 +1,70 @@
+---
+name: Auto Merge Compliance
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Existing weekly-compliance PR number to enable auto-merge for"
+        required: true
+        type: string
+
+concurrency:
+  group: auto-merge-compliance-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve target PR
+        id: resolve-pr
+        run: |
+          echo "pr_number=${{ github.event.pull_request.number || inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Check PR eligibility
+        id: eligibility
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          pr_json="$(gh pr view "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json author,baseRefName,headRefName,isDraft,title)"
+
+          base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
+          head_ref="$(jq -r '.headRefName' <<<"$pr_json")"
+          is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
+          title="$(jq -r '.title' <<<"$pr_json")"
+          author="$(jq -r '.author.login' <<<"$pr_json")"
+
+          if [ "$base_ref" != "main" ] || \
+            [[ "$head_ref" != weekly-compliance-* ]] || \
+            [[ "$title" != "🤖 Weekly Compliance Fixes"* ]] || \
+            [ "$author" != "app/claude" ] || \
+            [ "$is_draft" != "false" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "PR #$PR_NUMBER is not an eligible weekly-compliance PR; skipping."
+            exit 0
+          fi
+
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge for weekly compliance PRs
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.resolve-pr.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --auto


### PR DESCRIPTION
## Summary

- add `.github/workflows/auto-merge-compliance.yml`
- enable GitHub auto-merge for non-draft `weekly-compliance-*` PRs authored by `app/claude`
- add a `workflow_dispatch` input so existing open compliance PRs can be backfilled by PR number after this lands

## Why

Weekly compliance PRs can reach an approved state and still remain open because nothing turns on GitHub's native auto-merge. This workflow complements the recent review-token fix by queueing those PRs for squash merge while still leaving branch protection, required checks, and required reviews as the actual gate.

## Behavior

- listens on `pull_request_target` for `opened`, `reopened`, `synchronize`, and `ready_for_review`
- only acts when the PR targets `main`, the head branch matches `weekly-compliance-*`, the title starts with `🤖 Weekly Compliance Fixes`, the author is `app/claude`, and the PR is not a draft
- uses `gh pr merge --squash --auto` instead of approving or force-merging anything
- does not check out or execute PR branch code
- supports manual backfill with `workflow_dispatch.pr_number`

## Validation

- YAML parsed successfully with `ruby -e 'require "yaml"; YAML.load_file(...)'`
- repo hooks passed during commit, including `yamllint`, `codespell`, and EOF/whitespace checks

Related to #1579.