### PR TITLE
PR shepherd: also tend PRs on claude/ branches

### DIFF
--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -113,10 +113,13 @@ jobs:
 
             Candidate PRs:
             - If SPECIFIC_PR is set, inspect only that PR.
-            - Otherwise list open PRs in REPO and consider only PRs authored by:
-              `dragon-ai-agent`, `app/claude`, `app/github-actions`, `github-actions[bot]`, or
-              `cmungall`.
-            - Do not act on PRs from any other author.
+            - Otherwise list open PRs in REPO and consider PRs that match EITHER criterion:
+              (a) authored by: `dragon-ai-agent`, `app/claude`, `app/github-actions`,
+                  `github-actions[bot]`, or `cmungall`, OR
+              (b) the head branch name starts with `claude/` (these are Claude Code–created
+                  branches that may be authored by any user who triggered the session).
+            - A PR matching either (a) or (b) is a candidate. Do not act on PRs that match
+              neither criterion.
 
             Gather enough context for each candidate before choosing:
             - PR metadata: author, draft state, base/head refs, head SHA, updated/created time,


### PR DESCRIPTION
## Summary
- Expands PR shepherd candidate filter to include PRs whose head branch starts with `claude/`, in addition to the existing author-based filter
- Claude Code sessions create `claude/`-prefixed branches that may be authored by any user who triggered the session, so the author filter alone missed them

## Test plan
- [ ] Trigger shepherd with `dry_run: true` and verify claude/-branched PRs appear as candidates
- [ ] Verify non-claude, non-bot PRs are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)