### PR TITLE
Address Angelman Orphanet review feedback

### DIFF
--- a/kb/disorders/Angelman_Syndrome.yaml
+++ b/kb/disorders/Angelman_Syndrome.yaml
@@ -1032,6 +1032,12 @@ phenotypes:
       id: HP:0002066
       label: Gait ataxia
   evidence:
+  - reference: ORPHA:72
+    reference_title: "Angelman syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001251 | Ataxia | Very frequent (99-80%)"
+    explanation: Orphanet phenotype table confirms very frequent (99-80%) ataxia; gait ataxia is a child term.
   - reference: PMID:20301323
     reference_title: "Angelman Syndrome."
     supports: SUPPORT
@@ -1294,21 +1300,6 @@ phenotypes:
     evidence_source: OTHER
     snippet: "HP:0002120 | Cerebral cortical atrophy | Very frequent (99-80%)"
     explanation: Orphanet phenotype table rates cerebral cortical atrophy as very frequent (99-80%).
-- name: Ataxia
-  category: Neurological
-  frequency: VERY_FREQUENT
-  phenotype_term:
-    preferred_term: Ataxia
-    term:
-      id: HP:0001251
-      label: Ataxia
-  evidence:
-  - reference: ORPHA:72
-    reference_title: "Angelman syndrome (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0001251 | Ataxia | Very frequent (99-80%)"
-    explanation: Orphanet phenotype table confirms very frequent (99-80%) ataxia.
 - name: Broad-based gait
   category: Neurological
   frequency: VERY_FREQUENT
@@ -1504,11 +1495,11 @@ phenotypes:
     evidence_source: OTHER
     snippet: "HP:0002591 | Polyphagia | Frequent (79-30%)"
     explanation: Orphanet phenotype table rates polyphagia as frequent (79-30%).
-- name: Infantile muscular hypotonia
+- name: Infantile hypotonia
   category: Neurological
   frequency: FREQUENT
   phenotype_term:
-    preferred_term: Infantile muscular hypotonia
+    preferred_term: Infantile hypotonia
     term:
       id: HP:0008947
       label: Floppy infant
@@ -1518,7 +1509,7 @@ phenotypes:
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "HP:0008947 | Floppy infant | Frequent (79-30%)"
-    explanation: Orphanet phenotype table rates infantile muscular hypotonia as frequent (79-30%).
+    explanation: Orphanet phenotype table rates infantile hypotonia as frequent (79-30%).
 genetic:
 - name: UBE3A
   gene_term:


### PR DESCRIPTION
## Summary
Follow-up to #1855 (merged before review feedback could be applied).

- Remove redundant Ataxia (HP:0001251) phenotype — Gait ataxia (HP:0002066, child term) already exists; moved ORPHA:72 evidence there
- Rename "Infantile muscular hypotonia" → "Infantile hypotonia" — AS hypotonia is central/neurogenic, not muscular

## Test plan
- [x] `just validate kb/disorders/Angelman_Syndrome.yaml` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)