### PR TITLE
[codex] Add manual review trigger for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -11,11 +13,25 @@ on:
         type: number
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
+    if: >-
+      ${{
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          github.event.comment.body == '/review' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,21 +40,22 @@ jobs:
       id-token: write
 
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: Checkout PR branch (for workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Checkout PR branch (for manual review triggers)
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr checkout ${{ env.PR_NUMBER }}
 
       - name: Generate ai4c-agent token
         id: ai4c-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
@@ -49,7 +66,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ steps.ai4c-token.outputs.token }}
+          github_token: ${{ steps.ai4c-token.outputs.token || github.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
           allowed_bots: 'claude,github-actions'
           claude_args: |


### PR DESCRIPTION
## Summary

Adds an `issue_comment` trigger to the Claude Code Review workflow so maintainers can comment `/review` on a fork PR and run the review from the base repository context, where required secrets are available.

## Details

- Uses `github.event.issue.number` as the PR number for `issue_comment` events.
- Limits automatic `pull_request` review runs to same-repository branches, avoiding secret-related failures on fork PRs.
- Gates the `/review` trigger to PR comments from `OWNER`, `MEMBER`, or `COLLABORATOR` commenters.
- Checks out the PR branch for both `workflow_dispatch` and `/review` comment-triggered runs.
- Allows the ai4c-agent token step to continue on error and falls back to `github.token` for Claude review.

## Validation

- `git diff --check -- .github/workflows/claude-code-review.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "yaml ok"'`
- `env GOPATH=/tmp/codex-go-actionlint GOMODCACHE=/tmp/codex-go-actionlint/pkg/mod go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/claude-code-review.yml`
- Commit hooks: YAML checks, yamllint, codespell