### PR TITLE
[codex] Add Orphanet evidence for cystic fibrosis

### DIFF
--- a/kb/disorders/Cystic_Fibrosis.yaml
+++ b/kb/disorders/Cystic_Fibrosis.yaml
@@ -1,6 +1,6 @@
 name: Cystic Fibrosis
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-03-31T02:48:22Z'
+updated_date: '2026-04-27T01:12:40Z'
 description: >-
   Cystic fibrosis is a common life-limiting autosomal recessive genetic disorder
   caused by mutations in the CFTR gene encoding the cystic fibrosis transmembrane
@@ -18,6 +18,37 @@ category: Genetic
 parents:
 - Respiratory Disease
 - Inborn Error of Metabolism
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0009061
+      label: cystic fibrosis
+    mapping_predicate: skos:exactMatch
+    mapping_source: Orphanet ORPHA:586
+    mapping_justification: Orphanet ORPHA:586 cross-reference table lists MONDO:0009061 as an exact match.
+external_assertions:
+- name: Orphanet Cystic fibrosis record
+  source: Orphanet
+  assertion_type: structured_disease_record
+  external_id: ORPHA:586
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=586
+  description: >-
+    Orphanet structured record for cystic fibrosis, including synonyms,
+    definition, inheritance, natural history, epidemiology, genes, HPO
+    phenotypes, and cross-references.
+  evidence:
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "MONDO:0009061 | Exact"
+    explanation: Orphanet cross-references ORPHA:586 exactly to MONDO:0009061.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "OMIM:219700 | Exact"
+    explanation: Orphanet cross-references ORPHA:586 exactly to OMIM:219700.
 prevalence:
 - population: European descent
   percentage: 1 in 2,500 to 3,500 live births
@@ -48,8 +79,33 @@ prevalence:
       disorder, with highest prevalence in Europe, North America, and Australia."
     explanation: Lower prevalence in Asian populations is implied by highest
       prevalence being in European-descent populations.
+- population: Europe
+  percentage: 1-5 / 10 000 point prevalence
+  evidence:
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-5 / 10 000 | Europe | Point prevalence | ORPHANET"
+    explanation: Orphanet reports the European point prevalence class for cystic
+      fibrosis.
+- population: Europe
+  percentage: 1-5 / 10 000 prevalence at birth
+  evidence:
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-5 / 10 000 | Europe | Prevalence at birth | ORPHANET"
+    explanation: Orphanet reports the European prevalence-at-birth class for
+      cystic fibrosis.
 inheritance:
 - name: Autosomal Recessive
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
   evidence:
   - reference: PMID:30986316
     supports: SUPPORT
@@ -58,6 +114,24 @@ inheritance:
       by pancreatic insufficiency and chronic endobronchial airway infection."
     explanation: Clinical review confirms autosomal recessive inheritance
       pattern.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Autosomal recessive"
+    explanation: Orphanet lists cystic fibrosis inheritance as autosomal
+      recessive.
+progression:
+- phase: Age of onset
+  age_range: All ages
+  evidence:
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: All ages"
+    explanation: Orphanet's natural-history section records cystic fibrosis
+      onset as occurring across all ages.
 definitions:
 - name: CF Foundation Diagnostic Criteria (2017)
   definition_type: CASE_DEFINITION
@@ -1089,6 +1163,13 @@ phenotypes:
       by pancreatic insufficiency and chronic endobronchial airway infection."
     explanation: Clinical review identifies chronic airway infection as a
       defining characteristic of cystic fibrosis.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002205 | Recurrent respiratory infections | Very frequent (99-80%)"
+    explanation: Orphanet's HPO annotation independently supports recurrent
+      respiratory infections as a very frequent cystic fibrosis phenotype.
 - category: Respiratory
   name: Bronchiectasis
   description: Progressive airway damage from chronic infection and inflammation
@@ -1109,6 +1190,13 @@ phenotypes:
       respiratory failure, which is the leading cause of death in patients with CF."
     explanation: Clinical review confirms progressive bronchiectasis as a
       consequence of chronic airway infection in CF.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002110 | Bronchiectasis | Very frequent (99-80%)"
+    explanation: Orphanet's HPO annotation independently supports
+      bronchiectasis as a very frequent cystic fibrosis phenotype.
 - category: Respiratory
   name: Hemoptysis
   description: Coughing up blood due to erosion of bronchial arteries by chronic
@@ -1245,6 +1333,13 @@ phenotypes:
       by pancreatic insufficiency and chronic endobronchial airway infection."
     explanation: Clinical review identifies pancreatic insufficiency as a
       defining characteristic of cystic fibrosis.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001738 | Exocrine pancreatic insufficiency | Very frequent (99-80%)"
+    explanation: Orphanet's HPO annotation independently supports exocrine
+      pancreatic insufficiency as a very frequent cystic fibrosis phenotype.
 - category: Gastrointestinal
   name: Steatorrhea
   description: Fatty, bulky, foul-smelling stools resulting from fat
@@ -1286,6 +1381,13 @@ phenotypes:
       hepatobiliary disease, hyponatremic dehydration, and infertility."
     explanation: Clinical review lists bowel obstruction (including meconium
       ileus) among established complications of CF.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0004401 | Meconium ileus | Occasional (29-5%)"
+    explanation: Orphanet's HPO annotation independently supports meconium ileus
+      as an occasional cystic fibrosis phenotype.
 - category: Gastrointestinal
   name: Distal Intestinal Obstruction Syndrome
   description: Partial or complete intestinal obstruction in the ileocecal
@@ -1328,6 +1430,13 @@ phenotypes:
       liver and pancreatic dysfunction, and male infertility."
     explanation: Malnutrition from pancreatic insufficiency contributes to
       complications like rectal prolapse.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002035 | Rectal prolapse | Occasional (29-5%)"
+    explanation: Orphanet's HPO annotation independently supports rectal
+      prolapse as an occasional cystic fibrosis phenotype.
 - category: Gastrointestinal
   name: Gastroesophageal Reflux
   description: Increased gastroesophageal reflux in CF patients, potentially
@@ -1567,6 +1676,13 @@ phenotypes:
       liver and pancreatic dysfunction, and male infertility."
     explanation: Malabsorption from pancreatic insufficiency causes vitamin
       deficiencies.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002024 | Malabsorption | Very frequent (99-80%)"
+    explanation: Orphanet's HPO annotation independently supports malabsorption
+      as a very frequent cystic fibrosis phenotype.
 # Musculoskeletal phenotypes
 - category: Musculoskeletal
   name: Osteoporosis
@@ -1609,6 +1725,13 @@ biochemical:
       with a sweat chloride test."
     explanation: CF Foundation consensus guidelines recommend sweat chloride
       testing for all CFTR-related diagnoses.
+  - reference: ORPHA:586
+    reference_title: Cystic fibrosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012236 | Elevated sweat chloride | Very frequent (99-80%)"
+    explanation: Orphanet's HPO annotation independently supports elevated sweat
+      chloride as a very frequent cystic fibrosis finding.
 - name: Immunoreactive Trypsinogen (IRT)
   presence: Elevated
   context: Elevated in newborn dried blood spots; used as first-tier newborn

--- a/references_cache/ORPHA_586.md
+++ b/references_cache/ORPHA_586.md
@@ -1,0 +1,180 @@
+---
+reference_id: "ORPHA:586"
+title: "Cystic fibrosis"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:586  Cystic fibrosis
+
+**ORPHA:586** — Cystic fibrosis (Disease, Disorder)
+
+## Synonyms
+
+- CF
+- Mucoviscidosis
+
+## Definition
+
+A rare, genetic pulmonary disorder characterized by sweat, thick mucus secretions causing multisystem disease, chronic infections of the lungs, bulky diarrhea and short stature.
+
+## Inheritance
+
+- Autosomal recessive
+
+## Natural history
+
+- Age of onset: All ages
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| 1-9 / 100 000 | Austria | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | Austria | Prevalence at birth | PMID:18442953 |
+| 1-5 / 10 000 | Belgium | Point prevalence | PMID:30335254 |
+| 1-5 / 10 000 | Belgium | Prevalence at birth | PMID:30335254 |
+| 1-5 / 10 000 | Brazil | Annual incidence | PMID:35209917 |
+| 1-9 / 100 000 | Bulgaria | Point prevalence | PMID |
+| 1-5 / 10 000 | Bulgaria | Prevalence at birth | PMID |
+| 1-9 / 1 000 000 | China | Point prevalence | PMID:35313924 |
+| 1-9 / 100 000 | Cyprus | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | Cyprus | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Czech Republic | Point prevalence | PMID:31241292 |
+| 1-5 / 10 000 | Czech Republic | Prevalence at birth | PMID:31241292 |
+| 1-9 / 100 000 | Denmark | Point prevalence | PMID:31682332 |
+| 1-5 / 10 000 | Denmark | Prevalence at birth | PMID:31682332 |
+| 1-9 / 100 000 | Estonia | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | Estonia | Prevalence at birth | PMID:18442953 |
+| 1-5 / 10 000 | Europe | Point prevalence | ORPHANET |
+| 1-5 / 10 000 | Europe | Prevalence at birth | ORPHANET |
+| 1-9 / 100 000 | Finland | Point prevalence | PMID:18442953 |
+| 1-9 / 100 000 | Finland | Prevalence at birth | PMID:16051530,PMID:18442953 |
+| 1-5 / 10 000 | France | Point prevalence | PMID:25122143 |
+| 1-5 / 10 000 | France | Prevalence at birth | PMID:25122143 |
+| 1-5 / 10 000 | Germany | Point prevalence | PMID:25914230 |
+| 1-5 / 10 000 | Germany | Prevalence at birth | PMID:25914230 |
+| 1-9 / 100 000 | Greece | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | Greece | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Hungary | Point prevalence | PMID:18442953 |
+| Unknown | Hungary | Prevalence at birth | PMID:18442953 |
+| 1-5 / 10 000 | Ireland | Point prevalence | PMID:32483343 |
+| 1-5 / 10 000 | Ireland | Prevalence at birth | PMID:32483343 |
+| 1-5 / 10 000 | Italy | Point prevalence | PMID:31005549 |
+| 1-5 / 10 000 | Italy | Prevalence at birth | PMID:31005549 |
+| 1-9 / 100 000 | Latvia | Point prevalence | PMID:18442953 |
+| Unknown | Latvia | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Lithuania | Point prevalence | PMID:18442953 |
+| Unknown | Lithuania | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Luxembourg | Point prevalence | PMID:18442953 |
+| Unknown | Luxembourg | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Malta | Point prevalence | PMID:18442953 |
+| Unknown | Malta | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Netherlands | Point prevalence | PMID:30146269 |
+| 1-5 / 10 000 | Netherlands | Prevalence at birth | PMID:30146269 |
+| 1-9 / 100 000 | Norway | Point prevalence | PMID:26795017 |
+| 1-5 / 10 000 | Norway | Prevalence at birth | PMID:26795017 |
+| 1-5 / 10 000 | Poland | Point prevalence | PMID:22892530 |
+| 1-5 / 10 000 | Poland | Prevalence at birth | PMID:22892530 |
+| 1-9 / 100 000 | Portugal | Point prevalence | PMID:33072945 |
+| 1-5 / 10 000 | Portugal | Prevalence at birth | PMID:33072945 |
+| 1-9 / 100 000 | Romania | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | Romania | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Russian Federation | Point prevalence | ECFSNeonatalScreeningWorkingGroup |
+| 1-9 / 100 000 | Russian Federation | Prevalence at birth | ECFSNeonatalScreeningWorkingGroup |
+| 1-9 / 100 000 | Slovakia | Point prevalence | PMID:28544683 |
+| 1-5 / 10 000 | Slovakia | Prevalence at birth | PMID:28544683 |
+| 1-9 / 100 000 | Slovenia | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | Slovenia | Prevalence at birth | PMID:18442953 |
+| 1-9 / 100 000 | Spain | Point prevalence | PMID:25680858 |
+| 1-5 / 10 000 | Spain | Prevalence at birth | PMID:25680858 |
+| 1-5 / 10 000 | Sweden | Point prevalence | PMID:12243313,PMID:18442953 |
+| 1-5 / 10 000 | Sweden | Prevalence at birth | PMID:12243313,PMID:18442953 |
+| 1-5 / 10 000 | United Kingdom | Point prevalence | PMID:18442953 |
+| 1-5 / 10 000 | United Kingdom | Prevalence at birth | PMID:18442953 |
+
+## Genes
+
+| Symbol | Name | HGNC | Association |
+|---|---|---|---|
+| CEACAM3 | CEA cell adhesion molecule 3 | hgnc:1815 | Modifying germline mutation in |
+| CEACAM6 | CEA cell adhesion molecule 6 | hgnc:1818 | Modifying germline mutation in |
+| CFTR | CF transmembrane conductance regulator | hgnc:1884 | Disease-causing germline mutation(s) (loss of function) in |
+| CLCA4 | chloride channel accessory 4 | hgnc:2018 | Modifying germline mutation in |
+| DCTN4 | dynactin subunit 4 | hgnc:15518 | Modifying germline mutation in |
+| EDNRA | endothelin receptor type A | hgnc:3179 | Modifying germline mutation in |
+| GCLC | glutamate-cysteine ligase catalytic subunit | hgnc:4311 | Modifying germline mutation in |
+| GSTM3 | glutathione S-transferase mu 3 | hgnc:4635 | Modifying germline mutation in |
+| HFE | homeostatic iron regulator | hgnc:4886 | Modifying germline mutation in |
+| HMOX1 | heme oxygenase 1 | hgnc:5013 | Modifying germline mutation in |
+| KCNN4 | potassium calcium-activated channel subfamily N member 4 | hgnc:6293 | Modifying germline mutation in |
+| MIF | macrophage migration inhibitory factor | hgnc:7097 | Modifying germline mutation in |
+| SERPINA1 | serpin family A member 1 | hgnc:8941 | Modifying germline mutation in |
+| SLC11A1 | solute carrier family 11 member 1 | hgnc:10907 | Modifying germline mutation in |
+| SLC26A9 | solute carrier family 26 member 9 | hgnc:14469 | Modifying germline mutation in |
+| SLC6A14 | solute carrier family 6 member 14 | hgnc:11047 | Modifying germline mutation in |
+| SLC9A3 | solute carrier family 9 member A3 | hgnc:11073 | Modifying germline mutation in |
+| STX1A | syntaxin 1A | hgnc:11433 | Modifying germline mutation in |
+| TGFB1 | transforming growth factor beta 1 | hgnc:11766 | Modifying germline mutation in |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000246 | Sinusitis | Occasional (29-5%) |
+| HP:0000365 | Hearing impairment | Very rare (<4-1%) |
+| HP:0000716 | Depression | Occasional (29-5%) |
+| HP:0000739 | Anxiety | Occasional (29-5%) |
+| HP:0000787 | Nephrolithiasis | Very rare (<4-1%) |
+| HP:0000938 | Osteopenia | Occasional (29-5%) |
+| HP:0000939 | Osteoporosis | Very rare (<4-1%) |
+| HP:0001392 | Abnormality of the liver | Occasional (29-5%) |
+| HP:0001394 | Cirrhosis | Very rare (<4-1%) |
+| HP:0001508 | Failure to thrive | Frequent (79-30%) |
+| HP:0001738 | Exocrine pancreatic insufficiency | Very frequent (99-80%) |
+| HP:0002020 | Gastroesophageal reflux | Occasional (29-5%) |
+| HP:0002024 | Malabsorption | Very frequent (99-80%) |
+| HP:0002035 | Rectal prolapse | Occasional (29-5%) |
+| HP:0002099 | Asthma | Occasional (29-5%) |
+| HP:0002105 | Hemoptysis | Very rare (<4-1%) |
+| HP:0002107 | Pneumothorax | Very rare (<4-1%) |
+| HP:0002110 | Bronchiectasis | Very frequent (99-80%) |
+| HP:0002205 | Recurrent respiratory infections | Very frequent (99-80%) |
+| HP:0002570 | Steatorrhea | Occasional (29-5%) |
+| HP:0002724 | Recurrent Aspergillus infections | Occasional (29-5%) |
+| HP:0002726 | Recurrent Staphylococcus aureus infections | Occasional (29-5%) |
+| HP:0002783 | Recurrent lower respiratory tract infections | Occasional (29-5%) |
+| HP:0002842 | Recurrent Burkholderia cepacia infections | Very rare (<4-1%) |
+| HP:0002910 | Elevated circulating hepatic transaminase concentration | Occasional (29-5%) |
+| HP:0003251 | Male infertility | Frequent (79-30%) |
+| HP:0004401 | Meconium ileus | Occasional (29-5%) |
+| HP:0005376 | Recurrent Haemophilus influenzae infections | Occasional (29-5%) |
+| HP:0006536 | Airway obstruction | Very frequent (99-80%) |
+| HP:0012236 | Elevated sweat chloride | Very frequent (99-80%) |
+| HP:0012873 | Absent vas deferens | Very frequent (99-80%) |
+| HP:0032261 | Nontuberculous mycobacterial pulmonary infection | Very rare (<4-1%) |
+| HP:0032342 | Reduced forced expiratory volume in one second | Occasional (29-5%) |
+| HP:0045082 | Decreased body mass index | Occasional (29-5%) |
+| HP:0100582 | Nasal polyposis | Very rare (<4-1%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:6233 | Exact |
+| ICD-10:E84 | Exact |
+| ICD-10:E84.0 | Broader |
+| ICD-10:E84.1 | Broader |
+| ICD-10:E84.8 | Broader |
+| ICD-11:CA25 | Exact |
+| MONDO:0009061 | Exact |
+| MeSH:D003550 | Exact |
+| MedDRA:10011762 | Exact |
+| OMIM:219700 | Exact |
+| UMLS:C0010674 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=586)


### PR DESCRIPTION
## Summary

Adds Orphanet ORPHA:586 evidence to the cystic fibrosis knowledge-base entry.

## Changes

- Regenerated the structured Orphanet cache for ORPHA:586 from refreshed Orphadata XML.
- Added the generated `references_cache/ORPHA_586.md` file.
- Added Orphanet-backed cross-reference metadata, European prevalence rows, all-ages onset, autosomal recessive inheritance term/evidence, and selected phenotype/finding evidence to `kb/disorders/Cystic_Fibrosis.yaml`.
- Used exact snippets from the generated ORPHA:586 cache for all new Orphanet evidence items.

## Validation

- `just refresh-orphadata`
- `just structured-rebuild-orphanet --id 586`
- `just validate kb/disorders/Cystic_Fibrosis.yaml`
- `just validate-schema kb/disorders/Cystic_Fibrosis.yaml`
- `just check-reference-cache-frontmatter`
- Manual `rg -F` check that every new ORPHA snippet appears in `references_cache/ORPHA_586.md`

Note: local commit hooks were run with `yamlfix` skipped to avoid reflowing the entire pre-existing CF YAML file; the scoped YAML checks passed.