### PR TITLE
Add MED13 facial dysmorphism phenotype to Mediator umbrella entry

### DIFF
--- a/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
+++ b/kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Mediator Complex Neurodevelopmental Disorder
 creation_date: "2026-04-11T00:00:00Z"
-updated_date: "2026-04-12T16:39:21Z"
+updated_date: "2026-04-25T08:00:00Z"
 description: >-
   A group of neurodevelopmental disorders caused by germline mutations in genes encoding
   subunits of the Mediator complex, a multi-protein assembly required for RNA polymerase
@@ -1120,6 +1120,31 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Other features that were reported in two or more patients include autism spectrum disorder, attention deficit hyperactivity disorder, optic nerve abnormalities, Duane anomaly, hypotonia, mild congenital heart abnormalities, and dysmorphisms."
     explanation: Optic nerve abnormalities and Duane anomaly are recurrent ocular features in MED13 patients.
+
+- category: Craniofacial
+  name: Facial Dysmorphism (MED13)
+  description: >-
+    Facial dysmorphism is a recurrent feature of MED13/MRD61, listed among the
+    main symptoms of the disorder in the published case-series literature. The
+    pattern is generally less distinctive than the MED13L gestalt and is
+    described in qualitative terms in the available abstracts.
+  subtype: MED13
+  phenotype_term:
+    preferred_term: Abnormality of facial shape
+    term:
+      id: HP:0001999
+      label: Abnormal facial shape
+  evidence:
+  - reference: PMID:41195223
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The main symptoms are intellectual disability (ID) of varying degrees, developmental delay (DD), hypotonia during infancy, facial dysmorphism, language impairment, restricted growth, skeletal and limb abnormalities, and behavioral abnormalities."
+    explanation: 2025 review of 26 MRD61 cases lists facial dysmorphism among the main symptoms of MED13-related disorder.
+  - reference: PMID:29740699
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other features that were reported in two or more patients include autism spectrum disorder, attention deficit hyperactivity disorder, optic nerve abnormalities, Duane anomaly, hypotonia, mild congenital heart abnormalities, and dysmorphisms."
+    explanation: Dysmorphisms are reported in two or more patients in the syndrome-defining 13-patient MED13 cohort.
 
 # === MED13L-SPECIFIC PHENOTYPES ===
 - category: Craniofacial


### PR DESCRIPTION
## Summary

Adds an explicit `Craniofacial` phenotype node for **MED13/MRD61 facial dysmorphism** to `kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml`, mirroring the existing `Distinctive Facial Dysmorphism (MED13L)` entry.

This closes one of the gaps flagged in the 2026-04-12 auto-generated research summaries on issues #1139 and #1140: facial dysmorphism is described in the MED13 case-series prose but was not yet captured as a discrete subtype-scoped phenotype node.

## Evidence

Both snippets are exact substrings of already-cached PubMed abstracts — no new cache entries are needed.

| PMID | Citation | Snippet |
|------|----------|---------|
| 41195223 | Yang 2025, *Front Pediatr* (review of 26 MRD61 cases) | "...facial dysmorphism, language impairment, restricted growth, skeletal and limb abnormalities..." (listed among main symptoms) |
| 29740699 | Snijders Blok 2018, *Hum Genet* (syndrome-defining 13-patient cohort) | "Other features that were reported in two or more patients include... and dysmorphisms." |

`frequency:` is intentionally omitted — neither snippet gives a quantitative band, and per `docs/frequency-evidence-guidelines.md` the policy is to omit rather than fabricate justification.

## What was deliberately not done

- **No standalone `MED13_Related_Intellectual_Developmental_Disorder.yaml`**: that decision is gated on issue #1099 (G2P comparator policy for `has_subtypes[].subtype_term`).
- **No new pathophysiology node for the p.Thr326/Pro327 ubiquitination cluster**: the auto-summary called this out as a separate enhancement; left for a follow-up that can do it justice with a dedicated mechanism node.
- **No changes to MED13L / MED12 / MED23 sections**: scope kept narrow.

## Validation

- `just validate kb/disorders/Mediator_Complex_Neurodevelopmental_Disorder.yaml` — schema + term + reference validation all pass
- `just check-reference-cache-frontmatter` — pass
- Snippets verified as exact substrings of `references_cache/PMID_41195223.md` and `references_cache/PMID_29740699.md`

## Test plan

- [ ] CI `validate-all` passes
- [ ] CI `validate-references-all` passes
- [ ] CI `validate-terms-all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)