### PR TITLE
Add disease-level NCIT/MONDO mappings to Prostate Adenocarcinoma (#1115)

### DIFF
--- a/kb/disorders/Prostate_Adenocarcinoma.yaml
+++ b/kb/disorders/Prostate_Adenocarcinoma.yaml
@@ -1,6 +1,6 @@
 name: Prostate Adenocarcinoma
 creation_date: '2026-04-12T05:10:57Z'
-updated_date: '2026-04-12T16:03:50Z'
+updated_date: '2026-04-28T19:30:00Z'
 description: >-
   Prostate adenocarcinoma is the predominant histologic form of prostate cancer,
   arising from prostatic glandular epithelium and maintained by androgen
@@ -341,6 +341,21 @@ notes: >-
   separate entries [`Metastatic_Prostate_Cancer.yaml`](kb/disorders/Metastatic_Prostate_Cancer.yaml)
   and [`BRCA_Mutant_Prostate_Cancer.yaml`](kb/disorders/BRCA_Mutant_Prostate_Cancer.yaml)
   capture two important advanced or molecularly defined derivative states.
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0005082
+      label: prostate adenocarcinoma
+    mapping_predicate: skos:exactMatch
+    mapping_source: MONDO
+    mapping_justification: MONDO provides an exact disease term for prostate adenocarcinoma; this is the same term used as `disease_term` for this entry.
+  ncit_mappings:
+  - term:
+      id: NCIT:C2919
+      label: Prostate Adenocarcinoma
+    mapping_predicate: skos:exactMatch
+    mapping_source: NCIT
+    mapping_justification: NCIT provides an exact concept for prostate adenocarcinoma; MONDO:0005082 cross-references NCIT:C2919 in its xref list.
 classifications:
   icdo_morphology:
     classification_value: Adenocarcinoma


### PR DESCRIPTION
## Summary

Adds a disease-level `mappings:` block to `kb/disorders/Prostate_Adenocarcinoma.yaml`:

- `mondo_mappings` → `MONDO:0005082` (prostate adenocarcinoma) — `skos:exactMatch`
- `ncit_mappings` → `NCIT:C2919` (Prostate Adenocarcinoma) — `skos:exactMatch`

This matches the pattern recently established by:
- PR #1797 — Anaplastic Thyroid Carcinoma (`MONDO:0006468` / `NCIT:C3878`)
- PR #1805 — Bladder Urothelial Carcinoma (`MONDO:0005611` / `NCIT:C39851`)
- PR #1825 — Rhabdoid Tumor

## Term verification

Both terms verified with OAK against the local sqlite adapters:

```
runoak -i sqlite:obo:mondo info MONDO:0005082
  → MONDO:0005082 ! prostate adenocarcinoma
runoak -i sqlite:obo:ncit info NCIT:C2919
  → NCIT:C2919 ! Prostate Adenocarcinoma
```

The labels in the YAML exactly match these canonical labels (per CLAUDE.md "description MUST exactly match the ontology term's canonical label" rule).

## Scope

Single-file edit: 16 insertions (+ a one-line `updated_date` bump), no PMID lookups, no new evidence, no schema changes. Strictly addresses the NCIT/MONDO-mappings item in the prior scanner triage on #1115.

## Validation

- `just validate kb/disorders/Prostate_Adenocarcinoma.yaml` → schema + terms + references all pass

## Related

Issue #1115. Same mappings-enrichment pattern as #1797 / #1805 / #1825.

## Test plan

- [x] Schema validates
- [x] Terms validate
- [x] References validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)