### PR TITLE
[codex] Incorporate Orphanet evidence for Marfan syndrome

### DIFF
--- a/kb/disorders/Marfan_Syndrome.yaml
+++ b/kb/disorders/Marfan_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Marfan Syndrome
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-27T07:34:45Z'
+updated_date: '2026-04-27T12:39:26Z'
 description: Marfan syndrome is an autosomal dominant connective tissue disorder caused by mutations in FBN1, which encodes fibrillin-1. It affects multiple organ systems including the cardiovascular system (aortic root dilation and dissection), skeleton (tall stature, arachnodactyly, scoliosis), and eyes (ectopia lentis).
 category: Genetic
 parents:
@@ -181,7 +181,7 @@ pathophysiology:
   - reference: PMID:39096853
     reference_title: "Generation of Marfan syndrome-specific induced pluripotent stem cells harboring FBN1 mutations."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: Marfan syndrome (MFS) is a hereditary condition caused by mutations in the FBN1 gene. Genetic mutations in the FBN1 locus impact the function of the encoded protein, Fibrillin 1, a structural molecule forming microfibrils found in the connective tissue.
     explanation: The statement is supported by the description of FBN1 mutations affecting the function of fibrillin-1, which is crucial for connective tissue structure.
   - reference: PMID:17657824
@@ -285,7 +285,7 @@ pathophysiology:
     description: Weak zonular microfibrils predispose to lens displacement.
   - target: Scoliosis
     description: Ligamentous laxity and vertebral connective tissue weakness promote spinal curvature.
-  - target: Pneumothorax
+  - target: Spontaneous Pneumothorax
     description: Fragile connective tissue in lung apices increases risk of spontaneous pneumothorax.
 - name: Impaired Mechanotransduction
   description: Perturbed integrin-fibrillin interactions alter focal adhesion signaling and mechanosensing, contributing to maladaptive vascular smooth muscle cell responses to hemodynamic stress.

--- a/kb/disorders/Marfan_Syndrome.yaml
+++ b/kb/disorders/Marfan_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Marfan Syndrome
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-27T05:26:09Z'
+updated_date: '2026-04-27T07:34:45Z'
 description: Marfan syndrome is an autosomal dominant connective tissue disorder caused by mutations in FBN1, which encodes fibrillin-1. It affects multiple organ systems including the cardiovascular system (aortic root dilation and dissection), skeleton (tall stature, arachnodactyly, scoliosis), and eyes (ectopia lentis).
 category: Genetic
 parents:
@@ -651,6 +651,23 @@ phenotypes:
     term:
       id: HP:0002108
       label: Spontaneous pneumothorax
+- category: Respiratory
+  name: Sleep Apnea
+  description: Intermittent cessation of airflow during sleep, reflecting sleep-related breathing involvement reported in Marfan syndrome.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0010535 | Sleep apnea | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies sleep apnea as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Sleep apnea
+    description: Intermittent cessation of airflow at the mouth and nose during sleep.
+    term:
+      id: HP:0010535
+      label: Sleep apnea
 - category: Cardiovascular
   name: Aortic Dissection
   description: Life-threatening tear in the aortic wall allowing blood to enter between tissue layers, the leading cause of death in untreated Marfan syndrome.
@@ -698,6 +715,23 @@ phenotypes:
       id: HP:0001634
       label: Mitral valve prolapse
 - category: Cardiovascular
+  name: Tricuspid Valve Prolapse
+  description: Abnormal systolic displacement of tricuspid valve leaflets into the right atrium, representing right-sided atrioventricular valve involvement.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001704 | Tricuspid valve prolapse | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies tricuspid valve prolapse as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Tricuspid valve prolapse
+    description: Tricuspid valve leaflets bulge back into the right atrium during right ventricular contraction.
+    term:
+      id: HP:0001704
+      label: Tricuspid valve prolapse
+- category: Cardiovascular
   name: Aortic Root Aneurysm
   description: Progressive enlargement of the aortic root diameter, typically measured by echocardiography and tracked using Z-scores adjusted for age and body surface area.
   frequency: VERY_FREQUENT
@@ -715,6 +749,23 @@ phenotypes:
     term:
       id: HP:0002616
       label: Aortic root aneurysm
+- category: Cardiovascular
+  name: Ascending Tubular Aorta Aneurysm
+  description: Localized widening of the tubular ascending aorta, distinct from the aortic root and relevant to thoracic aortic surveillance.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0004970 | Ascending tubular aorta aneurysm | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies ascending tubular aorta aneurysm as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Ascending tubular aorta aneurysm
+    description: Localized dilatation of the tubular portion of the ascending aorta.
+    term:
+      id: HP:0004970
+      label: Ascending tubular aorta aneurysm
 - category: Musculoskeletal
   name: Pectus Carinatum
   description: Protrusion of the sternum and anterior chest wall, a common skeletal manifestation in Marfan syndrome.
@@ -853,6 +904,24 @@ phenotypes:
     term:
       id: HP:0001382
       label: Joint hypermobility
+- category: Musculoskeletal
+  name: Protrusio Acetabuli
+  description: Intrapelvic bulging of the medial acetabular wall, a skeletal feature included in systemic diagnostic scoring.
+  frequency: FREQUENT
+  diagnostic: true
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0003179 | Protrusio acetabuli | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies protrusio acetabuli as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Protrusio acetabuli
+    description: Intrapelvic bulging of the medial acetabular wall.
+    term:
+      id: HP:0003179
+      label: Protrusio acetabuli
 - category: Ocular
   name: Myopia
   description: Refractive error with clear near vision and blurred distance vision, reflecting ocular involvement in Marfan syndrome.

--- a/kb/disorders/Marfan_Syndrome.yaml
+++ b/kb/disorders/Marfan_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Marfan Syndrome
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-27T01:15:41Z'
+updated_date: '2026-04-27T05:26:09Z'
 description: Marfan syndrome is an autosomal dominant connective tissue disorder caused by mutations in FBN1, which encodes fibrillin-1. It affects multiple organ systems including the cardiovascular system (aortic root dilation and dissection), skeleton (tall stature, arachnodactyly, scoliosis), and eyes (ectopia lentis).
 category: Genetic
 parents:
@@ -610,9 +610,10 @@ phenotypes:
       id: HP:0002650
       label: Scoliosis
 - category: Respiratory
-  name: Pneumothorax
+  name: Spontaneous Pneumothorax
   description: Spontaneous lung collapse occurring in 5-11% of patients due to apical blebs from connective tissue abnormalities.
   frequency: OCCASIONAL
+  notes: Orphanet classifies spontaneous pneumothorax as Very frequent (99-80%), whereas PMID:25765122 reports 5-11%; frequency is retained as OCCASIONAL based on the direct quantitative clinical estimate.
   evidence:
   - reference: PMID:31883816
     reference_title: "[Recurrent spontaneous pneumothorax revealing Marfan's syndrome]."
@@ -638,12 +639,18 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: Increased risk of spontaneous pneumothorax has been described in patients with Marfan syndrome.
     explanation: The reference supports the statement by indicating an increased risk of pneumothorax in Marfan syndrome patients.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: "HP:0002108 | Spontaneous pneumothorax | Very frequent (99-80%)"
+    explanation: Orphanet supports the more specific spontaneous pneumothorax phenotype term for Marfan syndrome, but its Very frequent classification conflicts with the 5-11% estimate from PMID:25765122.
   phenotype_term:
-    preferred_term: Pneumothorax
-    description: Presence of air or gas in the pleural cavity causing lung collapse.
+    preferred_term: Spontaneous pneumothorax
+    description: Pneumothorax occurring without traumatic injury to the chest or lung.
     term:
-      id: HP:0002107
-      label: Pneumothorax
+      id: HP:0002108
+      label: Spontaneous pneumothorax
 - category: Cardiovascular
   name: Aortic Dissection
   description: Life-threatening tear in the aortic wall allowing blood to enter between tissue layers, the leading cause of death in untreated Marfan syndrome.
@@ -793,6 +800,111 @@ phenotypes:
     term:
       id: HP:0100775
       label: Dural ectasia
+- category: Constitutional
+  name: Chronic Fatigue
+  description: Persistent fatigue disproportionate to activity level, reported as a very frequent quality-of-life burden in Marfan syndrome.
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012432 | Chronic fatigue | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies chronic fatigue as Very frequent (99-80%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Chronic fatigue
+    description: Fatigue persisting for six months or longer.
+    term:
+      id: HP:0012432
+      label: Chronic fatigue
+- category: Musculoskeletal
+  name: Pectus Excavatum
+  description: Depression of the sternum and anterior chest wall, producing a caved-in chest-wall contour.
+  frequency: FREQUENT
+  diagnostic: true
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000767 | Pectus excavatum | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies pectus excavatum as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Pectus excavatum
+    description: Depression of the sternum giving the chest a caved-in appearance.
+    term:
+      id: HP:0000767
+      label: Pectus excavatum
+- category: Musculoskeletal
+  name: Joint Hypermobility
+  description: Increased passive or active joint range of motion beyond normal physiological limits.
+  frequency: FREQUENT
+  diagnostic: true
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001382 | Joint hypermobility | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies joint hypermobility as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Joint hypermobility
+    description: Ability of joints to move beyond normal limits along physiological axes.
+    term:
+      id: HP:0001382
+      label: Joint hypermobility
+- category: Ocular
+  name: Myopia
+  description: Refractive error with clear near vision and blurred distance vision, reflecting ocular involvement in Marfan syndrome.
+  frequency: FREQUENT
+  diagnostic: true
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000545 | Myopia | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies myopia as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Myopia
+    description: Nearsighted refractive error with blurred distance vision.
+    term:
+      id: HP:0000545
+      label: Myopia
+- category: Cardiovascular
+  name: Mitral Regurgitation
+  description: Incompetence of the mitral valve causing retrograde blood flow from the left ventricle into the left atrium during systole.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001653 | Mitral regurgitation | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies mitral regurgitation as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Mitral regurgitation
+    description: Retrograde leaking of blood through the mitral valve upon ventricular contraction.
+    term:
+      id: HP:0001653
+      label: Mitral regurgitation
+- category: Cardiovascular
+  name: Aortic Regurgitation
+  description: Aortic valve insufficiency causing backward blood flow from the aorta into the left ventricle.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001659 | Aortic regurgitation | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies aortic regurgitation as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Aortic regurgitation
+    description: Backward blood flow from the aorta into the left ventricle due to aortic valve insufficiency.
+    term:
+      id: HP:0001659
+      label: Aortic regurgitation
 biochemical:
 - name: Fibrillin-1 Protein
   presence: Abnormal
@@ -1060,6 +1172,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: losartan
+      term:
+        id: CHEBI:6541
+        label: losartan
 - name: Aortic Surgery
   description: Recommended for severe aortic dilation to prevent dissection.
   evidence:

--- a/kb/disorders/Marfan_Syndrome.yaml
+++ b/kb/disorders/Marfan_Syndrome.yaml
@@ -1,14 +1,107 @@
 name: Marfan Syndrome
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-26T00:00:00Z'
-description: Marfan syndrome is an autosomal dominant connective tissue disorder
-  caused by mutations in FBN1, which encodes fibrillin-1. It affects multiple
-  organ systems including the cardiovascular system (aortic root dilation and
-  dissection), skeleton (tall stature, arachnodactyly, scoliosis), and eyes
-  (ectopia lentis).
+updated_date: '2026-04-27T01:15:41Z'
+description: Marfan syndrome is an autosomal dominant connective tissue disorder caused by mutations in FBN1, which encodes fibrillin-1. It affects multiple organ systems including the cardiovascular system (aortic root dilation and dissection), skeleton (tall stature, arachnodactyly, scoliosis), and eyes (ectopia lentis).
 category: Genetic
 parents:
 - Connective Tissue Disorder
+mappings:
+  icd10cm_mappings:
+  - term:
+      id: ICD10CM:Q87.4
+      label: Marfan syndrome
+    mapping_predicate: skos:exactMatch
+    mapping_source: ORPHA:558
+    mapping_justification: Orphanet lists ICD-10 Q87.4 as an exact cross-reference for Marfan syndrome.
+    consistency:
+    - reference: ORPHA:558
+      consistent: CONSISTENT
+      notes: "ICD-10:Q87.4 | Exact"
+  icd11f_mappings:
+  - term:
+      id: icd11f:236564145
+      label: Marfan syndrome
+    mapping_predicate: skos:exactMatch
+    mapping_source: ORPHA:558
+    mapping_justification: Orphanet lists ICD-11 LD28.01 as an exact cross-reference; the local ICD-11 Foundation ontology represents this as icd11f:236564145.
+    consistency:
+    - reference: ORPHA:558
+      consistent: CONSISTENT
+      notes: "ICD-11:LD28.01 | Exact"
+  mondo_mappings:
+  - term:
+      id: MONDO:0007947
+      label: Marfan syndrome
+    mapping_predicate: skos:exactMatch
+    mapping_source: ORPHA:558
+    mapping_justification: Orphanet lists MONDO:0007947 as an exact cross-reference for Marfan syndrome.
+    consistency:
+    - reference: ORPHA:558
+      consistent: CONSISTENT
+      notes: "MONDO:0007947 | Exact"
+definitions:
+- name: Orphanet disease definition
+  definition_type: CASE_DEFINITION
+  description: >
+    Orphanet defines Marfan syndrome as a systemic connective-tissue disease
+    with cardiovascular, musculo-skeletal, ophthalmic, and pulmonary
+    manifestations.
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Marfan syndrome is a systemic disease of connective tissue characterized by a variable combination of cardiovascular, musculo-skeletal, ophthalmic and pulmonary manifestations."
+    explanation: Orphanet's definition supports the multisystem connective-tissue framing of this entry.
+external_assertions:
+- name: Orphanet Marfan syndrome record
+  source: Orphanet
+  assertion_type: Structured disease record
+  external_id: ORPHA:558
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=558
+  description: >
+    Orphanet structured record for Marfan syndrome, including curated
+    cross-references to MONDO, ICD-10, ICD-11, OMIM, MeSH, MedDRA, and UMLS
+    identifiers.
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "MONDO:0007947 | Exact"
+    explanation: The Orphanet cross-reference table exactly maps ORPHA:558 to MONDO:0007947.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "ICD-10:Q87.4 | Exact"
+    explanation: The Orphanet cross-reference table exactly maps ORPHA:558 to ICD-10 Q87.4.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "ICD-11:LD28.01 | Exact"
+    explanation: The Orphanet cross-reference table exactly maps ORPHA:558 to ICD-11 LD28.01.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "UMLS:C0024796 | Exact"
+    explanation: The Orphanet cross-reference table exactly maps ORPHA:558 to UMLS C0024796.
+inheritance:
+- name: Autosomal dominant inheritance
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Autosomal dominant"
+    explanation: Orphanet records autosomal dominant inheritance for Marfan syndrome.
 prevalence:
 - population: Global
   percentage: 0.01-0.02
@@ -17,72 +110,64 @@ prevalence:
     reference_title: "Marfan's syndrome: an overview."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan's syndrome is an autosomal dominant condition with an
-      estimated prevalence of one in 10,000 to 20,000 individuals.
-    explanation: The statement is partially supported as the prevalence is given
-      in a range (0.01-0.02) which matches the statement's value range, but it's
-      not explicitly stated as a percentage of the global population.
+    snippet: Marfan's syndrome is an autosomal dominant condition with an estimated prevalence of one in 10,000 to 20,000 individuals.
+    explanation: The statement is partially supported as the prevalence is given in a range (0.01-0.02) which matches the statement's value range, but it's not explicitly stated as a percentage of the global population.
   - reference: PMID:26631233
     reference_title: "Prevalence, incidence, and age at diagnosis in Marfan Syndrome."
     supports: REFUTE
     evidence_source: HUMAN_CLINICAL
-    snippet: We identified a total of 1628 persons with possible Marfan
-      syndrome. We confirmed the diagnosis in 412, whereof 46 were deceased,
-      yielding a maximum prevalence of 6.5/100,000 at the end of 2014.
-    explanation: This study reports a maximum prevalence of 6.5/100,000, which
-      is lower than the 0.01-0.02 percentage range stated in the question.
+    snippet: We identified a total of 1628 persons with possible Marfan syndrome. We confirmed the diagnosis in 412, whereof 46 were deceased, yielding a maximum prevalence of 6.5/100,000 at the end of 2014.
+    explanation: This study reports a maximum prevalence of 6.5/100,000, which is lower than the 0.01-0.02 percentage range stated in the question.
+- population: Worldwide (Orphanet point prevalence)
+  percentage: 0.01-0.05
+  notes: Orphanet reports a worldwide point-prevalence class of 1-5 per 10,000.
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-5 / 10 000 | Worldwide | Point prevalence | PMID:20301510"
+    explanation: The Orphanet epidemiology table provides a worldwide point-prevalence class for Marfan syndrome.
 progression:
 - phase: Onset
-  age_range: Childhood-Adolescence
+  age_range: All ages
   evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: All ages"
+    explanation: Orphanet records all ages as the age-of-onset category for Marfan syndrome.
   - reference: PMID:28383843
     reference_title: "[Marfan syndrome in childhood and adolescence]."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: The expression of the Marfan syndrome varies from the severe
-      neonatal presentation to the classical manifestations of the child and
-      young adult, but also comprises isolated features.
-    explanation: The reference indicates that Marfan syndrome can manifest from
-      neonatal stages to young adulthood, but it does not explicitly confirm
-      that the onset is limited to childhood-adolescence.
+    snippet: The expression of the Marfan syndrome varies from the severe neonatal presentation to the classical manifestations of the child and young adult, but also comprises isolated features.
+    explanation: The reference indicates that Marfan syndrome can manifest from neonatal stages to young adulthood, but it does not fully cover the all-age onset category.
   - reference: PMID:35420547
     reference_title: "A clinical scoring system for early onset (neonatal) Marfan syndrome."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: Distinct from classical Marfan syndrome in phenotype and morbidity,
-      eoMFS can be diagnosed clinically using an objective scoring system
-      encompassing the typical physical features and cardiac disease
-      manifestations.
-    explanation: This reference discusses early onset Marfan syndrome (eoMFS),
-      which can be diagnosed in early childhood. However, it does not specify
-      that the onset is restricted to childhood-adolescence.
+    snippet: Distinct from classical Marfan syndrome in phenotype and morbidity, eoMFS can be diagnosed clinically using an objective scoring system encompassing the typical physical features and cardiac disease manifestations.
+    explanation: This reference discusses early onset Marfan syndrome (eoMFS), which can be diagnosed in early childhood. However, it does not specify that the onset is restricted to childhood-adolescence.
   - reference: PMID:26631233
     reference_title: "Prevalence, incidence, and age at diagnosis in Marfan Syndrome."
-    supports: NO_EVIDENCE
+    supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
     snippet: 'We found a median age at diagnose of 19.0 years (range: 0.0-74).'
-    explanation: This study indicates that the age of diagnosis ranges widely,
-      from infancy to old age, suggesting that onset is not restricted to
-      childhood-adolescence.
+    explanation: This study reports a broad age-at-diagnosis range from birth to older adulthood, partially supporting a broad age-of-recognition spectrum while not directly measuring biological onset.
   - reference: PMID:38728377
     reference_title: "Mitral annular disjunction and its progression during childhood in Marfan syndrome."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: MAD was found in children of all ages, increased +0.18 mm/year (95%
-      CI +0.14, +0.22) during a median duration of 5.5 years (IQR 3.1, 7.5
-      years).
-    explanation: This study indicates that mitral annular disjunction (MAD)
-      associated with Marfan syndrome can be detected in children of all ages,
-      but it does not confirm that the onset of Marfan syndrome itself is
-      restricted to childhood-adolescence.
+    snippet: MAD was found in children of all ages, increased +0.18 mm/year (95% CI +0.14, +0.22) during a median duration of 5.5 years (IQR 3.1, 7.5 years).
+    explanation: This study indicates that mitral annular disjunction (MAD) associated with Marfan syndrome can be detected in children of all ages, but it does not confirm that the onset of Marfan syndrome itself is restricted to childhood-adolescence.
 pathophysiology:
 - name: FBN1 Gene Mutation
-  description: Mutations in the FBN1 gene result in defective fibrillin-1
-    protein, which affects the elasticity and strength of connective tissues.
+  description: Mutations in the FBN1 gene result in defective fibrillin-1 protein, which affects the elasticity and strength of connective tissues.
   gene:
     preferred_term: FBN1
-    description: Gene encoding fibrillin-1, a structural glycoprotein essential
-      for elastic fiber formation in connective tissue.
+    description: Gene encoding fibrillin-1, a structural glycoprotein essential for elastic fiber formation in connective tissue.
     term:
       id: hgnc:3603
       label: FBN1
@@ -91,86 +176,53 @@ pathophysiology:
     reference_title: "Identification of defects in the fibrillin gene and protein in individuals with the Marfan syndrome and related disorders."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The gene encoding for fibrillin, the FBN1 gene on chromosome 15,
-      has been identified as the defective gene causing the Marfan syndrome.
-      Fibrillin is the large glycoprotein with a repetitive domain structure and
-      is a major protein component of microfibrils, a fibrillar system closely
-      associated with elastin in connective tissue.
-    explanation: The statement is supported by the identification of the FBN1
-      gene as the cause of Marfan syndrome and its role in the structure of
-      connective tissue.
+    snippet: The gene encoding for fibrillin, the FBN1 gene on chromosome 15, has been identified as the defective gene causing the Marfan syndrome. Fibrillin is the large glycoprotein with a repetitive domain structure and is a major protein component of microfibrils, a fibrillar system closely associated with elastin in connective tissue.
+    explanation: The statement is supported by the identification of the FBN1 gene as the cause of Marfan syndrome and its role in the structure of connective tissue.
   - reference: PMID:39096853
     reference_title: "Generation of Marfan syndrome-specific induced pluripotent stem cells harboring FBN1 mutations."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome (MFS) is a hereditary condition caused by mutations
-      in the FBN1 gene. Genetic mutations in the FBN1 locus impact the function
-      of the encoded protein, Fibrillin 1, a structural molecule forming
-      microfibrils found in the connective tissue.
-    explanation: The statement is supported by the description of FBN1 mutations
-      affecting the function of fibrillin-1, which is crucial for connective
-      tissue structure.
+    snippet: Marfan syndrome (MFS) is a hereditary condition caused by mutations in the FBN1 gene. Genetic mutations in the FBN1 locus impact the function of the encoded protein, Fibrillin 1, a structural molecule forming microfibrils found in the connective tissue.
+    explanation: The statement is supported by the description of FBN1 mutations affecting the function of fibrillin-1, which is crucial for connective tissue structure.
   - reference: PMID:17657824
     reference_title: "The importance of mutation detection in Marfan syndrome and Marfan-related disorders: report of 193 FBN1 mutations."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Mutations in the FBN1 gene have been characterised in patients
-      affected by Marfan syndrome and Marfan-related disorders.
-    explanation: The statement is supported by the identification of FBN1
-      mutations in Marfan syndrome patients.
+    snippet: Mutations in the FBN1 gene have been characterised in patients affected by Marfan syndrome and Marfan-related disorders.
+    explanation: The statement is supported by the identification of FBN1 mutations in Marfan syndrome patients.
   - reference: PMID:12938084
     reference_title: "Update of the UMD-FBN1 mutation database and creation of an FBN1 polymorphism database."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Fibrillin is the major component of extracellular microfibrils.
-      Mutations in the fibrillin gene on chromosome 15 (FBN1) were first
-      described in the heritable connective disorder, Marfan syndrome (MFS).
-    explanation: The statement is supported by the role of fibrillin as a major
-      component of microfibrils and the impact of FBN1 mutations on connective
-      tissue.
+    snippet: Fibrillin is the major component of extracellular microfibrils. Mutations in the fibrillin gene on chromosome 15 (FBN1) were first described in the heritable connective disorder, Marfan syndrome (MFS).
+    explanation: The statement is supported by the role of fibrillin as a major component of microfibrils and the impact of FBN1 mutations on connective tissue.
   - reference: PMID:24555249
     reference_title: "[Marfan syndrome]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome is a genetic disorder of the connective tissue
-      caused by mutations in FBN1 gene.
-    explanation: The statement is supported by the description of Marfan
-      syndrome as a genetic disorder caused by FBN1 mutations.
+    snippet: Marfan syndrome is a genetic disorder of the connective tissue caused by mutations in FBN1 gene.
+    explanation: The statement is supported by the description of Marfan syndrome as a genetic disorder caused by FBN1 mutations.
   - reference: PMID:36004597
     reference_title: "[Ocular manifestations of Marfan syndrome]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome is an orphan disease that is caused by a mutation
-      in the FBN1 gene located on chromosome 15 (15q21.1) and is usually
-      inherited in an autosomal dominant manner.
-    explanation: The statement is supported by the identification of FBN1
-      mutations as the cause of Marfan syndrome.
+    snippet: Marfan syndrome is an orphan disease that is caused by a mutation in the FBN1 gene located on chromosome 15 (15q21.1) and is usually inherited in an autosomal dominant manner.
+    explanation: The statement is supported by the identification of FBN1 mutations as the cause of Marfan syndrome.
   - reference: PMID:25729264
     reference_title: "C596G mutation in FBN1 causes Marfan syndrome with exotropia in a Chinese family."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: A C596G mutation in FBN1 was identified in a Chinese family with
-      MFS. Our results expand the spectrum of FBN1 mutations and contribute to
-      the understanding of the role of FBN1 in the pathogenesis of Marfan
-      syndrome.
-    explanation: The statement is supported by the identification of specific
-      FBN1 mutations in Marfan syndrome patients and their impact on connective
-      tissue.
+    snippet: A C596G mutation in FBN1 was identified in a Chinese family with MFS. Our results expand the spectrum of FBN1 mutations and contribute to the understanding of the role of FBN1 in the pathogenesis of Marfan syndrome.
+    explanation: The statement is supported by the identification of specific FBN1 mutations in Marfan syndrome patients and their impact on connective tissue.
   downstream:
   - target: Dysregulated TGF-beta Signaling
-    description: Defective fibrillin microfibrils fail to properly sequester
-      latent TGF-beta complexes.
+    description: Defective fibrillin microfibrils fail to properly sequester latent TGF-beta complexes.
   - target: Extracellular Matrix Remodeling
-    description: Loss of normal fibrillin scaffold destabilizes elastic fiber
-      architecture and ECM integrity.
+    description: Loss of normal fibrillin scaffold destabilizes elastic fiber architecture and ECM integrity.
   - target: Impaired Mechanotransduction
-    description: Altered fibrillin-integrin interactions impair mechanosensing
-      in load-bearing connective tissues.
+    description: Altered fibrillin-integrin interactions impair mechanosensing in load-bearing connective tissues.
 - name: Dysregulated TGF-beta Signaling
-  description: Defective fibrillin-1 microfibrils fail to sequester latent
-    TGF-beta complexes, leading to increased bioavailable TGF-beta and excessive
-    SMAD2/3 signaling that drives vascular smooth muscle cell phenotypic
-    switching and ECM remodeling.
+  description: Defective fibrillin-1 microfibrils fail to sequester latent TGF-beta complexes, leading to increased bioavailable TGF-beta and excessive SMAD2/3 signaling that drives vascular smooth muscle cell phenotypic switching and ECM remodeling.
   biological_processes:
   - preferred_term: transforming growth factor beta receptor signaling pathway
     term:
@@ -192,21 +244,15 @@ pathophysiology:
       label: aorta
   downstream:
   - target: Extracellular Matrix Remodeling
-    description: Excess SMAD signaling increases protease activity and
-      maladaptive ECM turnover.
+    description: Excess SMAD signaling increases protease activity and maladaptive ECM turnover.
   - target: Aortic Root Aneurysm
-    description: Persistent TGF-beta activity accelerates medial degeneration
-      and progressive root dilation.
+    description: Persistent TGF-beta activity accelerates medial degeneration and progressive root dilation.
   - target: Tall Stature
-    description: Dysregulated growth factor signaling contributes to long bone
-      overgrowth.
+    description: Dysregulated growth factor signaling contributes to long bone overgrowth.
   - target: Arachnodactyly
-    description: Abnormal connective tissue growth signaling contributes to
-      elongated digits.
+    description: Abnormal connective tissue growth signaling contributes to elongated digits.
 - name: Extracellular Matrix Remodeling
-  description: Increased matrix metalloproteinase activity, elastic fiber
-    fragmentation, altered collagen composition, and proteoglycan accumulation
-    (especially versican) weaken the aortic wall medial layer.
+  description: Increased matrix metalloproteinase activity, elastic fiber fragmentation, altered collagen composition, and proteoglycan accumulation (especially versican) weaken the aortic wall medial layer.
   biological_processes:
   - preferred_term: extracellular matrix organization
     term:
@@ -232,23 +278,17 @@ pathophysiology:
       label: aorta tunica media
   downstream:
   - target: Aortic Aneurysm
-    description: Elastic fiber fragmentation and collagen disarray weaken the
-      aortic wall.
+    description: Elastic fiber fragmentation and collagen disarray weaken the aortic wall.
   - target: Mitral Valve Prolapse
-    description: Connective tissue degeneration in valve leaflets promotes
-      prolapse.
+    description: Connective tissue degeneration in valve leaflets promotes prolapse.
   - target: Ectopia Lentis
     description: Weak zonular microfibrils predispose to lens displacement.
   - target: Scoliosis
-    description: Ligamentous laxity and vertebral connective tissue weakness
-      promote spinal curvature.
+    description: Ligamentous laxity and vertebral connective tissue weakness promote spinal curvature.
   - target: Pneumothorax
-    description: Fragile connective tissue in lung apices increases risk of
-      spontaneous pneumothorax.
+    description: Fragile connective tissue in lung apices increases risk of spontaneous pneumothorax.
 - name: Impaired Mechanotransduction
-  description: Perturbed integrin-fibrillin interactions alter focal adhesion
-    signaling and mechanosensing, contributing to maladaptive vascular smooth
-    muscle cell responses to hemodynamic stress.
+  description: Perturbed integrin-fibrillin interactions alter focal adhesion signaling and mechanosensing, contributing to maladaptive vascular smooth muscle cell responses to hemodynamic stress.
   biological_processes:
   - preferred_term: cellular response to mechanical stimulus
     term:
@@ -274,12 +314,9 @@ pathophysiology:
       label: aorta
   downstream:
   - target: Aortic Root Aneurysm
-    description: Maladaptive vascular smooth muscle responses to pulsatile
-      stress accelerate root enlargement.
+    description: Maladaptive vascular smooth muscle responses to pulsatile stress accelerate root enlargement.
 - name: Vascular Inflammation
-  description: Angiotensin II type 1 receptor signaling and chemokine pathways
-    recruit macrophages and promote inflammatory mediators that exacerbate
-    vascular smooth muscle cell dysfunction and ECM degradation.
+  description: Angiotensin II type 1 receptor signaling and chemokine pathways recruit macrophages and promote inflammatory mediators that exacerbate vascular smooth muscle cell dysfunction and ECM degradation.
   biological_processes:
   - preferred_term: inflammatory response
     term:
@@ -309,12 +346,9 @@ pathophysiology:
       label: aorta tunica media
   downstream:
   - target: Aortic Dissection
-    description: Inflammatory ECM damage and smooth muscle dysfunction increase
-      risk of acute intimal tearing.
+    description: Inflammatory ECM damage and smooth muscle dysfunction increase risk of acute intimal tearing.
 - name: Mitochondrial Dysfunction
-  description: Emerging evidence implicates mitochondrial dysfunction and
-    oxidative stress in vascular smooth muscle cells and endothelial cells as
-    contributors to thoracic aortic aneurysm progression in Marfan syndrome.
+  description: Emerging evidence implicates mitochondrial dysfunction and oxidative stress in vascular smooth muscle cells and endothelial cells as contributors to thoracic aortic aneurysm progression in Marfan syndrome.
   biological_processes:
   - preferred_term: mitochondrial ATP synthesis coupled electron transport
     term:
@@ -340,90 +374,69 @@ pathophysiology:
       label: aorta
   downstream:
   - target: Aortic Dissection
-    description: Oxidative injury amplifies wall fragility and susceptibility to
-      dissection in advanced disease.
+    description: Oxidative injury amplifies wall fragility and susceptibility to dissection in advanced disease.
 phenotypes:
 - category: Cardiovascular
   name: Aortic Aneurysm
-  description: Progressive dilation of the aortic root beginning in childhood,
-    with risk of life-threatening aortic dissection.
-  frequency: FREQUENT
+  description: Progressive dilation of the aortic root beginning in childhood, with risk of life-threatening aortic dissection.
+  frequency: VERY_FREQUENT
   diagnostic: true
   sequelae:
   - target: Aortic Dissection
-    description: Progressive dilation weakens the aortic wall, predisposing to
-      acute dissection.
+    description: Progressive dilation weakens the aortic wall, predisposing to acute dissection.
     evidence:
     - reference: PMID:16321689
       reference_title: "Determinants of rapid progression of aortic root dilatation and complications in Marfan syndrome."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: Aortic dissection occurred more frequently in group R (7
-        patients, 47%) than in group S (0%, P < 0.001).
-      explanation: This study demonstrates that rapid aortic root dilation
-        significantly increases dissection risk, with 47% dissection rate in
-        rapidly progressing patients.
+      snippet: Aortic dissection occurred more frequently in group R (7 patients, 47%) than in group S (0%, P < 0.001).
+      explanation: This study demonstrates that rapid aortic root dilation significantly increases dissection risk, with 47% dissection rate in rapidly progressing patients.
   evidence:
   - reference: PMID:21797750
     reference_title: "Cardiovascular surgery in Marfan syndrome: implications of new molecular concepts in thoracic aortic disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: MFS is one of the most common inherited connective tissue disorders
-      affecting 1 in 5000 individuals. Although the phenotype of MFS can be
-      quite variable, aneurysmal dilation of the aortic root and consecutive
-      acute aortic dissection is the leading cause of death in this patient
-      population.
-    explanation: This reference confirms that aortic aneurysm and aortic
-      dissection are frequent cardiovascular manifestations in Marfan Syndrome.
+    snippet: MFS is one of the most common inherited connective tissue disorders affecting 1 in 5000 individuals. Although the phenotype of MFS can be quite variable, aneurysmal dilation of the aortic root and consecutive acute aortic dissection is the leading cause of death in this patient population.
+    explanation: This reference confirms that aortic aneurysm and aortic dissection are frequent cardiovascular manifestations in Marfan Syndrome.
   - reference: PMID:36058493
     reference_title: "Early Onset Marfan Syndrome with multivalvular insufficiency: Report from a tertiary hospital in Tanzania, and a review of the recurrent c.7606G>A p.0 variant in FBN1."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Early Onset Marfan Syndrome is at the severe end of the Marfan
-      syndrome spectrum and is frequently associated with variants in exons
-      24-32 of the FBN1 gene.
-    explanation: The literature discusses the severe cardiovascular
-      manifestations of Marfan Syndrome, supporting the frequent occurrence of
-      aortic aneurysm and dissection.
+    snippet: Early Onset Marfan Syndrome is at the severe end of the Marfan syndrome spectrum and is frequently associated with variants in exons 24-32 of the FBN1 gene.
+    explanation: The literature discusses the severe cardiovascular manifestations of Marfan Syndrome, supporting the frequent occurrence of aortic aneurysm and dissection.
   - reference: PMID:20364556
     reference_title: "Clinical presentation and echocardiographic findings of Thai patients with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The majority of those individuals had significant organ involvement
-      including dilatation of ascending aorta (78%).
-    explanation: This study indicates a high frequency of aortic dilation, a
-      precursor to aortic aneurysm, among Marfan Syndrome patients.
+    snippet: The majority of those individuals had significant organ involvement including dilatation of ascending aorta (78%).
+    explanation: This study indicates a high frequency of aortic dilation, a precursor to aortic aneurysm, among Marfan Syndrome patients.
   - reference: PMID:32290873
     reference_title: "Clinical significance of family history and bicuspid aortic valve in children and young adult patients with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome is an autosomal dominant disorder of the connective
-      tissue, whose cardinal features affect eyes, musculoskeletal, and
-      cardiovascular system.
-    explanation: The study highlights the cardiovascular system as a primary
-      area affected in Marfan Syndrome, supporting the frequent occurrence of
-      aortic aneurysms and dissection.
+    snippet: Marfan syndrome is an autosomal dominant disorder of the connective tissue, whose cardinal features affect eyes, musculoskeletal, and cardiovascular system.
+    explanation: The study highlights the cardiovascular system as a primary area affected in Marfan Syndrome, supporting the frequent occurrence of aortic aneurysms and dissection.
   - reference: PMID:7911041
     reference_title: "Cardiovascular molecular genetics."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The relation between Marfan syndrome and fibrillin mutations and
-      that between supravalvular aortic stenosis and William syndromes and
-      elastin mutations are reviewed.
-    explanation: This reference discusses the genetic basis of cardiovascular
-      issues in Marfan Syndrome, supporting the frequent occurrence of aortic
-      aneurysm and dissection.
+    snippet: The relation between Marfan syndrome and fibrillin mutations and that between supravalvular aortic stenosis and William syndromes and elastin mutations are reviewed.
+    explanation: This reference discusses the genetic basis of cardiovascular issues in Marfan Syndrome, supporting the frequent occurrence of aortic aneurysm and dissection.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0004942 | Aortic aneurysm | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies aortic aneurysm as Very frequent (99-80%) in Marfan syndrome.
   phenotype_term:
     preferred_term: Aortic Aneurysm
-    description: Abnormal dilation of the aorta due to weakening of the vessel
-      wall.
+    description: Abnormal dilation of the aorta due to weakening of the vessel wall.
     term:
       id: HP:0004942
       label: Aortic aneurysm
 - category: Musculoskeletal
   name: Tall Stature
-  description: Disproportionately tall stature with long limbs and increased arm
-    span-to-height ratio.
+  description: Disproportionately tall stature with long limbs and increased arm span-to-height ratio.
   frequency: VERY_FREQUENT
   diagnostic: true
   evidence:
@@ -431,42 +444,35 @@ phenotypes:
     reference_title: "Skeletal evolution in Marfan syndrome: growth curves from a French national cohort."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Boys and girls from the MFS group were significantly taller than
-      those in the non-MFS group and in the reference group at all ages
-      (P<0.0001).
-    explanation: The study found that children with Marfan syndrome were
-      significantly taller than their non-MFS counterparts at all ages,
-      supporting the statement that tall stature is a very frequent
-      musculoskeletal diagnostic feature of Marfan syndrome.
+    snippet: Boys and girls from the MFS group were significantly taller than those in the non-MFS group and in the reference group at all ages (P<0.0001).
+    explanation: The study found that children with Marfan syndrome were significantly taller than their non-MFS counterparts at all ages, supporting the statement that tall stature is a very frequent musculoskeletal diagnostic feature of Marfan syndrome.
   - reference: PMID:36058493
     reference_title: "Early Onset Marfan Syndrome with multivalvular insufficiency: Report from a tertiary hospital in Tanzania, and a review of the recurrent c.7606G>A p.0 variant in FBN1."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Early Onset Marfan Syndrome is at the severe end of the Marfan
-      syndrome spectrum and is frequently associated with variants in exons
-      24-32 of the FBN1 gene... presented with tall stature.
-    explanation: The report mentions that tall stature is frequently associated
-      with Early Onset Marfan Syndrome, supporting the statement.
+    snippet: Early Onset Marfan Syndrome is at the severe end of the Marfan syndrome spectrum and is frequently associated with variants in exons 24-32 of the FBN1 gene... presented with tall stature.
+    explanation: The report mentions that tall stature is frequently associated with Early Onset Marfan Syndrome, supporting the statement.
   - reference: PMID:31751304
     reference_title: "Genetic investigation of patients with tall stature."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: We selected 42 patients with tall stature after exclusion of
-      pathologies in GH/IGF1 axis and divided them into syndromic (n = 30) and
-      non-syndromic (n = 12) subgroups... FBN1 = 3...
-    explanation: The genetic investigation identified FBN1 mutations, which are
-      associated with Marfan syndrome, in patients with tall stature, supporting
-      the statement.
+    snippet: We selected 42 patients with tall stature after exclusion of pathologies in GH/IGF1 axis and divided them into syndromic (n = 30) and non-syndromic (n = 12) subgroups... FBN1 = 3...
+    explanation: The genetic investigation identified FBN1 mutations, which are associated with Marfan syndrome, in patients with tall stature, supporting the statement.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001519 | Disproportionate tall stature | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies disproportionate tall stature as Very frequent (99-80%) in Marfan syndrome.
   phenotype_term:
-    preferred_term: Tall Stature
-    description: Height significantly above the population mean for age and sex.
+    preferred_term: Disproportionate tall stature
+    description: Height significantly above the population mean with disproportionate limb and body proportions.
     term:
-      id: HP:0000098
-      label: Tall stature
+      id: HP:0001519
+      label: Disproportionate tall stature
 - category: Musculoskeletal
   name: Arachnodactyly
-  description: Abnormally long, slender fingers and toes (spider-like digits),
-    often demonstrated by positive wrist and thumb signs.
+  description: Abnormally long, slender fingers and toes (spider-like digits), often demonstrated by positive wrist and thumb signs.
   frequency: VERY_FREQUENT
   diagnostic: true
   evidence:
@@ -474,38 +480,29 @@ phenotypes:
     reference_title: "Arachnodactyly represented in art."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Arachnodactyly, a term used since 1902 to describe abnormally long
-      (spider-like) fingers, is a pathologic feature of several heritable
-      conditions, notably the Marfan syndrome...
-    explanation: The literature states that arachnodactyly is a notable feature
-      of Marfan syndrome.
+    snippet: Arachnodactyly, a term used since 1902 to describe abnormally long (spider-like) fingers, is a pathologic feature of several heritable conditions, notably the Marfan syndrome...
+    explanation: The literature states that arachnodactyly is a notable feature of Marfan syndrome.
   - reference: PMID:23478494
     reference_title: "Arachnodactyly--a key to diagnosing heritable disorders of connective tissue."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Arachnodactyly literally means spidery fingers, and describes the
-      long, slender fingers typical of patients with Marfan syndrome (MFS).
-    explanation: This reference confirms that arachnodactyly is a typical
-      feature of Marfan syndrome.
+    snippet: Arachnodactyly literally means spidery fingers, and describes the long, slender fingers typical of patients with Marfan syndrome (MFS).
+    explanation: This reference confirms that arachnodactyly is a typical feature of Marfan syndrome.
   - reference: ORPHA:558
     reference_title: "Marfan syndrome (Orphanet structured-database record)"
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "HP:0001166 | Arachnodactyly | Very frequent (99-80%)"
-    explanation: Orphanet's curated HPO frequency annotation classifies
-      arachnodactyly as Very frequent (99-80%) in Marfan syndrome,
-      independently supporting the VERY_FREQUENT frequency assertion.
+    explanation: Orphanet's curated HPO frequency annotation classifies arachnodactyly as Very frequent (99-80%) in Marfan syndrome, independently supporting the VERY_FREQUENT frequency assertion.
   phenotype_term:
     preferred_term: Arachnodactyly
-    description: Abnormally long and slender fingers and toes resembling spider
-      legs.
+    description: Abnormally long and slender fingers and toes resembling spider legs.
     term:
       id: HP:0001166
       label: Arachnodactyly
 - category: Ocular
   name: Ectopia Lentis
-  description: Superior and temporal displacement of the lens due to weakened
-    zonular fibers, affecting visual acuity.
+  description: Superior and temporal displacement of the lens due to weakened zonular fibers, affecting visual acuity.
   frequency: FREQUENT
   diagnostic: true
   notes: Dislocation of the lens
@@ -520,75 +517,59 @@ phenotypes:
     reference_title: "Ocular findings in 87 adults with Ghent-1 verified Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: In this strictly defined MFS group fulfilling the Ghent-1 criteria,
-      the prevalence of EL was 62.1%.
-    explanation: The study reports a high prevalence (62.1%) of ectopia lentis
-      in individuals with Marfan Syndrome, supporting the statement that it is a
-      frequent ocular diagnostic feature.
+    snippet: In this strictly defined MFS group fulfilling the Ghent-1 criteria, the prevalence of EL was 62.1%.
+    explanation: The study reports a high prevalence (62.1%) of ectopia lentis in individuals with Marfan Syndrome, supporting the statement that it is a frequent ocular diagnostic feature.
   - reference: PMID:18090894
     reference_title: "Pathophysiology of zonular diseases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The mechanisms implicated in the clinical manifestations of zonular
-      diseases, especially ectopia lentis, are reviewed.
-    explanation: The abstract mentions ectopia lentis as a clinical
-      manifestation of zonular diseases, which includes Marfan Syndrome.
+    snippet: The mechanisms implicated in the clinical manifestations of zonular diseases, especially ectopia lentis, are reviewed.
+    explanation: The abstract mentions ectopia lentis as a clinical manifestation of zonular diseases, which includes Marfan Syndrome.
   - reference: PMID:17134646
     reference_title: "Current concepts of ocular manifestations in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome is a widespread disorder of connective tissue. It
-      is characterized by systemic and ocular features due to mutations in the
-      fibrillin gene.
-    explanation: This reference supports the ocular diagnostic aspect of Marfan
-      Syndrome.
+    snippet: Marfan syndrome is a widespread disorder of connective tissue. It is characterized by systemic and ocular features due to mutations in the fibrillin gene.
+    explanation: This reference supports the ocular diagnostic aspect of Marfan Syndrome.
   - reference: PMID:11705149
     reference_title: "Management of ectopia lentis in children."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome, homocystinuria, trauma, and simple ectopia lentis
-      are the most common causes of pediatric lens subluxation.
-    explanation: This reference supports the association of Marfan Syndrome with
-      ectopia lentis.
+    snippet: Marfan syndrome, homocystinuria, trauma, and simple ectopia lentis are the most common causes of pediatric lens subluxation.
+    explanation: This reference supports the association of Marfan Syndrome with ectopia lentis.
   - reference: PMID:6984233
     reference_title: "Ectopia lentis."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Ectopia lentis may cause a marked reduction in visual acuity, which
-      varies with the type and degree of dislocation and the presence of other
-      ocular abnormalities.
-    explanation: This reference provides information on the clinical
-      significance of ectopia lentis.
+    snippet: Ectopia lentis may cause a marked reduction in visual acuity, which varies with the type and degree of dislocation and the presence of other ocular abnormalities.
+    explanation: This reference provides information on the clinical significance of ectopia lentis.
   - reference: PMID:36670079
     reference_title: "Clinical and genetic findings in Chinese families with congenital ectopia lentis."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Congenital ectopia lentis (EL) refers to the congenital dysplasia
-      or weakness of the lens suspensory ligament, resulting in an abnormal
-      position of the crystalline lens, which can appear as isolated EL or as an
-      ocular manifestation of a syndrome, such as the Marfan syndrome.
-    explanation: This reference supports the statement by linking ectopia lentis
-      as an ocular manifestation of Marfan Syndrome.
+    snippet: Congenital ectopia lentis (EL) refers to the congenital dysplasia or weakness of the lens suspensory ligament, resulting in an abnormal position of the crystalline lens, which can appear as isolated EL or as an ocular manifestation of a syndrome, such as the Marfan syndrome.
+    explanation: This reference supports the statement by linking ectopia lentis as an ocular manifestation of Marfan Syndrome.
   - reference: PMID:38088571
     reference_title: "Uncovering the Hidden World of Aqueous Humor Proteins for Discovery of Biomarkers for Marfan Syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Ectopia lentis is a hallmark of Marfan syndrome (MFS), a genetic
-      connective tissue disorder affecting 1/5000 to 1/10 000 individuals
-      worldwide.
-    explanation: This reference supports the statement by identifying ectopia
-      lentis as a hallmark of Marfan Syndrome.
+    snippet: Ectopia lentis is a hallmark of Marfan syndrome (MFS), a genetic connective tissue disorder affecting 1/5000 to 1/10 000 individuals worldwide.
+    explanation: This reference supports the statement by identifying ectopia lentis as a hallmark of Marfan Syndrome.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001083 | Ectopia lentis | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies ectopia lentis as Frequent (79-30%) in Marfan syndrome.
   phenotype_term:
     preferred_term: Ectopia Lentis
-    description: Displacement or malposition of the crystalline lens from its
-      normal location.
+    description: Displacement or malposition of the crystalline lens from its normal location.
     term:
       id: HP:0001083
       label: Ectopia lentis
 - category: Musculoskeletal
   name: Scoliosis
-  description: Lateral curvature of the spine occurring in approximately 63% of
-    Marfan syndrome patients, often progressive.
+  description: Lateral curvature of the spine occurring in approximately 63% of Marfan syndrome patients, often progressive.
   frequency: FREQUENT
   diagnostic: true
   evidence:
@@ -596,38 +577,32 @@ phenotypes:
     reference_title: "Infantile scoliosis in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The data on all patients seen at one institution who had Marfan
-      syndrome and scoliosis by age three were reviewed.
-    explanation: The study documents cases of scoliosis in patients with Marfan
-      syndrome, supporting the statement that scoliosis is a frequent
-      musculoskeletal diagnostic in Marfan syndrome.
+    snippet: The data on all patients seen at one institution who had Marfan syndrome and scoliosis by age three were reviewed.
+    explanation: The study documents cases of scoliosis in patients with Marfan syndrome, supporting the statement that scoliosis is a frequent musculoskeletal diagnostic in Marfan syndrome.
   - reference: PMID:37270806
     reference_title: "Analysis of GPR126 polymorphisms and their relationship with scoliosis in Marfan syndrome and Marfan-like syndrome in Mexican patients."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: A large cross-sectional study revealed a 63% prevalence of
-      scoliosis among patients with MFS.
-    explanation: This study provides statistical evidence of a high prevalence
-      of scoliosis in Marfan syndrome patients, reinforcing that scoliosis is
-      frequent in this condition.
+    snippet: A large cross-sectional study revealed a 63% prevalence of scoliosis among patients with MFS.
+    explanation: This study provides statistical evidence of a high prevalence of scoliosis in Marfan syndrome patients, reinforcing that scoliosis is frequent in this condition.
   - reference: PMID:34916231
     reference_title: "Impact of pathogenic FBN1 variant types on the development of severe scoliosis in patients with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Among the several musculoskeletal manifestations in patients with
-      Marfan syndrome, spinal deformity causes pain and respiratory impairment
-      and is a great hindrance to patients' daily activities.
-    explanation: This study highlights scoliosis as one of the significant
-      musculoskeletal manifestations in Marfan syndrome, supporting its frequent
-      occurrence.
+    snippet: Among the several musculoskeletal manifestations in patients with Marfan syndrome, spinal deformity causes pain and respiratory impairment and is a great hindrance to patients' daily activities.
+    explanation: This study highlights scoliosis as one of the significant musculoskeletal manifestations in Marfan syndrome, supporting its frequent occurrence.
   - reference: PMID:35248143
     reference_title: "Musculoskeletal diseases in Marfan syndrome: a nationwide registry study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: 'One out of six with Marfan syndrome was registered with scoliosis (HR:
-      36.7 (27.5-48.9).'
-    explanation: The nationwide epidemiological study confirms that scoliosis is
-      a common musculoskeletal diagnosis in Marfan syndrome patients.
+    snippet: 'One out of six with Marfan syndrome was registered with scoliosis (HR: 36.7 (27.5-48.9).'
+    explanation: The nationwide epidemiological study confirms that scoliosis is a common musculoskeletal diagnosis in Marfan syndrome patients.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002650 | Scoliosis | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies scoliosis as Frequent (79-30%) in Marfan syndrome.
   phenotype_term:
     preferred_term: Scoliosis
     description: Lateral curvature of the vertebral column.
@@ -636,110 +611,188 @@ phenotypes:
       label: Scoliosis
 - category: Respiratory
   name: Pneumothorax
-  description: Spontaneous lung collapse occurring in 5-11% of patients due to
-    apical blebs from connective tissue abnormalities.
+  description: Spontaneous lung collapse occurring in 5-11% of patients due to apical blebs from connective tissue abnormalities.
   frequency: OCCASIONAL
   evidence:
   - reference: PMID:31883816
     reference_title: "[Recurrent spontaneous pneumothorax revealing Marfan's syndrome]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Though cardiovascular, skeletal and ophthalmological manifestations
-      are the most frequent features, the respiratory system can also be
-      involved.
-    explanation: The reference mentions that Marfan syndrome can involve the
-      respiratory system, including pneumothorax.
+    snippet: Though cardiovascular, skeletal and ophthalmological manifestations are the most frequent features, the respiratory system can also be involved.
+    explanation: The reference mentions that Marfan syndrome can involve the respiratory system, including pneumothorax.
   - reference: PMID:25765122
     reference_title: "[Respiratory manifestations of Marfan's syndrome]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan's syndrome is a rare genetic disorder...but minor diagnostic
-      criteria also include pulmonary manifestations. Pneumothorax, frequently
-      relapsing, affects 5 to 11% of patients.
-    explanation: The reference states that pneumothorax affects 5 to 11% of
-      patients with Marfan syndrome, supporting the statement that it occurs
-      occasionally.
+    snippet: Marfan's syndrome is a rare genetic disorder...but minor diagnostic criteria also include pulmonary manifestations. Pneumothorax, frequently relapsing, affects 5 to 11% of patients.
+    explanation: The reference states that pneumothorax affects 5 to 11% of patients with Marfan syndrome, supporting the statement that it occurs occasionally.
   - reference: PMID:33896616
     reference_title: "Optimal treatment of pneumothorax in adolescents with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: Pneumothorax often develops in patients with Marfan syndrome.
-    explanation: The reference confirms that pneumothorax is a common occurrence
-      in patients with Marfan syndrome.
+    explanation: The reference confirms that pneumothorax is a common occurrence in patients with Marfan syndrome.
   - reference: PMID:21252480
     reference_title: "Pneumothorax and bullae in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Increased risk of spontaneous pneumothorax has been described in
-      patients with Marfan syndrome.
-    explanation: The reference supports the statement by indicating an increased
-      risk of pneumothorax in Marfan syndrome patients.
+    snippet: Increased risk of spontaneous pneumothorax has been described in patients with Marfan syndrome.
+    explanation: The reference supports the statement by indicating an increased risk of pneumothorax in Marfan syndrome patients.
   phenotype_term:
     preferred_term: Pneumothorax
-    description: Presence of air or gas in the pleural cavity causing lung
-      collapse.
+    description: Presence of air or gas in the pleural cavity causing lung collapse.
     term:
       id: HP:0002107
       label: Pneumothorax
 - category: Cardiovascular
   name: Aortic Dissection
-  description: Life-threatening tear in the aortic wall allowing blood to enter
-    between tissue layers, the leading cause of death in untreated Marfan
-    syndrome.
+  description: Life-threatening tear in the aortic wall allowing blood to enter between tissue layers, the leading cause of death in untreated Marfan syndrome.
   frequency: FREQUENT
   evidence:
   - reference: PMID:21797750
     reference_title: "Cardiovascular surgery in Marfan syndrome: implications of new molecular concepts in thoracic aortic disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: MFS is one of the most common inherited connective tissue disorders
-      affecting 1 in 5000 individuals. Although the phenotype of MFS can be
-      quite variable, aneurysmal dilation of the aortic root and consecutive
-      acute aortic dissection is the leading cause of death in this patient
-      population.
-    explanation: This reference directly states that aortic dissection is the
-      leading cause of death in Marfan syndrome patients.
+    snippet: MFS is one of the most common inherited connective tissue disorders affecting 1 in 5000 individuals. Although the phenotype of MFS can be quite variable, aneurysmal dilation of the aortic root and consecutive acute aortic dissection is the leading cause of death in this patient population.
+    explanation: This reference directly states that aortic dissection is the leading cause of death in Marfan syndrome patients.
   - reference: PMID:16321689
     reference_title: "Determinants of rapid progression of aortic root dilatation and complications in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Aortic dissection occurred more frequently in group R (7 patients,
-      47%) than in group S (0%, P < 0.001).
-    explanation: This study demonstrates that aortic dissection is a frequent
-      complication in patients with rapid aortic root dilation.
+    snippet: Aortic dissection occurred more frequently in group R (7 patients, 47%) than in group S (0%, P < 0.001).
+    explanation: This study demonstrates that aortic dissection is a frequent complication in patients with rapid aortic root dilation.
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002647 | Aortic dissection | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies aortic dissection as Frequent (79-30%) in Marfan syndrome.
   phenotype_term:
     preferred_term: Aortic Dissection
-    description: Tear in the inner layer of the aortic wall allowing blood to
-      flow between layers.
+    description: Tear in the inner layer of the aortic wall allowing blood to flow between layers.
     term:
       id: HP:0002647
       label: Aortic dissection
 - category: Cardiovascular
   name: Mitral Valve Prolapse
-  description: Myxomatous degeneration of mitral valve leaflets causing prolapse
-    into the left atrium during systole, often accompanied by mitral
-    regurgitation.
+  description: Myxomatous degeneration of mitral valve leaflets causing prolapse into the left atrium during systole, often accompanied by mitral regurgitation.
   frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001634 | Mitral valve prolapse | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies mitral valve prolapse as Frequent (79-30%) in Marfan syndrome.
   phenotype_term:
     preferred_term: Mitral valve prolapse
-    description: Abnormal systolic displacement of mitral valve leaflets into
-      the left atrium.
+    description: Abnormal systolic displacement of mitral valve leaflets into the left atrium.
     term:
       id: HP:0001634
       label: Mitral valve prolapse
 - category: Cardiovascular
   name: Aortic Root Aneurysm
-  description: Progressive enlargement of the aortic root diameter, typically
-    measured by echocardiography and tracked using Z-scores adjusted for age and
-    body surface area.
+  description: Progressive enlargement of the aortic root diameter, typically measured by echocardiography and tracked using Z-scores adjusted for age and body surface area.
   frequency: VERY_FREQUENT
   diagnostic: true
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002616 | Aortic root aneurysm | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies aortic root aneurysm as Very frequent (99-80%) in Marfan syndrome.
   phenotype_term:
     preferred_term: Aortic root aneurysm
     description: Abnormal widening of the aortic root.
     term:
       id: HP:0002616
       label: Aortic root aneurysm
+- category: Musculoskeletal
+  name: Pectus Carinatum
+  description: Protrusion of the sternum and anterior chest wall, a common skeletal manifestation in Marfan syndrome.
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000768 | Pectus carinatum | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies pectus carinatum as Very frequent (99-80%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Pectus carinatum
+    description: Protrusion of the sternum and ribs.
+    term:
+      id: HP:0000768
+      label: Pectus carinatum
+- category: Dermatologic
+  name: Striae Distensae
+  description: Stretch marks caused by connective-tissue fragility, often occurring without major weight change.
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001065 | Striae distensae | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies striae distensae as Very frequent (99-80%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Striae distensae
+    description: Linear dermal atrophic streaks caused by skin stretching.
+    term:
+      id: HP:0001065
+      label: Striae distensae
+- category: Musculoskeletal
+  name: Pes Planus
+  description: Flattening of the medial longitudinal arch of the foot.
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001763 | Pes planus | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies pes planus as Very frequent (99-80%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Pes planus
+    description: Flat foot with reduced or absent medial arch.
+    term:
+      id: HP:0001763
+      label: Pes planus
+- category: Constitutional
+  name: Slender Build
+  description: Thin body habitus with reduced soft-tissue bulk relative to height.
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001533 | Slender build | Very frequent (99-80%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies slender build as Very frequent (99-80%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Slender build
+    description: Thin body habitus.
+    term:
+      id: HP:0001533
+      label: Slender build
+- category: Neurological
+  name: Dural Ectasia
+  description: Widening or ballooning of the dural sac, typically in the lumbosacral spine, reflecting connective-tissue weakness.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:558
+    reference_title: "Marfan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0100775 | Dural ectasia | Frequent (79-30%)"
+    explanation: Orphanet's curated HPO frequency annotation classifies dural ectasia as Frequent (79-30%) in Marfan syndrome.
+  phenotype_term:
+    preferred_term: Dural ectasia
+    description: Abnormal widening of the dural sac.
+    term:
+      id: HP:0100775
+      label: Dural ectasia
 biochemical:
 - name: Fibrillin-1 Protein
   presence: Abnormal
@@ -749,222 +802,161 @@ biochemical:
     reference_title: "Identification of defects in the fibrillin gene and protein in individuals with the Marfan syndrome and related disorders."
     supports: REFUTE
     evidence_source: HUMAN_CLINICAL
-    snippet: Analysis of fibrillin protein or gene defects in individuals with
-      related phenotypes has revealed that a perinatal lethal syndrome, termed
-      neonatal Marfan syndrome, is due to FBN1 gene mutations.
-    explanation: The literature indicates that fibrillin-1 protein abnormalities
-      are directly linked to Marfan syndrome, which is relevant for both
-      research and diagnostic purposes.
+    snippet: Analysis of fibrillin protein or gene defects in individuals with related phenotypes has revealed that a perinatal lethal syndrome, termed neonatal Marfan syndrome, is due to FBN1 gene mutations.
+    explanation: The literature indicates that fibrillin-1 protein abnormalities are directly linked to Marfan syndrome, which is relevant for both research and diagnostic purposes.
   - reference: PMID:9586151
     reference_title: "[Marfan syndrome: diagnosis of cardiovascular manifestations]."
     supports: REFUTE
     evidence_source: HUMAN_CLINICAL
-    snippet: New diagnostic insights have eventually led to revised nosologic
-      criteria for the diagnosis of Marfan syndrome.
-    explanation: The literature discusses the importance of fibrillin-1 in the
-      diagnosis of Marfan syndrome, indicating its relevance in routine
-      diagnostics.
+    snippet: New diagnostic insights have eventually led to revised nosologic criteria for the diagnosis of Marfan syndrome.
+    explanation: The literature discusses the importance of fibrillin-1 in the diagnosis of Marfan syndrome, indicating its relevance in routine diagnostics.
   - reference: PMID:22705998
     reference_title: "Marfan syndrome: from gene to therapy."
     supports: REFUTE
     evidence_source: MODEL_ORGANISM
-    snippet: Although historically Marfan syndrome (MFS) has always been
-      considered as a condition caused by the deficiency of a structural
-      extracellular matrix protein, fibrillin-1, the study of Marfan mouse
-      models and Marfan-related conditions has shifted our current understanding
-      to a pathogenic model that involves dysregulation of the
-      cytokine-transforming growth factor beta (TGF-beta) signaling.
-    explanation: The literature highlights the role of fibrillin-1 in the
-      pathogenesis of Marfan syndrome, which is essential for both research and
-      diagnostic purposes.
+    snippet: Although historically Marfan syndrome (MFS) has always been considered as a condition caused by the deficiency of a structural extracellular matrix protein, fibrillin-1, the study of Marfan mouse models and Marfan-related conditions has shifted our current understanding to a pathogenic model that involves dysregulation of the cytokine-transforming growth factor beta (TGF-beta) signaling.
+    explanation: The literature highlights the role of fibrillin-1 in the pathogenesis of Marfan syndrome, which is essential for both research and diagnostic purposes.
   - reference: PMID:37688493
     reference_title: "The usefulness of the genetic panel in the classification and refinement of diagnostic accuracy of Mexican patients with Marfan syndrome and other connective tissue disorders."
     supports: REFUTE
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome (MFS) is a multisystem genetic disorder with over
-      3000 mutations described in the fibrillin 1 (FBN1) gene.
-    explanation: The literature underscores the diagnostic importance of
-      identifying fibrillin-1 mutations in Marfan syndrome.
+    snippet: Marfan syndrome (MFS) is a multisystem genetic disorder with over 3000 mutations described in the fibrillin 1 (FBN1) gene.
+    explanation: The literature underscores the diagnostic importance of identifying fibrillin-1 mutations in Marfan syndrome.
 genetic:
 - name: FBN1
   association: Pathogenic Variants
-  notes: Primary causative gene encoding fibrillin-1, a structural ECM
-    glycoprotein.
+  notes: Primary causative gene encoding fibrillin-1, a structural ECM glycoprotein.
   evidence:
   - reference: PMID:31163209
     reference_title: "FBN1 gene mutations in 26 Hungarian patients with suspected Marfan syndrome or related fibrillinopathies."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: FBN1 gene mutations lead to MFS and related connective tissue
-      disorders.
-    explanation: The abstract directly states that FBN1 gene mutations are
-      associated with Marfan syndrome and related disorders.
+    snippet: FBN1 gene mutations lead to MFS and related connective tissue disorders.
+    explanation: The abstract directly states that FBN1 gene mutations are associated with Marfan syndrome and related disorders.
   - reference: PMID:34916231
     reference_title: "Impact of pathogenic FBN1 variant types on the development of severe scoliosis in patients with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: We retrospectively evaluated 278 patients with pathogenic or likely
-      pathogenic FBN1 variants.
-    explanation: The study focuses on patients with Marfan syndrome who have
-      pathogenic FBN1 variants, supporting the association.
+    snippet: We retrospectively evaluated 278 patients with pathogenic or likely pathogenic FBN1 variants.
+    explanation: The study focuses on patients with Marfan syndrome who have pathogenic FBN1 variants, supporting the association.
   - reference: PMID:32130918
     reference_title: "Pathogenic FBN1 Genetic Variation and Aortic Dissection in Patients With Marfan Syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Aortic risk has not been evaluated in patients with Marfan syndrome
-      and documented pathogenic variants in the FBN1 gene.
-    explanation: The study describes aortic risks in patients with Marfan
-      syndrome with pathogenic FBN1 variants, supporting the association.
+    snippet: Aortic risk has not been evaluated in patients with Marfan syndrome and documented pathogenic variants in the FBN1 gene.
+    explanation: The study describes aortic risks in patients with Marfan syndrome with pathogenic FBN1 variants, supporting the association.
   - reference: PMID:35419902
     reference_title: "The fibrillinopathies: New insights with focus on the paradigm of opposing phenotypes for both FBN1 and FBN2."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Different pathogenic variants in the fibrillin-1 gene (FBN1) cause
-      Marfan syndrome and acromelic dysplasias.
-    explanation: The abstract states that pathogenic variants in FBN1 cause
-      Marfan syndrome, supporting the association.
+    snippet: Different pathogenic variants in the fibrillin-1 gene (FBN1) cause Marfan syndrome and acromelic dysplasias.
+    explanation: The abstract states that pathogenic variants in FBN1 cause Marfan syndrome, supporting the association.
   - reference: PMID:36004597
     reference_title: "[Ocular manifestations of Marfan syndrome]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome is an orphan disease that is caused by a mutation
-      in the FBN1 gene located on chromosome 15 (15q21.1).
-    explanation: The article reviews studies concerning the potential ocular
-      manifestations of Marfan syndrome caused by FBN1 mutations.
+    snippet: Marfan syndrome is an orphan disease that is caused by a mutation in the FBN1 gene located on chromosome 15 (15q21.1).
+    explanation: The article reviews studies concerning the potential ocular manifestations of Marfan syndrome caused by FBN1 mutations.
   - reference: PMID:30485715
     reference_title: "Autosomal dominant Marfan syndrome caused by a previously reported recessive FBN1 variant."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Pathogenic variants in FBN1 cause autosomal dominant Marfan
-      syndrome.
-    explanation: The abstract states that pathogenic variants in FBN1 cause
-      autosomal dominant Marfan syndrome, supporting the association.
+    snippet: Pathogenic variants in FBN1 cause autosomal dominant Marfan syndrome.
+    explanation: The abstract states that pathogenic variants in FBN1 cause autosomal dominant Marfan syndrome, supporting the association.
   - reference: PMID:19059503
     reference_title: "Compound-heterozygous Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: We report two families in which the probands have
-      compound-heterozygous Marfan syndrome (MFS).
-    explanation: The study reports cases of Marfan syndrome associated with
-      compound-heterozygous FBN1 mutations, supporting the association.
+    snippet: We report two families in which the probands have compound-heterozygous Marfan syndrome (MFS).
+    explanation: The study reports cases of Marfan syndrome associated with compound-heterozygous FBN1 mutations, supporting the association.
 - name: TGFBR1
   association: Implicated
-  notes: Type I TGF-beta receptor; variants can cause overlapping Loeys-Dietz
-    syndrome phenotype.
+  notes: Type I TGF-beta receptor; variants can cause overlapping Loeys-Dietz syndrome phenotype.
 - name: TGFBR2
   association: Implicated
-  notes: Type II TGF-beta receptor; mutations alter TGF-beta signaling in aortic
-    disease.
+  notes: Type II TGF-beta receptor; mutations alter TGF-beta signaling in aortic disease.
 - name: SMAD2
   association: Implicated
-  notes: Canonical TGF-beta signaling mediator; nuclear translocation drives ECM
-    remodeling.
+  notes: Canonical TGF-beta signaling mediator; nuclear translocation drives ECM remodeling.
 - name: SMAD3
   association: Implicated
-  notes: TGF-beta effector involved in medial remodeling and inflammatory
-    responses.
+  notes: TGF-beta effector involved in medial remodeling and inflammatory responses.
 - name: ACTA2
   association: Implicated
-  notes: Alpha-smooth muscle actin; pathogenic variants cause familial thoracic
-    aortic aneurysm and dissection.
+  notes: Alpha-smooth muscle actin; pathogenic variants cause familial thoracic aortic aneurysm and dissection.
 - name: AGTR1
   association: Implicated
-  notes: Angiotensin II type 1 receptor; modulates hemodynamic stress and
-    pro-fibrotic signaling.
+  notes: Angiotensin II type 1 receptor; modulates hemodynamic stress and pro-fibrotic signaling.
 - name: ITGAV
   association: Implicated
-  notes: Integrin alpha-V subunit; mediates cell-ECM adhesion and
-    mechanotransduction.
+  notes: Integrin alpha-V subunit; mediates cell-ECM adhesion and mechanotransduction.
 - name: NOS2
   association: Implicated
   notes: Inducible nitric oxide synthase; upregulated in inflamed aortic tissue.
 - name: VCAN
   association: Implicated
-  notes: Versican proteoglycan; accumulation drives AKT/NOS2 pathways in aortic
-    disease.
+  notes: Versican proteoglycan; accumulation drives AKT/NOS2 pathways in aortic disease.
 diagnosis:
 - name: Genetic Testing for FBN1 Mutations
-  description: Sequencing of the FBN1 gene to identify pathogenic variants
-    causing Marfan syndrome.
+  description: Sequencing of the FBN1 gene to identify pathogenic variants causing Marfan syndrome.
   presence: Positive in affected individuals
   evidence:
   - reference: PMID:17657824
     reference_title: "The importance of mutation detection in Marfan syndrome and Marfan-related disorders: report of 193 FBN1 mutations."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Mutations in the FBN1 gene have been characterised in patients
-      affected by Marfan syndrome and Marfan-related disorders.
-    explanation: This study confirms that FBN1 mutations are present in
-      individuals affected by Marfan syndrome.
+    snippet: Mutations in the FBN1 gene have been characterised in patients affected by Marfan syndrome and Marfan-related disorders.
+    explanation: This study confirms that FBN1 mutations are present in individuals affected by Marfan syndrome.
   - reference: PMID:26903455
     reference_title: "Genetic testing in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Genetic testing is aiding rapid diagnosis of Marfan syndrome as a
-      basis for management of eye, heart and skeletal disease.
-    explanation: This article supports the presence of genetic testing for FBN1
-      mutations in individuals with Marfan syndrome.
+    snippet: Genetic testing is aiding rapid diagnosis of Marfan syndrome as a basis for management of eye, heart and skeletal disease.
+    explanation: This article supports the presence of genetic testing for FBN1 mutations in individuals with Marfan syndrome.
   - reference: PMID:27234404
     reference_title: "Genetic testing of the FBN1 gene in Chinese patients with Marfan/Marfan-like syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Here, we performed genetic testing of the FBN1 gene in 39 Chinese
-      probands with Marfan/Marfan-like syndrome and their related family members
-      by Sanger sequencing.
-    explanation: This research supports the presence of FBN1 mutations in
-      affected individuals through genetic testing.
+    snippet: Here, we performed genetic testing of the FBN1 gene in 39 Chinese probands with Marfan/Marfan-like syndrome and their related family members by Sanger sequencing.
+    explanation: This research supports the presence of FBN1 mutations in affected individuals through genetic testing.
   - reference: PMID:27906200
     reference_title: "Evaluating the quality of Marfan genotype-phenotype correlations in existing FBN1 databases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Genetic FBN1 testing is pivotal for confirming the clinical
-      diagnosis of Marfan syndrome.
-    explanation: The study highlights the importance of FBN1 genetic testing in
-      diagnosing Marfan syndrome.
+    snippet: Genetic FBN1 testing is pivotal for confirming the clinical diagnosis of Marfan syndrome.
+    explanation: The study highlights the importance of FBN1 genetic testing in diagnosing Marfan syndrome.
   - reference: PMID:30166242
     reference_title: "Correction of the Marfan Syndrome Pathogenic FBN1 Mutation by Base Editing in Human Cells and Heterozygous Embryos."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Taking advantage of this technology, we corrected a Marfan syndrome
-      pathogenic mutation, FBN1T7498C.
-    explanation: This study demonstrates the presence of a specific FBN1
-      mutation in individuals with Marfan syndrome.
+    snippet: Taking advantage of this technology, we corrected a Marfan syndrome pathogenic mutation, FBN1T7498C.
+    explanation: This study demonstrates the presence of a specific FBN1 mutation in individuals with Marfan syndrome.
   - reference: PMID:25652400
     reference_title: "The clinical presentation of Marfan syndrome is modulated by expression of wild-type FBN1 allele."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Marfan syndrome is an autosomal dominant disorder mainly caused by
-      mutations within FBN1 gene.
-    explanation: This article supports the presence of FBN1 mutations in
-      individuals with Marfan syndrome.
+    snippet: Marfan syndrome is an autosomal dominant disorder mainly caused by mutations within FBN1 gene.
+    explanation: This article supports the presence of FBN1 mutations in individuals with Marfan syndrome.
   - reference: PMID:19059503
     reference_title: "Compound-heterozygous Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: We report two families in which the probands have
-      compound-heterozygous Marfan syndrome (MFS).
-    explanation: This study supports the presence of FBN1 mutations in
-      individuals with Marfan syndrome.
+    snippet: We report two families in which the probands have compound-heterozygous Marfan syndrome (MFS).
+    explanation: This study supports the presence of FBN1 mutations in individuals with Marfan syndrome.
   - reference: PMID:20709720
     reference_title: "Cardiovascular manifestations in men and women carrying a FBN1 mutation."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: In patients with Marfan syndrome and other type-1
-      fibrillinopathies, genetic testing is becoming more easily available,
-      leading to the identification of mutations early in the course of the
-      disease.
-    explanation: The article supports the identification of FBN1 mutations in
-      individuals with Marfan syndrome through genetic testing.
+    snippet: In patients with Marfan syndrome and other type-1 fibrillinopathies, genetic testing is becoming more easily available, leading to the identification of mutations early in the course of the disease.
+    explanation: The article supports the identification of FBN1 mutations in individuals with Marfan syndrome through genetic testing.
   - reference: PMID:25652356
     reference_title: "Decreased frequency of FBN1 missense variants in Ghent criteria-positive Marfan syndrome and characterization of novel FBN1 variants."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: Testing yielded 207 pathogenic or likely pathogenic FBN1 variants.
-    explanation: This study supports the presence of FBN1 mutations in
-      individuals who meet the Ghent criteria for Marfan syndrome.
+    explanation: This study supports the presence of FBN1 mutations in individuals who meet the Ghent criteria for Marfan syndrome.
 - name: Echocardiogram
-  description: Ultrasound imaging to measure aortic root diameter and assess
-    cardiac valve function.
+  description: Ultrasound imaging to measure aortic root diameter and assess cardiac valve function.
   presence: Aortic root dilation
   notes: Often used to monitor cardiovascular complications.
   evidence:
@@ -972,44 +964,28 @@ diagnosis:
     reference_title: "[Marfan syndrome: diagnosis of cardiovascular manifestations]."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The diagnostic reliability as well as the advantage and limitation
-      of these recent diagnostic strategies are discussed; moreover diagnostic
-      concepts for patients with neonatal as well as classic Marfan syndrome are
-      presented and discussed in the context of the clinical management...
-    explanation: The reference discusses the use of echocardiography, among
-      other diagnostic tools, in the evaluation and management of cardiovascular
-      manifestations in Marfan syndrome patients.
+    snippet: The diagnostic reliability as well as the advantage and limitation of these recent diagnostic strategies are discussed; moreover diagnostic concepts for patients with neonatal as well as classic Marfan syndrome are presented and discussed in the context of the clinical management...
+    explanation: The reference discusses the use of echocardiography, among other diagnostic tools, in the evaluation and management of cardiovascular manifestations in Marfan syndrome patients.
   - reference: PMID:33843540
     reference_title: "Comparability of different Z-score equations for aortic root dimensions in children with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Aortic root dilation is a major complication of Marfan syndrome and
-      is one of the most important criteria in establishing the diagnosis.
-    explanation: The reference highlights that aortic root dilation is a
-      significant complication of Marfan syndrome and is a key criterion for
-      diagnosis, which is typically monitored using echocardiography.
+    snippet: Aortic root dilation is a major complication of Marfan syndrome and is one of the most important criteria in establishing the diagnosis.
+    explanation: The reference highlights that aortic root dilation is a significant complication of Marfan syndrome and is a key criterion for diagnosis, which is typically monitored using echocardiography.
   - reference: PMID:35550817
     reference_title: "Prevalence and Outcomes of Primary Left Ventricular Dysfunction in Marfan Syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Even in the absence of significant valvular disease, patients with
-      Marfan syndrome (MFS) have evidence of impaired left ventricular (LV)
-      performance, suggestive of a primary cardiomyopathy.
-    explanation: The reference indicates that echocardiography is used to
-      monitor left ventricular performance and other cardiovascular
-      complications in Marfan syndrome patients.
+    snippet: Even in the absence of significant valvular disease, patients with Marfan syndrome (MFS) have evidence of impaired left ventricular (LV) performance, suggestive of a primary cardiomyopathy.
+    explanation: The reference indicates that echocardiography is used to monitor left ventricular performance and other cardiovascular complications in Marfan syndrome patients.
   - reference: PMID:29972109
     reference_title: "Utility of serial 12-lead electrocardiograms in children with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Children ≤18 years who met the revised Ghent criteria for Marfan
-      syndrome and received a 12-lead electrocardiogram and echocardiogram
-      within a 3-month period were included.
-    explanation: The reference confirms that echocardiograms are routinely used
-      to monitor cardiovascular complications in children with Marfan syndrome.
+    snippet: Children ≤18 years who met the revised Ghent criteria for Marfan syndrome and received a 12-lead electrocardiogram and echocardiogram within a 3-month period were included.
+    explanation: The reference confirms that echocardiograms are routinely used to monitor cardiovascular complications in children with Marfan syndrome.
 - name: Slit Lamp Exam
-  description: Ophthalmic examination using magnified light to detect lens
-    subluxation and other ocular abnormalities.
+  description: Ophthalmic examination using magnified light to detect lens subluxation and other ocular abnormalities.
   presence: Ectopia lentis
   notes: Used to detect lens dislocation.
   evidence:
@@ -1017,56 +993,34 @@ diagnosis:
     reference_title: "Ocular findings in 87 adults with Ghent-1 verified Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The position of the lens was noted by observing the eye in
-      different gaze directions in maximal mydriasis during slit lamp
-      examination.
-    explanation: The study confirms that slit lamp examination is used to detect
-      lens dislocation (ectopia lentis) in patients with Marfan syndrome.
+    snippet: The position of the lens was noted by observing the eye in different gaze directions in maximal mydriasis during slit lamp examination.
+    explanation: The study confirms that slit lamp examination is used to detect lens dislocation (ectopia lentis) in patients with Marfan syndrome.
 environmental:
 - name: Physical Activity Restrictions
-  description: Avoidance of strenuous isometric exercise and contact sports to
-    reduce hemodynamic stress on the aorta.
+  description: Avoidance of strenuous isometric exercise and contact sports to reduce hemodynamic stress on the aorta.
   effect: Reduces risk of aortic dissection.
   evidence:
   - reference: PMID:9789865
     reference_title: "Exercise and the Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The person with Marfan syndrome is often tall and agile and may
-      unknowingly participate in certain physical activities and sports, putting
-      himself or herself at risk for aortic dissection and sudden death.
-    explanation: The article suggests that physical activity restrictions are
-      necessary to prevent aortic dissection in individuals with Marfan
-      syndrome.
+    snippet: The person with Marfan syndrome is often tall and agile and may unknowingly participate in certain physical activities and sports, putting himself or herself at risk for aortic dissection and sudden death.
+    explanation: The article suggests that physical activity restrictions are necessary to prevent aortic dissection in individuals with Marfan syndrome.
   - reference: PMID:36453629
     reference_title: "Can 10 000 Healthy Steps a Day Slow Aortic Root Dilation in Pediatric Patients With Marfan Syndrome?"
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: We instructed patients to take 10 000 steps per day, tracked by an
-      activity tracker... AoR Z score in the intervention group had a
-      significantly lower rate of change per year compared with the controls
-      (rate of change, -0.24 versus +0.008; P=0.01).
-    explanation: The study indicates that controlled physical activity can
-      reduce the rate of aortic root dilation, which is associated with a lower
-      risk of aortic dissection.
+    snippet: We instructed patients to take 10 000 steps per day, tracked by an activity tracker... AoR Z score in the intervention group had a significantly lower rate of change per year compared with the controls (rate of change, -0.24 versus +0.008; P=0.01).
+    explanation: The study indicates that controlled physical activity can reduce the rate of aortic root dilation, which is associated with a lower risk of aortic dissection.
   - reference: PMID:28947563
     reference_title: "Cardiovascular Benefits of Moderate Exercise Training in Marfan Syndrome: Insights From an Animal Model."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: Over the 5-month experimental period, aortic root dilation rate was
-      significantly greater in the sedentary MF group, compared with the
-      wild-type group (∆mm, 0.27±0.07 versus 0.13±0.02, respectively). Exercise
-      significantly blunted the aortic root dilation rate in MF mice compared
-      with sedentary MF littermates (∆mm, 0.10±0.04 versus 0.27±0.07,
-      respectively).
-    explanation: Moderate dynamic exercise mitigates the progression of
-      cardiovascular issues in Marfan syndrome, indirectly supporting the idea
-      that physical activity restrictions can help manage aortic dissection
-      risk.
+    snippet: Over the 5-month experimental period, aortic root dilation rate was significantly greater in the sedentary MF group, compared with the wild-type group (∆mm, 0.27±0.07 versus 0.13±0.02, respectively). Exercise significantly blunted the aortic root dilation rate in MF mice compared with sedentary MF littermates (∆mm, 0.10±0.04 versus 0.27±0.07, respectively).
+    explanation: Moderate dynamic exercise mitigates the progression of cardiovascular issues in Marfan syndrome, indirectly supporting the idea that physical activity restrictions can help manage aortic dissection risk.
   exposure_term:
     preferred_term: Physical activity exposure
-    description: Exposure to physical exertion that may impact cardiovascular
-      stress.
+    description: Exposure to physical exertion that may impact cardiovascular stress.
     term:
       id: XCO:0000059
       label: physical activity
@@ -1078,46 +1032,31 @@ treatments:
     reference_title: "Drug-based cardiovascular prevention in patients with Marfan Syndrome: a systematic review."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: Beta-blockers remain the mainstay of therapy as they have proven to
-      slow aortic enlargement. Angiotensin receptor blockers are a useful
-      alternative and with proven benefit as an add-on therapy to limit aortic
-      growth.
-    explanation: Beta-blockers are used to slow aortic enlargement, which
-      indirectly reduces stress on the aorta. However, they do not prevent
-      aortic enlargement entirely.
+    snippet: Beta-blockers remain the mainstay of therapy as they have proven to slow aortic enlargement. Angiotensin receptor blockers are a useful alternative and with proven benefit as an add-on therapy to limit aortic growth.
+    explanation: Beta-blockers are used to slow aortic enlargement, which indirectly reduces stress on the aorta. However, they do not prevent aortic enlargement entirely.
   - reference: PMID:17845137
     reference_title: "Therapy of Marfan syndrome."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: Traditional medical therapies, such as beta-adrenergic receptor
-      blockade, are used to slow pathologic aortic growth and decrease the risk
-      of aortic dissection by decreasing hemodynamic stress.
-    explanation: Beta-blockers are used to slow aortic growth and decrease
-      hemodynamic stress, but they do not completely prevent aortic enlargement.
+    snippet: Traditional medical therapies, such as beta-adrenergic receptor blockade, are used to slow pathologic aortic growth and decrease the risk of aortic dissection by decreasing hemodynamic stress.
+    explanation: Beta-blockers are used to slow aortic growth and decrease hemodynamic stress, but they do not completely prevent aortic enlargement.
   - reference: PMID:17376944
     reference_title: "Marfan's syndrome and the heart."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: Medical treatment with beta-blockers is probably helpful in most
-      children with aortic root dilatation.
-    explanation: Beta-blockers are helpful in slowing the progression of aortic
-      root dilatation, but they do not completely prevent it.
+    snippet: Medical treatment with beta-blockers is probably helpful in most children with aortic root dilatation.
+    explanation: Beta-blockers are helpful in slowing the progression of aortic root dilatation, but they do not completely prevent it.
   treatment_term:
     preferred_term: beta adrenergic agent therapy
-    description: Treatment using medications that block beta-adrenergic
-      receptors to reduce heart rate and blood pressure.
+    description: Treatment using medications that block beta-adrenergic receptors to reduce heart rate and blood pressure.
     term:
       id: MAXO:0000186
       label: beta adrenergic agent therapy
 - name: Angiotensin Receptor Blockers
-  description: ARBs such as losartan reduce aortic root growth by blocking
-    angiotensin II type 1 receptor signaling and modulating TGF-beta pathways.
-    Pediatric data show superior tolerability and efficacy compared to
-    beta-blockers.
+  description: ARBs such as losartan reduce aortic root growth by blocking angiotensin II type 1 receptor signaling and modulating TGF-beta pathways. Pediatric data show superior tolerability and efficacy compared to beta-blockers.
   treatment_term:
     preferred_term: pharmacotherapy
-    description: Treatment using medications such as losartan to modulate
-      pathological signaling pathways.
+    description: Treatment using medications such as losartan to modulate pathological signaling pathways.
     term:
       id: MAXO:0000058
       label: pharmacotherapy
@@ -1128,24 +1067,17 @@ treatments:
     reference_title: "Overview of current surgical strategies for aortic disease in patients with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: To prevent such catastrophic aortic events, a lower threshold has
-      been recommended for prophylactic interventions on the aortic root.
-    explanation: The literature mentions that prophylactic aortic root
-      replacement is recommended to prevent severe aortic events such as
-      dissections.
+    snippet: To prevent such catastrophic aortic events, a lower threshold has been recommended for prophylactic interventions on the aortic root.
+    explanation: The literature mentions that prophylactic aortic root replacement is recommended to prevent severe aortic events such as dissections.
   - reference: PMID:29948025
     reference_title: "Predictors of Rapid Aortic Root Dilation and Referral for Aortic Surgery in Marfan Syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Few data exist regarding predictors of rapid aortic root dilation
-      and referral for aortic surgery in Marfan syndrome (MFS).
-    explanation: The study investigates predictors for referral for aortic
-      surgery in patients with Marfan syndrome, indicating that surgery is
-      recommended for severe aortic dilation.
+    snippet: Few data exist regarding predictors of rapid aortic root dilation and referral for aortic surgery in Marfan syndrome (MFS).
+    explanation: The study investigates predictors for referral for aortic surgery in patients with Marfan syndrome, indicating that surgery is recommended for severe aortic dilation.
   treatment_term:
     preferred_term: surgical procedure
-    description: Operative intervention to repair or replace damaged anatomical
-      structures.
+    description: Operative intervention to repair or replace damaged anatomical structures.
     term:
       id: MAXO:0000004
       label: surgical procedure
@@ -1156,95 +1088,62 @@ treatments:
     reference_title: "Surgical treatment of scoliosis in Marfan syndrome: guidelines for a successful outcome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The authors recommend arthrodesing both the primary and secondary
-      curves in all patients with Marfan syndrome.
-    explanation: The study discusses surgical treatment of scoliosis in Marfan
-      syndrome and provides guidelines for successful outcomes through
-      orthopedic interventions.
+    snippet: The authors recommend arthrodesing both the primary and secondary curves in all patients with Marfan syndrome.
+    explanation: The study discusses surgical treatment of scoliosis in Marfan syndrome and provides guidelines for successful outcomes through orthopedic interventions.
   - reference: PMID:11880731
     reference_title: "Marfan syndrome: orthopedic and genetic review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The major orthopedic manifestations of Marfan syndrome include
-      scoliosis, chest wall deformity, dural ectasia, joint hypermobility, and
-      acetabular protrusion.
-    explanation: This review highlights the orthopedic aspects of Marfan
-      syndrome, including treatments for scoliosis and other skeletal
-      abnormalities.
+    snippet: The major orthopedic manifestations of Marfan syndrome include scoliosis, chest wall deformity, dural ectasia, joint hypermobility, and acetabular protrusion.
+    explanation: This review highlights the orthopedic aspects of Marfan syndrome, including treatments for scoliosis and other skeletal abnormalities.
   - reference: PMID:34916231
     reference_title: "Impact of pathogenic FBN1 variant types on the development of severe scoliosis in patients with Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: We elucidated the genetic risk factors for the development of
-      severe scoliosis in patients with Marfan syndrome.
-    explanation: The study investigates the genetic risk factors for severe
-      scoliosis in Marfan syndrome, which is relevant to orthopedic
-      interventions.
+    snippet: We elucidated the genetic risk factors for the development of severe scoliosis in patients with Marfan syndrome.
+    explanation: The study investigates the genetic risk factors for severe scoliosis in Marfan syndrome, which is relevant to orthopedic interventions.
   - reference: PMID:17945136
     reference_title: "Spinal deformities in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Kyphoscoliosis, spondylolisthesis, and atlantoaxial subluxation are
-      common spinal deformities in Marfan syndrome... Surgical correction is
-      associated with complications, such as failure of fixation and additional
-      deformity; however good results are possible when consideration is given
-      to the unique challenges presented by patients who have Marfan syndrome.
-    explanation: The article discusses common spinal deformities in Marfan
-      syndrome and the complexities of surgical correction, supporting the
-      statement on orthopedic interventions.
+    snippet: Kyphoscoliosis, spondylolisthesis, and atlantoaxial subluxation are common spinal deformities in Marfan syndrome... Surgical correction is associated with complications, such as failure of fixation and additional deformity; however good results are possible when consideration is given to the unique challenges presented by patients who have Marfan syndrome.
+    explanation: The article discusses common spinal deformities in Marfan syndrome and the complexities of surgical correction, supporting the statement on orthopedic interventions.
   - reference: PMID:26130954
     reference_title: "Disease-specific Growth Charts of Marfan Syndrome Patients in Korea."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Patients with Marfan syndrome (MFS) presents with primary skeletal
-      manifestations such as tall stature, chest wall abnormality, and
-      scoliosis.
-    explanation: This study covers the primary skeletal manifestations of Marfan
-      syndrome, including scoliosis, which require orthopedic interventions.
+    snippet: Patients with Marfan syndrome (MFS) presents with primary skeletal manifestations such as tall stature, chest wall abnormality, and scoliosis.
+    explanation: This study covers the primary skeletal manifestations of Marfan syndrome, including scoliosis, which require orthopedic interventions.
   treatment_term:
     preferred_term: surgical procedure
-    description: Operative intervention to correct skeletal abnormalities such
-      as scoliosis.
+    description: Operative intervention to correct skeletal abnormalities such as scoliosis.
     term:
       id: MAXO:0000004
       label: surgical procedure
 - name: Vision Correction
-  description: Management of ocular issues such as ectopia lentis with glasses
-    or surgery.
+  description: Management of ocular issues such as ectopia lentis with glasses or surgery.
   evidence:
   - reference: PMID:24698610
     reference_title: "Surgical management of lens subluxation in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Anterior lensectomy and limited vitrectomy with aphakic correction
-      is safe and provides a consistent visual outcome in patients with lens
-      subluxation secondary to Marfan syndrome.
-    explanation: The study discusses surgical management of ectopia lentis in
-      Marfan syndrome patients, which supports the statement about managing
-      ocular issues with surgery.
+    snippet: Anterior lensectomy and limited vitrectomy with aphakic correction is safe and provides a consistent visual outcome in patients with lens subluxation secondary to Marfan syndrome.
+    explanation: The study discusses surgical management of ectopia lentis in Marfan syndrome patients, which supports the statement about managing ocular issues with surgery.
   - reference: PMID:23661206
     reference_title: "Ocular features and management challenges of Marfan's Syndrome in Benin City, Nigeria."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The ocular features were ectopia lentis in 92.3% of the patients...
-      The best corrected visual acuity in 4 out of 5 patients who had cataract
-      extraction at 8 weeks post op. was 6/60 to 6/12.
-    explanation: This study highlights the use of surgical intervention for
-      vision correction in Marfan syndrome patients with ectopia lentis.
+    snippet: The ocular features were ectopia lentis in 92.3% of the patients... The best corrected visual acuity in 4 out of 5 patients who had cataract extraction at 8 weeks post op. was 6/60 to 6/12.
+    explanation: This study highlights the use of surgical intervention for vision correction in Marfan syndrome patients with ectopia lentis.
   - reference: PMID:30260057
     reference_title: "Ten-year reinvestigation of ocular manifestations in Marfan syndrome."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Our study indicates that even though EL typically occurs at an
-      early stage in most MFS patients, there is still a risk of developing EL
-      in adulthood.
-    explanation: The study confirms the management of ectopia lentis (EL) in
-      Marfan syndrome, indicating the necessity for vision correction, which can
-      include glasses or surgery.
+    snippet: Our study indicates that even though EL typically occurs at an early stage in most MFS patients, there is still a risk of developing EL in adulthood.
+    explanation: The study confirms the management of ectopia lentis (EL) in Marfan syndrome, indicating the necessity for vision correction, which can include glasses or surgery.
   treatment_term:
     preferred_term: surgical procedure
-    description: Operative intervention to correct lens dislocation or other
-      ocular abnormalities.
+    description: Operative intervention to correct lens dislocation or other ocular abnormalities.
     term:
       id: MAXO:0000004
       label: surgical procedure
@@ -1284,8 +1183,7 @@ datasets:
 
 # Aortic dissection gene expression
 - accession: geo:GSE52093
-  title: Genome-wide analysis of gene expression of ascending aorta from
-    patients with acute Stanford type A aortic dissection
+  title: Genome-wide analysis of gene expression of ascending aorta from patients with acute Stanford type A aortic dissection
   description: >-
     Gene expression profiling comparing dissected ascending aorta
     tissue from acute Stanford type A aortic dissection patients
@@ -1315,15 +1213,13 @@ datasets:
 
 disease_term:
   preferred_term: Marfan syndrome
-  description: A heritable connective tissue disorder caused by mutations in
-    FBN1, characterized by cardiovascular, ocular, and skeletal abnormalities.
+  description: A heritable connective tissue disorder caused by mutations in FBN1, characterized by cardiovascular, ocular, and skeletal abnormalities.
   term:
     id: MONDO:0007947
     label: Marfan syndrome
 references:
 - reference: DOI:10.1007/s00392-023-02221-4
-  title: 'Prophylactic effect of angiotensin receptor blockers in children with genetic
-    aortopathies: the early bird catches the worm'
+  title: 'Prophylactic effect of angiotensin receptor blockers in children with genetic aortopathies: the early bird catches the worm'
   findings: []
 - reference: DOI:10.3389/fcell.2023.1302285
   title: The extracellular matrix glycoprotein fibrillin-1 in health and disease
@@ -1332,15 +1228,11 @@ references:
   title: 'Marfan syndrome: insights from animal models'
   findings: []
 - reference: DOI:10.3390/ijms25095025
-  title: Investigation of Strategies to Block Downstream Effectors of
-    AT1R-Mediated Signalling to Prevent Aneurysm Formation in Marfan Syndrome
+  title: Investigation of Strategies to Block Downstream Effectors of AT1R-Mediated Signalling to Prevent Aneurysm Formation in Marfan Syndrome
   findings: []
 - reference: DOI:10.3390/ijms25137367
-  title: Coding and Non-Coding Transcriptomic Landscape of Aortic Complications
-    in Marfan Syndrome
+  title: Coding and Non-Coding Transcriptomic Landscape of Aortic Complications in Marfan Syndrome
   findings: []
 - reference: DOI:10.3390/ijms26073067
-  title: Analysis of FBN1, TGFβ2, TGFβR1 and TGFβR2 mRNA as Key Molecular
-    Mechanisms in the Damage of Aortic Aneurysm and Dissection in Marfan
-    Syndrome
+  title: Analysis of FBN1, TGFβ2, TGFβR1 and TGFβR2 mRNA as Key Molecular Mechanisms in the Damage of Aortic Aneurysm and Dissection in Marfan Syndrome
   findings: []


### PR DESCRIPTION
## Summary

- Adds ORPHA:558-backed disease definition, external assertion, and exact cross-reference mappings for Marfan syndrome.
- Adds Orphanet evidence for autosomal dominant inheritance, all-age onset, and worldwide point prevalence.
- Adds Orphanet HPO phenotype frequency evidence to existing Marfan phenotypes and adds several missing Orphanet-supported phenotype entries.

## Notes

- Ran `just refresh-orphadata` and rebuilt ORPHA:558 with `just structured-rebuild-orphanet --id 558`; `references_cache/ORPHA_558.md` had no content diff after regeneration.
- The repo YAML formatter reformatted the touched disease file during commit.

## Validation

- `just validate kb/disorders/Marfan_Syndrome.yaml`
- `just validate-terms kb/disorders/Marfan_Syndrome.yaml`
- `just validate-schema kb/disorders/Marfan_Syndrome.yaml`
- `git diff --check`
- Fixed-string check confirmed the new ORPHA snippets are present in `references_cache/ORPHA_558.md`.