### PR TITLE
[codex] add evidence to Kabuki syndrome entry

### DIFF
--- a/kb/disorders/Kabuki_Syndrome.yaml
+++ b/kb/disorders/Kabuki_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Kabuki Syndrome
 creation_date: '2026-03-15T23:04:41Z'
-updated_date: '2026-04-28T00:00:00Z'
+updated_date: '2026-04-30T20:04:42Z'
 category: Mendelian
 description: >-
   Kabuki syndrome is a multisystem Mendelian chromatin disorder caused primarily
@@ -1147,6 +1147,15 @@ phenotypes:
     supports: SUPPORT
     snippet: "HP:0000175 | Cleft palate | Frequent (79-30%)"
     explanation: Orphanet classifies cleft palate as frequent in Kabuki syndrome.
+  - reference: PMID:17105332
+    reference_title: "Cleft palate in Kabuki syndrome: a report of six cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Although cleft palate is a feature that is sometimes observed in patients
+      with Kabuki syndrome, there are few clinical reports of cleft palate
+      associated with Kabuki syndrome.
+    explanation: Supports cleft palate as a recognized craniofacial manifestation of Kabuki syndrome.
 - name: Congenital Anomalies of the Kidney and Urinary Tract
   category: Genitourinary
   description: >-
@@ -1565,6 +1574,37 @@ prevalence:
     snippet: >-
       The minimum birth prevalence was calculated at 1 in 86,000.
     explanation: Australian/New Zealand estimate of minimum birth prevalence at 1 in 86,000.
+datasets:
+- accession: geo:GSE149688
+  title: The KMT2D Kabuki syndrome histone methylase controls neural crest cell differentiation and facial morphology
+  description: >-
+    RNA-seq from E14.25 wild-type and Kmt2d neural crest cell knockout mouse
+    palatal shelves, supporting analysis of KMT2D-dependent craniofacial
+    developmental gene expression.
+  organism:
+    preferred_term: mouse
+    term:
+      id: NCBITaxon:10090
+      label: Mus musculus
+  data_type: BULK_RNA_SEQ
+  conditions:
+  - E14.25 wild-type palatal shelves
+  - E14.25 Kmt2d neural crest cell knockout palatal shelves
+  publication: PMID:32541010
+  notes: >-
+    GEO series linked to the KMT2D neural crest and palatal shelf model used to
+    study craniofacial features of Kabuki syndrome.
+  evidence:
+  - reference: PMID:32541010
+    reference_title: "The KMT2D Kabuki syndrome histone methylase controls neural crest cell differentiation and facial morphology."
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      We mutated KMT2D in neural crest cells (NCCs) to study cellular and
+      molecular functions in craniofacial development with respect to UTX.
+    explanation: >-
+      Supports the mouse neural crest experimental context for this GEO RNA-seq
+      dataset; the GEO accession identifies the deposited series.
 treatments:
 - name: HDAC Inhibitor Therapy (Experimental)
   description: >-
@@ -1620,6 +1660,15 @@ treatments:
     Short stature is a core feature of KS. Growth hormone therapy has been
     used in patients with documented GH deficiency, though abstract-level
     evidence for efficacy is limited.
+  evidence:
+  - reference: PMID:28793284
+    reference_title: "Growth Hormone Therapy in Children with Kabuki Syndrome: 1-year Treatment Results."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All participants experienced catch-up growth during the year of rhGH
+      treatment, but without an influence on body proportions.
+    explanation: Supports recombinant human growth hormone as a treatment that can improve linear growth in children with Kabuki syndrome.
 - name: Speech Therapy
   description: >-
     Speech and language therapy is an important component of developmental

--- a/references_cache/PMID_17105332.md
+++ b/references_cache/PMID_17105332.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:17105332"
+title: "Cleft palate in Kabuki syndrome: a report of six cases."
+authors:
+- Iida T
+- Park S
+- Kato K
+- Kitano I
+journal: Cleft Palate Craniofac J
+year: '2006'
+doi: 10.1597/05-174
+keywords:
+- "Abnormalities, Multiple"
+- Articulation Disorders/therapy
+- "Cleft Palate/pathology, surgery"
+- Craniofacial Abnormalities/pathology
+- Female
+- Follow-Up Studies
+- Humans
+- "Infant, Newborn"
+- Male
+- Palate/surgery
+- Pharynx/surgery
+- Surgical Flaps
+- Syndrome
+- Velopharyngeal Insufficiency/therapy
+content_type: abstract_only
+---
+
+# Cleft palate in Kabuki syndrome: a report of six cases.
+**Authors:** Iida T, Park S, Kato K, Kitano I
+**Journal:** Cleft Palate Craniofac J (2006)
+**DOI:** [10.1597/05-174](https://doi.org/10.1597/05-174)
+
+## Content
+
+1. Cleft Palate Craniofac J. 2006 Nov;43(6):756-61. doi: 10.1597/05-174.
+
+Cleft palate in Kabuki syndrome: a report of six cases.
+
+Iida T(1), Park S, Kato K, Kitano I.
+
+Author information:
+(1)Department of Plastic and Reconstructive Surgery, Shizuoka Cancer Center,
+1007 Shimonagakubo, Nagai-zumi, Shizuoka 411-8777, Japan. tiida-tky@umin.ac.jp
+
+Kabuki syndrome is a syndrome of rare congenital anomalies that was named after
+its characteristic appearance, a face resembling that of an actor in a Kabuki
+play. Although cleft palate is a feature that is sometimes observed in patients
+with Kabuki syndrome, there are few clinical reports of cleft palate associated
+with Kabuki syndrome. This report presents six cases of Kabuki syndrome with
+cleft palate and reviews their clinical features. Our results suggest that (1)
+patients with cleft palate in Kabuki syndrome tend to fail in acquiring normal
+velopharyngeal function and (2) submucous cleft palate might be more common in
+patients with Kabuki syndrome than previously was reported.
+
+DOI: 10.1597/05-174
+PMID: 17105332 [Indexed for MEDLINE]

--- a/references_cache/PMID_28793284.md
+++ b/references_cache/PMID_28793284.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:28793284"
+title: "Growth Hormone Therapy in Children with Kabuki Syndrome: 1-year Treatment Results."
+authors:
+- Schott DA
+- Gerver WJM
+- Stumpel CTRM
+journal: Horm Res Paediatr
+year: '2017'
+doi: 10.1159/000479368
+keywords:
+- "Abnormalities, Multiple/drug therapy, genetics"
+- Child
+- "Child, Preschool"
+- DNA-Binding Proteins/genetics
+- "Dwarfism, Pituitary/drug therapy, genetics"
+- Face/abnormalities
+- Female
+- "Hematologic Diseases/drug therapy, genetics"
+- Histone Demethylases/genetics
+- Hormone Replacement Therapy
+- Human Growth Hormone/therapeutic use
+- Humans
+- Male
+- Mutation
+- Neoplasm Proteins/genetics
+- Nuclear Proteins/genetics
+- Treatment Outcome
+- "Vestibular Diseases/drug therapy, genetics"
+content_type: abstract_only
+---
+
+# Growth Hormone Therapy in Children with Kabuki Syndrome: 1-year Treatment Results.
+**Authors:** Schott DA, Gerver WJM, Stumpel CTRM
+**Journal:** Horm Res Paediatr (2017)
+**DOI:** [10.1159/000479368](https://doi.org/10.1159/000479368)
+
+## Content
+
+1. Horm Res Paediatr. 2017;88(3-4):258-264. doi: 10.1159/000479368. Epub 2017 Aug
+ 9.
+
+Growth Hormone Therapy in Children with Kabuki Syndrome: 1-year Treatment
+Results.
+
+Schott DA(1), Gerver WJM(2), Stumpel CTRM(3).
+
+Author information:
+(1)Department of Paediatrics, Zuyderland Medical Centre, Heerlen, the
+Netherlands.
+(2)Department of Paediatrics Endocrinology, Maastricht UMC+, Maastricht, the
+Netherlands.
+(3)Department of Clinical Genetics and GROW - School for Oncology and
+Developmental Biology, Maastricht UMC+, Maastricht, the Netherlands.
+
+BACKGROUND/AIMS: Kabuki syndrome (KS) is a rare genetic malformation syndrome,
+resulting in characteristic features such as short stature. We investigate
+whether growth hormone (GH) treatment increases linear height and influences
+body proportions in KS children.
+METHODS: In this prospective study, 18 genetically confirmed prepubertal KS
+children (9 females and 9 males) aged from 3.8 to 10.1 years (mean 6.8 ± 2.1
+years) were treated with recombinant human GH (rhGH) for 1 year. Calculations
+for height, height velocity, BMI, sitting height, and subischial leg length were
+made. Bone age, insulin-like growth factor (IGF-I), and IGF binding protein 3
+(IGFBP-3) were also measured.
+RESULTS: This study showed an increase in height standard deviation score (SDS)
+for the whole group from -2.40 to -1.69 (p < 0.05) after 1 year of rhGH
+treatment. The change in height SDS within 1 year was >0.7 SDS for 10 subjects
+and >0.5 SDS for 3 subjects. The mean IGF-I SDS at the start of the study was
+-0.70 (±1.07), which increased after 12 months to 1.41 (±0.91) (p < 0.05). KS
+children who received rhGH at a younger age displayed significantly greater
+increases in height than those who started when they were older. The same was
+true for both gene mutation KMT2D versus KDM6A and for GH deficiency versus
+non-GH deficiency KS children (p < 0.05). Throughout the course of rhGH
+treatment, the subjects' body proportions remained normal.
+CONCLUSIONS: All participants experienced catch-up growth during the year of
+rhGH treatment, but without an influence on body proportions.
+
+© 2017 S. Karger AG, Basel.
+
+DOI: 10.1159/000479368
+PMID: 28793284 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Adds the non-duplicative Kabuki syndrome improvements that remain after rebasing onto the newer `main` curation:

- Adds exact-snippet human clinical evidence for cleft palate from `PMID:17105332`.
- Adds public GEO dataset `GSE149688` for the KMT2D neural crest/palatal shelf mouse RNA-seq study, with organism annotation and evidence.
- Adds exact-snippet human clinical evidence for recombinant human growth hormone therapy from `PMID:28793284`.
- Adds generated reference cache files for the newly cited PMIDs.

## Validation

- `just validate kb/disorders/Kabuki_Syndrome.yaml`
- `just compliance kb/disorders/Kabuki_Syndrome.yaml` -> global `75.1% (223/297)`, weighted `74.7%` after rebasing onto the expanded Kabuki entry on `main`; the PR-added dataset and evidence items are compliant.

## Notes

Reference cache files were generated with `just fetch-reference`; no `references_cache/*.md` files were hand-created or hand-edited.

The branch was rebased onto `origin/main` to resolve conflicts from newer Kabuki syndrome curation that landed after this branch was opened.