### PR TITLE
Fix Pathograph uncategorized node filtering

### DIFF
--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -1872,7 +1872,7 @@
         biochemical: "Biochemical",
         experimental_model: "Experimental Models / Non-animal Systems",
         computational_model: "Computational Models",
-        orphan: "Orphan"
+        orphan: "Uncategorized"
     };
     var NODE_STROKE = {
         pathophysiology: "#93c5fd",
@@ -2316,7 +2316,7 @@
 
         /* -- Legend -- */
         var typesInGraph = {};
-        data.nodes.forEach(function(n) { if (!n.is_orphan) typesInGraph[n.node_type] = n.color; });
+        data.nodes.forEach(function(n) { typesInGraph[n.node_type] = n.color; });
         var activeTypes = new Set(Object.keys(typesInGraph));
 
         Object.keys(typesInGraph).forEach(function(type) {

--- a/src/dismech/templates/module.html.j2
+++ b/src/dismech/templates/module.html.j2
@@ -495,7 +495,7 @@
         treatment: "Treatments",
         biochemical: "Biochemical",
         experimental_model: "Experimental Models / Non-animal Systems",
-        orphan: "Orphan"
+        orphan: "Uncategorized"
     };
     var NODE_STROKE = {
         pathophysiology: "#93c5fd",
@@ -778,7 +778,7 @@
 
         var typesInGraph = {};
         data.nodes.forEach(function(n) {
-            if (!n.is_orphan) typesInGraph[n.node_type] = n.color;
+            typesInGraph[n.node_type] = n.color;
         });
         var activeTypes = new Set(Object.keys(typesInGraph));
 


### PR DESCRIPTION
Summary:
- Include orphan Pathograph nodes in the legend/active type set so they do not disappear when another category is toggled off.
- Rename the orphan legend label to Uncategorized for clearer UI language.
- Apply the same fix to disorder and shared module Pathograph templates.

Validation:
- just gen-page kb/disorders/22q11.2_Deletion_Syndrome.yaml
- Confirmed generated repro page contains the Uncategorized legend/type handling, then restored generated HTML so it is not committed.

Fixes #580