### PR TITLE
Switch proxy job submission from `title` to `short_title`

### DIFF
--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -345,16 +345,26 @@ async function handleSubmitJob(
     "   to the user's question.",
   ].join("\n");
 
-  // Build title
-  const titleQuestion =
-    trimmedQuestion.length > 200
-      ? trimmedQuestion.slice(0, 197) + "..."
-      : trimmedQuestion;
-  const title = `${disease_name}: ${titleQuestion}`;
+  // Build short_title (display label shown in OpenScientist UI surfaces — jobs list,
+  // ntfy, download filenames). Max 100 chars per the OpenScientist API contract;
+  // give the disease name precedence and truncate the question excerpt as needed.
+  const SHORT_TITLE_MAX = 100;
+  const ELLIPSIS = "...";
+  const prefix = `${disease_name}: `;
+  const remaining = SHORT_TITLE_MAX - prefix.length;
+  let questionPart = trimmedQuestion;
+  if (remaining < ELLIPSIS.length) {
+    // Disease name alone exceeds (or nearly exceeds) the budget; just use the
+    // disease name, truncated.
+    questionPart = "";
+  } else if (questionPart.length > remaining) {
+    questionPart = questionPart.slice(0, remaining - ELLIPSIS.length) + ELLIPSIS;
+  }
+  const shortTitle = (prefix + questionPart).slice(0, SHORT_TITLE_MAX);
 
   // Build multipart form
   const formData = new FormData();
-  formData.append("title", title.slice(0, 255));
+  formData.append("short_title", shortTitle);
   formData.append("research_question", researchQuestion);
   formData.append("max_iterations", "5");
   formData.append("use_hypotheses", "false");


### PR DESCRIPTION
## Summary

OpenScientist removed the `title` field from `JobCreate` in [openscientist-io/openscientist#110](https://github.com/openscientist-io/openscientist/pull/110), deployed to production on 2026-05-04. Pydantic's default `extra="ignore"` silently drops unknown fields, so the proxy hasn't broken — but the carefully-built `<disease>: <question>` display label that we send as `title` no longer reaches OpenScientist's UI. Switch to the new `short_title` field so the label is preserved.

## What changes

`proxy/src/index.ts:347-358`:

- `formData.append("title", title.slice(0, 255))` → `formData.append("short_title", shortTitle)`.
- The `short_title` field is capped at 100 chars (down from `title`'s 255), so the truncation logic is reworked to give the disease name precedence and ellipsize the question excerpt within whatever budget remains. Edge case where the disease name alone exceeds the budget is handled (use disease name, drop question excerpt).
- No request-shape break: `research_question`, `data_files`, and other form fields are unchanged.

## Why now

The display label currently shows up as the first ~50 chars of `research_question` ("You are researching the disorder X..."), which is the agent prompt template prefix, not a meaningful label. Affected surfaces: OpenScientist jobs list, ntfy notifications, download filenames. (Mostly visible to whoever owns the `dismech-key` API key on openscientist.io — the dismech browser UI itself doesn't fetch this label, so end users don't see it.)

The agent overwrites `short_title` with its own AI-generated label later in the run, so this fix only affects the display during pending and very-early-running states — but those states are most of what's visible in the jobs list at any given moment.

## Test plan

- [x] `npx tsc --noEmit` passes (no type errors).
- [ ] Smoke test: hit `/api/jobs` on staging worker (or after deploy), confirm OpenScientist jobs list shows `<disease>: <question>` instead of the prompt template prefix.

## Notes

- No worker config / secrets change.
- Auto-deploys to BBOP Cloudflare account on merge per existing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
