### PR TITLE
Review OI type IV evidence quality

### DIFF
--- a/kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
+++ b/kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
@@ -1,6 +1,6 @@
 name: Osteogenesis Imperfecta Type IV
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-19T15:11:01Z'
+updated_date: '2026-04-24T15:48:08Z'
 category: Mendelian
 description: >
   Osteogenesis imperfecta type IV represents moderate severity OI, intermediate
@@ -101,17 +101,19 @@ pathophysiology:
       id: GO:0030282
       label: bone mineralization
   evidence:
-  - reference: PMID:7643358
-    reference_title: "Perinatal lethal osteogenesis imperfecta."
+  - reference: PMID:16786509
+    reference_title: "Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The abnormal molecules are poorly secreted, more susceptible to degradation,
-      and impair the formation of the extracellular matrix. The collagen fibres
-      are abnormally organised and mineralisation is impaired.
+      Most patients with a clinical diagnosis of OI type I-IV have a mutation in
+      the COL1A1 or COL1A2 genes which encode the two alpha chains of type I
+      collagen, the major component of the bone matrix.
     explanation: >-
-      Describes the molecular consequences of collagen structural mutations that
-      affect bone matrix formation, applicable across the OI severity spectrum.
+      This type I-IV mutation-analysis cohort directly links classical OI,
+      including type IV, to COL1A1/COL1A2 defects in type I collagen, the major
+      bone matrix component, avoiding reliance on a perinatal lethal type II
+      review for this mechanism.
   downstream:
   - target: Dysregulated Bone Remodeling
 - name: Dysregulated Bone Remodeling
@@ -172,17 +174,16 @@ genetic:
     type III, possibly explaining the milder phenotype given the
     2:1 ratio of alpha1 to alpha2 chains in type I collagen.
   evidence:
-  - reference: PMID:7643358
-    reference_title: "Perinatal lethal osteogenesis imperfecta."
+  - reference: PMID:16786509
+    reference_title: "Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The severity of the clinical phenotype appears to be related to the type of
-      mutation, its location in the alpha chain, the surrounding amino acid
-      sequences, and the level of expression of the mutant allele.
+      Analysis of COL1A1 and COL1A2 in a cohort of 83 unrelated patients with OI
+      type I-IV identified a total of 62 mutations.
     explanation: >-
-      Establishes that mutation type and location determine phenotypic severity,
-      explaining the variable expressivity in moderate OI type IV.
+      This cohort directly supports COL1A1/COL1A2 variants as the molecular basis
+      for clinically diagnosed OI type I-IV, including type IV.
 phenotypes:
 - name: Moderate Short Stature
   description: >
@@ -501,6 +502,34 @@ treatments:
       Practical treatment guidelines explicitly include physical therapy and
       rehabilitation as standard nonsurgical management in OI.
 datasets:
+- accession: PMID:16786509
+  title: Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV.
+  description: >-
+    Human clinical molecular cohort of 83 unrelated patients diagnosed with OI
+    types I-IV, identifying COL1A1 and COL1A2 variants relevant to classical
+    collagen-related OI including type IV.
+  organism:
+    preferred_term: human
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  data_type: VARIANT_DATABASE
+  sample_count: 83
+  conditions:
+  - osteogenesis imperfecta type I-IV
+  - COL1A1/COL1A2 pathogenic variants
+  publication: PMID:16786509
+  evidence:
+  - reference: PMID:16786509
+    reference_title: "Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Analysis of COL1A1 and COL1A2 in a cohort of 83 unrelated patients with OI
+      type I-IV identified a total of 62 mutations.
+    explanation: >-
+      This abstract defines a reusable human variant cohort for classical OI
+      types I-IV and documents the sample count and mutation yield.
 references:
 - reference: PMID:10923226
   title: Hearing loss in children with osteogenesis imperfecta.
@@ -513,6 +542,9 @@ references:
   findings: []
 - reference: PMID:15883638
   title: Controlled trial of pamidronate in children with types III and IV osteogenesis imperfecta confirms vertebral gains but not short-term functional improvement.
+  findings: []
+- reference: PMID:16786509
+  title: Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV.
   findings: []
 - reference: PMID:16961127
   title: "Skull base abnormalities in osteogenesis imperfecta: a cephalometric evaluation of 54 patients and 108 control volunteers."
@@ -544,9 +576,6 @@ references:
 - reference: DOI:10.1007/s00223-024-01248-7
   title: A Dyadic Nosology for Osteogenesis Imperfecta and Bone Fragility Syndromes 2024
   findings: []
-- reference: DOI:10.1007/s00223-024-01293-2
-  title: 'Dental Abnormalities in Osteogenesis Imperfecta: A Systematic Review'
-  findings: []
 - reference: DOI:10.1007/s00439-021-02302-2
   title: Collagen transport and related pathways in Osteogenesis Imperfecta
   findings: []
@@ -558,9 +587,6 @@ references:
   findings: []
 - reference: DOI:10.1515/jpem-2024-0512
   title: 'Osteogenesis imperfecta: shifting paradigms in pathophysiology and care in children'
-  findings: []
-- reference: DOI:10.3390/jcm13041065
-  title: New Perspectives of Therapies in Osteogenesis Imperfecta—A Literature Review
   findings: []
 - reference: DOI:10.3892/wasj.2024.284
   title: 'Beyond brittle bones: Genetic mechanisms underlying osteogenesis imperfecta (Review)'

--- a/references_cache/PMID_16786509.md
+++ b/references_cache/PMID_16786509.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:16786509"
+title: Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV.
+authors:
+- Pollitt R
+- McMahon R
+- Nunn J
+- Bamford R
+- Afifi A
+- Bishop N
+- Dalton A
+journal: Hum Mutat
+year: '2006'
+doi: 10.1002/humu.9430
+keywords:
+- Base Sequence
+- Cohort Studies
+- "Collagen/chemistry, genetics"
+- "Collagen Type I/chemistry, genetics"
+- "Collagen Type I, alpha 1 Chain"
+- DNA Mutational Analysis
+- Exons
+- Female
+- Humans
+- Male
+- Mutation
+- "Osteogenesis Imperfecta/diagnosis, epidemiology, genetics"
+- Point Mutation
+- "Protein Structure, Tertiary"
+- Sequence Deletion
+content_type: abstract_only
+---
+
+# Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis imperfecta type I-IV.
+**Authors:** Pollitt R, McMahon R, Nunn J, Bamford R, Afifi A, Bishop N, Dalton A
+**Journal:** Hum Mutat (2006)
+**DOI:** [10.1002/humu.9430](https://doi.org/10.1002/humu.9430)
+
+## Content
+
+1. Hum Mutat. 2006 Jul;27(7):716. doi: 10.1002/humu.9430.
+
+Mutation analysis of COL1A1 and COL1A2 in patients diagnosed with osteogenesis 
+imperfecta type I-IV.
+
+Pollitt R(1), McMahon R, Nunn J, Bamford R, Afifi A, Bishop N, Dalton A.
+
+Author information:
+(1)Sheffield Molecular Genetics Service, Sheffield Children's NHS Trust, 
+Sheffield, United Kingdom. rebecca.pollitt@sch.nhs.uk
+
+Osteogenesis Imperfecta (OI) is a heterogeneous group of inherited disorders 
+characterized by increased bone fragility, with clinical severity ranging from 
+mild to lethal. To date, seven types of OI have been described, based on 
+clinical phenotype and histological findings. Most patients with a clinical 
+diagnosis of OI type I-IV have a mutation in the COL1A1 or COL1A2 genes which 
+encode the two alpha chains of type I collagen, the major component of the bone 
+matrix. Analysis of COL1A1 and COL1A2 in a cohort of 83 unrelated patients with 
+OI type I-IV identified a total of 62 mutations. Thirty-eight appear novel, 26 
+in COL1A1, and 12 in COL1A2, and these are described here. The largest group 
+consists of point mutations affecting glycine residues in the triple helical 
+domain of the two alpha chains, predicted to disrupt protein folding and 
+structure. This is in accordance with previously published data. A doublet GC 
+deletion, an unusual 398 base deletion predicted to completely remove exon 20 of 
+COL1A2, and a point mutation resulting in substitution of a conserved cysteine 
+in the C-terminal propeptide are described. In addition rare mutations at the 
+cleavage sites of the C-propeptide and the N-terminal signal peptide are 
+described.
+
+Copyright 2006 Wiley-Liss, Inc.
+
+DOI: 10.1002/humu.9430
+PMID: 16786509 [Indexed for MEDLINE]


### PR DESCRIPTION
Summary:
- Replaced the remaining PMID:7643358 evidence in OI type IV with PMID:16786509, a COL1A1/COL1A2 mutation-analysis cohort covering OI types I-IV.
- Added PMID:16786509 as a dataset entry for the human type I-IV molecular cohort.
- Removed stale bibliography entries for the dental review and generic therapy review that were flagged in issue #915 and are no longer cited.
- Left the already-improved hearing impairment and treatment evidence unchanged because current main now uses direct supporting sources.

Validation:
- just validate kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
- just validate-references kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
- just validate-schema kb/disorders/Osteogenesis_Imperfecta_Type_IV.yaml
- just check-reference-cache-frontmatter

Addresses #915