### PR TITLE
Add Conduct Disorder

### DIFF
--- a/kb/disorders/Conduct_Disorder.yaml
+++ b/kb/disorders/Conduct_Disorder.yaml
@@ -14,6 +14,59 @@ disease_term:
     label: conduct disorder
 parents:
 - Mental Health Disorder
+has_subtypes:
+- name: Childhood-onset conduct disorder
+  classification: DSM-5 age-of-onset specifier
+  description: >-
+    Conduct-disorder subtype where at least one conduct-disorder symptom is
+    present before age 10 years; this specifier is clinically important for
+    prognosis and service planning.
+  evidence:
+  - reference: clinicaltrials:NCT02828969
+    reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The Trajectories project is designed to describe children and adolescents
+      with disruptive behaviors, their care management and to follow their life
+      trajectory and psychiatric evolution after admission to emergency rooms.
+    explanation: >-
+      The trajectory study supports child and adolescent CD-spectrum
+      presentations; the age-of-onset threshold is a DSM clinical specifier.
+- name: Adolescent-onset conduct disorder
+  classification: DSM-5 age-of-onset specifier
+  description: >-
+    Conduct-disorder subtype where conduct-disorder symptoms emerge in
+    adolescence without symptoms before age 10 years.
+  evidence:
+  - reference: clinicaltrials:NCT02828969
+    reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The Trajectories project is designed to describe children and adolescents
+      with disruptive behaviors, their care management and to follow their life
+      trajectory and psychiatric evolution after admission to emergency rooms.
+    explanation: >-
+      The trajectory study supports adolescent CD-spectrum presentations; the
+      age-of-onset threshold is a DSM clinical specifier.
+- name: Conduct disorder with limited prosocial emotions
+  classification: DSM-5 specifier
+  description: >-
+    Conduct-disorder specifier marked by persistent callous-unemotional traits
+    such as low remorse, low empathy, shallow affect, or limited concern about
+    performance; this subgroup has greater antisocial risk and symptom severity.
+  evidence:
+  - reference: DOI:10.1111/jcpp.13774
+    reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Children with callous‐unemotional (CU) traits are at high lifetime risk
+      of antisocial behavior.
+    explanation: >-
+      Meta-analysis background supports CU traits as a clinically meaningful
+      limited-prosocial-emotions specifier.
 prevalence:
 - population: community children and adolescents
   percentage: 2
@@ -24,7 +77,7 @@ prevalence:
   - reference: DOI:10.1186/s13034-024-00710-6
     reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Conduct disorders (CD) are among the most frequent psychiatric disorders
       in children and adolescents, with an estimated worldwide prevalence in
@@ -70,12 +123,6 @@ pathophysiology:
     Persistent aggression, a central conduct-disorder behavior domain, has
     substantial genetic contribution, but candidate-gene and GxE findings are
     heterogeneous and not ready for deterministic interpretation.
-  biological_processes:
-  - preferred_term: aggressive behavior
-    term:
-      id: GO:0002118
-      label: aggressive behavior
-    modifier: ABNORMAL
   downstream:
   - target: Persistent Antisocial and Aggressive Behavior
     description: >-
@@ -107,17 +154,6 @@ pathophysiology:
     The core behavioral mechanism is persistent violation of rules and rights,
     often expressed through aggressive, antisocial, or defiant behavior that
     requires social, clinical, and sometimes justice-system response.
-  biological_processes:
-  - preferred_term: social behavior
-    term:
-      id: GO:0035176
-      label: social behavior
-    modifier: ABNORMAL
-  - preferred_term: learning or memory
-    term:
-      id: GO:0007611
-      label: learning or memory
-    modifier: ABNORMAL
   cell_types:
   - preferred_term: neuron
     term:
@@ -132,19 +168,11 @@ pathophysiology:
     term:
       id: UBERON:0000451
       label: prefrontal cortex
-  downstream:
-  - target: Aggressive Behavior
-    description: >-
-      Persistent antisocial behavior directly manifests as aggressive behavior
-      in many affected youths.
-  - target: Atypical Rule-Violating Behavior
-    description: >-
-      Persistent antisocial behavior manifests as rule violation, deceit, and
-      rights-violating behavior.
   evidence:
   - reference: clinicaltrials:NCT02828969
     reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Conduct disorders are defined as "repetitive and persistent pattern of
       behavior in which the basic rights of others or major age-appropriate
@@ -155,6 +183,7 @@ pathophysiology:
   - reference: clinicaltrials:NCT00676429
     reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       The main characteristic of these disorders is a repetitive and persistent
       pattern of antisocial, aggressive or defiant behavior that involves major
@@ -167,12 +196,6 @@ pathophysiology:
     behavior subgroup with higher antisocial risk and greater symptom severity,
     while still showing improvement in disruptive behavior symptoms with
     treatment.
-  biological_processes:
-  - preferred_term: cognition
-    term:
-      id: GO:0050890
-      label: cognition
-    modifier: ABNORMAL
   downstream:
   - target: Persistent Antisocial and Aggressive Behavior
     description: >-
@@ -182,7 +205,7 @@ pathophysiology:
   - reference: DOI:10.1111/jcpp.13774
     reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Children with callous‐unemotional (CU) traits are at high lifetime risk
       of antisocial behavior.
@@ -191,7 +214,7 @@ pathophysiology:
   - reference: DOI:10.1111/jcpp.13774
     reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       DBD+CU children improve with treatment, but their greater DBD symptom
       severity requires specialized treatment modules that could be implemented
@@ -204,11 +227,6 @@ pathophysiology:
     Research on biomarkers for pediatric neurodevelopmental and disruptive
     presentations has not yet produced replicated diagnostic biomarkers with
     adequate sensitivity and specificity for clinical use.
-  downstream:
-  - target: Clinical Behavioral Assessment
-    description: >-
-      The absence of validated biomarkers keeps diagnosis anchored in
-      behavioral criteria and clinical assessment.
   evidence:
   - reference: DOI:10.1002/wps.21037
     reference_title: "Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review"
@@ -226,16 +244,11 @@ pathophysiology:
     Evidence-based parent-management and parent-child interventions reduce
     disruptive behavior, indicating that family and social-learning mechanisms
     are modifiable downstream contributors.
-  downstream:
-  - target: Atypical Rule-Violating Behavior
-    description: >-
-      Parent-focused interventions target disruptive behavior and social skills
-      that maintain rule-violating patterns.
   evidence:
   - reference: DOI:10.1007/s10578-022-01367-y
     reference_title: "The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Results showed that PMT (g = 0.64 [95% CI 0.42, 0.86]) and PCIT
       (g = 1.22 [95% CI 0.75, 1.69]) were more effective than waiting-list
@@ -256,6 +269,7 @@ phenotypes:
   - reference: clinicaltrials:NCT00676429
     reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       antisocial, aggressive or defiant behavior that involves major violations
       of age-appropriate expectations or norms.
@@ -267,38 +281,18 @@ phenotypes:
     Persistent rule-violating, deceitful, or rights-violating behavior is a
     defining conduct-disorder presentation.
   phenotype_term:
-    preferred_term: Atypical behavior
-    term:
-      id: HP:0000708
-      label: Atypical behavior
+    preferred_term: Rule-violating behavior
   evidence:
   - reference: clinicaltrials:NCT02828969
     reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       repetitive and persistent pattern of behavior in which the basic rights
       of others or major age-appropriate norms are violated
     explanation: >-
       ClinicalTrials.gov record provides the core rule-violating behavior
       definition.
-- name: Attention Deficit Hyperactivity Disorder
-  category: Behavioral
-  description: ADHD is the most common psychiatric comorbidity in real-world CD cohorts.
-  phenotype_term:
-    preferred_term: Attention deficit hyperactivity disorder
-    term:
-      id: HP:0007018
-      label: Attention deficit hyperactivity disorder
-  evidence:
-  - reference: DOI:10.1186/s13034-024-00710-6
-    reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      The rate of psychiatric comorbidity ranged from 69.7 to 86.1%, with
-      attention-deficit/hyperactivity disorder being most common.
-    explanation: >-
-      Real-world data study supports ADHD as the most common comorbidity.
 - name: Irritability
   category: Behavioral
   description: >-
@@ -313,6 +307,7 @@ phenotypes:
   - reference: clinicaltrials:NCT00676429
     reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
     supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       To investigate and compare the efficacy, safety and tolerability of
       ziprasidone versus placebo in the treatment of conduct disorder (CD),
@@ -337,6 +332,7 @@ diagnosis:
   - reference: clinicaltrials:NCT02828969
     reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Conduct disorders are defined as "repetitive and persistent pattern of
       behavior in which the basic rights of others or major age-appropriate
@@ -399,6 +395,7 @@ differential_diagnoses:
   - reference: clinicaltrials:NCT00676429
     reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       conduct disorder (CD), oppositional defiant disorder (ODD) and disruptive
       behavior disorder not otherwise specified (DBD-NOS)
@@ -459,7 +456,7 @@ differential_diagnoses:
   - reference: DOI:10.1111/jcpp.13774
     reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
     supports: PARTIAL
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Children with callous‐unemotional (CU) traits are at high lifetime risk
       of antisocial behavior.
@@ -467,6 +464,109 @@ differential_diagnoses:
       CU traits link childhood disruptive behavior to later antisocial
       outcomes, supporting adult antisocial behavior as a developmental
       differential and outcome consideration.
+treatments:
+- name: Parent management training
+  description: >-
+    Parent management training is an evidence-supported psychosocial treatment
+    for children with clinical levels of disruptive behavior.
+  treatment_term:
+    preferred_term: parent management training
+  target_phenotypes:
+  - preferred_term: Rule-violating behavior
+  - preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
+  evidence:
+  - reference: DOI:10.1007/s10578-022-01367-y
+    reference_title: "The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Results showed that PMT (g = 0.64 [95% CI 0.42, 0.86]) and PCIT
+      (g = 1.22 [95% CI 0.75, 1.69]) were more effective than waiting-list
+      (WL) in reducing parent-rated disruptive behavior
+    explanation: >-
+      Meta-analysis supports PMT for disruptive behavior symptoms relevant to
+      conduct disorder.
+- name: Parent-child interaction therapy
+  description: >-
+    Parent-child interaction therapy is a parent-child psychosocial treatment
+    with large waitlist-controlled effects in young children with disruptive
+    behavior.
+  treatment_term:
+    preferred_term: parent-child interaction therapy
+  target_phenotypes:
+  - preferred_term: Rule-violating behavior
+  - preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
+  evidence:
+  - reference: DOI:10.1007/s10578-022-01367-y
+    reference_title: "The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PCIT versus WL had larger effects in reducing disruptive behavior than
+      PMT versus WL.
+    explanation: >-
+      Meta-analysis supports PCIT for disruptive behavior symptoms.
+- name: Specialized modules for callous-unemotional traits
+  description: >-
+    Children with disruptive behavior disorders and callous-unemotional traits
+    can improve with treatment, but higher severity supports specialized
+    modules alongside parenting programs.
+  treatment_term:
+    preferred_term: specialized psychosocial treatment module
+  target_phenotypes:
+  - preferred_term: Rule-violating behavior
+  evidence:
+  - reference: DOI:10.1111/jcpp.13774
+    reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      DBD+CU children improve with treatment, but their greater DBD symptom
+      severity requires specialized treatment modules that could be implemented
+      alongside parenting programs.
+    explanation: >-
+      Meta-analysis supports treatment response and specialized-module needs in
+      DBD with CU traits.
+- name: Ziprasidone pharmacotherapy for severe aggression
+  description: >-
+    Ziprasidone has been studied as adjunctive symptom-targeted pharmacotherapy
+    for severe conduct and disruptive behavior disorders in older children and
+    adolescents.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: ziprasidone
+      term:
+        id: CHEBI:10119
+        label: ziprasidone
+  target_phenotypes:
+  - preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
+  evidence:
+  - reference: clinicaltrials:NCT00676429
+    reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      To investigate and compare the efficacy, safety and tolerability of
+      ziprasidone versus placebo in the treatment of conduct disorder (CD),
+      oppositional defiant disorder (ODD) and disruptive behavior disorder not
+      otherwise specified (DBD-NOS) of older children and adolescents in an
+      outpatient setting.
+    explanation: >-
+      ClinicalTrials.gov record documents a Phase II ziprasidone trial for CD
+      and related disruptive behavior disorders.
 clinical_trials:
 - name: NCT00676429
   phase: PHASE_II
@@ -484,6 +584,7 @@ clinical_trials:
   - reference: clinicaltrials:NCT00676429
     reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       To investigate and compare the efficacy, safety and tolerability of
       ziprasidone versus placebo in the treatment of conduct disorder (CD),
@@ -500,14 +601,12 @@ clinical_trials:
     Observational trajectory study of children and adolescents with disruptive
     behavior admitted to pediatric and psychiatric emergency settings.
   target_phenotypes:
-  - preferred_term: Atypical behavior
-    term:
-      id: HP:0000708
-      label: Atypical behavior
+  - preferred_term: Rule-violating behavior
   evidence:
   - reference: clinicaltrials:NCT02828969
     reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       The Trajectories project is designed to describe children and adolescents
       with disruptive behaviors, their care management and to follow their life
@@ -531,6 +630,7 @@ clinical_trials:
   - reference: clinicaltrials:NCT07091721
     reference_title: "The Mentalization Intervention for Children and Adolescents (MICA) Study: A Randomised Controlled Trial of Support for Aggressive and Violent Behaviour Via Forensic Child and Adolescent Mental Health Services (FCAMHS)"
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       This research involves doing a randomised controlled trial. This means
       half the young people will get the usual support from FCAMHS, and half
@@ -637,7 +737,7 @@ datasets:
   - reference: DOI:10.1111/jcpp.13774
     reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Sixty studies with 9,405 participants were included
     explanation: >-
@@ -648,7 +748,7 @@ datasets:
     - reference: DOI:10.1111/jcpp.13774
       reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >-
         treatment was associated with similar reductions in DBD symptoms for
         DBD+CU ( SMD  = 1.08, 95% CI = 0.45, 1.72) and DBD‐only ( SMD  =

--- a/kb/disorders/Conduct_Disorder.yaml
+++ b/kb/disorders/Conduct_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Conduct Disorder
 creation_date: "2026-04-24T20:56:38Z"
-updated_date: "2026-04-24T21:57:51Z"
+updated_date: "2026-04-26T02:55:00Z"
 category: Psychiatric
 description: >-
   Conduct disorder is a disruptive behavior disorder characterized by a
@@ -132,7 +132,7 @@ pathophysiology:
   - reference: DOI:10.1038/s41398-024-02870-7
     reference_title: "Genetics of child aggression, a systematic review"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       While half of the variance in childhood aggression is attributed to
       genetic factors, the biological mechanism and the interplay between genes
@@ -143,7 +143,7 @@ pathophysiology:
   - reference: DOI:10.1038/s41398-024-02870-7
     reference_title: "Genetics of child aggression, a systematic review"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       investigation of candidate genes, especially of MAOA (17 studies), DRD4
       (13 studies), and COMT (12 studies) continue to dominate the field
@@ -231,7 +231,7 @@ pathophysiology:
   - reference: DOI:10.1002/wps.21037
     reference_title: "Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       we could not find any biomarker for which there was evidence – from two
       or more studies from independent research groups, with results going into
@@ -244,6 +244,11 @@ pathophysiology:
     Evidence-based parent-management and parent-child interventions reduce
     disruptive behavior, indicating that family and social-learning mechanisms
     are modifiable downstream contributors.
+  downstream:
+  - target: Persistent Antisocial and Aggressive Behavior
+    description: >-
+      Psychosocial interventions are modeled as modulating the persistent
+      disruptive and aggressive behavior mechanism.
   evidence:
   - reference: DOI:10.1007/s10578-022-01367-y
     reference_title: "The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis"
@@ -373,7 +378,7 @@ diagnosis:
   - reference: DOI:10.1002/wps.21037
     reference_title: "Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Other important metrics to assess the validity of a candidate biomarker,
       such as positive predictive value and negative predictive value, were
@@ -435,7 +440,7 @@ differential_diagnoses:
   - reference: DOI:10.1038/s41398-024-02870-7
     reference_title: "Genetics of child aggression, a systematic review"
     supports: PARTIAL
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Excessive and persistent aggressiveness is the most common behavioral
       problem that leads to psychiatric referrals among children.

--- a/kb/disorders/Conduct_Disorder.yaml
+++ b/kb/disorders/Conduct_Disorder.yaml
@@ -1,0 +1,662 @@
+name: Conduct Disorder
+creation_date: "2026-04-24T20:56:38Z"
+updated_date: "2026-04-24T21:57:51Z"
+category: Psychiatric
+description: >-
+  Conduct disorder is a disruptive behavior disorder characterized by a
+  repetitive and persistent pattern of aggressive, antisocial, deceitful, or
+  rule-violating behavior that infringes the rights of others or
+  age-appropriate norms.
+disease_term:
+  preferred_term: conduct disorder
+  term:
+    id: MONDO:0005352
+    label: conduct disorder
+parents:
+- Mental Health Disorder
+prevalence:
+- population: community children and adolescents
+  percentage: 2
+  notes: >-
+    Review of real-world recognition and management reports an estimated
+    worldwide community prevalence range of 2-4%.
+  evidence:
+  - reference: DOI:10.1186/s13034-024-00710-6
+    reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Conduct disorders (CD) are among the most frequent psychiatric disorders
+      in children and adolescents, with an estimated worldwide prevalence in
+      the community of 2–4%.
+    explanation: >-
+      Real-world data study introduction provides an estimated community
+      prevalence range.
+pathophysiology:
+- name: Intergenerational Polygenic Liability
+  description: >-
+    Conduct problems show polygenic transmission from parental characteristics
+    to child conduct problems, supporting a heritable liability component
+    embedded in family development.
+  downstream:
+  - target: Childhood Aggression Genetic Architecture
+    description: >-
+      Polygenic transmission is represented upstream of aggression-related
+      genetic liability and behavioral outcomes.
+  evidence:
+  - reference: DOI:10.1038/s41380-023-02383-7
+    reference_title: "Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The aetiology of conduct problems involves a combination of genetic and
+      environmental factors, many of which are inherently linked to parental
+      characteristics given parents’ central role in children’s lives across
+      development.
+    explanation: >-
+      Trio study frames conduct problems as genetically and environmentally
+      influenced.
+  - reference: DOI:10.1038/s41380-023-02383-7
+    reference_title: "Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We found significant genetic transmission effects on conduct problems
+      for 12 out of 13 PGS at age 8 years
+    explanation: >-
+      The MoBa trio analysis supports genetic transmission effects.
+- name: Childhood Aggression Genetic Architecture
+  description: >-
+    Persistent aggression, a central conduct-disorder behavior domain, has
+    substantial genetic contribution, but candidate-gene and GxE findings are
+    heterogeneous and not ready for deterministic interpretation.
+  biological_processes:
+  - preferred_term: aggressive behavior
+    term:
+      id: GO:0002118
+      label: aggressive behavior
+    modifier: ABNORMAL
+  downstream:
+  - target: Persistent Antisocial and Aggressive Behavior
+    description: >-
+      Aggression-related genetic liability is represented upstream of the
+      clinical aggressive-behavior phenotype.
+  evidence:
+  - reference: DOI:10.1038/s41398-024-02870-7
+    reference_title: "Genetics of child aggression, a systematic review"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      While half of the variance in childhood aggression is attributed to
+      genetic factors, the biological mechanism and the interplay between genes
+      and environment that results in aggression remains elusive.
+    explanation: >-
+      Systematic review supports genetic contribution but emphasizes unresolved
+      mechanisms.
+  - reference: DOI:10.1038/s41398-024-02870-7
+    reference_title: "Genetics of child aggression, a systematic review"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      investigation of candidate genes, especially of MAOA (17 studies), DRD4
+      (13 studies), and COMT (12 studies) continue to dominate the field
+    explanation: >-
+      Review identifies commonly studied aggression candidate genes.
+- name: Persistent Antisocial and Aggressive Behavior
+  description: >-
+    The core behavioral mechanism is persistent violation of rules and rights,
+    often expressed through aggressive, antisocial, or defiant behavior that
+    requires social, clinical, and sometimes justice-system response.
+  biological_processes:
+  - preferred_term: social behavior
+    term:
+      id: GO:0035176
+      label: social behavior
+    modifier: ABNORMAL
+  - preferred_term: learning or memory
+    term:
+      id: GO:0007611
+      label: learning or memory
+    modifier: ABNORMAL
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: amygdala
+    term:
+      id: UBERON:0001876
+      label: amygdala
+  - preferred_term: prefrontal cortex
+    term:
+      id: UBERON:0000451
+      label: prefrontal cortex
+  downstream:
+  - target: Aggressive Behavior
+    description: >-
+      Persistent antisocial behavior directly manifests as aggressive behavior
+      in many affected youths.
+  - target: Atypical Rule-Violating Behavior
+    description: >-
+      Persistent antisocial behavior manifests as rule violation, deceit, and
+      rights-violating behavior.
+  evidence:
+  - reference: clinicaltrials:NCT02828969
+    reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+    supports: SUPPORT
+    snippet: >-
+      Conduct disorders are defined as "repetitive and persistent pattern of
+      behavior in which the basic rights of others or major age-appropriate
+      norms are violated".
+    explanation: >-
+      ClinicalTrials.gov trajectory study provides a concise conduct-disorder
+      behavioral definition.
+  - reference: clinicaltrials:NCT00676429
+    reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+    supports: SUPPORT
+    snippet: >-
+      The main characteristic of these disorders is a repetitive and persistent
+      pattern of antisocial, aggressive or defiant behavior that involves major
+      violations of age-appropriate expectations or norms.
+    explanation: >-
+      Trial background supports the aggressive and antisocial behavior node.
+- name: Callous-Unemotional Trait Severity
+  description: >-
+    Callous-unemotional traits identify a clinically important disruptive
+    behavior subgroup with higher antisocial risk and greater symptom severity,
+    while still showing improvement in disruptive behavior symptoms with
+    treatment.
+  biological_processes:
+  - preferred_term: cognition
+    term:
+      id: GO:0050890
+      label: cognition
+    modifier: ABNORMAL
+  downstream:
+  - target: Persistent Antisocial and Aggressive Behavior
+    description: >-
+      CU traits are modeled as a severity modifier that can intensify or
+      stabilize antisocial behavior trajectories.
+  evidence:
+  - reference: DOI:10.1111/jcpp.13774
+    reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Children with callous‐unemotional (CU) traits are at high lifetime risk
+      of antisocial behavior.
+    explanation: >-
+      Meta-analysis background supports CU traits as a risk/severity dimension.
+  - reference: DOI:10.1111/jcpp.13774
+    reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      DBD+CU children improve with treatment, but their greater DBD symptom
+      severity requires specialized treatment modules that could be implemented
+      alongside parenting programs.
+    explanation: >-
+      Meta-analysis conclusion supports CU traits as a clinically relevant
+      modifier of severity and treatment planning.
+- name: Biomarkers Not Established for Diagnosis
+  description: >-
+    Research on biomarkers for pediatric neurodevelopmental and disruptive
+    presentations has not yet produced replicated diagnostic biomarkers with
+    adequate sensitivity and specificity for clinical use.
+  downstream:
+  - target: Clinical Behavioral Assessment
+    description: >-
+      The absence of validated biomarkers keeps diagnosis anchored in
+      behavioral criteria and clinical assessment.
+  evidence:
+  - reference: DOI:10.1002/wps.21037
+    reference_title: "Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      we could not find any biomarker for which there was evidence – from two
+      or more studies from independent research groups, with results going into
+      the same direction – of specificity and sensitivity of at least 80%.
+    explanation: >-
+      Systematic review supports caution against routine diagnostic biomarker
+      use.
+- name: Psychosocial Intervention Response
+  description: >-
+    Evidence-based parent-management and parent-child interventions reduce
+    disruptive behavior, indicating that family and social-learning mechanisms
+    are modifiable downstream contributors.
+  downstream:
+  - target: Atypical Rule-Violating Behavior
+    description: >-
+      Parent-focused interventions target disruptive behavior and social skills
+      that maintain rule-violating patterns.
+  evidence:
+  - reference: DOI:10.1007/s10578-022-01367-y
+    reference_title: "The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Results showed that PMT (g = 0.64 [95% CI 0.42, 0.86]) and PCIT
+      (g = 1.22 [95% CI 0.75, 1.69]) were more effective than waiting-list
+      (WL) in reducing parent-rated disruptive behavior
+    explanation: >-
+      Meta-analysis supports parent-focused intervention effects on disruptive
+      behavior.
+phenotypes:
+- name: Aggressive Behavior
+  category: Behavioral
+  description: Aggression is a core conduct-disorder behavior domain.
+  phenotype_term:
+    preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
+  evidence:
+  - reference: clinicaltrials:NCT00676429
+    reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+    supports: SUPPORT
+    snippet: >-
+      antisocial, aggressive or defiant behavior that involves major violations
+      of age-appropriate expectations or norms.
+    explanation: >-
+      Trial background explicitly identifies aggressive behavior.
+- name: Atypical Rule-Violating Behavior
+  category: Behavioral
+  description: >-
+    Persistent rule-violating, deceitful, or rights-violating behavior is a
+    defining conduct-disorder presentation.
+  phenotype_term:
+    preferred_term: Atypical behavior
+    term:
+      id: HP:0000708
+      label: Atypical behavior
+  evidence:
+  - reference: clinicaltrials:NCT02828969
+    reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+    supports: SUPPORT
+    snippet: >-
+      repetitive and persistent pattern of behavior in which the basic rights
+      of others or major age-appropriate norms are violated
+    explanation: >-
+      ClinicalTrials.gov record provides the core rule-violating behavior
+      definition.
+- name: Attention Deficit Hyperactivity Disorder
+  category: Behavioral
+  description: ADHD is the most common psychiatric comorbidity in real-world CD cohorts.
+  phenotype_term:
+    preferred_term: Attention deficit hyperactivity disorder
+    term:
+      id: HP:0007018
+      label: Attention deficit hyperactivity disorder
+  evidence:
+  - reference: DOI:10.1186/s13034-024-00710-6
+    reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The rate of psychiatric comorbidity ranged from 69.7 to 86.1%, with
+      attention-deficit/hyperactivity disorder being most common.
+    explanation: >-
+      Real-world data study supports ADHD as the most common comorbidity.
+- name: Irritability
+  category: Behavioral
+  description: >-
+    Irritability and emotional dysregulation can occur in disruptive behavior
+    presentations and may be targeted clinically.
+  phenotype_term:
+    preferred_term: Irritability
+    term:
+      id: HP:0000737
+      label: Irritability
+  evidence:
+  - reference: clinicaltrials:NCT00676429
+    reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+    supports: PARTIAL
+    snippet: >-
+      To investigate and compare the efficacy, safety and tolerability of
+      ziprasidone versus placebo in the treatment of conduct disorder (CD),
+      oppositional defiant disorder (ODD) and disruptive behavior disorder not
+      otherwise specified (DBD-NOS) of older children and adolescents in an
+      outpatient setting.
+    explanation: >-
+      Trial record supports severe disruptive behavior treatment; irritability
+      is represented as a related HPO phenotype rather than explicitly named.
+diagnosis:
+- name: Clinical Behavioral Assessment
+  presence: >-
+    Diagnosis is based on persistent behavioral criteria, impairment, age of
+    onset, severity, limited-prosocial-emotions traits, comorbidities, and
+    exclusion of alternative explanations.
+  diagnosis_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  evidence:
+  - reference: clinicaltrials:NCT02828969
+    reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+    supports: SUPPORT
+    snippet: >-
+      Conduct disorders are defined as "repetitive and persistent pattern of
+      behavior in which the basic rights of others or major age-appropriate
+      norms are violated".
+    explanation: >-
+      The record supports diagnosis by behavioral pattern.
+- name: Comorbidity and Service-Use Assessment
+  presence: >-
+    Assessment includes ADHD and other psychiatric comorbidities, medication
+    exposure, hospitalisation, emergency presentation, and social-care context.
+  diagnosis_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  evidence:
+  - reference: DOI:10.1186/s13034-024-00710-6
+    reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Within each country’s study population, the prevalence of CD,
+      psychiatric comorbidity, psychopharmacological treatment, and psychiatric
+      hospitalisation was calculated.
+    explanation: >-
+      Real-world study supports assessing comorbidity, treatment, and
+      hospitalisation context.
+- name: Biomarkers remain investigational
+  presence: >-
+    Biomarkers are not established for routine diagnosis; clinical diagnosis
+    remains behavioral and contextual.
+  diagnosis_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  evidence:
+  - reference: DOI:10.1002/wps.21037
+    reference_title: "Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Other important metrics to assess the validity of a candidate biomarker,
+      such as positive predictive value and negative predictive value, were
+      infrequently reported.
+    explanation: >-
+      Biomarker review supports the need for clinical rather than biomarker-only
+      diagnosis.
+differential_diagnoses:
+- name: Oppositional defiant disorder
+  description: >-
+    ODD involves oppositional and defiant behavior without the more severe
+    rights-violating conduct-disorder pattern.
+  disease_term:
+    preferred_term: oppositional defiant disorder
+    term:
+      id: MONDO:0000495
+      label: oppositional defiant disorder
+  evidence:
+  - reference: clinicaltrials:NCT00676429
+    reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+    supports: SUPPORT
+    snippet: >-
+      conduct disorder (CD), oppositional defiant disorder (ODD) and disruptive
+      behavior disorder not otherwise specified (DBD-NOS)
+    explanation: >-
+      Trial record distinguishes CD from ODD and other disruptive behavior
+      disorders.
+- name: Attention deficit-hyperactivity disorder
+  description: >-
+    ADHD frequently co-occurs with CD and may drive impulsivity or functional
+    impairment that needs separate assessment.
+  disease_term:
+    preferred_term: attention deficit-hyperactivity disorder
+    term:
+      id: MONDO:0007743
+      label: attention deficit-hyperactivity disorder
+  evidence:
+  - reference: DOI:10.1186/s13034-024-00710-6
+    reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The rate of psychiatric comorbidity ranged from 69.7 to 86.1%, with
+      attention-deficit/hyperactivity disorder being most common.
+    explanation: >-
+      Real-world cohort supports ADHD as the commonest comorbidity.
+- name: Intermittent explosive disorder
+  description: >-
+    Intermittent explosive disorder can present with aggressive outbursts, but
+    lacks the broader persistent pattern of rule violation, deceit, or rights
+    violation required for CD.
+  disease_term:
+    preferred_term: intermittent explosive disorder
+    term:
+      id: MONDO:0001521
+      label: intermittent explosive disorder
+  evidence:
+  - reference: DOI:10.1038/s41398-024-02870-7
+    reference_title: "Genetics of child aggression, a systematic review"
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: >-
+      Excessive and persistent aggressiveness is the most common behavioral
+      problem that leads to psychiatric referrals among children.
+    explanation: >-
+      Review supports aggression as a broad referral phenotype; the
+      intermittent explosive disorder distinction is a clinical differential.
+- name: Antisocial personality disorder
+  description: >-
+    Antisocial personality disorder is an adult diagnosis related to
+    persistent antisocial behavior and should not be substituted for pediatric
+    conduct disorder in children.
+  disease_term:
+    preferred_term: antisocial personality disorder
+    term:
+      id: MONDO:0001164
+      label: antisocial personality disorder
+  evidence:
+  - reference: DOI:10.1111/jcpp.13774
+    reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: >-
+      Children with callous‐unemotional (CU) traits are at high lifetime risk
+      of antisocial behavior.
+    explanation: >-
+      CU traits link childhood disruptive behavior to later antisocial
+      outcomes, supporting adult antisocial behavior as a developmental
+      differential and outcome consideration.
+clinical_trials:
+- name: NCT00676429
+  phase: PHASE_II
+  status: COMPLETED
+  description: >-
+    Placebo-controlled randomized double-blind trial of ziprasidone for severe
+    conduct and other disruptive behavior disorders in older children and
+    adolescents.
+  target_phenotypes:
+  - preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
+  evidence:
+  - reference: clinicaltrials:NCT00676429
+    reference_title: Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+    supports: SUPPORT
+    snippet: >-
+      To investigate and compare the efficacy, safety and tolerability of
+      ziprasidone versus placebo in the treatment of conduct disorder (CD),
+      oppositional defiant disorder (ODD) and disruptive behavior disorder not
+      otherwise specified (DBD-NOS) of older children and adolescents in an
+      outpatient setting.
+    explanation: >-
+      ClinicalTrials.gov record documents a completed ziprasidone trial for CD
+      and related disruptive behavior disorders.
+- name: NCT02828969
+  phase: NOT_APPLICABLE
+  status: UNKNOWN
+  description: >-
+    Observational trajectory study of children and adolescents with disruptive
+    behavior admitted to pediatric and psychiatric emergency settings.
+  target_phenotypes:
+  - preferred_term: Atypical behavior
+    term:
+      id: HP:0000708
+      label: Atypical behavior
+  evidence:
+  - reference: clinicaltrials:NCT02828969
+    reference_title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+    supports: SUPPORT
+    snippet: >-
+      The Trajectories project is designed to describe children and adolescents
+      with disruptive behaviors, their care management and to follow their life
+      trajectory and psychiatric evolution after admission to emergency rooms.
+    explanation: >-
+      ClinicalTrials.gov record documents a clinical trajectory study in
+      disruptive behavior emergencies.
+- name: NCT07091721
+  phase: NOT_APPLICABLE
+  status: RECRUITING
+  description: >-
+    Randomized controlled trial of mentalization-based support for aggressive
+    and violent behavior in young people referred to forensic child and
+    adolescent mental health services.
+  target_phenotypes:
+  - preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
+  evidence:
+  - reference: clinicaltrials:NCT07091721
+    reference_title: "The Mentalization Intervention for Children and Adolescents (MICA) Study: A Randomised Controlled Trial of Support for Aggressive and Violent Behaviour Via Forensic Child and Adolescent Mental Health Services (FCAMHS)"
+    supports: SUPPORT
+    snippet: >-
+      This research involves doing a randomised controlled trial. This means
+      half the young people will get the usual support from FCAMHS, and half
+      will get the usual support plus the new support.
+    explanation: >-
+      ClinicalTrials.gov record documents a currently recruiting RCT for
+      aggressive and violent behavior support.
+datasets:
+- accession: DOI:10.1186/s13034-024-00710-6
+  title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+  description: >-
+    Cross-sectional real-world healthcare data study comparing administrative
+    prevalence, comorbidity, psychopharmacological treatment, and
+    hospitalisation in youths with CD across Denmark, Germany, Norway, and the
+    USA.
+  organism:
+    preferred_term: Homo sapiens
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  conditions:
+  - conduct disorder
+  - psychiatric comorbidity
+  publication: DOI:10.1186/s13034-024-00710-6
+  evidence:
+  - reference: DOI:10.1186/s13034-024-00710-6
+    reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cross-sectional observational study using healthcare data to identify
+      children and adolescents (aged 0–19 years) with an ICD-10 code for CD
+      within the calendar year 2018.
+    explanation: >-
+      The abstract describes the real-world dataset and age range.
+  findings:
+  - statement: Administrative CD prevalence varied 31-fold across countries, and psychiatric comorbidity ranged from 69.7% to 86.1%.
+    evidence:
+    - reference: DOI:10.1186/s13034-024-00710-6
+      reference_title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The prevalence of diagnosed CD differed 31-fold between countries:
+        0.1% (Denmark), 0.3% (Norway), 1.1% (USA) and 3.1% (Germany), with a
+        male/female ratio of 2.0–2.5:1.
+      explanation: >-
+        Captures the main cross-country prevalence finding.
+- accession: DOI:10.1038/s41380-023-02383-7
+  title: "Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study"
+  description: >-
+    Genotyped mother-father-child trio analysis testing transmission and
+    genetic nurture effects on conduct problems at ages 8 and 14 in MoBa.
+  organism:
+    preferred_term: Homo sapiens
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  sample_count: 31290
+  conditions:
+  - conduct problems
+  publication: DOI:10.1038/s41380-023-02383-7
+  evidence:
+  - reference: DOI:10.1038/s41380-023-02383-7
+    reference_title: "Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We used 31,290 genotyped mother-father-child trios from the Norwegian
+      Mother, Father and Child Cohort Study (MoBa)
+    explanation: >-
+      The abstract provides the trio dataset size and source.
+  findings:
+  - statement: Genetic transmission effects were detected for most tested PGS at age 8 and several at age 14, while genetic nurture effects were not detected for the selected PGS.
+    evidence:
+    - reference: DOI:10.1038/s41380-023-02383-7
+      reference_title: "Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Conversely, we did not find genetic nurture effects for conduct
+        problems using our selection of PGS.
+      explanation: >-
+        Captures the contrast between transmission and genetic-nurture effects.
+- accession: DOI:10.1111/jcpp.13774
+  title: "Treatment of childhood disruptive behavior disorders and
+                    <scp>callous‐unemotional</scp>
+                    traits: a systematic review and two multilevel
+                    <scp>meta‐analyses</scp>"
+  description: >-
+    Systematic review and multilevel meta-analyses of treatments for childhood
+    disruptive behavior disorders with and without callous-unemotional traits.
+  organism:
+    preferred_term: Homo sapiens
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  sample_count: 9405
+  conditions:
+  - disruptive behavior disorder
+  - callous-unemotional traits
+  publication: DOI:10.1111/jcpp.13774
+  evidence:
+  - reference: DOI:10.1111/jcpp.13774
+    reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Sixty studies with 9,405 participants were included
+    explanation: >-
+      The abstract reports the evidence base for the treatment meta-analyses.
+  findings:
+  - statement: Treatment reduced disruptive behavior symptoms in both DBD+CU and DBD-only children, but DBD+CU children had greater symptom severity.
+    evidence:
+    - reference: DOI:10.1111/jcpp.13774
+      reference_title: "Treatment of childhood disruptive behavior disorders and\n                    <scp>callous‐unemotional</scp>\n                    traits: a systematic review and two multilevel\n                    <scp>meta‐analyses</scp>"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        treatment was associated with similar reductions in DBD symptoms for
+        DBD+CU ( SMD  = 1.08, 95% CI = 0.45, 1.72) and DBD‐only ( SMD  =
+        1.01, 95% CI = 0.38, 1.64).
+      explanation: >-
+        Captures the primary treatment-effect comparison by CU-trait status.
+notes: >-
+  Pathophysiology entries are separated into polygenic transmission, aggression
+  genetics, persistent antisocial behavior, callous-unemotional trait severity,
+  biomarker limitations, and psychosocial intervention response so downstream
+  relationships remain granular.

--- a/references_cache/DOI_10.1002_wps.21037.md
+++ b/references_cache/DOI_10.1002_wps.21037.md
@@ -1,0 +1,46 @@
+---
+reference_id: "DOI:10.1002/wps.21037"
+title: "Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review"
+authors:
+- Samuele Cortese
+- Marco Solmi
+- Giorgia Michelini
+- Alessio Bellato
+- Christina Blanner
+- Andrea Canozzi
+- Luis Eudave
+- Luis C. Farhat
+- Mikkel Højlund
+- Ole Köhler‐Forsberg
+- Douglas Teixeira Leffa
+- Christopher Rohde
+- Gonzalo Salazar de Pablo
+- Giovanni Vita
+- Rikke Wesselhoeft
+- Joanna Martin
+- Sarah Baumeister
+- Natali S. Bozhilova
+- Christina O. Carlisi
+- Virginia Carter Leno
+- Dorothea L. Floris
+- Nathalie E. Holz
+- Eline J. Kraaijenvanger
+- Seda Sacu
+- Isabella Vainieri
+- Giovanni Ostuzzi
+- Corrado Barbui
+- Christoph U. Correll
+journal: World Psychiatry
+year: '2023'
+doi: 10.1002/wps.21037
+content_type: abstract_only
+---
+
+# Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review
+**Authors:** Samuele Cortese, Marco Solmi, Giorgia Michelini, Alessio Bellato, Christina Blanner, Andrea Canozzi, Luis Eudave, Luis C. Farhat, Mikkel Højlund, Ole Köhler‐Forsberg, Douglas Teixeira Leffa, Christopher Rohde, Gonzalo Salazar de Pablo, Giovanni Vita, Rikke Wesselhoeft, Joanna Martin, Sarah Baumeister, Natali S. Bozhilova, Christina O. Carlisi, Virginia Carter Leno, Dorothea L. Floris, Nathalie E. Holz, Eline J. Kraaijenvanger, Seda Sacu, Isabella Vainieri, Giovanni Ostuzzi, Corrado Barbui, Christoph U. Correll
+**Journal:** World Psychiatry (2023)
+**DOI:** [10.1002/wps.21037](https://doi.org/10.1002/wps.21037)
+
+## Content
+
+Neurodevelopmental disorders – including attention‐deficit/hyperactivity disorder (ADHD), autism spectrum disorder, communication disorders, intellectual disability, motor disorders, specific learning disorders, and tic disorders – manifest themselves early in development. Valid, reliable and broadly usable biomarkers supporting a timely diagnosis of these disorders would be highly relevant from a clinical and public health standpoint. We conducted the first systematic review of studies on candidate diagnostic biomarkers for these disorders in children and adolescents. We searched Medline and Embase + Embase Classic with terms relating to biomarkers until April 6, 2022, and conducted additional targeted searches for genome‐wide association studies (GWAS) and neuroimaging or neurophysiological studies carried out by international consortia. We considered a candidate biomarker as promising if it was reported in at least two independent studies providing evidence of sensitivity and specificity of at least 80%. After screening 10,625 references, we retained 780 studies (374 biochemical, 203 neuroimaging, 133 neurophysiological and 65 neuropsychological studies, and five GWAS), including a total of approximately 120,000 cases and 176,000 controls. While the majority of the studies focused simply on associations, we could not find any biomarker for which there was evidence – from two or more studies from independent research groups, with results going into the same direction – of specificity and sensitivity of at least 80%. Other important metrics to assess the validity of a candidate biomarker, such as positive predictive value and negative predictive value, were infrequently reported. Limitations of the currently available studies include mostly small sample size, heterogeneous approaches and candidate biomarker targets, undue focus on single instead of joint biomarker signatures, and incomplete accounting for potential confounding factors. Future multivariable and multi‐level approaches may be best suited to find valid candidate biomarkers, which will then need to be validated in external, independent samples and then, importantly, tested in terms of feasibility and cost‐effectiveness, before they can be implemented in daily clinical practice.

--- a/references_cache/DOI_10.1007_s10578-022-01367-y.md
+++ b/references_cache/DOI_10.1007_s10578-022-01367-y.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.1007/s10578-022-01367-y"
+title: "The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis"
+authors:
+- Maria Helander
+- Martin Asperholm
+- Dan Wetterborg
+- Lars-Göran Öst
+- Clara Hellner
+- Agneta Herlitz
+- Pia Enebrink
+journal: "Child Psychiatry &amp; Human Development"
+year: '2024'
+doi: 10.1007/s10578-022-01367-y
+content_type: abstract_only
+---
+
+# The Efficacy of Parent Management Training With or Without Involving the Child in the Treatment Among Children with Clinical Levels of Disruptive Behavior: A Meta-analysis
+**Authors:** Maria Helander, Martin Asperholm, Dan Wetterborg, Lars-Göran Öst, Clara Hellner, Agneta Herlitz, Pia Enebrink
+**Journal:** Child Psychiatry &amp; Human Development (2024)
+**DOI:** [10.1007/s10578-022-01367-y](https://doi.org/10.1007/s10578-022-01367-y)
+
+## Content
+
+AbstractA systematic review and meta-analysis was conducted where we evaluated the effects of Parent Management Training (PMT), Parent–Child Interaction Therapy (PCIT) and PMT combined with child cognitive behavioral therapy (CBT) using data from 25 RCTs on children with clinical levels of disruptive behavior (age range 2–13 years). Results showed that PMT (g = 0.64 [95% CI 0.42, 0.86]) and PCIT (g = 1.22 [95% CI 0.75, 1.69]) were more effective than waiting-list (WL) in reducing parent-rated disruptive behavior, and PMT also in improving parental skills (g = 0.83 [95% CI 0.67, 0.98]) and child social skills (g = 0.49 [95% CI 0.30, 0.68]). PCIT versus WL had larger effects in reducing disruptive behavior than PMT versus WL. In the few studies found, the addition of child CBT to PMT did not yield larger effects than PMT or WL. These results support offering PMT to children with clinical levels of disruptive behavior and highlight the additional benefits of PCIT for younger ages.

--- a/references_cache/DOI_10.1038_s41380-023-02383-7.md
+++ b/references_cache/DOI_10.1038_s41380-023-02383-7.md
@@ -1,0 +1,33 @@
+---
+reference_id: "DOI:10.1038/s41380-023-02383-7"
+title: "Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study"
+authors:
+- Leonard Frach
+- Wikus Barkhuizen
+- Andrea G. Allegrini
+- Helga Ask
+- Laurie J. Hannigan
+- Elizabeth C. Corfield
+- Ole A. Andreassen
+- Frank Dudbridge
+- Eivind Ystrom
+- Alexandra Havdahl
+- Jean-Baptiste Pingault
+journal: Molecular Psychiatry
+year: '2024'
+doi: 10.1038/s41380-023-02383-7
+content_type: abstract_only
+---
+
+# Examining intergenerational risk factors for conduct problems using polygenic scores in the Norwegian Mother, Father and Child Cohort Study
+**Authors:** Leonard Frach, Wikus Barkhuizen, Andrea G. Allegrini, Helga Ask, Laurie J. Hannigan, Elizabeth C. Corfield, Ole A. Andreassen, Frank Dudbridge, Eivind Ystrom, Alexandra Havdahl, Jean-Baptiste Pingault
+**Journal:** Molecular Psychiatry (2024)
+**DOI:** [10.1038/s41380-023-02383-7](https://doi.org/10.1038/s41380-023-02383-7)
+
+## Content
+
+Abstract
+
+                    The aetiology of conduct problems involves a combination of genetic and environmental factors, many of which are inherently linked to parental characteristics given parents’ central role in children’s lives across development. It is important to disentangle to what extent links between parental heritable characteristics and children’s behaviour are due to transmission of genetic risk or due to parental indirect genetic influences via the environment (i.e.,
+                    genetic nurture
+                    ). We used 31,290 genotyped mother-father-child trios from the Norwegian Mother, Father and Child Cohort Study (MoBa), testing genetic transmission and genetic nurture effects on conduct problems using 13 polygenic scores (PGS) spanning psychiatric conditions, substance use, education-related factors, and other risk factors. Maternal or self-reports of conduct problems at ages 8 and 14 years were available for up to 15,477 children. We found significant genetic transmission effects on conduct problems for 12 out of 13 PGS at age 8 years (strongest association: PGS for smoking, β = 0.07, 95% confidence interval = [0.05, 0.08]) and for 4 out of 13 PGS at age 14 years (strongest association: PGS for externalising problems, β = 0.08, 95% confidence interval = [0.05, 0.11]). Conversely, we did not find genetic nurture effects for conduct problems using our selection of PGS. Our findings provide evidence for genetic transmission in the association between parental characteristics and child conduct problems. Our results may also indicate that genetic nurture via traits indexed by our polygenic scores is of limited aetiological importance for conduct problems—though effects of small magnitude or effects via parental traits not captured by the included PGS remain a possibility.

--- a/references_cache/DOI_10.1038_s41398-024-02870-7.md
+++ b/references_cache/DOI_10.1038_s41398-024-02870-7.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.1038/s41398-024-02870-7"
+title: "Genetics of child aggression, a systematic review"
+authors:
+- Emiko Koyama
+- Tuana Kant
+- Atsushi Takata
+- James L. Kennedy
+- Clement C. Zai
+journal: Translational Psychiatry
+year: '2024'
+doi: 10.1038/s41398-024-02870-7
+content_type: abstract_only
+---
+
+# Genetics of child aggression, a systematic review
+**Authors:** Emiko Koyama, Tuana Kant, Atsushi Takata, James L. Kennedy, Clement C. Zai
+**Journal:** Translational Psychiatry (2024)
+**DOI:** [10.1038/s41398-024-02870-7](https://doi.org/10.1038/s41398-024-02870-7)
+
+## Content
+
+AbstractExcessive and persistent aggressiveness is the most common behavioral problem that leads to psychiatric referrals among children. While half of the variance in childhood aggression is attributed to genetic factors, the biological mechanism and the interplay between genes and environment that results in aggression remains elusive. The purpose of this systematic review is to provide an overview of studies examining the genetics of childhood aggression irrespective of psychiatric diagnosis. PubMed, PsycINFO, and MEDLINE databases were searched using predefined search terms for aggression, genes and the specific age group. From the 652 initially yielded studies, eighty-seven studies were systematically extracted for full-text review and for further quality assessment analyses. Findings show that (i) investigation of candidate genes, especially of MAOA (17 studies), DRD4 (13 studies), and COMT (12 studies) continue to dominate the field, although studies using other research designs and methods including genome-wide association and epigenetic studies are increasing, (ii) the published articles tend to be moderate in sizes, with variable methods of assessing aggressive behavior and inconsistent categorizations of tandem repeat variants, resulting in inconclusive findings of genetic main effects, gene-gene, and gene-environment interactions, (iii) the majority of studies are conducted on European, male-only or male-female mixed, participants. To our knowledge, this is the first study to systematically review the effects of genes on youth aggression. To understand the genetic underpinnings of childhood aggression, more research is required with larger, more diverse sample sets, consistent and reliable assessments and standardized definition of the aggression phenotypes. The search for the biological mechanisms underlying child aggression will also benefit from more varied research methods, including epigenetic studies, transcriptomic studies, gene system and genome-wide studies, longitudinal studies that track changes in risk/ameliorating factors and aggression-related outcomes, and studies examining causal mechanisms.

--- a/references_cache/DOI_10.1111_jcpp.13774.md
+++ b/references_cache/DOI_10.1111_jcpp.13774.md
@@ -1,0 +1,73 @@
+---
+reference_id: "DOI:10.1111/jcpp.13774"
+title: "Treatment of childhood disruptive behavior disorders and
+                    <scp>callous‐unemotional</scp>
+                    traits: a systematic review and two multilevel
+                    <scp>meta‐analyses</scp>"
+authors:
+- Samantha Perlstein
+- Maddy Fair
+- Emily Hong
+- Rebecca Waller
+journal: Journal of Child Psychology and Psychiatry
+year: '2023'
+doi: 10.1111/jcpp.13774
+content_type: abstract_only
+---
+
+# Treatment of childhood disruptive behavior disorders and
+                    <scp>callous‐unemotional</scp>
+                    traits: a systematic review and two multilevel
+                    <scp>meta‐analyses</scp>
+**Authors:** Samantha Perlstein, Maddy Fair, Emily Hong, Rebecca Waller
+**Journal:** Journal of Child Psychology and Psychiatry (2023)
+**DOI:** [10.1111/jcpp.13774](https://doi.org/10.1111/jcpp.13774)
+
+## Content
+
+Background
+Children with callous‐unemotional (CU) traits are at high lifetime risk of antisocial behavior. It is unknown if treatments for disruptive behavior disorders are as effective for children with CU traits (DBD+CU) as those without (DBD‐only), nor if treatments directly reduce CU traits. Separate multilevel meta‐analyses were conducted to compare treatment effects on DBD symptoms for DBD+CU versus DBD‐only children and evaluate direct treatment‐related reductions in CU traits, as well as to examine moderating factors for both questions.
+
+
+Methods
+We systematically searched PsycINFO, PubMed, Cochran Library (Trials), EMBASE, MEDLINE, APA PsycNet, Scopus, and Web of Science. Eligible studies were randomized controlled trials, controlled trials, and uncontrolled studies evaluating child‐focused, parenting‐focused, pharmacological, family‐focused, or multimodal treatments.
+
+
+Results
+
+                      Sixty studies with 9,405 participants were included (
+                      M
+age
+                       
+                      =
+                       10.04,
+                      SD
+age
+                       = 3.89 years, 25.09% female, 44.10% racial/ethnic minority). First, treatment was associated with similar reductions in DBD symptoms for DBD+CU (
+                      SMD
+                       = 1.08, 95% CI = 0.45, 1.72) and DBD‐only (
+                      SMD
+                       = 1.01, 95% CI = 0.38, 1.64). However, DBD+CU started (
+                      SMD
+                       = 1.18, 95% CI = 0.57, 1.80) and ended (
+                      SMD
+                       = 0.73,
+                      p
+                       < .001; 95% CI = 0.43, 1.04) treatment with more DBD symptoms. Second, although there was no overall direct effect of treatment on CU traits (
+                      SMD
+                       = .09, 95% CI = −0.02, 0.20), there were moderating factors. Significant treatment‐related reductions in CU traits were found for studies testing parenting‐focused components (
+                      SMD
+                       = 0.21, 95% CI = 0.06, 0.35), using parent‐reported measures (
+                      SMD
+                       = 0.16, 95% CI = 0.04, 0.28), rated as higher quality (
+                      SMD
+                       = 0.26, 95% CI = 0.13, 0.39), conducted outside the United States (
+                      SMD
+                       = 0.19, 95% CI = 0.05, 0.32), and with less than half the sample from a racial/ethnic minority group (
+                      SMD
+                       = 0.15, 95% CI = 0.002, 0.30).
+                    
+
+
+Conclusions
+DBD+CU children improve with treatment, but their greater DBD symptom severity requires specialized treatment modules that could be implemented alongside parenting programs. Conclusions are tempered by heterogeneity across studies and scant evidence from randomized controlled trials.

--- a/references_cache/DOI_10.1186_s13034-024-00710-6.md
+++ b/references_cache/DOI_10.1186_s13034-024-00710-6.md
@@ -1,0 +1,39 @@
+---
+reference_id: "DOI:10.1186/s13034-024-00710-6"
+title: "Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries"
+authors:
+- Christian J Bachmann
+- Oliver Scholle
+- Mette Bliddal
+- Susan dosReis
+- Ingvild Odsbu
+- Svetlana Skurtveit
+- Rikke Wesselhoeft
+- Annika Vivirito
+- Chengchen Zhang
+- Stephen Scott
+journal: Child and Adolescent Psychiatry and Mental Health
+year: '2024'
+doi: 10.1186/s13034-024-00710-6
+content_type: abstract_only
+---
+
+# Recognition and management of children and adolescents with conduct disorder: a real-world data study from four western countries
+**Authors:** Christian J Bachmann, Oliver Scholle, Mette Bliddal, Susan dosReis, Ingvild Odsbu, Svetlana Skurtveit, Rikke Wesselhoeft, Annika Vivirito, Chengchen Zhang, Stephen Scott
+**Journal:** Child and Adolescent Psychiatry and Mental Health (2024)
+**DOI:** [10.1186/s13034-024-00710-6](https://doi.org/10.1186/s13034-024-00710-6)
+
+## Content
+
+Abstract
+Background
+Conduct disorders (CD) are among the most frequent psychiatric disorders in children and adolescents, with an estimated worldwide prevalence in the community of 2–4%. Evidence-based psychological outpatient treatment leads to significant improvement in about two-thirds of cases. However, there seems to be considerable variation in rates of CD diagnoses and implementation of evidence-based interventions between nations. The aim of this study was to compare administrative prevalence and treatment patterns for CD in children and adolescents seen in health care systems across four Western countries (Denmark, Germany, Norway, and the USA).
+
+Methods
+Cross-sectional observational study using healthcare data to identify children and adolescents (aged 0–19 years) with an ICD-10 code for CD within the calendar year 2018. Within each country’s study population, the prevalence of CD, psychiatric comorbidity, psychopharmacological treatment, and psychiatric hospitalisation was calculated.
+
+Results
+The prevalence of diagnosed CD differed 31-fold between countries: 0.1% (Denmark), 0.3% (Norway), 1.1% (USA) and 3.1% (Germany), with a male/female ratio of 2.0–2.5:1. The rate of psychiatric comorbidity ranged from 69.7 to 86.1%, with attention-deficit/hyperactivity disorder being most common. Between 4.0% (Germany) and 12.2% (USA) of youths with a CD diagnosis were prescribed antipsychotic medication, and 1.2% (Norway) to 12.5% (Germany) underwent psychiatric hospitalisation.
+
+Conclusion
+Recognition and characteristics of youths diagnosed with CD varied greatly by country. In some countries, the administrative prevalence of diagnosed CD was markedly lower than the average estimated worldwide prevalence. This variation might reflect country-specific differences in CD prevalence, referral thresholds for mental health care, diagnostic tradition, and international variation in service organisation, CD recognition, and availability of treatment offers for youths with CD. The rather high rates of antipsychotic prescription and hospitalisation in some countries are remarkable, due to the lack of evidence for these therapeutic approaches. These findings stress the need of prioritising evidence-based treatment options in CD. Future research should focus on possible reasons for inter-country variation in recognition and management of CD, and also address possible differences in patient-level outcomes.

--- a/references_cache/clinicaltrials_NCT00676429.md
+++ b/references_cache/clinicaltrials_NCT00676429.md
@@ -1,0 +1,13 @@
+---
+reference_id: clinicaltrials:NCT00676429
+title: "Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial"
+content_type: summary
+---
+
+# Ziprasidone for Severe Conduct and Other Disruptive Behavior Disorders in Children and Adolescents - a Placebo Controlled, Randomized, Double Blind Clinical Trial
+
+## Content
+
+To investigate and compare the efficacy, safety and tolerability of ziprasidone versus placebo in the treatment of conduct disorder (CD), oppositional defiant disorder (ODD) and disruptive behavior disorder not otherwise specified (DBD-NOS) of older children and adolescents in an outpatient setting.
+
+Conduct and other behavior disorders are some of the most common forms of psychopathology in children and adolescents. The main characteristic of these disorders is a repetitive and persistent pattern of antisocial, aggressive or defiant behavior that involves major violations of age-appropriate expectations or norms. According to the guidelines of the German Society for Child \& Adolescent Psychiatry \& Psychotherapy (Deutsche Gesellschaft für Kinder- und Jugendpsychiatrie und -psychotherapie DGKJPP), the European Society for Child and Adolescent Psychiatry (ESCAP), and the American Academy of Child and Adolescent Psychiatry (AACAP) currently no standard pharmacotherapy is established and recommended for children and adolescents. However Risperidone has been shown to be effective in the treatment of patients with disruptive behavior disorders and below average IQ.

--- a/references_cache/clinicaltrials_NCT02828969.md
+++ b/references_cache/clinicaltrials_NCT02828969.md
@@ -1,0 +1,15 @@
+---
+reference_id: clinicaltrials:NCT02828969
+title: Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+content_type: summary
+---
+
+# Clinical Trajectory of Children and Adolescents With Disruptive Behavior Admitted to Pediatric and Psychiatric Emergencies.
+
+## Content
+
+Conduct disorders are defined as "repetitive and persistent pattern of behavior in which the basic rights of others or major age-appropriate norms are violated". So defined, these disorders are at the crossroads of psychiatry, social field and justice. Conduct disorder management is a public health issue and a societal question. Conduct disorders affect 5 to 9% of 15-year old boys.
+
+Care management of children and adolescents admitted for disruptive behaviors in emergency rooms is an issue. No consensus or official recommendation exists. However, use of emergency care in this context is increasing in most western countries and it exposes to several risks (inappropriate use of hospitalizations, social rupture, ignorance of comorbidities and suicide risk). The Trajectories project is designed to describe children and adolescents with disruptive behaviors, their care management and to follow their life trajectory and psychiatric evolution after admission to emergency rooms. Better understanding this population will improve their medical and social care management, thereby giving professionals the right tools.
+
+The main objective of this project is to implement a multidisciplinary and integrative research combining clinical considerations and social sciences to determine the "trajectory" of this population.

--- a/references_cache/clinicaltrials_NCT07091721.md
+++ b/references_cache/clinicaltrials_NCT07091721.md
@@ -1,0 +1,17 @@
+---
+reference_id: clinicaltrials:NCT07091721
+title: "The Mentalization Intervention for Children and Adolescents (MICA) Study: A Randomised Controlled Trial of Support for Aggressive and Violent Behaviour Via Forensic Child and Adolescent Mental Health Services (FCAMHS)"
+content_type: summary
+---
+
+# The Mentalization Intervention for Children and Adolescents (MICA) Study: A Randomised Controlled Trial of Support for Aggressive and Violent Behaviour Via Forensic Child and Adolescent Mental Health Services (FCAMHS)
+
+## Content
+
+The MICA Study is a research project that has been designed to work out how helpful mentalisation based therapy is. This is a new type of support that helps young people make sense of their own behaviours and feelings, and those of others. It involves meeting regularly with a mental health practitioner and parents/carers can be involved in some meetings too. It is hoped that this new type of support will help young people stop acting aggressively/violently.
+
+This project will be delivered in Forensic Child and Adolescent Mental Health Services (FCAMHS) in England. This service supports some of the most vulnerable young people in the country, who may also have involvement from other professionals including the Youth Justice System.
+
+The aim of the research is to make the support better for young people who use these services. This research involves doing a randomised controlled trial. This means half the young people will get the usual support from FCAMHS, and half will get the usual support plus the new support. The results will be used to compare mentalisation based therapy to the support FCAMHS usually provides. This will show the best way to support young people with their aggressive/violent behaviours.
+
+To start with, young people will answer a questionnaire. Following this, young people will receive either usual support or usual support plus MBT for six months. After this, young people will answer a questionnaire again. Some young people will be asked to take part in an optional interview to share their thoughts on this research. All young people aged 10-17 years who have been referred to a FCAMHS in England will be asked to take part, as long as they can speak and understand English. Some young people might not want to take part in this research and that will not change the support they receive.

--- a/research/Conduct_Disorder-deep-research-falcon.md
+++ b/research/Conduct_Disorder-deep-research-falcon.md
@@ -1,0 +1,1331 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-04-24T17:00:53.743204'
+end_time: '2026-04-24T17:16:26.109032'
+duration_seconds: 932.37
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Conduct Disorder
+  mondo_id: ''
+  category: Psychiatric
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 54
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Conduct Disorder
+- **MONDO ID:**  (if available)
+- **Category:** Psychiatric
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Conduct Disorder** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Conduct Disorder
+- **MONDO ID:**  (if available)
+- **Category:** Psychiatric
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Conduct Disorder** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Conduct Disorder (CD): Disease Characteristics Research Report (Psychiatric)
+
+## Target disease
+- **Disease name:** Conduct Disorder (CD) (DSM-5/DSM-5-TR terminology) (masi2023contemporarydiagnosisand pages 1-5)
+- **ICD-11 closest entity:** **Conduct-dissocial disorder** (ICD-11 code **6C91**) (ruotsalainen2022childhoodpsychopathyin pages 18-21)
+- **MONDO ID:** Not identified from the retrieved sources in this run (no MONDO mapping document retrieved).
+
+## Executive summary
+Conduct disorder is a childhood/adolescent-onset psychiatric disorder defined by a persistent pattern of behaviors violating the rights of others and major societal norms/rules, spanning aggression, property destruction, deceit/theft, and serious rule violations (masi2023contemporarydiagnosisand pages 1-5, ruotsalainen2022childhoodpsychopathyin pages 38-43). Modern classification emphasizes clinically meaningful heterogeneity via specifiers for **age of onset** and **limited prosocial emotions (LPE)/callous-unemotional (CU)** traits, which are associated with more severe antisocial trajectories and may moderate treatment response (masi2023contemporarydiagnosisand pages 5-7, masi2023contemporarydiagnosisand pages 1-5). Current evidence supports **psychosocial interventions as first-line**, especially parenting and family-involving approaches; medication is adjunctive and symptom-targeted (e.g., severe aggression, comorbid ADHD), with limited disorder-specific evidence (masi2023contemporarydiagnosisand pages 17-20, masi2023contemporarydiagnosisand pages 28-30).
+
+## Key structured facts (artifact)
+| Item | Key details | Best supporting source (author year) | URL | Evidence citation ID |
+|---|---|---|---|---|
+| Nosology / identifiers | **DSM-5/DSM-5-TR:** Conduct Disorder (CD), in the chapter *Disruptive, Impulse-Control, and Conduct Disorders*. **ICD-11:** *Conduct-dissocial disorder* code **6C91**, under disruptive behaviour/dissocial disorders. ICD-11 explicitly separates ODD and conduct-dissocial disorder and uses a lifespan approach. | Masi et al. 2023; Reed et al. 2019 | https://doi.org/10.1080/14737175.2023.2271169 ; https://doi.org/10.1002/wps.20611 | (masi2023contemporarydiagnosisand pages 1-5, ruotsalainen2022childhoodpsychopathyin pages 18-21) |
+| Core diagnostic domains / criteria summary | DSM framework: persistent, repetitive violation of others’ rights and age-appropriate norms; **15 criteria** across 4 domains: **aggression to people/animals, destruction of property, deceitfulness/theft, serious rule violations**. Diagnosis requires **≥3 criteria in 12 months** and **≥1 in past 6 months**, with clinically significant impairment. | Masi et al. 2023; Ruotsalainen 2022 | https://doi.org/10.1080/14737175.2023.2271169 | (masi2023contemporarydiagnosisand pages 1-5, ruotsalainen2022childhoodpsychopathyin pages 38-43) |
+| ICD-11 diagnostic structure | ICD-11 conduct-dissocial disorder uses similar 4 behavioural groupings; evidence summarized in recent review notes ICD-11 requires a **persistent pattern over at least 12 months** and includes affective/interpersonal qualifiers. | Özbay et al. 2024 | https://doi.org/10.18863/pgy.1331287 | (ozbay2024conductdisorderan pages 5-7) |
+| Age-of-onset specifiers | **Childhood-onset:** at least 1 symptom before age 10. **Adolescent-onset:** no symptoms before age 10. Childhood-onset is linked to earlier onset, greater severity, neurobiological vulnerability, and worse long-term outcomes than later-onset presentations. | Masi et al. 2023 | https://doi.org/10.1080/14737175.2023.2271169 | (masi2023contemporarydiagnosisand pages 5-7, masi2023contemporarydiagnosisand pages 1-5) |
+| Limited prosocial emotions / callous-unemotional specifier | DSM-5 **with Limited Prosocial Emotions (LPE)** / CU traits: at least **2 of 4** traits for **12 months across settings**: lack of remorse/guilt, callous-lack of empathy, unconcern about performance, shallow/deficient affect. Associated with more severe antisocial behaviour and poorer prognosis/treatment response. | Masi et al. 2023 | https://doi.org/10.1080/14737175.2023.2271169 | (masi2023contemporarydiagnosisand pages 5-7, ruotsalainen2022childhoodpsychopathyin pages 38-43) |
+| ICD-11 LPE-related qualifier | ICD-11 includes an LPE-related qualifier and, compared with DSM-5, adds an indicator related to **indifference to punishment**; recent summaries note qualifier use in conduct-dissocial disorder and ODD. | Masi et al. 2023; Ruotsalainen 2022 | https://doi.org/10.1080/14737175.2023.2271169 | (masi2023contemporarydiagnosisand pages 5-7, ruotsalainen2022childhoodpsychopathyin pages 47-48) |
+| Recent epidemiology: community prevalence | Recent reviews cite **global prevalence ~1.5%** and broader community estimates often **2–4%**; a recent European estimate reported **1.5% overall**, **1.8% in males**, **1.0% in females**. | Masi et al. 2023; Özbay et al. 2024; Bachmann et al. 2024 | https://doi.org/10.1080/14737175.2023.2271169 ; https://doi.org/10.18863/pgy.1331287 ; https://doi.org/10.1186/s13034-024-00710-6 | (masi2023contemporarydiagnosisand pages 1-5, ozbay2024conductdisorderan pages 7-8) |
+| Sex ratio / demographic pattern | Boys show roughly **2:1** higher prevalence than girls; recent real-world cross-country study found male:female ratio **2.0–2.5:1** for diagnosed CD. Boys more often show physical aggression/property damage; girls more often serious rule violations/relational aggression. | Bachmann et al. 2024; Masi et al. 2023 | https://doi.org/10.1186/s13034-024-00710-6 ; https://doi.org/10.1080/14737175.2023.2271169 | (masi2023contemporarydiagnosisand pages 1-5) |
+| Real-world administrative prevalence variation | Among youths aged 0–19 years in 2018 health-system data, diagnosed CD prevalence differed **31-fold** across countries: **0.1% Denmark, 0.3% Norway, 1.1% USA, 3.1% Germany**; comorbidity was high (**69.7–86.1%**), ADHD most common. | Bachmann et al. 2024 | https://doi.org/10.1186/s13034-024-00710-6 | (masi2023contemporarydiagnosisand pages 1-5) |
+| Psychosocial treatment meta-analysis (adolescents) | 2023 meta-analysis of **17 RCTs / 1,954 adolescents** found psychosocial treatments had a **large short-term effect** on externalizing symptoms (**SMD ≈ 0.98** in magnitude at endpoint), but benefit **did not persist at follow-up**; family-format interventions were most effective. | Boldrini et al. 2023 | https://doi.org/10.1016/j.jaac.2022.05.002 | (boldrini2023systematicreviewand pages 6-9, boldrini2023systematicreviewand pages 16-19) |
+| Parent Management Training (PMT) | 2024 meta-analysis of **25 RCTs** in children with clinical disruptive behaviour found **PMT vs waiting list: g = 0.64 (95% CI 0.42–0.86)** for reducing parent-rated disruptive behaviour; PMT also improved parental skills (**g = 0.83**) and child social skills (**g = 0.49**). | Helander et al. 2024 | https://doi.org/10.1007/s10578-022-01367-y | (helander2024theefficacyof pages 1-2) |
+| Parent–Child Interaction Therapy (PCIT) | Same 2024 meta-analysis found **PCIT vs waiting list: g = 1.22 (95% CI 0.75–1.69)**, larger than PMT for younger children with disruptive behaviour. | Helander et al. 2024 | https://doi.org/10.1007/s10578-022-01367-y | (helander2024theefficacyof pages 1-2) |
+| PMT + child CBT | In the limited available studies, adding child-directed CBT to PMT **did not show added benefit** over PMT alone. | Helander et al. 2024 | https://doi.org/10.1007/s10578-022-01367-y | (helander2024theefficacyof pages 1-2) |
+| DBD with CU/LPE traits treatment response | 2023 multilevel meta-analysis of **60 studies / 9,405 participants**: treatment reduced DBD symptoms similarly in **DBD+CU (SMD = 1.08)** and **DBD-only (SMD = 1.01)**, but CU/LPE youths started and ended treatment with more severe symptoms; parenting-focused components showed small direct reductions in CU traits (**SMD = 0.21**). | Perlstein et al. 2023 | https://doi.org/10.1111/jcpp.13774 | (perlstein2023treatmentofchildhood pages 1-3, perlstein2023treatmentofchildhood pages 11-12) |
+| Functional Family Therapy (FFT) evidence | 2023 Campbell review: **20 studies** (15 meta-analyzable; **10,980 families**). Pairwise meta-analysis found **no clear evidence of benefit** of FFT over active comparators on primary outcomes; overall correlated-effects estimate **SMD = 0.19, SE = 0.09**, not significantly different from zero; certainty **very low**. | Littell et al. 2023 | https://doi.org/10.1002/cl2.1324 | (littell2023functionalfamilytherapy pages 1-2) |
+| Treatment hierarchy / implementation takeaway | Expert reviews recommend **psychosocial interventions first-line**; medications are **adjunctive, symptom-targeted** (e.g., severe aggression, emotional dysregulation, comorbid ADHD), not disease-specific first-line therapy. | Masi et al. 2023 | https://doi.org/10.1080/14737175.2023.2271169 | (masi2023contemporarydiagnosisand pages 17-20, masi2023contemporarydiagnosisand pages 1-5, masi2023contemporarydiagnosisand pages 28-30) |
+
+
+*Table: This table summarizes core nosology, diagnostic structure, specifiers, epidemiology, and treatment-effect evidence for Conduct Disorder / ICD-11 conduct-dissocial disorder. It is designed as a compact knowledge-base artifact with direct links and context-ID citations for rapid reuse.*
+
+---
+
+## 1. Disease information
+
+### 1.1 Overview / definition
+Conduct disorder (CD) is characterized by “persistent, repetitive behaviors that violate societal norms and others’ rights” (reviewed in contemporary clinical synthesis) (masi2023contemporarydiagnosisand pages 1-5). DSM-5-TR places CD within *Disruptive, Impulse-Control, and Conduct Disorders* (masi2023contemporarydiagnosisand pages 1-5).
+
+**Core symptom domains (DSM framing):**
+- Aggression toward people/animals
+- Destruction of property
+- Deceitfulness or theft
+- Serious violations of rules (masi2023contemporarydiagnosisand pages 1-5, ruotsalainen2022childhoodpsychopathyin pages 38-43)
+
+**DSM-5 diagnostic threshold (summary):** ≥3 of 15 criteria in the past 12 months, with ≥1 present in the last 6 months, plus clinically significant impairment (ruotsalainen2022childhoodpsychopathyin pages 38-43, ozbay2024conductdisorderan pages 2-3).
+
+### 1.2 Key identifiers / terminologies
+- **ICD-11:** conduct-dissocial disorder (**6C91**) (ruotsalainen2022childhoodpsychopathyin pages 18-21)
+- **ICD-11 grouping:** described as under disruptive behaviour/dissocial disorders in secondary summaries (ozbay2024conductdisorderan pages 5-7)
+- **MeSH / OMIM / Orphanet:** Not identified from retrieved sources in this run.
+
+### 1.3 Synonyms / alternative names
+- “Conduct-dissocial disorder” (ICD-11 naming) (ruotsalainen2022childhoodpsychopathyin pages 18-21)
+- “Disruptive behavior disorders” (DBDs; an umbrella term often used in treatment evidence that includes CD and ODD) (boldrini2023systematicreviewand pages 6-9, perlstein2023treatmentofchildhood pages 1-3)
+
+### 1.4 Evidence source type
+This report is derived from **aggregated disease-level resources** (systematic reviews, meta-analyses, expert reviews) and selected **primary clinical/epidemiologic studies** (e.g., administrative prevalence comparisons; cohort/AI prediction studies) (boldrini2023systematicreviewand pages 6-9, helander2024theefficacyof pages 1-2, lacy2023selectivelypredictingthe pages 1-2).
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (multifactorial)
+Recent expert synthesis emphasizes CD as etiologically heterogeneous and multifactorial, involving genetic, individual neurodevelopmental, and psychosocial factors (masi2023contemporarydiagnosisand pages 1-5).
+
+### 2.2 Risk factors
+
+#### 2.2.1 Genetic liability (polygenic)
+Childhood aggression (closely related to conduct problems/CD phenotypes) is consistently reported as substantially heritable in modern synthesis.
+- **Abstract quote:** “While half of the variance in childhood aggression is attributed to genetic factors…” (Koyama et al., 2024) (koyama2024geneticsofchild pages 1-2).
+- Candidate gene literature has historically focused on monoaminergic and catecholaminergic genes such as **MAOA, DRD4, COMT**, though conclusions are often inconsistent due to sample size and phenotyping heterogeneity (koyama2024geneticsofchild pages 3-4, koyama2024geneticsofchild pages 1-2).
+
+**Polygenic score (PGS) transmission evidence (parent–child trios):**
+- **Abstract quote:** “We found significant genetic transmission effects on conduct problems for 12 out of 13 PGS at age 8 years (strongest association: PGS for smoking, β = 0.07…) … Conversely, we did not find genetic nurture effects…” (Frach et al., 2024; MoBa trios n=31,290) (frach2024examiningintergenerationalrisk pages 1-2).
+
+#### 2.2.2 Environmental and social risk factors
+A recent update review summarizes evidence that exposure to social violence is associated with markedly increased likelihood of CD (e.g., “two- and four-fold” increased likelihood for witnessing vs being a victim) (ozbay2024conductdisorderan pages 7-8). Although this is not a mechanistic causal claim, it supports violence exposure as a prominent risk correlate.
+
+#### 2.2.3 Physiological correlates are not necessarily causal
+A Mendelian randomization study testing low resting heart rate (RHR) as a potential causal risk factor for antisocial behavior (ASB; related to CD spectrum) found **no evidence of a causal association**, indicating some observed physiological associations may reflect confounding.
+- **Abstract quote:** “No causal association was observed between RHR and ASB…” and “previously observed associations… may arise from confounding…” (Karwatowska et al., 2023) (masi2023contemporarydiagnosisand pages 5-7).
+
+### 2.3 Protective factors
+Direct protective-factor estimates specific to CD were not available from the retrieved sources. However, in intergenerational genetic work, PGS for educational attainment were negatively associated with conduct problems, consistent with a broader protective correlation pattern (frach2024examiningintergenerationalrisk pages 6-7).
+
+### 2.4 Gene–environment interactions (GxE)
+Modern genetic synthesis of childhood aggression notes the field increasingly studies GxE and reports examples (e.g., genetic effects moderated by parenting/social feedback, maltreatment-linked moderation in stress-response genes), but emphasizes inconsistent findings due to methodological heterogeneity (koyama2024geneticsofchild pages 23-24, koyama2024geneticsofchild pages 3-4).
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core behavioral phenotype domains (DSM)
+Phenotypes correspond to the DSM domains above (aggression; property destruction; deceit/theft; serious rule violations) (masi2023contemporarydiagnosisand pages 1-5, ruotsalainen2022childhoodpsychopathyin pages 38-43).
+
+**Suggested HPO term mappings (proposed; approximate):**
+- Aggressive behavior (**HP:0000718**; “Aggression”) — maps to aggression domain.
+- Antisocial behavior (**HP:0031932**; if available in current HPO versions) — maps to rights/norm violations.
+- Impulsivity (**HP:0000737**) — commonly comorbid/related externalizing dimension.
+- Deceitful behavior / pathological lying (HPO term availability varies; may map via broader “Abnormal social behavior” **HP:0000730**).
+
+*(Note: HPO term IDs are suggested mappings for knowledge-base normalization; they were not extracted from the cited papers.)*
+
+### 3.2 Specifiers / clinical subtypes
+
+#### 3.2.1 Age-of-onset specifiers
+DSM subtyping includes:
+- **Childhood-onset:** ≥1 symptom before age 10.
+- **Adolescent-onset:** symptoms begin after age 10. (masi2023contemporarydiagnosisand pages 1-5)
+
+Childhood-onset presentations are described as associated with earlier onset, greater severity, and worse long-term outcomes (including substance abuse and criminality) in expert synthesis (masi2023contemporarydiagnosisand pages 5-7).
+
+#### 3.2.2 Limited prosocial emotions (LPE) / callous-unemotional (CU) traits
+DSM-5 LPE specifier criteria (summary): at least **2 of 4 features** for **12 months** across relationships/settings—lack of remorse/guilt, callousness/lack of empathy, unconcern about performance, shallow/deficient affect (masi2023contemporarydiagnosisand pages 5-7, ruotsalainen2022childhoodpsychopathyin pages 38-43).
+
+**Abstract-linked context from expert review:** the specifier aims to identify a developmental trajectory toward adult antisocial outcomes (masi2023contemporarydiagnosisand pages 5-7).
+
+**Longitudinal prognosis relevance (2023):** A 10-year prospective study in residential care reported that LPE is associated with future offending, with dimensional LPE score retaining association with violent offending after adjustment for prior violent offending.
+- **Abstract quote:** “the dimensional LPE score was associated with both future general and violent offending… [and] remained significant even after controlling for gender, age, and prior violent offending.” (Boonmann et al., 2023) (masi2023contemporarydiagnosisand pages 5-7).
+
+### 3.3 Comorbidity patterns
+High psychiatric comorbidity is typical in health-system cohorts.
+- A cross-country administrative study reported comorbidity rates **69.7–86.1%**, with ADHD most common (Bachmann et al., 2024 abstract) (masi2023contemporarydiagnosisand pages 5-7).
+
+---
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes
+Conduct disorder is not a Mendelian disorder; **no single causal gene** is established. Available evidence supports **polygenic** and **multifactorial** architecture (frach2024examiningintergenerationalrisk pages 1-2, koyama2024geneticsofchild pages 1-2).
+
+### 4.2 Candidate genes / pathways studied
+A recent systematic review of childhood aggression genetics (often used as an etiologic window into CD-spectrum behaviors) reports dominance of candidate gene research, particularly:
+- **MAOA** (17 studies)
+- **DRD4** (13 studies)
+- **COMT** (12 studies) (koyama2024geneticsofchild pages 1-2)
+
+However, the same review emphasizes inconsistent results and methodological limitations (moderate sample sizes, heterogeneous phenotyping) (koyama2024geneticsofchild pages 1-2).
+
+### 4.3 Polygenic risk / PGS
+Intergenerational trio analyses show measurable transmission effects across multiple parental-trait PGS with conduct problems at ages 8 and 14, with limited evidence of genetic nurture in the tested PGS set (frach2024examiningintergenerationalrisk pages 1-2).
+
+### 4.4 Epigenetics / transcriptomics
+Epigenetic and transcriptomic approaches are described as increasing in frequency in aggression genetics research, but no specific replicated biomarkers for CD were identified in the retrieved evidence (koyama2024geneticsofchild pages 1-2).
+
+---
+
+## 5. Environmental information
+Direct toxin/pathogen associations were not identified in the retrieved sources. The strongest available environmental evidence in this run pertains to **violence exposure** as a risk correlate and to broader psychosocial determinants highlighted in predictive modeling work (ozbay2024conductdisorderan pages 7-8, lacy2023selectivelypredictingthe pages 1-2).
+
+---
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Neurocognitive and neurocircuit mechanisms (current understanding)
+Expert synthesis links CD/CU phenotypes to dysfunction in systems supporting empathy and social learning.
+- Altered **amygdala responses** and dysfunction in other regions involved in empathy/social learning are described in fMRI literature; CU traits show reduced recognition/response to emotional stimuli across behavioral and physiological measures (masi2023contemporarydiagnosisand pages 7-10).
+
+**Causal chain (conceptual):** early neurodevelopmental and environmental risks → atypical emotional learning/empathy and/or threat processing (e.g., amygdala-related processing) → persistent antisocial rule-violating behavior patterns; CU/LPE traits represent a subgroup with diminished prosocial emotional processing and more stable/severe antisocial trajectories (masi2023contemporarydiagnosisand pages 5-7, masi2023contemporarydiagnosisand pages 7-10).
+
+### 6.2 Physiological arousal and aggression subtypes
+Reactive aggression is described as associated with physiological overarousal and poor emotion regulation (masi2023contemporarydiagnosisand pages 7-10).
+
+### 6.3 Biomarkers and molecular profiling: current limitations
+A high-authority World Psychiatry systematic review assessed candidate diagnostic biomarkers (biochemical, neuroimaging, neurophysiological, etc.) across pediatric neurodevelopmental disorders and reported **no biomarker** meeting replication criteria of ≥80% sensitivity and specificity in ≥2 independent studies (cortese2023candidatediagnosticbiomarkers pages 1-2).
+- **Abstract quote:** “we could not find any biomarker for which there was evidence… of specificity and sensitivity of at least 80%.” (Cortese et al., 2023) (cortese2023candidatediagnosticbiomarkers pages 1-2).
+
+For conduct disorder/externalizing biomarker evidence specifically, the same review found only limited cross-sectional evidence with poor replication.
+- “Only a single study achieved sensitivity and specificity ≥80%… There were no biomarkers for which sensitivity, specificity, PPV, NPV and ROC AUC had been evaluated in more than one study…” (Cortese et al., 2023) (cortese2023candidatediagnosticbiomarkers pages 12-13).
+
+**Implication:** at present, biomarkers are not ready for routine CD diagnosis; research-grade predictive modeling exists but requires external validation and implementation studies.
+
+### 6.4 Advanced technologies: AI prediction using multimodal features
+A 2023 ABCD-based study used deep learning to predict future onset of CD/ODD/ADHD over 2 years using multimodal features including neuroimaging, physiology, and psychosocial measures.
+- **Abstract quote:** “Multimodal models achieved ~86–97% accuracy, 0.919–0.996 AUROC…” (de Lacy & Ramshaw, 2023) (lacy2023selectivelypredictingthe pages 1-2).
+This suggests potential for risk prediction, but the authors emphasize the need for external validation and generalizability assessment (lacy2023selectivelypredictingthe pages 1-2).
+
+**Suggested GO biological process terms (conceptual mapping):**
+- Social behavior (GO:0035176)
+- Regulation of emotional behavior (GO:0046834)
+- Learning (GO:0007612)
+
+**Suggested Cell Ontology / UBERON mappings (conceptual):**
+- Amygdala (UBERON:0001876)
+- Prefrontal cortex (UBERON:0000451)
+- Neurons (CL:0000540)
+- Microglia (CL:0000129) *(note: microglia were not specifically evidenced for CD in retrieved sources; included only as a general CNS immune cell type)*
+
+---
+
+## 7. Anatomical structures affected
+Primary involvement is neuropsychiatric/behavioral, implicating brain circuits for emotion regulation, empathy, and reward/threat learning.
+- Evidence emphasizes **amygdala** and broader networks supporting empathy and social learning in CD/CU traits (masi2023contemporarydiagnosisand pages 7-10).
+
+Suggested UBERON structures (conceptual mapping):
+- Amygdala (UBERON:0001876)
+- Prefrontal cortex (UBERON:0000451)
+
+---
+
+## 8. Temporal development
+
+### 8.1 Onset
+CD onset is typically during school years or early adolescence; DSM-5 uses onset before vs after age 10 for subtype specification (masi2023contemporarydiagnosisand pages 1-5).
+
+### 8.2 Progression / course
+Expert synthesis describes developmental shifts: aggressive behaviors tend to decline with age, while non-aggressive rule violations increase in adolescence (masi2023contemporarydiagnosisand pages 1-5).
+
+### 8.3 Critical periods
+The frequent developmental sequence from ODD to CD, with CD sometimes emerging before school age, supports early prevention and early treatment as critical (masi2023contemporarydiagnosisand pages 5-7).
+
+---
+
+## 9. Inheritance and population
+
+### 9.1 Epidemiology (recent estimates)
+Recent expert review and update articles report community prevalence in the low single-digit percentages.
+- Global prevalence around **~1.5%** (expert review summary) (masi2023contemporarydiagnosisand pages 1-5).
+- Recent European estimate summarized as **1.5% overall; 1.8% males; 1.0% females** (secondary review citing Sacco et al. 2021) (ozbay2024conductdisorderan pages 7-8).
+
+### 9.2 Sex ratio
+Male prevalence is consistently higher than female prevalence, approximately ~2:1 in multiple sources.
+- Boys 3–4% vs girls 0.5–1% cited in expert synthesis (masi2023contemporarydiagnosisand pages 1-5).
+
+### 9.3 Administrative prevalence variation across countries (real-world data)
+A 2024 real-world data study compared 2018 health-system data across Denmark, Norway, USA, and Germany.
+- **Abstract quote (prevalence):** “The prevalence of diagnosed CD differed 31-fold between countries: 0.1% (Denmark), 0.3% (Norway), 1.1% (USA) and 3.1% (Germany)…” (Bachmann et al., 2024) (masi2023contemporarydiagnosisand pages 5-7).
+- **Abstract quote (sex ratio):** “…with a male/female ratio of 2.0–2.5:1.” (Bachmann et al., 2024) (masi2023contemporarydiagnosisand pages 5-7).
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical criteria (DSM-5 framing)
+Diagnosis relies on clinical/behavioral criteria (no validated diagnostic biomarker).
+- DSM-5 criteria are organized across four behavioral domains; diagnosis requires persistence and impairment (ruotsalainen2022childhoodpsychopathyin pages 38-43, ozbay2024conductdisorderan pages 2-3).
+
+### 10.2 ICD-11 diagnostic framing
+ICD-11 uses conduct-dissocial disorder (6C91) with similar behavioral groupings and an emphasized duration threshold (secondary summary indicates 12 months vs 6 months in ICD-10) (ozbay2024conductdisorderan pages 5-7).
+
+### 10.3 Differential diagnosis / assessment considerations
+High comorbidity with ADHD is common; comorbidity complicates specificity of candidate biomarkers and requires careful clinical assessment (cortese2023candidatediagnosticbiomarkers pages 2-3).
+
+### 10.4 Biomarkers and omics-based diagnostics
+Not clinically established.
+- **Abstract quote:** no biomarker met pre-specified replication standards (Cortese et al., 2023) (cortese2023candidatediagnosticbiomarkers pages 1-2).
+
+---
+
+## 11. Outcome / prognosis
+
+### 11.1 Prognosis by subtype
+Childhood-onset CD and CU/LPE traits are linked to worse longitudinal outcomes in expert synthesis (e.g., persistence, severity, antisocial trajectory) (masi2023contemporarydiagnosisand pages 5-7).
+
+### 11.2 Offending and long-term antisocial outcomes
+Longitudinal evidence supports LPE/CU traits as relevant to future offending risk, but effect sizes are influenced by static risk factors (gender, prior offending).
+- **Abstract quote:** “This relationship… should not be overestimated, as there are other (static) factors (e.g. gender and prior offending behavior)…” (Boonmann et al., 2023) (masi2023contemporarydiagnosisand pages 5-7).
+
+---
+
+## 12. Treatment
+
+### 12.1 First-line: psychosocial interventions (evidence base)
+The best-supported treatments are psychosocial, especially parenting and family-involving interventions.
+
+**Adolescents (psychosocial treatments):**
+- A 2023 systematic review/meta-analysis (17 RCTs; n=1,954) found short-term improvement in disruptive/externalizing outcomes, with limited durability at follow-up.
+  - **Abstract/summary evidence:** large endpoint effects and family-format interventions most effective; effects did not persist at follow-up (boldrini2023systematicreviewand pages 6-9).
+
+**Children (parent-focused treatments):**
+- Parent Management Training (PMT) and Parent–Child Interaction Therapy (PCIT) show moderate-to-large effects vs waitlist.
+  - **Abstract quote:** “PMT (g = 0.64…) and PCIT (g = 1.22…) were more effective than waiting-list…” (Helander et al., 2024) (helander2024theefficacyof pages 1-2).
+
+**DBD with CU/LPE traits:**
+- **Abstract quote:** “Treatment was associated with similar reductions in DBD symptoms for DBD+CU (SMD = 1.08…) and DBD-only (SMD = 1.01…)… [but] no overall direct effect… on CU traits (SMD = .09…).” (Perlstein et al., 2023) (perlstein2023treatmentofchildhood pages 1-3).
+
+**MAXO suggestions (treatment actions; conceptual mapping):**
+- Behavioral parent training / parenting intervention (MAXO: behavioral therapy / parent training; exact MAXO IDs not retrieved)
+- Family therapy (FFT/MST modalities)
+- Cognitive behavioral therapy (CBT) modules for anger, problem-solving, emotion regulation
+
+### 12.2 Real-world implementation: variation in treatment patterns
+Real-world administrative data show substantial between-country variation and notable psychopharmacology use.
+- **Abstract quote:** “Between 4.0% (Germany) and 12.2% (USA) of youths with a CD diagnosis were prescribed antipsychotic medication…” (Bachmann et al., 2024) (masi2023contemporarydiagnosisand pages 5-7).
+
+### 12.3 Pharmacotherapy (adjunctive, symptom-targeted)
+Contemporary expert reviews emphasize medications are not first-line for CD itself, but can target severe aggression, irritability, emotional dysregulation, or comorbid ADHD.
+- “psychosocial… interventions are the primary (first-line) treatments… Pharmacological treatments are considered adjunctive and targeted” (masi2023contemporarydiagnosisand pages 25-28).
+- Limited licensing: risperidone has a narrow indication for short-term persistent aggression in DBD with intellectual disability (masi2023contemporarydiagnosisand pages 17-20).
+
+**Medication classes commonly discussed for target symptoms:**
+- **Stimulants** when ADHD is comorbid; meta-analytic evidence indicates stimulants reduce pediatric aggression (masi2023contemporarydiagnosisand pages 22-25).
+- **Second-generation antipsychotics** (notably risperidone; also aripiprazole/olanzapine/quetiapine) for severe aggression; metabolic risks require monitoring and time-limited use (masi2023contemporarydiagnosisand pages 28-30, masi2023contemporarydiagnosisand pages 50-52).
+- **Mood stabilizers** (e.g., lithium; divalproex) for aggression/emotional dysregulation with modest average effects (masi2023contemporarydiagnosisand pages 22-25).
+
+**MAXO suggestions (pharmacologic actions; conceptual mapping):**
+- Antipsychotic therapy
+- Psychostimulant therapy
+- Mood stabilizer therapy
+
+---
+
+## 13. Prevention
+Evidence specific to CD prevention programs was not comprehensively retrieved in this run; however, the etiologic and course evidence indicates early intervention is important because CD may follow ODD and can emerge before school age (masi2023contemporarydiagnosisand pages 5-7).
+
+Clinical trial registry entries retrieved include prevention-oriented and stepped-care behavioral interventions for conduct problems (not cited here because corresponding trial text evidence was not gathered in this run).
+
+---
+
+## 14. Other species / natural disease
+No primary comparative psychiatry evidence for conduct disorder analogs in other species was retrieved in this run.
+
+---
+
+## 15. Model organisms
+No conduct-disorder-specific model organism paper was retrieved in this run. Genetic and neurobiological syntheses emphasize that translational progress may benefit from diverse methods (including longitudinal and multi-omics approaches), but specific animal model evidence was not captured in the retrieved sources (koyama2024geneticsofchild pages 1-2).
+
+---
+
+## Expert opinion and analysis (authoritative synthesis)
+A major recent expert review stresses that CD is heterogeneous and that careful subtyping (age of onset, CU/LPE traits, emotional dysregulation, comorbidity) is crucial for prognosis and treatment selection (masi2023contemporarydiagnosisand pages 1-5). The same synthesis emphasizes a stepped-care logic: psychosocial interventions first; medications only when necessary to target specific severe dimensions (aggression/ADHD/emotional reactivity) and with cautious monitoring given limited evidence quality and adverse-effect risks (masi2023contemporarydiagnosisand pages 17-20, masi2023contemporarydiagnosisand pages 28-30).
+
+---
+
+## URLs and publication dates (selected key sources used)
+- Masi G. et al. **Oct 2023**. *Expert Review of Neurotherapeutics*. https://doi.org/10.1080/14737175.2023.2271169 (masi2023contemporarydiagnosisand pages 1-5)
+- Özbay A. et al. **Mar 2024**. *Psikiyatride Güncel Yaklaşımlar*. https://doi.org/10.18863/pgy.1331287 (ozbay2024conductdisorderan pages 1-2)
+- Frach L. et al. **Jan 2024**. *Molecular Psychiatry*. https://doi.org/10.1038/s41380-023-02383-7 (frach2024examiningintergenerationalrisk pages 1-2)
+- Koyama E. et al. **Jun 2024**. *Translational Psychiatry*. https://doi.org/10.1038/s41398-024-02870-7 (koyama2024geneticsofchild pages 1-2)
+- Cortese S. et al. **Jan 2023**. *World Psychiatry*. https://doi.org/10.1002/wps.21037 (cortese2023candidatediagnosticbiomarkers pages 1-2)
+- Helander M. et al. **Jul 2024**. *Child Psychiatry & Human Development*. https://doi.org/10.1007/s10578-022-01367-y (helander2024theefficacyof pages 1-2)
+- Perlstein S. et al. **Mar 2023**. *JCPP*. https://doi.org/10.1111/jcpp.13774 (perlstein2023treatmentofchildhood pages 1-3)
+- Boldrini T. et al. **May 2023**. *JAACAP*. https://doi.org/10.1016/j.jaac.2022.05.002 (boldrini2023systematicreviewand pages 6-9)
+- Bachmann C.J. et al. **Jan 2024**. *Child and Adolescent Psychiatry and Mental Health*. https://doi.org/10.1186/s13034-024-00710-6 (masi2023contemporarydiagnosisand pages 5-7)
+- de Lacy N. & Ramshaw M.J. **Dec 2023**. *Frontiers in Psychiatry*. https://doi.org/10.3389/fpsyt.2023.1280326 (lacy2023selectivelypredictingthe pages 1-2)
+
+
+References
+
+1. (masi2023contemporarydiagnosisand pages 1-5): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+2. (ruotsalainen2022childhoodpsychopathyin pages 18-21): N Ruotsalainen. Childhood psychopathy in defining heterogeneity of conduct problems. Unknown journal, 2022.
+
+3. (ruotsalainen2022childhoodpsychopathyin pages 38-43): N Ruotsalainen. Childhood psychopathy in defining heterogeneity of conduct problems. Unknown journal, 2022.
+
+4. (masi2023contemporarydiagnosisand pages 5-7): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+5. (masi2023contemporarydiagnosisand pages 17-20): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+6. (masi2023contemporarydiagnosisand pages 28-30): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+7. (ozbay2024conductdisorderan pages 5-7): Ahmet ÖZBAY, Osman ÖZÇELİK, and Süleyman KAHRAMAN. Conduct disorder: an update. Psikiyatride Güncel Yaklaşımlar, 16:72-87, Mar 2024. URL: https://doi.org/10.18863/pgy.1331287, doi:10.18863/pgy.1331287. This article has 3 citations.
+
+8. (ruotsalainen2022childhoodpsychopathyin pages 47-48): N Ruotsalainen. Childhood psychopathy in defining heterogeneity of conduct problems. Unknown journal, 2022.
+
+9. (ozbay2024conductdisorderan pages 7-8): Ahmet ÖZBAY, Osman ÖZÇELİK, and Süleyman KAHRAMAN. Conduct disorder: an update. Psikiyatride Güncel Yaklaşımlar, 16:72-87, Mar 2024. URL: https://doi.org/10.18863/pgy.1331287, doi:10.18863/pgy.1331287. This article has 3 citations.
+
+10. (boldrini2023systematicreviewand pages 6-9): Tommaso Boldrini, Viola Ghiandoni, Elisa Mancinelli, Silvia Salcuni, and Marco Solmi. Systematic review and meta-analysis: psychosocial treatments for disruptive behavior symptoms and disorders in adolescence. Journal of the American Academy of Child and Adolescent Psychiatry, May 2023. URL: https://doi.org/10.1016/j.jaac.2022.05.002, doi:10.1016/j.jaac.2022.05.002. This article has 17 citations and is from a highest quality peer-reviewed journal.
+
+11. (boldrini2023systematicreviewand pages 16-19): Tommaso Boldrini, Viola Ghiandoni, Elisa Mancinelli, Silvia Salcuni, and Marco Solmi. Systematic review and meta-analysis: psychosocial treatments for disruptive behavior symptoms and disorders in adolescence. Journal of the American Academy of Child and Adolescent Psychiatry, May 2023. URL: https://doi.org/10.1016/j.jaac.2022.05.002, doi:10.1016/j.jaac.2022.05.002. This article has 17 citations and is from a highest quality peer-reviewed journal.
+
+12. (helander2024theefficacyof pages 1-2): Maria Helander, Martin Asperholm, Dan Wetterborg, Lars-Göran Öst, Clara Hellner, Agneta Herlitz, and Pia Enebrink. The efficacy of parent management training with or without involving the child in the treatment among children with clinical levels of disruptive behavior: a meta-analysis. Child Psychiatry and Human Development, 55:164-181, Jul 2024. URL: https://doi.org/10.1007/s10578-022-01367-y, doi:10.1007/s10578-022-01367-y. This article has 69 citations and is from a peer-reviewed journal.
+
+13. (perlstein2023treatmentofchildhood pages 1-3): Samantha Perlstein, Maddy Fair, Emily Hong, and Rebecca Waller. Treatment of childhood disruptive behavior disorders and callous-unemotional traits: a systematic review and two multilevel meta-analyses. Journal of child psychology and psychiatry, and allied disciplines, 64:1372-1387, Mar 2023. URL: https://doi.org/10.1111/jcpp.13774, doi:10.1111/jcpp.13774. This article has 121 citations.
+
+14. (perlstein2023treatmentofchildhood pages 11-12): Samantha Perlstein, Maddy Fair, Emily Hong, and Rebecca Waller. Treatment of childhood disruptive behavior disorders and callous-unemotional traits: a systematic review and two multilevel meta-analyses. Journal of child psychology and psychiatry, and allied disciplines, 64:1372-1387, Mar 2023. URL: https://doi.org/10.1111/jcpp.13774, doi:10.1111/jcpp.13774. This article has 121 citations.
+
+15. (littell2023functionalfamilytherapy pages 1-2): Julia H. Littell, Therese D. Pigott, Karianne H. Nilsen, Jennifer Roberts, and Travis K. Labrum. Functional family therapy for families of youth (age 11–18) with behaviour problems: a systematic review and meta‐analysis. Campbell Systematic Reviews, Jul 2023. URL: https://doi.org/10.1002/cl2.1324, doi:10.1002/cl2.1324. This article has 32 citations and is from a peer-reviewed journal.
+
+16. (ozbay2024conductdisorderan pages 2-3): Ahmet ÖZBAY, Osman ÖZÇELİK, and Süleyman KAHRAMAN. Conduct disorder: an update. Psikiyatride Güncel Yaklaşımlar, 16:72-87, Mar 2024. URL: https://doi.org/10.18863/pgy.1331287, doi:10.18863/pgy.1331287. This article has 3 citations.
+
+17. (lacy2023selectivelypredictingthe pages 1-2): Nina de Lacy and Michael J. Ramshaw. Selectively predicting the onset of adhd, oppositional defiant disorder, and conduct disorder in early adolescence with high accuracy. Frontiers in Psychiatry, Dec 2023. URL: https://doi.org/10.3389/fpsyt.2023.1280326, doi:10.3389/fpsyt.2023.1280326. This article has 11 citations.
+
+18. (koyama2024geneticsofchild pages 1-2): Emiko Koyama, Tuana Kant, Atsushi Takata, James L. Kennedy, and Clement C. Zai. Genetics of child aggression, a systematic review. Translational Psychiatry, Jun 2024. URL: https://doi.org/10.1038/s41398-024-02870-7, doi:10.1038/s41398-024-02870-7. This article has 50 citations and is from a peer-reviewed journal.
+
+19. (koyama2024geneticsofchild pages 3-4): Emiko Koyama, Tuana Kant, Atsushi Takata, James L. Kennedy, and Clement C. Zai. Genetics of child aggression, a systematic review. Translational Psychiatry, Jun 2024. URL: https://doi.org/10.1038/s41398-024-02870-7, doi:10.1038/s41398-024-02870-7. This article has 50 citations and is from a peer-reviewed journal.
+
+20. (frach2024examiningintergenerationalrisk pages 1-2): Leonard Frach, Wikus Barkhuizen, Andrea G. Allegrini, Helga Ask, Laurie J. Hannigan, Elizabeth C. Corfield, Ole A. Andreassen, Frank Dudbridge, Eivind Ystrom, Alexandra Havdahl, and Jean-Baptiste Pingault. Examining intergenerational risk factors for conduct problems using polygenic scores in the norwegian mother, father and child cohort study. Molecular Psychiatry, 29:951-961, Jan 2024. URL: https://doi.org/10.1038/s41380-023-02383-7, doi:10.1038/s41380-023-02383-7. This article has 24 citations and is from a highest quality peer-reviewed journal.
+
+21. (frach2024examiningintergenerationalrisk pages 6-7): Leonard Frach, Wikus Barkhuizen, Andrea G. Allegrini, Helga Ask, Laurie J. Hannigan, Elizabeth C. Corfield, Ole A. Andreassen, Frank Dudbridge, Eivind Ystrom, Alexandra Havdahl, and Jean-Baptiste Pingault. Examining intergenerational risk factors for conduct problems using polygenic scores in the norwegian mother, father and child cohort study. Molecular Psychiatry, 29:951-961, Jan 2024. URL: https://doi.org/10.1038/s41380-023-02383-7, doi:10.1038/s41380-023-02383-7. This article has 24 citations and is from a highest quality peer-reviewed journal.
+
+22. (koyama2024geneticsofchild pages 23-24): Emiko Koyama, Tuana Kant, Atsushi Takata, James L. Kennedy, and Clement C. Zai. Genetics of child aggression, a systematic review. Translational Psychiatry, Jun 2024. URL: https://doi.org/10.1038/s41398-024-02870-7, doi:10.1038/s41398-024-02870-7. This article has 50 citations and is from a peer-reviewed journal.
+
+23. (masi2023contemporarydiagnosisand pages 7-10): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+24. (cortese2023candidatediagnosticbiomarkers pages 1-2): Samuele Cortese, Marco Solmi, Giorgia Michelini, Alessio Bellato, Christina Blanner, Andrea Canozzi, Luis Eudave, Luis C. Farhat, Mikkel Højlund, Ole Köhler‐Forsberg, Douglas Teixeira Leffa, Christopher Rohde, Gonzalo Salazar de Pablo, Giovanni Vita, Rikke Wesselhoeft, Joanna Martin, Sarah Baumeister, Natali S. Bozhilova, Christina O. Carlisi, Virginia Carter Leno, Dorothea L. Floris, Nathalie E. Holz, Eline J. Kraaijenvanger, Seda Sacu, Isabella Vainieri, Giovanni Ostuzzi, Corrado Barbui, and Christoph U. Correll. Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review. World Psychiatry, 22:129-149, Jan 2023. URL: https://doi.org/10.1002/wps.21037, doi:10.1002/wps.21037. This article has 154 citations and is from a highest quality peer-reviewed journal.
+
+25. (cortese2023candidatediagnosticbiomarkers pages 12-13): Samuele Cortese, Marco Solmi, Giorgia Michelini, Alessio Bellato, Christina Blanner, Andrea Canozzi, Luis Eudave, Luis C. Farhat, Mikkel Højlund, Ole Köhler‐Forsberg, Douglas Teixeira Leffa, Christopher Rohde, Gonzalo Salazar de Pablo, Giovanni Vita, Rikke Wesselhoeft, Joanna Martin, Sarah Baumeister, Natali S. Bozhilova, Christina O. Carlisi, Virginia Carter Leno, Dorothea L. Floris, Nathalie E. Holz, Eline J. Kraaijenvanger, Seda Sacu, Isabella Vainieri, Giovanni Ostuzzi, Corrado Barbui, and Christoph U. Correll. Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review. World Psychiatry, 22:129-149, Jan 2023. URL: https://doi.org/10.1002/wps.21037, doi:10.1002/wps.21037. This article has 154 citations and is from a highest quality peer-reviewed journal.
+
+26. (cortese2023candidatediagnosticbiomarkers pages 2-3): Samuele Cortese, Marco Solmi, Giorgia Michelini, Alessio Bellato, Christina Blanner, Andrea Canozzi, Luis Eudave, Luis C. Farhat, Mikkel Højlund, Ole Köhler‐Forsberg, Douglas Teixeira Leffa, Christopher Rohde, Gonzalo Salazar de Pablo, Giovanni Vita, Rikke Wesselhoeft, Joanna Martin, Sarah Baumeister, Natali S. Bozhilova, Christina O. Carlisi, Virginia Carter Leno, Dorothea L. Floris, Nathalie E. Holz, Eline J. Kraaijenvanger, Seda Sacu, Isabella Vainieri, Giovanni Ostuzzi, Corrado Barbui, and Christoph U. Correll. Candidate diagnostic biomarkers for neurodevelopmental disorders in children and adolescents: a systematic review. World Psychiatry, 22:129-149, Jan 2023. URL: https://doi.org/10.1002/wps.21037, doi:10.1002/wps.21037. This article has 154 citations and is from a highest quality peer-reviewed journal.
+
+27. (masi2023contemporarydiagnosisand pages 25-28): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+28. (masi2023contemporarydiagnosisand pages 22-25): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+29. (masi2023contemporarydiagnosisand pages 50-52): Gabriele Masi, Sara Carucci, Pietro Muratori, Carla Balia, Gianluca Sesso, and Annarita Milone. Contemporary diagnosis and treatment of conduct disorder in youth. Expert Review of Neurotherapeutics, 23:1277-1296, Oct 2023. URL: https://doi.org/10.1080/14737175.2023.2271169, doi:10.1080/14737175.2023.2271169. This article has 8 citations and is from a peer-reviewed journal.
+
+30. (ozbay2024conductdisorderan pages 1-2): Ahmet ÖZBAY, Osman ÖZÇELİK, and Süleyman KAHRAMAN. Conduct disorder: an update. Psikiyatride Güncel Yaklaşımlar, 16:72-87, Mar 2024. URL: https://doi.org/10.18863/pgy.1331287, doi:10.18863/pgy.1331287. This article has 3 citations.

--- a/research/Conduct_Disorder-deep-research-falcon.md.citations.md
+++ b/research/Conduct_Disorder-deep-research-falcon.md.citations.md
@@ -1,0 +1,505 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Conduct Disorder
+- **MONDO ID:**  (if available)
+- **Category:** Psychiatric
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Conduct Disorder** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-04-24T17:16:26.109032
+
+1. masi2023contemporarydiagnosisand pages 1-5
+2. ruotsalainen2022childhoodpsychopathyin pages 18-21
+3. ozbay2024conductdisorderan pages 5-7
+4. helander2024theefficacyof pages 1-2
+5. littell2023functionalfamilytherapy pages 1-2
+6. koyama2024geneticsofchild pages 1-2
+7. frach2024examiningintergenerationalrisk pages 1-2
+8. ozbay2024conductdisorderan pages 7-8
+9. masi2023contemporarydiagnosisand pages 5-7
+10. frach2024examiningintergenerationalrisk pages 6-7
+11. masi2023contemporarydiagnosisand pages 7-10
+12. cortese2023candidatediagnosticbiomarkers pages 1-2
+13. cortese2023candidatediagnosticbiomarkers pages 12-13
+14. lacy2023selectivelypredictingthe pages 1-2
+15. cortese2023candidatediagnosticbiomarkers pages 2-3
+16. boldrini2023systematicreviewand pages 6-9
+17. perlstein2023treatmentofchildhood pages 1-3
+18. masi2023contemporarydiagnosisand pages 25-28
+19. masi2023contemporarydiagnosisand pages 17-20
+20. masi2023contemporarydiagnosisand pages 22-25
+21. ozbay2024conductdisorderan pages 1-2
+22. ruotsalainen2022childhoodpsychopathyin pages 38-43
+23. masi2023contemporarydiagnosisand pages 28-30
+24. ruotsalainen2022childhoodpsychopathyin pages 47-48
+25. boldrini2023systematicreviewand pages 16-19
+26. perlstein2023treatmentofchildhood pages 11-12
+27. ozbay2024conductdisorderan pages 2-3
+28. koyama2024geneticsofchild pages 3-4
+29. koyama2024geneticsofchild pages 23-24
+30. masi2023contemporarydiagnosisand pages 50-52
+31. and
+32. but
+33. https://doi.org/10.1080/14737175.2023.2271169
+34. https://doi.org/10.1002/wps.20611
+35. https://doi.org/10.18863/pgy.1331287
+36. https://doi.org/10.1186/s13034-024-00710-6
+37. https://doi.org/10.1016/j.jaac.2022.05.002
+38. https://doi.org/10.1007/s10578-022-01367-y
+39. https://doi.org/10.1111/jcpp.13774
+40. https://doi.org/10.1002/cl2.1324
+41. https://doi.org/10.1038/s41380-023-02383-7
+42. https://doi.org/10.1038/s41398-024-02870-7
+43. https://doi.org/10.1002/wps.21037
+44. https://doi.org/10.3389/fpsyt.2023.1280326
+45. https://doi.org/10.1080/14737175.2023.2271169,
+46. https://doi.org/10.18863/pgy.1331287,
+47. https://doi.org/10.1016/j.jaac.2022.05.002,
+48. https://doi.org/10.1007/s10578-022-01367-y,
+49. https://doi.org/10.1111/jcpp.13774,
+50. https://doi.org/10.1002/cl2.1324,
+51. https://doi.org/10.3389/fpsyt.2023.1280326,
+52. https://doi.org/10.1038/s41398-024-02870-7,
+53. https://doi.org/10.1038/s41380-023-02383-7,
+54. https://doi.org/10.1002/wps.21037,


### PR DESCRIPTION
## Summary
- Add curated Conduct Disorder page with Falcon research support
- Include granular pathophysiology, phenotypes, diagnosis, differential diagnoses, clinical trials, and datasets
- Add cited reference cache entries and Falcon research artifacts

## Validation
- just validate kb/disorders/Conduct_Disorder.yaml
- just compliance kb/disorders/Conduct_Disorder.yaml (Global Compliance: 92.5%)