### PR TITLE
[codex] Remove human author from PR shepherd candidates

### DIFF
--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -113,9 +113,8 @@ jobs:
 
             Candidate PRs:
             - If SPECIFIC_PR is set, inspect only that PR.
-            - Otherwise list open PRs in REPO and consider only PRs authored by:
-              `dragon-ai-agent`, `app/claude`, `app/github-actions`, `github-actions[bot]`, or
-              `cmungall`.
+            - Otherwise list open PRs in REPO and consider only bot-authored PRs from:
+              `dragon-ai-agent`, `app/claude`, `app/github-actions`, or `github-actions[bot]`.
             - Do not act on PRs from any other author.
 
             Gather enough context for each candidate before choosing:


### PR DESCRIPTION
## Summary

- Remove `cmungall` from the PR Shepherd candidate author list.
- Clarify that automatic shepherding should consider only bot-authored PRs.

## Impact

This keeps the shepherd workflow from tending human-authored PRs while preserving the existing bot-author allowlist.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-shepherd.yml"); puts "ok"'`
- `python3 -c 'from pathlib import Path; p=Path(".github/workflows/pr-shepherd.yml"); s=p.read_text(); assert "`cmungall`" not in s and "consider only bot-authored PRs" in s; print("ok")'`
- pre-commit hooks during commit: check yaml, end-of-file, trailing whitespace, yamllint, codespell