### PR TITLE
Add variant G and index for frontpage candidates

### DIFF
--- a/frontpage-candidates/g/index.html
+++ b/frontpage-candidates/g/index.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>dismech - Disease Mechanisms Knowledge Base</title>
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --dark: #09090b;
+  --white: #ffffff;
+  --muted: #a1a1aa;
+  --accent: #10b981;
+  --accent-hover: #059669;
+  --gradient-start: #14b8a6;
+  --gradient-mid: #3b82f6;
+  --gradient-end: #8b5cf6;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--dark);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Navigation */
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 3rem;
+}
+
+.nav-wordmark {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--white);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.nav-cta {
+  font-size: 0.9rem;
+  color: var(--white);
+  text-decoration: none;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.nav-cta:hover { opacity: 1; }
+
+/* Hero */
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: var(--dark);
+  padding: 6rem 2rem 4rem;
+}
+
+.hero-heading {
+  font-size: clamp(2.8rem, 8vw, 5.5rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-mid), var(--gradient-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  max-width: 900px;
+  margin-bottom: 1.5rem;
+}
+
+.hero-sub {
+  font-size: 1.15rem;
+  color: var(--muted);
+  max-width: 640px;
+  line-height: 1.7;
+  margin-bottom: 2.5rem;
+}
+
+.hero-actions { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.9rem 2rem;
+  background: var(--accent);
+  color: var(--white);
+  text-decoration: none;
+  border-radius: 100px;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+
+.hero-secondary {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.2s;
+}
+
+.hero-secondary:hover { color: var(--white); }
+
+.gradient-line {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--gradient-start), var(--gradient-mid), var(--gradient-end), var(--gradient-start));
+  background-size: 200% 100%;
+  animation: shimmer 4s linear infinite;
+}
+
+@keyframes shimmer { 0% { background-position: 0% 0; } 100% { background-position: 200% 0; } }
+
+/* Sections */
+.section-dark {
+  background: var(--dark);
+  color: var(--white);
+  padding: 8rem 2rem;
+}
+
+.section-light {
+  background: var(--white);
+  color: var(--dark);
+  padding: 8rem 2rem;
+}
+
+.section-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.section-narrow {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  margin-bottom: 1.5rem;
+}
+
+.section-heading {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin-bottom: 1.5rem;
+}
+
+.section-text {
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: var(--muted);
+}
+
+.section-dark .section-text { color: #a1a1aa; }
+.section-light .section-text { color: #52525b; }
+
+/* Product showcase */
+.product-image-wrapper {
+  margin: 4rem auto 3rem;
+  max-width: 900px;
+  transform: perspective(1000px) rotateY(-2deg) rotateX(1deg);
+  transition: transform 0.4s;
+}
+
+.product-image-wrapper:hover { transform: perspective(1000px) rotateY(0) rotateX(0); }
+
+.product-image {
+  width: 100%;
+  border-radius: 12px;
+  box-shadow: 0 40px 80px rgba(20, 184, 166, 0.15), 0 10px 30px rgba(0,0,0,0.4);
+}
+
+.product-caption {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-top: 1.5rem;
+}
+
+.stats-row {
+  display: flex;
+  justify-content: center;
+  gap: 4rem;
+  margin-top: 4rem;
+  flex-wrap: wrap;
+}
+
+.stat { text-align: center; }
+
+.stat-number {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-mid));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.stat-label { font-size: 0.85rem; color: var(--muted); margin-top: 0.25rem; }
+
+/* Steps */
+.steps { margin-top: 3rem; }
+
+.step {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  padding: 2.5rem 0;
+  border-bottom: 1px solid #e4e4e7;
+}
+
+.step:last-child { border-bottom: none; }
+
+.step-number {
+  font-size: 3rem;
+  font-weight: 800;
+  color: #e4e4e7;
+  letter-spacing: -0.04em;
+  min-width: 80px;
+}
+
+.step-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.step-desc {
+  font-size: 1rem;
+  color: #52525b;
+  line-height: 1.7;
+  margin-bottom: 0.75rem;
+}
+
+.step-link {
+  font-size: 0.9rem;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.step-link:hover { text-decoration: underline; }
+
+/* Flow diagram */
+.flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 3rem 0;
+}
+
+.flow-node {
+  padding: 0.75rem 1.25rem;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--white);
+  background: #18181b;
+}
+
+.flow-arrow { color: var(--muted); font-size: 1.2rem; }
+
+.flow-caption {
+  text-align: center;
+  color: var(--muted);
+  font-size: 1rem;
+  margin-bottom: 2rem;
+}
+
+/* Grid links */
+.link-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin: 3rem 0;
+}
+
+.link-grid a {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--dark);
+  text-decoration: none;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid #e4e4e7;
+  transition: color 0.2s;
+}
+
+.link-grid a:hover { color: var(--accent); }
+
+.link-grid a::after { content: ' \2192'; opacity: 0.5; }
+
+.ecosystem-note {
+  font-size: 1rem;
+  color: #52525b;
+  margin-top: 2rem;
+}
+
+/* Final CTA */
+.final-cta {
+  text-align: center;
+}
+
+.final-cta .section-heading { margin-bottom: 2rem; }
+
+.final-cta .hero-secondary { display: inline-block; margin-top: 1rem; }
+
+/* Footer */
+.footer {
+  background: var(--dark);
+  color: var(--muted);
+  text-align: center;
+  padding: 2rem;
+  font-size: 0.85rem;
+  border-top: 1px solid #27272a;
+}
+
+.footer a { color: var(--muted); text-decoration: none; }
+.footer a:hover { color: var(--white); }
+
+/* Fade-in animation */
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .nav { padding: 1rem 1.5rem; }
+  .hero { padding: 5rem 1.5rem 3rem; }
+  .section-dark, .section-light { padding: 5rem 1.5rem; }
+  .product-image-wrapper { transform: none; }
+  .product-image-wrapper:hover { transform: none; }
+  .stats-row { gap: 2rem; }
+  .stat-number { font-size: 2rem; }
+  .step { flex-direction: column; gap: 0.5rem; }
+  .step-number { font-size: 2rem; min-width: auto; }
+  .flow { gap: 0.3rem; }
+  .flow-node { padding: 0.5rem 0.75rem; font-size: 0.75rem; }
+}
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="#" class="nav-wordmark">dismech</a>
+  <a href="../../app/index.html" class="nav-cta">Get Started &rarr;</a>
+</nav>
+
+<section class="hero">
+  <h1 class="hero-heading">Disease mechanisms,<br>finally understood.</h1>
+  <p class="hero-sub">An AI-curated knowledge base that maps 810 disorders from mutated gene to clinical phenotype. Every claim backed by evidence. Every mechanism a causal graph.</p>
+  <div class="hero-actions">
+    <a href="../../app/index.html" class="btn-primary">Explore the Knowledge Base &rarr;</a>
+    <a href="https://zenodo.org/records/18720444" class="hero-secondary">Watch the keynote &rarr;</a>
+  </div>
+  <div class="gradient-line"></div>
+</section>
+
+<section class="section-light">
+  <div class="section-narrow fade-in">
+    <p class="label">WHY</p>
+    <h2 class="section-heading">Disease knowledge is scattered, unstructured, and unverifiable.</h2>
+    <p class="section-text">Clinicians rely on textbooks. Researchers parse papers manually. AI hallucinates. We built something different.</p>
+  </div>
+</section>
+
+<section class="section-dark">
+  <div class="section-inner fade-in">
+    <p class="label">THE PRODUCT</p>
+    <h2 class="section-heading">Every disease. One causal graph.</h2>
+    <div class="product-image-wrapper">
+      <img src="../../docs/images/pathograph_asthma.png" alt="Asthma mechanism graph" class="product-image">
+    </div>
+    <p class="product-caption">Interactive mechanism graph -- Asthma. One of 810.</p>
+    <div class="stats-row">
+      <div class="stat">
+        <div class="stat-number">810</div>
+        <div class="stat-label">Disorders</div>
+      </div>
+      <div class="stat">
+        <div class="stat-number">1,027</div>
+        <div class="stat-label">Research Reports</div>
+      </div>
+      <div class="stat">
+        <div class="stat-number">22K+</div>
+        <div class="stat-label">Evidence Citations</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-light">
+  <div class="section-narrow fade-in">
+    <p class="label">HOW IT WORKS</p>
+    <h2 class="section-heading">From literature to mechanism in three steps.</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-number">01</div>
+        <div>
+          <div class="step-title">AI researches the disease</div>
+          <p class="step-desc">Deep research agents synthesize literature from PubMed, generating comprehensive mechanism reports.</p>
+          <a href="https://github.com/monarch-initiative/dismech/tree/main/research" class="step-link">See 1,027 research reports &rarr;</a>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-number">02</div>
+        <div>
+          <div class="step-title">Experts curate the graph</div>
+          <p class="step-desc">Structured YAML, ontology-linked terms, validated references. No hallucinations survive.</p>
+          <a href="../../elements/" class="step-link">View the schema &rarr;</a>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-number">03</div>
+        <div>
+          <div class="step-title">The mechanism is revealed</div>
+          <p class="step-desc">From gene to phenotype, every causal step documented and visualized.</p>
+          <a href="../../app/index.html" class="step-link">Browse disorders &rarr;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-dark">
+  <div class="section-inner fade-in">
+    <p class="label">IN PRACTICE</p>
+    <h2 class="section-heading">Fanconi Anemia, decoded.</h2>
+    <div class="flow">
+      <div class="flow-node">Gene Defect</div>
+      <span class="flow-arrow">&rarr;</span>
+      <div class="flow-node">DNA Repair Failure</div>
+      <span class="flow-arrow">&rarr;</span>
+      <div class="flow-node">Stem Cell Loss</div>
+      <span class="flow-arrow">&rarr;</span>
+      <div class="flow-node">Bone Marrow Failure</div>
+      <span class="flow-arrow">&rarr;</span>
+      <div class="flow-node">Cancer Risk</div>
+    </div>
+    <p class="flow-caption">22 complementation groups. 12 genes mapped. 4 treatment pathways documented.</p>
+    <div style="text-align: center;">
+      <a href="../../pages/disorders/Fanconi_Anemia.html" class="btn-primary">See the full mechanism &rarr;</a>
+    </div>
+  </div>
+</section>
+
+<section class="section-light">
+  <div class="section-inner fade-in">
+    <h2 class="section-heading">Part of something bigger</h2>
+    <div class="link-grid">
+      <a href="../../pages/modules/index.html">Mechanism Modules</a>
+      <a href="../../pages/comorbidities/">Disease Trajectories</a>
+      <a href="../../pages/classifications/">Classification Systems</a>
+      <a href="https://monarchinitiative.org">Monarch Initiative</a>
+    </div>
+    <p class="ecosystem-note">Open source. CC-BY 4.0. Built by the Monarch Initiative.</p>
+  </div>
+</section>
+
+<section class="section-dark final-cta">
+  <div class="section-inner fade-in">
+    <h2 class="section-heading">Start exploring.</h2>
+    <a href="../../app/index.html" class="btn-primary">Browse 810 Disorders &rarr;</a>
+    <br>
+    <a href="https://github.com/monarch-initiative/dismech" class="hero-secondary">View on GitHub &rarr;</a>
+  </div>
+</section>
+
+<footer class="footer">
+  &copy; Monarch Initiative &nbsp;|&nbsp; <a href="https://github.com/monarch-initiative/dismech">GitHub</a> &nbsp;|&nbsp; CC-BY 4.0
+</footer>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var els = document.querySelectorAll('.fade-in');
+  var observer = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+      }
+    });
+  }, { threshold: 0.15 });
+  els.forEach(function(el) { observer.observe(el); });
+});
+</script>
+
+</body>
+</html>

--- a/frontpage-candidates/index.html
+++ b/frontpage-candidates/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frontpage Candidates - dismech</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 48px 24px;
+            background: #f8fffe;
+            color: #134e4a;
+            line-height: 1.6;
+        }
+        h1 { font-size: 2rem; margin-bottom: 8px; }
+        .subtitle { color: #5f7a78; margin-bottom: 40px; }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            background: white;
+            border: 1px solid #ccfbf1;
+            border-radius: 12px;
+            padding: 24px;
+            text-decoration: none;
+            color: inherit;
+            transition: all 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 8px 24px rgba(15, 118, 110, 0.12);
+        }
+        .card h2 { font-size: 1.3rem; margin: 0 0 4px; }
+        .card .label {
+            display: inline-block;
+            font-size: 0.75rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            padding: 2px 8px;
+            border-radius: 4px;
+            margin-bottom: 12px;
+        }
+        .card .label-portal { background: #ccfbf1; color: #0f766e; }
+        .card .label-narrative { background: #e0e7ff; color: #4338ca; }
+        .card .label-visual { background: #fef3c7; color: #92400e; }
+        .card p { color: #5f7a78; font-size: 0.95rem; margin: 0; }
+        .footer { margin-top: 48px; font-size: 0.85rem; color: #5f7a78; }
+        .footer a { color: #0f766e; }
+    </style>
+</head>
+<body>
+    <h1>Frontpage Redesign Candidates</h1>
+    <p class="subtitle">Vote for your favourite! See <a href="https://github.com/monarch-initiative/dismech/issues/2055">#2055</a> for context.</p>
+
+    <div class="grid">
+        <a href="a/" class="card">
+            <span class="label label-portal">Portal</span>
+            <h2>A — Dashboard</h2>
+            <p>Compact hero, content grid with real counts. Every box links somewhere. Hub-style.</p>
+        </a>
+        <a href="b/" class="card">
+            <span class="label label-narrative">Narrative</span>
+            <h2>B — Minimal Walkthrough</h2>
+            <p>Clean, airy. Scrolls through Fanconi Anemia gene → phenotype. Lots of whitespace.</p>
+        </a>
+        <a href="c/" class="card">
+            <span class="label label-narrative">Narrative</span>
+            <h2>C — Bold Walkthrough</h2>
+            <p>Dark hero, timeline treatment, bigger typography. Same FA story, more visual weight.</p>
+        </a>
+        <a href="d/" class="card">
+            <span class="label label-visual">Visual</span>
+            <h2>D — Glassmorphism</h2>
+            <p>Animated gradients, frosted glass cards, floating orbs, scroll-triggered reveals.</p>
+        </a>
+        <a href="e/" class="card">
+            <span class="label label-visual">Visual</span>
+            <h2>E — Magazine/Editorial</h2>
+            <p>Serif headings, pull-quotes, asymmetric layout. Print-inspired, NEJM-meets-design-mag.</p>
+        </a>
+        <a href="f/" class="card">
+            <span class="label label-visual">Visual</span>
+            <h2>F — Dark + Neon</h2>
+            <p>Glowing causal flow diagram, terminal-styled evidence, bioinformatics aesthetic.</p>
+        </a>
+        <a href="g/" class="card">
+            <span class="label label-visual">Visual</span>
+            <h2>G — AI Company Splash</h2>
+            <p>Anthropic/Linear/Vercel vibes. Gradient text, floating product shots, big confident statements.</p>
+        </a>
+    </div>
+
+    <div class="footer">
+        <p><a href="https://github.com/monarch-initiative/dismech">monarch-initiative/dismech</a> • Temporary — will be removed after vote</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the missing files from the frontpage candidates PR (the last commit was pushed after the squash merge):

- **Variant G**: AI company splash — gradient text, floating product screenshots, bold confident statements (Anthropic/Linear/Vercel inspired)
- **Index page**: Card grid linking to all 7 variants for easy team browsing

## Context

See #2055. Variants A–F are already live at `dismech.monarchinitiative.org/frontpage-candidates/{a-f}/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)