### PR TITLE
Add normalize-cache to validate targets

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -47,6 +47,7 @@ validate-all:
             echo "  ✓ OK"
         fi
     done
+    just normalize-cache
     echo ""
     echo "================================"
     if [ ${#failed_files[@]} -eq 0 ]; then
@@ -71,6 +72,7 @@ validate file:
     echo "Reference validation..."
     just fix-references-cache
     {{ref_validator}} validate data {{file}} --schema {{schema_path}} --target-class Disease --config {{ref_validator_config}}
+    just normalize-cache
     echo "✓ All validations passed for {{file}}"
 
 # Schema-only validation (fast, structure check)


### PR DESCRIPTION
## Summary
- Adds `just normalize-cache` as the final step of both `validate` and `validate-all` targets
- Ensures every validation run produces sorted, deterministic cache output so diffs stay clean

## Test plan
- [ ] Run `just validate kb/disorders/Asthma.yaml` and verify normalize-cache runs at the end
- [ ] Run `just validate-all` and verify normalize-cache runs after the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)