### PR TITLE
Incorporate Orphanet evidence for Stickler Syndrome Type 1

### DIFF
--- a/kb/disorders/Stickler_Syndrome_Type_1.yaml
+++ b/kb/disorders/Stickler_Syndrome_Type_1.yaml
@@ -1,6 +1,6 @@
 name: Stickler Syndrome Type 1
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-04-28T18:00:00Z'
+updated_date: '2026-04-29T12:00:00Z'
 category: Mendelian
 description: >
   Stickler syndrome type 1 (STL1) is the most common and mildest form of the type
@@ -119,7 +119,7 @@ prevalence:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Background:  Stickler syndrome is the most common genetic cause of rhegmatogenous retinal detachment (RRD) in children, and has a high risk of blindness. Type I (STL1) is the most common subtype, caused by COL2A1 mutations.
+      BACKGROUND: Stickler syndrome is the most common genetic cause of rhegmatogenous retinal detachment (RRD) in children, and has a high risk of blindness. Type I (STL1) is the most common subtype, caused by COL2A1 mutations.
     explanation: >-
       This systematic review supports using the overall Stickler incidence as a
       proxy in the type 1 file because STL1 is the most common subtype.
@@ -203,6 +203,8 @@ pathophysiology:
     explanation: >
       Study examining vitreous phenotypes confirms that premature termination
       codons causing haploinsufficiency are the predominant mutation type in STL1.
+  downstream:
+  - target: Vitreous Collagen Abnormality
 - name: Vitreous Collagen Abnormality
   description: >
     Type II collagen is essential for vitreous structure. Reduced collagen
@@ -240,10 +242,27 @@ pathophysiology:
 genetic:
 - name: COL2A1 Mutations
   association: Causative
+  gene_term:
+    preferred_term: COL2A1
+    term:
+      id: hgnc:2200
+      label: COL2A1
   notes: >
     Heterozygous null mutations in COL2A1 causing haploinsufficiency. Most are
     premature termination codons (nonsense mutations, frameshift mutations, or
     splice mutations leading to frameshifts) that trigger nonsense-mediated decay.
+  evidence:
+  - reference: PMID:20179744
+    reference_title: "Stickler syndrome caused by COL2A1 mutations: genotype-phenotype correlation in a series of 100 patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Stickler syndrome type 1 is predominantly caused by loss-of-function
+      mutations in the COL2A1 gene as >90% of the mutations were predicted
+      to result in nonsense-mediated decay.
+    explanation: >
+      Large genotype-phenotype study confirms COL2A1 as the causative gene
+      for STL1 with haploinsufficiency as the predominant mechanism.
 phenotypes:
 - name: Membranous Vitreous
   frequency: VERY_FREQUENT
@@ -381,9 +400,11 @@ phenotypes:
     snippet: "HP:0000505 | Visual impairment | Very frequent (99-80%)"
     explanation: Orphanet records visual impairment as very frequent in Stickler syndrome.
 - name: Cataract
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   description: >
-    Cataracts are a common ocular complication in Stickler syndrome.
+    Cataracts are a common ocular complication in Stickler syndrome. Orphanet
+    reports very frequent for all Stickler types combined; frequency in STL1
+    specifically may be lower as STL2/STL3 have more prominent cataracts.
   phenotype_term:
     preferred_term: Cataract
     term:
@@ -395,7 +416,10 @@ phenotypes:
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "HP:0000518 | Cataract | Very frequent (99-80%)"
-    explanation: Orphanet records cataract as very frequent in Stickler syndrome.
+    explanation: >
+      Orphanet records cataract as very frequent across all Stickler subtypes.
+      Downgraded to FREQUENT for STL1 specifically as STL2/STL3 have more
+      prominent cataract involvement.
 - name: Lattice Retinal Degeneration
   frequency: FREQUENT
   description: >
@@ -570,19 +594,32 @@ phenotypes:
   frequency: VERY_FREQUENT
   description: >
     Joint pain, often widespread, is very common and may precede the
-    development of osteoarthritis.
+    development of osteoarthritis. Orphanet reports very frequent across all
+    Stickler subtypes; retained as very frequent for STL1 given the 75%
+    early-onset osteoarthritis rate documented in the literature.
   phenotype_term:
     preferred_term: Arthralgia
     term:
       id: HP:0002829
       label: Arthralgia
   evidence:
+  - reference: PMID:20462780
+    reference_title: "Early-onset progressive osteoarthritis with hereditary progressive ophtalmopathy or Stickler syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Osteoarthritis (75% of patients) with onset before 30 years of age is
+      a severe manifestation that causes chronic hip and low back pain and
+      functional impairments. Joint replacement surgery is often required.
+    explanation: >
+      The 75% rate of early-onset osteoarthritis with chronic pain supports
+      VERY_FREQUENT arthralgia in Stickler syndrome.
   - reference: ORPHA:828
     reference_title: "Stickler syndrome (Orphanet structured-database record)"
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "HP:0002829 | Arthralgia | Very frequent (99-80%)"
-    explanation: Orphanet records arthralgia as very frequent in Stickler syndrome.
+    explanation: Orphanet records arthralgia as very frequent across all Stickler subtypes.
 - name: Joint Hypermobility
   frequency: FREQUENT
   description: >
@@ -629,10 +666,12 @@ phenotypes:
     snippet: "HP:0002758 | Osteoarthritis | Frequent (79-30%)"
     explanation: Orphanet records osteoarthritis as frequent in Stickler syndrome.
 - name: Skeletal Dysplasia
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   description: >
-    Generalized skeletal dysplasia with abnormalities of vertebral bodies
-    and epiphyses.
+    Skeletal dysplasia with abnormalities of vertebral bodies and epiphyses.
+    Orphanet reports very frequent across all Stickler types; downgraded to
+    frequent for STL1 specifically as skeletal features are relatively mild
+    compared to other type 2 collagenopathies.
   phenotype_term:
     preferred_term: Skeletal dysplasia
     term:
@@ -644,7 +683,10 @@ phenotypes:
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "HP:0002652 | Skeletal dysplasia | Very frequent (99-80%)"
-    explanation: Orphanet records skeletal dysplasia as very frequent in Stickler syndrome.
+    explanation: >
+      Orphanet records skeletal dysplasia as very frequent across all Stickler
+      subtypes. Downgraded to FREQUENT for STL1 specifically as skeletal
+      features are relatively mild in this subtype.
 - name: Scoliosis
   frequency: FREQUENT
   description: >
@@ -725,6 +767,70 @@ phenotypes:
     evidence_source: OTHER
     snippet: "HP:0001166 | Arachnodactyly | Frequent (79-30%)"
     explanation: Orphanet records arachnodactyly as frequent in Stickler syndrome.
+- name: Kyphosis
+  frequency: FREQUENT
+  description: >
+    Exaggerated thoracic kyphosis as part of the spinal manifestations.
+  phenotype_term:
+    preferred_term: Kyphosis
+    term:
+      id: HP:0002808
+      label: Kyphosis
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002808 | Kyphosis | Frequent (79-30%)"
+    explanation: Orphanet records kyphosis as frequent in Stickler syndrome.
+- name: Pectus Carinatum
+  frequency: FREQUENT
+  description: >
+    Protrusion of the sternum reflecting connective tissue abnormalities.
+  phenotype_term:
+    preferred_term: Pectus carinatum
+    term:
+      id: HP:0000768
+      label: Pectus carinatum
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000768 | Pectus carinatum | Frequent (79-30%)"
+    explanation: Orphanet records pectus carinatum as frequent in Stickler syndrome.
+- name: Spondylolisthesis
+  frequency: FREQUENT
+  description: >
+    Anterior slippage of vertebrae, contributing to spinal instability.
+  phenotype_term:
+    preferred_term: Spondylolisthesis
+    term:
+      id: HP:0003302
+      label: Spondylolisthesis
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0003302 | Spondylolisthesis | Frequent (79-30%)"
+    explanation: Orphanet records spondylolisthesis as frequent in Stickler syndrome.
+- name: Chronic Otitis Media
+  frequency: FREQUENT
+  description: >
+    Chronic middle ear infections contributing to conductive hearing loss.
+  phenotype_term:
+    preferred_term: Chronic otitis media
+    term:
+      id: HP:0000389
+      label: Chronic otitis media
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000389 | Chronic otitis media | Frequent (79-30%)"
+    explanation: Orphanet records chronic otitis media as frequent in Stickler syndrome.
 treatments:
 - name: Prophylactic Retinal Treatment
   description: >
@@ -762,6 +868,11 @@ treatments:
   description: >
     Regular audiologic monitoring with hearing aids as needed for
     progressive hearing loss.
+  treatment_term:
+    preferred_term: Hearing aid usage
+    term:
+      id: MAXO:0009030
+      label: hearing aid usage
 - name: Joint Protection
   description: >
     Physical therapy, joint protection strategies, and management

--- a/kb/disorders/Stickler_Syndrome_Type_1.yaml
+++ b/kb/disorders/Stickler_Syndrome_Type_1.yaml
@@ -1,6 +1,6 @@
 name: Stickler Syndrome Type 1
 creation_date: '2026-02-06T03:25:37Z'
-updated_date: '2026-02-17T21:53:14Z'
+updated_date: '2026-04-28T18:00:00Z'
 category: Mendelian
 description: >
   Stickler syndrome type 1 (STL1) is the most common and mildest form of the type
@@ -19,11 +19,84 @@ disease_term:
 parents:
 - Type 2 Collagenopathy
 - Stickler Syndrome
+definitions:
+- name: Orphanet disease definition
+  definition_type: CASE_DEFINITION
+  description: >
+    Orphanet defines Stickler syndrome as a rare group of genetic connective
+    tissue disorders characterized by ophthalmic, auditory, orofacial and
+    articular manifestations, with type 1 distinguished by a vestigial
+    vitreous gel bordered by a distinct folded membrane.
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "A rare group of genetic connective tissue disorders characterized by ophthalmic, auditory, orofacial and articular manifestations"
+    explanation: Orphanet's definition for the broader Stickler syndrome group encompasses the type 1 subtype.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "stickler type 1 by a vestigial vitreous gel in the immediate retrolental space, bordered by a distinct folded membrane"
+    explanation: Orphanet's definition explicitly describes the type 1 vitreous phenotype.
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0019354
+      label: Stickler syndrome
+    mapping_predicate: skos:broadMatch
+    mapping_source: ORPHA:828
+    mapping_justification: >
+      Orphanet lists MONDO:0019354 as an exact cross-reference for the broader
+      Stickler syndrome grouping class. This entry curates type 1 specifically
+      (MONDO:0007160), so the mapping is broad.
+    consistency:
+    - reference: ORPHA:828
+      consistent: CONSISTENT
+      notes: "MONDO:0019354 | Exact"
+external_assertions:
+- name: Orphanet Stickler syndrome record
+  source: Orphanet
+  assertion_type: Structured disease record
+  external_id: ORPHA:828
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=828
+  description: >
+    Orphanet structured record for Stickler syndrome (all types), including
+    curated cross-references to MONDO, ICD-10, ICD-11, OMIM, MedDRA, and UMLS
+    identifiers. ORPHA:828 covers the broader Stickler syndrome group; type 1
+    is the most common subtype and the primary referent for COL2A1-related
+    findings in this record.
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "MONDO:0019354 | Exact"
+    explanation: The Orphanet cross-reference table maps ORPHA:828 to MONDO:0019354.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "OMIM:108300 | Broader"
+    explanation: Orphanet maps to OMIM:108300 (STL1) as a broader mapping, confirming type 1 is a subtype of the ORPHA:828 group.
 inheritance:
 - name: Autosomal Dominant
   description: >
     Autosomal dominant inheritance with high penetrance but variable expressivity.
     Both familial cases and de novo mutations occur.
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Autosomal dominant"
+    explanation: Orphanet records autosomal dominant inheritance for Stickler syndrome, consistent with STL1.
 prevalence:
 - population: Live births with Stickler syndrome overall; type 1 is the most common subtype
   percentage: 1 in 21,844 live births (Stickler syndrome overall)
@@ -50,6 +123,42 @@ prevalence:
     explanation: >-
       This systematic review supports using the overall Stickler incidence as a
       proxy in the type 1 file because STL1 is the most common subtype.
+- population: Europe (Orphanet point prevalence)
+  percentage: 0.001-0.009
+  notes: Orphanet reports 1-9 per 100,000 point prevalence in Europe for Stickler syndrome overall.
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-9 / 100 000 | Europe | Point prevalence | PMID:2012"
+    explanation: Orphanet epidemiology table provides a European point-prevalence class for Stickler syndrome.
+- population: Worldwide (Orphanet prevalence at birth)
+  percentage: 0.01-0.05
+  notes: Orphanet reports 1-5 per 10,000 prevalence at birth worldwide for Stickler syndrome overall.
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "1-5 / 10 000 | Worldwide | Prevalence at birth | PMID:20301479"
+    explanation: Orphanet epidemiology table provides a worldwide prevalence-at-birth class for Stickler syndrome.
+progression:
+- phase: Onset
+  age_range: Antenatal to Childhood
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Antenatal"
+    explanation: Orphanet records antenatal onset as the earliest age-of-onset category for Stickler syndrome, consistent with congenital vitreous and craniofacial findings.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Infancy"
+    explanation: Orphanet also records infancy as an onset category, reflecting early recognition of myopia, hearing loss, and midface hypoplasia.
 pathophysiology:
 - name: Type II Collagen Haploinsufficiency
   description: >
@@ -137,6 +246,7 @@ genetic:
     splice mutations leading to frameshifts) that trigger nonsense-mediated decay.
 phenotypes:
 - name: Membranous Vitreous
+  frequency: VERY_FREQUENT
   description: >
     Characteristic membranous vitreous appearance on slit-lamp examination,
     pathognomonic for STL1.
@@ -168,7 +278,34 @@ phenotypes:
     explanation: >
       Vitreous anomalies are significantly associated with confirmed COL2A1
       mutations in STL1 patients.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0031153 | Membranous vitreous appearance | Frequent (79-30%)"
+    explanation: >
+      Orphanet records membranous vitreous appearance as frequent in Stickler
+      syndrome. Frequency may be higher in type 1 specifically given COL2A1
+      haploinsufficiency universally produces this phenotype.
+- name: Abnormal Vitreous Humor Morphology
+  frequency: VERY_FREQUENT
+  description: >
+    Abnormal vitreous humor morphology encompassing both membranous and other
+    vitreous structural abnormalities.
+  phenotype_term:
+    preferred_term: Abnormal vitreous humor morphology
+    term:
+      id: HP:0004327
+      label: Abnormal vitreous humor morphology
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0004327 | Abnormal vitreous humor morphology | Very frequent (99-80%)"
+    explanation: Orphanet records abnormal vitreous humor morphology as very frequent in Stickler syndrome.
 - name: High Myopia
+  frequency: VERY_FREQUENT
   description: >
     Congenital high myopia, often severe, is a cardinal feature.
   phenotype_term:
@@ -176,7 +313,21 @@ phenotypes:
     term:
       id: HP:0000545
       label: Myopia
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000545 | Myopia | Very frequent (99-80%)"
+    explanation: Orphanet records myopia as very frequent in Stickler syndrome.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0011003 | High myopia | Frequent (79-30%)"
+    explanation: Orphanet also records high myopia specifically as frequent, supporting severe myopia as a common feature.
 - name: Retinal Detachment
+  frequency: VERY_FREQUENT
   description: >
     Significantly increased lifetime risk of retinal detachment, often
     giant retinal tears. May be bilateral and recurrent.
@@ -206,7 +357,64 @@ phenotypes:
       may cause blindness (4% of cases).
     explanation: >
       Review confirms the high retinal detachment risk in Stickler syndrome.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000541 | Retinal detachment | Very frequent (99-80%)"
+    explanation: Orphanet records retinal detachment as very frequent in Stickler syndrome.
+- name: Visual Impairment
+  frequency: VERY_FREQUENT
+  description: >
+    Visual impairment resulting from myopia, retinal detachment, cataracts,
+    and other ocular complications.
+  phenotype_term:
+    preferred_term: Visual impairment
+    term:
+      id: HP:0000505
+      label: Visual impairment
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000505 | Visual impairment | Very frequent (99-80%)"
+    explanation: Orphanet records visual impairment as very frequent in Stickler syndrome.
+- name: Cataract
+  frequency: VERY_FREQUENT
+  description: >
+    Cataracts are a common ocular complication in Stickler syndrome.
+  phenotype_term:
+    preferred_term: Cataract
+    term:
+      id: HP:0000518
+      label: Cataract
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000518 | Cataract | Very frequent (99-80%)"
+    explanation: Orphanet records cataract as very frequent in Stickler syndrome.
+- name: Lattice Retinal Degeneration
+  frequency: FREQUENT
+  description: >
+    Lattice degeneration of the retina predisposing to retinal tears and
+    detachment.
+  phenotype_term:
+    preferred_term: Lattice retinal degeneration
+    term:
+      id: HP:0007992
+      label: Lattice retinal degeneration
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0007992 | Lattice retinal degeneration | Frequent (79-30%)"
+    explanation: Orphanet records lattice retinal degeneration as frequent in Stickler syndrome.
 - name: Sensorineural Hearing Loss
+  frequency: FREQUENT
   description: >
     Progressive sensorineural hearing loss, typically high-frequency,
     affects many individuals.
@@ -237,7 +445,31 @@ phenotypes:
     explanation: >
       While hearing loss is less frequent in STL1 (COL2A1) than other types,
       over half of STL1 patients have hearing impairment.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000407 | Sensorineural hearing impairment | Frequent (79-30%)"
+    explanation: Orphanet records sensorineural hearing impairment as frequent in Stickler syndrome.
+- name: Hearing Impairment
+  frequency: FREQUENT
+  description: >
+    General hearing impairment including conductive and mixed types in addition
+    to sensorineural loss, often related to chronic otitis media.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000365 | Hearing impairment | Frequent (79-30%)"
+    explanation: Orphanet records hearing impairment as frequent in Stickler syndrome.
 - name: Midface Hypoplasia
+  frequency: VERY_FREQUENT
   description: >
     Flat midface with depressed nasal bridge is common.
   phenotype_term:
@@ -245,7 +477,64 @@ phenotypes:
     term:
       id: HP:0011800
       label: Midface retrusion
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0011800 | Midface retrusion | Very frequent (99-80%)"
+    explanation: Orphanet records midface retrusion as very frequent in Stickler syndrome.
+- name: Depressed Nasal Bridge
+  frequency: VERY_FREQUENT
+  description: >
+    Depressed nasal bridge contributing to the characteristic flat facial profile.
+  phenotype_term:
+    preferred_term: Depressed nasal bridge
+    term:
+      id: HP:0005280
+      label: Depressed nasal bridge
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0005280 | Depressed nasal bridge | Very frequent (99-80%)"
+    explanation: Orphanet records depressed nasal bridge as very frequent in Stickler syndrome.
+- name: Microretrognathia
+  frequency: VERY_FREQUENT
+  description: >
+    Small, posteriorly positioned jaw contributing to Pierre Robin sequence
+    when present.
+  phenotype_term:
+    preferred_term: Microretrognathia
+    term:
+      id: HP:0000308
+      label: Microretrognathia
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000308 | Microretrognathia | Very frequent (99-80%)"
+    explanation: Orphanet records microretrognathia as very frequent in Stickler syndrome.
+- name: Malar Flattening
+  frequency: VERY_FREQUENT
+  description: >
+    Flattened malar region contributing to the midface hypoplasia phenotype.
+  phenotype_term:
+    preferred_term: Malar flattening
+    term:
+      id: HP:0000272
+      label: Malar flattening
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000272 | Malar flattening | Very frequent (99-80%)"
+    explanation: Orphanet records malar flattening as very frequent in Stickler syndrome.
 - name: Cleft Palate
+  frequency: FREQUENT
   description: >
     Cleft palate, often Pierre Robin sequence with micrognathia
     and glossoptosis, occurs in some affected individuals.
@@ -254,7 +543,48 @@ phenotypes:
     term:
       id: HP:0000175
       label: Cleft palate
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000175 | Cleft palate | Frequent (79-30%)"
+    explanation: Orphanet records cleft palate as frequent in Stickler syndrome.
+- name: Glossoptosis
+  frequency: FREQUENT
+  description: >
+    Posterior displacement of the tongue, often as part of Pierre Robin sequence.
+  phenotype_term:
+    preferred_term: Glossoptosis
+    term:
+      id: HP:0000162
+      label: Glossoptosis
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000162 | Glossoptosis | Frequent (79-30%)"
+    explanation: Orphanet records glossoptosis as frequent in Stickler syndrome.
+- name: Arthralgia
+  frequency: VERY_FREQUENT
+  description: >
+    Joint pain, often widespread, is very common and may precede the
+    development of osteoarthritis.
+  phenotype_term:
+    preferred_term: Arthralgia
+    term:
+      id: HP:0002829
+      label: Arthralgia
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002829 | Arthralgia | Very frequent (99-80%)"
+    explanation: Orphanet records arthralgia as very frequent in Stickler syndrome.
 - name: Joint Hypermobility
+  frequency: FREQUENT
   description: >
     Generalized joint hypermobility is common in childhood, often
     evolving into joint pain and early-onset osteoarthritis.
@@ -263,7 +593,15 @@ phenotypes:
     term:
       id: HP:0001382
       label: Joint hypermobility
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001382 | Joint hypermobility | Frequent (79-30%)"
+    explanation: Orphanet records joint hypermobility as frequent in Stickler syndrome.
 - name: Premature Osteoarthritis
+  frequency: FREQUENT
   description: >
     Premature degenerative joint disease, particularly affecting
     weight-bearing joints.
@@ -284,6 +622,109 @@ phenotypes:
     explanation: >
       Review documents high prevalence of early-onset osteoarthritis in
       Stickler syndrome, with 75% of patients affected before age 30.
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002758 | Osteoarthritis | Frequent (79-30%)"
+    explanation: Orphanet records osteoarthritis as frequent in Stickler syndrome.
+- name: Skeletal Dysplasia
+  frequency: VERY_FREQUENT
+  description: >
+    Generalized skeletal dysplasia with abnormalities of vertebral bodies
+    and epiphyses.
+  phenotype_term:
+    preferred_term: Skeletal dysplasia
+    term:
+      id: HP:0002652
+      label: Skeletal dysplasia
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002652 | Skeletal dysplasia | Very frequent (99-80%)"
+    explanation: Orphanet records skeletal dysplasia as very frequent in Stickler syndrome.
+- name: Scoliosis
+  frequency: FREQUENT
+  description: >
+    Scoliosis occurs frequently as part of the skeletal manifestations.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002650 | Scoliosis | Frequent (79-30%)"
+    explanation: Orphanet records scoliosis as frequent in Stickler syndrome.
+- name: Platyspondyly
+  frequency: FREQUENT
+  description: >
+    Flattened vertebral bodies seen on spinal imaging.
+  phenotype_term:
+    preferred_term: Platyspondyly
+    term:
+      id: HP:0000926
+      label: Platyspondyly
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000926 | Platyspondyly | Frequent (79-30%)"
+    explanation: Orphanet records platyspondyly as frequent in Stickler syndrome.
+- name: Mitral Valve Prolapse
+  frequency: FREQUENT
+  description: >
+    Mitral valve prolapse related to connective tissue abnormalities.
+  phenotype_term:
+    preferred_term: Mitral valve prolapse
+    term:
+      id: HP:0001634
+      label: Mitral valve prolapse
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001634 | Mitral valve prolapse | Frequent (79-30%)"
+    explanation: Orphanet records mitral valve prolapse as frequent in Stickler syndrome.
+- name: Hypotonia
+  frequency: FREQUENT
+  description: >
+    Muscular hypotonia, particularly in infancy and early childhood.
+  phenotype_term:
+    preferred_term: Hypotonia
+    term:
+      id: HP:0001252
+      label: Hypotonia
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001252 | Hypotonia | Frequent (79-30%)"
+    explanation: Orphanet records hypotonia as frequent in Stickler syndrome.
+- name: Arachnodactyly
+  frequency: FREQUENT
+  description: >
+    Long, slender fingers reflecting the underlying connective tissue disorder.
+  phenotype_term:
+    preferred_term: Arachnodactyly
+    term:
+      id: HP:0001166
+      label: Arachnodactyly
+  evidence:
+  - reference: ORPHA:828
+    reference_title: "Stickler syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001166 | Arachnodactyly | Frequent (79-30%)"
+    explanation: Orphanet records arachnodactyly as frequent in Stickler syndrome.
 treatments:
 - name: Prophylactic Retinal Treatment
   description: >

--- a/references_cache/ORPHA_828.md
+++ b/references_cache/ORPHA_828.md
@@ -1,0 +1,150 @@
+---
+reference_id: "ORPHA:828"
+title: "Stickler syndrome"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:828  Stickler syndrome
+
+**ORPHA:828** — Stickler syndrome (Disease, Disorder)
+
+## Synonyms
+
+- Hereditary progressive arthroophthalmopathy
+
+## Definition
+
+A rare group of genetic connective tissue disorders characterized by ophthalmic, auditory, orofacial and articular manifestations. The two main clinical forms are clinically distinguished by the vitreous phenotype; stickler type 1 by a vestigial vitreous gel in the immediate retrolental space, bordered by a distinct folded membrane, and Stickler type 2 by sparse and irregularly thickened bundles of &#64257;bers throughout the vitreous cavity.
+
+## Inheritance
+
+- Autosomal dominant
+- Autosomal recessive
+
+## Natural history
+
+- Age of onset: Antenatal
+- Age of onset: Childhood
+- Age of onset: Infancy
+- Age of onset: Neonatal
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| 1-9 / 100 000 | Europe | Point prevalence | PMID:2012 |
+| 1-9 / 100 000 | Europe | Prevalence at birth | PMID:2012 |
+| 1-9 / 1 000 000 | France | Point prevalence | PMID:22925539 |
+| 1-9 / 1 000 000 | France | Prevalence at birth | PMID:22925539 |
+| 1-5 / 10 000 | Worldwide | Prevalence at birth | PMID:20301479 |
+
+## Genes
+
+| Symbol | Name | HGNC | Association |
+|---|---|---|---|
+| BMP4 | bone morphogenetic protein 4 | hgnc:1071 | Disease-causing germline mutation(s) in |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000158 | Macroglossia | Frequent (79-30%) |
+| HP:0000162 | Glossoptosis | Frequent (79-30%) |
+| HP:0000175 | Cleft palate | Frequent (79-30%) |
+| HP:0000193 | Bifid uvula | Frequent (79-30%) |
+| HP:0000204 | Cleft upper lip | Frequent (79-30%) |
+| HP:0000272 | Malar flattening | Very frequent (99-80%) |
+| HP:0000286 | Epicanthus | Very frequent (99-80%) |
+| HP:0000308 | Microretrognathia | Very frequent (99-80%) |
+| HP:0000316 | Hypertelorism | Occasional (29-5%) |
+| HP:0000327 | Hypoplasia of the maxilla | Very frequent (99-80%) |
+| HP:0000343 | Long philtrum | Very frequent (99-80%) |
+| HP:0000347 | Micrognathia | Frequent (79-30%) |
+| HP:0000365 | Hearing impairment | Frequent (79-30%) |
+| HP:0000389 | Chronic otitis media | Frequent (79-30%) |
+| HP:0000407 | Sensorineural hearing impairment | Frequent (79-30%) |
+| HP:0000457 | Depressed nasal ridge | Frequent (79-30%) |
+| HP:0000463 | Anteverted nares | Frequent (79-30%) |
+| HP:0000483 | Astigmatism | Frequent (79-30%) |
+| HP:0000486 | Strabismus | Occasional (29-5%) |
+| HP:0000501 | Glaucoma | Occasional (29-5%) |
+| HP:0000505 | Visual impairment | Very frequent (99-80%) |
+| HP:0000506 | Telecanthus | Very frequent (99-80%) |
+| HP:0000518 | Cataract | Very frequent (99-80%) |
+| HP:0000519 | Developmental cataract | Occasional (29-5%) |
+| HP:0000520 | Proptosis | Frequent (79-30%) |
+| HP:0000541 | Retinal detachment | Very frequent (99-80%) |
+| HP:0000545 | Myopia | Very frequent (99-80%) |
+| HP:0000554 | Uveitis | Occasional (29-5%) |
+| HP:0000618 | Blindness | Occasional (29-5%) |
+| HP:0000682 | Abnormality of dental enamel | Occasional (29-5%) |
+| HP:0000768 | Pectus carinatum | Frequent (79-30%) |
+| HP:0000926 | Platyspondyly | Frequent (79-30%) |
+| HP:0000940 | Abnormal diaphysis morphology | Occasional (29-5%) |
+| HP:0001083 | Ectopia lentis | Occasional (29-5%) |
+| HP:0001166 | Arachnodactyly | Frequent (79-30%) |
+| HP:0001252 | Hypotonia | Frequent (79-30%) |
+| HP:0001373 | Joint dislocation | Frequent (79-30%) |
+| HP:0001382 | Joint hypermobility | Frequent (79-30%) |
+| HP:0001519 | Disproportionate tall stature | Frequent (79-30%) |
+| HP:0001533 | Slender build | Occasional (29-5%) |
+| HP:0001634 | Mitral valve prolapse | Frequent (79-30%) |
+| HP:0002020 | Gastroesophageal reflux | Frequent (79-30%) |
+| HP:0002205 | Recurrent respiratory infections | Frequent (79-30%) |
+| HP:0002650 | Scoliosis | Frequent (79-30%) |
+| HP:0002652 | Skeletal dysplasia | Very frequent (99-80%) |
+| HP:0002653 | Bone pain | Frequent (79-30%) |
+| HP:0002758 | Osteoarthritis | Frequent (79-30%) |
+| HP:0002808 | Kyphosis | Frequent (79-30%) |
+| HP:0002827 | Hip dislocation | Occasional (29-5%) |
+| HP:0002829 | Arthralgia | Very frequent (99-80%) |
+| HP:0002857 | Genu valgum | Frequent (79-30%) |
+| HP:0003179 | Protrusio acetabuli | Occasional (29-5%) |
+| HP:0003196 | Short nose | Very frequent (99-80%) |
+| HP:0003202 | Skeletal muscle atrophy | Occasional (29-5%) |
+| HP:0003302 | Spondylolisthesis | Frequent (79-30%) |
+| HP:0003312 | Abnormal form of the vertebral bodies | Very frequent (99-80%) |
+| HP:0003416 | Spinal canal stenosis | Occasional (29-5%) |
+| HP:0004322 | Short stature | Occasional (29-5%) |
+| HP:0004326 | Cachexia | Occasional (29-5%) |
+| HP:0004327 | Abnormal vitreous humor morphology | Very frequent (99-80%) |
+| HP:0004349 | Reduced bone mineral density | Occasional (29-5%) |
+| HP:0004374 | Hemiplegia/hemiparesis | Occasional (29-5%) |
+| HP:0005280 | Depressed nasal bridge | Very frequent (99-80%) |
+| HP:0005930 | Abnormality of epiphysis morphology | Very frequent (99-80%) |
+| HP:0006288 | Advanced eruption of teeth | Occasional (29-5%) |
+| HP:0006461 | Proximal femoral epiphysiolysis | Frequent (79-30%) |
+| HP:0007992 | Lattice retinal degeneration | Frequent (79-30%) |
+| HP:0008872 | Feeding difficulties in infancy | Occasional (29-5%) |
+| HP:0009804 | Tooth agenesis | Occasional (29-5%) |
+| HP:0010290 | Short hard palate | Occasional (29-5%) |
+| HP:0010807 | Open bite | Occasional (29-5%) |
+| HP:0011003 | High myopia | Frequent (79-30%) |
+| HP:0011530 | Retinal hole | Frequent (79-30%) |
+| HP:0011675 | Arrhythmia | Frequent (79-30%) |
+| HP:0011800 | Midface retrusion | Very frequent (99-80%) |
+| HP:0031153 | Membranous vitreous appearance | Frequent (79-30%) |
+| HP:0031154 | Beaded vitreous appearance | Occasional (29-5%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:10782 | Exact |
+| ICD-10:Q87.0 | Narrower |
+| ICD-11:LD2F.1Y | Narrower |
+| MONDO:0019354 | Exact |
+| MedDRA:10063402 | Exact |
+| OMIM:108300 | Broader |
+| OMIM:604841 | Broader |
+| OMIM:609508 | Broader |
+| OMIM:614134 | Broader |
+| OMIM:614284 | Broader |
+| UMLS:C0265253 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=828)


### PR DESCRIPTION
## Summary

- Integrates ORPHA:828 (Stickler syndrome) structured-database evidence into the Stickler Syndrome Type 1 entry
- Adds new sections: `definitions`, `mappings`, `external_assertions`, `progression` with Orphanet evidence
- Enhances `inheritance` with structured inheritance_term (HP:0000006) and ORPHA evidence
- Adds Orphanet epidemiology to `prevalence` (European point prevalence, worldwide birth prevalence)
- Expands phenotype coverage from 8 to 24 entries with Orphanet frequency annotations
- New phenotypes include: cataract, skeletal dysplasia, scoliosis, platyspondyly, mitral valve prolapse, hypotonia, arachnodactyly, arthralgia, glossoptosis, depressed nasal bridge, malar flattening, microretrognathia, visual impairment, hearing impairment, abnormal vitreous humor morphology, lattice retinal degeneration
- All existing PMID evidence preserved; all ORPHA:828 snippets are exact substrings of the cache file
- Validation: schema ✅, terms ✅, references ✅ — compliance 94.4%

## Notes

ORPHA:828 covers the broader Stickler syndrome group (all types). Where Orphanet frequency differs from type-1-specific literature (e.g., membranous vitreous is "Frequent" in ORPHA but pathognomonic/universal in STL1 per PMID:11007540), the entry uses the type-1-specific frequency with explanation.

## Test plan

- [x] `just validate kb/disorders/Stickler_Syndrome_Type_1.yaml` passes
- [x] `just compliance kb/disorders/Stickler_Syndrome_Type_1.yaml` — 94.4%
- [ ] Reviewer checks ORPHA snippet accuracy against cache file

🤖 Generated with [Claude Code](https://claude.com/claude-code)