### PR TITLE
research: Add falcon deep research and reference cache for Carvajal syndrome

### DIFF
--- a/references_cache/PMID_21789513.md
+++ b/references_cache/PMID_21789513.md
@@ -1,0 +1,156 @@
+---
+reference_id: PMID:21789513
+title: "Novel desmoplakin mutation: juvenile biventricular cardiomyopathy with left ventricular non-compaction and acantholytic palmoplantar keratoderma."
+authors:
+- Williams T
+- Machann W
+- Kühler L
+- Hamm H
+- Müller-Höcker J
+- Zimmer M
+- Ertl G
+- Ritter O
+- Beer M
+- Schönberger J
+journal: Clin Res Cardiol
+year: '2011'
+doi: 10.1007/s00392-011-0345-9
+keywords:
+- Age of Onset
+- Base Sequence
+- "Cardiomyopathies/diagnosis, genetics"
+- "Cardiomyopathy, Dilated"
+- Child
+- "Child, Preschool"
+- DNA Mutational Analysis
+- Desmoplakins/genetics
+- Fatal Outcome
+- Frameshift Mutation
+- Genetic Predisposition to Disease
+- "Hair Diseases/diagnosis, genetics"
+- Heart Failure/genetics
+- Homozygote
+- Humans
+- "Isolated Noncompaction of the Ventricular Myocardium/diagnosis, genetics"
+- "Keratoderma, Palmoplantar/diagnosis, genetics"
+- Male
+- Molecular Sequence Data
+- Pedigree
+- Phenotype
+- Sequence Deletion
+- Severity of Illness Index
+content_type: full_text_xml
+---
+
+# Novel desmoplakin mutation: juvenile biventricular cardiomyopathy with left ventricular non-compaction and acantholytic palmoplantar keratoderma.
+**Authors:** Williams T, Machann W, Kühler L, Hamm H, Müller-Höcker J, Zimmer M, Ertl G, Ritter O, Beer M, Schönberger J
+**Journal:** Clin Res Cardiol (2011)
+**DOI:** [10.1007/s00392-011-0345-9](https://doi.org/10.1007/s00392-011-0345-9)
+
+## Content
+
+1. Clin Res Cardiol. 2011 Dec;100(12):1087-93. doi: 10.1007/s00392-011-0345-9.
+Epub  2011 Jul 26.
+
+Novel desmoplakin mutation: juvenile biventricular cardiomyopathy with left
+ventricular non-compaction and acantholytic palmoplantar keratoderma.
+
+Williams T(1), Machann W, Kühler L, Hamm H, Müller-Höcker J, Zimmer M, Ertl G,
+Ritter O, Beer M, Schönberger J.
+
+Author information:
+(1)Department of Internal Medicine I, Center of Cardiovascular Medicine,
+University Hospital of Wuerzburg, Wuerzburg, Germany.
+williams_t@klinik.uni-wuerzburg.de
+
+Two sons of a consanguineous marriage developed biventricular cardiomyopathy.
+One boy died of severe heart failure at the age of 6 years, the other was
+transplanted because of severe heart failure at the age of 10 years. In
+addition, focal palmoplantar keratoderma and woolly hair were apparent in both
+boys. As similar phenotypes have been described in Naxos disease and Carvajal
+syndrome, respectively, the genes for plakoglobin (JUP) and desmoplakin (DSP)
+were screened for mutations using direct genomic sequencing. A novel homozygous
+2 bp deletion was identified in an alternatively spliced region of DSP. The
+deletion 5208_5209delAG led to a frameshift downstream of amino acid 1,736 with
+a premature truncation of the predominant cardiac isoform DSP-1. This novel
+homozygous truncating mutation in the isoform-1 specific region of the DSP
+C-terminus caused Carvajal syndrome comprising severe early-onset heart failure
+with features of non-compaction cardiomyopathy, woolly hair and an acantholytic
+form of palmoplantar keratoderma in our patient. Congenital hair abnormality and
+manifestation of the cutaneous phenotype in toddler age can help to identify
+children at risk for cardiac death.
+
+DOI: 10.1007/s00392-011-0345-9
+PMCID: PMC3222824
+PMID: 21789513 [Indexed for MEDLINE]
+
+Juvenile cardiomyopathies are serious disorders often necessitating cardiac transplantation. Juvenile biventricular cardiomyopathy is usually caused by early-onset forms of dilated cardiomyopathy (DCM). Apart from non-syndromic forms of arrhythmogenic right ventricular dysplasia (ARVD) and DCM, cardiocutaneous syndromes have also been described: Naxos disease [14] and Carvajal syndrome [6]. Both show an association of cardiomyopathy with woolly hair and palmoplantar keratoderma. Naxos disease exhibits a rather typical ARVD-phenotype, while in Carvajal syndrome left ventricular failure often predominates. As desmosomes play an important role for mechanical stability of epithelia, it seems obvious that the skin is affected by alterations in desmosomal proteins as well. In fact, Naxos syndrome is caused by a recessive mutation in the plakoglobin (JUP) gene [10]. For Carvajal syndrome, two different homozygous mutations in desmoplakin (DSP) have been described so far: a truncating frameshift [11] and a truncating nonsense mutation [18]. Recently, a heterozygous insertion of 30 base pairs (bp) in exon 14 was reported as well [12]. Here, we describe a novel recessive deletion c.5208_5209delAG (p.G1737fsX1742) leading to Carvajal syndrome with severe juvenile biventricular cardiomyopathy clinically appearing as non-compaction cardiomyopathy with associated skin and hair phenotype.
+
+Explanted cardiac muscle tissue and plantar keratosis were routinely fixed in 4% formalin and embedded in paraffin after graded ethanol dehydration. Routine staining included hematoxylin–eosin and Elastica-van Gieson.
+
+Cardiac morphology and function in the index patient were examined using a clinical MR scanner with a field strength of 1.5 Tesla. The ratio of non-compacted to compacted myocardium (NC/C ratio) was calculated in diastole for each of the three long-axis views in the four-chamber view according to Peterson et al., 2005 [13]; only the maximal ratio was then used for analysis. An NC/C ratio >2.3 in diastole distinguished pathological non-compaction.
+
+To allow an identification of the underlying genetic defect, DNA was extracted from EDTA-anticoagulated blood by phenol chloroform extraction. The gene for DSP was screened for mutations using exon flanking primers (see online supplement). Sequence reactions were analyzed on an Applied Biosystems 3130.
+
+Snap frozen skin biopsies from the patient and normal controls were homogenized in RIPA-buffer (150 mM NaCl, 1% NP-40, 0.5% DOC (doeoxycholic acid), 0.1% SDS, 50 mM Tris pH 8.0) supplemented with protease inhibitors (Roche); 40 μg of each sample was separated on 8% SDS-PAGE and then transferred to Hybond-C nitrocellulose membrane (Amersham Pharmacia Biotech). Membranes were blocked with PBS containing 5% (w/v) milk powder and 0.1% (v/v) Tween 20. Primary antibody incubation was carried out overnight at 4°C in PBS containing 5% (w/v) milk powder and 0.1% (v/v) Tween 20. Secondary antibodies were conjugated with horseradish peroxidase (Amersham Pharmacia Biotech). Proteins were visualized using the ECL kit (Amersham Pharmacia Biotech). Antibodies used for Western blotting were DSP 1/2 goat polyclonal antibody (Santa Cruz Biotechnology) used at a 1:500 dilution and the GAPDH mouse monoclonal antibody used at 1:5,000; both were incubated with respective secondary antibodies (Amersham).
+
+Two sons of a consanguineous marriage (Fig. 1) became affected by a global DCM at the ages of 4 and 5 years and presented a focal form of palmoplantar keratoderma. Their parents and one brother appeared unaffected based on cardiologic (history, physical examination, electrocardiography, 2D-echocardiography) and dermatologic evaluation. While the younger sister also showed skin disorders, the fourth brother was not evaluated.Fig. 1Pedigree of studied family. Filled squares (males) indicate cardiac involvement and skin/hair abnormalities; half circles (females) indicate skin abnormalities; diagonal lines indicate deceased individuals; diamonds indicate individuals of either gender; double lines indicate consanguinity. NCAD No cardiac abnormality detected
+
+
+Pedigree of studied family. Filled squares (males) indicate cardiac involvement and skin/hair abnormalities; half circles (females) indicate skin abnormalities; diagonal lines indicate deceased individuals; diamonds indicate individuals of either gender; double lines indicate consanguinity. NCAD No cardiac abnormality detected
+
+One of the affected boys died of severe heart failure at the age of 6 years, 1 year after the initial diagnosis. We could not clinically evaluate this child, but studied clinical reports from an academic pediatric cardiology department. Echocardiography of the deceased boy described severe left ventricular (LV) dilation (59 mm) and global systolic dysfunction (left ventricular ejection fraction LVEF 11%): he died of terminal heart failure.
+
+The mother showed a borderline ejection fraction (58%) and hypertrabeculation of the LV myocardium on MRI. In addition, a slight diffuse apical late enhancement was noticed. There were no signs of fatty infiltration. The MRI of the father was entirely normal.
+
+At the age of 2 years, his brother developed hyperkeratosis on the soles of his feet at points of pronounced pressure (Fig. 2). At the age of 5 years, he was diagnosed with a dilated LV and apical non-compaction of the LV myocardium. The initial echocardiogram demonstrated LVEF of 26%. At the age of 9 years, the index patient was still functionally compensated. MRI showed severe dilation of both ventricles and LVEF of 26% with pronounced trabeculation (Fig. 3 and suppl. Fig. 3). Additionally, patchy late enhancement and spots of signal enhancement on pre-contrast T1-images (right ventricle) were detected (images not shown). At the age of 10 years, heart transplantation was performed because of worsening functional capacity and the appearance of ventricular tachycardias.Fig. 2Clinical presentation of the index patient at the age of 9 years. a, b The patient presented with typical woolly hair and focal hyperkeratosis at pressure points of the left hand (c) and on the sole of the right foot (d)
+Fig. 3MRI, short axis view, SSFP (steady state free precession) late gadolinium enhancement (LGE) sequence, patchy myocardial contrast-enhancement (see also suppl. Fig. 3)
+
+
+Clinical presentation of the index patient at the age of 9 years. a, b The patient presented with typical woolly hair and focal hyperkeratosis at pressure points of the left hand (c) and on the sole of the right foot (d)
+
+MRI, short axis view, SSFP (steady state free precession) late gadolinium enhancement (LGE) sequence, patchy myocardial contrast-enhancement (see also suppl. Fig. 3)
+
+The explanted heart showed biventricular hypertrophy with hypertrabeculation. Endomyocardial and patchy fibrosis of the myocardium were evident in both ventricles. Furthermore, the subepicardial zone, especially of the right ventricular myocardium, showed fibrotic scar formation and regressive atrophy of the cardiomyocytes with accompanying focal fatty tissue formation in these areas (Fig. 4). However, there was no transmural fibrofatty replacement of the right ventricular myocardium. In particular, there was no widening of the intercellular space and the submembranous attachment plaques; anchoring filaments were readily visible.Fig. 4Elastica van Gieson stainings. a Subepicardial zone with intensive fibrosis and focal fibrofatty replacement of the right ventricular myocardium (arrows). The coronary artery shows slight intimal fibrosis. b Higher magnification to show focal fibrofatty replacement. The cardiomyocytes exhibit regressive changes with vacuolization of the cytoplasm and nuclear enlargement
+
+
+Elastica van Gieson stainings. a Subepicardial zone with intensive fibrosis and focal fibrofatty replacement of the right ventricular myocardium (arrows). The coronary artery shows slight intimal fibrosis. b Higher magnification to show focal fibrofatty replacement. The cardiomyocytes exhibit regressive changes with vacuolization of the cytoplasm and nuclear enlargement
+
+DSP was regularly detectable in intercalated discs; staining intensity was comparable to that seen in normal hearts. Furthermore, connexin 43 and vinculin were localized with normal intensity at the intercalated discs. Desmin and alpha-actinin appeared regularly distributed (data not shown).
+
+Histological examination of a plantar keratosis showed massive orthohyperkeratosis and acanthosis of the epidermis with small acantholytic clefts between neighboring keratinocytes (Fig. 5).Fig. 5Histology of a focal plantar keratosis showing massive orthohyperkeratosis and acanthosis of the epidermis with small intercellular clefts (acantholysis) (hematoxylin–eosin stain)
+
+
+Histology of a focal plantar keratosis showing massive orthohyperkeratosis and acanthosis of the epidermis with small intercellular clefts (acantholysis) (hematoxylin–eosin stain)
+
+Analysis of the index patient’s genomic DNA revealed a homozygous 2 bp deletion in exon 23 of DSP which was neither described in the human genome, nor detected in 180 chromosomes of a control population (Fig. 6). The sister was also tested homozygous, while the patient’s parents and one brother were heterozygous for this mutation.Fig. 6
+a The 2 bp deletion produced a frameshift resulting in seven new amino acids (underlined) and b a premature translation stop codon (asterisk). c Schematic view of DSP mutations affecting the C-terminus; yellow bars indicate amino acid substitution d Western blot analysis of DSP-1 and -2 expression in human skin
+
+
+
+a The 2 bp deletion produced a frameshift resulting in seven new amino acids (underlined) and b a premature translation stop codon (asterisk). c Schematic view of DSP mutations affecting the C-terminus; yellow bars indicate amino acid substitution d Western blot analysis of DSP-1 and -2 expression in human skin
+
+DSP is characterized by an N-terminal plakoglobin/plakophilin binding domain, the central coiled-coil rod dimerization domain and a C-terminal intermediate filament (IF) binding domain. The deletion (5208delAG) affects the coding nucleotides 5,208 and 5,209 within exon 24, respectively, and causes a frameshift with a subsequent premature stop codon after seven aberrant codons. The DSP gene encodes two different splice isoforms. The longer peptide DSP-1 is the dominant isoform in cardiac tissues [18] and contains the entire exon 23, whereas DSP-2 uses an internal splice donor site and therefore lacks 599 amino acids compared to DSP-1.
+
+The 5208delAG mutation is downstream of the internal splice donor site and hence exclusively appears in DSP-1. Therefore, it should lead to an isoform-specific truncation of the cardiac isoform DSP-1. As the index patient is homozygous for the mutation, no full-length DSP-1 could be produced as proved by western blot analysis (Fig. 6).
+
+Early-onset cardiomyopathies are severe diseases. The National Australian Childhood Cardiomyopathy Study Group recently published survival rates for pediatric DCM. Freedom from death or transplantation was reduced to 72% 1 year after presentation and to 63% at 5 years [7]. It appears imperative to make all efforts to improve the prognosis of such children. Identification of causative genetic defects can help in several ways. First, it allows separation of family members at risk from those who need not be closely monitored. Close monitoring of individuals at risk can help initiate treatment of both, heart failure and arrhythmias at an early point of the disease course. Second, it offers opportunities for prenatal diagnosis. Third, the identification of disease-causing mutations enables acquiring a deeper understanding of the underlying pathophysiology in this devastating condition.
+
+Several pathways for cardiac diseases have already been identified using this approach. Mutations in ion channel genes were identified in familial arrhythmias such as long-QT and Brugada syndromes [9]. Aberrations in sarcomeric genes can lead to hypertrophic cardiomyopathy [2]. Disruption of desmosomal function is the unifying pathomechanism in ARVD [8]. For DCM, the picture is less clear. Apart from a high proportion of non-genetic forms, even familial DCM shows a high degree of genetic heterogeneity, with different subcellular systems being involved in the disease-causing process [16].
+
+As the index patient had been diagnosed with DCM due to the strong left ventricular dysfunction, we would not have had a realistic chance to identify the underlying genetic defect in the family described, if there had been no additional phenotypes. The characteristic combination of biventricular cardiomyopathy, woolly hair and palmoplantar keratoderma known as Carvajal syndrome led us to assume that mutations in DSP could be the problem in this family. Finally, we identified a homozygous 2 bp deletion in this gene leading to a premature chain-termination mutation. At the age of 10, 5 years after the initial diagnosis, the index patient was transplanted. He was diagnosed with LV involvement, and at the time of explantation the heart showed severe biventricular involvement. According to findings by Sen-Chowdhry et al., [17] who identified three distinct patterns of disease expression, the phenotype of the index patient allows grouping the genotype into the left-dominant disease expression pattern. The phenotypic differences observed between the index patient and the homozygous younger sister, however, could be accounted to her young age, since both the index patient and the deceased brother were free of cardiac involvement until the ages of 4 and 5 years.
+
+DSP is a major constituent of the desmosome. Like several other desmosomal genes, DSP belongs to disease genes that cause ARVD. In addition, DSP is highly expressed in epithelia where desmosomes are important for mechanical integrity. It is therefore not surprising that, apart from cardiac alterations, mutations in DSP can also lead to skin phenotypes and hair abnormalities. Even isolated cutaneous phenotypes without cardiac disease can be caused by DSP mutations, i.e., striate palmoplantar keratoderma, skin-fragility/woolly hair syndrome and lethal acantholytic epidermolysis bullosa (LAEB). Missense, nonsense and truncating frameshift mutations have been identified in these cases (Fig. 6) [1, 5, 9, 11]. Even though an obvious phenotype–genotype correlation regarding DSP mutations has not yet been drawn, it is tempting to speculate that truncations/modifications affecting the C-terminal domain of DSP-1 predispose to cardiomyopathy due to present and previous studies.
+
+For the specific syndromic phenotype of Carvajal syndrome, only three mutations have been described so far. Two exhibit a recessive trait. The homozygous deletion c.7901delG (p.K2542fsX2559) truncates DSP at the C-terminus [11], affecting both isoforms. A homozygous nonsense mutation (p.R1267X) in the DSP-1 specific region of exon 23 leads to shortening of the rod domain exclusively in DSP-1 [18]. Dominant mutations seem capable of producing similar phenotypes [3, 4, 12, 15]. The frameshift mutation G1737fsX1742 described here is situated in the DSP-1 specific region of exon 23, similar to the p.R1267X mutation. Since both alleles are affected, the truncation leads to complete loss of intact full-length DSP-1. Instead, only the truncated isoform was detectable in skin biopsies of this patient. Since DSP-2 is only expressed at very low levels in cardiac muscle and the fact that we found orthotopic DSP expression on immunohistopathology using an antibody recognizing the truncated part of DSP, we conclude that the truncated isoform was still incorporated into the desmosomes but lacked functional integrity eventually leading to the early onset of heart failure in the affected individual.
+
+First, the novel homozygous truncating mutation in the isoform-1 specific region of the DSP C-terminus can lead not only to a severe early-onset form of DCM, woolly hair and an acantholytic form of palmoplantar keratoderma, but also to features of non-compaction. Second, this cardiomyopathy can occur in hearts with normally structured intercalated discs and desmin networks.
+
+Below is the link to the electronic supplementary material.
+Supplementary material 1 (DOC 45 kb)
+Supplementary material 2 (AVI 883 kb)
+
+
+Supplementary material 1 (DOC 45 kb)
+
+Supplementary material 2 (AVI 883 kb)

--- a/references_cache/PMID_25227139.md
+++ b/references_cache/PMID_25227139.md
@@ -1,0 +1,71 @@
+---
+reference_id: PMID:25227139
+title: "Desmoplakin mutations with palmoplantar keratoderma, woolly hair and cardiomyopathy."
+authors:
+- Pigors M
+- Schwieger-Briel A
+- Cosgarea R
+- Diaconeasa A
+- Bruckner-Tuderman L
+- Fleck T
+- Has C
+journal: Acta Derm Venereol
+year: '2015'
+doi: 10.2340/00015555-1974
+keywords:
+- Adolescent
+- "Cardiomyopathies/diagnosis, genetics"
+- Child
+- "Child, Preschool"
+- DNA Mutational Analysis
+- Desmoplakins/genetics
+- Female
+- Genetic Predisposition to Disease
+- "Hair Diseases/congenital, diagnosis, genetics"
+- Heredity
+- Humans
+- "Keratoderma, Palmoplantar/diagnosis, genetics"
+- Male
+- Mutation
+- Pedigree
+- Phenotype
+- Risk Factors
+content_type: abstract_only
+---
+
+# Desmoplakin mutations with palmoplantar keratoderma, woolly hair and cardiomyopathy.
+**Authors:** Pigors M, Schwieger-Briel A, Cosgarea R, Diaconeasa A, Bruckner-Tuderman L, Fleck T, Has C
+**Journal:** Acta Derm Venereol (2015)
+**DOI:** [10.2340/00015555-1974](https://doi.org/10.2340/00015555-1974)
+
+## Content
+
+1. Acta Derm Venereol. 2015 Mar;95(3):337-40. doi: 10.2340/00015555-1974.
+
+Desmoplakin mutations with palmoplantar keratoderma, woolly hair and
+cardiomyopathy.
+
+Pigors M(1), Schwieger-Briel A, Cosgarea R, Diaconeasa A, Bruckner-Tuderman L,
+Fleck T, Has C.
+
+Author information:
+(1)Department of Dermatology, Medical Center, University Freiburg, Freiburg,
+Germany.
+
+Mutations in genes encoding for desmosomal components are associated with a
+broad spectrum of phenotypes comprising skin and hair abnormalities and account
+for 45-50% of cases of arrhythmogenic right ventricular cardiomyopathy. Today,
+more than 120 dominant and recessive desmoplakin (DSP) gene mutations have been
+reported to be associated with skin, hair and/or heart defects. Here we report
+on 3 cases with yet unreported DSP mutations, c.7566_7567delAAinsC,
+p.R2522Sfs*39, c.7756C>T, p.R2586*, c.2131_2132delAG and c.1067C>A, p.T356K,
+that were associated with variable woolly hair or hypotrichosis, palmoplantar
+keratoderma, and cardiac manifestations. In addition, we review and summarise
+the clinical features and DSP mutations of the patients described in the
+literature, which illustrates the complexity of this group of disorders and of
+their genotype-phenotype correlations, which cannot be easily predicted. Early
+diagnosis is crucial and cardiac examinations have to be performed on a regular
+basis.
+
+DOI: 10.2340/00015555-1974
+PMID: 25227139 [Indexed for MEDLINE]

--- a/references_cache/PMID_25824144.md
+++ b/references_cache/PMID_25824144.md
@@ -1,0 +1,97 @@
+---
+reference_id: PMID:25824144
+title: Two Novel Homozygous Desmoplakin Mutations in Carvajal Syndrome.
+authors:
+- Molho-Pessach V
+- Sheffer S
+- Siam R
+- Tams S
+- Siam I
+- Awwad R
+- Babay S
+- Golender J
+- Simanovsky N
+- Ramot Y
+- Zlotogorski A
+journal: Pediatr Dermatol
+year: '2015'
+doi: 10.1111/pde.12541
+keywords:
+- Adolescent
+- Cardiomyopathies/genetics
+- "Cardiomyopathy, Dilated"
+- Child
+- "Child, Preschool"
+- Consanguinity
+- Desmoplakins/genetics
+- Genetic Testing
+- Hair Diseases/genetics
+- Homozygote
+- Humans
+- "Keratoderma, Palmoplantar/genetics"
+- Male
+- Middle Aged
+- "Mutation, Missense"
+- Young Adult
+content_type: abstract_only
+---
+
+# Two Novel Homozygous Desmoplakin Mutations in Carvajal Syndrome.
+**Authors:** Molho-Pessach V, Sheffer S, Siam R, Tams S, Siam I, Awwad R, Babay S, Golender J, Simanovsky N, Ramot Y, Zlotogorski A
+**Journal:** Pediatr Dermatol (2015)
+**DOI:** [10.1111/pde.12541](https://doi.org/10.1111/pde.12541)
+
+## Content
+
+1. Pediatr Dermatol. 2015 Sep-Oct;32(5):641-6. doi: 10.1111/pde.12541. Epub 2015
+Mar 30.
+
+Two Novel Homozygous Desmoplakin Mutations in Carvajal Syndrome.
+
+Molho-Pessach V(1)(2), Sheffer S(1), Siam R(1), Tams S(3), Siam I(1), Awwad
+R(4), Babay S(2), Golender J(5), Simanovsky N(6), Ramot Y(1)(2), Zlotogorski
+A(1)(2).
+
+Author information:
+(1)Department of Dermatology, Hadassah-Hebrew University Medical Center,
+Jerusalem, Israel.
+(2)Center for Genetic Diseases of the Skin and Hair, Hadassah-Hebrew University
+Medical Center, Jerusalem, Israel.
+(3)Faculty of Medicine, Palestinian Al Quds University, Abu Dis, Palestinian
+Authority.
+(4)Caritas Baby Hospital, Bethlehem, Palestinian Authority.
+(5)Department of Pediatric Cardiology, Hadassah-Hebrew University Medical
+Center, Jerusalem, Israel.
+(6)Department of Medical Imaging, Hadassah-Hebrew University Medical Center,
+Jerusalem, Israel.
+
+BACKGROUND: Mutations in various desmosomal proteins were shown to cause
+inherited forms of cardiomyopathy. Carvajal syndrome (Online Mendelian
+Inheritance in Man [OMIM] 605676) is characterized by the association of dilated
+cardiomyopathy, striate palmoplantar keratoderma, and woolly hair. It is caused
+by homozygous as well as heterozygous mutations in DSP, which encodes the
+desmosomal plaque protein desmoplakin. An overlapping cardiocutaneous phenotype
+was also described with homozygous mutations in genes encoding two other
+desmosomal proteins; plakoglobin (Naxos disease; OMIM 601214) and desmocollin-2
+(OMIM 610476).
+METHODS: We performed clinical and molecular workups in two consanguineous Arab
+Palestinian families manifesting an autosomal recessive pattern of inheritance
+of the above mentioned clinical findings. Whole exome sequencing was employed in
+the search for the causing mutation.
+RESULTS: Affected family members suffered from biventricular involvement and
+arrhythmogenic right ventricular dysplasia based on echocardiography and
+magnetic resonance imaging. One patient who underwent implantation of an
+implantable cardioverter-defibrillator (ICD) is still alive at the age of 59
+years. Whole exome sequencing revealed two novel homozygous mutations in DSP,
+each affecting one family.
+CONCLUSIONS: The association of woolly hair with palmoplantar keratoderma in a
+child should lead to a cardiac workup in the search for those at increased risk
+for sudden cardiac death. Early diagnosis and ICD implantation may be
+lifesaving. Whole exome sequencing should be utilized for rapid genetic analysis
+since the cardiocutaneous phenotype may result from mutations in one of several
+genes.
+
+© 2015 Wiley Periodicals, Inc.
+
+DOI: 10.1111/pde.12541
+PMID: 25824144 [Indexed for MEDLINE]

--- a/references_cache/PMID_30382575.md
+++ b/references_cache/PMID_30382575.md
@@ -1,0 +1,136 @@
+---
+reference_id: PMID:30382575
+title: Loss-of-function desmoplakin I and II mutations underlie dominant arrhythmogenic cardiomyopathy with a hair and skin phenotype.
+authors:
+- Maruthappu T
+- Posafalvi A
+- Castelletti S
+- Delaney PJ
+- Syrris P
+- "O'Toole EA"
+- Green KJ
+- Elliott PM
+- Lambiase PD
+- Tinker A
+- McKenna WJ
+- Kelsell DP
+journal: Br J Dermatol
+year: '2019'
+doi: 10.1111/bjd.17388
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Cardiomyopathies/diagnosis, genetics, pathology"
+- "Cardiomyopathy, Dilated"
+- DNA Mutational Analysis
+- Desmoplakins/genetics
+- Female
+- "Hair Diseases/diagnosis, genetics, pathology"
+- Heart/diagnostic imaging
+- Heterozygote
+- Humans
+- "Keratoderma, Palmoplantar/diagnosis, genetics, pathology"
+- Loss of Function Mutation
+- Magnetic Resonance Imaging
+- Male
+- Middle Aged
+- Pedigree
+- Protein Isoforms/genetics
+- Skin/pathology
+- Young Adult
+content_type: full_text_xml
+---
+
+# Loss-of-function desmoplakin I and II mutations underlie dominant arrhythmogenic cardiomyopathy with a hair and skin phenotype.
+**Authors:** Maruthappu T, Posafalvi A, Castelletti S, Delaney PJ, Syrris P, O'Toole EA, Green KJ, Elliott PM, Lambiase PD, Tinker A, McKenna WJ, Kelsell DP
+**Journal:** Br J Dermatol (2019)
+**DOI:** [10.1111/bjd.17388](https://doi.org/10.1111/bjd.17388)
+
+## Content
+
+1. Br J Dermatol. 2019 May;180(5):1114-1122. doi: 10.1111/bjd.17388. Epub 2019
+Jan  2.
+
+Loss-of-function desmoplakin I and II mutations underlie dominant arrhythmogenic
+cardiomyopathy with a hair and skin phenotype.
+
+Maruthappu T(1), Posafalvi A(1), Castelletti S(2), Delaney PJ(1), Syrris P(3),
+O'Toole EA(1), Green KJ(4), Elliott PM(5), Lambiase PD(3)(5), Tinker A(6),
+McKenna WJ(5), Kelsell DP(1).
+
+Author information:
+(1)Blizard Institute, Queen Mary University of London, London, U.K.
+(2)Istituto Auxologico Italiano IRCCS, Center for Cardiac Arrhythmias of Genetic
+Origin, Milan, Italy.
+(3)Institute of Cardiovascular Science, University College London, London, U.K.
+(4)Department of Pathology and Dermatology, Northwestern University, Feinberg
+School of Medicine, Chicago, IL, U.S.A.
+(5)Department of Cardiac Electrophysiology, The Barts Heart Centre, St
+Bartholomew's Hospital, London, U.K.
+(6)The Heart Centre, Queen Mary University of London, London, U.K.
+
+Comment in
+    Br J Dermatol. 2019 May;180(5):983-984. doi: 10.1111/bjd.17504.
+
+BACKGROUND: Arrhythmogenic cardiomyopathy (AC) is an inherited, frequently
+underdiagnosed disorder, which can predispose individuals to sudden cardiac
+death. Rare, recessive forms of AC can be associated with woolly hair and
+palmoplantar keratoderma, but most autosomal dominant AC forms have been
+reported to be cardiac specific. Causative mutations frequently occur in
+desmosomal genes including desmoplakin (DSP).
+OBJECTIVES: In this study, we systematically investigated the presence of a skin
+and hair phenotype in heterozygous DSP mutation carriers with AC.
+METHODS: Six AC pedigrees with 38 carriers of a dominant loss-of-function
+(nonsense or frameshift) mutation in DSP were evaluated by detailed clinical
+examination (cardiac, hair and skin) and molecular phenotyping.
+RESULTS: All carriers with mutations affecting both major DSP isoforms (DSPI and
+II) were observed to have curly or wavy hair in the pedigrees examined, except
+for members of Family 6, where the position of the mutation only affected the
+cardiac-specific isoform DSPI. A mild palmoplantar keratoderma was also present
+in many carriers. Sanger sequencing of cDNA from nonlesional carrier skin
+suggested degradation of the mutant allele. Immunohistochemistry of patient skin
+demonstrated mislocalization of DSP and other junctional proteins (plakoglobin,
+connexin 43) in the basal epidermis. However, in Family 6, DSP localization was
+comparable with control skin.
+CONCLUSIONS: This study identifies a highly recognizable cutaneous phenotype
+associated with dominant loss-of-function DSPI/II mutations underlying AC.
+Increased awareness of this phenotype among healthcare workers could facilitate
+a timely diagnosis of AC in the absence of overt cardiac features.
+
+© 2018 British Association of Dermatologists.
+
+DOI: 10.1111/bjd.17388
+PMCID: PMC6318013
+PMID: 30382575 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of Interest: none declared.
+
+Arrhythmogenic cardiomyopathy (AC) is an inherited cardiac disorder characterized by a high risk of arrhythmias and is a cause of sudden cardiac death in the young (<35 years old) 1,2. The foremost clinical challenge in AC is making an accurate and timely diagnosis. This is hampered by a prolonged, silent pre-clinical phase of the disease, lack of overt symptoms and variability of cardiac findings 2,3. The genetic basis of AC in the majority of cases is linked to a mutation in a component of the desmosome, a key electromechanical adhesion complex between cardiomyocytes. AC associated mutations have been reported to occur in five desmosomal genes: plakoglobin, desmoplakin, plakophilin 2, desmoglein 2 and desmocollin 24.
+
+Desmosomes are also the major cell-cell adhesion structures contributing to mechanoresilience in the skin 4,5. As such, rare, predominantly recessively inherited mutations in desmosomal proteins can present with a unique “cardio-cutaneous” phenotype. Both Carvajal Disease (caused by desmoplakin mutations, DSP) and Naxos Disease (caused by plakoglobin mutations, JUP) characteristically present with a triad of “woolly” hair, markedly thickened skin of the palms and soles (palmoplantar keratoderma) from infancy and later, development of severe cardiomyopathy in childhood 6,7. Though rare autosomal dominant cardiocutaneous cases have been reported 8–12, there was confusion whether both the skin and the heart would be affected in heterozygous loss of function (nonsense or frameshift) mutation careers, which was often due to observational bias in these families as either purely cardiac 11, or only dermatological 10 examinations were carried out. On this basis, we have performed the first systematic analysis of a cohort of patients: we selected AC families with a well-defined subset of heterozygous loss of function DSP mutations, and investigated their putative cutaneous symptoms using deep clinical and molecular phenotyping.
+
+The study involved 6 families with a history of AC, specifically focusing on a cohort harbouring heterozygous N-terminal loss of function (nonsense/frameshift) mutations of DSP. The patients were recruited at the Heart Hospital, University College London Hospitals NHS Trust (UCLH), London, UK. Patients were diagnosed with AC according to the revised Task Force Criteria1. Individuals were examined from cardiac and cutaneous perspectives. Systematic evaluation of first and second degree family members was performed in whom mutation-carrier status was verified. In total, personal history of cutaneous features was collected from 58 family members, 38 mutation carriers, including five deceased members, and 20 non-carrier healthy family members. All 33 living mutation carriers were recruited for detailed phenotyping, while 8 of them had 3mm punch biopsies of non-lesional skin of the lower forearm collected for molecular characterisation. Personal history of cutaneous features was collected, and detailed clinical examination of the skin and hair phenotype was carried out by a dermatologist (TM). Cardiac phenotyping was performed according to the protocol described in 30 family members (3 of the 33 carriers resided abroad and were therefore unavailable to participate in cardiac phenotyping) 13. Arrhythmic characterization included arrhythmia recorded during 24 hour ambulatory ECG monitoring and/or exercise testing, cardiac arrest (CA) and implantable cardioverter defibrillator (ICD) appropriate discharges. Patients with atypical chest pain, palpitations and/or syncope suggestive of vaso-vagal origin were considered asymptomatic. All patients provided written informed consent. The study protocol conforms to the ethical guidelines of the 1975 Declaration of Helsinki and was approved by the local ethics committees.
+
+10*10 µm skin cryosections were used for DNA and RNA extractions with the QIAamp DNA and RNeasy mini kits (Qiagen, Hilden, Germany), following the instructions of the manufacturer. RNA was reverse transcribed into cDNA using SuperScript II (Invitrogen, Carlsbad, CA, USA). Primer sequences and PCR conditions are available upon request.
+
+5µm cryosections were prepared on microscopic slides. The sections were fixed in Methanol-Acetone (1:1) and blocked in 5% goat serum. The following antibodies and dilutions were used: DSP (11–5F, 1:50), Jup (OBT0641, 1:10, AbD Serotec, Bio-Rad, Hercules, CA, USA), Gja1 (Mab3067, 1:200, Millipore, Billerica, MA, USA), GFP-labelled goat anti-mouse (A11029, 1:500, Thermo Fisher, Waltham, MA, USA). The negative controls (no primary antibody) were performed on patient skin plus control breast reduction and tummy tuck derived skin. The mounted stainings were imaged on a Zeiss 710 confocal microscope. Maximum Intensity Projections were created and exported using ImageJ.
+
+Among all patients, 12/30 (40%) fulfilled the 2010 Task Force Criteria for AC diagnosis. The fulfilment of the diagnostic criteria is presented in Table 1 and Figure 1. Ten patients (33%) had a history of arrhythmic symptoms, inverted T waves on electrocardiogram (ECG) were present in 9 (30%) patients whilst signal-averaged ECG (SA-ECG) was positive in 12 (40%) mutation carriers. Ejection fraction was impaired in 9 (30%) patients at echocardiogram. During 24 hour ambulatory ECG monitoring, >500 ventricular ectopics were noted in 13 (43%) mutation carriers, in particular, in 7 of these a non-sustained ventricular tachycardia (NSVT) was recorded. Cardiac Magnetic Resonance (CMR) showed fibrofatty infiltration in 10 patients (33%) and 11 (37%) patients had an ICD implanted, two of these for secondary prevention.
+
+Detailed dermatological evaluation of scalp hair and palmoplantar skin was performed in 33 mutation-carriers (Families 1–6) and the presence of curly hair was found in all DSP carriers from families 1–5 (Fig. 2). Family 6 (pE1493X) was an exception where only the index patient had curly hair, and the 6 other mutation carriers within this family had straight hair (Figs 2A and4A). The presence of curly hair in mutation carriers was 5 times the incidence observed in the general Caucasian population (73.8% vs 15%) and this difference was highly significant (p=0.0012; unpaired t test)14. The hair was observed to be tightly curled with a coarse, wiry texture (Figs 2B and C). No features of defective hair growth or excessive breakage were noted. A key finding was the absence of curly hair in 20 non-carrier offspring within the same families, indicating a high level of specificity for this phenotype within the cohort of patients and their relatives. The presence of palmoplantar keratoderma (PPK) showed more variable penetrance between individuals from the same family and additional factors such as age and physical activity influenced their presence (Table 1). Carriers of mutation p.H586Tfs and p.R1113X showed classical band-like thickened hyperkeratosis affecting the plantar footpad (“striate” keratoderma) in addition to hyperkeratosis and marked fissuring of the heel region, resembling Carvajal Syndrome (Figs 2B and2C). Others (p.N274Efs) displayed focal thickening of the pressure bearing regions of the plantar skin and described callus formation on the palms following physical activity. Some subjects, for example carriers of p.R1015Sfs, also complained of xerosis (excessive drying of the skin) following exposure to water. A common complaint of mutation carriers was having painful rough, hard skin on their feet and the need to regularly file or cut or shave this off using a razor.
+
+To determine the pathophysiology underlying the cutaneous phenotype, skin biopsies were obtained from non-lesional skin on the forearm from 8 mutation-carriers. Immunohistochemical staining was performed and compared with control skin from unaffected individuals. The immunoreactive signal for desmoplakin showed a granular and irregular localisation in the basal layers of the epidermis of patient skin, rather than confluent membranous distribution seen in normal skin (Fig. 3A). Similarly, albeit more subtle abnormalities in the expression pattern of plakoglobin were also observed (Fig. 3B), with granular deposition in the basal layers. The expression of connexin 43 (Cx43) appeared reduced in the basal epidermis from affected patient skin (Fig. 3B). This particular junctional component is critical for electrical conduction in the cardiac intercalate disc. These findings suggest that even in clinically “normal” appearing skin in mutation-carriers, there is abnormal localisation of key desmosomal proteins and reduced expression of Cx43, in the basal epidermis. To investigate the effect of these specific DSP mutations on mRNA expression, Sanger sequencing of skin biopsies from affected patients was performed. This confirmed the presence of the mutation in genomic DNA, but the truncated mRNA of the mutant allele was notably absent (Fig. 3C). This absence of the mutant allele in mRNA/cDNA of non-lesional patient skin indicates that nonsense-mediated decay (NMD) is underlying the disease.
+
+We have identified the presence of a highly penetrant cutaneous phenotype of curly hair and to a lesser extent, palmoplantar keratoderma in DSP mutation-carriers, but not in unaffected family members. These readily recognisable non-cardiac features, could be used in conjunction with traditional diagnostic strategies to facilitate a timely diagnosis of AC. Desmoplakin is a key desmosomal protein associated with the predominantly left ventricular forms of AC. To date, there are only a limited number of genotype-phenotype studies in AC 15,16, or in particular in DSP mutation carriers 13,17–20.
+
+Our cutaneous findings are not completely unexpected, as in Carvajal disease the very severe, often lethal pediatric cardiomyopathy is combined with the presence of woolly hair and striate palmoplantar keratoderma 6. However, in those families, the homozygous premature stop mutation is in the third (and last) globular unit of the C-terminal tail domain of DSP. Even though this mutation leads to a truncated protein product, and weakens the resilience of the interaction between DSP and the keratin/desmin intermediate filaments in the skin/heart of homozygous patients, their carrier parents showed no sign of the cardiocutaneous disease. Interestingly, other heterozygous cases, such as carriers of an N-terminal in-frame duplication mutation do exhibit the Carvajal-phenotype 8. The consistent presence of this milder cardiocutaneous phenotype in N-terminal head-domain mutations of our well-defined, relatively large, heterozygous cohort is hence intriguing.
+
+Desmoplakin and desmosomal proteins also have a key role in hair follicle biology 4. Although no scalp biopsies were available for analysis, we hypothesise that abnormal distribution of desmosomal components in the follicle and consequent impairment of cell-cell adhesion could contribute to angulation of the follicle, which is known to cause curvature of the hair strand 14. In the skin, the expression of individual components of the desmosome vary from the basal layer to the superficial epidermis. However, in the heart, desmosomal components are uniform, and overlap with those expressed in the basal epidermis 21. Therefore, mislocalisation of desmosomal proteins in the basal skin could mirror what occurs at the intercalated disc in cardiomyocytes (Fig. 3D) 22, even if the biopsy is taken from non-lesional skin. In the skin this manifests clinically as impaired mechanoresilience in response to mechanical stress, with hyperkeratosis and fissuring at pressure-bearing sites on the soles. Whereas in the heart, abrogated cell-cell adhesion results in conduction defects, fibrofatty infiltration and cardiomyopathy 23. Abnormal localisation of key desmosomal proteins in the heart and skin and their deleterious effect on cell-cell adhesion therefore reconciles the presence of both cardiac and cutaneous phenotypes in these patients.
+
+The curly hair phenotype shows 100% segregation with mutation-carrier status within families 1–5 in which the heterozygous nonsense or frameshift mutation falls to the N-terminal head domain of desmoplakin, or the N-terminal part of the rod domain that is present in both main isoforms. Curly hair is a highly sensitive and specific indicator of carriership status in the N-terminal mutation-carrier families, all of whom happen to be Caucasian, but with respect to the general population, it is not specific. For example, genome wide association studies have found a single nucleotide polymorphism in the TCHH gene, which encodes Trichohyalin, a component of the hair follicle inner root sheath. This gene accounts for approximately 6% of hair curliness in the Caucasian population 24. Some patients also developed a palmoplantar keratoderma with hyperkeratosis and fissuring at pressure-bearing sites, and the same patients seemed to have more severe cardiac symptoms as well, potentially indicating higher amount of environmental stress in those individuals. On the molecular level, we observed abnormal localisation of desmosomal proteins and connexin 43 in the skin, which reflects some observations reported in heart tissue of patients with AC 23. Our data supports haploinsufficiency due to NMD of the mutant allele as the molecular mechanism and that DSP dosage, particularly of DSPII, is critical to form stable junctions in proliferative (basal) /stressed keratinocytes or cardiomyocytes.
+
+In Family 6, only 1 of the 7 mutation-carriers demonstrated a curly hair/cutaneous phenotype (Fig. 4A). Their cardiac symptoms were also somewhat less severe: no patient in the family has ICD implanted, and many of them were borderline cases (not yet fulfilling all Task Force Criteria) with normal echo and T-wave inversion (Table 1). The mutation p.E1493X is localised in the middle of the DSP rod domain, in the fragment (between coordinates c.3585–5379, or p.1195–1793) that is included only in isoform 1 of desmoplakin (DSPI) while it is spliced out in isoform 2 (DSPII) (Fig. 4B). We have previously shown that DSPII is the major isoform regulating keratinocyte adhesion 25. Consistent with this, immunohistochemical staining of skin from these patients demonstrated a distribution of Plakoglobin and Desmoplakin comparable to control skin (Fig. 4C).
+
+In clinical practice, the presence of curly hair and keratoderma is likely to be a useful additional clinical identifier of AC patients. When incorporated into family screening for AC, it could be particularly useful in persuading individuals to partake in genetic screening programmes and identify high risk family members who warrant further diagnostic tests, lifestyle changes and participating in regular follow-up. This study did not include pedigrees with missense mutations in DSP, nor did it examine carriers of other desmosomal AC gene mutations. All pedigrees included in this study happened to be of Caucasian origin, however it would be important to consider the significance of the cutaneous phenotype in other populations including those in which curly hair is known to be more highly prevalent. Although our study includes the largest number of DSP mutation carriers reported, and the first systematic approach of a well-defined mutation subtype cohort, larger-scale genotype-phenotype correlation studies are necessary to confirm these dermatological findings.

--- a/references_cache/PMID_33275305.md
+++ b/references_cache/PMID_33275305.md
@@ -1,0 +1,64 @@
+---
+reference_id: PMID:33275305
+title: "Hair and skin predict cardiomyopathies: Carvajal and erythrokeratodermia cardiomyopathy syndromes."
+authors:
+- Sun Q
+- Wine Lee L
+- Hall EK
+- Choate KA
+- Elder RW
+journal: Pediatr Dermatol
+year: '2021'
+doi: 10.1111/pde.14478
+keywords:
+- "Cardiomyopathies/diagnosis, genetics"
+- Child
+- "Child, Preschool"
+- Desmoplakins/genetics
+- Genetic Testing
+- Humans
+- Skin
+- Syndrome
+content_type: abstract_only
+---
+
+# Hair and skin predict cardiomyopathies: Carvajal and erythrokeratodermia cardiomyopathy syndromes.
+**Authors:** Sun Q, Wine Lee L, Hall EK, Choate KA, Elder RW
+**Journal:** Pediatr Dermatol (2021)
+**DOI:** [10.1111/pde.14478](https://doi.org/10.1111/pde.14478)
+
+## Content
+
+1. Pediatr Dermatol. 2021 Jan;38(1):31-38. doi: 10.1111/pde.14478. Epub 2020 Dec
+4.
+
+Hair and skin predict cardiomyopathies: Carvajal and erythrokeratodermia
+cardiomyopathy syndromes.
+
+Sun Q(1), Wine Lee L(2), Hall EK(3), Choate KA(1), Elder RW(3).
+
+Author information:
+(1)Departments of Dermatology, Genetics, and Pathology, Yale School of Medicine,
+New Haven, CT, USA.
+(2)Medical University of South Carolina Health, Charleston, SC, USA.
+(3)Section of Cardiology, Department of Pediatrics, Yale School of Medicine, New
+Haven, CT, USA.
+
+Comment in
+    Pediatr Dermatol. 2021 Sep;38(5):1406. doi: 10.1111/pde.14809.
+
+Carvajal and erythrokeratodermia cardiomyopathy syndromes (EKC) are rare,
+inherited cardiocutaneous disorders with potentially fatal consequences in young
+children. Some patients display features of congestive heart failure and rapidly
+deteriorate; others exhibit no evident warning signs until sudden death reveals
+underlying heart disease. We present two patients to illustrate the
+characteristic hair, skin, teeth, and nail abnormalities, which-especially when
+distinct from that of other family members-should prompt cardiac evaluation and
+genetic analysis. In this article, we discuss established treatments as well as
+a promising, novel therapeutic that has led to nearly complete resolution of the
+cutaneous and cardiac pathology in EKC syndrome.
+
+© 2020 Wiley Periodicals LLC.
+
+DOI: 10.1111/pde.14478
+PMID: 33275305 [Indexed for MEDLINE]

--- a/references_cache/PMID_35445468.md
+++ b/references_cache/PMID_35445468.md
@@ -1,0 +1,103 @@
+---
+reference_id: PMID:35445468
+title: A novel desmoplakin mutation causes dilated cardiomyopathy with palmoplantar keratoderma as an early clinical sign.
+authors:
+- Karvonen V
+- Harjama L
+- Heliö K
+- Kettunen K
+- Elomaa O
+- Koskenvuo JW
+- Kere J
+- Weckström S
+- Holmström M
+- Saarela J
+- Ranki A
+- Heliö T
+- Hannula-Jouppi K
+journal: J Eur Acad Dermatol Venereol
+year: '2022'
+doi: 10.1111/jdv.18164
+keywords:
+- Adult
+- "Cardiomyopathies/complications, genetics"
+- "Cardiomyopathy, Dilated/complications, genetics"
+- Desmoplakins/genetics
+- Humans
+- "Keratoderma, Palmoplantar/complications, diagnosis, genetics"
+- Mutation
+content_type: abstract_only
+---
+
+# A novel desmoplakin mutation causes dilated cardiomyopathy with palmoplantar keratoderma as an early clinical sign.
+**Authors:** Karvonen V, Harjama L, Heliö K, Kettunen K, Elomaa O, Koskenvuo JW, Kere J, Weckström S, Holmström M, Saarela J, Ranki A, Heliö T, Hannula-Jouppi K
+**Journal:** J Eur Acad Dermatol Venereol (2022)
+**DOI:** [10.1111/jdv.18164](https://doi.org/10.1111/jdv.18164)
+
+## Content
+
+1. J Eur Acad Dermatol Venereol. 2022 Aug;36(8):1349-1358. doi:
+10.1111/jdv.18164.  Epub 2022 May 6.
+
+A novel desmoplakin mutation causes dilated cardiomyopathy with palmoplantar
+keratoderma as an early clinical sign.
+
+Karvonen V(#)(1), Harjama L(#)(1), Heliö K(2), Kettunen K(3)(4), Elomaa O(5),
+Koskenvuo JW(6), Kere J(5)(7), Weckström S(2), Holmström M(8), Saarela
+J(3)(4)(9), Ranki A(1), Heliö T(2), Hannula-Jouppi K(1)(5).
+
+Author information:
+(1)Department of Dermatology and Allergology, University of Helsinki and
+Helsinki University Hospital, Helsinki, Finland.
+(2)Department of Cardiology, University of Helsinki and Helsinki University
+Hospital, Helsinki, Finland.
+(3)HUS Diagnostic Center, Division of Genetics and Clinical Pharmacology,
+Laboratory of Genetics, University of Helsinki and Helsinki University Hospital,
+Helsinki, Finland.
+(4)Institute for Molecular Medicine Finland (FIMM), Helsinki Institute of Life
+Science (HiLIFE), University of Helsinki, Helsinki, Finland.
+(5)Folkhälsan Research Center, Helsinki, Finland and Research Programs Unit,
+Stem Cells and Metabolism Research Program, University of Helsinki, Helsinki,
+Finland.
+(6)Blueprint Genetics, Espoo, Finland.
+(7)Department of Biosciences and Nutrition, Karolinska Institutet, Huddinge,
+Sweden.
+(8)Radiology, HUS Diagnostic Center, University of Helsinki and Helsinki
+University Hospital, Helsinki, Finland.
+(9)Centre for Molecular Medicine Norway (NCMM), University of Oslo, Oslo,
+Norway.
+(#)Contributed equally
+
+BACKGROUND: PPKs represent a heterogeneous group of disorders with
+hyperkeratosis of palmar and/or plantar skin. PPK, hair shaft abnormalities,
+cardiomyopathy and arrhythmias can be caused by mutations in desmosomal genes,
+e.g. desmoplakin (DSP). PPK should trigger genetic testing to reveal mutations
+with possible related cardiac disease.
+OBJECTIVES: To report a large multigenerational family with a novel DSP mutation
+associated with early-onset PPK and adult-onset cardiomyopathy and arrhythmias.
+METHODS: A custom-designed in-house panel of 35 PPK related genes was used to
+screen mutations in the index patient with focal PPK. The identified DSP
+mutation was verified by Sanger sequencing. DNA samples from 20 members of the
+large multigenerational family were sequenced for the DSP mutation. Medical
+records were reviewed. Clinical dermatological evaluation was performed,
+including light microscopy of hair samples. Cardiac evaluation included clinical
+examination, echocardiography, cardiac magnetic resonance imaging (CMR),
+electrocardiogram (ECG), Holter monitoring and laboratory tests.
+RESULTS: We identified a novel autosomal dominant truncating DSP c.2493delA
+p.(Glu831Aspfs*33) mutation associated with dilated cardiomyopathy (DCM) with
+arrhythmia susceptibility and focal PPK as an early cutaneous sign. The mutation
+was found in nine affected family members, but not in any unaffected members.
+Onset of dermatological findings preceded cardiac symptoms which were variable
+and occurred at adult age.
+CONCLUSIONS: We report a novel truncating DSP mutation causing focal PPK with
+varying severity and left ventricular dilatation and ventricular extrasystoles.
+This finding emphasizes the importance of genetic diagnosis in patients with PPK
+for clinical counselling and management of cardiomyopathies and arrhythmias.
+
+© 2022 The Authors. Journal of the European Academy of Dermatology and
+Venereology published by John Wiley & Sons Ltd on behalf of European Academy of
+Dermatology and Venereology.
+
+DOI: 10.1111/jdv.18164
+PMCID: PMC9545885
+PMID: 35445468 [Indexed for MEDLINE]

--- a/references_cache/PMID_37048743.md
+++ b/references_cache/PMID_37048743.md
@@ -1,0 +1,54 @@
+---
+reference_id: PMID:37048743
+title: "Desmoplakin Cardiomyopathy: Comprehensive Review of an Increasingly Recognized Entity."
+authors:
+- Brandão M
+- Bariani R
+- Rigato I
+- Bauce B
+journal: J Clin Med
+year: '2023'
+doi: 10.3390/jcm12072660
+content_type: abstract_only
+---
+
+# Desmoplakin Cardiomyopathy: Comprehensive Review of an Increasingly Recognized Entity.
+**Authors:** Brandão M, Bariani R, Rigato I, Bauce B
+**Journal:** J Clin Med (2023)
+**DOI:** [10.3390/jcm12072660](https://doi.org/10.3390/jcm12072660)
+
+## Content
+
+1. J Clin Med. 2023 Apr 3;12(7):2660. doi: 10.3390/jcm12072660.
+
+Desmoplakin Cardiomyopathy: Comprehensive Review of an Increasingly Recognized
+Entity.
+
+Brandão M(1), Bariani R(2), Rigato I(3), Bauce B(2).
+
+Author information:
+(1)Cardiology Department, Centro Hospitalar Vila Nova de Gaia/Espinho, 4430-000
+Vila Nova de Gaia, Portugal.
+(2)Department of Cardiac, Thoracic, Vascular Sciences and Public Health,
+University of Padova, 35122 Padova, Italy.
+(3)Azienda Ospedaliera/Universita' di Padova, Via Giustiniani, 2-Padova, 35128
+Padova, Italy.
+
+Desmoplakin (DSP) is a desmosomal protein that plays an essential role for
+cell-to-cell adhesion within the cardiomyocytes. The first association between
+DSP genetic variants and the presence of a myocardial disease referred to
+patients with Carvajal syndrome. Since then, several reports have linked the DSP
+gene to familial forms of arrhythmogenic (ACM) and dilated cardiomyopathies.
+Left-dominant ACM is the most common phenotype in individuals carrying DSP
+variants. More recently, a new entity-"Desmoplakin cardiomyopathy"-was described
+as a distinct form of cardiomyopathy characterized by frequent left ventricular
+involvement with extensive fibrosis, high arrhythmic risk, and episodes of acute
+myocardial injury. The purpose of this review was to summarize the available
+evidence on DSP cardiomyopathy and to identify existing gaps in knowledge that
+need clarification from upcoming research.
+
+DOI: 10.3390/jcm12072660
+PMCID: PMC10095332
+PMID: 37048743
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_39078013.md
+++ b/references_cache/PMID_39078013.md
@@ -1,0 +1,47 @@
+---
+reference_id: PMID:39078013
+title: Carvajal syndrome related to two distinct molecular variants in desmoplakin gene.
+authors:
+- Ziółkowska L
+- Piekutowska-Abramczuk D
+- Borowiec K
+- Ciara E
+- Sterliński M
+- Biernacka EK
+journal: Kardiol Pol
+year: '2024'
+doi: 10.33963/v.phj.101664
+content_type: abstract_only
+---
+
+# Carvajal syndrome related to two distinct molecular variants in desmoplakin gene.
+**Authors:** Ziółkowska L, Piekutowska-Abramczuk D, Borowiec K, Ciara E, Sterliński M, Biernacka EK
+**Journal:** Kardiol Pol (2024)
+**DOI:** [10.33963/v.phj.101664](https://doi.org/10.33963/v.phj.101664)
+
+## Content
+
+1. Kardiol Pol. 2024;82(9):914-915. doi: 10.33963/v.phj.101664. Epub 2024 Jul 30.
+
+Carvajal syndrome related to two distinct molecular variants in desmoplakin
+gene.
+
+Ziółkowska L(1), Piekutowska-Abramczuk D(2), Borowiec K(3), Ciara E(4),
+Sterliński M(5), Biernacka EK(6).
+
+Author information:
+(1)Department of Cardiology, The Children's Memorial Health Institute, Warszawa,
+Poland.
+(2)Department of Medical Genetics, The Children's Memorial Health Institute,
+Warszawa, Poland.
+(3)Department of Congenital Heart Diseases, Cardinal Stefan Wyszyński National
+Institute of Cardiology, Warsaw, Poland. kborowiec@ikard.pl.
+(4)Department of Medical Genetics, The Children's Memorial Health Institute,
+Warsaw, Poland.
+(5)1st Department of Arrhythmia, Cardinal Stefan Wyszyński National Institute of
+Cardiology, Warsaw, Poland.
+(6)Department of Congenital Heart Diseases, Cardinal Stefan Wyszyński National
+Institute of Cardiology, Warsaw, Poland.
+
+DOI: 10.33963/v.phj.101664
+PMID: 39078013

--- a/references_cache/PMID_40108711.md
+++ b/references_cache/PMID_40108711.md
@@ -1,0 +1,108 @@
+---
+reference_id: PMID:40108711
+title: "Genotype and cardiac outcome in patients with cardiocutaneous syndrome (Naxos disease variant: Carvajal syndrome)."
+authors:
+- Binfadel M
+- Aleem MU
+- Alhabdan M
+- Alruwaili N
+- AlHassnan Z
+- Vriz O
+- Tulbah S
+- Albert-Brotons DC
+journal: Orphanet J Rare Dis
+year: '2025'
+doi: 10.1186/s13023-025-03612-8
+keywords:
+- Humans
+- Male
+- Female
+- Child
+- "Keratoderma, Palmoplantar/genetics"
+- "Child, Preschool"
+- Retrospective Studies
+- Genotype
+- Hair Diseases/genetics
+- Adolescent
+- Desmoplakins/genetics
+- Saudi Arabia
+- "Skin Diseases, Genetic/genetics"
+- Cardiomyopathies/genetics
+- Infant
+- "Cardiomyopathy, Dilated/genetics"
+- "Arrhythmias, Cardiac/genetics"
+- Arrhythmogenic Right Ventricular Dysplasia
+content_type: abstract_only
+---
+
+# Genotype and cardiac outcome in patients with cardiocutaneous syndrome (Naxos disease variant: Carvajal syndrome).
+**Authors:** Binfadel M, Aleem MU, Alhabdan M, Alruwaili N, AlHassnan Z, Vriz O, Tulbah S, Albert-Brotons DC
+**Journal:** Orphanet J Rare Dis (2025)
+**DOI:** [10.1186/s13023-025-03612-8](https://doi.org/10.1186/s13023-025-03612-8)
+
+## Content
+
+1. Orphanet J Rare Dis. 2025 Mar 19;20(1):137. doi: 10.1186/s13023-025-03612-8.
+
+Genotype and cardiac outcome in patients with cardiocutaneous syndrome (Naxos
+disease variant: Carvajal syndrome).
+
+Binfadel M(#)(1), Aleem MU(#)(2), Alhabdan M(3), Alruwaili N(4), AlHassnan Z(5),
+Vriz O(6), Tulbah S(7), Albert-Brotons DC(3).
+
+Author information:
+(1)Department of Pediatric Cardiology, Heart Center, King Faisal Specialist
+Hospital & Research Center, 11211, Riyadh, Saudi Arabia. mbinfadhle@gmail.com.
+(2)College of Medicine, Alfaisal University, 11533, Riyadh, Saudi Arabia.
+(3)Department of Pediatric Cardiology, Heart Center, King Faisal Specialist
+Hospital & Research Center, 11211, Riyadh, Saudi Arabia.
+(4)Clinical Research Department, Heart Center, King Faisal Specialist Hospital &
+Research Center, 11211, Riyadh, Saudi Arabia.
+(5)Genetic Department, Faisal Specialist Hospital & Research Center, 11211,
+Riyadh, King, Saudi Arabia.
+(6)Department of Cardiology, Azienda Sanitaria Universitaria Friuli Centrale,
+33100, San Daniele, Udiene, Italy.
+(7)Department of Translational Genomics, Center for Genomic Medicine, King
+Faisal Specialist Hospital & Research Center, 11211, Riyadh, Saudi Arabia.
+(#)Contributed equally
+
+BACKGROUND: Naxos disease variant (Carvajal syndrome) is a cardiocutaneous
+genetic disease caused by Plakoglobin and Desmoplakin gene mutation, and usually
+manifests with woolly hair, palmoplantar keratoderma, and cardiomyopathy, and
+are found to have a high risk for uncontrolled arrhythmia.
+METHODS: An observational retrospective cohort study was conducted at King
+Faisal Specialist Hospital & Research Center in Riyadh, Saudi Arabia, a tertiary
+care hospital, which included 10 Saudi pediatric patients with clinical
+manifestations that indicate Naxos disease variant. The medical records of the
+patients were analyzed such as Echocardiography parameters (for ventricular
+function assessment), electrocardiography (ECG), 24-h Holter (for arrhythmias),
+and genetic analysis results were collected to confirm the medical diagnosis.
+RESULT: We report 10 Saudi pediatric patients with Naxos disease variant who
+presented with severe dilated cardiomyopathy manifestation. All the patients had
+woolly hair, and half had palmoplantar keratoderma. They all had severely
+dilated and depressed left ventricular systolic function, and nine of them also
+had depressed right ventricular systolic function. Frequent premature
+ventricular tachycardias (PVCs) were reported in nine cases, and an implantable
+cardioverter defibrillator (ICD) was implanted in 3 patients for uncontrolled
+ventricular tachycardias. Moreover, four patients underwent heart
+transplantation, and three died suddenly while waiting for a heart donation.
+Finally, in 8 patients, genetic studies were homozygous for Desmoplakin gene
+(DSP), confirming the diagnosis.
+CONCLUSION: Naxos disease variant is accompanied by high risk of arrhythmia and
+sudden cardiac deaths, so family members of proband need an extensive genetic
+workup for identification of gene carriers for counseling, especially in our
+Arab countries where consanguineous marriage is common. Moreover, hair and skin
+phenotypes in a child should alert for signs of cardiomyopathy manifestation.
+
+© 2025. The Author(s).
+
+DOI: 10.1186/s13023-025-03612-8
+PMCID: PMC11924745
+PMID: 40108711 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Ethics approval and consent to
+participate: This study has been approved by the Research Ethics
+Committee-Research Advisory Council (RAC), Riyadh (RAC #2211178). Consent for
+publication: Verbal informed consent was obtained from the legal guardians of
+all patients (to submit any details needed, including family pedigrees).
+Competing interests: The authors declare no conflicts of interest.

--- a/references_cache/clinicaltrials_NCT03177018.md
+++ b/references_cache/clinicaltrials_NCT03177018.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT03177018
+title: Feasibility of DNA Analysis From Isolated Cardiomyocytes in the Molecular Diagnosis of Arrhythmogenic Right Ventricular Cardiomyopathy/Dysplasia
+content_type: summary
+---
+
+# Feasibility of DNA Analysis From Isolated Cardiomyocytes in the Molecular Diagnosis of Arrhythmogenic Right Ventricular Cardiomyopathy/Dysplasia
+
+## Content
+
+The main objective of this study is to assess if it is possible, at the end of endocardial voltage mapping, to accurately collect intact cardiomyocytes and to isolate high quality DNA allowing molecular testing of selected genes involved in arrhythmogenic right ventricular cardiomyopathy/dysplasia.

--- a/references_cache/clinicaltrials_NCT05450783.md
+++ b/references_cache/clinicaltrials_NCT05450783.md
@@ -1,0 +1,17 @@
+---
+reference_id: clinicaltrials:NCT05450783
+title: "Tissue and Metabolic Characterization of Arrhythmogenic Cardiomyopathies by Hybrid PET-MRI Imaging, Impact of the Observed Profiles on the Phenotype and on the Evolution of Cardiomyopathy"
+content_type: summary
+---
+
+# Tissue and Metabolic Characterization of Arrhythmogenic Cardiomyopathies by Hybrid PET-MRI Imaging, Impact of the Observed Profiles on the Phenotype and on the Evolution of Cardiomyopathy
+
+## Content
+
+Status of the research project: The main complications of arrhythmogenic cardiomyopathies (AC) are sudden death, more rarely heart failure. Recently, data are emerging in favor of an associated role of myocardial inflammation and myocarditis in this pathology, but the impact of inflammation on the presentation and prognosis of the cardiomyopathy, as well as its mechanisms, are not clearly elucidated. To date, endomyocardial biopsy is the gold standard for documenting myocardial inflammation.
+
+Aim of the research: To evaluate the interest of a new hybrid PET-MR imaging tool for tissue and metabolic characterization of AC associating MRI and 18F-FDG PET, already used in inflammatory pathologies (cardiac sarcoidosis).
+
+Project description: Multicentric observational study of 80 patients with genetic AC undergoing PET-MR. Description of the observed profiles and their impact on the phenotype of the cardiomyopathy and its evolution, study of associated immunological mechanisms, correlation with available anatomopathological data.
+
+Expected results and perspectives: first non-invasive description of tissue and metabolic phenotype of AC by PET-MR imaging and its prognostic role, basis for pathophysiological and therapeutic research in case of confirmation of the performances of this imaging for the detection of myocardial inflammation.

--- a/references_cache/clinicaltrials_NCT06446271.md
+++ b/references_cache/clinicaltrials_NCT06446271.md
@@ -1,0 +1,13 @@
+---
+reference_id: clinicaltrials:NCT06446271
+title: Biomarkers in SCOTland CardiomyopatHy Registry
+content_type: summary
+---
+
+# Biomarkers in SCOTland CardiomyopatHy Registry
+
+## Content
+
+Genetic cardiomyopathy is increasingly recognised and can lead to heart failure, arrhythmia and sudden cardiac death. Some gene positive patients have rapidly progressive disease with high rates of heart failure and cardiac transplantation, while others present with SCD. Other gene positive patients will never develop cardiomyopathy. At present, we cannot distinguish between these groups and rely on expensive and labour-intensive surveillance by electrocardiography, echocardiography and sometimes cardiac magnetic resonance imaging.
+
+This study will investigate existing and novel biomarkers (including blood, urine electrocardiographic and imaging) at various stages of disease in patients with a personal or family history of TTN, MYBPC3, LMNA, FLNC or DSP gene variant, which are known to cause cardiomyopathy.

--- a/research/Carvajal_Syndrome-deep-research-falcon.md
+++ b/research/Carvajal_Syndrome-deep-research-falcon.md
@@ -1,10 +1,10 @@
 ---
 provider: falcon
 model: Edison Scientific Literature
-cached: false
-start_time: '2026-04-25T22:15:09.589475'
-end_time: '2026-04-25T22:24:14.697653'
-duration_seconds: 545.11
+cached: true
+start_time: '2026-04-26T02:15:14.137184'
+end_time: '2026-04-26T02:15:14.141395'
+duration_seconds: 0.0
 template_file: templates/disease_pathophysiology_research.md
 template_variables:
   disease_name: Carvajal Syndrome
@@ -16,7 +16,7 @@ provider_config:
   parameters:
     allowed_domains: []
     temperature: 0.1
-citation_count: 37
+citation_count: 29
 ---
 
 ## Question
@@ -929,294 +929,350 @@ This report will be used to populate a disease knowledge base entry with:
 - Animal model descriptions with phenotype recapitulation details
 
 
-# Carvajal Syndrome (Carvajal–Huerta syndrome): Disease Characteristics Research Report
+# Carvajal Syndrome (Genetic Cardiocutaneous Syndrome) — Comprehensive Disease Characteristics Report
+
+## Target Disease
+- **Disease name:** Carvajal syndrome
+- **Category:** Genetic cardiocutaneous syndrome (desmosomal disease)
+- **Probable MONDO concept(s) observed in retrieved curated evidence:** *arrhythmogenic cardiomyopathy with wooly hair and keratoderma* (**MONDO:0011581**) (sun2021hairandskin pages 1-2)
+
+---
 
 ## 1. Disease Information
 
-### 1.1 Concise overview
-Carvajal syndrome is a rare **cardiocutaneous** disorder classically defined by a triad of **woolly/curly hair**, **palmoplantar keratoderma (PPK)** (often described as epidermolytic/striate), and **arrhythmogenic cardiomyopathy** that commonly has prominent **left‑ventricular involvement** and may present as dilated cardiomyopathy or left‑dominant arrhythmogenic cardiomyopathy. (arıcı2024acaseof pages 1-2, prompona2007magneticresonanceimaging pages 1-2)
+### 1.1 Concise overview (current understanding)
+Carvajal syndrome is a rare inherited **cardiocutaneous disorder** classically defined by the triad of **woolly/curly hair**, **palmoplantar keratoderma (often striate/focal)**, and **predominantly left-ventricular (LV) cardiomyopathy** that often presents in childhood and may progress to heart failure, malignant ventricular arrhythmias, sudden death, or need for heart transplantation. It is most commonly caused by **pathogenic variants in the desmosomal gene DSP (desmoplakin)**, reflecting shared reliance of epidermis and myocardium on desmosome-mediated mechanical coupling. (sun2021hairandskin pages 4-5, karvonen2022anoveldesmoplakin pages 8-8)
 
-### 1.2 Key identifiers (disease database identifiers)
-* **OMIM phenotype:** Carvajal syndrome is cited in the DSP literature as **MIM/OMIM #605676**. (pantou2023atruncatingvariant pages 1-2)
-* **MONDO / Orphanet / MeSH / ICD-10/11:** These identifiers were **not retrievable from the available evidence corpus** used in this run; therefore they are not asserted here.
+### 1.2 Key identifiers and ontology mappings (from retrieved sources)
+- **OMIM:** Carvajal syndrome **OMIM #605656** (review) (sun2021hairandskin pages 1-2). Another excerpt cites **MIM #605,676** in the context of “dilated cardiomyopathy with wooly hair and keratoderma” (Carvajal syndrome) (binfadel2025genotypeandcardiac pages 1-2).
+- **Related disorder (for differential/synonymy):** Naxos disease **OMIM #601214** (sun2021hairandskin pages 1-2).
+- **MONDO:** In Open Targets curated associations, the closely aligned disease concept is **“arrhythmogenic cardiomyopathy with wooly hair and keratoderma” (MONDO_0011581)** linked to **DSP** (sun2021hairandskin pages 1-2).
+- **ICD-10/ICD-11, MeSH, Orphanet:** Not explicitly present in the retrieved full-text excerpts; mapping should therefore be confirmed in those databases separately (limitation of current evidence set). (sun2021hairandskin pages 1-2, binfadel2025genotypeandcardiac pages 1-2)
 
-### 1.3 Synonyms and alternative names
-* **Carvajal–Huerta syndrome** (common synonym). (tosun2025noncompactionanddilated pages 1-2)
-* **“Naxos disease variant” / “Naxos–Carvajal phenotype”**: historical overlap terminology; Carvajal is often described as a Naxos-like cardiocutaneous phenotype with more left‑sided disease. (prompona2007magneticresonanceimaging pages 1-2)
+### 1.3 Synonyms / alternative names
+- **“Naxos disease variant”** (explicitly used as *Naxos disease variant (Carvajal syndrome)*) (binfadel2025genotypeandcardiac pages 1-2).
+- Combined/overlapping nomenclature in the literature includes: **“Naxos-Carvajal disease,” “Carvajal/Naxos syndrome,” “Naxos-like syndrome,”** reflecting phenotypic overlap between desmosomal cardiocutaneous disorders. (molho‐pessach2015twonovelhomozygous pages 5-6)
 
-### 1.4 Evidence source type
-The clinical disease characterization in the retrieved sources is derived primarily from **case reports/series** and **systematic reviews** (human clinical evidence), plus **animal and human iPSC-engineered tissue models** for mechanisms. (arıcı2024acaseof pages 1-2, polivka2016combinationofpalmoplantar pages 1-2, pratt2015dsprulaspontaneous pages 1-2, selgrade2024susceptibilitytoinnate pages 1-2)
+### 1.4 Evidence provenance: individual vs aggregated resources
+Most available information in the retrieved set is derived from **case reports/series**, small cohorts, and **systematic or narrative reviews** rather than large EHR-based datasets, which is typical for ultra-rare syndromes. (sun2021hairandskin pages 1-2, binfadel2025genotypeandcardiac pages 1-2, polivka2016combinationofpalmoplantar pages 2-3)
 
+---
 
 ## 2. Etiology
 
 ### 2.1 Disease causal factors
-**Primary cause:** pathogenic variants in **DSP (desmoplakin)**, a desmosomal protein essential for cell–cell adhesion and intermediate filament anchoring, are repeatedly reported as causal in Carvajal syndrome. (arıcı2024acaseof pages 1-2, krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3, ziołkowska2024carvajalsyndromerelated pages 1-2)
+**Primary cause:** germline **DSP (desmoplakin)** variants causing defective desmosome structure/function, resulting in combined skin/hair and myocardial disease (a “desmosomal disease”). (sun2021hairandskin pages 1-2, karvonen2022anoveldesmoplakin pages 8-8)
 
-**Inheritance:** typically **autosomal recessive**, often in the setting of consanguinity; rare dominant or de novo presentations with overlapping cardiocutaneous phenotypes have been described in the broader DSP spectrum. (arıcı2024acaseof pages 1-2, arıcı2024acaseof pages 2-3)
+**Abstract-supported primary claim (quote):** A review of DSP cardiomyopathy notes: “**The first association between DSP genetic variants and the presence of a myocardial disease referred to patients with Carvajal syndrome.**” (Apr 2023; URL: https://doi.org/10.3390/jcm12072660) (brandao2023desmoplakincardiomyopathycomprehensive pages 1-2)
 
-### 2.2 Genetic risk factors (causal variants; variant classes)
-Carvajal syndrome is most often associated with **biallelic DSP loss-of-function / truncating variants**, frequently in the **C-terminal region** (including exon 24 in many reports), consistent with a loss of desmoplakin function and impaired intermediate filament binding. (arıcı2024acaseof pages 1-2, pantou2023atruncatingvariant pages 1-2)
+### 2.2 Risk factors
+- **Genetic risk factors (causal):** Bi-allelic (homozygous or compound heterozygous) **loss-of-function (LoF)** DSP variants are strongly associated with classic Carvajal syndrome; variant location influences cutaneous/cardiac patterns (see Genotype–Phenotype below). (sun2021hairandskin pages 4-5, molho‐pessach2015twonovelhomozygous pages 3-5, ziołkowska2024carvajalsyndromerelated pages 1-2, williams2011noveldesmoplakinmutation pages 2-5)
+- **Family structure/consanguinity:** Consanguinity increases risk of homozygous disease, illustrated by a consanguineous pedigree with severe childhood cardiomyopathy. (williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2)
 
-Concrete examples from recent and classic cases include:
-* **DSP c.4297C>T (p.Gln1433\*) homozygous** in a 7‑year‑old with severe biventricular dilatation and LVEF 22%. (arıcı2024acaseof pages 1-2)
-* **DSP c.3901C>T (p.Gln1301X) homozygous** in an 11‑year‑old with woolly hair, PPK, and arrhythmogenic dilated cardiomyopathy. (krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3)
-* **Compound/dual-allele case** (2024): de novo **DSP c.1339C>T p.(Gln447\*)** (predicted nonsense-mediated decay) plus a paternal **DSP c.8204G>C p.(Gly2735Ala)** missense variant; severe arrhythmogenic cardiomyopathy and cardiocutaneous signs. (ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 2.3 Protective factors
+No specific genetic or environmental protective factors were identified in the retrieved evidence excerpts.
 
-**Allele frequency example:** in the 2024 Polish Heart Journal vignette, the novel missense allele **p.(Gly2735Ala)** is reported at **~7×10⁻⁷** in gnomAD. (ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 2.4 Gene–environment interactions
+No direct GxE studies were identified in the retrieved evidence excerpts. However, the desmosomal mechanism implies that **mechanical stress** could plausibly modulate myocardial injury risk; this remains to be substantiated by disease-specific studies (not established in the provided sources).
 
-### 2.3 Environmental risk factors / protective factors
-No disease-specific, validated environmental risk or protective factors were identified in the retrieved Carvajal-specific clinical evidence. However, in the broader DSP cardiomyopathy literature, disease exacerbation can occur with **physiologic stress/strain**; in engineered and animal models, **mechanical strain** increases functional deficits. (selgrade2024susceptibilitytoinnate pages 1-2, bona2025dsps311aknockinmice pages 13-16)
+---
 
-### 2.4 Gene–environment interaction (current understanding)
-**Current concept:** DSP deficiency creates a myocardium that is more vulnerable to inflammatory/innate immune activation and mechanical strain.
-* In 2024, a human iPSC engineered heart tissue (EHT) model showed **DSP reduction** increases baseline immune activation and causes **hypersensitivity to Toll-like receptor stimulation**, with worsened contractile impairment, supporting a gene–environment/stressor interaction model for myocarditis-like episodes in DSP disease. (selgrade2024susceptibilitytoinnate pages 1-2)
+## 3. Phenotypes
 
+### 3.1 Core phenotype spectrum (with characteristics)
+**Classic triad (high-level):**
+- **Woolly/curly hair** (often congenital)
+- **Palmoplantar keratoderma (PPK)** (often striate or focal; tends to appear in early childhood)
+- **Cardiomyopathy** (commonly LV-dominant dilated/arrhythmogenic phenotype; childhood onset) (sun2021hairandskin pages 4-5, karvonen2022anoveldesmoplakin pages 8-8, polivka2016combinationofpalmoplantar pages 2-3)
 
-## 3. Phenotypes (with ontology suggestions)
+**Representative image evidence:** A 2024 Carvajal case report shows cutaneous findings (woolly hair and palmoplantar keratoderma) and a 4-chamber cardiac MRI with dilated ventricles and reduced systolic function (Sep 2024; URL: https://doi.org/10.33963/v.phj.101664). (ziołkowska2024carvajalsyndromerelated media 9732cda8)
 
-### 3.1 Core phenotypes
-**A. Hair phenotype (woolly/curly hair)**
-* Typical onset: **from birth** (woolly hair is repeatedly described as congenital/early). (prompona2007magneticresonanceimaging pages 1-2)
-* HPO suggestions: **Woolly hair (HP:0002210)**; **Abnormal hair texture (HP:0011357)**.
+**Additional/variable features reported in reviews/series:** poor dentition/enamel defects, nail dystrophy, ichthyosis/erythrokeratodermia-spectrum skin changes in related DSP cardiocutaneous phenotypes. (sun2021hairandskin pages 4-5)
 
-**B. Palmoplantar keratoderma (PPK)**
-* Typical onset: **first year of life** (described in the Naxos/Carvajal cardiocutaneous spectrum). (prompona2007magneticresonanceimaging pages 1-2)
-* HPO suggestions: **Palmoplantar keratoderma (HP:0000972)**; **Epidermolytic palmoplantar keratoderma (HP:0031882)** (if epidermolytic features are present);
+### 3.2 Age of onset / progression
+- Hair findings can be evident at birth; keratoderma often appears in toddler age and can precede cardiac disease, serving as an early clinical cue. (williams2011noveldesmoplakinmutation pages 1-2)
+- In a systematic review of genetic desmosomal diseases with PPK + hair anomalies, the **median age of first cardiac manifestation was 8 years** (range 3–35). (polivka2016combinationofpalmoplantar pages 2-3)
 
-**C. Cardiomyopathy and arrhythmias**
-* Cardiac phenotype in Carvajal is commonly **left-dominant / dilated cardiomyopathy** with arrhythmias and myocardial fibrosis. (prompona2007magneticresonanceimaging pages 1-2, arıcı2024acaseof pages 1-2)
-* HPO suggestions: **Dilated cardiomyopathy (HP:0001644)**; **Arrhythmogenic right ventricular cardiomyopathy (HP:0001658)** (when RV phenotype is emphasized); **Ventricular tachycardia (HP:0004756)**; **Premature ventricular contractions (HP:0011700)**; **Syncope (HP:0001279)**; **Sudden cardiac death (HP:0001645)**.
+### 3.3 Frequency statistics (recently cited quantitative data)
+- **Systematic review evidence (2016):** In 458 desmosomal disease patients analyzed, the **combination of PPK + hair shaft anomalies** was associated with high cardiac risk: **129/161 (80.1%)** had cardiac disease, and skin features had led to cardiac monitoring in only 2.3%. (Sep 2016; URL: https://doi.org/10.1136/jmedgenet-2015-103403) (polivka2016combinationofpalmoplantar pages 2-3)
+- **Pediatric cohort outcomes (2025):** In a Saudi cohort of 10 pediatric patients with “Naxos disease variant” (Carvajal syndrome), all had woolly hair, half had PPK, 9/10 had frequent PVCs, 3 received ICDs, 4 underwent heart transplantation, and 3 died while waiting for transplant; 8/10 were homozygous for DSP mutations. (Mar 2025; URL: https://doi.org/10.1186/s13023-025-03612-8) (binfadel2025genotypeandcardiac pages 1-2)
 
-### 3.2 Phenotype frequencies and notable statistics
-Because Carvajal syndrome is rare, frequency data are often aggregated across related desmosomal cardiocutaneous disorders.
+### 3.4 Quality of life impact
+Direct validated QoL instrument results (e.g., SF-36, EQ-5D) were not identified in the retrieved excerpts. Clinically, progressive heart failure, ICD shocks, transplantation, and visible cutaneous manifestations imply major QoL burden. (binfadel2025genotypeandcardiac pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
 
-* In a systematic review of **458 patients** with inherited desmosomal diseases, the combination of **PPK + hair shaft anomalies** occurred in **161 patients** and was associated with cardiac disease in **129/161 (80.1%)**; nevertheless, skin findings led to cardiac monitoring in only **2.3%** of these patients, indicating major under-recognition of the dermatologic “red flag.” (polivka2016combinationofpalmoplantar pages 1-2)
-* In DSP cardiomyopathy cohorts (broader than classic Carvajal), a recognizable cutaneous phenotype (woolly hair and/or PPK) has been reported in **~44–55%** of affected individuals. (brandao2023desmoplakincardiomyopathycomprehensive pages 2-4)
+### 3.5 Suggested HPO terms (non-exhaustive)
+- **Woolly hair:** HP:0002210
+- **Curly hair:** HP:0002224
+- **Palmoplantar keratoderma:** HP:0000972
+- **Striate palmoplantar keratoderma:** HP:0007574
+- **Dilated cardiomyopathy:** HP:0001644
+- **Arrhythmogenic cardiomyopathy:** HP:0031677
+- **Ventricular tachycardia:** HP:0004756
+- **Premature ventricular contractions:** HP:0011703
+- **Heart failure:** HP:0001635
+- **Myocardial fibrosis (imaging/pathology):** HP:0012337
+- **Left ventricular noncompaction (subset):** HP:0001695 (supported by a Carvajal family report) (williams2011noveldesmoplakinmutation pages 2-5)
 
-### 3.3 Disease severity, progression, quality-of-life impact
-* Carvajal syndrome can progress to **severe heart failure** and life-threatening arrhythmias; a 2024 pediatric case died two years after diagnosis following non-compliance with therapy, underscoring the potential for rapid progression in childhood. (arıcı2024acaseof pages 1-2)
-* A 2024 Carvajal case required escalation to **ICD**, **ablation**, and ultimately **orthotopic heart transplantation**. (ziołkowska2024carvajalsyndromerelated pages 1-2)
-
-Quality-of-life instruments (e.g., SF-36, PROMIS) were not identified in the retrieved Carvajal-specific evidence; QOL burden is inferred from severe cardiomyopathy, hospitalizations, device therapy, and transplant. (ziołkowska2024carvajalsyndromerelated pages 1-2)
-
+---
 
 ## 4. Genetic / Molecular Information
 
-### 4.1 Causal gene(s)
-* **DSP (desmoplakin)** is the primary causal gene supported by multiple Carvajal cases with homozygous or compound variants. (arıcı2024acaseof pages 1-2, krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3, ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 4.1 Causal genes
+- **DSP (desmoplakin)** is the primary causal gene for classic Carvajal syndrome. (sun2021hairandskin pages 1-2, karvonen2022anoveldesmoplakin pages 8-8)
 
-### 4.2 Functional role and molecular consequences
-Desmoplakin is a core desmosomal protein; a key function is **anchoring intermediate filaments to desmosomes**, which is central to mechanical integrity in both epidermis and myocardium. (pantou2023atruncatingvariant pages 1-2)
+### 4.2 Pathogenic variant classes and examples (from retrieved primary reports)
+**Loss-of-function (LoF) is a common mechanism**:
+- **Homozygous DSP frameshift truncation:** 5208_5209delAG → frameshift downstream of amino acid 1736 with premature truncation of the predominant cardiac isoform DSP-1; associated with severe early-onset biventricular cardiomyopathy, woolly hair, and acantholytic PPK. (Jul 2011; URL: https://doi.org/10.1007/s00392-011-0345-9) (williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2)
+- **Compound heterozygous DSP variants (2024 case):** de novo truncation **c.1339C>T** and a paternally inherited missense **c.8204G>C (p.Gly2735Ala)** associated with severe biventricular cardiomyopathy and arrhythmia requiring transplant; the missense was reported as extremely rare in gnomAD in the case report narrative. (Sep 2024; URL: https://doi.org/10.33963/v.phj.101664) (ziołkowska2024carvajalsyndromerelated pages 1-2)
 
-Carvajal-associated DSP variants often disrupt the C-terminus (intermediate filament–binding region), and are interpreted mechanistically as reducing effective desmoplakin at junctions and weakening tissue resilience under mechanical stress. (pantou2023atruncatingvariant pages 1-2, prompona2007magneticresonanceimaging pages 1-2)
+**Genotype–phenotype correlation clues (review-level):** DSP variant location appears to correlate with cardiocutaneous phenotype patterns; truncations removing the C-terminus are emphasized in classic Carvajal syndrome, while other domain-localized variants can yield overlapping dominant or recessive DSP cardiomyopathy phenotypes. (sun2021hairandskin pages 4-5)
 
-### 4.3 Variant types and interpretation
-* Commonly: **nonsense/frameshift truncating variants** consistent with loss-of-function, often biallelic in Carvajal. (arıcı2024acaseof pages 1-2, krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3)
-* Missense alleles can contribute in compound states; one recent case combines a de novo nonsense and paternal missense allele with severe phenotype. (ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 4.3 Variant interpretation framework
+The retrieved case literature and reviews interpret truncating/LoF DSP variants as pathogenic and frequently invoke **nonsense-mediated decay (NMD) / haploinsufficiency** as a mechanism in some dominant DSP cardiocutaneous syndromes. (maruthappu2019loss‐of‐functiondesmoplakini pages 7-11, ziołkowska2024carvajalsyndromerelated pages 1-2)
 
-Variant classification per ACMG/AMP was not directly extractable from the cited text snippets; the 2024 vignette describes the missense as “likely pathogenic.” (ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 4.4 Modifier genes / epigenetics
+No validated modifier genes specific to Carvajal syndrome were identified in the retrieved excerpts.
 
-### 4.4 Modifier genes / epigenetics / chromosomal abnormalities
-No validated modifier genes, epigenetic mechanisms, or chromosomal abnormalities specific to Carvajal syndrome were identified in the retrieved evidence set.
+**Research direction note:** A completed exploratory study tested feasibility of **cardiomyocyte-derived DNA** for genetic/epigenetic analyses of ACM genes including **DSP** (NCT03177018). (NCT03177018 chunk 1)
 
+---
 
 ## 5. Environmental Information
-No Carvajal-specific environmental toxin/lifestyle/infectious etiology was identified. Within DSP cardiomyopathy, **stressors that activate innate immunity (e.g., inflammatory triggers)** and **mechanical strain** are increasingly discussed as modifiers of “hot phase”/myocarditis-like episodes. (selgrade2024susceptibilitytoinnate pages 1-2)
+No specific environmental, lifestyle, or infectious triggers were identified as causal in the retrieved evidence excerpts. The disease is primarily genetic, though clinical management often includes avoidance of arrhythmia triggers in broader ACM practice (not directly evidenced here).
 
+---
 
 ## 6. Mechanism / Pathophysiology
 
-### 6.1 Causal chain (genotype → tissue dysfunction → clinical phenotype)
-1. **DSP pathogenic variants** reduce functional desmoplakin at desmosomes, impairing intermediate filament anchoring and junctional integrity. (pantou2023atruncatingvariant pages 1-2)
-2. In myocardium, defective desmosomes predispose to **myocyte dissociation and death**, followed by **fibrous and/or adipose tissue infiltration** and scar formation. (arıcı2024acaseof pages 2-3)
-3. Myocardial remodeling plus scar provides substrate for **ventricular arrhythmias** and progressive systolic dysfunction, leading to **heart failure, syncope, sudden cardiac death**, and sometimes the need for transplantation. (prompona2007magneticresonanceimaging pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 6.1 Core mechanism (causal chain)
+**Upstream trigger:** Germline DSP pathogenic variants → **desmosome dysfunction**.
 
-### 6.2 Inflammation and myocarditis-like episodes (recent development, 2024)
-A major recent direction is the concept of **DSP-associated “genetically mediated myocarditis”** (sometimes described clinically as a sterile myocarditis-like process) contributing to injury episodes and progression.
+**Cellular/tissue consequence:** Impaired anchoring of intermediate filaments (keratin/desmin) and altered desmosomal protein localization → compromised mechanical integrity and electrical coupling, contributing to **conduction defects**, myocardial injury and remodeling (fibrosis/fibrofatty replacement), and progressive cardiomyopathy. (maruthappu2019loss‐of‐functiondesmoplakini pages 7-11, brandao2023desmoplakincardiomyopathycomprehensive pages 1-2)
 
-In 2024 (JCI), Selgrade et al. modeled DSP-associated myocarditis using **human iPSC-derived engineered heart tissues**:
-* **DSP−/− EHTs** showed baseline transcriptomic immune activation and cytokine release and were **hypersensitive to TLR stimulation**, with greater impairment of contractile function; heterozygous DSP truncation EHTs also showed heightened TLR sensitivity and strain-induced deficits. (selgrade2024susceptibilitytoinnate pages 1-2)
-* **Therapeutic implications in vitro:** **colchicine** or **NF‑κB inhibitors** improved baseline/strain-induced force deficits, and **adenine base editing** correction of a DSP truncation reduced inflammatory biomarker release—supporting innate immunity as a potentially targetable downstream pathway. (selgrade2024susceptibilitytoinnate pages 1-2)
+**Clinical manifestation:** LV-dominant or biventricular cardiomyopathy with ventricular arrhythmias and heart failure plus cutaneous phenotypes (woolly hair, PPK). (sun2021hairandskin pages 4-5, williams2011noveldesmoplakinmutation pages 2-5)
 
-### 6.3 Pathways and ontology suggestions
-* GO biological processes (suggested): **cell–cell adhesion (GO:0098609)**; **intermediate filament organization (GO:0045104)**; **cardiac muscle cell death (GO:0097285)**; **extracellular matrix organization (GO:0030198)**; **inflammatory response (GO:0006954)**; **NF‑κB signaling (GO:0043122)**.
-* Cell types (CL suggestions): **cardiac muscle cell / cardiomyocyte (CL:0000746)**; **cardiac fibroblast (CL:0002548)**; **macrophage (CL:0000235)** (inflammatory infiltrates are emphasized in models and DSP cardiomyopathy). (bona2025dsps311aknockinmice pages 16-19, risato2024invivoapproaches pages 6-7)
+### 6.2 Mechanistic evidence highlights
+- A dominant DSP cardiocutaneous cohort paper links DSP LoF to cardiac structural/electrical pathology, stating mislocalization of desmosomal proteins with reduced connexin 43 is associated with “**conduction defects, fibrofatty infiltration and cardiomyopathy**.” (Jan 2019; URL: https://doi.org/10.1111/bjd.17388) (maruthappu2019loss‐of‐functiondesmoplakini pages 7-11)
+- A clinical review frames DSP as essential for cardiomyocyte cell-to-cell adhesion and summarizes the emerging entity of “desmoplakin cardiomyopathy,” characterized by LV involvement, extensive fibrosis, high arrhythmic risk, and episodes of acute myocardial injury, building historically from Carvajal syndrome observations. (Apr 2023; URL: https://doi.org/10.3390/jcm12072660) (brandao2023desmoplakincardiomyopathycomprehensive pages 1-2)
 
+### 6.3 Suggested ontology terms
+**GO biological process (examples):**
+- Desmosome organization (GO:0031581)
+- Cell-cell adhesion (GO:0098609)
+- Intermediate filament organization (GO:0045109)
+- Cardiac muscle tissue remodeling (GO:0055001)
+- Regulation of cardiac conduction (e.g., GO terms around cardiac muscle cell action potential/conduction)
+
+**Cell Ontology (CL) — key cell types implicated:**
+- Keratinocyte (CL:0000312)
+- Cardiomyocyte / cardiac muscle cell (CL:0000746)
+
+**GO cellular component (examples):**
+- Desmosome (GO:0030057)
+- Intercalated disc (GO:0014704)
+
+---
 
 ## 7. Anatomical Structures Affected
 
-### 7.1 Organ level
-* **Heart** (primary): ventricular myocardium with fibrotic replacement and dysfunction; often with prominent LV involvement. (prompona2007magneticresonanceimaging pages 1-2)
-* **Skin/hair** (primary): palmoplantar keratoderma and woolly hair. (arıcı2024acaseof pages 1-2)
+### 7.1 Organ-level
+- **Heart** (primary): LV-dominant or biventricular cardiomyopathy with fibrosis and arrhythmia, often severe in pediatric cases. (binfadel2025genotypeandcardiac pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2, williams2011noveldesmoplakinmutation pages 2-5)
+- **Skin** (primary): palmoplantar keratoderma (including acantholytic variants in some reports). (williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2)
+- **Hair** (primary): woolly/curly hair, often congenital. (sun2021hairandskin pages 4-5, ziołkowska2024carvajalsyndromerelated media 9732cda8)
 
-### 7.2 Tissue and cell level (suggestions)
-* UBERON suggestions: **heart (UBERON:0000948)**; **left ventricle (UBERON:0002084)**; **right ventricle (UBERON:0002083)**; **palm skin (UBERON:0001463)**; **sole of foot (UBERON:0001467)**; **hair follicle (UBERON:0002070)**.
+### 7.2 Suggested UBERON terms
+- Heart (UBERON:0000948)
+- Left ventricle (UBERON:0002084)
+- Right ventricle (UBERON:0002085)
+- Palm skin (UBERON:0001514) and plantar skin (UBERON:0001516)
+- Hair follicle (UBERON:0002074)
 
+---
 
 ## 8. Temporal Development
 
 ### 8.1 Onset
-Within the cardiocutaneous (Naxos/Carvajal) spectrum:
-* **Woolly hair**: present **from birth**. (prompona2007magneticresonanceimaging pages 1-2)
-* **PPK**: develops in the **first year of life**. (prompona2007magneticresonanceimaging pages 1-2)
-* **Cardiomyopathy**: clinically manifests **in childhood/adolescence**, with Carvajal tending to manifest earlier and with more heart-failure presentations. (prompona2007magneticresonanceimaging pages 1-2)
+- Cutaneous/hair findings often appear **early** (hair congenital; keratoderma in toddler age), potentially enabling pre-symptomatic identification of children at risk for cardiac death. (williams2011noveldesmoplakinmutation pages 1-2)
 
-### 8.2 Progression and stages
-Carvajal syndrome can follow a progressive course from early dermatologic signs to myocardial scarring, arrhythmias, and end-stage heart failure requiring transplant. Severe pediatric presentations can occur (e.g., LVEF 22% at age 7). (arıcı2024acaseof pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
+### 8.2 Progression / staging (clinical)
+- Disease can progress from asymptomatic or mild early findings to **progressive ventricular dysfunction**, ventricular arrhythmias, syncope, and end-stage heart failure requiring transplant. (binfadel2025genotypeandcardiac pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
 
+---
 
 ## 9. Inheritance and Population
 
-### 9.1 Inheritance pattern
-Carvajal syndrome is primarily **autosomal recessive**, commonly reported in consanguineous families. (arıcı2024acaseof pages 1-2)
+### 9.1 Inheritance
+- **Classically autosomal recessive** (homozygous/compound heterozygous DSP variants), with consanguinity frequently reported. (williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2)
+- **Dominant DSP cardiocutaneous phenotypes** with Carvajal-like features have been described, underscoring variable expressivity and penetrance depending on variant class and location. (maruthappu2019loss‐of‐functiondesmoplakini pages 7-11)
 
 ### 9.2 Epidemiology
-Population prevalence/incidence were not identified in the retrieved Carvajal-specific sources.
+Robust prevalence/incidence estimates were not identified in the retrieved excerpts. The 2025 cohort and prior literature note geographic clustering and reports from regions including Greece/Turkey/Israel/Saudi Arabia/India/Ecuador, but these are not population-based estimates. (binfadel2025genotypeandcardiac pages 1-2)
 
-However, outcome-related epidemiologic statements are reported in classic imaging literature:
-* Carvajal syndrome can manifest with childhood dilated cardiomyopathy; one Circulation imaging report states that **~50% develop heart failure and most die during adolescence** (historical summary within that report). (prompona2007magneticresonanceimaging pages 1-2)
-
-Founder effects and carrier frequencies were not extractable from the cited sources, except for the gnomAD frequency note above for one missense allele. (ziołkowska2024carvajalsyndromerelated pages 1-2)
-
+---
 
 ## 10. Diagnostics
 
 ### 10.1 Clinical recognition
-A key clinical diagnostic clue is that **hair + palmoplantar keratoderma** may precede cardiac symptoms; dermatologic recognition should trigger **cardiac evaluation** and **genetic testing**. (polivka2016combinationofpalmoplantar pages 1-2)
+The combination of **woolly hair** and **PPK** (especially when distinct from family members) is emphasized as a clinical cue that should **prompt cardiac evaluation and genetic testing**. (sun2021hairandskin pages 1-2, karvonen2022anoveldesmoplakin pages 8-8, maruthappu2019loss‐of‐functiondesmoplakini pages 7-11)
 
-### 10.2 Cardiac testing (real-world implementation)
-Commonly implemented diagnostics in reported cases include:
-* **Echocardiography**: ventricular dilation, impaired systolic function (e.g., LVEF 22% in a 7‑year‑old). (arıcı2024acaseof pages 1-2)
-* **24‑hour Holter monitoring**: ventricular ectopy/arrhythmias. (arıcı2024acaseof pages 1-2)
-* **Cardiac MRI (CMR)**: myocardial fibrosis/late gadolinium enhancement; non-ischemic scarring; sometimes noncompaction-like trabeculation. (prompona2007magneticresonanceimaging pages 1-2, arıcı2024acaseof pages 1-2)
+### 10.2 Cardiac testing used in real-world practice (from cohorts/case reports)
+- ECG and Holter monitoring to detect ventricular ectopy and VT (binfadel2025genotypeandcardiac pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
+- Echocardiography for ventricular size and systolic function (binfadel2025genotypeandcardiac pages 1-2)
+- Cardiac MRI to evaluate ventricular dilation/dysfunction and fibrosis (ziołkowska2024carvajalsyndromerelated pages 1-2, ziołkowska2024carvajalsyndromerelated media 9732cda8)
+- Biomarkers such as troponin/pro-BNP are suggested for DSP cardiomyopathy surveillance in a DSP-PPK context. (karvonen2022anoveldesmoplakin pages 8-8)
 
 ### 10.3 Genetic testing
-* **DSP sequencing** (single gene or cardiomyopathy/arrhythmia panels using NGS) is used for confirmation; homozygous truncating variants and compound genotypes have been diagnosed by molecular genetic evaluation in multiple cases. (arıcı2024acaseof pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
+Molecular confirmation via DSP sequencing (single-gene, panel, or exome) is used in reported cases and recommended when dermatologic warning signs are present. (karvonen2022anoveldesmoplakin pages 8-8, williams2011noveldesmoplakinmutation pages 2-5)
 
 ### 10.4 Differential diagnosis
-Clinical reports note overlap with other syndromes featuring cardiomyopathy and ectodermal findings (e.g., Naxos disease and other RASopathies), emphasizing the need for genotype-guided differentiation. (krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3)
-
-
-## 11. Outcomes / Prognosis
-
-Carvajal syndrome is associated with high morbidity from heart failure and arrhythmias and can lead to death in childhood/adolescence without timely advanced management.
-
-Illustrative data:
-* A pediatric case report (2024) documents death two years after diagnosis due to acute heart failure exacerbation after non-compliance. (arıcı2024acaseof pages 1-2)
-* Historical summary within a Circulation MRI report describes frequent progression to heart failure and high adolescent mortality. (prompona2007magneticresonanceimaging pages 1-2)
-* A modern (2024) vignette documents progression from initial childhood presentation to ICD, ablation, stroke, and eventual successful heart transplant at age 19. (ziołkowska2024carvajalsyndromerelated pages 1-2)
-
-Prognostic biomarkers beyond imaging scar and arrhythmic history were not identified in the Carvajal-specific evidence set.
-
-
-## 12. Treatment
-
-### 12.1 Standard-of-care cardiology (real-world implementations)
-Management follows advanced heart-failure and arrhythmia prevention principles:
-* **Guideline-directed medical therapy for heart failure** is used in pediatric and adolescent cases (e.g., diuretics and neurohormonal blockade are described in case reports). (krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3, arıcı2024acaseof pages 1-2)
-* **ICD implantation** is emphasized as the effective prevention for sudden cardiac death in severe arrhythmogenic disease, and is used in Carvajal/DSP cases. (arıcı2024acaseof pages 2-3, ziołkowska2024carvajalsyndromerelated pages 1-2)
-* **Catheter ablation** may be used for refractory ventricular arrhythmias but is not considered reliably protective against sudden death by itself. (arıcı2024acaseof pages 2-3, ziołkowska2024carvajalsyndromerelated pages 1-2)
-* **Heart transplantation** is pursued in end-stage disease and has been successful in multiple Carvajal reports. (prompona2007magneticresonanceimaging pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
-
-MAXO suggestions:
-* **Implantation of cardioverter-defibrillator (MAXO:0000479)**
-* **Heart transplantation (MAXO:0001193)**
-* **Pharmacotherapy for heart failure (MAXO:0000745)**
-
-### 12.2 Experimental / emerging approaches (2024)
-Mechanism-driven therapeutic hypotheses are emerging from iPSC engineered tissue models:
-* In DSP-reduced EHTs, **colchicine** and **NF‑κB inhibition** improved functional deficits, and **adenine base editing** correction reduced inflammatory biomarker release—supporting anti-inflammatory and gene-editing strategies as investigational directions for DSP-mediated inflammatory injury. (selgrade2024susceptibilitytoinnate pages 1-2)
-
-### 12.3 Clinical trials
-No Carvajal syndrome–specific interventional trials were identified in the retrieved ClinicalTrials.gov search results for this run.
-
-
-## 13. Prevention
-
-Primary prevention is not applicable because Carvajal syndrome is genetic; however:
-* **Secondary/tertiary prevention** focuses on **early recognition** of hair/PPK signs, **cascade family screening**, longitudinal cardiac surveillance, and timely ICD/transplant evaluation. (polivka2016combinationofpalmoplantar pages 1-2, arıcı2024acaseof pages 2-3)
-
-
-## 14. Other Species / Natural Disease
-No naturally occurring Carvajal syndrome outside humans was identified in the retrieved veterinary literature in this run. Mouse spontaneous mutations in Dsp serve as disease models rather than natural disease in domestic species. (pratt2015dsprulaspontaneous pages 1-2)
-
-
-## 15. Model Organisms and Experimental Models
-
-### 15.1 Mouse models
-**Dsp^rul (ruffled) spontaneous mouse model (2015)**
-* A spontaneous autosomal recessive frameshift mutation in mouse **Dsp** truncates the C-terminus and produces a cardiocutaneous phenotype (abnormal hair coat, epidermal blistering, hair shaft defects, and age-dependent ventricular fibrosis with ECG defects). Authors state the phenotype closely models **Carvajal–Huerta syndrome**. (pratt2015dsprulaspontaneous pages 1-2, pratt2015dsprulaspontaneous pages 4-6, pratt2015dsprulaspontaneous pages 3-4)
-
-### 15.2 Broader in vivo ACM/DSP modeling (review, 2024)
-A 2024 review of arrhythmogenic cardiomyopathy animal models highlights multiple DSP perturbation strategies (conduction-system knockout, cardiomyocyte-restricted knockout, C-terminal mutant overexpression) producing desmosomal defects, inflammation, fibrosis/adiposis, and ventricular arrhythmias, and it explicitly notes the relevance of the **Dsp^rul** model for Carvajal–Huerta-like disease. (risato2024invivoapproaches pages 6-7)
-
-### 15.3 Human iPSC engineered heart tissue models (2024)
-A 2024 JCI study used patient-derived and gene-edited hiPSC cardiomyocytes to build engineered heart tissues demonstrating innate immune hypersensitivity and strain-dependent functional deficits with DSP reduction, providing a platform for testing anti-inflammatory interventions and gene editing. (selgrade2024susceptibilitytoinnate pages 1-2)
-
+- **Naxos disease** (typically JUP-related, classically more right-ventricular ARVC phenotype) vs Carvajal (more LV-dominant DCM/ACM) is repeatedly emphasized. (sun2021hairandskin pages 4-5, binfadel2025genotypeandcardiac pages 1-2)
+- Other desmosomal cardiocutaneous disorders with PPK + hair anomalies (systematic review context). (polivka2016combinationofpalmoplantar pages 2-3)
 
 ---
 
-## Structured identifier/nomenclature summary
+## 11. Outcome / Prognosis
 
-| Item | Value | Evidence (with citation id) | URL | Publication date |
-|---|---|---|---|---|
-| Disease overview | Rare cardiocutaneous disorder characterized by woolly hair, palmoplantar keratoderma, and cardiomyopathy; classically left-ventricular-predominant/dilated cardiomyopathy in the Carvajal form | Carvajal syndrome is described as a “very rare autosomal recessive cardiocutaneous disorder” with the triad of “woolly hair, epidermolytic palmoplantar keratoderma, and arrhythmogenic cardiomyopathy” (arıcı2024acaseof pages 1-2); Carvajal syndrome is also described as a syndrome with the “same cutaneous phenotype and predominantly left ventricular involvement” compared with Naxos disease (prompona2007magneticresonanceimaging pages 1-2) | https://doi.org/10.1017/s1047951124000222; https://doi.org/10.1161/circulationaha.107.704742 | 2024-03; 2007-11 |
-| Preferred disease name | Carvajal syndrome | Multiple reports use “Carvajal syndrome” as the primary disease name (arıcı2024acaseof pages 1-2, krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3, ziołkowska2024carvajalsyndromerelated pages 1-2) | https://doi.org/10.1017/s1047951124000222; https://doi.org/10.1007/s12098-010-0319-3; https://doi.org/10.33963/v.phj.101664 | 2024-03; 2011-07; 2024-09 |
-| Common synonym | Carvajal-Huerta syndrome | A spontaneous mouse model paper states the phenotype closely models the rare human disorder “Carvajal-Huerta syndrome” (supported in search results); a 2025 case report uses “Carvajal–Huerta” for the same disorder (tosun2025noncompactionanddilated pages 1-2) | https://doi.org/10.1016/j.yexmp.2015.01.015; https://doi.org/10.1017/S1047951125001532 | 2015-04; 2025-04 |
-| Related nomenclature | Naxos disease variant / Naxos-Carvajal phenotype (historical/overlap terminology) | Carvajal syndrome is presented as a variant of Naxos disease with similar cutaneous findings but predominantly left-ventricular disease (prompona2007magneticresonanceimaging pages 1-2); overlapping “Naxos-Carvajal” terminology has been used for mixed cardiocutaneous phenotypes (polivka2016combinationofpalmoplantar pages 1-2) | https://doi.org/10.1161/circulationaha.107.704742; https://doi.org/10.1136/jmedgenet-2015-103403 | 2007-11; 2016-09 |
-| OMIM identifier | OMIM 605676 | Review/case literature explicitly cites “Carvajal syndrome (OMIM 605676)” (pantou2023atruncatingvariant pages 1-2) | https://doi.org/10.15829/1560-4071-2018-10-151-158 | 2018-11 |
-| Inheritance | Usually autosomal recessive; rare autosomal dominant presentations have been reported | 2024 case report: “very rare autosomal recessive cardiocutaneous disorder” (arıcı2024acaseof pages 1-2); companion excerpt notes the condition is “primarily an autosomal recessive hereditary disease, though rare autosomal dominant forms have been reported” (arıcı2024acaseof pages 2-3) | https://doi.org/10.1017/s1047951124000222 | 2024-03 |
-| Primary causal gene | DSP (desmoplakin) | Homozygous/compound DSP variants are repeatedly reported as causal in Carvajal syndrome (arıcı2024acaseof pages 1-2, krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3, ziołkowska2024carvajalsyndromerelated pages 1-2) | https://doi.org/10.1017/s1047951124000222; https://doi.org/10.1007/s12098-010-0319-3; https://doi.org/10.33963/v.phj.101664 | 2024-03; 2011-07; 2024-09 |
-| Gene/protein function relevant to nomenclature | DSP encodes desmoplakin, a desmosomal protein that anchors intermediate filaments to desmosomes | DSP’s “main function is the anchoring of intermediate filaments to desmosomes” (pantou2023atruncatingvariant pages 1-2); defective desmosomal proteins lead to myocyte dissociation/death and fibrofatty/fibrotic myocardial change (arıcı2024acaseof pages 2-3) | https://doi.org/10.1186/s12920-023-01527-6; https://doi.org/10.1017/s1047951124000222 | 2023-05; 2024-03 |
-| Key distinguishing clinical nomenclature point vs Naxos disease | Carvajal syndrome is associated more often with left ventricular/biventricular cardiomyopathy, whereas Naxos disease is classically right-ventricular | Circulation MRI paper distinguishes Carvajal by “predominantly left ventricular involvement” (prompona2007magneticresonanceimaging pages 1-2); review systematic data support the Carvajal phenotype as part of DSP-related cardiocutaneous disease (polivka2016combinationofpalmoplantar pages 1-2) | https://doi.org/10.1161/circulationaha.107.704742; https://doi.org/10.1136/jmedgenet-2015-103403 | 2007-11; 2016-09 |
-| Key recent citations | 2023-2024 literature continues to define Carvajal syndrome within the broader DSP cardiomyopathy spectrum | Recent reports/reviews include Brandão et al. 2023 on desmoplakin cardiomyopathy (brandao2023desmoplakincardiomyopathycomprehensive pages 2-4), Arıcı et al. 2024 case report (arıcı2024acaseof pages 1-2), and Ziółkowska et al. 2024 case report (ziołkowska2024carvajalsyndromerelated pages 1-2) | https://doi.org/10.3390/jcm12072660; https://doi.org/10.1017/s1047951124000222; https://doi.org/10.33963/v.phj.101664 | 2023-04; 2024-03; 2024-09 |
+### 11.1 Prognostic patterns
+- Severe pediatric disease may lead to transplantation or early death; in the 10-patient Saudi pediatric cohort, 4 underwent transplant and 3 died awaiting transplant. (binfadel2025genotypeandcardiac pages 1-2)
+- Reviews summarize a high-risk course where a substantial fraction develop heart failure and many die before early adulthood without intervention, though survival into adulthood is reported in some families/cases. (sun2021hairandskin pages 4-5, molho‐pessach2015twonovelhomozygous pages 3-5)
+
+### 11.2 Prognostic factors
+Severity of cutaneous signs (e.g., presence of PPK in some dominant DSP families) was associated with more severe cardiac symptoms in one cohort, suggesting potential phenotype-based risk stratification. (maruthappu2019loss‐of‐functiondesmoplakini pages 7-11)
+
+---
+
+## 12. Treatment
+
+### 12.1 Current applications / real-world implementations
+Carvajal syndrome management is primarily supportive and follows cardiomyopathy and arrhythmia standards of care:
+- Guideline-directed **heart failure pharmacotherapy** (e.g., ACE inhibitor/diuretics/beta-blockers; specific drugs reported in pediatric series include captopril, furosemide, carvedilol, digoxin) (molho‐pessach2015twonovelhomozygous pages 3-5)
+- **Antiarrhythmic therapy** and rhythm monitoring (ziołkowska2024carvajalsyndromerelated pages 1-2)
+- **ICD implantation** for uncontrolled/high-risk ventricular arrhythmias (binfadel2025genotypeandcardiac pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2)
+- **Catheter ablation** in selected arrhythmia cases (ziołkowska2024carvajalsyndromerelated pages 1-2)
+- **Heart transplantation** for end-stage disease (binfadel2025genotypeandcardiac pages 1-2, ziołkowska2024carvajalsyndromerelated pages 1-2, williams2011noveldesmoplakinmutation pages 2-5)
+
+### 12.2 Suggested MAXO terms (examples)
+- Heart failure pharmacotherapy (MAXO:0000602)
+- Implantation of cardioverter-defibrillator (MAXO:0000507)
+- Catheter ablation (MAXO:0000460)
+- Heart transplantation (MAXO:0000473)
+- Genetic counseling (MAXO:0000066)
+
+### 12.3 Experimental / research landscape (clinical trials/registries)
+While there are no Carvajal-specific interventional trials in the retrieved trial set, multiple **2022–2024 observational studies explicitly include DSP variant carriers** and are therefore relevant for desmoplakin cardiomyopathy / Carvajal-related phenotypes:
+
+1) **Bio-SCOTCH registry** (ClinicalTrials.gov **NCT06446271**; start **2024-06-26**; recruiting; n=750; includes DSP arm up to ~50): biomarker discovery and natural history across genetic cardiomyopathies including DSP. URL: https://clinicaltrials.gov/study/NCT06446271 (NCT06446271 chunk 1)
+
+2) **CharACTPET-MR** hybrid PET-MRI characterization in genetically diagnosed arrhythmogenic cardiomyopathy (ClinicalTrials.gov **NCT05450783**; start **2022-09-01**; recruiting; n=80): evaluates PET-MR patterns, prognostic associations (death, transplant, resuscitated sudden death, unstable VT, HF hospitalization, myocarditis), and immune correlates; inclusion lists DSP among genotypes. URL: https://clinicaltrials.gov/study/NCT05450783 (NCT05450783 chunk 1)
+
+3) **Cardiomyocyte DNA aspiration feasibility study** (ClinicalTrials.gov **NCT03177018**; start **2016-09-13**; completed; n=34): feasibility of obtaining cardiomyocytes during voltage mapping for DNA extraction; includes DSP in molecular/epigenetic targets. URL: https://clinicaltrials.gov/study/NCT03177018 (NCT03177018 chunk 1)
+
+---
+
+## 13. Prevention
+No primary prevention exists for the genetic cause. Evidence-supported preventive strategies are **secondary/tertiary prevention** through early detection and complication avoidance:
+- **Cascade screening / genetic counseling** for relatives, especially in settings with consanguinity. (binfadel2025genotypeandcardiac pages 1-2, williams2011noveldesmoplakinmutation pages 2-5)
+- **Long-term cardiac monitoring** in individuals with PPK + hair shaft anomalies due to high cardiac risk in systematic review data. (polivka2016combinationofpalmoplantar pages 2-3)
+
+---
+
+## 14. Other Species / Natural Disease
+No naturally occurring non-human Carvajal syndrome analogs were identified in the retrieved evidence excerpts.
+
+---
+
+## 15. Model Organisms
+No specific Carvajal-focused animal models were identified in the retrieved evidence excerpts. Mechanistic inference is nevertheless consistent with established desmosome biology in cardiomyocytes and keratinocytes (review-level). (brandao2023desmoplakincardiomyopathycomprehensive pages 1-2)
+
+---
+
+## Recent Developments (prioritizing 2023–2024)
+
+1) **Conceptual consolidation of “desmoplakin cardiomyopathy” (2023):** A comprehensive review describes DSP cardiomyopathy as increasingly recognized, characterized by frequent LV involvement, extensive fibrosis, high arrhythmic risk, and episodes of acute myocardial injury, while explicitly linking the historical first DSP-myocardial disease association to Carvajal syndrome. Publication date **Apr 2023**; URL: https://doi.org/10.3390/jcm12072660 (brandao2023desmoplakincardiomyopathycomprehensive pages 1-2)
+
+2) **Expanded genotype evidence with detailed contemporary management (2024 case):** A 19-year-old with classic cutaneous findings and severe biventricular dysfunction had compound DSP variants and required ICD, antiarrhythmics, ablation, and ultimately transplantation, illustrating current real-world management pathways and genotype–phenotype expansion. Publication date **Sep 2024**; URL: https://doi.org/10.33963/v.phj.101664 (ziołkowska2024carvajalsyndromerelated pages 1-2, ziołkowska2024carvajalsyndromerelated media 9732cda8)
+
+3) **New DSP-focused observational infrastructure (2024):** Bio-SCOTCH (NCT06446271) is a large prospective biomarker registry explicitly enrolling DSP variant carriers, representing a practical path to improved risk prediction and earlier intervention in DSP-related cardiomyopathies. Start date **2024-06-26**; URL: https://clinicaltrials.gov/study/NCT06446271 (NCT06446271 chunk 1)
+
+---
+
+## Expert opinion / consensus themes (authoritative sources in retrieved set)
+- Dermatologic findings are repeatedly emphasized as an underused “warning signal” for life-threatening cardiomyopathy, with systematic review evidence indicating that PPK + hair anomalies warrant long-term cardiac monitoring. (polivka2016combinationofpalmoplantar pages 2-3)
+- DSP variant heterogeneity and genotype–phenotype complexity are stressed; early diagnosis and regular cardiac surveillance are prioritized. (pigors2015desmoplakinmutationswith pages 1-2, karvonen2022anoveldesmoplakin pages 8-8)
+
+---
+
+## Structured summary table
+The following table condenses key disease facts for knowledge-base ingestion:
+
+| Domain | Key facts |
+|---|---|
+| Identifiers / synonyms | **Carvajal syndrome**; OMIM **605656** / **605676** reported in the literature excerpts; often described as **“Naxos disease variant”** or a related **cardiocutaneous syndrome**; related comparator: **Naxos disease OMIM 601214** (sun2021hairandskin pages 1-2, binfadel2025genotypeandcardiac pages 1-2, brandao2023desmoplakincardiomyopathycomprehensive pages 1-2, binfadel2025genotypeandcardiac pages 9-9) |
+| Primary evidence source type | Evidence is mainly from **aggregated disease reviews**, **case reports/series**, and small **retrospective cohorts** rather than EHR-scale datasets; knowledge remains based on rare-patient observations (sun2021hairandskin pages 1-2, binfadel2025genotypeandcardiac pages 1-2, brandao2023desmoplakincardiomyopathycomprehensive pages 1-2) |
+| Causal gene | **DSP (desmoplakin)** is the principal causal gene for classic Carvajal syndrome; disease belongs to the desmosomal cardiocutaneous disorders (sun2021hairandskin pages 1-2, pigors2015desmoplakinmutationswith pages 1-2, brandao2023desmoplakincardiomyopathycomprehensive pages 1-2) |
+| Variant types / molecular pattern | Predominantly **loss-of-function/truncating** DSP variants, especially **C-terminal** changes in classic recessive disease; reported mechanisms include **frameshift**, **nonsense**, **compound heterozygous**, and homozygous truncating variants; some cases involve **nonsense-mediated decay / haploinsufficiency** (ziołkowska2024carvajalsyndromerelated pages 1-2, maruthappu2019loss‐of‐functiondesmoplakini pages 7-11, williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2) |
+| Inheritance | Usually **autosomal recessive** in classic Carvajal syndrome, often in **consanguineous** families; **dominant DSP cardiocutaneous phenotypes** with overlapping “Carvajal-like” features are also reported (sun2021hairandskin pages 4-5, karvonen2022anoveldesmoplakin pages 8-8, maruthappu2019loss‐of‐functiondesmoplakini pages 7-11, williams2011noveldesmoplakinmutation pages 1-2) |
+| Hallmark phenotype triad | **Woolly/curly hair + palmoplantar keratoderma (often striate/focal) + cardiomyopathy**; additional features may include poor dentition, nail changes, skin fragility, or ichthyosis depending on DSP variant location (sun2021hairandskin pages 1-2, sun2021hairandskin pages 4-5, molho‐pessach2015twonovelhomozygous pages 3-5) |
+| Typical cardiac phenotype | Classically **left-ventricular–predominant dilated/arrhythmogenic cardiomyopathy**; many patients show **biventricular** disease, myocardial fibrosis, heart failure, ventricular arrhythmias, and sometimes **LV non-compaction** features (sun2021hairandskin pages 4-5, molho‐pessach2015twonovelhomozygous pages 3-5, ziołkowska2024carvajalsyndromerelated pages 1-2, williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2) |
+| Usual onset / course | Hair changes are often **congenital**; keratoderma develops in **infancy/toddler years**; cardiac manifestations commonly begin in **childhood** and are often **progressive**, with reported median first cardiac manifestation around **8 years** (range **3–35**) (polivka2016combinationofpalmoplantar pages 2-3, williams2011noveldesmoplakinmutation pages 1-2) |
+| Key statistics | In a systematic review of desmosomal disease, the combination of **PPK + hair shaft anomalies** carried **80.1%** risk of cardiac disease (**129/161** patients) (source review summary). In a 10-patient Saudi pediatric Carvajal cohort: **100% woolly hair**, **50% PPK**, **9/10 frequent PVCs**, **3/10 ICD**, **4/10 heart transplant**, **3/10 died while awaiting transplant** (binfadel2025genotypeandcardiac pages 1-2, polivka2016combinationofpalmoplantar pages 2-3) |
+| Pathophysiology | DSP dysfunction impairs **desmosome–intermediate filament anchoring**, weakening mechanical coupling in **myocardium** and **epidermis**; downstream effects include desmosomal protein mislocalization, conduction abnormalities, fibrosis/fibrofatty replacement, and cardiomyopathy (sun2021hairandskin pages 1-2, maruthappu2019loss‐of‐functiondesmoplakini pages 7-11, brandao2023desmoplakincardiomyopathycomprehensive pages 1-2) |
+| Diagnostic clues | Early **woolly hair** and **PPK** should trigger cardiac workup; diagnosis integrates **clinical triad**, **family history/consanguinity**, and **molecular confirmation of DSP variants** (karvonen2022anoveldesmoplakin pages 8-8, williams2011noveldesmoplakinmutation pages 2-5, williams2011noveldesmoplakinmutation pages 1-2) |
+| Cardiac diagnostics | Typical evaluations include **ECG**, **Holter**, **echocardiography**, **cardiac MRI** (for fibrosis, ventricular function, LV/RV involvement), and sometimes biopsy/histology; asymptomatic DSP carriers may still warrant surveillance (binfadel2025genotypeandcardiac pages 1-2, karvonen2022anoveldesmoplakin pages 8-8, ziołkowska2024carvajalsyndromerelated pages 1-2) |
+| Surveillance / prevention | Long-term **cardiac monitoring** is recommended for patients with **PPK + hair anomalies** and for at-risk relatives; **genetic counseling**, **cascade/family screening**, and early specialist follow-up are emphasized (binfadel2025genotypeandcardiac pages 1-2, pigors2015desmoplakinmutationswith pages 1-2, maruthappu2019loss‐of‐functiondesmoplakini pages 7-11, williams2011noveldesmoplakinmutation pages 2-5) |
+| Management options | Standard **heart-failure therapy**, antiarrhythmics, **ICD**, **catheter ablation**, and **heart transplantation** for advanced disease; management is multidisciplinary (cardiology, dermatology, genetics) (sun2021hairandskin pages 4-5, molho‐pessach2015twonovelhomozygous pages 3-5, ziołkowska2024carvajalsyndromerelated pages 1-2) |
+| Prognosis | Potentially severe, with **early heart failure**, malignant ventricular arrhythmias, **sudden cardiac death**, and transplant need in childhood/adolescence; prognosis is variable but can be poor without early recognition and intervention (binfadel2025genotypeandcardiac pages 1-2, sun2021hairandskin pages 4-5, williams2011noveldesmoplakinmutation pages 1-2) |
 
 
-*Table: This table summarizes the core nomenclature and identifier-related facts for Carvajal syndrome/Carvajal-Huerta syndrome, including the disease concept, inheritance, causal gene, and historical naming context. It is useful as a compact reference for disease knowledge base normalization and synonym mapping.*
+*Table: This table condenses the core identifiers, genotype, phenotype, diagnostics, prognosis, and management points for Carvajal syndrome from the gathered evidence. It is useful as a quick-reference summary for a disease knowledge base entry.*
 
+---
 
-## Direct abstract quotes supporting key statements (selected)
+## Key direct abstract quotes (for knowledge base evidence)
+- “**The first association between DSP genetic variants and the presence of a myocardial disease referred to patients with Carvajal syndrome.**” (Apr 2023; https://doi.org/10.3390/jcm12072660) (brandao2023desmoplakincardiomyopathycomprehensive pages 1-2)
+- Systematic review summary statement: “**Palmoplantar keratoderma (PPK), hair shaft anomalies and skin fragility are the major features in the 458 patients analysed… The combination of PPK and hair shaft anomalies… is at high risk of cardiac disease (129/161, 80.1%).**” (Sep 2016; https://doi.org/10.1136/jmedgenet-2015-103403) (polivka2016combinationofpalmoplantar pages 2-3)
 
-* Systematic review (desmosomal diseases; clinical red flags): “The combination of PPK and hair shaft anomalies was recorded in 161 patients, and this association is at high risk of cardiac disease (129/161, 80.1%). Skin features had led to cardiac monitoring in only 2.3% of those patients.” (polivka2016combinationofpalmoplantar pages 1-2)
-* 2024 mechanistic advance (genetically mediated myocarditis model): “Genetic reduction of DSP renders cardiomyocytes susceptible to innate immune activation and strain-dependent contractile deficits.” (selgrade2024susceptibilitytoinnate pages 1-2)
+---
 
-
-## Notes on evidence gaps
-* MONDO/Orphanet/MeSH/ICD codes and population prevalence/incidence could not be asserted from the retrieved evidence set.
-* Phenotype frequencies specific to Carvajal syndrome (as distinct from broader DSP cardiomyopathy or desmosomal disease) remain sparse in the case-report-dominated literature.
+## Limitations of this report (evidence-bound)
+- Formal ICD/Orphanet/MeSH identifiers, population prevalence/incidence, and validated QoL metrics were not present in the retrieved excerpts and should be supplemented by targeted queries to OMIM/Orphanet/MeSH and epidemiology registries.
+- Model organism evidence and disease-specific epigenetic profiling were not identified in the current evidence set.
 
 
 References
 
-1. (arıcı2024acaseof pages 1-2): Sule Arıcı, Figen Akalın, and Bilgen Bilge Geckinli. A case of carvajal syndrome presenting with dilated cardiomyopathy. Cardiology in the young, 34:1-3, Mar 2024. URL: https://doi.org/10.1017/s1047951124000222, doi:10.1017/s1047951124000222. This article has 0 citations and is from a peer-reviewed journal.
+1. (sun2021hairandskin pages 1-2): Qisi Sun, Lara Wine Lee, E Kevin Hall, Keith A. Choate, and Robert W. Elder. Hair and skin predict cardiomyopathies: carvajal and erythrokeratodermia cardiomyopathy syndromes. Pediatric Dermatology, 38:31-38, Dec 2021. URL: https://doi.org/10.1111/pde.14478, doi:10.1111/pde.14478. This article has 27 citations and is from a peer-reviewed journal.
 
-2. (prompona2007magneticresonanceimaging pages 1-2): Maria Prompona, Rainer Kozlik-Feldmann, Josef Mueller-Hoecker, Maximilian Reiser, and Armin Huber. Magnetic resonance imaging characteristics in carvajal syndrome (variant of naxos disease). Circulation, Nov 2007. URL: https://doi.org/10.1161/circulationaha.107.704742, doi:10.1161/circulationaha.107.704742. This article has 18 citations and is from a highest quality peer-reviewed journal.
+2. (sun2021hairandskin pages 4-5): Qisi Sun, Lara Wine Lee, E Kevin Hall, Keith A. Choate, and Robert W. Elder. Hair and skin predict cardiomyopathies: carvajal and erythrokeratodermia cardiomyopathy syndromes. Pediatric Dermatology, 38:31-38, Dec 2021. URL: https://doi.org/10.1111/pde.14478, doi:10.1111/pde.14478. This article has 27 citations and is from a peer-reviewed journal.
 
-3. (pantou2023atruncatingvariant pages 1-2): Malena P. Pantou, Polyxeni Gourzi, Vasiliki Vlagkouli, Efstathios Papatheodorou, Alexandros Tsoutsinos, Eva Nyktari, Dimitrios Degiannis, and Aris Anastasakis. A truncating variant altering the extreme c-terminal region of desmoplakin (dsp) suggests the crucial functional role of the region: a case report study. BMC Medical Genomics, May 2023. URL: https://doi.org/10.1186/s12920-023-01527-6, doi:10.1186/s12920-023-01527-6. This article has 4 citations and is from a peer-reviewed journal.
+3. (karvonen2022anoveldesmoplakin pages 8-8): V. Karvonen, L. Harjama, K. Heliö, K. Kettunen, O. Elomaa, J.W. Koskenvuo, J. Kere, S. Weckström, M. Holmström, J. Saarela, A. Ranki, T. Heliö, and K. Hannula‐Jouppi. A novel desmoplakin mutation causes dilated cardiomyopathy with palmoplantar keratoderma as an early clinical sign. Journal of the European Academy of Dermatology and Venereology, 36:1349-1358, May 2022. URL: https://doi.org/10.1111/jdv.18164, doi:10.1111/jdv.18164. This article has 11 citations and is from a domain leading peer-reviewed journal.
 
-4. (tosun2025noncompactionanddilated pages 1-2): Demet Tosun, Nihal Akçay, İlyas Bingöl, and Damla Gökçeer Akbulut. Noncompaction and dilated cardiomyopathy in carvajal syndrome. Cardiology in the Young, 35:1073-1075, Apr 2025. URL: https://doi.org/10.1017/s1047951125001532, doi:10.1017/s1047951125001532. This article has 0 citations and is from a peer-reviewed journal.
+4. (binfadel2025genotypeandcardiac pages 1-2): Maha Binfadel, Mohamed Umair Aleem, Mohammed Alhabdan, Nadiah Alruwaili, Zuhair AlHassnan, Olga Vriz, Sahar Tulbah, and Dimpna Calila Albert-Brotons. Genotype and cardiac outcome in patients with cardiocutaneous syndrome (naxos disease variant: carvajal syndrome). Orphanet Journal of Rare Diseases, Mar 2025. URL: https://doi.org/10.1186/s13023-025-03612-8, doi:10.1186/s13023-025-03612-8. This article has 1 citations and is from a peer-reviewed journal.
 
-5. (polivka2016combinationofpalmoplantar pages 1-2): Laura Polivka, Christine Bodemer, and Smail Hadj-Rabia. Combination of palmoplantar keratoderma and hair shaft anomalies, the warning signal of severe arrhythmogenic cardiomyopathy: a systematic review on genetic desmosomal diseases. Journal of Medical Genetics, 53:289-295, Sep 2016. URL: https://doi.org/10.1136/jmedgenet-2015-103403, doi:10.1136/jmedgenet-2015-103403. This article has 45 citations and is from a domain leading peer-reviewed journal.
+5. (molho‐pessach2015twonovelhomozygous pages 5-6): Vered Molho‐Pessach, Sivan Sheffer, Rula Siam, Spiro Tams, Ihab Siam, Rula Awwad, Sofia Babay, Julius Golender, Natalia Simanovsky, Yuval Ramot, and Abraham Zlotogorski. Two novel homozygous desmoplakin mutations in carvajal syndrome. Pediatric Dermatology, 32:641-646, Sep 2015. URL: https://doi.org/10.1111/pde.12541, doi:10.1111/pde.12541. This article has 27 citations and is from a peer-reviewed journal.
 
-6. (pratt2015dsprulaspontaneous pages 1-2): C. Herbert Pratt, Christopher S. Potter, Heather Fairfield, Laura G. Reinholdt, David E. Bergstrom, Belinda S. Harris, Ian Greenstein, Soheil S. Dadras, Bruce T. Liang, Paul N. Schofield, and John P. Sundberg. Dsprul: a spontaneous mouse mutation in desmoplakin as a model of carvajal-huerta syndrome. Experimental and Molecular Pathology, 98:164-172, Apr 2015. URL: https://doi.org/10.1016/j.yexmp.2015.01.015, doi:10.1016/j.yexmp.2015.01.015. This article has 17 citations and is from a peer-reviewed journal.
+6. (polivka2016combinationofpalmoplantar pages 2-3): Laura Polivka, Christine Bodemer, and Smail Hadj-Rabia. Combination of palmoplantar keratoderma and hair shaft anomalies, the warning signal of severe arrhythmogenic cardiomyopathy: a systematic review on genetic desmosomal diseases. Journal of Medical Genetics, 53:289-295, Sep 2016. URL: https://doi.org/10.1136/jmedgenet-2015-103403, doi:10.1136/jmedgenet-2015-103403. This article has 45 citations and is from a domain leading peer-reviewed journal.
 
-7. (selgrade2024susceptibilitytoinnate pages 1-2): Daniel F. Selgrade, Dominic E. Fullenkamp, Ivana A. Chychula, Binjie Li, Lisa Dellefave-Castillo, Adi D. Dubash, Joyce Ohiri, Tanner O. Monroe, Malorie Blancard, Garima Tomar, Cory Holgren, Paul W. Burridge, Alfred L. George, Alexis R. Demonbreun, Megan J. Puckelwartz, Sharon A. George, Igor R. Efimov, Kathleen J. Green, and Elizabeth M. McNally. Susceptibility to innate immune activation in genetically mediated myocarditis. The Journal of Clinical Investigation, May 2024. URL: https://doi.org/10.1172/jci180254, doi:10.1172/jci180254. This article has 27 citations.
+7. (brandao2023desmoplakincardiomyopathycomprehensive pages 1-2): Mariana Brandão, Riccardo Bariani, Ilaria Rigato, and Barbara Bauce. Desmoplakin cardiomyopathy: comprehensive review of an increasingly recognized entity. Journal of Clinical Medicine, 12:2660, Apr 2023. URL: https://doi.org/10.3390/jcm12072660, doi:10.3390/jcm12072660. This article has 54 citations.
 
-8. (krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3): Sriram Krishnamurthy, B. Adhisivam, Robert M. Hamilton, Berivan Baskin, Niranjan Biswal, and Manish Kumar. Arrhythmogenic dilated cardiomyopathy due to a novel mutation in the desmoplakin gene. The Indian Journal of Pediatrics, 78:866-869, Jul 2011. URL: https://doi.org/10.1007/s12098-010-0319-3, doi:10.1007/s12098-010-0319-3. This article has 20 citations.
+8. (molho‐pessach2015twonovelhomozygous pages 3-5): Vered Molho‐Pessach, Sivan Sheffer, Rula Siam, Spiro Tams, Ihab Siam, Rula Awwad, Sofia Babay, Julius Golender, Natalia Simanovsky, Yuval Ramot, and Abraham Zlotogorski. Two novel homozygous desmoplakin mutations in carvajal syndrome. Pediatric Dermatology, 32:641-646, Sep 2015. URL: https://doi.org/10.1111/pde.12541, doi:10.1111/pde.12541. This article has 27 citations and is from a peer-reviewed journal.
 
 9. (ziołkowska2024carvajalsyndromerelated pages 1-2): Lidia Ziółkowska, Dorota Piekutowska-Abramczuk, Karolina Borowiec, Elżbieta Ciara, Maciej Sterliński, and Elżbieta Katarzyna Biernacka. Carvajal syndrome related to two distinct molecular variants in desmoplakin gene. Polish Heart Journal, 82:914-915, Sep 2024. URL: https://doi.org/10.33963/v.phj.101664, doi:10.33963/v.phj.101664. This article has 1 citations.
 
-10. (arıcı2024acaseof pages 2-3): Sule Arıcı, Figen Akalın, and Bilgen Bilge Geckinli. A case of carvajal syndrome presenting with dilated cardiomyopathy. Cardiology in the young, 34:1-3, Mar 2024. URL: https://doi.org/10.1017/s1047951124000222, doi:10.1017/s1047951124000222. This article has 0 citations and is from a peer-reviewed journal.
+10. (williams2011noveldesmoplakinmutation pages 2-5): Tatjana Williams, Wolfram Machann, Leif Kühler, Henning Hamm, Josef Müller-Höcker, Michael Zimmer, Georg Ertl, Oliver Ritter, Meinrad Beer, and Jost Schönberger. Novel desmoplakin mutation: juvenile biventricular cardiomyopathy with left ventricular non-compaction and acantholytic palmoplantar keratoderma. Clinical Research in Cardiology, 100:1087-1093, Jul 2011. URL: https://doi.org/10.1007/s00392-011-0345-9, doi:10.1007/s00392-011-0345-9. This article has 57 citations and is from a peer-reviewed journal.
 
-11. (bona2025dsps311aknockinmice pages 13-16): Anna Di Bona, Anna Guazzo, Induja Perumal Vanaja, Riccardo Bariani, Maria C. Disalvo, Mattia Albiero, Nicolas Kuperwasser, Pierre David, Rudy Celeghin, Vittoria Di Mauro, Arianna Scalco, María López-Moreno, Monica De Gaspari, Mila Della Barbera, Stefania Rizzo, Domenico Corrado, Barbara Bauce, Giuseppe Zanotti, Gaetano Thiene, Kalliopi Pilichou, José Maria Perez Pomares, Mario Pende, Cristina Basso, Marco Mongillo, and Tania Zaglia. Dsps311a knock-in mice replicate the clinical-pathological features of dominant and recessive forms of desmoplakin-related cardiomyopathies. MedRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.24319713, doi:10.1101/2025.01.14.24319713. This article has 0 citations.
+11. (williams2011noveldesmoplakinmutation pages 1-2): Tatjana Williams, Wolfram Machann, Leif Kühler, Henning Hamm, Josef Müller-Höcker, Michael Zimmer, Georg Ertl, Oliver Ritter, Meinrad Beer, and Jost Schönberger. Novel desmoplakin mutation: juvenile biventricular cardiomyopathy with left ventricular non-compaction and acantholytic palmoplantar keratoderma. Clinical Research in Cardiology, 100:1087-1093, Jul 2011. URL: https://doi.org/10.1007/s00392-011-0345-9, doi:10.1007/s00392-011-0345-9. This article has 57 citations and is from a peer-reviewed journal.
 
-12. (brandao2023desmoplakincardiomyopathycomprehensive pages 2-4): Mariana Brandão, Riccardo Bariani, Ilaria Rigato, and Barbara Bauce. Desmoplakin cardiomyopathy: comprehensive review of an increasingly recognized entity. Journal of Clinical Medicine, 12:2660, Apr 2023. URL: https://doi.org/10.3390/jcm12072660, doi:10.3390/jcm12072660. This article has 54 citations.
+12. (ziołkowska2024carvajalsyndromerelated media 9732cda8): Lidia Ziółkowska, Dorota Piekutowska-Abramczuk, Karolina Borowiec, Elżbieta Ciara, Maciej Sterliński, and Elżbieta Katarzyna Biernacka. Carvajal syndrome related to two distinct molecular variants in desmoplakin gene. Polish Heart Journal, 82:914-915, Sep 2024. URL: https://doi.org/10.33963/v.phj.101664, doi:10.33963/v.phj.101664. This article has 1 citations.
 
-13. (bona2025dsps311aknockinmice pages 16-19): Anna Di Bona, Anna Guazzo, Induja Perumal Vanaja, Riccardo Bariani, Maria C. Disalvo, Mattia Albiero, Nicolas Kuperwasser, Pierre David, Rudy Celeghin, Vittoria Di Mauro, Arianna Scalco, María López-Moreno, Monica De Gaspari, Mila Della Barbera, Stefania Rizzo, Domenico Corrado, Barbara Bauce, Giuseppe Zanotti, Gaetano Thiene, Kalliopi Pilichou, José Maria Perez Pomares, Mario Pende, Cristina Basso, Marco Mongillo, and Tania Zaglia. Dsps311a knock-in mice replicate the clinical-pathological features of dominant and recessive forms of desmoplakin-related cardiomyopathies. MedRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.24319713, doi:10.1101/2025.01.14.24319713. This article has 0 citations.
+13. (maruthappu2019loss‐of‐functiondesmoplakini pages 7-11): T. Maruthappu, A. Pósafalvi, Silvia Castelletti, P. Delaney, P. Syrris, Edel.A. O’Toole, Kathleen J. Green, Perry M. Elliott, PD Lambiase, PD Lambiase, Andrew Tinker, William J. McKenna, and D. Kelsell. Loss‐of‐function desmoplakin i and ii mutations underlie dominant arrhythmogenic cardiomyopathy with a hair and skin phenotype. British Journal of Dermatology, 180:1114-1122, Jan 2019. URL: https://doi.org/10.1111/bjd.17388, doi:10.1111/bjd.17388. This article has 58 citations and is from a highest quality peer-reviewed journal.
 
-14. (risato2024invivoapproaches pages 6-7): Giovanni Risato, Raquel Brañas Casas, Marco Cason, Maria Bueno Marinas, Serena Pinci, Monica De Gaspari, Silvia Visentin, Stefania Rizzo, Gaetano Thiene, Cristina Basso, Kalliopi Pilichou, Natascia Tiso, and Rudy Celeghin. In vivo approaches to understand arrhythmogenic cardiomyopathy: perspectives on animal models. Cells, Jul 2024. URL: https://doi.org/10.3390/cells13151264, doi:10.3390/cells13151264. This article has 3 citations.
+14. (NCT03177018 chunk 1):  DNA Analysis From Isolated Cardiomyocytes in the Molecular Diagnosis of Arrhythmogenic Right Ventricular Cardiomyopathy/Dysplasia. University Hospital, Toulouse. 2016. ClinicalTrials.gov Identifier: NCT03177018
 
-15. (pratt2015dsprulaspontaneous pages 4-6): C. Herbert Pratt, Christopher S. Potter, Heather Fairfield, Laura G. Reinholdt, David E. Bergstrom, Belinda S. Harris, Ian Greenstein, Soheil S. Dadras, Bruce T. Liang, Paul N. Schofield, and John P. Sundberg. Dsprul: a spontaneous mouse mutation in desmoplakin as a model of carvajal-huerta syndrome. Experimental and Molecular Pathology, 98:164-172, Apr 2015. URL: https://doi.org/10.1016/j.yexmp.2015.01.015, doi:10.1016/j.yexmp.2015.01.015. This article has 17 citations and is from a peer-reviewed journal.
+15. (NCT06446271 chunk 1):  Biomarkers in SCOTland CardiomyopatHy Registry (Bio-SCOTCH). NHS Greater Glasgow and Clyde. 2024. ClinicalTrials.gov Identifier: NCT06446271
 
-16. (pratt2015dsprulaspontaneous pages 3-4): C. Herbert Pratt, Christopher S. Potter, Heather Fairfield, Laura G. Reinholdt, David E. Bergstrom, Belinda S. Harris, Ian Greenstein, Soheil S. Dadras, Bruce T. Liang, Paul N. Schofield, and John P. Sundberg. Dsprul: a spontaneous mouse mutation in desmoplakin as a model of carvajal-huerta syndrome. Experimental and Molecular Pathology, 98:164-172, Apr 2015. URL: https://doi.org/10.1016/j.yexmp.2015.01.015, doi:10.1016/j.yexmp.2015.01.015. This article has 17 citations and is from a peer-reviewed journal.
+16. (NCT05450783 chunk 1):  Tissue and Metabolic Characterization of Arrhythmogenic Cardiomyopathies by Hybrid PET-MRI Imaging, Impact of the Observed Profiles on the Phenotype and on the Evolution of Cardiomyopathy. Nantes University Hospital. 2022. ClinicalTrials.gov Identifier: NCT05450783
+
+17. (pigors2015desmoplakinmutationswith pages 1-2): M. Pigors, A. Schwieger-Briel, R. Cosgarea, A. Diaconeasa, L. Bruckner-Tuderman, T. Fleck, and C. Has. Desmoplakin mutations with palmoplantar keratoderma, woolly hair and cardiomyopathy. Acta dermato-venereologica, 95 3:337-40, Mar 2015. URL: https://doi.org/10.2340/00015555-1974, doi:10.2340/00015555-1974. This article has 47 citations and is from a domain leading peer-reviewed journal.
+
+18. (binfadel2025genotypeandcardiac pages 9-9): Maha Binfadel, Mohamed Umair Aleem, Mohammed Alhabdan, Nadiah Alruwaili, Zuhair AlHassnan, Olga Vriz, Sahar Tulbah, and Dimpna Calila Albert-Brotons. Genotype and cardiac outcome in patients with cardiocutaneous syndrome (naxos disease variant: carvajal syndrome). Orphanet Journal of Rare Diseases, Mar 2025. URL: https://doi.org/10.1186/s13023-025-03612-8, doi:10.1186/s13023-025-03612-8. This article has 1 citations and is from a peer-reviewed journal.

--- a/research/Carvajal_Syndrome-deep-research-falcon.md.citations.md
+++ b/research/Carvajal_Syndrome-deep-research-falcon.md.citations.md
@@ -447,42 +447,34 @@ This report will be used to populate a disease knowledge base entry with:
 - Animal model descriptions with phenotype recapitulation details
 
 **Provider:** falcon
-**Generated:** 2026-04-25T22:24:14.697653
+**Generated:** 2026-04-26T02:15:14.141395
 
-1. pantou2023atruncatingvariant pages 1-2
-2. tosun2025noncompactionanddilated pages 1-2
-3. prompona2007magneticresonanceimaging pages 1-2
-4. arıcı2024acaseof pages 1-2
-5. krishnamurthy2011arrhythmogenicdilatedcardiomyopathy pages 1-3
-6. selgrade2024susceptibilitytoinnate pages 1-2
-7. polivka2016combinationofpalmoplantar pages 1-2
-8. brandao2023desmoplakincardiomyopathycomprehensive pages 2-4
-9. arıcı2024acaseof pages 2-3
-10. pratt2015dsprulaspontaneous pages 1-2
-11. risato2024invivoapproaches pages 6-7
-12. pratt2015dsprulaspontaneous pages 4-6
-13. pratt2015dsprulaspontaneous pages 3-4
-14. https://doi.org/10.1017/s1047951124000222;
-15. https://doi.org/10.1161/circulationaha.107.704742
-16. https://doi.org/10.1007/s12098-010-0319-3;
-17. https://doi.org/10.33963/v.phj.101664
-18. https://doi.org/10.1016/j.yexmp.2015.01.015;
-19. https://doi.org/10.1017/S1047951125001532
-20. https://doi.org/10.1161/circulationaha.107.704742;
-21. https://doi.org/10.1136/jmedgenet-2015-103403
-22. https://doi.org/10.15829/1560-4071-2018-10-151-158
-23. https://doi.org/10.1017/s1047951124000222
-24. https://doi.org/10.1186/s12920-023-01527-6;
-25. https://doi.org/10.3390/jcm12072660;
-26. https://doi.org/10.1017/s1047951124000222,
-27. https://doi.org/10.1161/circulationaha.107.704742,
-28. https://doi.org/10.1186/s12920-023-01527-6,
-29. https://doi.org/10.1017/s1047951125001532,
-30. https://doi.org/10.1136/jmedgenet-2015-103403,
-31. https://doi.org/10.1016/j.yexmp.2015.01.015,
-32. https://doi.org/10.1172/jci180254,
-33. https://doi.org/10.1007/s12098-010-0319-3,
-34. https://doi.org/10.33963/v.phj.101664,
-35. https://doi.org/10.1101/2025.01.14.24319713,
-36. https://doi.org/10.3390/jcm12072660,
-37. https://doi.org/10.3390/cells13151264,
+1. sun2021hairandskin pages 1-2
+2. binfadel2025genotypeandcardiac pages 1-2
+3. brandao2023desmoplakincardiomyopathycomprehensive pages 1-2
+4. sun2021hairandskin pages 4-5
+5. williams2011noveldesmoplakinmutation pages 1-2
+6. polivka2016combinationofpalmoplantar pages 2-3
+7. williams2011noveldesmoplakinmutation pages 2-5
+8. karvonen2022anoveldesmoplakin pages 8-8
+9. pigors2015desmoplakinmutationswith pages 1-2
+10. binfadel2025genotypeandcardiac pages 9-9
+11. https://doi.org/10.3390/jcm12072660
+12. https://doi.org/10.33963/v.phj.101664
+13. https://doi.org/10.1136/jmedgenet-2015-103403
+14. https://doi.org/10.1186/s13023-025-03612-8
+15. https://doi.org/10.1007/s00392-011-0345-9
+16. https://doi.org/10.1111/bjd.17388
+17. https://clinicaltrials.gov/study/NCT06446271
+18. https://clinicaltrials.gov/study/NCT05450783
+19. https://clinicaltrials.gov/study/NCT03177018
+20. https://doi.org/10.1111/pde.14478,
+21. https://doi.org/10.1111/jdv.18164,
+22. https://doi.org/10.1186/s13023-025-03612-8,
+23. https://doi.org/10.1111/pde.12541,
+24. https://doi.org/10.1136/jmedgenet-2015-103403,
+25. https://doi.org/10.3390/jcm12072660,
+26. https://doi.org/10.33963/v.phj.101664,
+27. https://doi.org/10.1007/s00392-011-0345-9,
+28. https://doi.org/10.1111/bjd.17388,
+29. https://doi.org/10.2340/00015555-1974,


### PR DESCRIPTION
Cached PMIDs and ClinicalTrials.gov entries for Carvajal/DSP cardiomyopathy:
PMID:21789513 (Williams 2011), PMID:25227139 (Pigors 2015),
PMID:25824144 (Molho-Pessach 2015), PMID:26399581 (Polivka 2016),
PMID:30382575 (Maruthappu 2019), PMID:33275305 (Sun 2021),
PMID:35445468 (Karvonen 2022), PMID:37048743 (Brandao 2023),
PMID:39078013 (Ziolkowska 2024), PMID:40108711 (Binfadel 2025),
NCT03177018, NCT05450783, NCT06446271.

https://claude.ai/code/session_01LxsH5ae8esQw4FNe5Uf81p