### PR TITLE
[codex] Fix MONDO priority dashboard DB initialization

### DIFF
--- a/src/dismech/compare/mondo_export.py
+++ b/src/dismech/compare/mondo_export.py
@@ -8,11 +8,18 @@ import sqlite3
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from .mondo_priority import build_coverage_index
 
+DEFAULT_MONDO_ADAPTER_SPEC = "sqlite:obo:mondo"
 DEFAULT_MONDO_DB_PATH = Path.home() / ".data" / "oaklib" / "mondo.db"
 DEFAULT_DISEASE_ROOT_ID = "MONDO:0000001"
+REQUIRED_MONDO_TABLES = {
+    "deprecated_node",
+    "entailed_edge",
+    "statements",
+}
 DEFAULT_PRIORITY_SUBSETS = {
     "obo:mondo#rare",
     "obo:mondo#gard_rare",
@@ -33,6 +40,73 @@ def _normalize_text(text: str | None) -> str:
 
 def _join_values(values: list[str]) -> str:
     return "|".join(sorted(dict.fromkeys(value for value in values if value)))
+
+
+def _normalized_path(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _is_default_mondo_db_path(path: Path) -> bool:
+    return _normalized_path(path) == _normalized_path(DEFAULT_MONDO_DB_PATH)
+
+
+def _materialize_default_mondo_db() -> Path:
+    """Use OAK's sqlite:obo resolver to download/materialize the default MONDO DB."""
+    from oaklib import get_adapter
+
+    adapter = get_adapter(DEFAULT_MONDO_ADAPTER_SPEC)
+    database = adapter.engine.url.database
+    if database:
+        return _normalized_path(Path(database))
+    return _normalized_path(DEFAULT_MONDO_DB_PATH)
+
+
+def _connect_readonly_sqlite(path: Path) -> sqlite3.Connection:
+    uri = f"file:{quote(str(_normalized_path(path)))}?mode=ro"
+    return sqlite3.connect(uri, uri=True)
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    query = """
+    SELECT name
+    FROM sqlite_master
+    WHERE type IN ('table', 'view')
+    """
+    return {row[0] for row in conn.execute(query)}
+
+
+def _resolve_mondo_db_path(mondo_db_path: Path) -> Path:
+    path = _normalized_path(mondo_db_path)
+    if _is_default_mondo_db_path(path) and (
+        not path.exists() or path.stat().st_size == 0
+    ):
+        if path.exists():
+            path.unlink()
+        path = _materialize_default_mondo_db()
+
+    if not path.exists():
+        raise FileNotFoundError(
+            f"MONDO SQLite database not found: {path}. "
+            f"Use the default {DEFAULT_MONDO_ADAPTER_SPEC} cache or set MONDO_DB_PATH "
+            "to an existing semantic-sql MONDO database."
+        )
+
+    return path
+
+
+def _connect_mondo_db(mondo_db_path: Path) -> sqlite3.Connection:
+    path = _resolve_mondo_db_path(mondo_db_path)
+    conn = _connect_readonly_sqlite(path)
+    missing_tables = sorted(REQUIRED_MONDO_TABLES - _table_names(conn))
+    if missing_tables:
+        conn.close()
+        raise RuntimeError(
+            f"MONDO SQLite database at {path} is missing required semantic-sql "
+            f"tables/views: {', '.join(missing_tables)}. "
+            f"Refresh the OAK cache for {DEFAULT_MONDO_ADAPTER_SPEC} or set "
+            "MONDO_DB_PATH to a compatible MONDO database."
+        )
+    return conn
 
 
 def _query_single_value_map(
@@ -189,7 +263,7 @@ def export_mondo_priority_candidates(
     """Export MONDO descendants of the disease root into prioritizer rows."""
     priority_subset_ids = priority_subset_ids or DEFAULT_PRIORITY_SUBSETS
 
-    with sqlite3.connect(mondo_db_path) as conn:
+    with _connect_mondo_db(mondo_db_path) as conn:
         descendant_ids = _query_descendant_ids(conn, disease_root_id)
         labels = _query_single_value_map(conn, "rdfs:label")
         definitions = _query_single_value_map(conn, "IAO:0000115")

--- a/tests/test_mondo_export.py
+++ b/tests/test_mondo_export.py
@@ -2,8 +2,10 @@ import csv
 import sqlite3
 from pathlib import Path
 
+import pytest
 import yaml
 
+from dismech.compare import mondo_export
 from dismech.compare.mondo_export import export_mondo_priority_candidates
 
 
@@ -185,3 +187,98 @@ def test_export_mondo_priority_candidates_limit_applies_after_curated_filter(
     rows = _read_tsv(output_path)
     assert result["exported_rows"] == 2
     assert len(rows) == 2
+
+
+def test_export_mondo_priority_candidates_materializes_default_mondo_db(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    default_path = tmp_path / "oaklib" / "mondo.db"
+    materialized_path = tmp_path / "downloaded" / "mondo.db"
+    output_path = tmp_path / "candidates.tsv"
+
+    default_path.parent.mkdir(parents=True)
+    default_path.write_bytes(b"")
+    materialized_path.parent.mkdir(parents=True)
+    _create_schema(materialized_path)
+    _insert_rows(
+        materialized_path,
+        "statements",
+        [
+            ("MONDO:0000001", "rdfs:label", None, "disease"),
+            ("MONDO:1000000", "rdfs:label", None, "system disease"),
+            ("MONDO:1000000", "rdfs:subClassOf", "MONDO:0000001", None),
+            ("MONDO:2000000", "rdfs:label", None, "Downloaded disease"),
+            ("MONDO:2000000", "rdfs:subClassOf", "MONDO:1000000", None),
+        ],
+    )
+    _insert_rows(
+        materialized_path,
+        "entailed_edge",
+        [
+            ("MONDO:1000000", "rdfs:subClassOf", "MONDO:0000001"),
+            ("MONDO:2000000", "rdfs:subClassOf", "MONDO:0000001"),
+            ("MONDO:2000000", "rdfs:subClassOf", "MONDO:1000000"),
+        ],
+    )
+
+    def fake_materialize_default_mondo_db() -> Path:
+        assert not default_path.exists()
+        return materialized_path
+
+    monkeypatch.setattr(mondo_export, "DEFAULT_MONDO_DB_PATH", default_path)
+    monkeypatch.setattr(
+        mondo_export,
+        "_materialize_default_mondo_db",
+        fake_materialize_default_mondo_db,
+    )
+
+    result = export_mondo_priority_candidates(
+        mondo_db_path=default_path,
+        output_path=output_path,
+    )
+
+    rows = _read_tsv(output_path)
+    assert result["exported_rows"] == 2
+    assert [row["mondo_id"] for row in rows] == ["MONDO:1000000", "MONDO:2000000"]
+
+
+def test_export_mondo_priority_candidates_missing_custom_db_does_not_create_file(
+    tmp_path: Path,
+) -> None:
+    missing_path = tmp_path / "missing.db"
+
+    with pytest.raises(FileNotFoundError, match="MONDO SQLite database not found"):
+        export_mondo_priority_candidates(
+            mondo_db_path=missing_path,
+            output_path=tmp_path / "candidates.tsv",
+        )
+
+    assert not missing_path.exists()
+
+
+def test_export_mondo_priority_candidates_reports_incompatible_schema(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "bad.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE statements (
+            subject TEXT,
+            predicate TEXT,
+            object TEXT,
+            value TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(
+        RuntimeError, match="missing required semantic-sql tables/views"
+    ):
+        export_mondo_priority_candidates(
+            mondo_db_path=db_path,
+            output_path=tmp_path / "candidates.tsv",
+        )


### PR DESCRIPTION
## Summary

Fixes the Generate Pages failure in `gen-dashboard`/`gen-priority-dashboard` where `scripts/export_mondo_priority_candidates.py` opened `~/.data/oaklib/mondo.db` with `sqlite3.connect()` before OAK had materialized the MONDO cache. On a fresh GitHub Actions runner that silently created an empty SQLite file, leading to `sqlite3.OperationalError: no such table: entailed_edge`.

## Changes

- Materialize the default `sqlite:obo:mondo` OAK cache before opening the MONDO database.
- Open the MONDO SQLite database read-only so missing custom paths do not create empty DB files.
- Validate required semantic-sql tables/views up front and report a clearer cache/schema error.
- Add regression coverage for default cache materialization, missing custom DB paths, and incompatible SQLite schemas.

## Validation

- `uv run pytest tests/test_mondo_export.py -q`
- `uv run python scripts/export_mondo_priority_candidates.py --output tmp/mondo_priority_smoke.tsv --kb-dir kb/disorders --limit 50`
- `uv run python scripts/generate_priority_dashboard.py --candidates tmp/mondo_priority_smoke.tsv --kb-dir kb/disorders --config conf/mondo_prioritizer.yaml --dashboard-dir tmp/priority-dashboard-smoke --dashboard-index tmp/priority-dashboard-smoke/index.html`
- `uv run python scripts/export_mondo_priority_candidates.py --output tmp/mondo_priority_candidates_full.verify.tsv --kb-dir kb/disorders`
- `uv run python scripts/generate_priority_dashboard.py --candidates tmp/mondo_priority_candidates_full.verify.tsv --kb-dir kb/disorders --config conf/mondo_prioritizer.yaml --dashboard-dir tmp/priority-dashboard-full-verify --dashboard-index tmp/priority-dashboard-full-verify/index.html`