### PR TITLE
Fix ASA glutathione evidence source

### DIFF
--- a/kb/disorders/Argininosuccinic_Aciduria.yaml
+++ b/kb/disorders/Argininosuccinic_Aciduria.yaml
@@ -660,9 +660,9 @@ biochemical:
   - reference: PMID:38198573
     reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: Up-regulation of cysteine metabolism contrasted with glutathione depletion and down-regulated antioxidant pathways.
-    explanation: Confirms glutathione depletion alongside altered cysteine handling.
+    explanation: Confirms glutathione depletion alongside altered cysteine handling in ASL-deficient patients and mice.
 - name: Nitric oxide
   presence: DECREASED
   context: 'Tissue and systemic NO production is reduced due to impaired ASL-mediated channeling of arginine to NOS. NO deficiency drives endothelial dysfunction, BBB disruption, hypertension, and may contribute to catecholamine dysregulation and movement disorders.


### PR DESCRIPTION
## Summary
- Reclassify the biochemical Glutathione evidence item for PMID:38198573 from MODEL_ORGANISM to HUMAN_CLINICAL.
- Aligns the biochemical section with the already-fixed pathophysiology evidence, since the paper reports ASL-deficient patients and mice.

## Validation
- `just validate kb/disorders/Argininosuccinic_Aciduria.yaml`
- `git diff --check -- kb/disorders/Argininosuccinic_Aciduria.yaml`