### PR TITLE
Audit fix: replace fabricated PMID:36606642 cache used by CADASIL Type 1

### DIFF
--- a/kb/disorders/CADASIL_Type_1.yaml
+++ b/kb/disorders/CADASIL_Type_1.yaml
@@ -1,6 +1,6 @@
 name: CADASIL Type 1
 creation_date: '2026-02-14T02:39:04Z'
-updated_date: '2026-04-25T20:00:00Z'
+updated_date: '2026-04-25T20:30:00Z'
 description: >-
   Cerebral Autosomal Dominant Arteriopathy with Subcortical Infarcts and
   Leukoencephalopathy (CADASIL) is a hereditary small vessel disease caused by
@@ -21,23 +21,39 @@ disease_term:
 parents:
 - Hereditary Stroke Disorder
 - Small Vessel Disease
+review_notes: >-
+  2026-04-25 audit fix (issue #1737): replaced fabricated cache content for
+  PMID:36606642 (Yamamoto et al. 2023, J Clin Neurol) with the real PubMed
+  abstract via `just fetch-reference --force`, then re-anchored the prevalence
+  evidence snippet to an exact quote from that abstract. The prior snippet
+  ("3.4 and 3.8 per 100,000" for cysteine-altering NOTCH3 variants) does not
+  appear in the actual abstract; the paper reports a clinical CADASIL
+  prevalence of 1.3-4.1 per 100,000 adults. Prevalence percentage and notes
+  updated to match the paper. The prior 3.4-3.8 per 100,000 figure for
+  cysteine-altering variants likely came from a different source (e.g., Rutten
+  et al. gnomAD-derived NOTCH3 variant frequencies) and should be re-cited if
+  retained in a future curation pass.
 prevalence:
 - population: General population
-  percentage: 3.4-3.8 per 100,000
+  percentage: 1.3-4.1 per 100,000 adults
   notes: >-
-    Clinically associated cysteine-altering NOTCH3 variant prevalence is
-    estimated at 3.4-3.8 per 100,000 in the general population, although
-    sequencing-based NOTCH3 carrier frequencies can be far higher than
-    clinically recognized CADASIL because of variable penetrance and variant
-    context.
+    CADASIL was classically considered a very rare disease with a clinical
+    prevalence of 1.3-4.1 per 100,000 adults, but recent large-scale genomic
+    studies have revealed a substantially higher prevalence of pathogenic
+    NOTCH3 variants in the general population, with the highest carrier
+    frequency among Asians. Sequencing-based NOTCH3 carrier frequencies are
+    therefore far higher than clinically recognized CADASIL because of
+    variable penetrance and variant context.
   evidence:
   - reference: PMID:36606642
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The estimated prevalence of cysteine-altering NOTCH3 variants associated with CADASIL is between 3.4 and 3.8 per 100,000."
+    snippet: "CADASIL was once considered a very rare disease with an estimated prevalence of 1.3-4.1 per 100,000 adults."
     explanation: >-
-      This review provides a contemporary prevalence estimate for CADASIL-
-      associated NOTCH3 variants in the general population.
+      This 2023 review summarizes the classical clinical CADASIL prevalence
+      estimate while noting that recent large-scale genomic studies show
+      pathogenic NOTCH3 variants are far more common in the general
+      population, particularly among Asians.
 pathophysiology:
 - name: NOTCH3 Mutation and ECD Aggregation
   description: >-

--- a/references_cache/PMID_36606642.md
+++ b/references_cache/PMID_36606642.md
@@ -1,13 +1,75 @@
 ---
 reference_id: "PMID:36606642"
-title: "CADASIL prevalence and penetrance review"
+title: "Update on the Epidemiology, Pathogenesis, and Biomarkers of Cerebral Autosomal Dominant Arteriopathy With Subcortical Infarcts and Leukoencephalopathy."
+authors:
+- Yamamoto Y
+- Liao YC
+- Lee YC
+- Ihara M
+- Choi JC
+journal: J Clin Neurol
+year: '2023'
+doi: 10.3988/jcn.2023.19.1.12
 content_type: abstract_only
 ---
 
-# CADASIL prevalence and penetrance review
+# Update on the Epidemiology, Pathogenesis, and Biomarkers of Cerebral Autosomal Dominant Arteriopathy With Subcortical Infarcts and Leukoencephalopathy.
+**Authors:** Yamamoto Y, Liao YC, Lee YC, Ihara M, Choi JC
+**Journal:** J Clin Neurol (2023)
+**DOI:** [10.3988/jcn.2023.19.1.12](https://doi.org/10.3988/jcn.2023.19.1.12)
 
 ## Content
 
-The estimated prevalence of cysteine-altering NOTCH3 variants associated with CADASIL is between 3.4 and 3.8 per 100,000.
+1. J Clin Neurol. 2023 Jan;19(1):12-27. doi: 10.3988/jcn.2023.19.1.12.
 
+Update on the Epidemiology, Pathogenesis, and Biomarkers of Cerebral Autosomal 
+Dominant Arteriopathy With Subcortical Infarcts and Leukoencephalopathy.
+
+Yamamoto Y(#)(1), Liao YC(#)(2)(3)(4), Lee YC(2)(3)(4), Ihara M(1), Choi 
+JC(5)(6).
+
+Author information:
+(1)Department of Neurology, National Cerebral and Cardiovascular Center, Osaka, 
+Japan.
+(2)Department of Neurology, Taipei Veterans General Hospital, Taipei, Taiwan.
+(3)Faculty of Medicine, School of Medicine, National Yang Ming Chiao Tung 
+University, Taipei, Taiwan.
+(4)Brain Research Center, National Yang Ming Chiao Tung University, Taipei, 
+Taiwan.
+(5)Department of Neurology, Jeju National University, Jeju, Korea.
+(6)Institute for Medical Science, Jeju National University, Jeju, Korea. 
+jaychoi@jejunu.ac.kr.
+(#)Contributed equally
+
+Cerebral autosomal dominant arteriopathy with subcortical infarcts and 
+leukoencephalopathy (CADASIL) is the most common monogenic disorder of the 
+cerebral small blood vessels. It is caused by mutations in the NOTCH3 gene on 
+chromosome 19, and more than 280 distinct pathogenic mutations have been 
+reported to date. CADASIL was once considered a very rare disease with an 
+estimated prevalence of 1.3-4.1 per 100,000 adults. However, recent large-scale 
+genomic studies have revealed a high prevalence of pathogenic NOTCH3 variants 
+among the general population, with the highest risk being among Asians. The 
+disease severity and age at onset vary significantly even among individuals who 
+carry the same NOTCH3 mutations. It is still unclear whether a significant 
+genotype-phenotype correlation is present in CADASIL. The accumulation of 
+granular osmiophilic material in the vasculature is a characteristic feature of 
+CADASIL. However, the exact pathogenesis of CADASIL remains largely unclear 
+despite various laboratory and clinical observations being made. Major 
+hypotheses proposed so far have included aberrant NOTCH3 signaling, toxic 
+aggregation, and abnormal matrisomes. Several characteristic features have been 
+observed in the brain magnetic resonance images of patients with CADASIL, 
+including subcortical lacunar lesions and white matter hyperintensities in the 
+anterior temporal lobe or external capsule, which were useful in differentiating 
+CADASIL from sporadic stroke in patients. The number of lacunes and the degree 
+of brain atrophy were useful in predicting the clinical outcomes of patients 
+with CADASIL. Several promising blood biomarkers have also recently been 
+discovered for CADASIL, which require further research for validation.
+
+Copyright © 2023 Korean Neurological Association.
+
+DOI: 10.3988/jcn.2023.19.1.12
+PMCID: PMC9833879
 PMID: 36606642
+
+Conflict of interest statement: The authors have no potential conflicts of 
+interest to disclose.


### PR DESCRIPTION
## Summary

First concrete finding from issue #1737 (audit deep-research outputs for hallucinated PMIDs, snippets, and ontology terms). The `references_cache/` entry for **PMID:36606642** — used by `kb/disorders/CADASIL_Type_1.yaml` to source a prevalence claim — was **fabricated**.

The fake cache file (311 bytes total) contained only:

```
title: "CADASIL prevalence and penetrance review"
content: "The estimated prevalence of cysteine-altering NOTCH3 variants associated with CADASIL is between 3.4 and 3.8 per 100,000."
```

The "content" section was just the YAML snippet itself, which made `linkml-reference-validator`'s substring check trivially pass — the validator was effectively checking the snippet against itself.

After `just fetch-reference --force PMID:36606642`, the real PubMed entry came back as:

> **Yamamoto Y, Liao YC, Lee YC, Ihara M, Choi JC.** Update on the Epidemiology, Pathogenesis, and Biomarkers of Cerebral Autosomal Dominant Arteriopathy With Subcortical Infarcts and Leukoencephalopathy. *J Clin Neurol* 2023;19(1):12-27. doi:10.3988/jcn.2023.19.1.12

The real abstract reports CADASIL clinical prevalence as **1.3-4.1 per 100,000 adults** — not 3.4-3.8 per 100,000 for cysteine-altering NOTCH3 variants. The 3.4-3.8 figure likely comes from Rutten et al.'s gnomAD-derived NOTCH3 variant frequency analysis (different paper).

## Changes

**`references_cache/PMID_36606642.md`** — regenerated via `just fetch-reference --force` (real ~2.8 KB abstract, proper authors/journal/DOI metadata).

**`kb/disorders/CADASIL_Type_1.yaml`** (the only consumer of that cache entry):
- `prevalence.percentage`: `3.4-3.8 per 100,000` → `1.3-4.1 per 100,000 adults` (matches what the paper actually says)
- `prevalence.notes`: rewritten to reflect the abstract's actual framing (clinical prevalence vs. high pathogenic-variant carrier frequency in genomic studies, especially among Asians)
- `evidence.snippet`: replaced with an exact quote from the real abstract — `"CADASIL was once considered a very rare disease with an estimated prevalence of 1.3-4.1 per 100,000 adults."`
- `evidence.explanation`: rewritten to match the paper's actual scope
- `review_notes` added documenting the audit fix and pointing to issue #1737

## Validation

- `just validate kb/disorders/CADASIL_Type_1.yaml` → ✅ schema + terms + references all pass
- `just check-reference-cache-frontmatter` → ✅ pass
- **Sanity check:** I temporarily perturbed the new snippet to confirm the validator now catches a mismatch against the real abstract (it does — emits `Text part not found as substring`). So the substring check is genuinely doing its job, not silently passing.

## Diff hygiene

`just validate-references` side-effects ~50 unrelated cache files via `fix-references-cache` (cosmetic frontmatter normalization: `reference_id: PMID:NNNN` → `"PMID:NNNN"`). I reverted all of those before committing — same approach as PR #1429 — so the diff is strictly: 1 YAML + 1 cache file.

## Broader pattern (out of scope for this PR)

While auditing, I found ~20 other small cache files (<500 bytes) with generic-sounding titles that match the same suspicious pattern:

| PMID | Title |
|------|-------|
| 19232111 | "Osteopetrosis review" (194 bytes) |
| 19464397 | "Brachydactyly type A1 family report" (282 bytes) |
| 22231430 | "Autosomal recessive osteopetrosis review" (338 bytes) |
| 41235131 | "Report of six new beta-mannosidosis cases and literature review" (328 bytes) |
| 17395137 | "Episodic ataxia type 2" (330 bytes) |

…and others. Many of these were created in commit `83237a20e` ("feat: add prevalence data for rare diseases (batch 2)", PR #774), well before the recent Falcon/DR PRs. The DR-sourced PRs are not the only source of fabrication risk — older batch curation runs left fabricated cache files behind too. A separate audit sweep is warranted.

## Test plan

- [ ] CI `validate-all` passes
- [ ] CI `validate-references-all` passes
- [ ] CI `validate-terms-all` passes
- [ ] Human review of the prevalence numerical change: agree to use Yamamoto 2023's `1.3-4.1 per 100,000 adults` for the clinical prevalence, with a follow-up curation pass to find the right paper for the cysteine-altering NOTCH3 variant frequency

Refs #1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)