### PR TITLE
[codex] Curate ADSL deficiency

### DIFF
--- a/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
+++ b/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
@@ -1,0 +1,681 @@
+name: Adenylosuccinate Lyase Deficiency
+category: Mendelian
+creation_date: '2026-05-03T00:00:00Z'
+updated_date: '2026-05-03T00:00:00Z'
+synonyms:
+- ADSL deficiency
+- Adenylosuccinase deficiency
+description: >
+  Adenylosuccinate lyase deficiency is an ultra-rare autosomal recessive
+  disorder of purine metabolism caused by biallelic pathogenic variants in
+  ADSL, which encodes adenylosuccinate lyase. ADSL catalyzes two nonsequential
+  reactions in de novo purine nucleotide synthesis and the purine nucleotide
+  cycle. Deficiency reduces ADSL enzymatic activity and causes accumulation of
+  the dephosphorylated substrates succinylaminoimidazolecarboxamide riboside
+  (SAICAr) and succinyladenosine (S-Ado) in body fluids. The clinical spectrum
+  ranges from fatal neonatal encephalopathy to severe or milder childhood-onset
+  neurodevelopmental disease with severe global developmental delay,
+  intellectual disability, seizures, hypotonia, absent or severely impaired
+  speech, autistic features, microcephaly, and abnormal brain white matter MRI.
+disease_term:
+  preferred_term: adenylosuccinate lyase deficiency
+  term:
+    id: MONDO:0007068
+    label: adenylosuccinate lyase deficiency
+parents:
+- Inborn Error of Metabolism
+- Inborn Error of Purine Metabolism
+- Mendelian Neurodevelopmental Disorder
+prevalence:
+- population: Worldwide
+  percentage: Less than 1 per 1,000,000
+  notes: >
+    Orphanet reports worldwide point prevalence below one per million and
+    describes the evidence base as cases and families.
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "<1 / 1 000 000 | Worldwide | Point prevalence | ORPHANET"
+    explanation: Orphanet reports worldwide point prevalence below one per million.
+progression:
+- phase: Neonatal to childhood-onset neurologic disease
+  notes: >
+    ADSL deficiency has a continuum of severity. The fatal neonatal form
+    presents from birth with severe encephalopathy, respiratory failure, and
+    intractable seizures. More common severe childhood presentations begin in
+    early infancy with severe psychomotor retardation, microcephaly, seizures,
+    hypotonia, and autistic features; milder forms can present later in the
+    first years of life.
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "Age of onset: Infancy"
+    explanation: Orphanet records infancy as one age of onset.
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "Age of onset: Neonatal"
+    explanation: Orphanet records neonatal onset for part of the clinical spectrum.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "fatal neonatal form has onset from birth and presents with fatal neonatal"
+    explanation: Review evidence supports a fatal neonatal presentation.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "characterized by severe psychomotor retardation, microcephaly, early"
+    explanation: Review evidence supports the severe childhood neurologic phenotype.
+  - reference: DOI:10.1186/s13023-021-01731-6
+    reference_title: "Clinical and molecular characterization of patients with adenylosuccinate lyase deficiency"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One patient had a fatal neonatal form of ADSL deficiency, seven showed features fitting type I, and nine were characterized by a milder condition"
+    explanation: A contemporary cohort supports neonatal, type I, and milder type II presentations.
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "58 % (51/88) were classified as having ADSL deficiency type I"
+    explanation: A recent long-term follow-up and literature appraisal supports the distribution of type I, type II, and neonatal presentations.
+pathophysiology:
+- name: ADSL molecular function deficiency
+  description: >
+    Biallelic pathogenic ADSL variants reduce adenylosuccinate lyase enzymatic
+    activity. ADSL is a homotetrameric bifunctional enzyme acting in de novo
+    purine synthesis and purine nucleotide recycling, and lower residual enzyme
+    activity is associated with more severe clinical phenotypes.
+  genes:
+  - preferred_term: ADSL
+    term:
+      id: hgnc:291
+      label: ADSL
+  molecular_functions:
+  - preferred_term: adenylosuccinate lyase activity
+    term:
+      id: GO:0004018
+      label: N6-(1,2-dicarboxyethyl)AMP AMP-lyase (fumarate-forming) activity
+  biological_processes:
+  - preferred_term: purine nucleotide biosynthetic process
+    term:
+      id: GO:0006164
+      label: purine nucleotide biosynthetic process
+  evidence:
+  - reference: PMID:10888601
+    reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Adenylosuccinate lyase (ADSL) is a bifunctional enzyme acting in de novo purine"
+    explanation: Establishes the ADSL enzyme function affected in the disorder.
+  - reference: PMID:10888601
+    reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "residual enzyme activity correlates with the severity of the clinical phenotype."
+    explanation: Supports residual enzyme activity as a severity modifier.
+  - reference: PMID:23714113
+    reference_title: "Inherent properties of adenylosuccinate lyase could explain S-Ado/SAICAr ratio due to homozygous R426H and R303C mutations."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "homotetrameric enzyme involved in the de novo"
+    explanation: Biochemical study supports ADSL homotetrameric enzyme biology and purine-pathway role.
+  downstream:
+  - target: Purine biosynthesis and nucleotide-cycle disruption
+    description: Loss of ADSL activity impairs ADSL-dependent purine pathway flux.
+- name: Purine biosynthesis and nucleotide-cycle disruption
+  description: >
+    ADSL catalyzes the conversion of SAICAR to AICAR in de novo purine synthesis
+    and the conversion of adenylosuccinate to AMP in the purine nucleotide cycle.
+    Impaired flux through these reactions is hypothesized to affect purine
+    availability and cellular energy balance in vulnerable tissues.
+  biological_processes:
+  - preferred_term: purine nucleotide biosynthetic process
+    term:
+      id: GO:0006164
+      label: purine nucleotide biosynthetic process
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "catalyzes two non-sequential steps in the de novo synthesis of purine nucleotides"
+    explanation: Review evidence describes the two ADSL-dependent purine-pathway reactions.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Deficient synthesis of purine nucleotides caused by ADSL deficiency"
+    explanation: Review evidence describes deficient purine nucleotide synthesis as a plausible contributor while noting incomplete mechanistic certainty.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "ADSL also participates in the purine nucleotide cycle"
+    explanation: Review evidence supports purine nucleotide-cycle impairment as another proposed mechanism.
+  downstream:
+  - target: Succinylpurine accumulation and neurotoxicity
+- name: Succinylpurine accumulation and neurotoxicity
+  description: >
+    Reduced ADSL activity causes intracellular accumulation of ADSL substrates
+    and extracellular accumulation of their dephosphorylated forms, SAICAr and
+    S-Ado. Accumulating succinylpurines, particularly SAICAr, are hypothesized to
+    contribute to neuronopathic disease; however, human neurotoxicity evidence
+    remains indirect. Model-organism work also supports wider metabolic
+    perturbations downstream of adsl loss, including disrupted tyrosine and
+    tyramine signaling.
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "normally undetectable compounds, succinylaminoimidazole carboxamide riboside"
+    explanation: Review evidence identifies SAICAr and S-Ado as abnormal compounds formed from the enzyme substrates.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "toxic effects of accumulating succinylpurines"
+    explanation: Review evidence presents succinylpurine toxicity as a leading but incompletely proven pathogenesis hypothesis.
+  - reference: PMID:23714113
+    reference_title: "Inherent properties of adenylosuccinate lyase could explain S-Ado/SAICAr ratio due to homozygous R426H and R303C mutations."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "riboside (SAICAr) and succinyladenosine (S-Ado), the dephosphorylated"
+    explanation: Biochemical study supports SAICAr and S-Ado as dephosphorylated ADSL substrate derivatives.
+  - reference: DOI:10.1371/journal.pgen.1010974
+    reference_title: "Adenylosuccinate lyase deficiency affects neurobehavior via perturbations to tyramine signaling in Caenorhabditis elegans"
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: "perturbation in tyrosine metabolism and show that a lack of tyramine"
+    explanation: C. elegans model evidence supports wider metabolic perturbation downstream of adsl deficiency.
+phenotypes:
+- name: Severe global developmental delay
+  frequency: VERY_FREQUENT
+  description: Severe global developmental delay is a core manifestation.
+  phenotype_term:
+    preferred_term: Severe global developmental delay
+    term:
+      id: HP:0011344
+      label: Severe global developmental delay
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0011344 | Severe global developmental delay | Very frequent (99-80%)"
+    explanation: Orphanet reports severe global developmental delay as very frequent.
+- name: Intellectual disability
+  frequency: VERY_FREQUENT
+  description: Intellectual disability is a major neurodevelopmental feature.
+  phenotype_term:
+    preferred_term: Intellectual disability
+    term:
+      id: HP:0001249
+      label: Intellectual disability
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0001249 | Intellectual disability | Very frequent (99-80%)"
+    explanation: Orphanet reports intellectual disability as very frequent.
+  - reference: PMID:18830228
+    reference_title: "Misleading behavioural phenotype with adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "mental retardation, epilepsy and autistic features"
+    explanation: Case report abstract summarizes the characteristic neurodevelopmental phenotype.
+- name: Seizure
+  frequency: VERY_FREQUENT
+  description: Seizures are very frequent and can be intractable, especially in severe forms.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0001250 | Seizure | Very frequent (99-80%)"
+    explanation: Orphanet reports seizure as very frequent.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "ADSL deficiency can cause onset of epilepsy in the first year of life."
+    explanation: Review evidence supports early-onset epilepsy in ADSL deficiency.
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Epilepsy is present in 81.8% of the patients"
+    explanation: Recent literature appraisal quantifies high seizure frequency and frequent intractability.
+- name: Generalized hypotonia
+  frequency: VERY_FREQUENT
+  description: Generalized hypotonia is common in severe ADSL deficiency.
+  phenotype_term:
+    preferred_term: Generalized hypotonia
+    term:
+      id: HP:0001290
+      label: Generalized hypotonia
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0001290 | Generalized hypotonia | Very frequent (99-80%)"
+    explanation: Orphanet reports generalized hypotonia as very frequent.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hypotonia (axial and generalized) is a common feature"
+    explanation: Review evidence supports hypotonia as a common severe-form feature.
+- name: Absent speech
+  frequency: VERY_FREQUENT
+  description: Absent or severely impaired speech is very frequent.
+  phenotype_term:
+    preferred_term: Absent speech
+    term:
+      id: HP:0001344
+      label: Absent speech
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0001344 | Absent speech | Very frequent (99-80%)"
+    explanation: Orphanet reports absent speech as very frequent.
+  - reference: PMID:18830228
+    reference_title: "Misleading behavioural phenotype with adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "global developmental delay, motor apraxia, severe speech deficits, seizures and"
+    explanation: Case report documents severe speech deficits in affected siblings.
+- name: Autistic behavior
+  description: Autistic features are part of the recognized neurobehavioral phenotype.
+  phenotype_term:
+    preferred_term: Autistic behavior
+    term:
+      id: HP:0000729
+      label: Autistic behavior
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "seizures, and autistic features."
+    explanation: Orphanet includes autistic features in the disorder definition.
+  - reference: PMID:18830228
+    reference_title: "Misleading behavioural phenotype with adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "mental retardation, epilepsy and autistic features"
+    explanation: Case report abstract supports autistic features as part of the phenotype.
+- name: Microcephaly
+  frequency: VERY_FREQUENT
+  description: Microcephaly is a frequent cranial manifestation.
+  phenotype_term:
+    preferred_term: Microcephaly
+    term:
+      id: HP:0000252
+      label: Microcephaly
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000252 | Microcephaly | Very frequent (99-80%)"
+    explanation: Orphanet reports microcephaly as very frequent.
+- name: Thin upper lip vermilion
+  frequency: VERY_FREQUENT
+  description: Thin upper lip vermilion is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Thin upper lip vermilion
+    term:
+      id: HP:0000219
+      label: Thin upper lip vermilion
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000219 | Thin upper lip vermilion | Very frequent (99-80%)"
+    explanation: Orphanet reports thin upper lip vermilion as very frequent.
+- name: Brachycephaly
+  frequency: VERY_FREQUENT
+  description: Brachycephaly is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Brachycephaly
+    term:
+      id: HP:0000248
+      label: Brachycephaly
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000248 | Brachycephaly | Very frequent (99-80%)"
+    explanation: Orphanet reports brachycephaly as very frequent.
+- name: Smooth philtrum
+  frequency: VERY_FREQUENT
+  description: Smooth philtrum is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Smooth philtrum
+    term:
+      id: HP:0000319
+      label: Smooth philtrum
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000319 | Smooth philtrum | Very frequent (99-80%)"
+    explanation: Orphanet reports smooth philtrum as very frequent.
+- name: Long philtrum
+  frequency: VERY_FREQUENT
+  description: Long philtrum is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Long philtrum
+    term:
+      id: HP:0000343
+      label: Long philtrum
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000343 | Long philtrum | Very frequent (99-80%)"
+    explanation: Orphanet reports long philtrum as very frequent.
+- name: Low-set ears
+  frequency: VERY_FREQUENT
+  description: Low-set ears are a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Low-set ears
+    term:
+      id: HP:0000369
+      label: Low-set ears
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000369 | Low-set ears | Very frequent (99-80%)"
+    explanation: Orphanet reports low-set ears as very frequent.
+- name: Anteverted nares
+  frequency: VERY_FREQUENT
+  description: Anteverted nares are a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Anteverted nares
+    term:
+      id: HP:0000463
+      label: Anteverted nares
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0000463 | Anteverted nares | Very frequent (99-80%)"
+    explanation: Orphanet reports anteverted nares as very frequent.
+- name: Abnormal facial shape
+  frequency: VERY_FREQUENT
+  description: Abnormal facial shape is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Abnormal facial shape
+    term:
+      id: HP:0001999
+      label: Abnormal facial shape
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0001999 | Abnormal facial shape | Very frequent (99-80%)"
+    explanation: Orphanet reports abnormal facial shape as very frequent.
+- name: Short nose
+  frequency: VERY_FREQUENT
+  description: Short nose is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Short nose
+    term:
+      id: HP:0003196
+      label: Short nose
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0003196 | Short nose | Very frequent (99-80%)"
+    explanation: Orphanet reports short nose as very frequent.
+- name: Flat occiput
+  frequency: VERY_FREQUENT
+  description: Flat occiput is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Flat occiput
+    term:
+      id: HP:0005469
+      label: Flat occiput
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0005469 | Flat occiput | Very frequent (99-80%)"
+    explanation: Orphanet reports flat occiput as very frequent.
+- name: Prominent metopic ridge
+  frequency: VERY_FREQUENT
+  description: Prominent metopic ridge is a very frequent craniofacial feature in Orphanet.
+  phenotype_term:
+    preferred_term: Prominent metopic ridge
+    term:
+      id: HP:0005487
+      label: Prominent metopic ridge
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0005487 | Prominent metopic ridge | Very frequent (99-80%)"
+    explanation: Orphanet reports prominent metopic ridge as very frequent.
+- name: Hypointensity of cerebral white matter on MRI
+  frequency: VERY_FREQUENT
+  description: Brain MRI may show white matter abnormalities, including hypointensity.
+  phenotype_term:
+    preferred_term: Hypointensity of cerebral white matter on MRI
+    term:
+      id: HP:0007103
+      label: Hypointensity of cerebral white matter on MRI
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "HP:0007103 | Hypointensity of cerebral white matter on MRI | Very frequent (99-80%)"
+    explanation: Orphanet reports cerebral white matter MRI hypointensity as very frequent.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Reported findings on brain MRI in ADSL deficiency include atrophy"
+    explanation: Review evidence supports structural brain MRI abnormalities in ADSL deficiency.
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "white matter abnormalities among the three types."
+    explanation: Recent long-term follow-up and literature appraisal supports white matter abnormalities across clinical types.
+biochemical:
+- name: Reduced adenylosuccinate lyase activity
+  presence: DECREASED
+  context: >
+    Reduced ADSL enzyme activity is the proximal biochemical defect caused by
+    pathogenic ADSL variants.
+  evidence:
+  - reference: PMID:10888601
+    reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "residual enzyme activity correlates with the severity of the clinical phenotype."
+    explanation: Patient-derived variant studies support reduced residual enzyme activity as central to the disorder.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "large decrease of ADSL activity"
+    explanation: Review evidence supports decreased ADSL enzyme activity as diagnostic support.
+- name: Increased succinylpurines in body fluids
+  presence: INCREASED
+  context: >
+    SAICAr and S-Ado are elevated in urine, cerebrospinal fluid, and plasma, and
+    their detection is a major biochemical diagnostic clue.
+  evidence:
+  - reference: PMID:18830228
+    reference_title: "Misleading behavioural phenotype with adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "accumulation of succinylpurines in body fluids."
+    explanation: Case report abstract describes succinylpurine accumulation.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "presence of enormously elevated concentrations of their dephosphorylated forms"
+    explanation: Review evidence supports elevated SAICAr and S-Ado in extracellular fluids.
+  - reference: PMID:27504266
+    reference_title: "Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in plasma reveals a phenotypic spectrum."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "accumulation of SAICAr and"
+    explanation: Metabolomic profiling study supports SAICAr and S-Ado accumulation in biofluids as the biochemical phenotype.
+genetic:
+- name: ADSL variants
+  gene_term:
+    preferred_term: ADSL
+    term:
+      id: hgnc:291
+      label: ADSL
+  inheritance:
+  - name: Autosomal recessive
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      snippet: "Autosomal recessive"
+      explanation: Orphanet reports autosomal recessive inheritance.
+    - reference: PMID:27504266
+      reference_title: "Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in plasma reveals a phenotypic spectrum."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "ADSL) deficiency is a rare autosomal recessive"
+      explanation: Metabolomic profiling study describes ADSL deficiency as autosomal recessive.
+  variants:
+  - name: Pathogenic ADSL variants
+    description: >
+      Pathogenic ADSL variants impair enzyme activity, homotetramerization, or
+      catalytic function. Most reported pathogenic variants are missense, with
+      residual enzymatic activity contributing to clinical severity.
+    evidence:
+    - reference: DOI:10.1186/s13023-021-01731-6
+      reference_title: "Clinical and molecular characterization of patients with adenylosuccinate lyase deficiency"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Eighteen different variants were distributed along the entire ADSL coding sequence"
+      explanation: Cohort data document diverse ADSL variants across the coding sequence.
+    - reference: PMID:10888601
+      reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Eight mutations were identified in a group of six"
+      explanation: Early molecular study identified pathogenic variants in affected patients.
+  features: >
+    ADSL encodes adenylosuccinate lyase, the enzyme affected in ADSL deficiency.
+    Orphanet lists ADSL as the disease-causing gene with direct MONDO exact
+    cross-reference for adenylosuccinate lyase deficiency.
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "ADSL | adenylosuccinate lyase | hgnc:291 | Disease-causing germline mutation(s) in"
+    explanation: Orphanet lists ADSL as the disease-causing gene.
+  - reference: ORPHA:46
+    supports: SUPPORT
+    snippet: "MONDO:0007068 | Exact"
+    explanation: Orphanet provides a direct exact mapping to MONDO:0007068.
+treatments:
+- name: Seizure-directed supportive care
+  description: >
+    There is no established disease-specific corrective therapy for ADSL
+    deficiency. Management is supportive, with seizure-directed pharmacotherapy
+    and consideration of ketogenic diet in selected patients with refractory
+    epilepsy.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  target_mechanisms:
+  - target: Succinylpurine accumulation and neurotoxicity
+    treatment_effect: MODULATES
+    description: Supportive care manages neurologic consequences without correcting the upstream enzyme defect.
+  evidence:
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "To date, there is no specific and effective therapy"
+    explanation: Review evidence indicates no established disease-specific effective therapy.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Treatment with anticonvulsive drugs"
+    explanation: Review evidence supports seizure-directed pharmacotherapy.
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A ketogenic diet could be considered a valid therapeutic option"
+    explanation: Review evidence supports ketogenic diet consideration for refractory seizures, with monitoring.
+- name: Investigational allopurinol therapy
+  description: >
+    Allopurinol has phase II prospective evidence in ADSL deficiency. Over
+    12 months, younger and less cognitively impaired participants showed
+    adaptive, cognitive, behavioral, and urinary SAICAr biomarker improvements,
+    whereas epilepsy did not improve. This supports allopurinol as an emerging
+    specialist-directed option rather than a proven corrective therapy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: allopurinol
+      term:
+        id: CHEBI:40279
+        label: allopurinol
+  target_mechanisms:
+  - target: Succinylpurine accumulation and neurotoxicity
+    treatment_effect: MODULATES
+    description: Allopurinol inhibits purine synthesis and may reduce toxic SAICAr accumulation.
+  evidence:
+  - reference: PMID:41053929
+    reference_title: "Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A Phase II, prospective trial evaluated the"
+    explanation: The published results paper supports that allopurinol has prospective phase II evidence in ADSL deficiency.
+  - reference: PMID:41053929
+    reference_title: "Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "clinical improvements in younger,"
+    explanation: The phase II report supports age- and severity-dependent clinical benefit.
+  - reference: PMID:41053929
+    reference_title: "Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "significant decreases in urinary SAICAr levels"
+    explanation: The phase II report supports a biomarker response consistent with the proposed succinylpurine mechanism.
+  - reference: PMID:41053929
+    reference_title: "Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Allopurinol had no effect on epilepsy but was well"
+    explanation: The phase II report limits the treatment claim by showing no epilepsy response while supporting tolerability.
+  - reference: clinicaltrials:NCT03776656
+    reference_title: "Evaluation of a Treatment With Allopurinol on Autistic Disorders and Epilepsy in Adenylosuccinate Lyase Deficiency (ADSL)"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "evaluate the effectiveness of allopurinol treatment at 12 months"
+    explanation: ClinicalTrials.gov registry supports allopurinol as an investigational therapy.
+  - reference: clinicaltrials:NCT03776656
+    reference_title: "Evaluation of a Treatment With Allopurinol on Autistic Disorders and Epilepsy in Adenylosuccinate Lyase Deficiency (ADSL)"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The decrease in the concentration of SAICAR and S-Ado metabolites"
+    explanation: The trial registry lists succinylpurine biomarkers as measured endpoints.

--- a/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
+++ b/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
@@ -79,6 +79,46 @@ progression:
     evidence_source: HUMAN_CLINICAL
     snippet: "58 % (51/88) were classified as having ADSL deficiency type I"
     explanation: A recent long-term follow-up and literature appraisal supports the distribution of type I, type II, and neonatal presentations.
+has_subtypes:
+- name: ADSL deficiency type I
+  display_name: Type I (severe)
+  description: >
+    The most common subtype in a recent 88-patient literature appraisal. Type I
+    typically presents in infancy with severe psychomotor retardation,
+    microcephaly, early-onset epilepsy, hypotonia, and autistic features.
+  evidence:
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "58 % (51/88) were classified as having ADSL deficiency type I"
+    explanation: Literature appraisal classified type I as the most common ADSL deficiency subtype.
+- name: ADSL deficiency type II
+  display_name: Type II (moderate/mild)
+  description: >
+    Type II is a milder childhood-onset subtype with moderate psychomotor
+    retardation, later or absent seizures, and more variable behavioral or
+    contact disturbances.
+  evidence:
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "28% (25/88) as having type II"
+    explanation: Literature appraisal classified 28% of reported patients as type II.
+- name: Neonatal ADSL deficiency
+  display_name: Fatal neonatal form
+  description: >
+    Neonatal ADSL deficiency presents from birth with severe encephalopathy,
+    respiratory failure, and intractable seizures, and is often fatal within the
+    first weeks of life.
+  evidence:
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "14% (12/88) as having neonatal"
+    explanation: Literature appraisal classified 14% of reported patients as neonatal ADSL deficiency.
 pathophysiology:
 - name: ADSL molecular function deficiency
   description: >
@@ -491,6 +531,36 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "white matter abnormalities among the three types."
     explanation: Recent long-term follow-up and literature appraisal supports white matter abnormalities across clinical types.
+- name: Cerebral atrophy
+  frequency: VERY_FREQUENT
+  description: Cerebral atrophy, often with frontal predominance, is a consistent imaging feature across reported ADSL deficiency types.
+  phenotype_term:
+    preferred_term: Cerebral atrophy
+    term:
+      id: HP:0002059
+      label: Cerebral atrophy
+  evidence:
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types"
+    explanation: Literature appraisal reports cerebral atrophy as a consistent imaging finding across the three ADSL deficiency types.
+- name: Cerebellar atrophy
+  frequency: VERY_FREQUENT
+  description: Cerebellar atrophy is a consistent imaging feature across reported ADSL deficiency types.
+  phenotype_term:
+    preferred_term: Cerebellar atrophy
+    term:
+      id: HP:0001272
+      label: Cerebellar atrophy
+  evidence:
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types"
+    explanation: Literature appraisal reports cerebellar atrophy as a consistent imaging finding across the three ADSL deficiency types.
 biochemical:
 - name: Reduced adenylosuccinate lyase activity
   presence: DECREASED

--- a/references_cache/DOI_10.1002_epi4.12837.md
+++ b/references_cache/DOI_10.1002_epi4.12837.md
@@ -1,0 +1,29 @@
+---
+reference_id: "DOI:10.1002/epi4.12837"
+title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long‐term follow‐up of seven patients from four families and appraisal of the literature"
+authors:
+- Gianni Cutillo
+- Silvia Masnada
+- Gaetan Lesca
+- Dorothée Ville
+- Patrizia Accorsi
+- Lucio Giordano
+- Anna Pichiecchio
+- Marialuisa Valente
+- Paola Borrelli
+- Ottavia Eleonora Ferraro
+- Pierangelo Veggiotti
+journal: Epilepsia Open
+year: '2024'
+doi: 10.1002/epi4.12837
+content_type: abstract_only
+---
+
+# Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long‐term follow‐up of seven patients from four families and appraisal of the literature
+**Authors:** Gianni Cutillo, Silvia Masnada, Gaetan Lesca, Dorothée Ville, Patrizia Accorsi, Lucio Giordano, Anna Pichiecchio, Marialuisa Valente, Paola Borrelli, Ottavia Eleonora Ferraro, Pierangelo Veggiotti
+**Journal:** Epilepsia Open (2024)
+**DOI:** [10.1002/epi4.12837](https://doi.org/10.1002/epi4.12837)
+
+## Content
+
+AbstractObjectiveAdenylosuccinate lyase (ADSL) deficiency is a rare inherited metabolic disorder with a wide phenotypic presentation, classically grouped into three types (neonatal, type I, and type II). We aim to better delineate the pathological spectrum, focusing on the electroclinical characteristics and phenotypic differences of patients with ADSL deficiency.Patients and MethodsSeven patients, from four different families, underwent serial electroencephalogram (EEG), clinical assessment, and neuroimaging. We also performed a systematic review of the cases published in the literature, summarizing the available clinical, neurophysiological, and genetic data.ResultsWe report seven previously unreported ADSL deficiency patients with long‐term follow‐up (10–34 years). From the literature review, we collected 81 previously reported cases. Of the included patient population, 58 % (51/88) were classified as having ADSL deficiency type I, 28% (25/88) as having type II, and 14% (12/88) as having neonatal. The most frequently reported pathogenic variants are p.R426H homozygous (19 patients), p.Y114H in compound heterozygosity (13 patients), and p.D430N homozygous (6 patients). In the majority (89.2%), disease onset was within the first year of life. Epilepsy is present in 81.8% of the patients, with polymorphic and often intractable seizures. EEG features seem to display common patterns and developmental trajectories: (i) poor general background organization with theta‐delta activity; (ii) hypsarrhythmia with spasms, usually adrenocorticotropic hormone‐responsive; (iii) generalized epileptic discharges with frontal or frontal temporal predominance; and (iv) epileptic discharge activation in sleep with an altered sleep structure. Imaging features present consistent findings of cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types.SignificanceADSL deficiency presents variable phenotypic expression, whose severity could be partially attributed to residual activity of the mutant protein. Although a precise phenotype‐genotype correlation was not yet feasible, we delineated a common pattern of clinical, neuroradiological, and neurophysiological features.

--- a/references_cache/DOI_10.1016_j.ymgme.2023.107686.md
+++ b/references_cache/DOI_10.1016_j.ymgme.2023.107686.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.1016/j.ymgme.2023.107686"
+title: A Caenorhabditis elegans model of adenylosuccinate lyase deficiency reveals neuromuscular and reproductive phenotypes of distinct etiology
+authors:
+- Adam R. Fenton
+- Haley N. Janowitz
+- Latisha P. Franklin
+- Riley G. Young
+- Corinna A. Moro
+- Michael V. DeGennaro
+- Melanie R. McReynolds
+- Wenqing Wang
+- Wendy Hanna-Rose
+journal: Molecular Genetics and Metabolism
+year: '2023'
+doi: 10.1016/j.ymgme.2023.107686
+content_type: unavailable
+---
+
+# A Caenorhabditis elegans model of adenylosuccinate lyase deficiency reveals neuromuscular and reproductive phenotypes of distinct etiology
+**Authors:** Adam R. Fenton, Haley N. Janowitz, Latisha P. Franklin, Riley G. Young, Corinna A. Moro, Michael V. DeGennaro, Melanie R. McReynolds, Wenqing Wang, Wendy Hanna-Rose
+**Journal:** Molecular Genetics and Metabolism (2023)
+**DOI:** [10.1016/j.ymgme.2023.107686](https://doi.org/10.1016/j.ymgme.2023.107686)
+
+## Content

--- a/references_cache/DOI_10.1186_s13023-021-01731-6.md
+++ b/references_cache/DOI_10.1186_s13023-021-01731-6.md
@@ -1,0 +1,41 @@
+---
+reference_id: "DOI:10.1186/s13023-021-01731-6"
+title: Clinical and molecular characterization of patients with adenylosuccinate lyase deficiency
+authors:
+- Gerarda Mastrogiorgio
+- Marina Macchiaiolo
+- Paola Sabrina Buonuomo
+- Emanuele Bellacchio
+- Matteo Bordi
+- Davide Vecchio
+- Kari Payne Brown
+- Natalie Karen Watson
+- Benedetta Contardi
+- Francesco Cecconi
+- Marco Tartaglia
+- Andrea Bartuli
+journal: Orphanet Journal of Rare Diseases
+year: '2021'
+doi: 10.1186/s13023-021-01731-6
+content_type: abstract_only
+---
+
+# Clinical and molecular characterization of patients with adenylosuccinate lyase deficiency
+**Authors:** Gerarda Mastrogiorgio, Marina Macchiaiolo, Paola Sabrina Buonuomo, Emanuele Bellacchio, Matteo Bordi, Davide Vecchio, Kari Payne Brown, Natalie Karen Watson, Benedetta Contardi, Francesco Cecconi, Marco Tartaglia, Andrea Bartuli
+**Journal:** Orphanet Journal of Rare Diseases (2021)
+**DOI:** [10.1186/s13023-021-01731-6](https://doi.org/10.1186/s13023-021-01731-6)
+
+## Content
+
+Abstract
+Background
+Adenylosuccinate lyase deficiency (ADSLD) is an ultrarare neurometabolic recessive disorder caused by loss-of-function mutations in the ADSL gene. The disease is characterized by wide clinical variability. Here we provide an updated clinical profiling of the disorder and discuss genotype–phenotype correlations.
+
+
+Results
+Data were collected through "Our Journey with ADSL deficiency Association" by using a dedicated web survey filled-in by parents.
+
+Clinical and molecular data were collected from 18 patients (12 males, median age 10.9 years ± 7.3), from 13 unrelated families. The age at onset ranged from birth to the first three years (median age 0.63 years ± 0.84 SD), and age at diagnosis varied from 2 months to 17 years, (median age 6.4 years ± 6.1 SD). The first sign was a psychomotor delay in 8/18 patients, epilepsy in 3/18, psychomotor delay and epilepsy in 3/18, and apneas, hypotonia, nystagmus in single cases. One patient (sibling of a previously diagnosed child) had a presymptomatic diagnosis. The diagnosis was made by exome sequencing in 7/18 patients. All patients were definitively diagnosed with ADSL deficiency based on pathogenic variants and/or biochemical assessment. One patient had a fatal neonatal form of ADSL deficiency, seven showed features fitting type I, and nine were characterized by a milder condition (type II), with two showing a very mild phenotype. Eighteen different variants were distributed along the entire ADSL coding sequence and were predicted to have a variable structural impact by impairing proper homotetramerization or catalytic activity of the enzyme. Six variants had not previously been reported. All but two variants were missense.
+
+Conclusions
+The study adds more details on the spectrum of ADSLD patients’ phenotypes and molecular data.

--- a/references_cache/DOI_10.1371_journal.pgen.1010974.md
+++ b/references_cache/DOI_10.1371_journal.pgen.1010974.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.1371/journal.pgen.1010974"
+title: Adenylosuccinate lyase deficiency affects neurobehavior via perturbations to tyramine signaling in Caenorhabditis elegans
+authors:
+- Corinna A. Moro
+- Sabrina A. Sony
+- Latisha P. Franklin
+- Shirley Dong
+- Mia M. Peifer
+- Kathryn E. Wittig
+- Wendy Hanna-Rose
+journal: PLOS Genetics
+year: '2023'
+doi: 10.1371/journal.pgen.1010974
+content_type: abstract_only
+---
+
+# Adenylosuccinate lyase deficiency affects neurobehavior via perturbations to tyramine signaling in Caenorhabditis elegans
+**Authors:** Corinna A. Moro, Sabrina A. Sony, Latisha P. Franklin, Shirley Dong, Mia M. Peifer, Kathryn E. Wittig, Wendy Hanna-Rose
+**Journal:** PLOS Genetics (2023)
+**DOI:** [10.1371/journal.pgen.1010974](https://doi.org/10.1371/journal.pgen.1010974)
+
+## Content
+
+Adenylosuccinate lyase deficiency is an ultrarare congenital metabolic disorder associated with muscle weakness and neurobehavioral dysfunction. Adenylosuccinate lyase is required for de novo purine biosynthesis, acting twice in the pathway at non-sequential steps. Genetic models can contribute to our understanding of the etiology of disease phenotypes and pave the way for development of therapeutic treatments. Here, we establish the first model to specifically study neurobehavioral aspects of adenylosuccinate lyase deficiency. We show that reduction of adsl-1 function in C. elegans is associated with a novel learning phenotype in a gustatory plasticity assay. The animals maintain capacity for gustatory plasticity, evidenced by a change in their behavior in response to cue pairing. However, their behavioral output is distinct from that of control animals. We link substrate accumulation that occurs upon adsl-1 deficiency to an unexpected perturbation in tyrosine metabolism and show that a lack of tyramine mediates the behavioral changes through action on the metabotropic TYRA-2 tyramine receptor. Our studies reveal a potential for wider metabolic perturbations, beyond biosynthesis of purines, to impact behavior under conditions of adenylosuccinate lyase deficiency.

--- a/references_cache/ORPHA_46.md
+++ b/references_cache/ORPHA_46.md
@@ -1,0 +1,83 @@
+---
+reference_id: "ORPHA:46"
+title: "Adenylosuccinate lyase deficiency"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:46  Adenylosuccinate lyase deficiency
+
+**ORPHA:46** — Adenylosuccinate lyase deficiency (Disease, Disorder)
+
+## Synonyms
+
+- ADSL deficiency
+- Adenylosuccinase deficiency
+
+## Definition
+
+A disorder of purine metabolism characterized by intellectual disability, psychomotor delay and/or regression, seizures, and autistic features.
+
+## Inheritance
+
+- Autosomal recessive
+
+## Natural history
+
+- Age of onset: Childhood
+- Age of onset: Infancy
+- Age of onset: Neonatal
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| - | Worldwide | Cases/families | PMID:18830228 |
+| <1 / 1 000 000 | Worldwide | Point prevalence | ORPHANET |
+
+## Genes
+
+| Symbol | Name | HGNC | Association |
+|---|---|---|---|
+| ADSL | adenylosuccinate lyase | hgnc:291 | Disease-causing germline mutation(s) in |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000219 | Thin upper lip vermilion | Very frequent (99-80%) |
+| HP:0000248 | Brachycephaly | Very frequent (99-80%) |
+| HP:0000252 | Microcephaly | Very frequent (99-80%) |
+| HP:0000319 | Smooth philtrum | Very frequent (99-80%) |
+| HP:0000343 | Long philtrum | Very frequent (99-80%) |
+| HP:0000369 | Low-set ears | Very frequent (99-80%) |
+| HP:0000463 | Anteverted nares | Very frequent (99-80%) |
+| HP:0001249 | Intellectual disability | Very frequent (99-80%) |
+| HP:0001250 | Seizure | Very frequent (99-80%) |
+| HP:0001290 | Generalized hypotonia | Very frequent (99-80%) |
+| HP:0001344 | Absent speech | Very frequent (99-80%) |
+| HP:0001999 | Abnormal facial shape | Very frequent (99-80%) |
+| HP:0003196 | Short nose | Very frequent (99-80%) |
+| HP:0005469 | Flat occiput | Very frequent (99-80%) |
+| HP:0005487 | Prominent metopic ridge | Very frequent (99-80%) |
+| HP:0007103 | Hypointensity of cerebral white matter on MRI | Very frequent (99-80%) |
+| HP:0011344 | Severe global developmental delay | Very frequent (99-80%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:550 | Exact |
+| ICD-10:E79.8 | Narrower |
+| ICD-11:5C55.0Y | Narrower |
+| MONDO:0007068 | Exact |
+| MeSH:C538235 | Exact |
+| MedDRA:10081681 | Exact |
+| OMIM:103050 | Exact |
+| UMLS:C0268126 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=46)

--- a/references_cache/PMID_10888601.md
+++ b/references_cache/PMID_10888601.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:10888601"
+title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
+authors:
+- Kmoch S
+- Hartmannová H
+- Stibůrková B
+- Krijt J
+- Zikánová M
+- Sebesta I
+journal: Hum Mol Genet
+year: '2000'
+doi: 10.1093/hmg/9.10.1501
+keywords:
+- "Adenylosuccinate Lyase/biosynthesis, chemistry, deficiency, genetics"
+- Alternative Splicing
+- Amino Acid Sequence
+- Base Sequence
+- "Cells, Cultured"
+- Child
+- "Child, Preschool"
+- "Cloning, Molecular"
+- "DNA, Complementary/metabolism"
+- Escherichia coli/metabolism
+- Exons
+- Female
+- Fibroblasts/metabolism
+- Genotype
+- Humans
+- Infant
+- Kinetics
+- Male
+- Molecular Sequence Data
+- Mutation
+- Phenotype
+- "Promoter Regions, Genetic"
+- Protein Isoforms
+- "Sequence Analysis, DNA"
+- Temperature
+- Tissue Distribution
+content_type: abstract_only
+---
+
+# Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients.
+**Authors:** Kmoch S, Hartmannová H, Stibůrková B, Krijt J, Zikánová M, Sebesta I
+**Journal:** Hum Mol Genet (2000)
+**DOI:** [10.1093/hmg/9.10.1501](https://doi.org/10.1093/hmg/9.10.1501)
+
+## Content
+
+1. Hum Mol Genet. 2000 Jun 12;9(10):1501-13. doi: 10.1093/hmg/9.10.1501.
+
+Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length
+cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in
+six patients.
+
+Kmoch S(1), Hartmannová H, Stibůrková B, Krijt J, Zikánová M, Sebesta I.
+
+Author information:
+(1)Institute for Inherited Metabolic Disorders, Department of Clinical
+Biochemistry, Charles University 1st School of Medicine and General Faculty
+Hospital, Prague, Czech Republic. skmoch@lf1.cuni.cz
+
+Adenylosuccinate lyase (ADSL) is a bifunctional enzyme acting in de novo purine
+synthesis and purine nucleotide recycling. ADSL deficiency is a selectively
+neuronopathic disorder with psychomotor retardation and epilepsy as leading
+traits. Both dephosphorylated enzyme substrates,
+succinylaminoimidazole-carboxamide riboside (SAICAr) and succinyladenosine
+(S-Ado), accumulate in the cerebrospinal fluid (CSF) of affected individuals
+with S-Ado/SAICAr concentration ratios proportional to the phenotype severity.
+We studied the disorder at various levels in a group of six patients with ADSL
+deficiency. We identified the complete ADSL cDNA and its alternatively spliced
+isoform resulting from exon 12 skipping. Both mRNA isoforms were expressed in
+all the tissues studied with the non-spliced form 10-fold more abundant. Both
+cDNAs were expressed in Escherichia coli and functionally characterized at the
+protein level. The results showed only the unspliced ADSL to be active. The gene
+consists of 13 exons spanning 23 kb. The promotor region shows typical features
+of the housekeeping gene. Eight mutations were identified in a group of six
+patients. The expression studies of the mutant proteins carried out in an
+attempt to study genotype-phenotype correlation showed that the level of
+residual enzyme activity correlates with the severity of the clinical phenotype.
+All the mutant enzymes studied in vitro displayed a proportional decrease in
+activity against both of their substrates. However, this was not concordant with
+strikingly different concentration ratios in the CSF of individual patients.
+This suggests either different in vivo enzyme activities against each of the
+substrates and/or their different turnover across the CSF-blood barrier, which
+may be decisive in determining disease severity.
+
+DOI: 10.1093/hmg/9.10.1501
+PMID: 10888601 [Indexed for MEDLINE]

--- a/references_cache/PMID_18830228.md
+++ b/references_cache/PMID_18830228.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:18830228"
+title: Misleading behavioural phenotype with adenylosuccinate lyase deficiency.
+authors:
+- Gitiaux C
+- Ceballos-Picot I
+- Marie S
+- Valayannopoulos V
+- Rio M
+- Verrieres S
+- Benoist JF
+- Vincent MF
+- Desguerre I
+- Bahi-Buisson N
+journal: Eur J Hum Genet
+year: '2009'
+doi: 10.1038/ejhg.2008.174
+keywords:
+- "Adenosine/analogs & derivatives, urine"
+- "Adenylosuccinate Lyase/deficiency, genetics"
+- "Aminoimidazole Carboxamide/analogs & derivatives, urine"
+- Angelman Syndrome/diagnosis
+- Behavior
+- Child
+- "Chromatography, High Pressure Liquid"
+- Consanguinity
+- Female
+- Humans
+- "Intellectual Disability/genetics, psychology"
+- "Mutation, Missense"
+- Pedigree
+- Phenotype
+- "Purine-Pyrimidine Metabolism, Inborn Errors/diagnosis, genetics, psychology"
+- Ribonucleotides/urine
+- "Sequence Analysis, DNA"
+- Stereotyped Behavior
+content_type: abstract_only
+---
+
+# Misleading behavioural phenotype with adenylosuccinate lyase deficiency.
+**Authors:** Gitiaux C, Ceballos-Picot I, Marie S, Valayannopoulos V, Rio M, Verrieres S, Benoist JF, Vincent MF, Desguerre I, Bahi-Buisson N
+**Journal:** Eur J Hum Genet (2009)
+**DOI:** [10.1038/ejhg.2008.174](https://doi.org/10.1038/ejhg.2008.174)
+
+## Content
+
+1. Eur J Hum Genet. 2009 Jan;17(1):133-6. doi: 10.1038/ejhg.2008.174. Epub 2008
+Oct  1.
+
+Misleading behavioural phenotype with adenylosuccinate lyase deficiency.
+
+Gitiaux C(1), Ceballos-Picot I, Marie S, Valayannopoulos V, Rio M, Verrieres S,
+Benoist JF, Vincent MF, Desguerre I, Bahi-Buisson N.
+
+Author information:
+(1)Département de Pédiatrie, Hoôpital Necker Enfants Malades, AP-HP, Université
+Paris Descartes, Paris, France.
+
+Adenylosuccinate lyase deficiency is a rare autosomal disorder of de novo purine
+synthesis, which results in the accumulation of succinylpurines in body fluids.
+Patients with adenylosuccinate lyase deficiency show a variable combination of
+mental retardation, epilepsy and autistic features and are usually discovered
+during screens for unexplained encephalopathy using the Bratton-Marshall assay
+that reveals the excretion of the succinylaminoimidazolecarboxamide riboside
+(SAICAr). Here, we report on two sisters aged 11 and 12 years presented with
+global developmental delay, motor apraxia, severe speech deficits, seizures and
+behavioural features, which combined excessive laughter, a very happy
+disposition, hyperactivity, a short attention span, the mouthing of objects,
+tantrums and stereotyped movements that gave a behavioural profile mimicking
+Angelman syndrome. Both patients had an increased succinyladenosine/SAICAr ratio
+of 1.6, and exhibited a novel homozygous missense mutation (c.674T>C;
+p.Met225Thr) in the exon 6 of the ADSL gene. We suggest that these clinical
+features might be a new presentation of adenylosuccinate lyase deficiency. On
+the basis of this observation, although adenylosuccinate lyase deficiency is a
+rare disorder, this diagnosis should be considered in patients with mental
+retardation and a behavioural profile suggestive of Angelman syndrome.
+
+DOI: 10.1038/ejhg.2008.174
+PMCID: PMC2985950
+PMID: 18830228 [Indexed for MEDLINE]

--- a/references_cache/PMID_23714113.md
+++ b/references_cache/PMID_23714113.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:23714113"
+title: Inherent properties of adenylosuccinate lyase could explain S-Ado/SAICAr ratio due to homozygous R426H and R303C mutations.
+authors:
+- Ray SP
+- Duval N
+- Wilkinson TG 2nd
+- Shaheen SE
+- Ghosh K
+- Patterson D
+journal: Biochim Biophys Acta
+year: '2013'
+doi: 10.1016/j.bbapap.2013.05.013
+keywords:
+- "Adenosine/analogs & derivatives, metabolism"
+- "Adenylosuccinate Lyase/deficiency, genetics, metabolism"
+- "Aminoimidazole Carboxamide/analogs & derivatives, metabolism"
+- Autistic Disorder
+- "Chromatography, High Pressure Liquid"
+- Electrochemistry
+- Homozygote
+- Humans
+- Kinetics
+- "Mutagenesis, Site-Directed"
+- "Mutation, Missense/genetics"
+- "Purine-Pyrimidine Metabolism, Inborn Errors/diagnosis, genetics"
+- Ribonucleotides/metabolism
+- Substrate Specificity
+content_type: abstract_only
+---
+
+# Inherent properties of adenylosuccinate lyase could explain S-Ado/SAICAr ratio due to homozygous R426H and R303C mutations.
+**Authors:** Ray SP, Duval N, Wilkinson TG 2nd, Shaheen SE, Ghosh K, Patterson D
+**Journal:** Biochim Biophys Acta (2013)
+**DOI:** [10.1016/j.bbapap.2013.05.013](https://doi.org/10.1016/j.bbapap.2013.05.013)
+
+## Content
+
+1. Biochim Biophys Acta. 2013 Aug;1834(8):1545-53. doi:
+10.1016/j.bbapap.2013.05.013. Epub 2013 May 25.
+
+Inherent properties of adenylosuccinate lyase could explain S-Ado/SAICAr ratio
+due to homozygous R426H and R303C mutations.
+
+Ray SP(1), Duval N, Wilkinson TG 2nd, Shaheen SE, Ghosh K, Patterson D.
+
+Author information:
+(1)Department of Physics and Astronomy, University of Denver, Denver, CO, USA.
+Stephen.Ray@du.edu
+
+Adenylosuccinate lyase (ADSL) is a homotetrameric enzyme involved in the de novo
+purine biosynthesis pathway and purine nucleotide cycle. Missense mutations in
+the protein lead to ADSL deficiency, an inborn error of purine metabolism
+characterized by neurological and physiological symptoms. ADSL deficiency is
+biochemically diagnosed by elevated levels of succinylaminoimidazolecarboxamide
+riboside (SAICAr) and succinyladenosine (S-Ado), the dephosphorylated
+derivatives of the substrates. S-Ado/SAICAr ratios have been associated with
+three phenotypic groups. Different hypotheses to explain these ratios have been
+proposed. Recent studies have focused on measuring activity on the substrates
+independently. However, it is important to examine mixtures of the substrates to
+determine if mutations affect enzyme activity on both substrates similarly in
+these conditions. The two substrates may experience an indirect communication
+due to being acted upon by the same enzyme, altering their activities from the
+non-competitive case. In this study, we investigate this hidden coupling between
+the two substrates. We chose two mutations that represent extremes of the
+phenotype, R426H and R303C. We describe a novel electrochemical-detection method
+of measuring the kinetic activity of ADSL in solution with its two substrates at
+varying concentration ratios. Furthermore, we develop an enzyme kinetic model to
+predict substrate activity from a given ratio of substrate concentrations. Our
+findings indicate a non-linear dependence of the activities on the substrate
+ratios due to competitive binding, distinct differences in the behaviors of the
+different mutations, and S-Ado/SAICAr ratios in patients could be explained by
+inherent properties of the mutant enzyme.
+
+Copyright © 2013 Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.bbapap.2013.05.013
+PMID: 23714113 [Indexed for MEDLINE]

--- a/references_cache/PMID_25112391.md
+++ b/references_cache/PMID_25112391.md
@@ -1,0 +1,237 @@
+---
+reference_id: "PMID:25112391"
+title: Adenylosuccinate lyase deficiency.
+authors:
+- Jurecka A
+- Zikanova M
+- Kmoch S
+- Tylki-Szymańska A
+journal: J Inherit Metab Dis
+year: '2015'
+doi: 10.1007/s10545-014-9755-y
+keywords:
+- "Adenylosuccinate Lyase/deficiency, genetics"
+- Animals
+- "Autistic Disorder/diagnosis, enzymology, epidemiology, genetics, therapy"
+- "Diagnosis, Differential"
+- Disease Progression
+- Genetic Predisposition to Disease
+- Genetic Testing
+- Humans
+- Mutation
+- Phenotype
+- Predictive Value of Tests
+- Prognosis
+- "Purine-Pyrimidine Metabolism, Inborn Errors/diagnosis, enzymology, epidemiology, genetics, therapy"
+- Risk Factors
+content_type: full_text_xml
+---
+
+# Adenylosuccinate lyase deficiency.
+**Authors:** Jurecka A, Zikanova M, Kmoch S, Tylki-Szymańska A
+**Journal:** J Inherit Metab Dis (2015)
+**DOI:** [10.1007/s10545-014-9755-y](https://doi.org/10.1007/s10545-014-9755-y)
+
+## Content
+
+1. J Inherit Metab Dis. 2015 Mar;38(2):231-42. doi: 10.1007/s10545-014-9755-y.
+Epub  2014 Aug 12.
+
+Adenylosuccinate lyase deficiency.
+
+Jurecka A(1), Zikanova M, Kmoch S, Tylki-Szymańska A.
+
+Author information:
+(1)Department of Genetics, University of Gdańsk, ul. Wita Stwosza 59, 80-308,
+Gdańsk, Poland, ajurecka@gmail.com.
+
+Adenylosuccinate lyase ADSL) deficiency is a defect of purine metabolism
+affecting purinosome assembly and reducing metabolite fluxes through purine de
+novo synthesis and purine nucleotide recycling pathways. Biochemically this
+defect manifests by the presence in the biologic fluids of two dephosphorylated
+substrates of ADSL enzyme: succinylaminoimidazole carboxamide riboside (SAICAr)
+and succinyladenosine (S-Ado). More than 80 individuals with ADSL deficiency
+have been identified, but incidence of the disease remains unknown. The disorder
+shows a wide spectrum of symptoms from slowly to rapidly progressing forms. The
+fatal neonatal form has onset from birth and presents with fatal neonatal
+encephalopathy with a lack of spontaneous movement, respiratory failure, and
+intractable seizures resulting in early death within the first weeks of life.
+Patients with type I (severe form) present with a purely neurologic clinical
+picture characterized by severe psychomotor retardation, microcephaly, early
+onset of seizures, and autistic features. A more slowly progressing form has
+also been described (type II, moderate or mild form), as having later onset,
+usually within the first years of life, slight to moderate psychomotor
+retardation and transient contact disturbances. Diagnosis is facilitated by
+demonstration of SAICAr and S-Ado in extracellular fluids such as plasma,
+cerebrospinal fluid and/or followed by genomic and/or cDNA sequencing and
+characterization of mutant proteins. Over 50 ADSL mutations have been identified
+and their effects on protein biogenesis, structural stability and activity as
+well as on purinosome assembly were characterized. To date there is no specific
+and effective therapy for ADSL deficiency.
+
+DOI: 10.1007/s10545-014-9755-y
+PMCID: PMC4341013
+PMID: 25112391 [Indexed for MEDLINE]
+
+Adenylosuccinate lyase deficiency (OMIM 103 050) is an autosomal recessive defect of purine metabolism. It was first described in 1984 by Jaeken and van den Berghe (Jaeken and Van den Berghe 1984), who found succinylpurines in the cerebrospinal fluid (CSF), plasma, and urine of three patients with severe psychomotor delay and autistic features.
+
+The enzyme adenylosuccinate lyase (EC 4.3.2.2) catalyzes two non-sequential steps in the de novo synthesis of purine nucleotides leading to nonhydrolytic cleavage of succinyl groups to yield fumarate: the conversion of succinylaminoimidazole carboxamide ribotide (SAICAR) into aminoimidazole carboxamide ribotide (AICAR) and the formation of adenosine monophosphate nucleotides (Fig. 1). In addition to its role in purine biosynthesis, the enzyme is involved, together with adenylate deaminase and adenylosuccinate synthetase, in the purine nucleotide cycle. This cycle prevents adenosine monophosphate (AMP) accumulation following adenosine triphosphate (ATP) catabolism, and this, in turn, displaces the adenylate kinase reaction toward adenosine triphosphate formation (Sabina et al 1980). Moreover, the purine nucleotide cycle plays a role in maintaining the adenylate energy charge through the generation of intermediates for the citric-acid cycle from amino acids and through the stimulation of activities of glycogen phosphorylase and of phosphofructokinase, thus enhancing the rate of glycolysis (Tornheim and Lowenstein 1975; Aragon and Lowenstein 1980; Young et al 1996).Fig. 1
+De novo purine biosynthesis pathway. Abbreviations are as follows: PRPP, phosphoribosylpyrophosphate; SAICAR, succinylaminoimidazole carboxamide ribotide; SAICAr, succinylaminoimidazole carboxamide riboside; AICAR, aminoimidazole carbozamide ribotide; FAICAR, formyloaminoimidazole carboxamide ribotide; IMP, inosine monophosphate; S-AMP, adenylosuccinate; S-Ado, succinyladenosine; AMP, adenine monophosphate; XMP, xanthine monophosphate; GMP, guanine monophosphate; ADSL, adenylosuccinate lyase; AICAR TF, aminoimidazole carboxamide riboside transformylase; IMP CH, inosine monophosphate cyclohydrolase; ATIC, bifunctional enzyme AICAR transformylase/IMP cyclohydrolase
+
+
+
+De novo purine biosynthesis pathway. Abbreviations are as follows: PRPP, phosphoribosylpyrophosphate; SAICAR, succinylaminoimidazole carboxamide ribotide; SAICAr, succinylaminoimidazole carboxamide riboside; AICAR, aminoimidazole carbozamide ribotide; FAICAR, formyloaminoimidazole carboxamide ribotide; IMP, inosine monophosphate; S-AMP, adenylosuccinate; S-Ado, succinyladenosine; AMP, adenine monophosphate; XMP, xanthine monophosphate; GMP, guanine monophosphate; ADSL, adenylosuccinate lyase; AICAR TF, aminoimidazole carboxamide riboside transformylase; IMP CH, inosine monophosphate cyclohydrolase; ATIC, bifunctional enzyme AICAR transformylase/IMP cyclohydrolase
+
+The native human ADSL protein is a homotetramer with a subunit size of ~50 kDa. The protein contains four active sites. Each of them is formed from regions of three different subunits - Protein Data Bank (PDB) (2VD6; http://www.pdb.org/pdb/cgi/explore.cgi?pdbId=2VD6).
+
+The enzyme defect (MIM 103050) manifests itself by the presence in the biologic fluids of two normally undetectable compounds, succinylaminoimidazole carboxamide riboside (SAICAr) and succinyladenosine (S-Ado), which are formed by dephosphorylation of the two substrates of the enzyme.
+
+Incidence of ADSL deficiency remains unknown. To date almost 80 patients have been reported and the majority of them were found in Holland and Belgium, where the defect was discovered for the first time (Jaeken and Van den Berghe 1984; Kohler et al 1999). Other reported patients were from Czech Republic (Kmoch et al 2000; Mouchegh et al 2007), Poland (Jurecka et al 2008a, b), Germany (Kohler et al 1999; Mouchegh et al 2007), UK (Lundy et al 2010), Spain (Castro et al 2002; Perez-Duenas et al 2011), Italy (Nassogne et al 2000; Race et al 2000), Portugal (Edery et al 2003), France (Holder-Espinasse et al 2002), Norway (Marie et al 2002), Turkey (Kmoch et al 2000; Spiegel et al 2006), Morocco (Jaeken and Van den Berghe 1984; Stone et al 1992; Gitiaux et al 2009), Malaysia (Chen et al 2010), Australia (Stathis et al 2000; van Werkhoven et al 2013), Colombia (Castro et al 2002), and the US (Kmoch et al 2000; Spiegel et al 2006). Detailed and regularly updated information on identified patients may be found on ADSL database http://www1.lf1.cuni.cz/udmp/adsl.
+
+Although there is wide variation in the clinical presentation observed in patients with ADSL deficiency, descriptive systems have classified patients’ phenotypes as severe type I form, milder type II form, and fatal neonatal form (Jurecka et al 2008a, b).
+
+Recently, a larger number of patients with a neonatal form have been reported (van den Bergh et al 1998; Jurkiewicz et al 2007; Mouchegh et al 2007; Jurecka et al 2008a, b; Lundy et al 2010). These patients presented with fatal neonatal encephalopathy with a lack of spontaneous movement (“floppy infant”), respiratory failure and intractable seizures resulting in early death within the first weeks of life. Additionally it has been reported that ADSL may have prenatal manifestations, with impaired intrauterine growth, microcephaly, fetal hypokinesia (with all its consequences, up to arthrogryposis and pulmonary hypoplasia), and a loss of fetal heart rate variability (Mouchegh et al 2007).
+
+Most of the patients reported so far have adenylosuccinate lyase deficiency type I (severe form) with a purely neurologic clinical picture characterized by severe psychomotor retardation, early onset of seizures and microcephaly. These patients present within the first months of life and the further evolution is characterized by developmental arrest, lack of eye-to-eye contact and in some patients coma vigil (Jaeken et al 1988; Krijt et al 1994; Valik et al 1997; Kohler et al 1999; Jurecka et al 2008a, b; Gitiaux et al 2009; Lundy et al 2010; Jurecka et al 2012a, b). Severe cortical visual impairment corresponding to the degree of encephalopathy may also be a feature of the severe phenotype (Lundy et al 2010).
+
+Patients with type II (moderate or mild form), who develop symptoms within the first years of life, usually suffer from slight to moderate psychomotor retardation and transient contact disturbances (Jaeken et al 1988; Jaeken et al 1992; Jurecka et al 2008a, b; Jurecka et al 2014). Seizures, if present, appear later, often between the 2nd and 4th year of life (Castro et al 2002; Jurecka et al 2008a, b), but also reported starting as late as the 9th year of life (Gitiaux et al 2009). Speech impairment with a minimal use of words was noticed that contrast with a higher degree of receptive and non-verbal communication skills (Gitiaux et al 2009). Another described problem is ataxia, which may be the cause of increasing gait disturbance.
+
+The disease manifests symptoms along a continuum and despite the utility of communicating with the above-mentioned three descriptive categories; there are no fixed parameters to ascribe a particular patient to a single category. It has been suggested that the ratio of the accumulating succinyladenosine (S-Ado) and succinylaminoimidazolecarboxamide riboside (SAICAr) in body fluids is not predictive of phenotype severity; rather, it may be secondary to the degree of the patient’s development (i.e., to the age of the patient at the time of a sample collection) (Zikanova et al 2010).
+
+The majority of ADSL-deficient children are born after uncomplicated pregnancies with normal birth and family history. The neonatal period in mild form might be normal with growth parameters in the normal range. In severe type of disease neurologic symptom might occur early after birth (Ciardo et al 2001).
+
+Neurological symptoms are the most common and prominent clinical problems associated with adenylosuccinate lyase deficiency. Particularly common neurologic presentations include acute encephalopathy, chronic encephalopathy, and behavioral abnormalities.
+
+Acute encephalopathy is the most common presentation in the neonate and, typically, the affected neonate is born after a normal pregnancy, at or near term, with a normal birth weight and remains well in the early hours or days of life. Such an infant may be discharged from the newborn nursery, subsequently presenting as acutely unwell. Early signs of encephalopathy are non-specific, such as poor feeding, lethargy, vomiting, abnormalities of tone, and irritability. Later problems may include drowsiness, fits, hiccups, myoclonus, apneic episodes, marked hypotonia, irritability with cycling movements, seizures, and coma. Cerebral oedema may develop, contributing to the relentless deterioration if not treated.
+
+ADSL deficiency can cause onset of epilepsy in the first year of life. Seizures in early infancy should be thoroughly investigated for a metabolic basis while other, more common, causes are investigated. The clinical picture is usually complex and epilepsy is one of various other associated neurological symptoms, such as mental retardation, hypotonia, and microcephaly. Importantly, convulsions associated with ADSL deficiency may have a very early onset and be the reason for which the infant is referred to a neurologist in the first months of life, despite the presence of other, less easily identified symptoms such as delayed psychomotor acquisitions or muscle tone disorders. General characteristics of seizures secondary to ADSL deficiency are as follows: onset in the first months of life, usually partial; simple partial motor semiology of brief duration; and successive appearance, often closely related to partial seizures, tonic seizures, spasms, and massive myoclonus. Resistance to treatment is common.
+
+Developmental delay and psychomotor retardation are common in adenylosuccinase deficiency. There are some characteristics of the cognition which, when present should alert the clinician to the possibility of an underlying ADSL defect. First, it tends to be global, affecting all spheres of development to some extent. Although a mild developmental problem may present as speech delay, in most cases, a careful history and developmental examination shows that the defect extends to other developmental spheres. Secondly, severe irritability, impulsivity, aggressiveness, and hyperactivity are also common among infants with mental retardation caused by PP defects. Thirdly, the psychomotor retardation is usually progressive. There is generally a history of a period of apparently normal development, followed by loss of developmental milestones or progressive deterioration in school performance. Fourthly, the psychomotor retardation is usually associated with other objective evidence of neurologic dysfunction, such as disorders of tone (hypotonia sometimes followed after years by spasticity), seizures, pyramidal tract signs or evidence of extrapyramidal deficits.
+
+Corresponding to the clinical diversity, the epileptic phenotypes associated with ADSL deficiency are also highly variable, comprising myoclonus, partial seizures, infantile spasms, and status epilepticus (Ciardo et al 2001; Lundy et al 2010). Seizures usually start either early in the neonatal period or after the first year of life (van den Bergh et al 1998; Jurecka et al 2012a, b). Approximately half of the patients with ADSL deficiency suffer from epilepsy, which is often intractable, but not always associated with status epilepticus (Ciardo et al 2001).
+
+The autistic features in patients with ADSL deficiency include failure to make eye-to-eye contact, repetitive behavior, agitation, temper tantrums, and autoaggressivity (Van den Berghe et al 1997). Several stereotypies might include hand movements, repetitive manipulation of toys, grimacing, clapping hands, rubbing feet, inappropriate laughter, head and trunk rocking, and stereotyped sounds (Ciardo et al 2001; Perez-Duenas et al 2011). Gitiaux et al reported behavioral features in two patients, which combined excessive laughter, a very happy disposition, hyperactivity, a short/lack attention span, the mouthing of objects, tantrums, and stereotyped movements (Gitiaux et al 2009).
+
+ADSL deficiency has been reported to have some subtle dysmorphisms, but the primary and the most obvious problem is the biochemical derangement. Microcephaly is a characteristic clinical feature, but is not invariably present in the most mildly affected patients (Lundy et al 2010). Brachycephaly, flat occiput, prominent metopic sutures, intermittent divergent strabismus, small nose with anteverted nostrils, long, smooth philtrum, and thin upper lip and low set ears have been reported by Holder-Espinasse (Holder-Espinasse et al 2002). Other authors described wide mouth, wide-spaced teeth and a prominent mandible (Gitiaux et al 2009).
+
+Hypotonia (axial and generalized) is a common feature of severe type of ADSL deficiency and is often combined with peripheral hypertonia.
+
+Magnetic resonance imaging (MRI) can be a useful tool for diagnosing and monitoring the pathological progression of the changes in the course of the disease. Although over 60 patients with adenylosuccinate lyase deficiency have been reported, there are only 12 reports of brain imaging findings associated with the condition. These are mostly case reports or small series of cases with different phenotypes, and correlation with clinical symptoms is ambiguous. Reported findings on brain MRI in ADSL deficiency include atrophy of the cerebral cortex, corpus callosum, cerebellar vermis (Van den Berghe et al 1997; Edery et al 2003; Jurecka et al 2012a, b), lack of myelination (Kohler et al 1999; Jurecka et al 2012a, b), delayed myelination (Jurkiewicz et al 2007; Lundy et al 2010; Jurecka et al 2012a, b), anomalies of the white matter (Valik et al 1997; Nassogne et al 2000; Edery et al 2003; Marinaki et al 2004; Lundy et al 2010) and lissencephaly (Stathis et al 2000) (Figs. 2, 3 and 4).Fig. 2
+a-c. Axial and sagittal T2-weighted and T1-weighted cranial magnetic resonance imaging of a patient with type I ADSL deficiency: arrows indicate myelination of the posterior limbs of the internal capsules, enlarged subarachnoid space in the frontal regions, widened lateral ventricles (especially enlargement of the body and occipital horns), wide Sylvian fissures with hypoplasia operculum, thin corpus callosum and lack of myelination of the white matter volume
+Fig. 3
+a-b. Axial T2-weighted and T1-weighted cranial magnetic resonance of a patient with type I ADSL deficiency: arrows indicate symmetrical widening of the lateral ventricles, enlarged sulci of the brain cortex gyri, especially in the parieto-occipital lobes
+Fig. 4Photos of patients with type II adenylosuccinate lyase deficiency
+
+
+
+a-c. Axial and sagittal T2-weighted and T1-weighted cranial magnetic resonance imaging of a patient with type I ADSL deficiency: arrows indicate myelination of the posterior limbs of the internal capsules, enlarged subarachnoid space in the frontal regions, widened lateral ventricles (especially enlargement of the body and occipital horns), wide Sylvian fissures with hypoplasia operculum, thin corpus callosum and lack of myelination of the white matter volume
+
+
+a-b. Axial T2-weighted and T1-weighted cranial magnetic resonance of a patient with type I ADSL deficiency: arrows indicate symmetrical widening of the lateral ventricles, enlarged sulci of the brain cortex gyri, especially in the parieto-occipital lobes
+
+Photos of patients with type II adenylosuccinate lyase deficiency
+
+Adenylosuccinate lyase deficiency is inherited as an autosomal recessive trait. In humans the ADSL gene spans approximately 23 kb on chromosome 22 (22q13.1q13.2) (Van Keuren et al 1987; Fon et al 1993). It consists of 13 exons and its promoter has typical features of house-keeping gene. The ADSL gene is transcribed in most of the tissues into two transcript variants which are produced by alternative splicing of exon 12. Full length variant encodes an active ADSL protein composed of 484 amino acids. The alternatively spliced variant encodes variant missing 59 amino acid (residues 397–456). This variant is catalytically inactive and its biological relevance is not clear yet (Kmoch et al 2000).
+
+To date, over 50 different ADSL mutations have been identified in individuals with ADSL deficiency. A majority of the identified mutations represent missense mutations presenting in heterozygosis and producing an altered ADSL protein (Human Gene Mutation Database). A mutation of a regulatory region of the ADSL gene (in a nuclear respiratory factor 2 binding site in the promoter region) has also been identified in five patients (Marie et al 2002) as well as a mutation creating a new splice site and resulting in a 39 base pair deletion (Kohler et al 1999; Marie et al 1999). Mutation c.774_778insG results in the introduction of an early stop codon in position 284 of the protein (Chen et al 2010) and mutation c.889_891dupAAT predicted a duplication of the Asn297 residue at the active site of the enzyme (van Werkhoven et al 2013). Two-thirds of the diagnosed patients are compound heterozygotes and most mutations are private. The most common mutation, accounting for about one third of the patients’ alleles investigated, is a missense mutation R426H mutation.
+
+Recently, the existence of the purinosome has been described (An et al 2008). The purinosome is a multienzyme complex of the de novo purine synthesis (DNPS) enzymes (including ADSL) that cells transiently assemble in their cytosol upon depletion or increased demand of purines. The process of purinosome formation was first demonstrated and studied in HeLa and human C3A liver carcinoma cells transiently expressing recombinant fluorescently labeled DNPS proteins (An et al 2008). Then the existence of purinosome was proved in vivo conditions in cancer and normal non-transfected cells (Baresova et al 2012).
+
+The later studies showed that the first three enzymes in the pathway form a core of the purinosome (Deng et al 2012) and are substrates for protein kinase CK2, which suggests dynamic regulation by post-translational modifications (An et al 2010a, b). The assembly and disassembly of purinosomes are correlated with the rate of DNPS and for its formation the intact network of microtubules is needed (An et al 2010a, b). Also methenyltetrahydrofolate synthetase association with the purinosome in mammalian cells was studied and dependence of this process on methenyltetrahydrofolate synthetase stimulation was observed (Field et al 2011).
+
+The study of purinosome formation in skin fibroblasts of the patients with ADSL deficiency showed that significant differences of purinosome assembly exists among individual cases with ADSL deficiency and that the ability to form purinosomes inversely correlates with the severity of the phenotype (Baresova et al 2012). This finding corroborates the hypothesis that the phenotypic severity of ADSL deficiency is mainly determined by structural stability and residual catalytic capacity of the corresponding mutant ADSL protein complex, as this is a prerequisite for the formation and stability of the purinosome and at least partial channeling of SAICAR through the DNPS pathway (Zikanova et al 2010; Vliet et al 2011).
+
+Population sequencing (Exome sequence project) so far revealed 42 non-synonymous variants in ADSL gene, 25 is classified as probably damaging, four possibly damaging and 13 benign. Out of these variants five were already identified in patients, the most common mutation in ADSL patients R426H was not present. The probability of heterozygotes for a pathogenic ADSL mutation is about 1:10000.
+
+Current findings indicate that the severity of the clinical symptoms correlate with the residual enzymatic activity and stability of the recombinant mutant enzyme (Kmoch et al 2000; Ariyananda Lde et al 2009; Zikanova et al 2010; Ray et al 2013). In other words, the phenotypic severity in ADSL deficiency probably reflects the degree of structural stability and residual enzyme activity of the corresponding ADSL enzyme complex. This can be documented best by the biochemical properties of the recombinant mutant proteins associated with the neonatal fatal phenotype. These proteins display the lowest residual activity and significant thermal instability and the mutations mostly affect residues forming the catalytic sites or residues involved in substrate channeling. Recombinant mutant proteins associated with type II disease displayed mostly normal enzymatic activity; the proteins are stable, and the mutations seemed to be structurally benign based on in silico analysis of the ADSL structure. The pathogenic effects of these biochemically benign and structurally stable mutations, therefore, are probably not related to their intrinsic structural and/or catalytic properties but rather to abnormalities that may manifest only under in vivo conditions inside eukaryotic cells. Such mutations may affect protein folding, purinosome formation (Baresova et al 2012), slow down enzyme complex formation and/or lead to accelerated degradation. These mechanisms may decrease the amount of otherwise normally functioning enzyme complex and lead to a much milder enzyme deficiency (Zikanova et al 2010).
+
+In all cases studied so far, the combination of mutations produce ADSL enzymes that retain some residual enzyme activity (Van den Bergh et al 1993a, b; Van den Bergh et al 1993a, b); complete lack of ADSL activity in humans is probably lethal.
+
+Hypotheses regarding the pathogenesis include toxicity of high levels of SAICAR, AMPS, or their metabolites, deficiency of the de novo purine biosynthetic pathway, or lack of a completely functional purine cycle in muscle and brain.
+
+The main pathogenic effect has been attributed to the toxic effects of accumulating succinylpurines (Stone et al 1998). Although the absolute S-Ado and SAICAr concentrations in body fluids do not correlate with the severity of the phenotype, it has been found that different values for the ratio between S-Ado and SAICAr concentrations in cerebrospinal fluid (S-Ado/SAICAr ratio) correspond with the three main phenotypic groups (Van den Bergh et al 1993a, b; Mouchegh et al 2007):i)In patients with the neonatal fatal form, the S-Ado/SAICAr ratio is less than 1.ii)In patients with the severe childhood form, the S-Ado/SAICAr ratio is close to 1.iii)In patients with the moderate or mild form, the S-Ado/SAICAr ratio is more than 2.
+
+
+In patients with the neonatal fatal form, the S-Ado/SAICAr ratio is less than 1.
+
+In patients with the severe childhood form, the S-Ado/SAICAr ratio is close to 1.
+
+In patients with the moderate or mild form, the S-Ado/SAICAr ratio is more than 2.
+
+The observation of less severe intellectual impairment in patients with similar SAICAr levels but S-Ado/SAICA-r ratios above 2, suggests that SAICA-r is the offending/neurotoxic compound, and that S-Ado may be protective of SAICAr’s effects. The finding that infusion of SAICAr to rats induces neuronal damage in specific regions of the hippocampus is consistent with this hypothesis (Stone et al 1998). To date, however, all attempts to demonstrate evidence of neurotoxicity of the succinylpurines in humans have failed.
+
+Biochemical and structural analysis of mutant ADSL enzyme complexes have shown that different S-Ado/SAICAr ratios do not result from disproportionate SAMP and SAICAR enzyme activities. Almost all of the mutant protein complexes, if active, displayed a proportional decrease in activity toward both of the enzyme substrates.
+
+It seems that the ratio of the accumulating S-Ado and SAICAr in body fluids is not predictive of phenotype severity; rather, it may be secondary to the degree of the patient’s development (i.e., to the age of the patient at the time of a sample collection) (Zikanova et al 2010).
+
+Deficient synthesis of purine nucleotides caused by ADSL deficiency has been hypothesized to have detrimental effects during embryo development, primarily depending on de novo purine synthesis. However, normal levels of purine nucleotides were measured in various patients’ tissues (Van den Berghe and Jaeken 1986). This suggests that ADSL activity, although deeply reduced, may not be limiting for the de novo synthesis or that salvage pathway involving the enzymes hypoxanthine-guanine phosphoribosyltransferase, adenine phosphoribosyltransferase and adenosine kinase may compensate for the deficiency (Jaeken and Van den Berghe 1984; Jaeken et al 1988). Nevertheless, a deficiency of purine nucleotides could occur in some hitherto unidentified cell types with profound deficiency of adenylosuccinate lyase and low activity of the salvage pathway. Little is known about the actual purine levels in the living brain and about the regulation of purine synthesis during embryogenesis, which might be affected by deficits in purine metabolism.
+
+ADSL also participates in the purine nucleotide cycle along with AMP deaminase and adenylosuccinate synthetase, and the impairment of this cycle in ADSL deficiency has also been suggested to cause the disorder. Purine nucleotide cycle controls the level of fumarate, a Krebs cycle intermediate, and of AMP, particularly maintaining the ATP/AMP ratio in muscles (Van den Berghe et al 1992).
+
+
+demonstration of succinylaminoimidazolecarboxamide riboside (SAICAr) and succinyladenosine (S-Ado) in extracellular fluids such as plasma, cerebrospinal fluid and/or urine using HPLC with UV detection or HPLC-MS,mutation analysis — genomic and/or cDNA sequencing of ADSL gene and characterization of mutant proteins.
+
+
+demonstration of succinylaminoimidazolecarboxamide riboside (SAICAr) and succinyladenosine (S-Ado) in extracellular fluids such as plasma, cerebrospinal fluid and/or urine using HPLC with UV detection or HPLC-MS,
+
+mutation analysis — genomic and/or cDNA sequencing of ADSL gene and characterization of mutant proteins.
+
+Diagnosis is supported by the following:evidence of clinical phenotype,demonstration of SAICAr and S-Ado in extracellular fluids such as urine, cerebrospinal fluid and/or plasma using simple screening tests such as Bratton-Marshall or thin-layer chromatography,the analysis of ADSL enzyme activity in cultured skin fibroblasts at an accredited laboratory to demonstrate large decrease of ADSL activity. Although ADSL enzyme activity levels may be different between testing laboratories, ADSL activity in diagnosed ADSL patients is generally between 2-20 % of the lower limit of normal ADSL activity (Salerno et al 1995). Enzyme assay in lysates is not completely reliable due to tissue heterogeneity of ADSL defect (Mouchegh et al 2007).
+
+
+evidence of clinical phenotype,
+
+demonstration of SAICAr and S-Ado in extracellular fluids such as urine, cerebrospinal fluid and/or plasma using simple screening tests such as Bratton-Marshall or thin-layer chromatography,
+
+the analysis of ADSL enzyme activity in cultured skin fibroblasts at an accredited laboratory to demonstrate large decrease of ADSL activity. Although ADSL enzyme activity levels may be different between testing laboratories, ADSL activity in diagnosed ADSL patients is generally between 2-20 % of the lower limit of normal ADSL activity (Salerno et al 1995). Enzyme assay in lysates is not completely reliable due to tissue heterogeneity of ADSL defect (Mouchegh et al 2007).
+
+All standard laboratory investigations are normal: no signs of hypoglycemia, hypomagnesaemia or hypocalcaemia, and the laboratory metabolic investigations such as liver function tests, plasma lactate and pyruvate, ceruloplasmin, thyroid-stimulating hormone, amino acids, and organic acids are normal.
+
+The deficiency of ADSL activity results in accumulation of SAICAR and SAMP in the cells and the presence of enormously elevated concentrations of their dephosphorylated forms, SAICAr and S-Ado in extracellular fluids — urine and CSF, and to a lesser extent also in plasma. SAICAr and SAdo are present in low micromolar concentrations in body fluids of controls (Sebesta et al 1997; Krijt et al 1999). Several methods have been described for selective screening of subjects with ADSL deficiency that allow identification of either two or one of the relevant compounds in body fluids. The most commonly used include Bratton-Marshall test, thin-layer chromatography (TLC) for identification of SAICAr (Wadman, de Bree et al 1986), S-Ado (Maddocks and Reed 1989) and both nucleosides (Jaeken and van den Berghe 1989), isolation of SAICA riboside and S-Ado with a cation exchange resin and determination of A270/A250 ratio (UV absorbance of the ammonia eluate at 270 and 250 nm) (Domkin et al 1995), capillary electrophoresis (Gross et al 1995; Hornik et al 2007), and high resolution proton magnetic resonance spectroscopy (Wevers et al 1995; Henneke et al 2010). Bratton-Marshall test and TLC with Pauly reagent detects the presence of excessive urinary SAICA riboside (Laikind et al 1986), but may be false negative due to bacteria-mediated deribosylation of SAICAr and SAdo in urine (Krijt et al 2013) or SAICAr instability. The advantage of the Bratton-Marshall test is its simplicity of equipment and procedure, and the speed of test (Laikind et al 1986). HPLC-DAD, LC-MS/MS or other screening methods allowing simultaneous detection of SAICA-riboside ade and SAdo should be preferentially used for the diagnosis of ADSL deficiency. HPLC-DAD method employs resolution of SAdo and SAICAr from serum, urine, and CSF by reverse-phase high-pressure liquid chromatography (RP-HPLC) with detection by UV spectroscopy (Jaeken and Van den Berghe 1984; de Bree et al 1986; Jaeken et al 1988). The compounds are identified by spectral analyses and comparison to available standards. This method gives accurate results and has the advantage of quantifying the excretion of a large number of compounds. However, it requires expensive, specialized equipment and is usually employed as a second step to further identify the metabolite accumulating in any sample that gives a positive Bratton-Marshall or TLC test. Recently, high-throughput urine screening techniques for ADSL deficiency have been developed using HPLC combined with electrospray ionization (ESI) tandem mass spectrometry (MS/MS) (Ito et al 2000; Hartmann et al 2006; van van Werkhoven et al 2013). These methods allow rapid and specific screening for disorders of purine and pyrimidine metabolism with use of liquid urine samples or urine-soaked filter paper strips.
+
+Differential diagnoses within ADSL deficiency include:
+
+Neurological disorders with intractable seizures and encephalopathy
+
+Other inborn errors of purine and pyrimidine (P/P) metabolism with neurological manifestations
+
+The wide clinical spectrum of the disease accounts for possible difficulties in differential diagnosis with neurological disorders especially those with intractable seizures and encephalopathy.
+
+In the neonatal period, differential diagnosis should firstly be made with five treatable disorders that can present predominantly with intractable seizures: pyridoxine responsive seizures, pyridox(amine)-5'-phosphate oxidase deficiency, folinic acid-responsive seizures, 3-phosphoglycerate dehydrogenase deficiency, and hyperinsulinemic hypoglycemia (Saudubray et al 2006). Biotin-responsive holocarboxylase synthetase deficiency can also rarely present with neonatal seizures. In the first months of life, biotin-responsive biotinidase deficiency and GLUT1 deficiency, treatable by a hyperketotic diet, can also present with intractable seizures. Other, nontreatable inborn errors of metabolism can present in the neonatal period with severe epilepsy: nonketotic hyperglycinemia, D-2-hydroxyglutaric aciduria, mitochondrial glutamate transporter defect, peroxisomal biogenesis defects, respiratory chain disorders, sulfite oxidase deficiency, and Menkes disease. In infancy, the association of seizures and autistic features should prompt differential diagnosis with Angelman syndrome.
+
+Other inborn errors of purine and pyrimidine metabolism may present early in life with similar symptoms as ADSL deficiency. Selective screening for purines and pyrimidines is very valuable especially in children with nonspecific neurological symptoms.
+
+Prenatal diagnosis is limited to families having a previous child with ADSL deficiency and is based on mutational analysis for at-risk fetuses. Diagnostic testing may be conducted for prenatal diagnosis on viable fetal cells from chorionic villi, cultured amniotic fluid cells or in the newborn dried blood spots (Marie et al 2000).
+
+The wide clinical spectrum of the disease accounts for possible difficulties in differential diagnosis with neurological disorders especially those with intractable seizures and encephalopathy. For this reason, it is important to develop protocols for ADSL suspects and diagnosis to avoid useless investigations and treatments. The marked clinical heterogeneity justifies systemic screening for the disorder in patients with:newborns and infants with hypotonia and acquired microcephaly,unexplained psychomotor retardation,unexplained developmental delay,unexplained seizures especially intractable,MRI findings such as atrophy of the cerebral cortex, corpus callosum, cerebellar vermis, lack of myelination, delayed myelination, anomalies of the white matter.
+
+
+newborns and infants with hypotonia and acquired microcephaly,
+
+unexplained psychomotor retardation,
+
+unexplained developmental delay,
+
+unexplained seizures especially intractable,
+
+MRI findings such as atrophy of the cerebral cortex, corpus callosum, cerebellar vermis, lack of myelination, delayed myelination, anomalies of the white matter.
+
+Greater awareness of adenylosuccinate lyase deficiency amongst pediatricians, neonatologists, pediatric neurologists but also radiologists is the key to identifying the disorder in the early stage. Because the majority of newborns with neonatal as well as type I of ADSL deficiency have microcephaly, general pediatricians and neonatologists should exclude ADSL in newborns and infants with a small head circumference. General and emergency care pediatricians must consider ADSL deficiency in parallel with status epilepticus. Pediatric neurologists have an important role to play in bringing this disorder to the attention of the broader pediatric community and instructing them as to the key diagnostic clues. The finding of atrophy of the cerebral cortex, corpus callosum, cerebellar vermis, lack of/or delayed myelination, anomalies of the white matter or lissencephaly on MRI examination should alert neonatologists and radiologists to the possibility of ADSL deficiency.
+
+With such an approach, more patients may benefit from early diagnosis.
+
+When the prospects for treatment or disease-altering management are not prominent, patients and family members will benefit from definitive diagnosis. Diagnosis helps the patient and family members gain access to appropriate organizations that provide emotional support as well as practical advice and assistance in dealing with the life changes that arise as a result of disability. Accurate diagnosis is vital so that families can receive genetic counseling about risk recurrence and the possibility of a- or pre-symptomatic affected relatives.
+
+Despite the increasing number of ADSL-deficient patients reported, there are only a few communications of therapeutic considerations and efforts. Among them only two showed some beneficial effects (D-ribose and uridine administration) (Salerno et al 1998; Salerno et al 2000). D-ribose administration, which increases the provision of phosporibosylpyrophosphate (PRPP) and stimulates de novo purine synthesis, has been applied in a few ADSL patients. Salerno et al published promising results in motor coordination and seizure control in a 13-year-old female after several months of D-ribose therapy (Salerno et al 1998). These results, however, have not been confirmed in further studies (Jurecka et al 2008a, b; Perez-Duenas et al 2011).
+
+Recently Werkhoven et al evaluated S-adenosyl-l-methionine (SAMe) as a potential treatment for ADSL deficiency (van Werkhoven et al 2013). After 9 months of SAMe treatment, there was no clear response evidenced in urine metabolite levels or clinical parameters.
+
+The aim of treating epilepsy is to control or at least decrease seizure frequency with minimal side effects. Treatment with anticonvulsive drugs (e.g., valproic acid, phenobarbital, carbamazepine, topiramate, levetiracetam, phenitoin, clobazam) depends on the type of seizures. Patients with ADSL deficiency often require polypharmacy with the use of two or more anticonvulsants. Drug resistance is common.
+
+Recently there have been reports about positive use of a ketogenic diet for treatment of refractory epilepsy (Lefevre and Aronson 2000; Jurecka et al 2012a, b). Physiological consequences of a ketogenic diet are similar to fasting and include hypoglycemia and increased levels of ketone bodies and fatty acids. Various mechanisms have been hypothesized for the anticonvulsant effect of the ketogenic diet in ADSL patient (Jurecka et al 2012a, b). Some of these hypotheses focus on ketone bodies as crucial mediators of the beneficial effects of the ketogenic diet. Acetone shows the best anticonvulsant effects both in vivo and in vitro models (Masino and Geiger 2008). As a result of the diet, more glutamate becomes accessible to the glutamate decarboxylase reaction to yield gamma-aminobutyric acid (GABA), the major inhibitory neurotransmitter and an important antiseizure agent. In addition, the ketogenic diet appears to favor the synthesis of glutamine, an essential precursor to GABA (Yudkoff et al 2007). Both hypoglycemia and decreased pH are physiological changes that have been shown to increase adenosine and ATP levels. A purinenergic signaling hypothesis assumes neuroprotective and antiseizure actions of a ketogenic diet. Whilst on a ketogenic diet, increased mitochondrial biogenesis, brain energetics and brain ATP are observed.
+
+A ketogenic diet could be considered a valid therapeutic option in patients with intractable seizures in a course of ADSL deficiency, however due to the possibility of side effects that may present during the diet, patients require a thorough and systematic examinations, including biochemical parameters of blood (Jurecka et al 2012a, b).
+
+Lifespan in patients with adenylosuccinate lyase deficiency is variable: neonatal forms may lead to early death, whereas onset in early childhood usually entails stable evolution. There are important issues to be considered when counseling families regarding prognosis and prenatal diagnosis. One is uncertainty regarding the long-term outcome in patients with milder phenotypes. Another complicating issue in genetic counseling is the unpredictability of phenotype in individuals with the same ADSL phenotype. The clinical heterogeneity in ADSL phenotype is not well understood.
+
+Adenylosuccinate lyase deficiency is a progressive disease with central nervous system involvement. As our knowledge about the natural history of ADSL deficiency increases, it becomes evident that the disease manifests symptoms along a continuum ranging from severe to mild. Clinical heterogeneity is especially prominent in the less severe end of the spectrum and some attenuated patients may present no obvious signs of disease progression and degradation. Case reports/series are therefore particularly important to expand our knowledge and understanding of the disease. The pathomechanism of the disease still remains unclear and requires further research. To date, there is no specific and effective therapy for adenylosuccinase deficiency despite a few attempts that have been made. The purinosome may also represent a new pharmacological opportunity for therapeutic intervention.

--- a/references_cache/PMID_27504266.md
+++ b/references_cache/PMID_27504266.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:27504266"
+title: Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in plasma reveals a phenotypic spectrum.
+authors:
+- Donti TR
+- Cappuccio G
+- Hubert L
+- Neira J
+- Atwal PS
+- Miller MJ
+- Cardon AL
+- Sutton VR
+- Porter BE
+- Baumer FM
+- Wangler MF
+- Sun Q
+- Emrick LT
+- Elsea SH
+journal: Mol Genet Metab Rep
+year: '2016'
+doi: 10.1016/j.ymgmr.2016.07.007
+content_type: abstract_only
+---
+
+# Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in plasma reveals a phenotypic spectrum.
+**Authors:** Donti TR, Cappuccio G, Hubert L, Neira J, Atwal PS, Miller MJ, Cardon AL, Sutton VR, Porter BE, Baumer FM, Wangler MF, Sun Q, Emrick LT, Elsea SH
+**Journal:** Mol Genet Metab Rep (2016)
+**DOI:** [10.1016/j.ymgmr.2016.07.007](https://doi.org/10.1016/j.ymgmr.2016.07.007)
+
+## Content
+
+1. Mol Genet Metab Rep. 2016 Jul 27;8:61-6. doi: 10.1016/j.ymgmr.2016.07.007.
+eCollection 2016 Sep.
+
+Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in
+plasma reveals a phenotypic spectrum.
+
+Donti TR(1), Cappuccio G(2), Hubert L(1), Neira J(1), Atwal PS(1), Miller MJ(1),
+Cardon AL(3), Sutton VR(1), Porter BE(4), Baumer FM(4), Wangler MF(1), Sun Q(1),
+Emrick LT(5), Elsea SH(1).
+
+Author information:
+(1)Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, TX, United States.
+(2)Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, TX, United States; Department of Translational Medical Sciences,
+Section of Pediatrics, Federico II University, Naples, Italy.
+(3)Section of Pediatric Neurology and Neuroscience, Baylor College of Medicine,
+Houston, TX, United States.
+(4)Stanford Medical School, Stanford, CA, United States.
+(5)Department of Molecular and Human Genetics, Baylor College of Medicine,
+Houston, TX, United States; Section of Pediatric Neurology and Neuroscience,
+Baylor College of Medicine, Houston, TX, United States.
+
+Adenylosuccinate lyase (ADSL) deficiency is a rare autosomal recessive
+neurometabolic disorder that presents with a broad-spectrum of neurological and
+physiological symptoms. The ADSL gene produces an enzyme with binary molecular
+roles in de novo purine synthesis and purine nucleotide recycling. The
+biochemical phenotype of ADSL deficiency, accumulation of SAICAr and
+succinyladenosine (S-Ado) in biofluids of affected individuals, serves as the
+traditional target for diagnosis with targeted quantitative urine purine
+analysis employed as the predominate method of detection. In this study, we
+report the diagnosis of ADSL deficiency using an alternative method, untargeted
+metabolomic profiling, an analytical scheme capable of generating
+semi-quantitative z-score values for over 1000 unique compounds in a single
+analysis of a specimen. Using this method to analyze plasma, we diagnosed ADSL
+deficiency in four patients and confirmed these findings with targeted
+quantitative biochemical analysis and molecular genetic testing. ADSL deficiency
+is part of a large a group of neurometabolic disorders, with a wide range of
+severity and sharing a broad differential diagnosis. This phenotypic similarity
+among these many inborn errors of metabolism (IEMs) has classically stood as a
+hurdle in their initial diagnosis and subsequent treatment. The findings
+presented here demonstrate the clinical utility of metabolomic profiling in the
+diagnosis of ADSL deficiency and highlights the potential of this technology in
+the diagnostic evaluation of individuals with neurologic phenotypes.
+
+DOI: 10.1016/j.ymgmr.2016.07.007
+PMCID: PMC4969260
+PMID: 27504266

--- a/references_cache/PMID_41053929.md
+++ b/references_cache/PMID_41053929.md
@@ -1,0 +1,115 @@
+---
+reference_id: "PMID:41053929"
+title: "Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency."
+authors:
+- Rousselot-Pailley B
+- Semeraro M
+- Marquant F
+- Robel L
+- Gitiaux C
+- Kaminska A
+- Mochel F
+- Bakouboula P
+- Elie C
+- Hennequin C
+- Ceballos-Picot I
+- Sanquer S
+- de Lonlay P
+journal: J Inherit Metab Dis
+year: '2025'
+doi: 10.1002/jimd.70092
+keywords:
+- Humans
+- Allopurinol/therapeutic use
+- Male
+- Female
+- Adenylosuccinate Lyase/deficiency
+- Child
+- "Purine-Pyrimidine Metabolism, Inborn Errors/drug therapy, urine"
+- "Child, Preschool"
+- Cognition/drug effects
+- Young Adult
+- Prospective Studies
+- "Aminoimidazole Carboxamide/analogs & derivatives, urine, metabolism"
+- Biomarkers/urine
+- Adolescent
+- Adult
+- "Ribonucleosides/urine, metabolism"
+- Ribonucleotides/urine
+- Treatment Outcome
+- Infant
+- Autistic Disorder
+content_type: abstract_only
+---
+
+# Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency.
+**Authors:** Rousselot-Pailley B, Semeraro M, Marquant F, Robel L, Gitiaux C, Kaminska A, Mochel F, Bakouboula P, Elie C, Hennequin C, Ceballos-Picot I, Sanquer S, de Lonlay P
+**Journal:** J Inherit Metab Dis (2025)
+**DOI:** [10.1002/jimd.70092](https://doi.org/10.1002/jimd.70092)
+
+## Content
+
+1. J Inherit Metab Dis. 2025 Nov;48(6):e70092. doi: 10.1002/jimd.70092.
+
+Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and
+Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency.
+
+Rousselot-Pailley B(1)(2), Semeraro M(3)(4), Marquant F(3), Robel L(5), Gitiaux
+C(6), Kaminska A(6), Mochel F(7)(8), Bakouboula P(3), Elie C(3)(4), Hennequin
+C(9), Ceballos-Picot I(9), Sanquer S(9), de Lonlay P(10).
+
+Author information:
+(1)Service de psychiatrie, Hôpital Universitaire Necker Enfants-Malades,
+Assistance Publique-Hôpitaux de Paris (AP-HP), Paris, France.
+(2)Université Paris-Cité, CRPMS F75013, Paris, France.
+(3)Unité de Recherche clinique/Centre d'Investigation Clinique Necker P1419
+Necker Cochin, GHU Paris Centre Université Paris Cité, AP-HP, Paris, France.
+(4)Université Paris Cité Inserm, Pharmacologie et évaluations des thérapeutiques
+chez l'enfant et la femme enceinte, Paris, France.
+(5)UPPEA, Service de Psychiatrie de L'enfant et de L'adolescent IJ6, GHU
+Psychiatrie et Neurosciences, Paris, France.
+(6)Department of Clinical Neurophysiology, AP-HP, Necker-Enfants Malades
+Hospital, Paris, France.
+(7)Department of Medical Genetics, Reference Centers for Adult Neurometabolic
+Diseases and Adult Leukodystrophies, AP-HP, Pitié-Salpêtrière University
+Hospital, filière Maladies Rares G2m, Paris, France.
+(8)INSERM U 1127, CNRS UMR 7225, Sorbonne Universités, UPMC Univ Paris 06 UMR S
+1127, Institut du Cerveau, ICM, Paris, France.
+(9)Service de Biochimie, Hôpital Universitaire Necker Enfants-Malades,
+Assistance Publique-Hôpitaux de Paris (AP-HP), Paris, France.
+(10)Reference Center for Inherited Metabolic Diseases, Hôpital Universitaire
+Necker Enfants-Malades, Assistance Publique-Hôpitaux de Paris (AP-HP),
+Université Paris Cité, Paris, France.
+
+Adenylosuccinate lyase deficiency (ADSLD) is a rare neurological disorder
+characterized by psychomotor retardation, autistic behaviors, and seizures, with
+no specific treatment available. ADSL catalyzes the transformation of
+succinylaminoimidazole carboxamide ribotide (SAICAr) to AICAR, and succinyl-AMP
+(S-AMP) to AMP. The pathogenesis of the disease is primarily attributed to the
+toxicity of elevated SAICAr concentrations. Allopurinol, used primarily for
+hyperuricemia, inhibits purine synthesis and may reduce SAICAr levels. We
+hypothesized that administering allopurinol could decrease SAICAr levels and
+lead to clinical improvement. A Phase II, prospective trial evaluated the
+efficacy of allopurinol in patients with ADSLD over 12 months. Eight
+participants (four children, four young adults) with developmental delay and
+high SAICAr levels received Zyloric (10-20 mg/kg/day, maximum 400 mg/day for
+children and 900 mg/day for adults). The study assessed changes in adaptive and
+cognitive functioning, behavior, and urinary levels of SAICAr and
+succinyl-adenosine (S-Ado). Results showed clinical improvements in younger,
+less cognitively impaired patients, indicated by better Vineland Adaptive
+Behavior Scale (VABS II) scores and reduced hyperactivity on the Aberrant
+Behavior Checklist (ABC) and Conners Rating Scale-Revised (CRSR). These
+improvements correlated with significant decreases in urinary SAICAr levels and
+an increased S-Ado/SAICAr ratio. No changes were observed in older or
+noncompliant patients. Allopurinol had no effect on epilepsy but was well
+tolerated. Allopurinol showed behavioral and developmental benefits in younger
+ADSLD patients, suggesting that it may be a viable treatment option.
+
+© 2025 The Author(s). Journal of Inherited Metabolic Disease published by John
+Wiley & Sons Ltd on behalf of SSIEM.
+
+DOI: 10.1002/jimd.70092
+PMCID: PMC12501040
+PMID: 41053929 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/clinicaltrials_NCT03776656.md
+++ b/references_cache/clinicaltrials_NCT03776656.md
@@ -1,0 +1,15 @@
+---
+reference_id: "clinicaltrials:NCT03776656"
+title: Evaluation of a Treatment With Allopurinol on Autistic Disorders and Epilepsy in Adenylosuccinate Lyase Deficiency (ADSL)
+content_type: summary
+---
+
+# Evaluation of a Treatment With Allopurinol on Autistic Disorders and Epilepsy in Adenylosuccinate Lyase Deficiency (ADSL)
+
+## Content
+
+The aim of this study is to evaluate the effectiveness of allopurinol treatment at 12 months on the adaptive and cognitive functioning of patients with adenylosuccinate lyase deficiency (ADSL). The psychiatric evaluation will involve the use of standardized tools prior to initiation of treatment, and will be repeated 6 months and 12 months after the start of treatment.
+
+The decrease in the concentration of SAICAR and S-Ado metabolites, which are markers of adenylosuccinate lyase (ADSL) deficiency, will also be quantified.
+
+Similarly, the efficacy of allopurinol on epileptic seizures for epileptic patients and on electrocardiogram abnormalities will be evaluated secondarily

--- a/research/Adenylosuccinate_Lyase_Deficiency-deep-research-falcon.md
+++ b/research/Adenylosuccinate_Lyase_Deficiency-deep-research-falcon.md
@@ -1,0 +1,1212 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-03T00:00:55.090815'
+end_time: '2026-05-03T00:09:50.380137'
+duration_seconds: 535.29
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Adenylosuccinate Lyase Deficiency
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Adenylosuccinate Lyase Deficiency
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Adenylosuccinate Lyase Deficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Adenylosuccinate Lyase Deficiency
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Adenylosuccinate Lyase Deficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Adenylosuccinate Lyase Deficiency (ADSL deficiency / ASLD): Comprehensive Disease Characteristics Report
+
+## Executive summary
+Adenylosuccinate lyase deficiency (also called adenylosuccinase deficiency; ADSL deficiency; ASLD) is an ultra-rare, autosomal recessive inborn error of purine metabolism caused by biallelic pathogenic variants in **ADSL**, leading to reduced adenylosuccinate lyase activity in **de novo purine synthesis** and the **purine nucleotide cycle** and accumulation of the succinylpurine metabolites **SAICAr** and **succinyladenosine (S‑Ado)** in extracellular fluids. Clinical presentation is predominantly neurologic and includes developmental delay/intellectual disability, hypotonia, epilepsy (often intractable), microcephaly, and autistic features, with a spectrum from fatal neonatal encephalopathy to milder later-onset disease. (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, donti2016diagnosisofadenylosuccinate pages 1-2, cutillo2024electroclinicalfeaturesand pages 1-2)
+
+## 1. Disease information
+### 1.1 Definition and overview
+A widely cited review defines the disorder as a purine metabolism defect with characteristic metabolite accumulation: **“Biochemically this defect manifests by the presence in the biologic fluids of two dephosphorylated substrates of ADSL enzyme: succinylaminoimidazole carboxamide riboside (SAICAr) and succinyladenosine (S-Ado).”** (Journal of Inherited Metabolic Disease, online 2014; print Aug 2015) (jurecka2015adenylosuccinatelyasedeficiency pages 1-3).
+
+### 1.2 Key identifiers
+| Identifier system | ID | Label | Notes/Source URL |
+|---|---|---|---|
+| MONDO | MONDO_0007068 | adenylosuccinate lyase deficiency | Disease-target association record identifies MONDO_0007068 as “adenylosuccinate lyase deficiency.” https://platform.opentargets.org/disease/MONDO_0007068 (jurecka2015adenylosuccinatelyasedeficiency pages 1-3) |
+| OMIM | 103050 | Adenylosuccinate Lyase Deficiency | OMIM disease number explicitly cited in the literature and model-organism papers as “OMIM 103050” / “OMIM #103050.” https://omim.org/entry/103050 (donti2016diagnosisofadenylosuccinate pages 1-2, jurecka2015adenylosuccinatelyasedeficiency pages 1-3, moro2023adenylosuccinatelyasedeficiency pages 1-2) |
+| MeSH (suggested) | Not confirmed in retrieved papers; clinical trial record uses disease label | Adenylosuccinate Lyase Deficiency | ClinicalTrials.gov record lists the condition/MeSH-linked term “Adenylosuccinate lyase deficiency.” Suggested MeSH label for indexing/search; verify exact MeSH UID in NLM MeSH Browser. https://clinicaltrials.gov/study/NCT03776656 (NCT03776656 chunk 2) |
+| ClinicalTrials.gov condition label | NCT03776656 | Evaluation of a Treatment With Allopurinol in Adenylosuccinate Lyase Deficiency | Interventional phase II study naming the disease directly; useful practical identifier for recent clinical research. https://clinicaltrials.gov/study/NCT03776656 (NCT03776656 chunk 2, NCT03776656 chunk 1) |
+| Synonym | — | ADSL deficiency | Common literature shorthand used throughout reviews and case reports. https://doi.org/10.1007/s10545-014-9755-y ; https://doi.org/10.1016/j.ymgmr.2016.07.007 (donti2016diagnosisofadenylosuccinate pages 1-2, jurecka2015adenylosuccinatelyasedeficiency pages 1-3) |
+| Synonym | — | ASLD | Abbreviation used in 2023 mechanistic/model-organism literature for adenylosuccinate lyase deficiency. https://doi.org/10.1371/journal.pgen.1010974 ; https://doi.org/10.1016/j.ymgme.2023.107686 (moro2023adenylosuccinatelyasedeficiency pages 1-2, fenton2023acaenorhabditiselegans pages 1-3) |
+| Synonym | — | Adenylosuccinase deficiency | Historical/alternate enzyme-based synonym seen in purine-metabolism literature and references discussing ASL deficiency. https://doi.org/10.1016/j.ymgme.2023.107686 (fenton2023acaenorhabditiselegans pages 15-16) |
+
+
+*Table: This table summarizes the core disease identifiers and commonly used synonyms for adenylosuccinate lyase deficiency. It is useful for harmonizing nomenclature across OMIM, MONDO, clinical trial records, and literature sources.*
+
+**Additional identifiers not confirmed in retrieved full-text**: Orphanet (ORPHA ID), ICD-10/ICD-11 codes, and MeSH Unique ID (UID) were not explicitly present in the retrieved literature text; these should be verified in Orphanet/ICD/MeSH browsers and then mapped to the knowledge base entry.
+
+### 1.3 Common synonyms
+- Adenylosuccinate lyase deficiency; ADSL deficiency (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, donti2016diagnosisofadenylosuccinate pages 1-2)
+- ASLD (used in 2023 model-organism literature) (moro2023adenylosuccinatelyasedeficiency pages 1-2, fenton2023acaenorhabditiselegans pages 1-3)
+- Adenylosuccinase deficiency (historical enzyme-based synonym) (fenton2023acaenorhabditiselegans pages 15-16)
+
+### 1.4 Evidence source types
+- Aggregated disease-level resources/reviews: JIMD 2015 review; Metabolites 2023 review (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, camici2023inbornerrorsof pages 9-11)
+- Human clinical cohort/long-term follow-up: Epilepsia Open 2024 cohort + literature appraisal (cutillo2024electroclinicalfeaturesand pages 1-2, cutillo2024electroclinicalfeaturesand pages 2-4)
+- Human diagnostic method papers: plasma metabolomics diagnosis paper (2016) (donti2016diagnosisofadenylosuccinate pages 1-2, donti2016diagnosisofadenylosuccinate pages 3-4)
+- Interventional clinical research: allopurinol phase 2 trial registered at ClinicalTrials.gov (NCT03776656 chunk 1, NCT03776656 chunk 2)
+- Model organism: C. elegans mechanistic disease models (2023) (moro2023adenylosuccinatelyasedeficiency pages 1-2, fenton2023acaenorhabditiselegans pages 1-3)
+
+## 2. Etiology
+### 2.1 Disease causal factors
+**Primary cause**: biallelic pathogenic variants in **ADSL** causing reduced adenylosuccinate lyase function and accumulation of succinylpurines. The disorder is described as “a rare autosomal recessive neurometabolic disorder” caused by loss of ADSL enzymatic activity (donti2016diagnosisofadenylosuccinate pages 1-2, jurecka2015adenylosuccinatelyasedeficiency pages 1-3).
+
+**Molecular defect**: ADSL catalyzes two non-sequential steps in de novo purine synthesis; in a 2023 paper’s abstract, “Adenylosuccinate lyase is required for de novo purine biosynthesis, acting twice in the pathway at non-sequential steps.” (PLOS Genetics, Sep 2023) (moro2023adenylosuccinatelyasedeficiency pages 1-2).
+
+### 2.2 Risk factors
+- **Genetic**: autosomal recessive inheritance; consanguinity can increase risk (e.g., homozygous variants reported in consanguineous families) (donti2016diagnosisofadenylosuccinate pages 3-4).
+- **Environmental**: no established environmental risk factors were identified in the retrieved evidence; disease is primarily Mendelian (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, camici2023inbornerrorsof pages 9-11).
+
+### 2.3 Protective factors / gene–environment interactions
+No validated protective alleles or gene–environment interactions were identified in the retrieved evidence. Supportive factors may include early diagnosis and optimized symptomatic management (e.g., seizure control), but these are not “protective factors” in a causal sense (cutillo2024electroclinicalfeaturesand pages 14-15).
+
+## 3. Phenotypes
+### 3.1 Core phenotype spectrum and subtypes
+A foundational review describes three clinical groupings and gives hallmark neonatal and pediatric presentations, including: **“The fatal neonatal form has onset from birth… respiratory failure, and intractable seizures… early death within the first weeks of life.”** and later forms with severe neurodevelopmental features. (jurecka2015adenylosuccinatelyasedeficiency pages 1-3)
+
+A 2024 long-term cohort + literature appraisal provides a quantitative view of the spectrum (n=88 total, including 7 new and 81 literature cases):
+- **Type I**: 58% (51/88)
+- **Type II**: 28% (25/88)
+- **Neonatal**: 14% (12/88) (cutillo2024electroclinicalfeaturesand pages 1-2)
+
+### 3.2 Epilepsy and electroclinical features (2024 update)
+Epilepsy is common and often severe; the 2024 appraisal reports: **“Epilepsy is present in 81.8% of the patients, with polymorphic and often intractable seizures.”** (Epilepsia Open, Nov 2024) (cutillo2024electroclinicalfeaturesand pages 1-2).
+
+The same paper summarizes typical EEG evolution: **“EEG features seem to display common patterns and developmental trajectories: (i) poor general back-ground organization with theta-delta activity; (ii) hypsarrhythmia with spasms, usually adrenocorticotropic hormone-responsive; (iii) generalized epileptic discharges with frontal or frontal temporal predominance; and (iv) epileptic discharge activation in sleep with an altered sleep structure.”** (cutillo2024electroclinicalfeaturesand pages 1-2).
+
+### 3.3 Neurodevelopmental and neuromuscular phenotypes
+A 2023 mechanistic/model-organism paper summarizes human features and emphasizes neuromuscular and neurobehavioral dysfunction; its abstract begins: **“Adenylosuccinate lyase deficiency is an ultrarare congenital metabolic disorder associated with muscle weakness and neurobehavioral dysfunction.”** (PLOS Genetics, Sep 2023) (moro2023adenylosuccinatelyasedeficiency pages 1-2).
+
+Commonly described clinical features across reviews/cohorts include:
+- Developmental delay/intellectual disability; severe psychomotor retardation (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, donti2016diagnosisofadenylosuccinate pages 1-2)
+- Hypotonia; ataxia; dystonia (reported in clinical cohorts) (cutillo2024electroclinicalfeaturesand pages 2-4)
+- Autistic features/contact disturbances (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, camici2023inbornerrorsof pages 9-11)
+- Progressive cerebral/cerebellar atrophy and white matter changes on MRI in more severe phenotypes (cutillo2024electroclinicalfeaturesand pages 1-2, cutillo2024electroclinicalfeaturesand pages 2-4)
+
+### 3.4 Suggested HPO terms (non-exhaustive; to be validated per case)
+Based on phenotypes described in the cited literature (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, cutillo2024electroclinicalfeaturesand pages 1-2, cutillo2024electroclinicalfeaturesand pages 2-4):
+- Seizures (HP:0001250)
+- Epileptic spasms / Infantile spasms (HP:0012469)
+- Hypsarrhythmia (HP:0012465)
+- Global developmental delay (HP:0001263)
+- Intellectual disability (HP:0001249)
+- Hypotonia (HP:0001252)
+- Microcephaly (HP:0000252)
+- Autism (HP:0000717) / Autistic features
+- Ataxia (HP:0001251)
+- Dystonia (HP:0001332)
+- Cerebral atrophy (HP:0002059)
+- Cerebellar atrophy (HP:0001272)
+
+### 3.5 Quality of life impact
+No disease-specific QoL instruments were identified in the retrieved texts; however, long-term follow-up cases include severe disability (e.g., chronic refractory epilepsy, progressive neurodisability) implying major functional dependence (cutillo2024electroclinicalfeaturesand pages 2-4, cutillo2024electroclinicalfeaturesand pages 14-15).
+
+## 4. Genetic / molecular information
+### 4.1 Causal gene
+- **Gene**: **ADSL** (adenylosuccinate lyase) (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, shi2025thediagnosisand pages 1-3)
+- **Inheritance**: autosomal recessive (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, donti2016diagnosisofadenylosuccinate pages 1-2)
+
+### 4.2 Variant spectrum and genotype–phenotype
+The 2015 review notes: **“Over 50 ADSL mutations have been identified”** and the disorder is genetically heterogeneous (many private variants; frequent compound heterozygosity) (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, jurecka2015adenylosuccinatelyasedeficiency pages 4-6).
+
+The 2024 appraisal reports the most frequently observed variants in compiled cases: **“p.R426H homozygous (19 patients), p.Y114H in compound heterozygo-sity (13 patients), and p.D430N homozygous (6 patients).”** (cutillo2024electroclinicalfeaturesand pages 1-2).
+
+Genotype–phenotype relationships remain incomplete, but severity is suggested to track residual enzyme activity and certain variants are enriched in severe neonatal/type I phenotypes (cutillo2024electroclinicalfeaturesand pages 14-15).
+
+### 4.3 Population data / carrier frequencies
+From a 2016 diagnostic study referencing ExAC for ADSL p.Arg426His:
+- p.Arg426His is reported as the most common ADSL variant in ExAC, present on 31 chromosomes heterozygously, with allelic frequency **0.000255** and estimated carrier frequency **~1/2000**; most carriers were non-Finnish European (28/31). (Molecular Genetics and Metabolism Reports, Sep 2016) (donti2016diagnosisofadenylosuccinate pages 3-4).
+
+A 2015 review provided a broader, older estimate: an “estimated carrier (heterozygote) probability for a pathogenic ADSL allele of about **1:10,000**.” (jurecka2015adenylosuccinatelyasedeficiency pages 4-6). Differences likely reflect method/variant set and database updates; current carrier frequency should be re-estimated using contemporary gnomAD with careful pathogenicity filtering.
+
+### 4.4 Functional consequences
+Evidence across reviews and model-organism work supports a dual mechanism:
+- **Toxic substrate accumulation** (SAICAR/SAICAr and related succinylpurines)
+- **Reduced purine biosynthetic flux** and impaired purine homeostasis
+
+The C. elegans neurobehavioral work explicitly argues that altered behavior likely arises from accumulated substrate toxicity rather than only purine shortage (moro2023adenylosuccinatelyasedeficiency pages 1-2, moro2023adenylosuccinatelyasedeficiency pages 9-11).
+
+## 5. Environmental information
+No specific toxins, lifestyle factors, or infectious triggers were identified in the retrieved evidence. The disorder is primarily genetic, and management focuses on symptomatic care and experimental metabolic interventions (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, camici2023inbornerrorsof pages 9-11).
+
+## 6. Mechanism / pathophysiology
+### 6.1 Pathway context
+ADSL is required for **de novo purine biosynthesis** and acts twice at non-sequential steps (moro2023adenylosuccinatelyasedeficiency pages 1-2). A clinical review focused on epilepsy reiterates the enzymatic steps and toxic metabolite hypothesis in ADSL deficiency (shi2025thediagnosisand pages 1-3).
+
+**Biochemical hallmark**: accumulation of **SAICAr** and **S‑Ado** in extracellular fluids (urine, CSF, plasma) (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, jurecka2015adenylosuccinatelyasedeficiency pages 8-9).
+
+### 6.2 Proposed causal chain (integrated)
+1) **Biallelic ADSL variants → reduced ADSL activity** (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, donti2016diagnosisofadenylosuccinate pages 1-2)
+2) **Block at ADSL-catalyzed steps → accumulation of phosphorylated substrates → extracellular dephosphorylated succinylpurines (SAICAr, S‑Ado)** (jurecka2015adenylosuccinatelyasedeficiency pages 8-9, jurecka2015adenylosuccinatelyasedeficiency pages 1-3)
+3) **Neurodevelopmental dysfunction** via a combination of toxic metabolite effects and purine imbalance; model-organism data show broader metabolic perturbations (e.g., neurotransmitter signaling disruption) downstream of purine pathway disruption (moro2023adenylosuccinatelyasedeficiency pages 1-2, moro2023adenylosuccinatelyasedeficiency pages 9-11)
+4) **Clinical manifestations**: developmental delay/intellectual disability, hypotonia/ataxia, epilepsy with characteristic EEG patterns, and progressive neuroimaging abnormalities in severe phenotypes (cutillo2024electroclinicalfeaturesand pages 1-2, cutillo2024electroclinicalfeaturesand pages 2-4)
+
+### 6.3 Mechanistic advances (2023–2024)
+**Neurobehavioral mechanism in C. elegans (2023):** substrate accumulation due to adsl-1 deficiency perturbs tyrosine metabolism and tyramine signaling; behavioral phenotypes are rescued by tyramine supplementation and involve TYRA-2 receptor signaling (moro2023adenylosuccinatelyasedeficiency pages 1-2, moro2023adenylosuccinatelyasedeficiency pages 11-13, moro2023adenylosuccinatelyasedeficiency pages 9-11).
+
+**Separability of phenotypic etiologies (2023):** a C. elegans model suggests neuromuscular defects associate with intermediate accumulation while reproductive defects are rescued by purine supplementation—supporting the concept that multiple downstream mechanisms contribute to phenotype heterogeneity (fenton2023acaenorhabditiselegans pages 1-3, fenton2023acaenorhabditiselegans pages 8-9).
+
+### 6.4 Suggested ontology terms
+**GO Biological Process (suggested):**
+- de novo IMP biosynthetic process (purine biosynthesis)
+- AMP biosynthetic process
+- purine nucleotide metabolic process
+
+**GO Molecular Function (suggested):**
+- adenylosuccinate lyase activity
+
+**Cell types (CL; suggested, based on neurologic phenotype/EEG patterns):**
+- neurons (CL:0000540)
+- astrocytes (CL:0000127)
+- oligodendrocytes (CL:0000128)
+
+**Anatomy (UBERON; suggested):**
+- brain (UBERON:0000955)
+- cerebellum (UBERON:0002037)
+- cerebral cortex/frontal lobe (UBERON mapping; frontal predominance described on imaging) (cutillo2024electroclinicalfeaturesand pages 1-2)
+
+## 7. Anatomical structures affected
+Human cohorts and reviews emphasize CNS involvement with imaging showing cerebral/cerebellar atrophy and white matter abnormalities in many patients (cutillo2024electroclinicalfeaturesand pages 1-2, cutillo2024electroclinicalfeaturesand pages 2-4). Neuromuscular involvement (hypotonia, muscle weakness) is frequently noted (moro2023adenylosuccinatelyasedeficiency pages 1-2).
+
+## 8. Temporal development
+- **Onset** ranges from congenital/neonatal (fatal neonatal encephalopathy) to onset in the first years of life for type I and later onset in milder type II forms (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, cutillo2024electroclinicalfeaturesand pages 1-2).
+- **Progression** varies: rapidly progressive neonatal/type I vs slower courses in type II; long-term follow-up documents persistent epilepsy and progressive neurodisability in some patients over decades (cutillo2024electroclinicalfeaturesand pages 2-4, cutillo2024electroclinicalfeaturesand pages 14-15).
+
+## 9. Inheritance and population
+- **Inheritance**: autosomal recessive (jurecka2015adenylosuccinatelyasedeficiency pages 1-3, donti2016diagnosisofadenylosuccinate pages 1-2)
+- **Epidemiology**: incidence/prevalence remain uncertain; historical reviews noted “More than 80 individuals” identified by 2015 (jurecka2015adenylosuccinatelyasedeficiency pages 1-3), while the 2024 appraisal aggregated **88** patients (81 literature + 7 new) (cutillo2024electroclinicalfeaturesand pages 1-2).
+- **Variant enrichment/founder effects**: p.Arg426His is repeatedly the most common variant in patient cohorts and appears enriched in Europeans; ExAC-based estimates are provided above (donti2016diagnosisofadenylosuccinate pages 3-4, jurecka2015adenylosuccinatelyasedeficiency pages 4-6).
+
+## 10. Diagnostics
+### 10.1 Biochemical testing (core real-world implementation)
+The most established diagnostic hallmark is detecting elevated succinylpurines. The review states: **“Diagnosis is facilitated by demonstration of SAICAr and S-Ado in extracellular fluids such as plasma, cerebrospinal fluid…”** (jurecka2015adenylosuccinatelyasedeficiency pages 1-3).
+
+Methods described include HPLC-UV/HPLC-MS and high-throughput HPLC-ESI-MS/MS approaches; urine is commonly used, with CSF and plasma also reported (jurecka2015adenylosuccinatelyasedeficiency pages 8-9).
+
+### 10.2 Metabolomics-based diagnosis
+A 2016 study demonstrated untargeted plasma metabolomics as an alternative route to diagnosis and phenotype expansion, describing ADSL deficiency as OMIM 103050 and emphasizing SAICAr/S‑Ado accumulation as the biochemical hallmark typically detected in urine (donti2016diagnosisofadenylosuccinate pages 1-2).
+
+### 10.3 Genetic testing
+Diagnostic confirmation includes genomic sequencing (single-gene testing, panels, WES/WGS) and sometimes functional enzyme assessment; WES is emphasized as valuable for atypical/mild phenotypes (macchiaiolo2017amildform pages 7-7, jurecka2015adenylosuccinatelyasedeficiency pages 8-9).
+
+### 10.4 Differential diagnosis
+Not comprehensively extracted from the retrieved texts. In practice, differential diagnosis includes other inborn errors of metabolism presenting with developmental epileptic encephalopathy; nucleotide metabolism epilepsy reviews discuss ADSL deficiency among other nucleic acid/nucleotide disorders (shi2025thediagnosisand pages 1-3).
+
+### 10.5 Newborn screening
+No evidence in retrieved texts confirms routine newborn screening implementation for ADSL deficiency; given the need for specialized metabolite testing and uncertain treatability, ADSL deficiency is not established as a standard NBS target in the retrieved evidence.
+
+## 11. Outcomes / prognosis
+Outcomes depend strongly on subtype. Neonatal forms can be fatal in weeks (jurecka2015adenylosuccinatelyasedeficiency pages 1-3). Long-term follow-up (10–34 years) demonstrates survival into adulthood for some patients, but with severe disability and often drug-resistant epilepsy in type I and neonatal phenotypes (cutillo2024electroclinicalfeaturesand pages 2-4, cutillo2024electroclinicalfeaturesand pages 14-15).
+
+## 12. Treatment
+### 12.1 Current standard-of-care (real-world)
+There is no proven disease-modifying therapy; reviews emphasize symptomatic management. The 2015 review states: **“To date there is no specific and effective therapy for ADSL deficiency.”** (jurecka2015adenylosuccinatelyasedeficiency pages 1-3).
+
+Supportive/standard management includes:
+- Anti-seizure medications (ASM); some benefit in milder cases (cutillo2024electroclinicalfeaturesand pages 14-15)
+- Developmental therapies and supportive care (implied; not detailed in retrieved texts)
+
+### 12.2 Allopurinol (repurposing; clinical trial implementation)
+**ClinicalTrials.gov NCT03776656** (Phase 2, single-group, n=8, completed) evaluated oral **allopurinol** for 12 months. Key details:
+- Primary endpoint: Vineland II adaptive behavior composite score at 12 months (NCT03776656 chunk 1)
+- Biochemical endpoints: serial urinary and plasma SAICAr and S‑Ado (NCT03776656 chunk 2, NCT03776656 chunk 1)
+- Trial rationale notes the hypothesis that allopurinol reduces production of toxic SAICAr, and the protocol states the hypothesis “was validated in 3 minor patients with biological and clinical improvement” (NCT03776656 chunk 1).
+
+The trial record also cites a linked publication (not retrievable here) titled: “Allopurinol Treatment Improves Cognitive Skills, Adaptive Behavior, and Biochemical Markers in Young Patients With Adenylosuccinate Lyase Deficiency” (PMID listed in the record) (NCT03776656 chunk 2). Interpretation should be cautious until full peer-reviewed results are examined.
+
+### 12.3 Other attempted metabolic interventions (limited/experimental)
+Across reviews and cohort appraisal, reported attempts include:
+- Ketogenic diet trials with transient effects (camici2023inbornerrorsof pages 9-11)
+- D-ribose (inconsistent/limited evidence) (camici2023inbornerrorsof pages 9-11, cutillo2024electroclinicalfeaturesand pages 14-15)
+- S-adenosyl-L-methionine (limited success) (cutillo2024electroclinicalfeaturesand pages 14-15)
+- Uridine (mentioned among attempted therapies in epilepsy-focused reviews) (shi2025thediagnosisand pages 1-3)
+
+### 12.4 Suggested MAXO terms (examples)
+- Allopurinol therapy (MAXO term to be mapped)
+- Anticonvulsant therapy
+- Ketogenic diet therapy
+- Genetic counseling
+
+## 13. Prevention
+Primary prevention is not applicable beyond reproductive options because this is a Mendelian disorder.
+- **Carrier screening / cascade testing** in families; **prenatal diagnosis** is described as limited to families with an affected child and relies on mutation testing (jurecka2015adenylosuccinatelyasedeficiency pages 8-9).
+- **Secondary prevention**: earlier diagnosis to optimize seizure control and supportive interventions (jurecka2015adenylosuccinatelyasedeficiency pages 8-9).
+
+## 14. Other species / natural disease
+No naturally occurring veterinary syndrome was identified in the retrieved evidence.
+
+## 15. Model organisms
+### 15.1 C. elegans (2023): mechanistic and translational utility
+Two 2023 studies establish and leverage a **C. elegans adsl-1** model:
+- Neuromuscular and reproductive phenotypes with separable etiologies; some mobility defects reversible; fertility rescued by purine supplementation (fenton2023acaenorhabditiselegans pages 1-3, fenton2023acaenorhabditiselegans pages 8-9)
+- Neurobehavioral phenotypes driven by disrupted tyramine signaling downstream of adsl-1 deficiency; tyramine supplementation rescues gustatory plasticity phenotype (moro2023adenylosuccinatelyasedeficiency pages 1-2, moro2023adenylosuccinatelyasedeficiency pages 11-13, moro2023adenylosuccinatelyasedeficiency pages 9-11)
+
+**Applications:** pathway dissection (substrate toxicity vs purine deficiency), screening candidate interventions (e.g., pathway inhibitors or supplementation), and probing neurobehavioral mechanisms (fenton2023acaenorhabditiselegans pages 8-9, moro2023adenylosuccinatelyasedeficiency pages 9-11).
+
+## Key recent developments (2023–2024) — highlights
+- **Clinical natural history/electroclinical patterns (2024):** consolidated cohort of 88 patients, epilepsy prevalence 81.8%, and described EEG trajectories and imaging patterns (cutillo2024electroclinicalfeaturesand pages 1-2).
+- **Mechanistic expansion (2023):** evidence that ADSL deficiency can perturb neurotransmitter pathways (tyramine signaling) in vivo in a genetic model, supporting wider metabolic effects beyond purine synthesis itself (moro2023adenylosuccinatelyasedeficiency pages 1-2).
+
+## Limitations of this report (evidence gaps)
+- Orphanet (ORPHA), ICD-10/ICD-11, and definitive MeSH UID were not directly extractable from the retrieved full text and should be added via dedicated database queries.
+- The linked allopurinol results publication cited by ClinicalTrials.gov could not be retrieved in full text in this run; conclusions about efficacy should be treated as provisional until peer-reviewed results are reviewed (NCT03776656 chunk 2).
+
+
+References
+
+1. (jurecka2015adenylosuccinatelyasedeficiency pages 1-3): Agnieszka Jurecka, Marie Zikanova, Stanislav Kmoch, and Anna Tylki‐Szymańska. Adenylosuccinate lyase deficiency. Journal of Inherited Metabolic Disease, 38:231-242, Aug 2015. URL: https://doi.org/10.1007/s10545-014-9755-y, doi:10.1007/s10545-014-9755-y. This article has 158 citations and is from a peer-reviewed journal.
+
+2. (donti2016diagnosisofadenylosuccinate pages 1-2): Taraka R. Donti, Gerarda Cappuccio, Leroy Hubert, Juanita Neira, Paldeep S. Atwal, Marcus J. Miller, Aaron L. Cardon, V. Reid Sutton, Brenda E. Porter, Fiona M. Baumer, Michael F. Wangler, Qin Sun, Lisa T. Emrick, and Sarah H. Elsea. Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in plasma reveals a phenotypic spectrum. Molecular Genetics and Metabolism Reports, 8:61-66, Sep 2016. URL: https://doi.org/10.1016/j.ymgmr.2016.07.007, doi:10.1016/j.ymgmr.2016.07.007. This article has 66 citations.
+
+3. (cutillo2024electroclinicalfeaturesand pages 1-2): Gianni Cutillo, Silvia Masnada, Gaetan Lesca, Dorothée Ville, Patrizia Accorsi, Lucio Giordano, Anna Pichiecchio, Marialuisa Valente, Paola Borrelli, Ottavia Eleonora Ferraro, and Pierangelo Veggiotti. Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: long‐term follow‐up of seven patients from four families and appraisal of the literature. Epilepsia Open, 9:106-121, Nov 2024. URL: https://doi.org/10.1002/epi4.12837, doi:10.1002/epi4.12837. This article has 5 citations and is from a peer-reviewed journal.
+
+4. (moro2023adenylosuccinatelyasedeficiency pages 1-2): Corinna A. Moro, Sabrina A. Sony, Latisha P. Franklin, Shirley Dong, Mia M. Peifer, Kathryn E. Wittig, and Wendy Hanna-Rose. Adenylosuccinate lyase deficiency affects neurobehavior via perturbations to tyramine signaling in caenorhabditis elegans. PLOS Genetics, 19:e1010974, Sep 2023. URL: https://doi.org/10.1371/journal.pgen.1010974, doi:10.1371/journal.pgen.1010974. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+5. (NCT03776656 chunk 2):  Evaluation of a Treatment With Allopurinol in Adenylosuccinate Lyase Deficiency. Assistance Publique - Hôpitaux de Paris. 2019. ClinicalTrials.gov Identifier: NCT03776656
+
+6. (NCT03776656 chunk 1):  Evaluation of a Treatment With Allopurinol in Adenylosuccinate Lyase Deficiency. Assistance Publique - Hôpitaux de Paris. 2019. ClinicalTrials.gov Identifier: NCT03776656
+
+7. (fenton2023acaenorhabditiselegans pages 1-3): Adam R. Fenton, Haley N. Janowitz, Latisha P. Franklin, Riley G. Young, Corinna A. Moro, Michael V. DeGennaro, Melanie R. McReynolds, Wenqing Wang, and Wendy Hanna-Rose. A caenorhabditis elegans model of adenylosuccinate lyase deficiency reveals neuromuscular and reproductive phenotypes of distinct etiology. Molecular Genetics and Metabolism, 140:107686, Nov 2023. URL: https://doi.org/10.1016/j.ymgme.2023.107686, doi:10.1016/j.ymgme.2023.107686. This article has 5 citations and is from a peer-reviewed journal.
+
+8. (fenton2023acaenorhabditiselegans pages 15-16): Adam R. Fenton, Haley N. Janowitz, Latisha P. Franklin, Riley G. Young, Corinna A. Moro, Michael V. DeGennaro, Melanie R. McReynolds, Wenqing Wang, and Wendy Hanna-Rose. A caenorhabditis elegans model of adenylosuccinate lyase deficiency reveals neuromuscular and reproductive phenotypes of distinct etiology. Molecular Genetics and Metabolism, 140:107686, Nov 2023. URL: https://doi.org/10.1016/j.ymgme.2023.107686, doi:10.1016/j.ymgme.2023.107686. This article has 5 citations and is from a peer-reviewed journal.
+
+9. (camici2023inbornerrorsof pages 9-11): Marcella Camici, Mercedes Garcia-Gil, Simone Allegrini, Rossana Pesi, Giulia Bernardini, Vanna Micheli, and Maria Grazia Tozzi. Inborn errors of purine salvage and catabolism. Metabolites, 13:787, Jun 2023. URL: https://doi.org/10.3390/metabo13070787, doi:10.3390/metabo13070787. This article has 22 citations.
+
+10. (cutillo2024electroclinicalfeaturesand pages 2-4): Gianni Cutillo, Silvia Masnada, Gaetan Lesca, Dorothée Ville, Patrizia Accorsi, Lucio Giordano, Anna Pichiecchio, Marialuisa Valente, Paola Borrelli, Ottavia Eleonora Ferraro, and Pierangelo Veggiotti. Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: long‐term follow‐up of seven patients from four families and appraisal of the literature. Epilepsia Open, 9:106-121, Nov 2024. URL: https://doi.org/10.1002/epi4.12837, doi:10.1002/epi4.12837. This article has 5 citations and is from a peer-reviewed journal.
+
+11. (donti2016diagnosisofadenylosuccinate pages 3-4): Taraka R. Donti, Gerarda Cappuccio, Leroy Hubert, Juanita Neira, Paldeep S. Atwal, Marcus J. Miller, Aaron L. Cardon, V. Reid Sutton, Brenda E. Porter, Fiona M. Baumer, Michael F. Wangler, Qin Sun, Lisa T. Emrick, and Sarah H. Elsea. Diagnosis of adenylosuccinate lyase deficiency by metabolomic profiling in plasma reveals a phenotypic spectrum. Molecular Genetics and Metabolism Reports, 8:61-66, Sep 2016. URL: https://doi.org/10.1016/j.ymgmr.2016.07.007, doi:10.1016/j.ymgmr.2016.07.007. This article has 66 citations.
+
+12. (cutillo2024electroclinicalfeaturesand pages 14-15): Gianni Cutillo, Silvia Masnada, Gaetan Lesca, Dorothée Ville, Patrizia Accorsi, Lucio Giordano, Anna Pichiecchio, Marialuisa Valente, Paola Borrelli, Ottavia Eleonora Ferraro, and Pierangelo Veggiotti. Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: long‐term follow‐up of seven patients from four families and appraisal of the literature. Epilepsia Open, 9:106-121, Nov 2024. URL: https://doi.org/10.1002/epi4.12837, doi:10.1002/epi4.12837. This article has 5 citations and is from a peer-reviewed journal.
+
+13. (shi2025thediagnosisand pages 1-3): Yuqing Shi, Zihan Wei, Yan Feng, Ya-Jing Gan, Guo-Yan Li, and Yanchun Deng. The diagnosis and treatment of disorders of nucleic acid/nucleotide metabolism associated with epilepsy. Acta Epileptologica, Apr 2025. URL: https://doi.org/10.1186/s42494-025-00201-x, doi:10.1186/s42494-025-00201-x. This article has 3 citations.
+
+14. (jurecka2015adenylosuccinatelyasedeficiency pages 4-6): Agnieszka Jurecka, Marie Zikanova, Stanislav Kmoch, and Anna Tylki‐Szymańska. Adenylosuccinate lyase deficiency. Journal of Inherited Metabolic Disease, 38:231-242, Aug 2015. URL: https://doi.org/10.1007/s10545-014-9755-y, doi:10.1007/s10545-014-9755-y. This article has 158 citations and is from a peer-reviewed journal.
+
+15. (moro2023adenylosuccinatelyasedeficiency pages 9-11): Corinna A. Moro, Sabrina A. Sony, Latisha P. Franklin, Shirley Dong, Mia M. Peifer, Kathryn E. Wittig, and Wendy Hanna-Rose. Adenylosuccinate lyase deficiency affects neurobehavior via perturbations to tyramine signaling in caenorhabditis elegans. PLOS Genetics, 19:e1010974, Sep 2023. URL: https://doi.org/10.1371/journal.pgen.1010974, doi:10.1371/journal.pgen.1010974. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+16. (jurecka2015adenylosuccinatelyasedeficiency pages 8-9): Agnieszka Jurecka, Marie Zikanova, Stanislav Kmoch, and Anna Tylki‐Szymańska. Adenylosuccinate lyase deficiency. Journal of Inherited Metabolic Disease, 38:231-242, Aug 2015. URL: https://doi.org/10.1007/s10545-014-9755-y, doi:10.1007/s10545-014-9755-y. This article has 158 citations and is from a peer-reviewed journal.
+
+17. (moro2023adenylosuccinatelyasedeficiency pages 11-13): Corinna A. Moro, Sabrina A. Sony, Latisha P. Franklin, Shirley Dong, Mia M. Peifer, Kathryn E. Wittig, and Wendy Hanna-Rose. Adenylosuccinate lyase deficiency affects neurobehavior via perturbations to tyramine signaling in caenorhabditis elegans. PLOS Genetics, 19:e1010974, Sep 2023. URL: https://doi.org/10.1371/journal.pgen.1010974, doi:10.1371/journal.pgen.1010974. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+18. (fenton2023acaenorhabditiselegans pages 8-9): Adam R. Fenton, Haley N. Janowitz, Latisha P. Franklin, Riley G. Young, Corinna A. Moro, Michael V. DeGennaro, Melanie R. McReynolds, Wenqing Wang, and Wendy Hanna-Rose. A caenorhabditis elegans model of adenylosuccinate lyase deficiency reveals neuromuscular and reproductive phenotypes of distinct etiology. Molecular Genetics and Metabolism, 140:107686, Nov 2023. URL: https://doi.org/10.1016/j.ymgme.2023.107686, doi:10.1016/j.ymgme.2023.107686. This article has 5 citations and is from a peer-reviewed journal.
+
+19. (macchiaiolo2017amildform pages 7-7): Marina Macchiaiolo, Sabina Barresi, Francesco Cecconi, Ginevra Zanni, Marcello Niceta, Emanuele Bellacchio, Giacomo Lazzarino, Angela Maria Amorini, Enrico Silvio Bertini, Salvatore Rizza, Benedetta Contardi, Marco Tartaglia, and Andrea Bartuli. A mild form of adenylosuccinate lyase deficiency in absence of typical brain mri features diagnosed by whole exome sequencing. Italian Journal of Pediatrics, Aug 2017. URL: https://doi.org/10.1186/s13052-017-0383-7, doi:10.1186/s13052-017-0383-7. This article has 16 citations and is from a peer-reviewed journal.

--- a/research/Adenylosuccinate_Lyase_Deficiency-deep-research-falcon.md.citations.md
+++ b/research/Adenylosuccinate_Lyase_Deficiency-deep-research-falcon.md.citations.md
@@ -1,0 +1,483 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Adenylosuccinate Lyase Deficiency
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Adenylosuccinate Lyase Deficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-03T00:09:50.380137
+
+1. jurecka2015adenylosuccinatelyasedeficiency pages 1-3
+2. fenton2023acaenorhabditiselegans pages 15-16
+3. moro2023adenylosuccinatelyasedeficiency pages 1-2
+4. donti2016diagnosisofadenylosuccinate pages 3-4
+5. cutillo2024electroclinicalfeaturesand pages 14-15
+6. cutillo2024electroclinicalfeaturesand pages 1-2
+7. cutillo2024electroclinicalfeaturesand pages 2-4
+8. jurecka2015adenylosuccinatelyasedeficiency pages 4-6
+9. shi2025thediagnosisand pages 1-3
+10. jurecka2015adenylosuccinatelyasedeficiency pages 8-9
+11. donti2016diagnosisofadenylosuccinate pages 1-2
+12. camici2023inbornerrorsof pages 9-11
+13. fenton2023acaenorhabditiselegans pages 1-3
+14. moro2023adenylosuccinatelyasedeficiency pages 9-11
+15. moro2023adenylosuccinatelyasedeficiency pages 11-13
+16. fenton2023acaenorhabditiselegans pages 8-9
+17. macchiaiolo2017amildform pages 7-7
+18. https://platform.opentargets.org/disease/MONDO_0007068
+19. https://omim.org/entry/103050
+20. https://clinicaltrials.gov/study/NCT03776656
+21. https://doi.org/10.1007/s10545-014-9755-y
+22. https://doi.org/10.1016/j.ymgmr.2016.07.007
+23. https://doi.org/10.1371/journal.pgen.1010974
+24. https://doi.org/10.1016/j.ymgme.2023.107686
+25. https://doi.org/10.1007/s10545-014-9755-y,
+26. https://doi.org/10.1016/j.ymgmr.2016.07.007,
+27. https://doi.org/10.1002/epi4.12837,
+28. https://doi.org/10.1371/journal.pgen.1010974,
+29. https://doi.org/10.1016/j.ymgme.2023.107686,
+30. https://doi.org/10.3390/metabo13070787,
+31. https://doi.org/10.1186/s42494-025-00201-x,
+32. https://doi.org/10.1186/s13052-017-0383-7,


### PR DESCRIPTION
## Summary
- Add a new adenylosuccinate lyase deficiency curation with direct MONDO/Orphanet mapping.
- Integrate Falcon deep research into pathophysiology, phenotype, biochemical, genetic, progression, and treatment sections.
- Add generated Orphanet, PubMed, DOI, ClinicalTrials.gov reference caches and Falcon research artifacts, including the 2025 allopurinol phase II result paper.

## Validation
- `just validate kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml`
- Manual nested evidence snippet audit: 63/63 snippets found in generated reference caches.
- Subagent review completed; allopurinol result-paper blocker was fixed and targeted re-review found no remaining blockers.