### PR TITLE
[codex] Align ASA glutathione evidence source

### DIFF
--- a/kb/disorders/Argininosuccinic_Aciduria.yaml
+++ b/kb/disorders/Argininosuccinic_Aciduria.yaml
@@ -660,7 +660,7 @@ biochemical:
   - reference: PMID:38198573
     reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: Up-regulation of cysteine metabolism contrasted with glutathione depletion and down-regulated antioxidant pathways.
     explanation: Confirms glutathione depletion alongside altered cysteine handling.
 - name: Nitric oxide


### PR DESCRIPTION
## Summary

Follow-up to #2043: aligns the biochemical Glutathione evidence source in `Argininosuccinic_Aciduria.yaml` with the already-corrected pathophysiology node and downstream edge for PMID:38198573. The cached abstract describes ASL-deficient patients and mice, so this mixed human+mouse finding should not remain classified only as `MODEL_ORGANISM`.

## Validation

- `just validate kb/disorders/Argininosuccinic_Aciduria.yaml`
- `just validate kb/disorders/Arginase_Deficiency.yaml`