### PR TITLE
Audit fix: replace 6 fabricated reference caches and re-anchor snippets (#1737)

### DIFF
--- a/kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml
+++ b/kb/disorders/Autosomal_Recessive_Osteopetrosis.yaml
@@ -43,16 +43,16 @@ prevalence:
   - reference: PMID:19232111
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The estimated incidence is 1:250,000 births."
+    snippet: "autosomal recessive osteopetrosis (ARO) has an incidence of 1 in 250,000 births"
     explanation: >-
       This review gives the standard incidence estimate for autosomal recessive
       osteopetrosis.
   - reference: PMID:22231430
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Biallelic mutations in the TCIRG1 gene, encoding the a3 isoform of the vacuolar proton pump, are responsible for more than one half of ARO patients."
+    snippet: "Biallelic mutations in the TCIRG1 gene, encoding for the a3 subunit of this pump, are responsible for more than one half of ARO patients."
     explanation: >-
-      This review shows that TCIRG1-related disease represents the majority of
+      This study shows that TCIRG1-related disease represents the majority of
       autosomal recessive osteopetrosis cases, contextualizing prevalence for
       this subtype-specific file.
 pathophysiology:

--- a/kb/disorders/Biotinidase_Deficiency.yaml
+++ b/kb/disorders/Biotinidase_Deficiency.yaml
@@ -37,9 +37,10 @@ prevalence:
   - reference: PMID:2314964
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The incidence of biotinidase deficiency in symptomatic children was determined to be one in 84,000 and the frequency in newborns one in 61,067."
+    snippet: "The combined incidence of profound and partial deficiency was 1 case per 61,067 live births"
     explanation: >-
-      This multicenter survey provides a commonly cited newborn-screening
+      This multicountry newborn-screening survey (~4.4 million newborns
+      screened across 12 countries) provides a commonly cited combined
       incidence estimate for biotinidase deficiency.
   - reference: PMID:9713119
     supports: SUPPORT

--- a/kb/disorders/Brachydactyly_Type_A1.yaml
+++ b/kb/disorders/Brachydactyly_Type_A1.yaml
@@ -39,7 +39,7 @@ prevalence:
   - reference: PMID:19464397
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Here, we report the genetic and phenotypic analyses of six affected members in a large Swedish family."
+    snippet: "We investigated six affected members of a large Swedish family segregating autosomal dominant brachymesophalangia."
     explanation: >-
       This molecular report illustrates that published BDA1 data are largely
       family based rather than population based.

--- a/kb/disorders/CACNA1A_Related_Disorder.yaml
+++ b/kb/disorders/CACNA1A_Related_Disorder.yaml
@@ -88,7 +88,7 @@ prevalence:
   - reference: PMID:17395137
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "EA2 is a rare neurological disorder caused by mutations in the CACNA1A calcium channel gene and is characterized by episodes of cerebellar dysfunction and interictal nystagmus."
+    snippet: "Episodic ataxia type 2 (EA 2) is a rare neurological disorder of autosomal dominant inheritance resulting from dysfunction of a voltage-gated calcium channel."
     explanation: >-
       This review supports rarity for the best-defined CACNA1A subtype while
       noting that spectrum-wide prevalence remains unsettled.

--- a/references_cache/PMID_17395137.md
+++ b/references_cache/PMID_17395137.md
@@ -1,13 +1,67 @@
 ---
 reference_id: "PMID:17395137"
-title: "Episodic ataxia type 2"
+title: Episodic ataxia type 2.
+authors:
+- Strupp M
+- Zwergal A
+- Brandt T
+journal: Neurotherapeutics
+year: '2007'
+doi: 10.1016/j.nurt.2007.01.014
+keywords:
+- 4-Aminopyridine/therapeutic use
+- Acetazolamide/therapeutic use
+- Animals
+- "Calcium Channels/genetics, metabolism"
+- Carbonic Anhydrase Inhibitors/therapeutic use
+- "Cerebellar Ataxia/genetics, physiopathology, therapy"
+- "Disease Models, Animal"
+- Humans
+- Mutation
+- Potassium Channel Blockers/therapeutic use
+- "Calcium Channels, N-Type"
 content_type: abstract_only
 ---
 
-# Episodic ataxia type 2
+# Episodic ataxia type 2.
+**Authors:** Strupp M, Zwergal A, Brandt T
+**Journal:** Neurotherapeutics (2007)
+**DOI:** [10.1016/j.nurt.2007.01.014](https://doi.org/10.1016/j.nurt.2007.01.014)
 
 ## Content
 
-EA2 is a rare neurological disorder caused by mutations in the CACNA1A calcium channel gene and is characterized by episodes of cerebellar dysfunction and interictal nystagmus.
+1. Neurotherapeutics. 2007 Apr;4(2):267-73. doi: 10.1016/j.nurt.2007.01.014.
 
-PMID: 17395137
+Episodic ataxia type 2.
+
+Strupp M(1), Zwergal A, Brandt T.
+
+Author information:
+(1)Department of Neurology, University of Munich, Munich, Germany. 
+Michael.Strupp@med.uni-muenchen.de
+
+Episodic ataxia type 2 (EA 2) is a rare neurological disorder of autosomal 
+dominant inheritance resulting from dysfunction of a voltage-gated calcium 
+channel. It manifests with recurrent disabling attacks of imbalance, vertigo, 
+and ataxia, and can be provoked by physical exertion or emotional stress. In the 
+spell-free interval, patients present with central ocular motor dysfunction, 
+mainly downbeat nystagmus. A slow progression of cerebellar signs accompanied by 
+a slight atrophy of midline cerebellar structures is commonly observed during 
+the course of the disease. EA 2 is caused most often by the loss of function 
+mutations of the calcium channel gene CACNA1A, which encodes the Ca(v)2.1 
+subunit of the P/Q-type calcium channel and is primarily expressed in Purkinje 
+cells. To date, more than 30 mutations have been described. Two effective 
+treatment options have been established for EA 2: acetazolamide (ACTZ), which 
+probably changes the intracellular pH and thereby the transmembraneous 
+potential, and 4-aminopyridine (4-AP), a potassium channel blocker. 
+Approximately 70% of all patients respond to treatment with ACTZ, but the effect 
+is often only transient. In an open trial, 4-AP prevented attacks in five of six 
+patients with EA 2, most likely by increasing the resting activity and 
+excitability of the Purkinje cells. These findings were confirmed by experiments 
+in animal models of EA 2. Many aspects of the pathophysiology (e.g., induction 
+of the attacks) and treatment of EA 2 (e.g., mode of action of ACTZ and 4-AP) 
+still remain unclear and need to be addressed in further animal and clinical 
+studies.
+
+DOI: 10.1016/j.nurt.2007.01.014
+PMID: 17395137 [Indexed for MEDLINE]

--- a/references_cache/PMID_19232111.md
+++ b/references_cache/PMID_19232111.md
@@ -1,13 +1,77 @@
 ---
 reference_id: "PMID:19232111"
-title: "Osteopetrosis review"
+title: Osteopetrosis.
+authors:
+- Stark Z
+- Savarirayan R
+journal: Orphanet J Rare Dis
+year: '2009'
+doi: 10.1186/1750-1172-4-5
+keywords:
+- Adult
+- "Bone Marrow Diseases/epidemiology, genetics, pathology, therapy"
+- "Child, Preschool"
+- "Fractures, Spontaneous/epidemiology, genetics, pathology, therapy"
+- "Genes, Dominant"
+- "Genes, Recessive"
+- Humans
+- "Infant, Newborn"
+- Osteoclasts/pathology
+- "Osteopetrosis/epidemiology, genetics, pathology, therapy"
+- Prevalence
 content_type: abstract_only
 ---
 
-# Osteopetrosis review
+# Osteopetrosis.
+**Authors:** Stark Z, Savarirayan R
+**Journal:** Orphanet J Rare Dis (2009)
+**DOI:** [10.1186/1750-1172-4-5](https://doi.org/10.1186/1750-1172-4-5)
 
 ## Content
 
-The estimated incidence is 1:250,000 births.
+1. Orphanet J Rare Dis. 2009 Feb 20;4:5. doi: 10.1186/1750-1172-4-5.
 
-PMID: 19232111
+Osteopetrosis.
+
+Stark Z(1), Savarirayan R.
+
+Author information:
+(1)Genetic Health Services Victoria, and Murdoch Childrens Research Institute, 
+Melbourne, Australia. zornitza.stark@ghsv.org.au
+
+Osteopetrosis ("marble bone disease") is a descriptive term that refers to a 
+group of rare, heritable disorders of the skeleton characterized by increased 
+bone density on radiographs. The overall incidence of these conditions is 
+difficult to estimate but autosomal recessive osteopetrosis (ARO) has an 
+incidence of 1 in 250,000 births, and autosomal dominant osteopetrosis (ADO) has 
+an incidence of 1 in 20,000 births. Osteopetrotic conditions vary greatly in 
+their presentation and severity, ranging from neonatal onset with 
+life-threatening complications such as bone marrow failure (e.g. classic or 
+"malignant" ARO), to the incidental finding of osteopetrosis on radiographs 
+(e.g. osteopoikilosis). Classic ARO is characterised by fractures, short 
+stature, compressive neuropathies, hypocalcaemia with attendant tetanic 
+seizures, and life-threatening pancytopaenia. The presence of primary 
+neurodegeneration, mental retardation, skin and immune system involvement, or 
+renal tubular acidosis may point to rarer osteopetrosis variants, whereas onset 
+of primarily skeletal manifestations such as fractures and osteomyelitis in late 
+childhood or adolescence is typical of ADO. Osteopetrosis is caused by failure 
+of osteoclast development or function and mutations in at least 10 genes have 
+been identified as causative in humans, accounting for 70% of all cases. These 
+conditions can be inherited as autosomal recessive, dominant or X-linked traits 
+with the most severe forms being autosomal recessive. Diagnosis is largely based 
+on clinical and radiographic evaluation, confirmed by gene testing where 
+applicable, and paves the way to understanding natural history, specific 
+treatment where available, counselling regarding recurrence risks, and prenatal 
+diagnosis in severe forms. Treatment of osteopetrotic conditions is largely 
+symptomatic, although haematopoietic stem cell transplantation is employed for 
+the most severe forms associated with bone marrow failure and currently offers 
+the best chance of longer-term survival in this group. The severe infantile 
+forms of osteopetrosis are associated with diminished life expectancy, with most 
+untreated children dying in the first decade as a complication of bone marrow 
+suppression. Life expectancy in the adult onset forms is normal. It is 
+anticipated that further understanding of the molecular pathogenesis of these 
+conditions will reveal new targets for pharmacotherapy.
+
+DOI: 10.1186/1750-1172-4-5
+PMCID: PMC2654865
+PMID: 19232111 [Indexed for MEDLINE]

--- a/references_cache/PMID_19464397.md
+++ b/references_cache/PMID_19464397.md
@@ -1,13 +1,86 @@
 ---
 reference_id: "PMID:19464397"
-title: "Brachydactyly type A1 family report"
+title: Brachydactyly type A1 associated with unusual radiological findings and a novel Arg158Cys mutation in the Indian hedgehog (IHH) gene.
+authors:
+- Stattin EL
+- Lindén B
+- Lönnerholm T
+- Schuster J
+- Dahl N
+journal: Eur J Med Genet
+year: '2009'
+doi: 10.1016/j.ejmg.2009.05.008
+keywords:
+- Adult
+- "Aged, 80 and over"
+- Amino Acid Sequence
+- Amino Acid Substitution
+- Case-Control Studies
+- "Chromosomes, Human, Pair 2"
+- "Chromosomes, Human, Pair 5"
+- Cysteine/metabolism
+- "DNA/genetics, isolation & purification"
+- DNA Mutational Analysis
+- Female
+- "Genes, Dominant"
+- Genetic Markers
+- "Hedgehog Proteins/chemistry, genetics"
+- Heterozygote
+- Humans
+- "Limb Deformities, Congenital/diagnostic imaging, genetics"
+- Male
+- Microsatellite Repeats
+- Middle Aged
+- "Models, Molecular"
+- Molecular Sequence Data
+- "Mutation, Missense"
+- Pedigree
+- Phenotype
+- "Polymorphism, Genetic"
+- Protein Conformation
+- "Protein Structure, Tertiary"
+- Radiography
+- "Sequence Analysis, DNA"
+- "Sequence Homology, Amino Acid"
+- Sweden
 content_type: abstract_only
 ---
 
-# Brachydactyly type A1 family report
+# Brachydactyly type A1 associated with unusual radiological findings and a novel Arg158Cys mutation in the Indian hedgehog (IHH) gene.
+**Authors:** Stattin EL, Lindén B, Lönnerholm T, Schuster J, Dahl N
+**Journal:** Eur J Med Genet (2009)
+**DOI:** [10.1016/j.ejmg.2009.05.008](https://doi.org/10.1016/j.ejmg.2009.05.008)
 
 ## Content
 
-Here, we report the genetic and phenotypic analyses of six affected members in a large Swedish family.
+1. Eur J Med Genet. 2009 Sep-Oct;52(5):297-302. doi: 10.1016/j.ejmg.2009.05.008. 
+Epub 2009 May 21.
 
-PMID: 19464397
+Brachydactyly type A1 associated with unusual radiological findings and a novel 
+Arg158Cys mutation in the Indian hedgehog (IHH) gene.
+
+Stattin EL(1), Lindén B, Lönnerholm T, Schuster J, Dahl N.
+
+Author information:
+(1)Department of Medical Biosciences, Medical and Clinical genetics, Umeå 
+University, Umeå, Sweden. evalena.stattin@medbio.umu.se
+
+Brachydactyly type A1 (BDA1; MIM 112500) is characterized by shortness or 
+absence of the middle phalanx of the hands and feet. The condition is caused by 
+heterozygous mutations in the Indian hedgehog (IHH) gene or a yet unidentified 
+gene on chromosome 5p13. We investigated six affected members of a large Swedish 
+family segregating autosomal dominant brachymesophalangia. Affected individuals 
+show hypoplasia of the ulnar styloid processes, ulna minus, osteoarthritis, 
+normal length of all distal phalanges and shortening or absence of the middle 
+phalanges. Stationary ossicles or sesamoid bones were observed at the metacarpal 
+heads in all patients. Genetic analysis of the family showed that the IHH-gene 
+was linked to the disease (Z(max) 3.42 at theta 0.00) and sequence analysis of 
+IHH revealed a novel c.472C > T transition in all affected family members. The 
+mutation results in a p.158Arg > Cys substitution located in the highly 
+conserved amino-terminal domain of IHH. This domain is of importance for the 
+interaction between IHH and the Patched receptor. Our combined findings add 
+radiological findings to the BDA1 phenotype and confirm a critical functional 
+domain of IHH.
+
+DOI: 10.1016/j.ejmg.2009.05.008
+PMID: 19464397 [Indexed for MEDLINE]

--- a/references_cache/PMID_22231430.md
+++ b/references_cache/PMID_22231430.md
@@ -1,13 +1,75 @@
 ---
 reference_id: "PMID:22231430"
-title: "Autosomal recessive osteopetrosis review"
+title: "Autosomal recessive osteopetrosis: report of 41 novel mutations in the TCIRG1 gene and diagnostic implications."
+authors:
+- Pangrazio A
+- Caldana ME
+- Lo Iacono N
+- Mantero S
+- Vezzoni P
+- Villa A
+- Sobacchi C
+journal: Osteoporos Int
+year: '2012'
+doi: 10.1007/s00198-011-1878-5
+keywords:
+- DNA Mutational Analysis/methods
+- Gene Deletion
+- "Genes, Recessive"
+- Humans
+- Mutation
+- "Osteopetrosis/diagnosis, enzymology, genetics"
+- "Vacuolar Proton-Translocating ATPases/deficiency, genetics"
 content_type: abstract_only
 ---
 
-# Autosomal recessive osteopetrosis review
+# Autosomal recessive osteopetrosis: report of 41 novel mutations in the TCIRG1 gene and diagnostic implications.
+**Authors:** Pangrazio A, Caldana ME, Lo Iacono N, Mantero S, Vezzoni P, Villa A, Sobacchi C
+**Journal:** Osteoporos Int (2012)
+**DOI:** [10.1007/s00198-011-1878-5](https://doi.org/10.1007/s00198-011-1878-5)
 
 ## Content
 
-Biallelic mutations in the TCIRG1 gene, encoding the a3 isoform of the vacuolar proton pump, are responsible for more than one half of ARO patients.
+1. Osteoporos Int. 2012 Nov;23(11):2713-8. doi: 10.1007/s00198-011-1878-5. Epub 
+2012 Jan 10.
 
-PMID: 22231430
+Autosomal recessive osteopetrosis: report of 41 novel mutations in the TCIRG1 
+gene and diagnostic implications.
+
+Pangrazio A(1), Caldana ME, Lo Iacono N, Mantero S, Vezzoni P, Villa A, Sobacchi 
+C.
+
+Author information:
+(1)Milan Unit, Institute of Genetic and Biomedical Research (IRGB), National 
+Research Council, 20138, Milan, Italy.
+
+Erratum in
+    Osteoporos Int. 2012 Nov;23(11):2719. Iacono, N L [corrected to Lo Iacono, 
+N].
+
+Here we report 41 novel mutations in the TCIRG1 gene that is responsible for the 
+disease in more than 50% of ARO patients. The characterisation of mutations in 
+this gene might be useful in the process of drug design for osteoporosis 
+treatment.
+INTRODUCTION: Autosomal recessive osteopetrosis (ARO) is a genetically 
+heterogeneous disorder due to reduced bone resorption by osteoclasts. In this 
+process, a crucial role is played by the proton pump V-ATPase. Biallelic 
+mutations in the TCIRG1 gene, encoding for the a3 subunit of this pump, are 
+responsible for more than one half of ARO patients.
+METHODS: Patients with a clinical diagnosis of ARO have been collected for 7 
+years and mutation analysis of the TCIRG1 gene was performed using direct DNA 
+sequencing of PCR-amplified exons according to both a standard protocol and a 
+modified one.
+RESULTS: We report here 41 novel mutations identified in 67 unpublished 
+patients, all with biallelic mutations. In particular, we describe two novel 
+large genomic deletions and two splice site mutations in the 5' UTR of the 
+TCIRG1 gene, in patients previously classified as mono-allelic.
+CONCLUSIONS: Our data highlights the importance of two large genomic deletions 
+and mutations in the 5' UTR with respect to patient management and, more 
+critically, to prenatal diagnosis. With the present work, we strongly contribute 
+to the molecular dissection of TCIRG1-deficient ARO and identify several protein 
+residues which are fundamental for proton pump function and could thus be the 
+target of future drugs designed to inhibit osteoclast resorptive activity.
+
+DOI: 10.1007/s00198-011-1878-5
+PMID: 22231430 [Indexed for MEDLINE]

--- a/references_cache/PMID_2314964.md
+++ b/references_cache/PMID_2314964.md
@@ -1,13 +1,65 @@
 ---
 reference_id: "PMID:2314964"
-title: "Worldwide survey of neonatal screening for biotinidase deficiency"
+title: "Screening for biotinidase deficiency in newborns: worldwide experience."
+authors:
+- Wolf B
+- Heard GS
+journal: Pediatrics
+year: '1990'
+keywords:
+- Amidohydrolases/deficiency
+- Biotinidase
+- Canada
+- Europe
+- Humans
+- "Infant, Newborn/blood"
+- Japan
+- "Metabolism, Inborn Errors/prevention & control"
+- Neonatal Screening/methods
+- "Phenylketonurias/prevention & control"
+- United States
 content_type: abstract_only
 ---
 
-# Worldwide survey of neonatal screening for biotinidase deficiency
+# Screening for biotinidase deficiency in newborns: worldwide experience.
+**Authors:** Wolf B, Heard GS
+**Journal:** Pediatrics (1990)
 
 ## Content
 
-The incidence of biotinidase deficiency in symptomatic children was determined to be one in 84,000 and the frequency in newborns one in 61,067.
+1. Pediatrics. 1990 Apr;85(4):512-7.
 
-PMID: 2314964
+Screening for biotinidase deficiency in newborns: worldwide experience.
+
+Wolf B(1), Heard GS.
+
+Author information:
+(1)Departments of Human Genetics, Medical College of Virginia, Virginia 
+Commonwealth University, Richmond 23298-0033.
+
+Between January 24, 1984, and December 31, 1988, 29 screening programs for 
+biotinidase deficiency in newborns were established in 12 countries, and 
+4,396,834 newborns were screened. The worldwide incidence is based on screening 
+programs in Australia, Austria, Canada, Italy, Japan, Mexico, New Zealand, 
+Scotland, Spain, Switzerland, The United States, and West Germany. Biotinidase 
+deficiency was detected in 72 newborns; 32 had profound biotinidase deficiency 
+(less than 10% of mean normal activity level) and 40 had partial deficiency (10% 
+to 30% of mean normal activity level). The combined incidence of profound and 
+partial deficiency was 1 case per 61,067 live births (1:49 500 to 1:79 544; 95% 
+confidence interval), the estimated frequency of the recessive allele was 
+0.0040, and the frequency of heterozygosity was estimated to be 1:123. Profound 
+deficiency occurred in 1 per 137,401 live births (1:109,300 to 1:211,200), and 
+partial deficiency in 1 per 109,921 live births (1:86,600 to 1:159,700). Most 
+available parents of children with profound and partial deficiency had 
+biotinidase activity levels intermediate between zero and mean normal activity 
+levels. Six children with profound deficiency were symptomatic at, or soon 
+after, the time of diagnosis; no infant with partial deficiency has become 
+symptomatic, but little is known about the natural history of infants with 
+partial deficiency. Most children whose biotinidase deficiency was detected by 
+newborn screening were white, one was black, and one Hispanic; biotinidase 
+deficiency has not been detected in Oriental children. Although 8 pilot programs 
+have terminated, 21 will continue either indefinitely or until predetermined 
+targets are reached, and 3 new programs were scheduled to begin in January 
+1989.(ABSTRACT TRUNCATED AT 250 WORDS)
+
+PMID: 2314964 [Indexed for MEDLINE]

--- a/references_cache/PMID_41235131.md
+++ b/references_cache/PMID_41235131.md
@@ -1,13 +1,101 @@
 ---
 reference_id: "PMID:41235131"
-title: "Report of six new beta-mannosidosis cases and literature review"
+title: Expanding the Phenotype Spectrum of β-Mannosidosis.
+authors:
+- Martin Rios AM
+- Gibbs LH
+- Stepien KM
+- Hall K
+- Hall PL
+- Bentz Pino G
+- Wang RY
+- Pillai NR
+- Lund T
+- Orchard PJ
+- Kimonis VE
+journal: Neurol Genet
+year: '2025'
+doi: 10.1212/NXG.0000000000200317
 content_type: abstract_only
 ---
 
-# Report of six new beta-mannosidosis cases and literature review
+# Expanding the Phenotype Spectrum of β-Mannosidosis.
+**Authors:** Martin Rios AM, Gibbs LH, Stepien KM, Hall K, Hall PL, Bentz Pino G, Wang RY, Pillai NR, Lund T, Orchard PJ, Kimonis VE
+**Journal:** Neurol Genet (2025)
+**DOI:** [10.1212/NXG.0000000000200317](https://doi.org/10.1212/NXG.0000000000200317)
 
 ## Content
 
-Including our 6 patients, a total of 46 cases from 37 different families have been reported.
+1. Neurol Genet. 2025 Nov 7;11(6):e200317. doi: 10.1212/NXG.0000000000200317. 
+eCollection 2025 Dec.
 
+Expanding the Phenotype Spectrum of β-Mannosidosis.
+
+Martin Rios AM(1), Gibbs LH(2), Stepien KM(3), Hall K(1)(4), Hall PL(5), Bentz 
+Pino G(5), Wang RY(6)(7), Pillai NR(8), Lund T(9), Orchard PJ(9), Kimonis 
+VE(1)(4)(10)(11).
+
+Author information:
+(1)Division of Genetics, Department of Pediatrics, University of California, 
+Irvine, Orange, CA.
+(2)Department of Radiological Sciences, School of Medicine, University of 
+California, Irvine, Orange, CA.
+(3)Adult Inherited Metabolic Diseases Department, Salford Royal Organization, 
+Northern Care Alliance NHS Foundation Trust, Salford, United Kingdom.
+(4)CHOC Children's Hospital, Orange, CA.
+(5)Biochemical Genetics Laboratory, Division of Laboratory Genetics and 
+Genomics, Mayo Clinic, Rochester, MN.
+(6)Division of Metabolic Disorders CHOC Children's Hospital, Orange, CA.
+(7)Department of Pediatrics, University of California-Irvine School of Medicine, 
+Irvine, CA.
+(8)Division of Genetics and Metabolism, Department of Pediatrics, University of 
+Minnesota, Minneapolis, MN.
+(9)Division of Blood and Marrow Transplantation, Department of Pediatrics, 
+University of Minnesota, Minneapolis, MN.
+(10)Department of Neurology, University of California, Irvine, Orange, CA; and.
+(11)Department of Pathology, University of California, Irvine, Orange, CA.
+
+BACKGROUND AND OBJECTIVES: β-mannosidosis is an ultra-rare lysosomal storage 
+disorder caused by a deficiency of β-mannosidase, which catalyzes the last step 
+of glycoprotein degradation. Owing to the limited number of reported cases, 
+information on the natural history of the disease and brain imaging is scarce. 
+We report 6 new cases and review them together with all the previously reported 
+cases in the literature.
+METHODS: We describe the clinical features of 6 unrelated patients with 
+β-mannosidosis, their variants in MANBA, enzyme activity, urine oligosaccharide 
+profiles, brain MRI findings, and longitudinal MRI changes in 2 of them. We also 
+review previously reported patients to broaden the spectrum of clinical features 
+and identify genotype-phenotype correlations.
+RESULTS: Developmental regression, dysphagia, obsessive-compulsive-like 
+behavior, and erythromelalgia are newly described features associated with 
+β-mannosidosis among the 6 patients from our cohort. Nystagmus in association 
+with β-mannosidosis was also found in 1 patient. Half the patients have abnormal 
+brain MRIs, showing delayed myelination before 2 years of age and diffuse 
+hypomyelination thereafter. A new oligosaccharide was found in the urine of the 
+2 most severely affected patients. Including our 6 patients, a total of 46 cases 
+from 37 different families have been reported. The mean age of diagnosis is 12.8 
+years, and the mean age of symptom onset is 2.4 years. Hearing loss was the 
+initial symptom most frequently reported, and intellectual disability was the 
+most frequent symptom overall. Across the cohort, 29 pathogenic MANBA variants 
+were identified, 61.8% were private, and 38.2% have the recurrent c.2158-2A>G 
+variant. Neuroimaging abnormalities were reported in 40% of published cases and 
+included cortical and subcortical atrophy, basal ganglia and white matter 
+calcification, hydrocephalus, periventricular and subcortical white matter 
+hyperintensities, and delayed myelination.
+DISCUSSION: Genotype-phenotype correlation in β-mannosidosis remains elusive, 
+likely due to phenotypic variability, disease rarity, and lack of association 
+between the enzyme activity and the clinical severity. Modifier genes in the 
+N-glycan degradation pathway, such as CTBS, may influence disease expression. 
+β-mannosidosis should be considered as a differential diagnosis in patients with 
+syndromic or apparently nonsyndromic hearing loss, unexplained brain 
+hypomyelination, behavioral disturbances, and intellectual disability.
+
+Copyright © 2025 The Author(s). Published by Wolters Kluwer Health, Inc. on 
+behalf of the American Academy of Neurology.
+
+DOI: 10.1212/NXG.0000000000200317
+PMCID: PMC12608049
 PMID: 41235131
+
+Conflict of interest statement: The authors report no relevant disclosures. Go 
+to Neurology.org/NG for full disclosures.


### PR DESCRIPTION
## Summary

Follow-up to #1740 / audit issue #1737. The prior automated audit pass identified six small (`< 400 B`) `references_cache/PMID_*.md` files whose `## Content` sections were the disorder YAML snippet copy-pasted back — a fabrication that produced a tautological `linkml-reference-validator` pass.

This PR re-fetches each cache via `linkml-reference-validator cache reference --force` and updates the citing disorder YAMLs so each snippet is once again an exact-quote substring of the real PubMed abstract.

## Cache files replaced

| PMID | Real title (post-fetch) | Citing file | YAML snippet edit |
|------|-------------------------|-------------|--------------------|
| 19232111 | Stark & Savarirayan, *Orphanet J Rare Dis* (2009) — *Osteopetrosis.* | `Autosomal_Recessive_Osteopetrosis.yaml` | yes |
| 22231430 | Pangrazio et al., *Osteoporos Int* (2012) — TCIRG1 mutation report | `Autosomal_Recessive_Osteopetrosis.yaml` | yes (a3 isoform → a3 subunit) |
| 19464397 | Stattin et al., *Eur J Med Genet* (2009) — Swedish BDA1 family | `Brachydactyly_Type_A1.yaml` | yes |
| 17395137 | Strupp et al., *Neurotherapeutics* (2007) — Episodic ataxia type 2 | `CACNA1A_Related_Disorder.yaml` | yes |
| 2314964  | Wolf & Heard, *Pediatrics* (1990) — worldwide newborn screening | `Biotinidase_Deficiency.yaml` | yes (removed fabricated 1:84,000 figure) |
| 41235131 | Martin Rios et al., *Neurol Genet* (2025) — β-mannosidosis cohort | `Beta_Mannosidosis.yaml` | none — snippet happened to match verbatim |

## Notable correction

`Biotinidase_Deficiency.yaml` (PMID:2314964) previously used the snippet:
> "The incidence of biotinidase deficiency in symptomatic children was determined to be one in 84,000 and the frequency in newborns one in 61,067."

The "1 in 84,000" figure does not appear in the real Wolf & Heard 1990 abstract; it conflated two stats. Replaced with the abstract's actual combined incidence statement (1 in 61,067 live births).

## Validation

- `just validate kb/disorders/{Autosomal_Recessive_Osteopetrosis,Brachydactyly_Type_A1,CACNA1A_Related_Disorder,Biotinidase_Deficiency,Beta_Mannosidosis}.yaml` — schema + terms + references all pass
- `just check-reference-cache-frontmatter` — pass

## Diff hygiene

Reverted ~95 unrelated `references_cache/*.md` cosmetic frontmatter normalizations and ~6 cache CSV side-effects produced by the validator pass; commit is strictly scoped to the 4 disorder YAMLs + 6 PMID cache files (10 files / +424 −30).

## Why this matters

The previous validator behaviour — `snippet ⊆ cached_content` — passes any cache where `cached_content == snippet`. Re-fetching the abstract is the only way to break the loop. Issue #1737's task list flagged a defense-in-depth check (require non-empty `authors:` / `journal:` and a minimum content-length floor); not in scope for this PR but worth following up.

## Test plan

- [ ] CI runs `just qc` (schema + term + reference + frontmatter validators) and passes
- [ ] Re-review the snippet substitutions for editorial accuracy (especially Biotinidase, where the prevalence figure changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)