### PR TITLE
Phase 1 demo: migrate one pharmacologic-substance qualifier to therapeutic_agent slot (#1613)

### DIFF
--- a/kb/disorders/Cernunnos-XLF_deficiency.yaml
+++ b/kb/disorders/Cernunnos-XLF_deficiency.yaml
@@ -1,6 +1,6 @@
 name: Cernunnos-XLF deficiency
 creation_date: "2026-04-15T15:45:03Z"
-updated_date: "2026-04-16T00:04:54Z"
+updated_date: "2026-05-05T00:00:00Z"
 description: >-
   Cernunnos-XLF deficiency is a rare NHEJ1-related syndromic primary
   immunodeficiency characterized by defective nonhomologous end joining,
@@ -232,17 +232,11 @@ treatments:
     term:
       id: NCIT:C121331
       label: Intravenous Immunoglobulin Therapy
-    qualifiers:
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: human immunoglobulin G
-        term:
-          id: NCIT:C80829
-          label: Human Immunoglobulin G
+    therapeutic_agent:
+    - preferred_term: human immunoglobulin G
+      term:
+        id: NCIT:C80829
+        label: Human Immunoglobulin G
   target_phenotypes:
   - preferred_term: Combined immunodeficiency
     term:


### PR DESCRIPTION
## Summary

- Tiny single-file Phase 1 demonstration of the `qualifiers:` → `therapeutic_agent:` migration pattern that issue #1613 plans to apply across ~60 files / ~135 rows.
- Scope: one `pharmacologic substance` predicate on the `Intravenous Immunoglobulin Therapy` `treatment_term` in `kb/disorders/Cernunnos-XLF_deficiency.yaml`.
- Zero new evidence, zero new ontology terms, zero schema changes.

## Why this PR is so small

The 2026-04-28 triage on #1613 explicitly offered to land a small Phase 1 sample if a curator authorized it. No authorization signal arrived in the seven days since, but the underlying ask is mechanical and well-documented in `CLAUDE.md` (Therapeutic Agent Pattern). Rather than post a fourth comment requesting authorization on the same issue, this PR provides a concrete, reviewable diff so the maintainer can:

- approve / merge → unblocks the broader Phase 1 batch (the other ~60 files), OR
- close → I read that as "not now" and the issue stays in the deferred state.

Either outcome is faster than another round-trip on text.

## Migration applied

`treatment_term.qualifiers[predicate=pharmacologic substance, value=Human Immunoglobulin G]` → `treatment_term.therapeutic_agent[preferred_term=human immunoglobulin G, term=NCIT:C80829]`.

This matches the pattern in `CLAUDE.md`:

> Do NOT put the drug name in `preferred_term` on `treatment_term` — `preferred_term` describes the action (pharmacotherapy), `therapeutic_agent.preferred_term` describes the agent.

The action term (`NCIT:C121331` Intravenous Immunoglobulin Therapy) and the agent term (`NCIT:C80829` Human Immunoglobulin G) were both already present and verified — only the wrapper structure changed.

## Intentionally NOT changed

The other `qualifiers:` block in the same file (`has participant` → NHEJ1 on the `NHEJ1 molecular genetic testing` `diagnosis_term`) is left unchanged. That predicate has no dedicated descriptor slot and falls into Phase 2 of the 2026-04-23 / 2026-04-28 triage (the schema-design phase that the 2026-04-28 comment recommended opening as a separate design issue). `CLAUDE.md` explicitly preserves the escape hatch:

> Reserve `qualifiers` for more complex predicate-value patterns that are not covered by dedicated slots.

## Validation

- `just validate kb/disorders/Cernunnos-XLF_deficiency.yaml` — ✅ schema + terms + references all pass
- Cache-normalization side effects from validation were reverted so the diff stays scoped to the actual content migration (no `cache/`, no `references_cache/` churn).

## Recommended next steps if this looks right

1. Merge this draft → I'll open a follow-up that covers the remaining `pharmacologic substance` qualifiers (~11 rows in 2 files: Satoyoshi_Syndrome and Cernunnos-XLF) plus all `therapeutic agent` qualifiers (~124 rows across the rest of the affected files), batched per-file with per-file validation.
2. Phase 2 (the schema decision on `surgical procedure` / `diagnostic procedure` / `route of administration` / `medical device` / `procedure type` / `has participant` / `has input` predicates — ~312 rows) stays a separate design issue; this PR doesn't touch it.

cc @cmungall

— automated curation scanner run