### PR TITLE
[codex] Incorporate Orphanet evidence for Wilson disease

### DIFF
--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-28T01:31:01Z'
+updated_date: '2026-04-28T06:31:48Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -730,7 +730,7 @@ phenotypes:
     reference_title: "Wilson disease - liver pathology."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Most liver biopsy specimens show moderate to severe steatosis, variable"
+    snippet: "Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis."
     explanation: Liver biopsy review data support hepatic steatosis as a common histopathological phenotype in Wilson disease.
   - reference: ORPHA:905
     reference_title: "Wilson disease (Orphanet structured-database record)"
@@ -1212,14 +1212,22 @@ phenotypes:
       label: Excessive salivation
 - name: Proximal Lower Limb Muscle Weakness
   category: Neurological
-  frequency: VERY_FREQUENT
-  evidence:
-  - reference: ORPHA:905
-    reference_title: "Wilson disease (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0008994 | Proximal muscle weakness in lower limbs | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies proximal muscle weakness in lower limbs as very frequent in Wilson disease.
+  notes: >-
+    Base frequency is intentionally omitted because proximal lower-limb
+    weakness at a very-frequent rate is not corroborated in the cited clinical
+    literature; the Orphanet curated annotation is retained as source-specific
+    context.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives proximal lower-limb muscle weakness a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008994 | Proximal muscle weakness in lower limbs | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies proximal muscle weakness in lower limbs as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Proximal lower limb muscle weakness
     term:
@@ -1345,14 +1353,30 @@ phenotypes:
       label: Anxiety
 - name: Aggressive Behavior
   category: Psychiatric
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
+  notes: >-
+    Base frequency follows the symptomatic psychiatric cohort estimate for
+    personality changes including irritability and aggression; Orphanet's
+    curated HPO annotation uses a higher very-frequent band.
   evidence:
-  - reference: ORPHA:905
-    reference_title: "Wilson disease (Orphanet structured-database record)"
+  - reference: PMID:1821256
+    reference_title: "The psychiatric presentations of Wilson's disease."
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0000718 | Aggressive behavior | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies aggressive behavior as very frequent in Wilson disease.
+    snippet: |-
+      Personality changes, particularly irritability and aggression, were most
+      commonly described (45.9%), followed by depression (27%). Cognitive changes,
+    explanation: Cohort data support aggressive behavior as part of the frequent personality-change presentation in symptomatic Wilson disease.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives aggressive behavior a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000718 | Aggressive behavior | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies aggressive behavior as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Aggressive behavior
     term:
@@ -1487,6 +1511,10 @@ phenotypes:
 - name: Thrombocytopenia
   category: Hematologic
   frequency: VERY_FREQUENT
+  notes: >-
+    Frequency reflects the Orphanet curated HPO annotation; thrombocytopenia in
+    Wilson disease is often stage-dependent, including portal hypertension or
+    hypersplenism contexts.
   evidence:
   - reference: ORPHA:905
     reference_title: "Wilson disease (Orphanet structured-database record)"
@@ -1502,6 +1530,10 @@ phenotypes:
 - name: Anemia
   category: Hematologic
   frequency: VERY_FREQUENT
+  notes: >-
+    Frequency reflects the Orphanet curated HPO annotation; anemia in Wilson
+    disease can be stage- or presentation-dependent, including hemolytic and
+    advanced liver disease contexts.
   evidence:
   - reference: ORPHA:905
     reference_title: "Wilson disease (Orphanet structured-database record)"
@@ -1551,14 +1583,22 @@ phenotypes:
       label: Bone pain
 - name: Arthritis
   category: Skeletal
-  frequency: VERY_FREQUENT
-  evidence:
-  - reference: ORPHA:905
-    reference_title: "Wilson disease (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0001369 | Arthritis | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies arthritis as very frequent in Wilson disease.
+  notes: >-
+    Base frequency is intentionally omitted because a very-frequent inflammatory
+    arthritis rate is not independently corroborated in the cited clinical
+    literature; the Orphanet curated annotation is retained as source-specific
+    context.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives arthritis a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001369 | Arthritis | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies arthritis as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Arthritis
     term:
@@ -1566,14 +1606,22 @@ phenotypes:
       label: Arthritis
 - name: Joint Swelling
   category: Skeletal
-  frequency: VERY_FREQUENT
-  evidence:
-  - reference: ORPHA:905
-    reference_title: "Wilson disease (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0001386 | Joint swelling | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies joint swelling as very frequent in Wilson disease.
+  notes: >-
+    Base frequency is intentionally omitted because a very-frequent joint
+    swelling rate is not independently corroborated in the cited clinical
+    literature; the Orphanet curated annotation is retained as source-specific
+    context.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives joint swelling a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001386 | Joint swelling | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies joint swelling as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Joint swelling
     term:
@@ -1581,14 +1629,22 @@ phenotypes:
       label: Joint swelling
 - name: Pathologic Fracture
   category: Skeletal
-  frequency: VERY_FREQUENT
-  evidence:
-  - reference: ORPHA:905
-    reference_title: "Wilson disease (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0002756 | Pathologic fracture | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies pathologic fracture as very frequent in Wilson disease.
+  notes: >-
+    Base frequency is intentionally omitted because pathologic fracture should
+    be a subset of low bone density complications rather than a very-frequent
+    unselected Wilson disease feature; the Orphanet curated annotation is
+    retained as source-specific context.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives pathologic fracture a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002756 | Pathologic fracture | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies pathologic fracture as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Pathologic fracture
     term:

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-23T01:49:27Z'
+updated_date: '2026-04-27T01:14:12Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -20,6 +20,19 @@ disease_term:
   term:
     id: MONDO:0010200
     label: Wilson disease
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0010200
+      label: Wilson disease
+    mapping_predicate: skos:exactMatch
+    mapping_source: Orphanet ORPHA:905
+    mapping_justification: >-
+      ORPHA:905 cross-references Wilson disease to MONDO:0010200 with an Exact mapping.
+    notes: >-
+      ORPHA:905 also lists Genetic and Rare Diseases Information Center entry
+      7893, ICD-10:E83.0, ICD-11:5C64.00, MeSH:D006527, MedDRA:10019819,
+      OMIM:277900, and UMLS:C0019202.
 synonyms:
 - hepatolenticular degeneration
 - WD
@@ -39,6 +52,12 @@ inheritance:
     supports: SUPPORT
     snippet: "Inactivating mutations of the copper-transporting P-type ATPase, ATP7B, result in Wilson's disease, an autosomal recessive disorder"
     explanation: Directly states autosomal recessive inheritance for Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Autosomal recessive"
+    explanation: Orphanet's structured inheritance section independently classifies Wilson disease as autosomal recessive.
 prevalence:
 - population: Global clinically diagnosed populations
   percentage: 1 in 30,000
@@ -57,6 +76,31 @@ prevalence:
     evidence_source: HUMAN_CLINICAL
     snippet: "Results:  The average age- and sex-adjusted prevalence and incidence of WD between 2010 and 2020 were 3.06/100,000 and 0.11/100,000, respectively."
     explanation: A contemporary national claims analysis shows a clinically ascertained prevalence of 3.06 per 100,000 in Korea, consistent with rare-disease prevalence.
+- population: Orphanet worldwide and regional estimates
+  percentage: 1-9 per 100,000 worldwide; 1-5 per 10,000 in China, Japan, and some specific populations
+  notes: >-
+    Orphanet records both worldwide point/prevalence-at-birth estimates and higher
+    regional or specific-population ranges, indicating geographic variation in
+    clinically recognized Wilson disease frequency.
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-9 / 100 000 | Worldwide | Point prevalence | PMID:31449670"
+    explanation: Orphanet's epidemiology table gives a worldwide point-prevalence range for Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-9 / 100 000 | Worldwide | Prevalence at birth | PMID:31449670"
+    explanation: Orphanet separately records the same worldwide range as prevalence at birth.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-5 / 10 000 | China | Point prevalence | PMID:20301685"
+    explanation: Orphanet records a higher point-prevalence range for China, supporting regional variation.
 - population: Global population sequencing datasets
   percentage: 13.9 per 100,000
   notes: >-
@@ -74,6 +118,37 @@ prevalence:
     evidence_source: HUMAN_CLINICAL
     snippet: "Using this most conservative approach, the calculated frequency of individuals predicted to carry two mutant pathogenic ATP7B alleles is 1:7026 and thus still considerably higher than the typically reported prevalence of Wilson's disease of 1:30 000."
     explanation: Independent UK sequencing data supports a similarly elevated genetic prevalence estimate relative to diagnosed cases.
+progression:
+- phase: Onset
+  age_range: Childhood to elderly adulthood
+  notes: >-
+    Orphanet lists Wilson disease onset categories spanning childhood, adolescence,
+    adulthood, and elderly onset.
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Childhood"
+    explanation: Orphanet records childhood as an age-of-onset category for Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Adolescent"
+    explanation: Orphanet records adolescent onset as part of the Wilson disease natural history.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Adult"
+    explanation: Orphanet records adult onset as part of the Wilson disease natural history.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Elderly"
+    explanation: Orphanet records elderly onset as a possible Wilson disease natural-history category.
 mechanistic_hypotheses:
 - hypothesis_group_id: canonical_atp7b_copper_retention
   hypothesis_label: Canonical ATP7B Copper-Retention Model
@@ -586,12 +661,19 @@ phenotypes:
       label: Hepatomegaly
 - name: Jaundice
   category: Hepatic
+  frequency: VERY_FREQUENT
   evidence:
   - reference: PMID:3595645
     reference_title: "Presenting symptoms and natural history of Wilson disease."
     supports: SUPPORT
     snippet: "the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"
     explanation: Large case-series data identify jaundice among the common presenting symptoms of Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000952 | Jaundice | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies jaundice as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Jaundice
     term:
@@ -652,11 +734,32 @@ phenotypes:
     supports: SUPPORT
     snippet: "Wilson disease may be microscopically misinterpreted as many other liver diseases, including viral or autoimmune hepatitis, alcoholic/nonalcoholic steatohepatitis, toxic liver injury, cryptogenic cirrhosis"
     explanation: Wilson disease liver pathology frequently mimics hepatitis patterns, confirming hepatitis-like presentation.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012115 | Hepatitis | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table independently classifies hepatitis as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Hepatitis
     term:
       id: HP:0012115
       label: Hepatitis
+- name: Splenomegaly
+  category: Hepatic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001744 | Splenomegaly | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table lists splenomegaly as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Splenomegaly
+    term:
+      id: HP:0001744
+      label: Splenomegaly
 - name: Kayser-Fleischer Rings
   category: Ocular
   frequency: FREQUENT
@@ -678,6 +781,21 @@ phenotypes:
     term:
       id: HP:0200032
       label: Kayser-Fleischer ring
+- name: Sunflower Cataract
+  category: Ocular
+  frequency: VERY_RARE
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:6000642 | Sunflower cataract | Very rare (<4-1%)"
+    explanation: Orphanet's HPO table records sunflower cataract as a very rare ocular manifestation of Wilson disease.
+  phenotype_term:
+    preferred_term: Sunflower cataract
+    term:
+      id: HP:6000642
+      label: Sunflower cataract
 - name: Tremor
   category: Neurological
   frequency: FREQUENT
@@ -693,6 +811,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"
     explanation: Supports tremor as part of the core neurologic phenotype spectrum.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001337 | Tremor | Frequent (79-30%)"
+    explanation: Orphanet's HPO table classifies tremor as frequent in Wilson disease, matching the curated frequency band.
   phenotype_term:
     preferred_term: Tremor
     term:
@@ -712,6 +836,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"
     explanation: Supports dystonia as a core feature of neurologic Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001332 | Dystonia | Frequent (79-30%)"
+    explanation: Orphanet's HPO table classifies dystonia as frequent in Wilson disease, matching the curated frequency band.
   phenotype_term:
     preferred_term: Dystonia
     term:
@@ -846,12 +976,19 @@ phenotypes:
       label: Drooling
 - name: Vomiting
   category: Gastrointestinal
+  frequency: OCCASIONAL
   evidence:
   - reference: PMID:29914392
     reference_title: "Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease."
     supports: SUPPORT
     snippet: "These patients had clinical features such as numbness of hands and feet, vomiting, insomnia, palsy, liver failure and Kayser-Fleischer (K-F) rings"
     explanation: HPOA-linked case-series evidence supports vomiting as a gastrointestinal manifestation reported in Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002013 | Vomiting | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies vomiting as occasional in Wilson disease.
   phenotype_term:
     preferred_term: Vomiting
     term:
@@ -859,12 +996,19 @@ phenotypes:
       label: Vomiting
 - name: Anxiety
   category: Psychiatric
+  frequency: OCCASIONAL
   evidence:
   - reference: PMID:1821256
     reference_title: "The psychiatric presentations of Wilson's disease."
     supports: SUPPORT
     snippet: "Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred."
     explanation: Supports anxiety as a recognized psychiatric manifestation of Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000739 | Anxiety | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies anxiety as occasional in Wilson disease.
   phenotype_term:
     preferred_term: Anxiety
     term:
@@ -894,6 +1038,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred."
     explanation: Supports psychosis as a recognized, less frequent psychiatric presentation of Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000709 | Psychosis | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies psychosis as occasional in Wilson disease, matching the curated frequency band.
   phenotype_term:
     preferred_term: Psychosis
     term:
@@ -909,6 +1059,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%)."
     explanation: Directly supports personality change as a common psychiatric presentation in symptomatic Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000751 | Personality changes | Frequent (79-30%)"
+    explanation: Orphanet's HPO table classifies personality changes as frequent in Wilson disease, matching the curated frequency band.
   phenotype_term:
     preferred_term: Personality changes
     term:
@@ -992,6 +1148,7 @@ phenotypes:
       label: Hemolytic anemia
 - name: Osteoporosis
   category: Skeletal
+  frequency: FREQUENT
   evidence:
   - reference: PMID:29110062
     reference_title: "Osteoporosis and bone mineral density in patients with Wilson's disease: a systematic review and meta-analysis."
@@ -1003,6 +1160,12 @@ phenotypes:
     supports: SUPPORT
     snippet: "Patients with WD had significantly lower BMD as compared to control subjects (p < 0.05)."
     explanation: Supports reduced bone mineral density as a real skeletal manifestation in Wilson disease cohorts.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000939 | Osteoporosis | Frequent (79-30%)"
+    explanation: Orphanet's HPO table classifies osteoporosis as frequent in Wilson disease, matching the meta-analysis-supported frequency band.
   phenotype_term:
     preferred_term: Osteoporosis
     term:
@@ -1049,6 +1212,12 @@ biochemical:
     supports: SUPPORT
     snippet: "The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content."
     explanation: Directly supports low serum ceruloplasmin as a diagnostic biochemical feature.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0010837 | Decreased circulating ceruloplasmin concentration | Frequent (79-30%)"
+    explanation: Orphanet's HPO table independently annotates decreased circulating ceruloplasmin concentration as a frequent Wilson disease feature.
 - name: Non-Ceruloplasmin-Bound Serum Copper
   presence: Elevated
   context: Free copper fraction is elevated and used both diagnostically and for treatment monitoring
@@ -1108,6 +1277,12 @@ genetic:
     supports: SUPPORT
     snippet: "Thus far, more than 200 mutations of the WD gene have been detected, causing impairment of ATP7B function and, ultimately, copper accumulation."
     explanation: Confirms large number of ATP7B mutations causing Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "ATP7B | ATPase copper transporting beta | hgnc:870 | Disease-causing germline mutation(s) (loss of function) in"
+    explanation: Orphanet's structured gene table identifies ATP7B loss-of-function germline mutations as disease-causing for Wilson disease.
 environmental:
 - name: Dietary Copper
   notes: Dietary copper contributes to exposure, but strict long-term restriction beyond very high-copper foods is not well supported

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T14:32:36Z'
+updated_date: '2026-04-27T20:32:39Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -671,6 +671,36 @@ phenotypes:
     term:
       id: HP:0000952
       label: Jaundice
+- name: Bruising Susceptibility
+  category: Hepatic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000978 | Bruising susceptibility | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies bruising susceptibility as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Bruising susceptibility
+    term:
+      id: HP:0000978
+      label: Bruising susceptibility
+- name: Pruritus
+  category: Hepatic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000989 | Pruritus | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies pruritus as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Pruritus
+    term:
+      id: HP:0000989
+      label: Pruritus
 - name: Hepatic Steatosis
   category: Hepatic
   frequency: VERY_FREQUENT
@@ -732,6 +762,21 @@ phenotypes:
     term:
       id: HP:0006554
       label: Acute hepatic failure
+- name: Ascites
+  category: Hepatic
+  frequency: OCCASIONAL
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001541 | Ascites | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies ascites as occasional in Wilson disease.
+  phenotype_term:
+    preferred_term: Ascites
+    term:
+      id: HP:0001541
+      label: Ascites
 - name: Hepatitis
   category: Hepatic
   frequency: VERY_FREQUENT
@@ -758,6 +803,21 @@ phenotypes:
     term:
       id: HP:0012115
       label: Hepatitis
+- name: Acute Hepatitis
+  category: Hepatic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0200119 | Acute hepatitis | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies acute hepatitis as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Acute hepatitis
+    term:
+      id: HP:0200119
+      label: Acute hepatitis
 - name: Elevated Circulating Hepatic Transaminase Concentration
   category: Biochemical
   frequency: VERY_FREQUENT
@@ -824,6 +884,66 @@ phenotypes:
     term:
       id: HP:6000642
       label: Sunflower cataract
+- name: Intellectual Disability
+  category: Neurological
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001249 | Intellectual disability | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies intellectual disability as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Intellectual disability
+    term:
+      id: HP:0001249
+      label: Intellectual disability
+- name: Seizure
+  category: Neurological
+  frequency: OCCASIONAL
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001250 | Seizure | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies seizure as occasional in Wilson disease.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+- name: Gait Disturbance
+  category: Neurological
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001288 | Gait disturbance | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies gait disturbance as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Gait disturbance
+    term:
+      id: HP:0001288
+      label: Gait disturbance
+- name: Clumsiness
+  category: Neurological
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002312 | Clumsiness | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies clumsiness as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Clumsiness
+    term:
+      id: HP:0002312
+      label: Clumsiness
 - name: Tremor
   category: Neurological
   frequency: FREQUENT
@@ -989,6 +1109,51 @@ phenotypes:
     term:
       id: HP:0002015
       label: Dysphagia
+- name: Excessive Salivation
+  category: Neurological
+  frequency: OCCASIONAL
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0003781 | Excessive salivation | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies excessive salivation as occasional in Wilson disease.
+  phenotype_term:
+    preferred_term: Excessive salivation
+    term:
+      id: HP:0003781
+      label: Excessive salivation
+- name: Proximal Lower Limb Muscle Weakness
+  category: Neurological
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0008994 | Proximal muscle weakness in lower limbs | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies proximal muscle weakness in lower limbs as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Proximal lower limb muscle weakness
+    term:
+      id: HP:0008994
+      label: Proximal lower limb muscle weakness
+- name: Focal T2 Hyperintense Brainstem Lesion
+  category: Neurological
+  frequency: OCCASIONAL
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012748 | Focal T2 hyperintense brainstem lesion | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies focal T2 hyperintense brainstem lesion as occasional in Wilson disease.
+  phenotype_term:
+    preferred_term: Focal T2 hyperintense brainstem lesion
+    term:
+      id: HP:0012748
+      label: Focal T2 hyperintense brainstem lesion
 - name: Drooling
   category: Neurological
   evidence:
@@ -1022,6 +1187,21 @@ phenotypes:
     term:
       id: HP:0002013
       label: Vomiting
+- name: Abdominal Pain
+  category: Gastrointestinal
+  frequency: OCCASIONAL
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002027 | Abdominal pain | Occasional (29-5%)"
+    explanation: Orphanet's HPO table classifies abdominal pain as occasional in Wilson disease.
+  phenotype_term:
+    preferred_term: Abdominal pain
+    term:
+      id: HP:0002027
+      label: Abdominal pain
 - name: Weight Loss
   category: Constitutional
   frequency: VERY_FREQUENT

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T12:31:27Z'
+updated_date: '2026-04-27T14:32:36Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -1060,13 +1060,27 @@ phenotypes:
 - name: Depression
   category: Psychiatric
   frequency: OCCASIONAL
-  notes: One of the most common psychiatric manifestations of Wilson disease
+  notes: >-
+    One of the most common psychiatric manifestations of Wilson disease; the
+    base frequency follows the 27% symptomatic-cohort estimate, while Orphanet's
+    curated HPO annotation uses a higher frequency band.
   evidence:
   - reference: PMID:1821256
     reference_title: "The psychiatric presentations of Wilson's disease."
     supports: SUPPORT
-    snippet: "Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%)."
+    snippet: "followed by depression (27%)."
     explanation: Cohort data directly support depression as a common psychiatric manifestation in symptomatic Wilson disease.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives depression a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000716 | Depression | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies depression as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Depression
     term:

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T01:14:12Z'
+updated_date: '2026-04-27T07:33:53Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -20,19 +20,11 @@ disease_term:
   term:
     id: MONDO:0010200
     label: Wilson disease
-mappings:
-  mondo_mappings:
-  - term:
-      id: MONDO:0010200
-      label: Wilson disease
-    mapping_predicate: skos:exactMatch
-    mapping_source: Orphanet ORPHA:905
-    mapping_justification: >-
-      ORPHA:905 cross-references Wilson disease to MONDO:0010200 with an Exact mapping.
-    notes: >-
-      ORPHA:905 also lists Genetic and Rare Diseases Information Center entry
-      7893, ICD-10:E83.0, ICD-11:5C64.00, MeSH:D006527, MedDRA:10019819,
-      OMIM:277900, and UMLS:C0019202.
+notes: >-
+  ORPHA:905 cross-references Wilson disease to MONDO:0010200 with an Exact mapping
+  and also lists Genetic and Rare Diseases Information Center entry 7893,
+  ICD-10:E83.0, ICD-11:5C64.00, MeSH:D006527, MedDRA:10019819, OMIM:277900,
+  and UMLS:C0019202.
 synonyms:
 - hepatolenticular degeneration
 - WD
@@ -679,6 +671,27 @@ phenotypes:
     term:
       id: HP:0000952
       label: Jaundice
+- name: Hepatic Steatosis
+  category: Hepatic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: PMID:28433112
+    reference_title: "Wilson disease - liver pathology."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Most liver biopsy specimens show moderate to severe steatosis, variable"
+    explanation: Liver biopsy review data support hepatic steatosis as a common histopathological phenotype in Wilson disease.
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001397 | Hepatic steatosis | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies hepatic steatosis as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Hepatic steatosis
+    term:
+      id: HP:0001397
+      label: Hepatic steatosis
 - name: Cirrhosis
   category: Hepatic
   frequency: FREQUENT
@@ -745,6 +758,21 @@ phenotypes:
     term:
       id: HP:0012115
       label: Hepatitis
+- name: Elevated Circulating Hepatic Transaminase Concentration
+  category: Biochemical
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002910 | Elevated circulating hepatic transaminase concentration | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies elevated circulating hepatic transaminase concentration as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Elevated circulating hepatic transaminase concentration
+    term:
+      id: HP:0002910
+      label: Elevated circulating hepatic transaminase concentration
 - name: Splenomegaly
   category: Hepatic
   frequency: VERY_FREQUENT

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T07:33:53Z'
+updated_date: '2026-04-27T12:31:27Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -1022,6 +1022,21 @@ phenotypes:
     term:
       id: HP:0002013
       label: Vomiting
+- name: Weight Loss
+  category: Constitutional
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001824 | Weight loss | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies weight loss as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Weight loss
+    term:
+      id: HP:0001824
+      label: Weight loss
 - name: Anxiety
   category: Psychiatric
   frequency: OCCASIONAL
@@ -1154,6 +1169,21 @@ phenotypes:
     term:
       id: HP:0000124
       label: Renal tubular dysfunction
+- name: Thrombocytopenia
+  category: Hematologic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001873 | Thrombocytopenia | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies thrombocytopenia as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Thrombocytopenia
+    term:
+      id: HP:0001873
+      label: Thrombocytopenia
 - name: Hemolytic Anemia
   category: Hematologic
   frequency: OCCASIONAL
@@ -1174,6 +1204,21 @@ phenotypes:
     term:
       id: HP:0001878
       label: Hemolytic anemia
+- name: Bone Pain
+  category: Skeletal
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002653 | Bone pain | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies bone pain as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Bone pain
+    term:
+      id: HP:0002653
+      label: Bone pain
 - name: Osteoporosis
   category: Skeletal
   frequency: FREQUENT

--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T20:32:39Z'
+updated_date: '2026-04-28T01:31:01Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -640,12 +640,26 @@ phenotypes:
 - name: Hepatomegaly
   category: Hepatic
   frequency: OCCASIONAL
+  notes: >-
+    Base frequency follows pediatric cohort evidence; Orphanet's curated HPO
+    annotation gives a higher very-frequent band.
   evidence:
   - reference: PMID:22473403
     reference_title: "Wilson's disease: an analysis of 28 Brazilian children."
     supports: SUPPORT
     snippet: "three had hepatomegaly associated with neurological disorders"
     explanation: Pediatric cohort data directly support hepatomegaly as an occasional presenting phenotype in Wilson disease.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives hepatomegaly a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002240 | Hepatomegaly | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies hepatomegaly as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Hepatomegaly
     term:
@@ -688,14 +702,21 @@ phenotypes:
       label: Bruising susceptibility
 - name: Pruritus
   category: Hepatic
-  frequency: VERY_FREQUENT
-  evidence:
-  - reference: ORPHA:905
-    reference_title: "Wilson disease (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0000989 | Pruritus | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies pruritus as very frequent in Wilson disease.
+  notes: >-
+    Base frequency is intentionally omitted because pruritus is not a core
+    high-frequency Wilson disease manifestation in clinical guidance; the
+    Orphanet curated annotation is retained as source-specific context.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives pruritus a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000989 | Pruritus | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies pruritus as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Pruritus
     term:
@@ -725,7 +746,10 @@ phenotypes:
 - name: Cirrhosis
   category: Hepatic
   frequency: FREQUENT
-  notes: Can be presenting feature or develop over time
+  notes: >-
+    Can be a presenting feature or develop over time; base frequency follows
+    cohort evidence, while Orphanet's curated HPO annotation uses a higher
+    very-frequent band.
   evidence:
   - reference: PMID:35197085
     reference_title: "Wilson disease in Northern Portugal: a long-term follow-up study."
@@ -737,6 +761,17 @@ phenotypes:
     supports: PARTIAL
     snippet: "Liver transplantation is an option viewed as ultima ratio in end-stage liver disease with untreatable complications or acute liver failure."
     explanation: End-stage liver disease including cirrhosis is a major complication requiring transplantation.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives cirrhosis a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001394 | Cirrhosis | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies cirrhosis as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Cirrhosis
     term:
@@ -852,7 +887,10 @@ phenotypes:
   category: Ocular
   frequency: FREQUENT
   diagnostic: true
-  notes: Copper deposits in Descemet membrane, pathognomonic
+  notes: >-
+    Copper deposits in Descemet membrane, pathognomonic; base frequency follows
+    cohort detection data, while Orphanet's curated HPO annotation uses a
+    higher very-frequent band.
   evidence:
   - reference: PMID:16709660
     reference_title: "Clinical presentation, diagnosis and long-term outcome of Wilson's disease: a cohort study."
@@ -864,6 +902,17 @@ phenotypes:
     supports: SUPPORT
     snippet: "copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings"
     explanation: Confirms Kayser-Fleischer rings as a key clinical feature of Wilson's disease due to copper deposition in the eyes.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives Kayser-Fleischer ring a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0200032 | Kayser-Fleischer ring | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies Kayser-Fleischer ring as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Kayser-Fleischer ring
     term:
@@ -884,16 +933,39 @@ phenotypes:
     term:
       id: HP:6000642
       label: Sunflower cataract
-- name: Intellectual Disability
-  category: Neurological
+- name: Abnormality Of The Menstrual Cycle
+  category: Reproductive
   frequency: VERY_FREQUENT
   evidence:
   - reference: ORPHA:905
     reference_title: "Wilson disease (Orphanet structured-database record)"
     supports: SUPPORT
     evidence_source: OTHER
-    snippet: "HP:0001249 | Intellectual disability | Very frequent (99-80%)"
-    explanation: Orphanet's HPO table classifies intellectual disability as very frequent in Wilson disease.
+    snippet: "HP:0000140 | Abnormality of the menstrual cycle | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies abnormality of the menstrual cycle as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Abnormality of the menstrual cycle
+    term:
+      id: HP:0000140
+      label: Abnormality of the menstrual cycle
+- name: Intellectual Disability
+  category: Neurological
+  notes: >-
+    Base frequency is intentionally omitted because Wilson disease cognitive
+    dysfunction is not equivalent to formal intellectual disability across most
+    patients; the Orphanet curated annotation is retained as source-specific
+    context.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives intellectual disability a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001249 | Intellectual disability | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies intellectual disability as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Intellectual disability
     term:
@@ -1060,6 +1132,9 @@ phenotypes:
 - name: Dysarthria
   category: Neurological
   frequency: FREQUENT
+  notes: >-
+    Base frequency follows the broader clinical evidence already cited; Orphanet's
+    curated HPO annotation gives a higher very-frequent band.
   evidence:
   - reference: PMID:38731973
     reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
@@ -1071,6 +1146,17 @@ phenotypes:
     supports: SUPPORT
     snippet: "spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia"
     explanation: Confirms dysarthria among core neurologic Wilson disease features.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives dysarthria a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001260 | Dysarthria | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies dysarthria as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Dysarthria
     term:
@@ -1202,9 +1288,29 @@ phenotypes:
     term:
       id: HP:0002027
       label: Abdominal pain
+- name: Failure To Thrive
+  category: Constitutional
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001508 | Failure to thrive | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies failure to thrive as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
 - name: Weight Loss
   category: Constitutional
   frequency: VERY_FREQUENT
+  notes: >-
+    Orphanet also lists increased body weight as very frequent, which conflicts
+    with this weight-loss annotation; the weight-loss phenotype is retained and
+    the contradictory increased-body-weight row is not modeled as a base Wilson
+    disease phenotype.
   evidence:
   - reference: ORPHA:905
     reference_title: "Wilson disease (Orphanet structured-database record)"
@@ -1237,6 +1343,21 @@ phenotypes:
     term:
       id: HP:0000739
       label: Anxiety
+- name: Aggressive Behavior
+  category: Psychiatric
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000718 | Aggressive behavior | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies aggressive behavior as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Aggressive behavior
+    term:
+      id: HP:0000718
+      label: Aggressive behavior
 - name: Depression
   category: Psychiatric
   frequency: OCCASIONAL
@@ -1378,6 +1499,21 @@ phenotypes:
     term:
       id: HP:0001873
       label: Thrombocytopenia
+- name: Anemia
+  category: Hematologic
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001903 | Anemia | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies anemia as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Anemia
+    term:
+      id: HP:0001903
+      label: Anemia
 - name: Hemolytic Anemia
   category: Hematologic
   frequency: OCCASIONAL
@@ -1413,6 +1549,51 @@ phenotypes:
     term:
       id: HP:0002653
       label: Bone pain
+- name: Arthritis
+  category: Skeletal
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001369 | Arthritis | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies arthritis as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Arthritis
+    term:
+      id: HP:0001369
+      label: Arthritis
+- name: Joint Swelling
+  category: Skeletal
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001386 | Joint swelling | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies joint swelling as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Joint swelling
+    term:
+      id: HP:0001386
+      label: Joint swelling
+- name: Pathologic Fracture
+  category: Skeletal
+  frequency: VERY_FREQUENT
+  evidence:
+  - reference: ORPHA:905
+    reference_title: "Wilson disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002756 | Pathologic fracture | Very frequent (99-80%)"
+    explanation: Orphanet's HPO table classifies pathologic fracture as very frequent in Wilson disease.
+  phenotype_term:
+    preferred_term: Pathologic fracture
+    term:
+      id: HP:0002756
+      label: Pathologic fracture
 - name: Osteoporosis
   category: Skeletal
   frequency: FREQUENT
@@ -1458,12 +1639,26 @@ phenotypes:
       label: Osteopenia
 - name: Arthralgia
   category: Skeletal
+  notes: >-
+    Base frequency is not assigned from the presenting-symptom list alone;
+    Orphanet's curated HPO annotation gives a very-frequent frequency band.
   evidence:
   - reference: PMID:3595645
     reference_title: "Presenting symptoms and natural history of Wilson disease."
     supports: SUPPORT
     snippet: "the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia"
     explanation: Large case-series data identify arthralgia among the more common presenting symptoms of Wilson disease.
+  phenotype_contexts:
+  - population: Orphanet curated HPO annotation
+    frequency: VERY_FREQUENT
+    notes: Orphanet's structured HPO table gives arthralgia a very-frequent frequency band.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: "Wilson disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002829 | Arthralgia | Very frequent (99-80%)"
+      explanation: Orphanet's HPO table classifies arthralgia as very frequent in Wilson disease.
   phenotype_term:
     preferred_term: Arthralgia
     term:

--- a/references_cache/ORPHA_905.md
+++ b/references_cache/ORPHA_905.md
@@ -1,0 +1,134 @@
+---
+reference_id: "ORPHA:905"
+title: "Wilson disease"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:905  Wilson disease
+
+**ORPHA:905** — Wilson disease (Disease, Disorder)
+
+## Synonyms
+
+- Hepatolenticular degeneration
+
+## Definition
+
+A rare genetic disorder of copper metabolism presenting with non-specific hepatic, neurologic, psychiatric or ophthalmologic manifestations due to impaired biliary copper excretion and consecutive excessive copper deposition in the body.
+
+## Inheritance
+
+- Autosomal recessive
+
+## Natural history
+
+- Age of onset: Adolescent
+- Age of onset: Adult
+- Age of onset: Childhood
+- Age of onset: Elderly
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| 1-5 / 10 000 | China | Point prevalence | PMID:20301685 |
+| 1-9 / 100 000 | Europe | Point prevalence | PMID:2015 |
+| 1-9 / 1 000 000 | Finland | Annual incidence | PMID:32618023 |
+| 1-9 / 1 000 000 | Finland | Point prevalence | PMID:32618023 |
+| 1-9 / 100 000 | France | Point prevalence | PMID:28648494 |
+| 1-9 / 100 000 | Germany | Prevalence at birth | PMID:542546,PMID:17276780 |
+| 1-9 / 100 000 | Ireland | Prevalence at birth | PMID:8459248 |
+| 1-9 / 1 000 000 | Italy | Prevalence at birth | PMID:11953730 |
+| 1-5 / 10 000 | Japan | Prevalence at birth | PMID:7338703,PMID |
+| 1-5 / 10 000 | Specific population | Point prevalence | PMID:23486543 |
+| 1-5 / 10 000 | Specific population | Prevalence at birth | PMID:11953730 |
+| 1-9 / 100 000 | Worldwide | Point prevalence | PMID:31449670 |
+| 1-9 / 100 000 | Worldwide | Prevalence at birth | PMID:31449670 |
+
+## Genes
+
+| Symbol | Name | HGNC | Association |
+|---|---|---|---|
+| ATP7B | ATPase copper transporting beta | hgnc:870 | Disease-causing germline mutation(s) (loss of function) in |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000140 | Abnormality of the menstrual cycle | Very frequent (99-80%) |
+| HP:0000709 | Psychosis | Occasional (29-5%) |
+| HP:0000716 | Depression | Very frequent (99-80%) |
+| HP:0000718 | Aggressive behavior | Very frequent (99-80%) |
+| HP:0000738 | Hallucinations | Occasional (29-5%) |
+| HP:0000739 | Anxiety | Occasional (29-5%) |
+| HP:0000751 | Personality changes | Frequent (79-30%) |
+| HP:0000787 | Nephrolithiasis | Occasional (29-5%) |
+| HP:0000789 | Infertility | Occasional (29-5%) |
+| HP:0000829 | Hypoparathyroidism | Occasional (29-5%) |
+| HP:0000939 | Osteoporosis | Frequent (79-30%) |
+| HP:0000952 | Jaundice | Very frequent (99-80%) |
+| HP:0000978 | Bruising susceptibility | Very frequent (99-80%) |
+| HP:0000989 | Pruritus | Very frequent (99-80%) |
+| HP:0001155 | Abnormality of the hand | Very frequent (99-80%) |
+| HP:0001249 | Intellectual disability | Very frequent (99-80%) |
+| HP:0001250 | Seizure | Occasional (29-5%) |
+| HP:0001260 | Dysarthria | Very frequent (99-80%) |
+| HP:0001288 | Gait disturbance | Very frequent (99-80%) |
+| HP:0001288 | Gait disturbance | Frequent (79-30%) |
+| HP:0001332 | Dystonia | Frequent (79-30%) |
+| HP:0001337 | Tremor | Frequent (79-30%) |
+| HP:0001369 | Arthritis | Very frequent (99-80%) |
+| HP:0001386 | Joint swelling | Very frequent (99-80%) |
+| HP:0001394 | Cirrhosis | Very frequent (99-80%) |
+| HP:0001397 | Hepatic steatosis | Very frequent (99-80%) |
+| HP:0001508 | Failure to thrive | Very frequent (99-80%) |
+| HP:0001541 | Ascites | Occasional (29-5%) |
+| HP:0001733 | Pancreatitis | Occasional (29-5%) |
+| HP:0001744 | Splenomegaly | Very frequent (99-80%) |
+| HP:0001824 | Weight loss | Very frequent (99-80%) |
+| HP:0001873 | Thrombocytopenia | Very frequent (99-80%) |
+| HP:0001878 | Hemolytic anemia | Frequent (79-30%) |
+| HP:0001903 | Anemia | Very frequent (99-80%) |
+| HP:0002013 | Vomiting | Occasional (29-5%) |
+| HP:0002027 | Abdominal pain | Occasional (29-5%) |
+| HP:0002072 | Chorea | Frequent (79-30%) |
+| HP:0002240 | Hepatomegaly | Very frequent (99-80%) |
+| HP:0002312 | Clumsiness | Very frequent (99-80%) |
+| HP:0002653 | Bone pain | Very frequent (99-80%) |
+| HP:0002756 | Pathologic fracture | Very frequent (99-80%) |
+| HP:0002829 | Arthralgia | Very frequent (99-80%) |
+| HP:0002910 | Elevated circulating hepatic transaminase concentration | Very frequent (99-80%) |
+| HP:0003355 | Aminoaciduria | Occasional (29-5%) |
+| HP:0003418 | Back pain | Very frequent (99-80%) |
+| HP:0003781 | Excessive salivation | Occasional (29-5%) |
+| HP:0004324 | Increased body weight | Very frequent (99-80%) |
+| HP:0006554 | Acute hepatic failure | Very frequent (99-80%) |
+| HP:0008994 | Proximal muscle weakness in lower limbs | Very frequent (99-80%) |
+| HP:0010837 | Decreased circulating ceruloplasmin concentration | Frequent (79-30%) |
+| HP:0012115 | Hepatitis | Very frequent (99-80%) |
+| HP:0012748 | Focal T2 hyperintense brainstem lesion | Occasional (29-5%) |
+| HP:0100785 | Insomnia | Occasional (29-5%) |
+| HP:0200032 | Kayser-Fleischer ring | Very frequent (99-80%) |
+| HP:0200119 | Acute hepatitis | Very frequent (99-80%) |
+| HP:5200321 | Amplification of sexual behavior | Very frequent (99-80%) |
+| HP:6000642 | Sunflower cataract | Very rare (<4-1%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:7893 | Exact |
+| ICD-10:E83.0 | Narrower |
+| ICD-11:5C64.00 | Exact |
+| MONDO:0010200 | Exact |
+| MeSH:D006527 | Exact |
+| MedDRA:10019819 | Exact |
+| OMIM:277900 | Exact |
+| UMLS:C0019202 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=905)


### PR DESCRIPTION
## Summary

- Refreshed Orphadata and generated `references_cache/ORPHA_905.md` via the structured Orphanet rebuild workflow.
- Added ORPHA:905-backed Wilson disease metadata: MONDO cross-reference context, inheritance, worldwide/regional prevalence ranges, onset categories, selected HPO phenotype frequency evidence, ceruloplasmin phenotype evidence, and ATP7B gene-disease evidence.
- Kept generated validation side effects out of the commit; only the Wilson disease YAML and generated ORPHA:905 cache are included.

## Validation

- `just validate kb/disorders/Wilsons_Disease.yaml` passed.
- `just validate-references kb/disorders/Wilsons_Disease.yaml` passed, but reported `Total checks: 0` from the wrapper.
- `just validate-terms kb/disorders/Wilsons_Disease.yaml` passed.
- `just check-reference-cache-frontmatter` passed.
- `git diff --check` passed.
- Direct fixed-string check confirmed every new ORPHA:905 evidence snippet is present in `references_cache/ORPHA_905.md`.
- `just qc` was run; `Wilsons_Disease.yaml` passed in the all-disorder sweep, but the overall command failed on an unrelated pre-existing term label mismatch in `kb/disorders/Malignant_Peritoneal_Mesothelioma.yaml` for `NCIT:C36184` (`Necrotic Change` vs expected `Necrosis`).