### PR TITLE
Add NCIT/MONDO mappings to Spinocerebellar Ataxia Type 17 (refs #1675)

### DIFF
--- a/kb/disorders/Spinocerebellar_Ataxia_Type_17.yaml
+++ b/kb/disorders/Spinocerebellar_Ataxia_Type_17.yaml
@@ -1,6 +1,6 @@
 name: Spinocerebellar ataxia type 17
 creation_date: "2026-04-10T00:00:00Z"
-updated_date: "2026-04-30T00:00:00Z"
+updated_date: "2026-05-04T00:00:00Z"
 category: Mendelian
 synonyms:
 - SCA17
@@ -1337,3 +1337,18 @@ notes: >-
   threshold is narrow and penetrance is incomplete for smaller expanded alleles,
   repeat length should be interpreted together with phenotype, family history,
   and imaging findings.
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0011781
+      label: spinocerebellar ataxia type 17
+    mapping_predicate: skos:exactMatch
+    mapping_source: MONDO
+    mapping_justification: MONDO provides an exact disease term for spinocerebellar ataxia type 17.
+  ncit_mappings:
+  - term:
+      id: NCIT:C179861
+      label: Spinocerebellar Ataxia Type 17
+    mapping_predicate: skos:exactMatch
+    mapping_source: NCIT
+    mapping_justification: NCIT provides an exact term for spinocerebellar ataxia type 17; cross-referenced from MONDO:0011781.


### PR DESCRIPTION
## Summary

Adds a disease-level \`mappings:\` block to \`kb/disorders/Spinocerebellar_Ataxia_Type_17.yaml\` with:

- \`mondo_mappings\` → MONDO:0011781 (spinocerebellar ataxia type 17) — \`skos:exactMatch\` (already used as the file's \`disease_term\`)
- \`ncit_mappings\` → NCIT:C179861 (Spinocerebellar Ataxia Type 17) — \`skos:exactMatch\` (cross-referenced from MONDO:0011781)

Both terms verified against the local OAK sqlite adapters before opening this PR.

## Why this PR (and what it intentionally does NOT do)

This is a small scoped enrichment matching the same disease-level mappings pattern landed for the cancer batch (PRs #1797, #1801, #1802, #1805, #1825, #1835, #1873).

It is **deliberately separate from the larger work tracked in #1675** (the parent \`Autosomal_Dominant_Cerebellar_Ataxia_Type_I.yaml\` file refactor), which the prior curation-scanner runs on 2026-04-26, 2026-04-27, and 2026-04-30 deferred pending curator authorization. SCA17's MONDO definition explicitly classifies it as a subtype of ADCA-I, so adding the SCA17 mappings now is independently useful — and lossless — regardless of how the parent-file work is staged.

## Validation

- \`just validate kb/disorders/Spinocerebellar_Ataxia_Type_17.yaml\` → ✅ schema + terms + references all pass
- Cache / reference-cache normalization side-effects from the validator were intentionally **not** included (matches the rest of the cancer-batch mappings PR pattern; avoids cache-CSV drift).

## Test plan

- [x] \`just validate\` clean on the touched file
- [ ] CI green on this branch
- [ ] Maintainer confirms scoped change is desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)