### PR TITLE
Switch PR Shepherd from ai4c-agent to dragon-ai-agent PAT

### DIFF
--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -49,23 +49,16 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - name: Generate ai4c-agent token
-        id: ai4c-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
-          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.ai4c-token.outputs.token }}
+          token: ${{ secrets.PAT_FOR_PR }}
 
       - name: Configure git identity
         run: |
-          git config --global user.name "ai4c-agent[bot]"
-          git config --global user.email "${{ secrets.AI4C_AGENT_APP_ID }}+ai4c-agent[bot]@users.noreply.github.com"
+          git config --global user.name "dragon-ai-agent"
+          git config --global user.email "dragon-ai-agent@users.noreply.github.com"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -82,11 +75,11 @@ jobs:
         id: pr-shepherd
         uses: anthropics/claude-code-action@v1
         env:
-          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
-          GITHUB_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_PR }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ steps.ai4c-token.outputs.token }}
+          github_token: ${{ secrets.PAT_FOR_PR }}
           show_full_output: true
           allowed_bots: "dragon-ai-agent,claude,github-actions"
           claude_args: |
@@ -103,7 +96,7 @@ jobs:
             You are the automated PR Shepherd for the dismech repository. Your job is to tend
             stuck bot-authored pull requests and move at most MAX_PRS of them forward in this run.
 
-            You are authenticated with the ai4c-agent GitHub App token through GH_TOKEN. Use that
+            You are authenticated as dragon-ai-agent through GH_TOKEN. Use that
             token for all GitHub operations, including branch updates, comments, workflow dispatches,
             and merges.
 


### PR DESCRIPTION
## Summary
- Remove the `actions/create-github-app-token` step for ai4c-agent entirely
- Replace all `steps.ai4c-token.outputs.token` references with `secrets.PAT_FOR_PR`
- Update git config identity to `dragon-ai-agent`

## Test plan
- [ ] Verify `PAT_FOR_PR` secret is configured in the repo
- [ ] Trigger a manual workflow dispatch and confirm shepherd runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)