### PR TITLE
Address Noonan Orphanet review feedback

### DIFF
--- a/kb/disorders/Noonan_Syndrome.yaml
+++ b/kb/disorders/Noonan_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Noonan Syndrome
 creation_date: '2026-02-04T01:40:11Z'
-updated_date: '2026-04-28T00:00:00Z'
+updated_date: '2026-04-29T00:00:00Z'
 description: >-
   Noonan syndrome is an autosomal dominant RASopathy caused by germline mutations
   in genes of the RAS-MAPK signaling pathway, most commonly PTPN11 but also SOS1,
@@ -1139,8 +1139,8 @@ phenotypes:
     reference_title: "Noonan syndrome (Orphanet structured-database record)"
     supports: SUPPORT
     evidence_source: OTHER
-    snippet: "HP:0004415 | Pulmonary artery stenosis | Very frequent (99-80%)"
-    explanation: Orphanet lists pulmonary artery stenosis as very frequent; the related pulmonary valve stenosis phenotype in this entry is consistent with this annotation.
+    snippet: "HP:0001641 | Abnormal pulmonary valve morphology | Frequent (79-30%)"
+    explanation: Orphanet phenotype annotation for abnormal pulmonary valve morphology directly supports the pulmonary valve stenosis phenotype in this entry at a frequent classification.
 - category: Cardiovascular
   name: Hypertrophic Cardiomyopathy
   phenotype_term:
@@ -1349,10 +1349,10 @@ phenotypes:
       hematologic phenotype in Noonan syndrome.
   - reference: ORPHA:648
     reference_title: "Noonan syndrome (Orphanet structured-database record)"
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: OTHER
     snippet: "HP:0000978 | Bruising susceptibility | Occasional (29-5%)"
-    explanation: Orphanet classifies bruising susceptibility as occasional, whereas this entry uses FREQUENT based on clinical review data.
+    explanation: Orphanet classifies bruising susceptibility as occasional (29-5%), whereas this entry uses FREQUENT based on clinical review data; the lower Orphanet frequency only partially supports the stated frequency band.
 - category: Oncologic
   name: Tumor Predisposition
   phenotype_term:
@@ -1953,6 +1953,43 @@ genetic:
     evidence_source: OTHER
     snippet: "MRAS | muscle RAS oncogene homolog | hgnc:7227 | Disease-causing germline mutation(s) in"
     explanation: Orphanet gene-disease association supports MRAS as causative for Noonan syndrome.
+- name: CBL
+  gene_term:
+    preferred_term: CBL
+    term:
+      id: hgnc:1541
+      label: CBL
+  association: Pathogenic Variants
+  frequency: VERY_RARE
+  notes: >-
+    Rare Noonan-spectrum gene encoding an E3 ubiquitin ligase and negative
+    regulator of receptor tyrosine kinase signaling. Germline mutations cause
+    a Noonan-like syndrome with predisposition to JMML (CBL syndrome).
+  evidence:
+  - reference: ORPHA:648
+    reference_title: "Noonan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "CBL | Cbl proto-oncogene | hgnc:1541 | Disease-causing germline mutation(s) in"
+    explanation: Orphanet gene-disease association supports CBL as causative for Noonan syndrome.
+- name: SPRED2
+  gene_term:
+    preferred_term: SPRED2
+    term:
+      id: hgnc:17722
+      label: SPRED2
+  association: Pathogenic Variants
+  frequency: VERY_RARE
+  notes: >-
+    Rare Noonan-spectrum gene encoding a negative regulator of the RAS-MAPK
+    pathway. Loss-of-function variants lead to increased MAPK signaling.
+  evidence:
+  - reference: ORPHA:648
+    reference_title: "Noonan syndrome (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "SPRED2 | sprouty related EVH1 domain containing 2 | hgnc:17722 | Disease-causing germline mutation(s) in"
+    explanation: Orphanet gene-disease association supports SPRED2 as causative for Noonan syndrome.
 inheritance:
 - name: Autosomal Dominant
   description: Most cases follow autosomal dominant inheritance with variable expressivity. Approximately 30-75% of cases are de novo mutations.


### PR DESCRIPTION
## Summary
Follow-up to #1862, addressing reviewer suggestions from ai4c-agent:

- **Pulmonary Valve Stenosis**: switched Orphanet snippet from HP:0004415 (pulmonary artery stenosis, cross-term) to HP:0001641 (abnormal pulmonary valve morphology) for a direct term match
- **Bruising Susceptibility**: changed Orphanet evidence from SUPPORT to PARTIAL — Orphanet classifies as Occasional (29-5%) while YAML uses FREQUENT
- **CBL and SPRED2 genes**: added both missing Orphanet gene-disease associations to close the pre-existing gap

## Test plan
- [x] `just validate kb/disorders/Noonan_Syndrome.yaml` — schema, term, and reference validation all pass
- [ ] Reviewer confirms snippet substrings match ORPHA_648.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)