### PR TITLE
Migrate CDI FMT `clinical course` qualifier to `temporality: RECURRENT` (#1613, Phase 3)

### DIFF
--- a/kb/disorders/Clostridioides_difficile_Infection.yaml
+++ b/kb/disorders/Clostridioides_difficile_Infection.yaml
@@ -657,17 +657,7 @@ treatments:
     term:
       id: MAXO:0000748
       label: fecal microbiota transplantation
-    qualifiers:
-    - predicate:
-        preferred_term: clinical course
-        term:
-          id: NCIT:C28008
-          label: Clinical Course
-      value:
-        preferred_term: recurrent disease
-        term:
-          id: MONDO:0700096
-          label: recurrent disease
+    temporality: RECURRENT
   evidence:
   - reference: PMID:38508330
     reference_title: "Management of Clostridioides difficile Infection: Diagnosis, Treatment, and Future Perspectives."


### PR DESCRIPTION
## Summary

Bounded **Phase 3** action against issue #1613 (qualifiers migration). Migrates the **single** record in the KB whose `qualifiers:` block cleanly maps to one of the four explicit post-composition slots introduced by PR #1612.

- File: `kb/disorders/Clostridioides_difficile_Infection.yaml`
- Treatment: `Fecal microbiota transplantation` (`MAXO:0000748`)
- Old: `qualifiers:` with `predicate: clinical course (NCIT:C28008)` / `value: recurrent disease (MONDO:0700096)`
- New: `temporality: RECURRENT`

## Slot correction vs. prior #1613 assessment

The 2026-04-23 scanner assessment on #1613 suggested this row maps to `clinical_course:`. It actually maps to `temporality: RECURRENT` because:

- `ClinicalCourseEnum` = `{PROGRESSIVE, STABLE}` — no `RECURRENT` member
- `TemporalityEnum` includes `RECURRENT` (`HP:0031796` "Recurrent")
- `CLAUDE.md` documents `RECURRENT` under `temporality`, not `clinical_course`

The descriptor’s `description` (FMT for *recurrent infections*) and the linked evidence snippets ("recurrent C. difficile infection", "recurrent CDI") both confirm the temporal-recurrence reading.

## Phases not addressed in this PR

This is a strictly bounded Phase 3 PR. The four other phases from the prior assessment all remain:

- **Phase 1** — Migrate `therapeutic agent` / `pharmacologic substance` qualifiers (~135 rows, ~60 files) to the existing `therapeutic_agent:` slot. Mechanical and well-defined, but large enough to warrant explicit authorization before execution.
- **Phase 2** — Schema decision: do `surgical procedure`, `diagnostic procedure`, `route of administration`, etc. (~312 rows) warrant new first-class slots, or stay in `qualifiers:` as the documented escape hatch? Needs a separate design issue.
- **Phase 4** — Migrate remaining predicates per the Phase 2 outcome.
- **Phase 5** — Deprecate / remove `qualifiers:` from the schema once 1–4 are complete.

## Validation

```
just validate kb/disorders/Clostridioides_difficile_Infection.yaml
→ Schema validation: No issues found
→ Term validation: ✅ Validation passed
→ Reference validation: ✓ All validations passed
```

## Test plan

- [ ] CI `validate-all` passes
- [ ] CI `validate-terms-all` passes
- [ ] CI `validate-references-all` passes
- [ ] Spot-check rendered HTML for the FMT block on `Clostridioides_difficile_Infection` to confirm renderer handles `temporality:` on a `treatment_term`

Refs #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)