### PR TITLE
Audit fix: replace 2 fabricated PMID caches found in <500B sweep (#1737)

### DIFF
--- a/kb/disorders/Beta_Mannosidosis.yaml
+++ b/kb/disorders/Beta_Mannosidosis.yaml
@@ -27,10 +27,10 @@ prevalence:
   - reference: PMID:9097826
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Only 11 cases of beta mannosidase deficiency have been reported until now and all showed mental retardation and in some cases hearing loss."
+    snippet: "Only 11 cases of beta mannosidase deficiency have been reported until now."
     explanation: >-
-      This older review documents the extremely small number of reported cases
-      in the early literature.
+      This 1997 case report documents the extremely small number of reported
+      cases in the early literature, supporting the ultra-rare prevalence framing.
   - reference: PMID:41235131
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL

--- a/references_cache/PMID_8482284.md
+++ b/references_cache/PMID_8482284.md
@@ -1,13 +1,49 @@
 ---
 reference_id: "PMID:8482284"
 title: "Campomelic dysplasia--an underdiagnosed condition?"
+authors:
+- Normann EK
+- Pedersen JC
+- Stiris G
+- van der Hagen CB
+journal: Eur J Pediatr
+year: '1993'
+doi: 10.1007/BF01956747
+keywords:
+- "Dwarfism/diagnosis, epidemiology"
+- Female
+- Humans
+- Incidence
+- "Infant, Newborn"
+- Norway/epidemiology
 content_type: abstract_only
 ---
 
 # Campomelic dysplasia--an underdiagnosed condition?
+**Authors:** Normann EK, Pedersen JC, Stiris G, van der Hagen CB
+**Journal:** Eur J Pediatr (1993)
+**DOI:** [10.1007/BF01956747](https://doi.org/10.1007/BF01956747)
 
 ## Content
 
-Campomelic dysplasia (CD) is a rare skeletal dysplasia. The incidence, reported in the literature, is 0.05-0.09 per 10,000 live births. During the period December 1985-December 1990 there were 18,350 live births with 4 cases of CD at Aker University Hospital in Oslo, Norway.
+1. Eur J Pediatr. 1993 Apr;152(4):331-3. doi: 10.1007/BF01956747.
 
-PMID: 8482284
+Campomelic dysplasia--an underdiagnosed condition?
+
+Normann EK(1), Pedersen JC, Stiris G, van der Hagen CB.
+
+Author information:
+(1)Department of Paediatrics, Aker University Hospital, Oslo, Norway.
+
+Campomelic dysplasia (CD) is a rare skeletal dysplasia. The incidence, reported 
+in the literature, is 0.05-0.09 per 10,000 live births. During the period 
+December 1985-December 1990 there were 18,350 live births with 4 cases of CD at 
+Aker University Hospital in Oslo, Norway. This gives an incidence of CD in our 
+observation period of 2.2 per 10,000. Eliminating our first case, because of 
+Pakistani decent, the total incidence is 1.6 per 10,000 among Norwegian infants 
+which is much higher than the incidence previously mentioned. Perhaps CD is 
+under-reported and a high proportion of patients remain undiagnosed. We present 
+four cases and discuss the incidence.
+
+DOI: 10.1007/BF01956747
+PMID: 8482284 [Indexed for MEDLINE]

--- a/references_cache/PMID_9097826.md
+++ b/references_cache/PMID_9097826.md
@@ -1,13 +1,63 @@
 ---
 reference_id: "PMID:9097826"
-title: "Beta-mannosidosis review"
+title: "[Beta mannosidosis: a new case]."
+authors:
+- Gourrier E
+- Thomas MP
+- Munnich A
+- Poenaru L
+- Asensi D
+- Jan D
+- Leraillez J
+journal: Arch Pediatr
+year: '1997'
+doi: 10.1016/s0929-693x(97)86159-3
+keywords:
+- Deglutition Disorders/etiology
+- Esophageal Motility Disorders/etiology
+- Female
+- Humans
+- Infant
+- "alpha-Mannosidosis/complications, diagnosis"
 content_type: abstract_only
 ---
 
-# Beta-mannosidosis review
+# [Beta mannosidosis: a new case].
+**Authors:** Gourrier E, Thomas MP, Munnich A, Poenaru L, Asensi D, Jan D, Leraillez J
+**Journal:** Arch Pediatr (1997)
+**DOI:** [10.1016/s0929-693x(97)86159-3](https://doi.org/10.1016/s0929-693x(97)86159-3)
 
 ## Content
 
-Only 11 cases of beta mannosidase deficiency have been reported until now and all showed mental retardation and in some cases hearing loss.
+1. Arch Pediatr. 1997 Feb;4(2):147-51. doi: 10.1016/s0929-693x(97)86159-3.
 
-PMID: 9097826
+[Beta mannosidosis: a new case].
+
+[Article in French]
+
+Gourrier E(1), Thomas MP, Munnich A, Poenaru L, Asensi D, Jan D, Leraillez J.
+
+Author information:
+(1)Service de néonatologie et réanimation, hôpital René-Dubos, Pontoise, France.
+
+BACKGROUND: Only 11 cases of beta mannosidase deficiency have been reported 
+until now. We report a new case.
+CASE HISTORY: J was born at full term to consanguineous parents; her weight was 
+2,080 g and her height was 44 cm. During the first months of life she was 
+hypotonic and had feeding difficulties. At the age of 7 months, she was admitted 
+to an intensive care unit because of a serious inhalation. Standard blood 
+analysis, chest X-ray, abdominal ultrasonography, electroencephalogram, cerebral 
+nuclear magnetic resonance and electromyography were normal. Blood and urine 
+amino acids and urine organic acids were also normal. The only detected 
+abnormality was a marked deficiency of beta mannosidase in her serum and 
+leukocytes. Later on, she suffered from recurring respiratory infections, and 
+she had abnormalities of esophageal mobility, hypotoria of the lower esophageal 
+sphincter, and at the age of 2 years, achalasia requiring surgery. To date, her 
+motor development is retarded.
+CONCLUSIONS: The main clinical manifestations of beta mannosidosis are various 
+degrees of mental retardation, speech disorders and hearing loss. Our patient 
+presented with abnormalities of swallowing and esophageal motility resulting in 
+recurring respiratory infections, previously reported in some other cases.
+
+DOI: 10.1016/s0929-693x(97)86159-3
+PMID: 9097826 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Continuing the broader sweep of small/paraphrastic `references_cache/PMID_*.md` files called for in #1737. Picks up where PR #1740 (1 fabricated cache, CADASIL) and PR #1773 (6 fabricated caches) left off.

## Method

Found all 19 `references_cache/PMID_*.md` files under 500 bytes and inspected each by hand. 17 are legitimate minimal entries — pre-abstract-era papers (1960s–80s) and language-barrier abstracts where PubMed simply has no full text. They carry real author / journal / year / DOI metadata.

Two had the same fabrication fingerprint flagged in the prior audit (no journal, no authors, paraphrastic title, "content" was the YAML snippet copy-pasted back so the validator's substring check was effectively comparing the snippet to itself):

| PMID | Cached title (fake) | Real title | File |
|------|--------------------|------------|------|
| 9097826 | "Beta-mannosidosis review" | "[Beta mannosidosis: a new case]." (Gourrier et al. 1997, Arch Pediatr) | `kb/disorders/Beta_Mannosidosis.yaml` |
| 8482284 | "Campomelic dysplasia--an underdiagnosed condition?" | same — title was real, but cache lacked authors/journal/year and content was just the snippet | `kb/disorders/Campomelic_Dysplasia.yaml` |

Both re-fetched via `linkml-reference-validator cache reference --force`.

## Snippet impact

- **`Beta_Mannosidosis.yaml`** — original snippet `"Only 11 cases of beta mannosidase deficiency have been reported until now and all showed mental retardation and in some cases hearing loss."` was a **fabricated mash-up**. The first half ("Only 11 cases of beta mannosidase deficiency have been reported until now.") is a real abstract substring; the second half paraphrases the conclusions section ("various degrees of mental retardation, speech disorders and hearing loss") and does not appear verbatim. Re-anchored to the real-quote prefix; explanation updated to reflect this is a single 1997 case report (not a review).
- **`Campomelic_Dysplasia.yaml`** — original snippet happens to be an exact substring of the real abstract. **No YAML edit required**; only the cache file was replaced.

## Validation

- `just validate kb/disorders/Beta_Mannosidosis.yaml` → ✅ schema + terms + references all pass
- `just validate kb/disorders/Campomelic_Dysplasia.yaml` → ✅ schema + terms + references all pass
- `just check-reference-cache-frontmatter` → ✅ pass

## Diff hygiene

Reverted ~40 cosmetic `reference_id: "PMID:NNNN"` quoting rewrites that `linkml-reference-validator` side-effected on unrelated cache files, and the `cache/enums/*.csv` / `cache/{go,hp}/terms.csv` term-list updates that the term validator emitted. The diff is strictly scoped to the two intended cache files plus the `Beta_Mannosidosis.yaml` snippet fix.

## Status of the issue

This run:
- Verified the 19 small (`<500B`) `PMID_*.md` cache files. 2 fabricated (here), 17 legitimate.
- Did **not** implement the defense-in-depth `check-reference-cache-frontmatter` strengthening (require `authors:` / `journal:` / minimum content length) — same scope decision as PR #1773; that change lives in the validator codebase and warrants its own design discussion.

A wider sweep (e.g., `PMID_*.md` files <1 KB, or files with `content_type: abstract_only` and content shorter than the YAML snippets that cite them) would catch the next tier; left for a follow-up.

## Test plan

- [ ] CI `validate-all`, `validate-references-all`, `validate-terms-all`, `check-reference-cache-frontmatter` pass
- [ ] Reviewer spot-check: `references_cache/PMID_9097826.md` carries real Gourrier 1997 abstract, `Beta_Mannosidosis.yaml` snippet is a substring of it
- [ ] Reviewer spot-check: `references_cache/PMID_8482284.md` carries real Normann 1993 abstract, `Campomelic_Dysplasia.yaml` snippet is a substring of it

🤖 Generated with [Claude Code](https://claude.com/claude-code)