### PR TITLE
fix: prevent review bot from cancelling its own reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
         type: number
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
One-line fix. The concurrency group didn't include event_name, so issue_comment events (from progress comments) cancelled in-progress pull_request reviews. Every PR review has been systematically cancelled since the issue_comment trigger was added.