### PR TITLE
[codex] enhance dystrophic epidermolysis bullosa pathograph

### DIFF
--- a/kb/disorders/Dystrophic_Epidermolysis_Bullosa.yaml
+++ b/kb/disorders/Dystrophic_Epidermolysis_Bullosa.yaml
@@ -1,6 +1,6 @@
 name: Dystrophic Epidermolysis Bullosa
 creation_date: '2026-03-10T12:00:00Z'
-updated_date: '2026-03-15T21:59:08Z'
+updated_date: '2026-04-26T05:52:16Z'
 category: Mendelian
 description: >-
   Dystrophic epidermolysis bullosa (DEB) is caused by mutations in COL7A1
@@ -41,8 +41,7 @@ classifications:
       reference_title: "Dystrophic Epidermolysis Bullosa."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "Dystrophic epidermolysis bullosa (DEB) is characterized by skin
-        fragility manifested by blistering and erosions with minimal trauma"
+      snippet: "Dystrophic epidermolysis bullosa (DEB) is characterized by skin fragility manifested by blistering and erosions with minimal trauma"
       explanation: Supports classifying DEB as a skin disorder because the disorder is defined by traumatic skin blistering and erosions.
   - classification_value: hereditary disease
     evidence:
@@ -50,8 +49,7 @@ classifications:
       reference_title: "Dystrophic Epidermolysis Bullosa."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "DEB is inherited in either an autosomal dominant (DDEB) or
-        autosomal recessive (RDEB) manner"
+      snippet: "DEB is inherited in either an autosomal dominant (DDEB) or autosomal recessive (RDEB) manner"
       explanation: Supports classifying DEB as a hereditary disease because both dominant and recessive inherited forms are established.
 has_subtypes:
 - name: Dominant Dystrophic Epidermolysis Bullosa (DDEB)
@@ -96,27 +94,20 @@ prevalence:
     reference_title: "Epidemiology of Inherited Epidermolysis Bullosa Based on Incidence and Prevalence Estimates From the National Epidermolysis Bullosa Registry."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "the overall incidence and prevalence of inherited EB were 19.60
-      and 8.22 per 1 million live births, respectively"
-    explanation: US National EB Registry provides overall EB incidence and
-      prevalence data including DEB subtypes.
+    snippet: "the overall incidence and prevalence of inherited EB were 19.60 and 8.22 per 1 million live births, respectively"
+    explanation: US National EB Registry provides overall EB incidence and prevalence data including DEB subtypes.
   - reference: PMID:31920360
     reference_title: "From Clinical Phenotype to Genotypic Modelling: Incidence and Prevalence of Recessive Dystrophic Epidermolysis Bullosa (RDEB)."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "the widely estimated incidence (0.2-6.65 per million births)
-      and prevalence (3.5-20.4 per million people) of RDEB has been primarily
-      characterized by limited analyses of clinical databases or registries"
-    explanation: Summarizes the range of published RDEB incidence and
-      prevalence estimates across multiple registries.
+    snippet: "the widely estimated incidence (0.2-6.65 per million births) and prevalence (3.5-20.4 per million people) of RDEB has been primarily characterized by limited analyses of clinical databases or registries"
+    explanation: Summarizes the range of published RDEB incidence and prevalence estimates across multiple registries.
   - reference: PMID:19026465
     reference_title: "Epidermolysis bullosa and the risk of life-threatening cancers: the National EB Registry experience, 1986-2006."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Cumulative risks rose steeply in RDEB-HS, from 7.5% by age 20
-      to 67.8%, 80.2%, and 90.1% by ages 35, 45, and 55, respectively"
-    explanation: Demonstrates the extremely high cumulative SCC risk in severe
-      RDEB that drives mortality and reduced life expectancy.
+    snippet: "Cumulative risks rose steeply in RDEB-HS, from 7.5% by age 20 to 67.8%, 80.2%, and 90.1% by ages 35, 45, and 55, respectively"
+    explanation: Demonstrates the extremely high cumulative SCC risk in severe RDEB that drives mortality and reduced life expectancy.
 inheritance:
 - name: Autosomal dominant
   description: Dominant dystrophic epidermolysis bullosa (DDEB)
@@ -137,6 +128,61 @@ inheritance:
     snippet: "If both parents are known to be heterozygous for a COL7A1 pathogenic variant, each sib of an affected individual has at conception a 25% chance of being affected"
     explanation: GeneReviews confirms autosomal recessive inheritance for RDEB.
 pathophysiology:
+- name: Heterozygous COL7A1 Pathogenic Variant (DDEB)
+  description: >
+    A heterozygous pathogenic variant in COL7A1 is the molecular lesion in
+    dominant dystrophic epidermolysis bullosa. The resulting type VII collagen
+    dysfunction produces a usually milder, localized blistering phenotype that
+    often affects hands, feet, knees, elbows, and nails.
+  genes:
+  - preferred_term: COL7A1
+    term:
+      id: hgnc:2214
+      label: COL7A1
+  subtypes:
+  - Dominant Dystrophic Epidermolysis Bullosa (DDEB)
+  downstream:
+  - target: COL7A1 Mutations and Loss of Type VII Collagen
+    causal_link_type: DIRECT
+    description: >
+      Heterozygous COL7A1 pathogenic variants produce dysfunctional type VII
+      collagen and thereby converge on the collagen VII/anchoring fibril defect.
+  evidence:
+  - reference: PMID:20301481
+    reference_title: "Dystrophic Epidermolysis Bullosa."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "biallelic COL7A1 pathogenic variants (for RDEB) or a heterozygous pathogenic variant in COL7A1 (for DDEB)"
+    explanation: GeneReviews defines DDEB by a heterozygous COL7A1 pathogenic variant.
+- name: Biallelic COL7A1 Pathogenic Variants (RDEB)
+  description: >
+    Biallelic pathogenic variants in COL7A1 are the molecular lesion in
+    recessive dystrophic epidermolysis bullosa. Severe generalized RDEB reflects
+    marked type VII collagen deficiency, producing generalized neonatal
+    blistering, progressive scarring, pseudosyndactyly, esophageal strictures,
+    growth failure, and very high lifetime squamous cell carcinoma risk.
+  genes:
+  - preferred_term: COL7A1
+    term:
+      id: hgnc:2214
+      label: COL7A1
+  subtypes:
+  - Recessive Dystrophic Epidermolysis Bullosa, Severe Generalized (RDEB-sev gen)
+  - Recessive Dystrophic Epidermolysis Bullosa, Intermediate (RDEB-intermediate)
+  - Recessive Dystrophic Epidermolysis Bullosa Inversa
+  downstream:
+  - target: COL7A1 Mutations and Loss of Type VII Collagen
+    causal_link_type: DIRECT
+    description: >
+      Biallelic COL7A1 pathogenic variants reduce or abolish type VII collagen
+      function and thereby converge on the collagen VII/anchoring fibril defect.
+  evidence:
+  - reference: PMID:20301481
+    reference_title: "Dystrophic Epidermolysis Bullosa."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "biallelic COL7A1 pathogenic variants (for RDEB) or a heterozygous pathogenic variant in COL7A1 (for DDEB)"
+    explanation: GeneReviews defines RDEB by biallelic COL7A1 pathogenic variants.
 - name: COL7A1 Mutations and Loss of Type VII Collagen
   description: >
     Mutations in the COL7A1 gene encoding type VII collagen result in absent,
@@ -173,6 +219,7 @@ pathophysiology:
       label: fibroblast
   downstream:
   - target: Defective Anchoring Fibrils and Loss of Dermal-Epidermal Adhesion
+    causal_link_type: DIRECT
     description: >
       Absent or dysfunctional type VII collagen leads to defective
       anchoring fibrils that fail to secure the epidermis to the dermis.
@@ -214,14 +261,45 @@ pathophysiology:
       id: CL:0000312
       label: keratinocyte
   downstream:
+  - target: Skin Blistering
+    causal_link_type: DIRECT
+    description: >
+      Dermal-epidermal separation after minimal trauma produces the defining
+      blistering and erosions of DEB.
+  - target: Atrophic Scarring
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - blister healing with dermal matrix remodeling
+    description: >
+      Recurrent sub-lamina-densa blistering heals with dermal remodeling and
+      atrophic scarring.
+  - target: Milia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - healing of recurrent blisters
+    description: >
+      Milia form at sites of healed blistering and erosions.
+  - target: Nail Dystrophy
+    causal_link_type: DIRECT
+    description: >
+      Fragility of nail-unit adhesion causes dystrophic or absent nails,
+      especially in DDEB.
   - target: Chronic Wound-Inflammation-Fibrosis Cycle
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - repeated blistering and erosions
     description: >
       Repeated blistering and impaired wound healing create chronic wounds
       that drive a self-perpetuating cycle of inflammation and fibrosis.
   - target: Esophageal and Mucosal Blistering
+    causal_link_type: DIRECT
     description: >
       Loss of adhesion in mucosal epithelia causes blistering and erosions
       in the esophagus, oral cavity, and other mucosal surfaces.
+  - target: Corneal Erosions
+    causal_link_type: DIRECT
+    description: >
+      Epithelial fragility at ocular surfaces causes recurrent corneal erosions.
   evidence:
   - reference: PMID:32973163
     reference_title: "Epidermolysis bullosa."
@@ -265,11 +343,28 @@ pathophysiology:
       id: CL:0000057
       label: fibroblast
   downstream:
+  - target: Atrophic Scarring
+    causal_link_type: DIRECT
+    description: >
+      Chronic abnormal wound repair leaves progressive atrophic scars.
+  - target: Anemia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - chronic wound blood loss
+    - anemia of chronic inflammation
+    description: >
+      Chronic wounds and inflammation contribute to iron deficiency and anemia
+      of chronic disease.
   - target: Progressive Scarring and Pseudosyndactyly
+    causal_link_type: DIRECT
     description: >
       Chronic fibrosis leads to progressive scarring, tissue fusion,
       and mitten deformities of the hands and feet.
   - target: Chronic Wounds and Aggressive Squamous Cell Carcinoma
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - chronic non-healing wounds
+    - fibrotic inflammatory microenvironment
     description: >
       Chronic wounds with an immunosuppressive fibrotic microenvironment
       promote development of aggressive squamous cell carcinoma.
@@ -298,6 +393,12 @@ pathophysiology:
     term:
       id: GO:0030198
       label: extracellular matrix organization
+  downstream:
+  - target: Pseudosyndactyly
+    causal_link_type: DIRECT
+    description: >
+      Fibrotic fusion and contracture of digits manifests clinically as
+      pseudosyndactyly.
   evidence:
   - reference: PMID:20301481
     reference_title: "Dystrophic Epidermolysis Bullosa."
@@ -318,7 +419,41 @@ pathophysiology:
       id: GO:0007160
       label: cell-matrix adhesion
   downstream:
+  - target: Esophageal Stricture
+    causal_link_type: DIRECT
+    description: >
+      Esophageal erosions heal with webs and strictures.
+  - target: Dysphagia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - esophageal webs and strictures
+    description: >
+      Esophageal strictures impair swallowing and produce dysphagia.
+  - target: Microstomia
+    causal_link_type: DIRECT
+    description: >
+      Oral mucosal blistering and perioral scarring progressively reduce mouth
+      opening.
+  - target: Dental Caries
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - oral mucosal blistering and scarring
+    - microstomia limiting dental hygiene
+    description: >
+      Oral blistering, scarring, and restricted mouth opening impair dental
+      hygiene and contribute to dental caries risk.
+  - target: Constipation
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - anal and perianal blistering and stenosis
+    description: >
+      Gastrointestinal mucosal fragility and perianal scarring contribute to
+      chronic constipation.
   - target: Malnutrition and Growth Failure
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - severe dysphagia
+    - impaired oral intake
     description: >
       Esophageal strictures and oral involvement severely impair nutritional
       intake, leading to growth retardation and nutritional deficiencies.
@@ -346,6 +481,28 @@ pathophysiology:
     GO term omitted because malnutrition/growth failure is an organismal-level
     consequence best captured by HPO phenotype terms, not cellular-level GO
     biological processes.
+  downstream:
+  - target: Growth Retardation
+    causal_link_type: DIRECT
+    description: >
+      Protein-calorie malnutrition and micronutrient deficiency impair childhood
+      growth.
+  - target: Anemia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - iron deficiency
+    - micronutrient deficiency
+    description: >
+      Nutritional deficiency contributes to chronic anemia in severe RDEB.
+  - target: Osteoporosis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - vitamin D deficiency
+    - calcium deficiency
+    - reduced mobility
+    description: >
+      Malnutrition and limited mobility contribute to low bone mineral density
+      and osteoporosis.
   evidence:
   - reference: PMID:20301481
     reference_title: "Dystrophic Epidermolysis Bullosa."
@@ -382,6 +539,12 @@ pathophysiology:
     term:
       id: CL:0000312
       label: keratinocyte
+  downstream:
+  - target: Cutaneous Squamous Cell Carcinoma
+    causal_link_type: DIRECT
+    description: >
+      Aggressive cutaneous squamous cell carcinomas arise in chronically wounded
+      and scarred RDEB skin.
   evidence:
   - reference: PMID:19026465
     reference_title: "Epidermolysis bullosa and the risk of life-threatening cancers: the National EB Registry experience, 1986-2006."
@@ -673,16 +836,13 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "good dental care"
-    explanation: GeneReviews recommends dental care as part of DEB management,
-      indicating dental complications including caries from enamel involvement.
+    explanation: GeneReviews recommends dental care as part of DEB management, indicating dental complications including caries from enamel involvement.
   - reference: PMID:19700011
     reference_title: "Extracutaneous manifestations and complications of inherited epidermolysis bullosa: part II. Other organs."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Some epidermolysis bullosa subtypes are at risk for severe injury
-      of the bone marrow, musculoskeletal system, heart, kidney, and teeth"
-    explanation: Confirms dental/teeth involvement as an extracutaneous EB
-      complication requiring surveillance.
+    snippet: "Some epidermolysis bullosa subtypes are at risk for severe injury of the bone marrow, musculoskeletal system, heart, kidney, and teeth"
+    explanation: Confirms dental/teeth involvement as an extracutaneous EB complication requiring surveillance.
 - category: Musculoskeletal
   name: Osteoporosis
   description: >
@@ -733,6 +893,17 @@ treatments:
     term:
       id: MAXO:0001001
       label: gene therapy
+  target_mechanisms:
+  - target: COL7A1 Mutations and Loss of Type VII Collagen
+    treatment_effect: RESTORES
+    description: >
+      Topical HSV-1 COL7A1 delivery restores type VII collagen expression in
+      treated wounds.
+  - target: Defective Anchoring Fibrils and Loss of Dermal-Epidermal Adhesion
+    treatment_effect: RESTORES
+    description: >
+      Restored type VII collagen improves dermal-epidermal adhesion and wound
+      closure.
   evidence:
   - reference: PMID:36516090
     reference_title: "Trial of Beremagene Geperpavec (B-VEC) for Dystrophic Epidermolysis Bullosa."
@@ -759,24 +930,30 @@ treatments:
     term:
       id: MAXO:0001001
       label: gene therapy
+  target_mechanisms:
+  - target: COL7A1 Mutations and Loss of Type VII Collagen
+    treatment_effect: RESTORES
+    description: >
+      Autologous COL7A1 gene-modified keratinocyte sheets provide corrected
+      epidermis to chronic RDEB wounds.
+  - target: Defective Anchoring Fibrils and Loss of Dermal-Epidermal Adhesion
+    treatment_effect: RESTORES
+    description: >
+      Corrected grafts are intended to restore collagen VII at the wound bed and
+      improve adhesion.
   evidence:
   - reference: PMID:40570869
     reference_title: "Prademagene zamikeracel for recessive dystrophic epidermolysis bullosa wounds (VIITAL): a two-centre, randomised, open-label, intrapatient-controlled phase 3 trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "At week 24, 35 (81%) of 43 treated wounds were at least 50%
-      healed from baseline for prademagene zamikeracel compared with seven
-      (16%) of 43 control wounds"
-    explanation: Phase III VIITAL trial demonstrates statistically significant
-      wound healing efficacy of prademagene zamikeracel in RDEB.
+    snippet: "At week 24, 35 (81%) of 43 treated wounds were at least 50% healed from baseline for prademagene zamikeracel compared with seven (16%) of 43 control wounds"
+    explanation: Phase III VIITAL trial demonstrates statistically significant wound healing efficacy of prademagene zamikeracel in RDEB.
   - reference: PMID:40570869
     reference_title: "Prademagene zamikeracel for recessive dystrophic epidermolysis bullosa wounds (VIITAL): a two-centre, randomised, open-label, intrapatient-controlled phase 3 trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Prademagene zamikeracel is an autologous COL7A1 gene-modified
-      cellular sheet that is sutured onto to a large, chronic RDEB wound"
-    explanation: Describes the mechanism of prademagene zamikeracel as an
-      autologous gene-modified cellular sheet for RDEB wounds.
+    snippet: "Prademagene zamikeracel is an autologous COL7A1 gene-modified cellular sheet that is sutured onto to a large, chronic RDEB wound"
+    explanation: Describes the mechanism of prademagene zamikeracel as an autologous gene-modified cellular sheet for RDEB wounds.
 - name: Recombinant Type VII Collagen (PTR-01)
   description: >
     Investigational intravenous protein replacement therapy using recombinant
@@ -790,24 +967,30 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Defective Anchoring Fibrils and Loss of Dermal-Epidermal Adhesion
+    treatment_effect: RESTORES
+    description: >
+      Intravenous recombinant type VII collagen incorporates at the
+      dermal-epidermal junction in preclinical models.
+  - target: Chronic Wound-Inflammation-Fibrosis Cycle
+    treatment_effect: INHIBITS
+    description: >
+      Systemic collagen VII replacement reduced fibrosis and improved wound
+      healing in RDEB animal models.
   evidence:
   - reference: PMID:34606885
     reference_title: "Systemic Collagen VII Replacement Therapy for Advanced Recessive Dystrophic Epidermolysis Bullosa."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "Fortnightly IV injections of rC7 for 7 weeks in adult RDEB mice
-      reduced fibrosis of skin and eye"
-    explanation: Preclinical study demonstrates that systemic IV rC7
-      reduces fibrosis in adult RDEB animal models.
+    snippet: "Fortnightly IV injections of rC7 for 7 weeks in adult RDEB mice reduced fibrosis of skin and eye"
+    explanation: Preclinical study demonstrates that systemic IV rC7 reduces fibrosis in adult RDEB animal models.
   - reference: PMID:34606885
     reference_title: "Systemic Collagen VII Replacement Therapy for Advanced Recessive Dystrophic Epidermolysis Bullosa."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "IV rC7 in adult RDEB dogs incorporated in the dermal‒epidermal
-      junction of skin and improved disease by promoting wound healing and
-      reducing dermal‒epidermal separation"
-    explanation: Large animal model confirms that IV rC7 incorporates at the
-      DEJ and improves wound healing in established RDEB.
+    snippet: "IV rC7 in adult RDEB dogs incorporated in the dermal‒epidermal junction of skin and improved disease by promoting wound healing and reducing dermal‒epidermal separation"
+    explanation: Large animal model confirms that IV rC7 incorporates at the DEJ and improves wound healing in established RDEB.
 - name: Losartan
   description: >
     Anti-fibrotic angiotensin II type 1 receptor antagonist that reduces
@@ -820,23 +1003,25 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Chronic Wound-Inflammation-Fibrosis Cycle
+    treatment_effect: INHIBITS
+    description: >
+      Losartan is used as an anti-fibrotic intervention intended to reduce
+      TGF-beta-driven fibrosis and disease burden in RDEB.
   evidence:
   - reference: PMID:39539991
     reference_title: "Safety and tolerability of losartan to treat recessive dystrophic epidermolysis bullosa in children (REFLECT): an open-label, single-arm, phase 1/2 trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Losartan was well tolerated, no treatment-related severe
-      complications leading to a serious safety concern occurred"
-    explanation: REFLECT Phase 1/2 trial demonstrates safety and tolerability
-      of losartan in children with RDEB.
+    snippet: "Losartan was well tolerated, no treatment-related severe complications leading to a serious safety concern occurred"
+    explanation: REFLECT Phase 1/2 trial demonstrates safety and tolerability of losartan in children with RDEB.
   - reference: PMID:39539991
     reference_title: "Safety and tolerability of losartan to treat recessive dystrophic epidermolysis bullosa in children (REFLECT): an open-label, single-arm, phase 1/2 trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Similar to the EBDASI score, the BEBS showed a mean reduction
-      of -3 points, 95%-CI: -0.21 to -5,79, P = 0.036)"
-    explanation: REFLECT trial shows statistically significant improvement
-      in BEBS scores with losartan treatment in RDEB children.
+    snippet: "Similar to the EBDASI score, the BEBS showed a mean reduction of -3 points, 95%-CI: -0.21 to -5,79, P = 0.036)"
+    explanation: REFLECT trial shows statistically significant improvement in BEBS scores with losartan treatment in RDEB children.
 - name: Rigosertib
   description: >
     Polo-like kinase-1 (PLK1) inhibitor investigated for RDEB-associated
@@ -849,26 +1034,25 @@ treatments:
     term:
       id: MAXO:0000647
       label: chemotherapy
+  target_mechanisms:
+  - target: Chronic Wounds and Aggressive Squamous Cell Carcinoma
+    treatment_effect: INHIBITS
+    description: >
+      Rigosertib is directed at the aggressive RDEB-associated SCC compartment
+      that arises from chronic wounded fibrotic skin.
   evidence:
   - reference: PMID:40439508
     reference_title: "Efficacy and safety of rigosertib in patients with recessive dystrophic epidermolysis bullosa-associated advanced/metastatic cutaneous squamous cell carcinoma."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Antitumour efficacy with acceptable toxicity was seen in patients
-      on IV or oral therapy and two patients had a complete response within
-      6 months of treatment"
-    explanation: Phase II trial demonstrates antitumour activity and complete
-      responses with rigosertib in RDEB-SCC patients.
+    snippet: "Antitumour efficacy with acceptable toxicity was seen in patients on IV or oral therapy and two patients had a complete response within 6 months of treatment"
+    explanation: Phase II trial demonstrates antitumour activity and complete responses with rigosertib in RDEB-SCC patients.
   - reference: PMID:40439508
     reference_title: "Efficacy and safety of rigosertib in patients with recessive dystrophic epidermolysis bullosa-associated advanced/metastatic cutaneous squamous cell carcinoma."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "These data identify rigosertib as a promising drug therapy for
-      patients with RDEB-SCC where there is a substantial unmet need, absence
-      of approved therapies and where tumours arise on a background of a
-      unique fibrotic and inflammatory environment"
-    explanation: Identifies rigosertib as a promising therapeutic option for
-      the currently untreatable RDEB-associated SCC.
+    snippet: "These data identify rigosertib as a promising drug therapy for patients with RDEB-SCC where there is a substantial unmet need, absence of approved therapies and where tumours arise on a background of a unique fibrotic and inflammatory environment"
+    explanation: Identifies rigosertib as a promising therapeutic option for the currently untreatable RDEB-associated SCC.
 - name: Gentamicin Readthrough Therapy
   description: >
     Intravenous gentamicin induces translational readthrough of nonsense
@@ -883,24 +1067,25 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: COL7A1 Mutations and Loss of Type VII Collagen
+    treatment_effect: RESTORES
+    description: >
+      Gentamicin promotes readthrough of COL7A1 nonsense mutations to increase
+      type VII collagen at the dermal-epidermal junction.
   evidence:
   - reference: PMID:38366625
     reference_title: "Intravenous gentamicin therapy induces functional type VII collagen in patients with recessive dystrophic epidermolysis bullosa: an open-label clinical trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "After gentamicin treatment, skin biopsies from all three patients
-      (age range 18-28 years) exhibited increased C7 in their DEJ"
-    explanation: Open-label clinical trial demonstrates that IV gentamicin
-      restores type VII collagen at the DEJ in RDEB patients with nonsense
-      mutations.
+    snippet: "After gentamicin treatment, skin biopsies from all three patients (age range 18-28 years) exhibited increased C7 in their DEJ"
+    explanation: Open-label clinical trial demonstrates that IV gentamicin restores type VII collagen at the DEJ in RDEB patients with nonsense mutations.
   - reference: PMID:38366625
     reference_title: "Intravenous gentamicin therapy induces functional type VII collagen in patients with recessive dystrophic epidermolysis bullosa: an open-label clinical trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "At 1 and 3 months post-treatment, 100% of the monitored wounds
-      exhibited > 85% closure"
-    explanation: Demonstrates significant wound healing improvement after
-      IV gentamicin readthrough therapy in RDEB.
+    snippet: "At 1 and 3 months post-treatment, 100% of the monitored wounds exhibited > 85% closure"
+    explanation: Demonstrates significant wound healing improvement after IV gentamicin readthrough therapy in RDEB.
 - name: Wound Care and Specialized Dressings
   description: >
     Meticulous wound care is the cornerstone of DEB management. New blisters
@@ -912,6 +1097,12 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Chronic Wound-Inflammation-Fibrosis Cycle
+    treatment_effect: MODULATES
+    description: >
+      Nonadherent dressings, padding, blister drainage, and infection control
+      reduce wound trauma and downstream inflammation.
   evidence:
   - reference: PMID:32973163
     reference_title: "Epidermolysis bullosa."
@@ -929,6 +1120,12 @@ treatments:
     term:
       id: MAXO:0000004
       label: surgical procedure
+  target_mechanisms:
+  - target: Esophageal and Mucosal Blistering
+    treatment_effect: BYPASSES
+    description: >
+      Dilation bypasses the obstructive consequence of mucosal blistering and
+      scarring by mechanically opening esophageal strictures.
   evidence:
   - reference: PMID:20301481
     reference_title: "Dystrophic Epidermolysis Bullosa."
@@ -946,6 +1143,12 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Malnutrition and Growth Failure
+    treatment_effect: MODULATES
+    description: >
+      Nutritional supplementation and gastrostomy support address the downstream
+      malnutrition caused by dysphagia and chronic wounds.
   evidence:
   - reference: PMID:20301481
     reference_title: "Dystrophic Epidermolysis Bullosa."
@@ -979,6 +1182,12 @@ treatments:
     term:
       id: MAXO:0000004
       label: surgical procedure
+  target_mechanisms:
+  - target: Chronic Wounds and Aggressive Squamous Cell Carcinoma
+    treatment_effect: INHIBITS
+    description: >
+      Surgical excision removes established RDEB-associated squamous cell
+      carcinomas arising from chronic scarred wounds.
   evidence:
   - reference: PMID:19026465
     reference_title: "Epidermolysis bullosa and the risk of life-threatening cancers: the National EB Registry experience, 1986-2006."
@@ -1013,6 +1222,12 @@ treatments:
     term:
       id: MAXO:0000011
       label: physical therapy
+  target_mechanisms:
+  - target: Progressive Scarring and Pseudosyndactyly
+    treatment_effect: MODULATES
+    description: >
+      Physical and occupational therapy act downstream of fibrosis to preserve
+      hand function and reduce contracture burden.
   evidence:
   - reference: PMID:20301481
     reference_title: "Dystrophic Epidermolysis Bullosa."
@@ -1031,6 +1246,12 @@ treatments:
     term:
       id: MAXO:0000747
       label: hematopoietic stem cell transplantation
+  target_mechanisms:
+  - target: Defective Anchoring Fibrils and Loss of Dermal-Epidermal Adhesion
+    treatment_effect: RESTORES
+    description: >
+      Allogeneic bone marrow transplantation is intended to increase collagen
+      VII deposition in RDEB skin.
   evidence:
   - reference: PMID:20818854
     reference_title: "Bone marrow transplantation for recessive dystrophic epidermolysis bullosa."
@@ -1113,8 +1334,7 @@ genetic:
       reference_title: "Dystrophic Epidermolysis Bullosa."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "About 70% of individuals diagnosed with DDEB are reported to
-        have an affected parent"
+      snippet: "About 70% of individuals diagnosed with DDEB are reported to have an affected parent"
       explanation: GeneReviews confirms autosomal dominant inheritance for DDEB.
   - name: Autosomal recessive
     evidence:
@@ -1122,9 +1342,7 @@ genetic:
       reference_title: "Dystrophic Epidermolysis Bullosa."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "If both parents are known to be heterozygous for a COL7A1
-        pathogenic variant, each sib of an affected individual has at
-        conception a 25% chance of being affected"
+      snippet: "If both parents are known to be heterozygous for a COL7A1 pathogenic variant, each sib of an affected individual has at conception a 25% chance of being affected"
       explanation: GeneReviews confirms autosomal recessive inheritance for RDEB.
   notes: >
     COL7A1 on chromosome 3p21.31 encodes type VII collagen, the major
@@ -1174,5 +1392,4 @@ datasets:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "The goal of this study is to discover fibroblast subpopulations relevant to recessive dystrophic epidermolysis bullosa"
-    explanation: Directly supports this GEO series as a single-cell fibroblast
-      resource for DEB mechanism studies.
+    explanation: Directly supports this GEO series as a single-cell fibroblast resource for DEB mechanism studies.

--- a/kb/disorders/Dystrophic_Epidermolysis_Bullosa.yaml
+++ b/kb/disorders/Dystrophic_Epidermolysis_Bullosa.yaml
@@ -52,13 +52,25 @@ classifications:
       snippet: "DEB is inherited in either an autosomal dominant (DDEB) or autosomal recessive (RDEB) manner"
       explanation: Supports classifying DEB as a hereditary disease because both dominant and recessive inherited forms are established.
 has_subtypes:
-- name: Dominant Dystrophic Epidermolysis Bullosa (DDEB)
+- name: DDEB
+  display_name: Dominant Dystrophic Epidermolysis Bullosa (DDEB)
+  subtype_term:
+    preferred_term: dominant dystrophic epidermolysis bullosa
+    term:
+      id: MONDO:0007549
+      label: generalized dominant dystrophic epidermolysis bullosa
   description: >
     Mild, localized blistering caused by dominant-negative COL7A1 mutations.
     Nails are most commonly affected, and blistering is often limited to
     hands, feet, knees, and elbows. Heals with scarring but without the
     severe complications seen in recessive forms.
-- name: Recessive Dystrophic Epidermolysis Bullosa, Severe Generalized (RDEB-sev gen)
+- name: RDEB-sev gen
+  display_name: Recessive Dystrophic Epidermolysis Bullosa, Severe Generalized (RDEB-sev gen)
+  subtype_term:
+    preferred_term: severe generalized recessive dystrophic epidermolysis bullosa
+    term:
+      id: MONDO:0009179
+      label: recessive dystrophic epidermolysis bullosa
   description: >
     Formerly known as Hallopeau-Siemens RDEB. The most severe form, caused
     by biallelic loss-of-function COL7A1 mutations leading to absent or
@@ -66,14 +78,26 @@ has_subtypes:
     blistering from birth, progressive scarring, mitten deformities
     (pseudosyndactyly), esophageal strictures, and a lifetime squamous
     cell carcinoma risk exceeding 90%.
-- name: Recessive Dystrophic Epidermolysis Bullosa, Intermediate (RDEB-intermediate)
+- name: RDEB-intermediate
+  display_name: Recessive Dystrophic Epidermolysis Bullosa, Intermediate (RDEB-intermediate)
+  subtype_term:
+    preferred_term: intermediate recessive dystrophic epidermolysis bullosa
+    term:
+      id: MONDO:0019522
+      label: recessive dystrophic epidermolysis bullosa-generalized other
   description: >
     Formerly known as non-Hallopeau-Siemens RDEB. Moderate scarring with
     blistering that may be localized to hands, feet, knees, elbows, and
     flexural areas. Less severe than RDEB-sev gen, with lower SCC risk,
     but still carries significant morbidity from scarring and extracutaneous
     involvement.
-- name: Recessive Dystrophic Epidermolysis Bullosa Inversa
+- name: RDEB-Inversa
+  display_name: Recessive Dystrophic Epidermolysis Bullosa Inversa
+  subtype_term:
+    preferred_term: recessive dystrophic epidermolysis bullosa inversa
+    term:
+      id: MONDO:0019310
+      label: recessive dystrophic epidermolysis bullosa inversa
   description: >
     Blistering predominantly affects intertriginous (skin fold) areas
     including axillae, groin, and neck. May also involve the esophagus
@@ -140,7 +164,7 @@ pathophysiology:
       id: hgnc:2214
       label: COL7A1
   subtypes:
-  - Dominant Dystrophic Epidermolysis Bullosa (DDEB)
+  - DDEB
   downstream:
   - target: COL7A1 Mutations and Loss of Type VII Collagen
     causal_link_type: DIRECT
@@ -167,9 +191,9 @@ pathophysiology:
       id: hgnc:2214
       label: COL7A1
   subtypes:
-  - Recessive Dystrophic Epidermolysis Bullosa, Severe Generalized (RDEB-sev gen)
-  - Recessive Dystrophic Epidermolysis Bullosa, Intermediate (RDEB-intermediate)
-  - Recessive Dystrophic Epidermolysis Bullosa Inversa
+  - RDEB-sev gen
+  - RDEB-intermediate
+  - RDEB-Inversa
   downstream:
   - target: COL7A1 Mutations and Loss of Type VII Collagen
     causal_link_type: DIRECT
@@ -317,7 +341,7 @@ pathophysiology:
   description: >
     Repeated blistering and impaired wound healing in DEB create chronic
     wounds that drive persistent inflammation and progressive fibrosis.
-    TGF-beta signaling is upregulated in RDEB fibroblasts, promoting
+    TGF-β signaling is upregulated in RDEB fibroblasts, promoting
     excessive collagen deposition, tissue contraction, and extracellular
     matrix remodeling. This cycle underlies the progressive scarring,
     pseudosyndactyly, and tissue contractures characteristic of severe RDEB.
@@ -373,8 +397,8 @@ pathophysiology:
     reference_title: "Mechanistic interrogation of mutation-independent disease modulators of RDEB identifies the small leucine-rich proteoglycan PRELP as a TGF-β antagonist and inhibitor of fibrosis."
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: "severe RDEB was associated with enhanced response to TGF-beta stimulus, oxidoreductase activity, and cell contraction"
-    explanation: Gene expression profiling of RDEB fibroblasts reveals enhanced TGF-beta responsiveness driving fibrosis.
+    snippet: "severe RDEB was associated with enhanced response to TGF-β stimulus, oxidoreductase activity, and cell contraction"
+    explanation: Gene expression profiling of RDEB fibroblasts reveals enhanced TGF-β responsiveness driving fibrosis.
   - reference: PMID:35779740
     reference_title: "Mechanistic interrogation of mutation-independent disease modulators of RDEB identifies the small leucine-rich proteoglycan PRELP as a TGF-β antagonist and inhibitor of fibrosis."
     supports: SUPPORT
@@ -831,12 +855,12 @@ phenotypes:
       id: HP:0000670
       label: Carious teeth
   evidence:
-  - reference: PMID:20301481
-    reference_title: "Dystrophic Epidermolysis Bullosa."
+  - reference: PMID:22940071
+    reference_title: "Type VII collagen deficiency causes defective tooth enamel formation due to poor differentiation of ameloblasts."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "good dental care"
-    explanation: GeneReviews recommends dental care as part of DEB management, indicating dental complications including caries from enamel involvement.
+    snippet: "Patients with RDEB present a low oral hygiene index and prevalent tooth abnormalities with caries"
+    explanation: RDEB-specific study links type VII collagen deficiency to enamel structural defects and reports prevalent tooth abnormalities with caries.
   - reference: PMID:19700011
     reference_title: "Extracutaneous manifestations and complications of inherited epidermolysis bullosa: part II. Other organs."
     supports: SUPPORT
@@ -959,7 +983,7 @@ treatments:
     Investigational intravenous protein replacement therapy using recombinant
     type VII collagen (rC7) for systemic treatment of RDEB. Preclinical
     studies in RDEB mice and dogs demonstrated that IV rC7 accumulates at
-    the basement membrane zone, reduces fibrosis via decreased TGF-beta
+    the basement membrane zone, reduces fibrosis via decreased TGF-β
     signaling, and promotes wound healing. Phase 2 clinical trial results
     have been reported but not yet published in peer-reviewed literature.
   treatment_term:
@@ -994,7 +1018,7 @@ treatments:
 - name: Losartan
   description: >
     Anti-fibrotic angiotensin II type 1 receptor antagonist that reduces
-    TGF-beta signaling. The REFLECT Phase 1/2 trial enrolled 29 children
+    TGF-β signaling. The REFLECT Phase 1/2 trial enrolled 29 children
     with RDEB and demonstrated that losartan was well tolerated with
     improvements in EBDASI damage scores and BEBS scores. Losartan may
     reduce disease burden by mitigating progressive fibrosis.
@@ -1003,12 +1027,17 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: losartan
+      term:
+        id: CHEBI:6541
+        label: losartan
   target_mechanisms:
   - target: Chronic Wound-Inflammation-Fibrosis Cycle
     treatment_effect: INHIBITS
     description: >
       Losartan is used as an anti-fibrotic intervention intended to reduce
-      TGF-beta-driven fibrosis and disease burden in RDEB.
+      TGF-β-driven fibrosis and disease burden in RDEB.
   evidence:
   - reference: PMID:39539991
     reference_title: "Safety and tolerability of losartan to treat recessive dystrophic epidermolysis bullosa in children (REFLECT): an open-label, single-arm, phase 1/2 trial."
@@ -1067,6 +1096,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: gentamicin
+      term:
+        id: NCIT:C519
+        label: Gentamicin
   target_mechanisms:
   - target: COL7A1 Mutations and Loss of Type VII Collagen
     treatment_effect: RESTORES
@@ -1086,6 +1120,52 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "At 1 and 3 months post-treatment, 100% of the monitored wounds exhibited > 85% closure"
     explanation: Demonstrates significant wound healing improvement after IV gentamicin readthrough therapy in RDEB.
+- name: Filsuvez (Birch Triterpenes) Topical Gel
+  description: >
+    Oleogel-S10 (Filsuvez), a topical gel containing birch triterpenes, is used
+    for partial-thickness wounds associated with dystrophic and junctional EB in
+    patients aged 6 months and older. In the phase III EASE trial, Oleogel-S10
+    accelerated target wound closure compared with control gel.
+  treatment_term:
+    preferred_term: birch triterpenes topical gel
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: birch triterpenes
+      term:
+        id: NCIT:C177079
+        label: Birch Triterpenes
+    qualifiers:
+    - predicate:
+        preferred_term: route of administration
+        term:
+          id: NCIT:C38114
+          label: Route of Administration
+      value:
+        preferred_term: topical route of administration
+        term:
+          id: NCIT:C38304
+          label: Topical Route of Administration
+  target_mechanisms:
+  - target: Chronic Wound-Inflammation-Fibrosis Cycle
+    treatment_effect: MODULATES
+    description: >
+      Topical birch triterpenes accelerate wound closure, reducing persistence of
+      open wounds that sustain inflammation and fibrosis.
+  evidence:
+  - reference: PMID:36689495
+    reference_title: "Efficacy and safety of Oleogel-S10 (birch triterpenes) for epidermolysis bullosa: results from the phase III randomized double-blind phase of the EASE study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oleogel-S10 is the first therapy to demonstrate accelerated wound healing in EB"
+    explanation: Phase III EASE trial confirms Oleogel-S10 as a wound-healing therapy across EB subtypes including dystrophic EB.
+  - reference: PMID:39748581
+    reference_title: "Filsuvez(®) (Birch Triterpenes) Topical Gel."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Filsuvez® (birch triterpenes) topical gel received approval in 2023 for the treatment of epidermolysis bullosa (EB)"
+    explanation: Confirms regulatory approval of birch triterpenes topical gel for EB wound treatment.
 - name: Wound Care and Specialized Dressings
   description: >
     Meticulous wound care is the cornerstone of DEB management. New blisters
@@ -1118,8 +1198,8 @@ treatments:
   treatment_term:
     preferred_term: esophageal dilation
     term:
-      id: MAXO:0000004
-      label: surgical procedure
+      id: NCIT:C70908
+      label: Esophageal Dilation
   target_mechanisms:
   - target: Esophageal and Mucosal Blistering
     treatment_effect: BYPASSES

--- a/references_cache/PMID_22940071.md
+++ b/references_cache/PMID_22940071.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:22940071"
+title: Type VII collagen deficiency causes defective tooth enamel formation due to poor differentiation of ameloblasts.
+authors:
+- Umemoto H
+- Akiyama M
+- Domon T
+- Nomura T
+- Shinkuma S
+- Ito K
+- Asaka T
+- Sawamura D
+- Uitto J
+- Uo M
+- Kitagawa Y
+- Shimizu H
+journal: Am J Pathol
+year: '2012'
+doi: 10.1016/j.ajpath.2012.07.018
+keywords:
+- "Ameloblasts/metabolism, pathology"
+- Amelogenesis
+- Animals
+- "Calcification, Physiologic"
+- Cell Differentiation
+- Child
+- "Collagen Type VII/deficiency, metabolism"
+- "Dental Enamel/growth & development, metabolism, pathology, ultrastructure"
+- "Epidermolysis Bullosa Dystrophica/pathology, physiopathology"
+- Female
+- "Gene Expression Regulation, Developmental"
+- Humans
+- Mice
+- "Models, Biological"
+- Phenotype
+- "Tooth/growth & development, metabolism, pathology, ultrastructure"
+content_type: abstract_only
+---
+
+# Type VII collagen deficiency causes defective tooth enamel formation due to poor differentiation of ameloblasts.
+**Authors:** Umemoto H, Akiyama M, Domon T, Nomura T, Shinkuma S, Ito K, Asaka T, Sawamura D, Uitto J, Uo M, Kitagawa Y, Shimizu H
+**Journal:** Am J Pathol (2012)
+**DOI:** [10.1016/j.ajpath.2012.07.018](https://doi.org/10.1016/j.ajpath.2012.07.018)
+
+## Content
+
+1. Am J Pathol. 2012 Nov;181(5):1659-71. doi: 10.1016/j.ajpath.2012.07.018. Epub
+2012 Aug 31.
+
+Type VII collagen deficiency causes defective tooth enamel formation due to poor
+differentiation of ameloblasts.
+
+Umemoto H(1), Akiyama M, Domon T, Nomura T, Shinkuma S, Ito K, Asaka T, Sawamura
+D, Uitto J, Uo M, Kitagawa Y, Shimizu H.
+
+Author information:
+(1)Department of Dermatology, Hokkaido University Graduate School of Medicine,
+Sapporo, Japan.
+
+Recessive dystrophic epidermolysis bullosa (RDEB) is caused by mutations in the
+gene encoding type VII collagen (COL7), a major component of anchoring fibrils
+in the epidermal basement membrane zone. Patients with RDEB present a low oral
+hygiene index and prevalent tooth abnormalities with caries. We examined the
+tooth enamel structure of an RDEB patient by scanning electron microscopy. It
+showed irregular enamel prisms, indicating structural enamel defects. To
+elucidate the pathomechanisms of enamel defects due to COL7 deficiency, we
+investigated tooth formation in Col7a1(-/-) and COL7-rescued humanized mice that
+we have established. The enamel from Col7a1(-/-) mice had normal surface
+structure. The enamel calcification and chemical composition of Col7a1(-/-) mice
+were similar to those of the wild type. However, transverse sections of teeth
+from the Col7a1(-/-) mice showed irregular enamel prisms, which were also
+observed in the RDEB patient. Furthermore, the Col7a1(-/-) mice teeth had poorly
+differentiated ameloblasts, lacking normal enamel protein-secreting Tomes'
+processes, and showed reduced mRNA expression of amelogenin and other
+enamel-related molecules. These enamel abnormalities were corrected in the
+COL7-rescued humanized mice expressing a human COL7A1 transgene. These findings
+suggest that COL7 regulates ameloblast differentiation and is essential for the
+formation of Tomes' processes. Collectively, COL7 deficiency is thought to
+disrupt epithelial-mesenchymal interactions, leading to defective ameloblast
+differentiation and enamel malformation in RDEB patients.
+
+Copyright © 2012 American Society for Investigative Pathology. Published by
+Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ajpath.2012.07.018
+PMID: 22940071 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Adds explicit upstream COL7A1 mutation-class pathophysiology nodes for DDEB and RDEB.
- Completes downstream mutation-to-phenotype paths so every listed DEB phenotype is reached from the pathograph.
- Adds treatment-to-mechanism targets for gene therapy, protein replacement, anti-fibrotic therapy, SCC therapy, wound care, esophageal dilation, nutrition, PT/OT, and transplantation.

## Notes

I attempted `just research-disorder falcon Dystrophic_Epidermolysis_Bullosa`; the falcon subprocess remained idle for an extended period without writing the research markdown or citations file, so no generated research provenance file is included. The curation uses existing PubMed/GeneReviews-backed evidence already present in the entry.

## Validation

- `just validate kb/disorders/Dystrophic_Epidermolysis_Bullosa.yaml`
- Graph integrity check: 15/15 phenotypes targeted by pathophysiology downstream edges; no orphan targets.
- Pre-commit hooks during commit: `check yaml`, `yamllint`, `yamlfix`, `codespell` passed.