### PR TITLE
[codex] enhance central core myopathy pathograph

### DIFF
--- a/kb/disorders/Central_Core_Myopathy.yaml
+++ b/kb/disorders/Central_Core_Myopathy.yaml
@@ -1,6 +1,6 @@
 name: Central Core Myopathy
 creation_date: '2026-02-13T18:01:36Z'
-updated_date: '2026-02-27T21:52:54Z'
+updated_date: '2026-04-26T05:48:54Z'
 category: Mendelian
 description: >
   Central core myopathy (central core disease, CCD) is a congenital myopathy caused
@@ -107,6 +107,122 @@ inheritance:
       demonstrates the clinical distinction between dominant and recessive
       RYR1-related myopathies.
 pathophysiology:
+- name: Dominant RYR1 missense hotspot variants
+  description: >
+    Dominant central core myopathy is usually caused by heterozygous RYR1
+    missense variants concentrated in recognized mutational hotspot regions.
+    These variants alter RyR1 channel gating rather than simply reducing gene
+    dosage, creating an upstream mutation class that feeds into abnormal
+    sarcoplasmic-reticulum calcium release, congenital myopathy, and malignant
+    hyperthermia susceptibility.
+  gene:
+    preferred_term: RYR1
+    description: >
+      Ryanodine receptor 1, the skeletal muscle sarcoplasmic reticulum calcium
+      release channel mutated in dominant central core myopathy.
+    modifier: ABNORMAL
+    term:
+      id: hgnc:10483
+      label: RYR1
+  cell_types:
+  - preferred_term: Skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  biological_processes:
+  - preferred_term: Regulation of SR calcium release
+    modifier: ABNORMAL
+    term:
+      id: GO:0010880
+      label: regulation of release of sequestered calcium ion into cytosol by sarcoplasmic reticulum
+  evidence:
+  - reference: PMID:22473935
+    reference_title: "Clinical and genetic findings in a large cohort of patients with ryanodine receptor 1 gene-associated myopathies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Dominant mutations, typically missense, were frequently located in
+      recognized mutational hotspot regions, while recessive mutations were
+      distributed throughout the entire coding sequence.
+    explanation: >
+      Defines the dominant mutation class as mainly missense variants in RYR1
+      hotspot regions.
+  - reference: PMID:16917943
+    reference_title: "Mutations in RYR1 in malignant hyperthermia and central core disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      The majority of gene mutations reported are missense changes identified
+      in cases of MH and CCD.
+    explanation: >
+      Supports missense RYR1 variants as the common mutation type shared by
+      central core disease and malignant hyperthermia.
+  downstream:
+  - target: Abnormal RyR1 calcium release channel function
+    description: >
+      Missense hotspot variants alter RyR1 channel conformation and calcium
+      release behavior.
+    causal_link_type: DIRECT
+  - target: Anesthetic-triggered malignant hyperthermia mechanism
+    description: >
+      Dominant RYR1 missense variants create the allelic substrate for
+      malignant hyperthermia susceptibility in CCD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - altered RyR1 channel gating
+    - exaggerated calcium release after anesthetic trigger
+- name: Recessive RYR1 reduced-expression variants
+  description: >
+    Recessive RYR1-related myopathy often reflects biallelic variants spread
+    across the coding sequence, including nonsense and splice variants expected
+    to reduce RyR1 protein abundance. This mutation class is associated with
+    earlier onset, greater weakness, more functional limitation, and extraocular
+    or bulbar involvement compared with dominant disease.
+  gene:
+    preferred_term: RYR1
+    description: >
+      Ryanodine receptor 1, whose reduced expression can impair skeletal muscle
+      excitation-contraction coupling in recessive central core myopathy.
+    modifier: DECREASED
+    term:
+      id: hgnc:10483
+      label: RYR1
+  cell_types:
+  - preferred_term: Skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  evidence:
+  - reference: PMID:22473935
+    reference_title: "Clinical and genetic findings in a large cohort of patients with ryanodine receptor 1 gene-associated myopathies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Recessive mutations included nonsense and splice mutations expected to
+      result in reduced RyR1 protein.
+    explanation: >
+      Supports reduced RyR1 protein abundance as a recessive mutation-to-
+      mechanism path.
+  - reference: PMID:22473935
+    reference_title: "Clinical and genetic findings in a large cohort of patients with ryanodine receptor 1 gene-associated myopathies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      As a group, dominant mutations were associated with milder phenotypes;
+      patients with recessive inheritance had earlier onset, more weakness,
+      and functional limitations.
+    explanation: >
+      Links recessive inheritance to the more severe clinical phenotype
+      trajectory.
+  downstream:
+  - target: RyR1 deficiency and excitation-contraction uncoupling
+    description: >
+      Reduced RyR1 protein compromises the channel complex needed for normal
+      skeletal muscle excitation-contraction coupling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - reduced RyR1 protein
+    - impaired DHPR-RyR1 coupling
 - name: Abnormal RyR1 calcium release channel function
   description: >
     RYR1 mutations alter the function of the ryanodine receptor, the principal
@@ -183,6 +299,255 @@ pathophysiology:
     explanation: >
       Confirms functional evidence that RYR1 mutations alter calcium
       homeostasis through in vitro studies.
+  downstream:
+  - target: Excitation-contraction coupling impairment
+    description: >
+      Abnormal RyR1 calcium release disrupts the calcium signal that links
+      membrane depolarization to skeletal muscle contraction.
+    causal_link_type: DIRECT
+  - target: Mitochondrial depletion and oxidative metabolism deficiency in cores
+    description: >
+      Chronic calcium-homeostasis disturbance contributes to focal metabolic
+      and structural disruption within type 1 fibers.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - altered intracellular calcium homeostasis
+    - mitochondrial stress
+  - target: Anesthetic-triggered malignant hyperthermia mechanism
+    description: >
+      RyR1 channel instability provides the mechanism for exaggerated calcium
+      release during malignant-hyperthermia-triggering anesthesia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - volatile anesthetic or succinylcholine exposure
+    - uncontrolled sarcoplasmic reticulum calcium release
+- name: RyR1 deficiency and excitation-contraction uncoupling
+  description: >
+    Recessive RYR1 variants that lower RyR1 expression reduce the functional
+    channel pool available at the triad. The resulting excitation-contraction
+    uncoupling causes reduced calcium-triggered contraction and explains the
+    more severe congenital weakness, ophthalmoplegia, bulbar involvement, and
+    respiratory compromise observed in recessive disease.
+  gene:
+    preferred_term: RYR1
+    description: >
+      Ryanodine receptor 1 deficiency reduces the skeletal muscle calcium
+      release channel pool needed for excitation-contraction coupling.
+    modifier: DECREASED
+    term:
+      id: hgnc:10483
+      label: RYR1
+  cell_types:
+  - preferred_term: Skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  biological_processes:
+  - preferred_term: Regulation of skeletal muscle contraction by calcium signaling
+    modifier: DYSREGULATED
+    term:
+      id: GO:0014722
+      label: regulation of skeletal muscle contraction by calcium ion signaling
+  - preferred_term: Skeletal muscle contraction
+    modifier: DECREASED
+    term:
+      id: GO:0003009
+      label: skeletal muscle contraction
+  evidence:
+  - reference: PMID:22473935
+    reference_title: "Clinical and genetic findings in a large cohort of patients with ryanodine receptor 1 gene-associated myopathies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Recessive mutations included nonsense and splice mutations expected to
+      result in reduced RyR1 protein.
+    explanation: >
+      Supports the reduced-expression mechanism for recessive RYR1-related
+      myopathy.
+  - reference: PMID:29391587
+    reference_title: "Congenital myopathies: disorders of excitation-contraction coupling and muscle contraction."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      To date, congenital myopathies have been attributed to mutations in over
+      20 genes, which encode proteins implicated in skeletal muscle Ca2+
+      homeostasis, excitation-contraction coupling, thin-thick filament
+      assembly and interactions, and other mechanisms.
+    explanation: >
+      Places RYR1-related congenital myopathy in the broader mechanism class of
+      excitation-contraction coupling and calcium-homeostasis disorders.
+  downstream:
+  - target: Reduced skeletal muscle force generation
+    description: >
+      Uncoupling lowers calcium-dependent activation of contraction in skeletal
+      muscle fibers.
+    causal_link_type: DIRECT
+  - target: External ophthalmoplegia
+    description: >
+      Extraocular involvement is a recessive RYR1-enriched phenotype in the
+      cohort data.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - severe recessive RYR1-related myopathy
+    - extraocular muscle weakness
+  - target: Myopathic facies
+    description: >
+      Bulbar and facial weakness are linked to recessive RYR1 disease severity.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - severe recessive RYR1-related myopathy
+    - bulbar or facial muscle weakness
+  - target: Respiratory insufficiency
+    description: >
+      Severe recessive impairment of skeletal muscle contraction can involve
+      respiratory muscle groups.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - respiratory muscle weakness
+- name: Excitation-contraction coupling impairment
+  description: >
+    RyR1 dysfunction disrupts the DHPR-RyR1 calcium-release signal that couples
+    sarcolemmal depolarization to actin-myosin force generation. This provides
+    the central mechanistic bridge from RYR1 mutation classes to congenital
+    weakness, hypotonia, delayed motor development, respiratory involvement, and
+    core formation.
+  cell_types:
+  - preferred_term: Skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  - preferred_term: Type I muscle fiber
+    term:
+      id: CL:0002211
+      label: type I muscle cell
+  biological_processes:
+  - preferred_term: Regulation of skeletal muscle contraction by calcium signaling
+    modifier: DYSREGULATED
+    term:
+      id: GO:0014722
+      label: regulation of skeletal muscle contraction by calcium ion signaling
+  - preferred_term: Skeletal muscle contraction
+    modifier: DECREASED
+    term:
+      id: GO:0003009
+      label: skeletal muscle contraction
+  evidence:
+  - reference: PMID:16917943
+    reference_title: "Mutations in RYR1 in malignant hyperthermia and central core disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      The RYR1 gene encodes the skeletal muscle isoform ryanodine receptor
+      and is fundamental to the process of excitation-contraction coupling and
+      skeletal muscle calcium homeostasis.
+    explanation: >
+      Establishes RyR1 as the core channel linking mutation to
+      excitation-contraction coupling and calcium homeostasis.
+  - reference: PMID:29391587
+    reference_title: "Congenital myopathies: disorders of excitation-contraction coupling and muscle contraction."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      RYR1 mutations are the most frequent genetic cause, and CCD and MmD are
+      the most common subgroups.
+    explanation: >
+      Confirms that RYR1-mediated excitation-contraction coupling defects are a
+      major causal class among congenital myopathies.
+  downstream:
+  - target: Reduced skeletal muscle force generation
+    description: >
+      Impaired calcium release reduces calcium-dependent actin-myosin force
+      generation.
+    causal_link_type: DIRECT
+  - target: Mitochondrial depletion and oxidative metabolism deficiency in cores
+    description: >
+      Persistent calcium-homeostasis disturbance contributes to type 1 fiber
+      core formation and oxidative enzyme loss.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - altered intracellular calcium homeostasis
+    - local mitochondrial dysfunction
+- name: Reduced skeletal muscle force generation
+  description: >
+    Impaired RyR1-dependent calcium signaling reduces activation of skeletal
+    muscle contraction. The functional consequence is congenital hypotonia,
+    delayed motor milestones, predominantly proximal weakness, orthopedic
+    complications from chronic weakness and hypotonia, and respiratory
+    insufficiency in more severe disease.
+  cell_types:
+  - preferred_term: Skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  biological_processes:
+  - preferred_term: Skeletal muscle contraction
+    modifier: DECREASED
+    term:
+      id: GO:0003009
+      label: skeletal muscle contraction
+  evidence:
+  - reference: PMID:29391587
+    reference_title: "Congenital myopathies: disorders of excitation-contraction coupling and muscle contraction."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Pronounced weakness in axial and proximal muscle groups is a common
+      feature, and involvement of extraocular, cardiorespiratory and/or distal
+      muscles can implicate specific genetic defects.
+    explanation: >
+      Links congenital myopathy mechanisms to axial/proximal weakness and
+      possible cardiorespiratory involvement.
+  - reference: PMID:17504518
+    reference_title: "Central core disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      CCD typically presents in infancy with hypotonia and motor developmental
+      delay and is characterized by predominantly proximal weakness pronounced
+      in the hip girdle
+    explanation: >
+      Establishes the main downstream clinical consequences of impaired
+      skeletal muscle force generation in CCD.
+  downstream:
+  - target: Proximal muscle weakness
+    description: >
+      Reduced force output in skeletal muscle fibers produces predominantly
+      proximal weakness.
+    causal_link_type: DIRECT
+  - target: Neonatal hypotonia
+    description: >
+      Congenital weakness lowers resting tone in infancy.
+    causal_link_type: DIRECT
+  - target: Delayed gross motor development
+    description: >
+      Hypotonia and proximal weakness delay attainment of early gross motor
+      milestones.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neonatal hypotonia
+    - proximal weakness
+  - target: Scoliosis
+    description: >
+      Chronic axial and proximal weakness contributes to orthopedic
+      complications including scoliosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - axial muscle weakness
+    - altered spinal loading
+  - target: Congenital hip dislocation
+    description: >
+      Congenital hypotonia and weakness contribute to hip instability and other
+      orthopedic complications.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neonatal hypotonia
+    - periarticular muscle weakness
+  - target: Respiratory insufficiency
+    description: >
+      Severe skeletal muscle weakness may involve respiratory muscles.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - respiratory muscle weakness
 - name: Mitochondrial depletion and oxidative metabolism deficiency in cores
   description: >
     The central cores that define this myopathy histologically represent focal
@@ -218,7 +583,33 @@ pathophysiology:
     explanation: >
       Establishes the defining histopathological feature of CCD as central
       cores on muscle biopsy.
-- name: Malignant hyperthermia susceptibility
+  - reference: PMID:22473935
+    reference_title: "Clinical and genetic findings in a large cohort of patients with ryanodine receptor 1 gene-associated myopathies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Histopathological findings frequently feature central cores or
+      multi-minicores, more rarely, type 1 predominance/uniformity,
+      fiber-type disproportion, increased internal nucleation, and fatty and
+      connective tissue.
+    explanation: >
+      Confirms that central cores are frequent histopathological findings in
+      RYR1-related myopathies.
+  downstream:
+  - target: Central core regions in muscle fibers
+    description: >
+      Focal mitochondrial depletion and loss of oxidative enzyme activity
+      define central core regions on muscle biopsy.
+    causal_link_type: DIRECT
+  - target: Reduced skeletal muscle force generation
+    description: >
+      Core regions combine sarcomeric disorganization and metabolic deficiency,
+      contributing to reduced contractile performance.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - sarcomeric disorganization
+    - oxidative metabolism deficiency
+- name: Anesthetic-triggered malignant hyperthermia mechanism
   description: >
     RYR1 mutations predispose to malignant hyperthermia (MH), a pharmacogenetic
     disorder triggered by volatile anesthetic agents and succinylcholine. The
@@ -262,6 +653,12 @@ pathophysiology:
       Demonstrates that the same RYR1 mutation can cause CCD in one family
       and isolated MH susceptibility in another, establishing the allelic
       relationship.
+  downstream:
+  - target: Malignant hyperthermia susceptibility
+    description: >
+      RYR1-triggered excessive calcium release is the mechanism underlying the
+      malignant hyperthermia susceptibility phenotype.
+    causal_link_type: DIRECT
 phenotypes:
 - name: Proximal muscle weakness
   description: >
@@ -338,6 +735,40 @@ phenotypes:
       developmental delay
     explanation: >
       Motor developmental delay is identified as a typical presenting feature.
+- name: Central core regions in muscle fibers
+  description: >
+    Muscle biopsy shows well-demarcated central core regions in skeletal muscle
+    fibers, reflecting focal sarcomeric disorganization with mitochondrial and
+    oxidative-enzyme depletion. This is the defining histopathological feature
+    of central core myopathy.
+  phenotype_term:
+    preferred_term: Central core regions in muscle fibers
+    term:
+      id: HP:0030230
+      label: Central core regions in muscle fibers
+  evidence:
+  - reference: PMID:17504518
+    reference_title: "Central core disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Central core disease (CCD) is an inherited neuromuscular disorder
+      characterised by central cores on muscle biopsy and clinical features
+      of a congenital myopathy.
+    explanation: >
+      Establishes central cores on muscle biopsy as a defining disease feature.
+  - reference: PMID:22473935
+    reference_title: "Clinical and genetic findings in a large cohort of patients with ryanodine receptor 1 gene-associated myopathies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Histopathological findings frequently feature central cores or
+      multi-minicores, more rarely, type 1 predominance/uniformity,
+      fiber-type disproportion, increased internal nucleation, and fatty and
+      connective tissue.
+    explanation: >
+      Supports central cores as frequent biopsy findings in the RYR1-related
+      myopathy cohort.
 - name: Scoliosis
   description: >
     Scoliosis is a common orthopaedic complication that may require surgical

--- a/kb/disorders/Central_Core_Myopathy.yaml
+++ b/kb/disorders/Central_Core_Myopathy.yaml
@@ -1,6 +1,6 @@
 name: Central Core Myopathy
 creation_date: '2026-02-13T18:01:36Z'
-updated_date: '2026-04-26T05:48:54Z'
+updated_date: '2026-04-26T06:33:41Z'
 category: Mendelian
 description: >
   Central core myopathy (central core disease, CCD) is a congenital myopathy caused
@@ -292,7 +292,7 @@ pathophysiology:
   - reference: PMID:16917943
     reference_title: "Mutations in RYR1 in malignant hyperthermia and central core disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: >
       In vitro analysis has confirmed that alteration of normal calcium
       homeostasis is a functional consequence of some of these changes.
@@ -620,10 +620,12 @@ pathophysiology:
     phenotypes.
   biological_processes:
   - preferred_term: Muscle contraction
+    modifier: INCREASED
     term:
       id: GO:0006936
       label: muscle contraction
   - preferred_term: Calcium ion homeostasis
+    modifier: DYSREGULATED
     term:
       id: GO:0055074
       label: calcium ion homeostasis
@@ -741,6 +743,7 @@ phenotypes:
     fibers, reflecting focal sarcomeric disorganization with mitochondrial and
     oxidative-enzyme depletion. This is the defining histopathological feature
     of central core myopathy.
+  frequency: HP_0040280
   phenotype_term:
     preferred_term: Central core regions in muscle fibers
     term:


### PR DESCRIPTION
## Summary

Enhances `kb/disorders/Central_Core_Myopathy.yaml` with complete RYR1 mutation-to-phenotype pathograph paths.

Changes include:
- Added dominant RYR1 missense hotspot and recessive reduced-expression mutation-class pathophysiology roots.
- Connected mutation classes through RyR1 calcium-release dysfunction, excitation-contraction coupling impairment, reduced skeletal muscle force generation, core histopathology, and malignant hyperthermia mechanism nodes.
- Added downstream edges from mechanisms to the recorded clinical and histopathological phenotypes.
- Added an HPO-backed `Central core regions in muscle fibers` phenotype (`HP:0030230`).
- Updated the disorder `updated_date`.

## Validation

- `just validate kb/disorders/Central_Core_Myopathy.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Central_Core_Myopathy.yaml`
- Pre-commit on commit: `check yaml`, `fix end of files`, `trim trailing whitespace`, `yamllint`, `yamlfix (curation yaml)`, `codespell`, `ruff`/`ruff-format` skipped because no Python files were staged.

## Notes

I ran `just research-disorder falcon Central_Core_Myopathy` as requested. The first run exposed a sparse-checkout/tooling issue because `src/` was absent; after restoring the repo tooling files from `HEAD`, the command started successfully but then hung for roughly twenty minutes after a provider connection reset and produced no research output file. I stopped the hung process and integrated the curation from the existing validated PubMed-backed evidence already cached in the repo.