### PR TITLE
[codex] Add Orphanet evidence for Gaucher disease

### DIFF
--- a/kb/disorders/Gaucher_Disease.yaml
+++ b/kb/disorders/Gaucher_Disease.yaml
@@ -1,6 +1,6 @@
 name: Gaucher Disease
 creation_date: '2026-01-07T17:31:51Z'
-updated_date: '2026-04-26T05:25:25Z'
+updated_date: '2026-04-27T01:12:02Z'
 category: Genetic
 parents:
 - Lysosomal Storage Disorder
@@ -10,6 +10,51 @@ disease_term:
   term:
     id: MONDO:0018150
     label: Gaucher disease
+synonyms:
+- Acid beta-glucosidase deficiency
+- Glucocerebrosidase deficiency
+definitions:
+- name: Orphanet disease definition
+  definition_type: OTHER
+  description: >
+    Orphanet defines Gaucher disease as a lysosomal storage disorder spanning
+    three main forms plus fetal and cardiac-involvement variants.
+  scope: Orphanet structured disease record for ORPHA:355
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Gaucher disease (GD) is a lysosomal storage disorder encompassing three main forms (types 1, 2 and 3), a fetal form and a variant with cardiac involvement (Gaucher disease - ophthalmoplegia - cardiovascular calcification or Gaucher-like disease)."
+    explanation: Orphanet defines Gaucher disease as a lysosomal storage disorder with the major clinical forms represented in this entry.
+external_assertions:
+- name: Orphanet Gaucher disease record
+  source: Orphanet
+  assertion_type: Disease registry record
+  external_id: ORPHA:355
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=355
+  description: >
+    Orphanet ORPHA:355 is the structured registry record for Gaucher disease and
+    lists exact MONDO and other disease-code cross-references.
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "MONDO:0018150 | Exact"
+    explanation: Orphanet maps ORPHA:355 exactly to the MONDO term used as the disease anchor in this file.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "ICD-10:E75.2 | Narrower"
+    explanation: Orphanet lists ICD-10 E75.2 as a narrower cross-reference under the Gaucher disease record.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "OMIM:230800 | Broader"
+    explanation: Orphanet lists OMIM 230800 as one of the broader OMIM cross-references for Gaucher disease.
 has_subtypes:
 - name: Type 1
   display_name: Type 1 (Non-neuronopathic)
@@ -737,6 +782,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "The main cause of the cytopenia, splenomegaly, hepatomegaly, and bone lesions associated with the disease is considered to be the infiltration of the bone marrow, spleen, and liver by Gaucher cells."
     explanation: Review confirms hepatomegaly as a major manifestation of Gaucher disease.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002240 | Hepatomegaly | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO annotation independently classifies hepatomegaly as very frequent in Gaucher disease.
 - name: Splenomegaly
   category: Hematologic
   frequency: VERY_FREQUENT
@@ -753,9 +804,15 @@ phenotypes:
     supports: SUPPORT
     snippet: "The main cause of the cytopenia, splenomegaly, hepatomegaly, and bone lesions associated with the disease is considered to be the infiltration of the bone marrow, spleen, and liver by Gaucher cells."
     explanation: Review confirms splenomegaly as a major manifestation caused by Gaucher cell infiltration.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001744 | Splenomegaly | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO annotation independently classifies splenomegaly as very frequent in Gaucher disease.
 - name: Thrombocytopenia
   category: Hematologic
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   notes: Due to splenic sequestration and bone marrow infiltration
   phenotype_term:
     preferred_term: Thrombocytopenia
@@ -768,6 +825,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "More than 50% of patients had platelet counts of <100000 platelets per mm3 at baseline, but >95% had platelet counts above this level after 8 years of treatment."
     explanation: Study documents thrombocytopenia as a common baseline finding in Gaucher disease patients.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001873 | Thrombocytopenia | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO annotation supports classifying thrombocytopenia as frequent in Gaucher disease.
 - name: Anemia
   category: Hematologic
   frequency: VERY_FREQUENT
@@ -783,9 +846,31 @@ phenotypes:
     supports: SUPPORT
     snippet: "Anemia, although not severe, was present in >50% of patients at baseline and resolved for all patients after 8 years of treatment."
     explanation: Study confirms anemia as a common finding in over half of Gaucher disease patients.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001903 | Anemia | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO annotation independently classifies anemia as very frequent in Gaucher disease.
+- name: Fatigue
+  category: Constitutional
+  frequency: VERY_FREQUENT
+  notes: Orphanet classifies fatigue among the very frequent Gaucher disease phenotypes.
+  phenotype_term:
+    preferred_term: Fatigue
+    term:
+      id: HP:0012378
+      label: Fatigue
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012378 | Fatigue | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO annotation supports fatigue as a very frequent phenotype in Gaucher disease.
 - name: Bone Pain
   category: Musculoskeletal
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   notes: Bone crises can be severe
   phenotype_term:
     preferred_term: Bone Pain
@@ -798,6 +883,28 @@ phenotypes:
     supports: SUPPORT
     snippet: "Seventeen percent of patients reported a bone crisis before treatment and in the first 2 years of treatment, but no bone crises were reported after 2 years of enzyme replacement therapy."
     explanation: Study documents bone crises/pain as a significant manifestation that resolves with treatment.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002653 | Bone pain | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO annotation supports classifying bone pain as frequent in Gaucher disease.
+- name: Osteopenia
+  category: Musculoskeletal
+  frequency: FREQUENT
+  notes: Orphanet classifies osteopenia as a frequent skeletal phenotype.
+  phenotype_term:
+    preferred_term: Osteopenia
+    term:
+      id: HP:0000938
+      label: Osteopenia
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000938 | Osteopenia | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO annotation supports osteopenia as a frequent Gaucher disease phenotype.
 - name: Pathologic Fractures
   category: Musculoskeletal
   frequency: FREQUENT
@@ -828,6 +935,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "Erlenmeyer flask deformity is a common radiological finding in patients with Gaucher's disease"
     explanation: Study confirms Erlenmeyer flask deformity is a characteristic radiological finding in Gaucher disease.
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0004975 | Erlenmeyer flask deformity of the femurs | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO annotation supports Erlenmeyer flask deformity as frequent in Gaucher disease.
 # Neuronopathic phenotypes (Types 2 and 3)
 - name: Oculomotor Apraxia
   category: Neurologic
@@ -1119,6 +1232,26 @@ genetic:
     snippet: "Patients with type-1 GD-but also carriers of GBA1 mutation-have been found to be predisposed to developing Parkinson's disease"
     explanation: Review confirms both GD patients and GBA1 carriers have increased PD risk.
 prevalence:
+- population: Worldwide
+  percentage: "1-9 / 100 000"
+  notes: Orphanet reports worldwide prevalence at birth in the 1-9 per 100,000 class.
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-9 / 100 000 | Worldwide | Prevalence at birth | PMID:23046562"
+    explanation: Orphanet provides a worldwide prevalence-at-birth class for Gaucher disease.
+- population: Europe
+  percentage: "1-9 / 100 000"
+  notes: Orphanet reports both European annual incidence and point prevalence in the 1-9 per 100,000 class.
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-9 / 100 000 | Europe | Point prevalence | EXPERT"
+    explanation: Orphanet provides a European point-prevalence class for Gaucher disease.
 - subtype: Type 1
   population: Global
   notes: >
@@ -1140,6 +1273,16 @@ prevalence:
     snippet: "Gaucher disease is the most prevalent lysosomal storage disease and has its highest incidence in the Ashkenazi Jewish population."
     explanation: Review confirms highest incidence in Ashkenazi Jewish population.
 progression:
+- phase: Disease onset
+  age_range: All ages
+  notes: Orphanet records disease-level onset across all ages, complementing the subtype-specific onset patterns below.
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: All ages"
+    explanation: Orphanet's natural-history field supports broad all-age onset for Gaucher disease overall.
 - phase: Onset
   subtype: Type 1
   age_range: Childhood-Adulthood
@@ -1257,4 +1400,11 @@ inheritance:
     term:
       id: HP:0000007
       label: Autosomal recessive inheritance
+  evidence:
+  - reference: ORPHA:355
+    reference_title: "Gaucher disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Autosomal recessive"
+    explanation: Orphanet lists autosomal recessive inheritance for Gaucher disease.
 datasets:

--- a/references_cache/ORPHA_355.md
+++ b/references_cache/ORPHA_355.md
@@ -1,0 +1,170 @@
+---
+reference_id: "ORPHA:355"
+title: "Gaucher disease"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:355  Gaucher disease
+
+**ORPHA:355** — Gaucher disease (Disease, Disorder)
+
+## Synonyms
+
+- Acid beta-glucosidase deficiency
+- Glucocerebrosidase deficiency
+
+## Definition
+
+Gaucher disease (GD) is a lysosomal storage disorder encompassing three main forms (types 1, 2 and 3), a fetal form and a variant with cardiac involvement (Gaucher disease - ophthalmoplegia - cardiovascular calcification or Gaucher-like disease).
+
+## Inheritance
+
+- Autosomal recessive
+
+## Natural history
+
+- Age of onset: All ages
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| 1-9 / 100 000 | Australia | Prevalence at birth | PMID:9918480 |
+| 1-9 / 100 000 | Austria | Prevalence at birth | PMID:22133539 |
+| 1-9 / 1 000 000 | China | Point prevalence | PMID:34103049 |
+| 1-9 / 100 000 | Czech Republic | Prevalence at birth | PMID:20490927 |
+| 1-9 / 100 000 | Europe | Annual incidence | EXPERT |
+| 1-9 / 100 000 | Europe | Point prevalence | EXPERT |
+| 1-9 / 100 000 | France | Annual incidence | PMID:23046562 |
+| 1-9 / 1 000 000 | France | Point prevalence | PMID:23046562 |
+| 1-9 / 100 000 | France | Prevalence at birth | PMID:23046562 |
+| 1-9 / 100 000 | Hungary | Prevalence at birth | PMID:23430949 |
+| 1-9 / 100 000 | Netherlands | Prevalence at birth | PMID:10480370 |
+| 1-9 / 100 000 | Portugal | Prevalence at birth | PMID:14685153 |
+| 1-9 / 1 000 000 | Spain | Point prevalence | PMID:22429443 |
+| 1-9 / 100 000 | Sweden | Prevalence at birth | PMID:25274184 |
+| 1-9 / 1 000 000 | Turkey | Prevalence at birth | PMID:15275696 |
+| 1-9 / 100 000 | Worldwide | Prevalence at birth | PMID:23046562 |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000093 | Proteinuria | Occasional (29-5%) |
+| HP:0000225 | Gingival bleeding | Occasional (29-5%) |
+| HP:0000238 | Hydrocephalus | Occasional (29-5%) |
+| HP:0000365 | Hearing impairment | Occasional (29-5%) |
+| HP:0000486 | Strabismus | Frequent (79-30%) |
+| HP:0000488 | Retinopathy | Occasional (29-5%) |
+| HP:0000657 | Oculomotor apraxia | Occasional (29-5%) |
+| HP:0000716 | Depression | Frequent (79-30%) |
+| HP:0000726 | Dementia | Occasional (29-5%) |
+| HP:0000790 | Hematuria | Occasional (29-5%) |
+| HP:0000823 | Delayed puberty | Frequent (79-30%) |
+| HP:0000924 | Abnormality of the skeletal system | Frequent (79-30%) |
+| HP:0000938 | Osteopenia | Frequent (79-30%) |
+| HP:0000939 | Osteoporosis | Occasional (29-5%) |
+| HP:0001000 | Abnormality of skin pigmentation | Occasional (29-5%) |
+| HP:0001081 | Cholelithiasis | Frequent (79-30%) |
+| HP:0001103 | Abnormal macular morphology | Occasional (29-5%) |
+| HP:0001249 | Intellectual disability | Frequent (79-30%) |
+| HP:0001251 | Ataxia | Frequent (79-30%) |
+| HP:0001252 | Hypotonia | Occasional (29-5%) |
+| HP:0001300 | Parkinsonism | Occasional (29-5%) |
+| HP:0001337 | Tremor | Occasional (29-5%) |
+| HP:0001373 | Joint dislocation | Frequent (79-30%) |
+| HP:0001387 | Joint stiffness | Occasional (29-5%) |
+| HP:0001394 | Cirrhosis | Occasional (29-5%) |
+| HP:0001395 | Hepatic fibrosis | Occasional (29-5%) |
+| HP:0001399 | Hepatic failure | Very rare (<4-1%) |
+| HP:0001510 | Growth delay | Frequent (79-30%) |
+| HP:0001522 | Death in infancy | Occasional (29-5%) |
+| HP:0001637 | Abnormal myocardium morphology | Occasional (29-5%) |
+| HP:0001654 | Abnormal heart valve morphology | Occasional (29-5%) |
+| HP:0001697 | Abnormal pericardium morphology | Occasional (29-5%) |
+| HP:0001744 | Splenomegaly | Very frequent (99-80%) |
+| HP:0001789 | Hydrops fetalis | Occasional (29-5%) |
+| HP:0001873 | Thrombocytopenia | Frequent (79-30%) |
+| HP:0001876 | Pancytopenia | Occasional (29-5%) |
+| HP:0001882 | Leukopenia | Frequent (79-30%) |
+| HP:0001892 | Abnormal bleeding | Occasional (29-5%) |
+| HP:0001903 | Anemia | Very frequent (99-80%) |
+| HP:0001928 | Abnormality of coagulation | Occasional (29-5%) |
+| HP:0001945 | Fever | Frequent (79-30%) |
+| HP:0002015 | Dysphagia | Frequent (79-30%) |
+| HP:0002027 | Abdominal pain | Frequent (79-30%) |
+| HP:0002069 | Bilateral tonic-clonic seizure | Frequent (79-30%) |
+| HP:0002071 | Abnormality of extrapyramidal motor function | Occasional (29-5%) |
+| HP:0002092 | Pulmonary arterial hypertension | Occasional (29-5%) |
+| HP:0002093 | Respiratory insufficiency | Occasional (29-5%) |
+| HP:0002119 | Ventriculomegaly | Occasional (29-5%) |
+| HP:0002123 | Generalized myoclonic seizure | Frequent (79-30%) |
+| HP:0002179 | Opisthotonus | Occasional (29-5%) |
+| HP:0002206 | Pulmonary fibrosis | Occasional (29-5%) |
+| HP:0002240 | Hepatomegaly | Very frequent (99-80%) |
+| HP:0002376 | Developmental regression | Frequent (79-30%) |
+| HP:0002653 | Bone pain | Frequent (79-30%) |
+| HP:0002750 | Delayed skeletal maturation | Frequent (79-30%) |
+| HP:0002754 | Osteomyelitis | Occasional (29-5%) |
+| HP:0002756 | Pathologic fracture | Occasional (29-5%) |
+| HP:0002757 | Recurrent fractures | Frequent (79-30%) |
+| HP:0002758 | Osteoarthritis | Occasional (29-5%) |
+| HP:0002797 | Osteolysis | Occasional (29-5%) |
+| HP:0002804 | Arthrogryposis multiplex congenita | Occasional (29-5%) |
+| HP:0002808 | Kyphosis | Occasional (29-5%) |
+| HP:0002829 | Arthralgia | Frequent (79-30%) |
+| HP:0003233 | Decreased HDL cholesterol concentration | Occasional (29-5%) |
+| HP:0003281 | Increased circulating ferritin concentration | Frequent (79-30%) |
+| HP:0003330 | Abnormal bone structure | Frequent (79-30%) |
+| HP:0003459 | Polyclonal elevation of IgM | Occasional (29-5%) |
+| HP:0003656 | Decreased beta-glucocerebrosidase level | Very frequent (99-80%) |
+| HP:0004322 | Short stature | Occasional (29-5%) |
+| HP:0004374 | Hemiplegia/hemiparesis | Occasional (29-5%) |
+| HP:0004380 | Aortic valve calcification | Occasional (29-5%) |
+| HP:0004382 | Mitral valve calcification | Occasional (29-5%) |
+| HP:0004975 | Erlenmeyer flask deformity of the femurs | Frequent (79-30%) |
+| HP:0006530 | Abnormal pulmonary interstitial morphology | Occasional (29-5%) |
+| HP:0006775 | Multiple myeloma | Occasional (29-5%) |
+| HP:0006824 | Cranial nerve paralysis | Occasional (29-5%) |
+| HP:0007141 | Sensorimotor neuropathy | Occasional (29-5%) |
+| HP:0007957 | Corneal opacity | Occasional (29-5%) |
+| HP:0008064 | Ichthyosis | Occasional (29-5%) |
+| HP:0008872 | Feeding difficulties in infancy | Frequent (79-30%) |
+| HP:0010702 | Increased circulating antibody level | Occasional (29-5%) |
+| HP:0010729 | Cherry red spot of the macula | Occasional (29-5%) |
+| HP:0010885 | Avascular necrosis | Frequent (79-30%) |
+| HP:0011001 | Increased bone mineral density | Occasional (29-5%) |
+| HP:0011227 | Elevated circulating C-reactive protein concentration | Occasional (29-5%) |
+| HP:0012115 | Hepatitis | Occasional (29-5%) |
+| HP:0012223 | Splenic rupture | Very rare (<4-1%) |
+| HP:0012378 | Fatigue | Very frequent (99-80%) |
+| HP:0031047 | Paraproteinemia | Occasional (29-5%) |
+| HP:0032640 | Elevated circulating CCL18 level | Frequent (79-30%) |
+| HP:0034336 | Splenic infarction | Very rare (<4-1%) |
+| HP:0100022 | Abnormality of movement | Frequent (79-30%) |
+| HP:6000213 | Elevated circulating Angiotensin-converting enzyme concentration | Frequent (79-30%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:8233 | Exact |
+| ICD-10:E75.2 | Narrower |
+| ICD-11:5C56.0Y | Narrower |
+| MONDO:0018150 | Exact |
+| MeSH:D005776 | Exact |
+| MedDRA:10018048 | Exact |
+| OMIM:230800 | Broader |
+| OMIM:230900 | Broader |
+| OMIM:231000 | Broader |
+| OMIM:231005 | Broader |
+| OMIM:608013 | Broader |
+| OMIM:610539 | Broader |
+| UMLS:C0017205 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=355)


### PR DESCRIPTION
## Summary

- Regenerated the structured Orphanet cache for ORPHA:355 after refreshing Orphadata.
- Added Orphanet-backed synonyms, definition evidence, and an external assertion for the ORPHA:355 Gaucher disease record and cross-references.
- Added ORPHA:355 evidence for worldwide/European prevalence, all-age onset, autosomal recessive inheritance, and selected HPO phenotype frequencies.
- Added Orphanet-supported fatigue and osteopenia phenotypes, and aligned thrombocytopenia and bone pain frequency to Orphanet's Frequent band.

## Intentionally not changed

- Did not commit unrelated PMID cache normalization or term-cache side effects produced by validation commands.

## Validation

- `just refresh-orphadata`
- `just structured-rebuild-orphanet --id 355`
- `just validate kb/disorders/Gaucher_Disease.yaml`
- `just validate-schema kb/disorders/Gaucher_Disease.yaml`
- `just check-reference-cache-frontmatter`
- Manual exact-snippet presence check against `references_cache/ORPHA_355.md`
- Commit pre-hooks: YAML checks, `yamlfix`, `codespell`