### PR TITLE
Fix deep research summaries not rendering on disorder pages

### DIFF
--- a/src/dismech/render.py
+++ b/src/dismech/render.py
@@ -1026,11 +1026,21 @@ def render_disorder(
     reports_root = _resolve_nearby_dir(yaml_path.parent, "reports")
     research_root = _resolve_nearby_dir(yaml_path.parent, "research")
     disorder_slug = slugify(disorder.get("name") or yaml_path.stem)
+    file_stem = yaml_path.stem
     report_sections = collect_reports(disorder_slug, reports_root=reports_root)
     literature_sections = collect_literature_summaries(
         disorder_slug,
         research_root=research_root,
     )
+    # Research files are named after the YAML file stem, which may differ from
+    # the slugified disorder name.  Fall back to the file stem when needed.
+    if not literature_sections and file_stem != disorder_slug:
+        literature_sections = collect_literature_summaries(
+            file_stem,
+            research_root=research_root,
+        )
+    if not report_sections and file_stem != disorder_slug:
+        report_sections = collect_reports(file_stem, reports_root=reports_root)
 
     # Group phenotypes by HPO broad category
     phenotype_groups = _group_phenotypes_by_category(disorder.get("phenotypes") or [])


### PR DESCRIPTION
## Summary
- Research files are named after the YAML file stem (e.g., `ALK_Rearranged_NSCLC-deep-research-asta.md`), but `collect_literature_summaries` searched using the slugified disorder `name` field (e.g., `ALK-Rearranged_Non-Small_Cell_Lung_Cancer`), which frequently differs due to hyphens, commas, abbreviations, etc.
- Falls back to `yaml_path.stem` when the slug-based lookup finds no results, for both literature summaries and reports.
- Verified: ALK_Rearranged_NSCLC now correctly finds its 2 deep research files.

## Test plan
- [x] Confirmed slug vs stem mismatch affects many disorders
- [x] Verified fix finds research files for ALK_Rearranged_NSCLC (0 → 2 results)
- [x] Full render of test page shows Deep Research section with toggle entries
- [x] Pre-commit hooks (ruff, codespell, format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)