### PR TITLE
PR shepherd: remove cmungall from author list, add observability

### DIFF
--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -115,7 +115,7 @@ jobs:
             - If SPECIFIC_PR is set, inspect only that PR.
             - Otherwise list open PRs in REPO and consider PRs that match EITHER criterion:
               (a) authored by: `dragon-ai-agent`, `app/claude`, `app/github-actions`,
-                  `github-actions[bot]`, or `cmungall`, OR
+                  or `github-actions[bot]`, OR
               (b) the head branch name starts with `claude/` (these are Claude Code–created
                   branches that may be authored by any user who triggered the session).
             - A PR matching either (a) or (b) is a candidate. Do not act on PRs that match
@@ -182,5 +182,22 @@ jobs:
               clarification on the PR instead of guessing.
             - Spend this run on the selected PRs only.
 
+            Observability:
+            - For EVERY PR you act on (merge, update branch, push fixes, re-trigger review),
+              post a comment on the PR with this format:
+              🐑 **PR Shepherd** (action run) — [what you did]. [what happens next].
+              Example: "🐑 **PR Shepherd** (action run) — Squash-merged after checks passed. No further action needed."
+            - If you scan candidates but find nothing actionable, do NOT post comments.
+              Instead, print your summary to stdout so it can be captured in GITHUB_STEP_SUMMARY.
+
             End by posting or logging a concise summary of candidates scanned, selected PRs, actions
             taken, validation run, and any blockers that remain.
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## 🐑 PR Shepherd Run" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.pr-shepherd.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove `cmungall` from the candidate PR author list so the shepherd only tends bot-authored PRs and `claude/` branch PRs
- Add observability: instruct Claude to always post a `🐑 PR Shepherd` comment on any PR it acts on
- Add a post-step that writes the claude-code-action result to `GITHUB_STEP_SUMMARY` for visibility in the Actions UI

## Test plan
- [ ] Trigger a manual workflow dispatch with `dry_run: true` and verify the step summary appears
- [ ] Verify cmungall-authored PRs are no longer picked up as candidates
- [ ] Confirm shepherd comments appear on PRs it acts on

🤖 Generated with [Claude Code](https://claude.ai/claude-code)