### PR TITLE
Add idiopathic spontaneous coronary artery dissection

### DIFF
--- a/kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml
+++ b/kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml
@@ -1,0 +1,375 @@
+name: Idiopathic Spontaneous Coronary Artery Dissection
+creation_date: "2026-05-06T03:09:04Z"
+updated_date: "2026-05-06T03:09:04Z"
+description: >-
+  Idiopathic spontaneous coronary artery dissection is a non-traumatic,
+  non-iatrogenic coronary arteriopathy in which separation of the coronary
+  arterial wall, often with intramural hematoma, narrows the true lumen and
+  causes acute myocardial ischemia. It is distinct from atherosclerotic coronary
+  artery disease and is classically recognized in younger or middle-aged women,
+  including peripartum and postpartum presentations.
+category: Complex
+disease_term:
+  preferred_term: idiopathic spontaneous coronary artery dissection
+  term:
+    id: MONDO:0007385
+    label: idiopathic spontaneous coronary artery dissection
+parents:
+- Vascular disorder
+- Idiopathic disease
+synonyms:
+- Spontaneous coronary artery dissection
+- SCAD
+progression:
+- phase: Acute coronary syndrome presentation
+  notes: >-
+    SCAD most often enters clinical care as an acute coronary syndrome, with
+    presentations that include ST-elevation myocardial infarction, non-ST
+    elevation myocardial infarction, unstable angina, and less common acute
+    complications.
+  evidence:
+  - reference: PMID:41776338
+    reference_title: "Spontaneous coronary artery dissection: a clinically oriented narrative review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spontaneous coronary artery dissection (SCAD) is an important cause of acute coronary syndromes (ACS), with a higher incidence in younger female patients."
+    explanation: Narrative clinical review supports the acute-coronary-syndrome presentation pattern and demographic enrichment.
+  - reference: PMID:38298759
+    reference_title: "Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Approximately 48.5% of the patients were diagnosed with non-ST elevated myocardial infarction (NSTEMI), 36.8% with ST elevated myocardial infarction (STEMI), 3.41% with unstable angina, 0.56% with stable angina, and 0.11% were diagnosed with various types of arrhythmias."
+    explanation: Systematic review quantifies the distribution of acute cardiac presentations in SCAD cohorts.
+- phase: Follow-up and recurrence risk
+  notes: >-
+    Many acute dissections heal, but recurrence and major adverse cardiovascular
+    events remain clinically important during follow-up.
+  evidence:
+  - reference: PMID:38298759
+    reference_title: "Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The authors reported variable prevalence of MACE, recurrent SCAD up to 31%, ACS up to 27.4%, TVR up to 30%, repeat revascularization up to 14.7%, UA up to 13.3%, HF up to 17.4%, and stroke up to 3%."
+    explanation: Systematic review supports clinically meaningful recurrence and adverse-event risk after the index event.
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Eventually, SCAD follow-up is important, considering the risk of SCAD recurrence."
+    explanation: Review explicitly supports ongoing follow-up because recurrent SCAD is a recognized concern.
+pathophysiology:
+- name: Coronary arterial wall hematoma and false lumen formation
+  description: >-
+    A tear or hemorrhage within the coronary arterial wall creates a false
+    lumen or intramural hematoma. Expansion of this wall hematoma compresses the
+    true lumen, limits coronary blood flow, and can trigger myocardial ischemia
+    or infarction.
+  cell_types:
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  locations:
+  - preferred_term: coronary artery
+    term:
+      id: UBERON:0001621
+      label: coronary artery
+  - preferred_term: tunica media
+    term:
+      id: UBERON:0002522
+      label: tunica media
+  biological_processes:
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  - preferred_term: blood coagulation
+    modifier: ABNORMAL
+    term:
+      id: GO:0007596
+      label: blood coagulation
+  evidence:
+  - reference: PMID:38390446
+    reference_title: "Spontaneous coronary artery dissection in women in the generative period: clinical characteristics, treatment, and outcome-a systematic review and meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spontaneous coronary artery dissection (SCAD) is a non-traumatic and non-iatrogenic separation of the coronary arterial wall."
+    explanation: Systematic review supports the core lesion as spontaneous coronary arterial-wall separation.
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "no clear data are available about antiplatelet treatment because of the supposed risk of intramural hematoma enlargement."
+    explanation: Review identifies intramural hematoma enlargement as a clinically relevant SCAD mechanism considered during management.
+  downstream:
+  - target: Coronary flow limitation
+    description: Intramural hematoma or false-lumen expansion compresses the true lumen and reduces coronary perfusion.
+    causal_link_type: DIRECT
+  - target: Myocardial ischemia and infarction
+    description: Reduced coronary perfusion can produce angina, myocardial infarction, arrhythmia, or cardiogenic shock.
+    causal_link_type: DIRECT
+- name: Nonatherosclerotic arteriopathy and vessel wall vulnerability
+  description: >-
+    Many idiopathic SCAD presentations occur without plaque rupture,
+    atherosclerotic stenosis, trauma, or instrumentation. A systemic
+    nonatherosclerotic arteriopathy or extracellular matrix vulnerability is a
+    common clinical framework, especially when extracoronary fibromuscular
+    dysplasia, tortuosity, aneurysm, or additional dissections are found.
+  cell_types:
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  - preferred_term: fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
+  locations:
+  - preferred_term: coronary artery
+    term:
+      id: UBERON:0001621
+      label: coronary artery
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    modifier: ABNORMAL
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  evidence:
+  - reference: PMID:38089767
+    reference_title: "Contemporary review on spontaneous coronary artery dissection: insights into the angiographic finding and differential diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spontaneous coronary artery dissection (SCAD), although in the majority of cases presents as an acute coronary syndrome (ACS), has different pathophysiology from atherosclerosis that influences specific angiography findings and enables most patients to be solved by optimal medical therapy rather than percutaneous coronary intervention (PCI)."
+    explanation: Review supports SCAD as a nonatherosclerotic pathophysiologic entity with different angiographic and management implications from plaque-mediated ACS.
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The pathological substrates (fibromuscular dysplasia) and triggers (especially emotional stress) are commonly present in affected women."
+    explanation: Review supports the clinical framework of extracoronary arteriopathy and triggers predisposing to spontaneous dissection.
+  downstream:
+  - target: Coronary arterial wall hematoma and false lumen formation
+    description: Vessel wall vulnerability lowers the threshold for spontaneous coronary wall separation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+phenotypes:
+- category: Cardiovascular
+  name: Coronary artery dissection
+  diagnostic: true
+  description: Spontaneous dissection of an epicardial coronary artery is the defining lesion.
+  phenotype_term:
+    preferred_term: Coronary artery dissection
+    term:
+      id: HP:0006702
+      label: Coronary artery dissection
+  evidence:
+  - reference: PMID:38390446
+    reference_title: "Spontaneous coronary artery dissection in women in the generative period: clinical characteristics, treatment, and outcome-a systematic review and meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spontaneous coronary artery dissection (SCAD) is a non-traumatic and non-iatrogenic separation of the coronary arterial wall."
+    explanation: The disease definition directly supports coronary artery dissection as the diagnostic phenotype.
+- category: Cardiovascular
+  name: Chest pain
+  description: Acute chest pain is the common presenting symptom because SCAD usually presents as acute coronary syndrome.
+  phenotype_term:
+    preferred_term: Chest pain
+    term:
+      id: HP:0100749
+      label: Chest pain
+  evidence:
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Revascularization is recommended in the presence of high-risk features (such as left main or multivessel involvement, hemodynamic instability, recurrent chest pain, or ST elevation)."
+    explanation: Review recognizes recurrent chest pain as a clinically important SCAD feature used in acute management decisions.
+- category: Cardiovascular
+  name: Angina pectoris
+  description: Coronary lumen compression can produce ischemic angina.
+  phenotype_term:
+    preferred_term: Angina pectoris
+    term:
+      id: HP:0001681
+      label: Angina pectoris
+  evidence:
+  - reference: PMID:38298759
+    reference_title: "Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Approximately 48.5% of the patients were diagnosed with non-ST elevated myocardial infarction (NSTEMI), 36.8% with ST elevated myocardial infarction (STEMI), 3.41% with unstable angina, 0.56% with stable angina, and 0.11% were diagnosed with various types of arrhythmias."
+    explanation: Systematic review documents unstable and stable angina presentations among SCAD patients.
+- category: Cardiovascular
+  name: Myocardial infarction
+  description: Flow-limiting SCAD can cause myocardial infarction when coronary perfusion is sufficiently compromised.
+  phenotype_term:
+    preferred_term: Myocardial infarction
+    term:
+      id: HP:0001658
+      label: Myocardial infarction
+  evidence:
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Spontaneous coronary artery dissection (SCAD) is an under-recognized cause of acute coronary syndrome that predominantly affects women in adulthood and is the leading cause of acute myocardial infarction in pregnancy."
+    explanation: Review supports myocardial infarction as a major SCAD manifestation, especially in pregnancy-associated presentations.
+- category: Cardiovascular
+  name: Ventricular arrhythmia
+  description: Myocardial ischemia from SCAD can be complicated by ventricular arrhythmia.
+  phenotype_term:
+    preferred_term: Ventricular arrhythmia
+    term:
+      id: HP:0004308
+      label: Ventricular arrhythmia
+  evidence:
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most common clinical presentation is ST-segment elevation myocardial infarction (STEMI) or non-STEMI, followed by cardiogenic shock (∼2%), sudden cardiac death (0.8% in autopsy series), cardiac arrest, ventricular arrhythmias (∼5%), and Takotsubo syndrome."
+    explanation: Review explicitly lists ventricular arrhythmias among SCAD complications.
+- category: Cardiovascular
+  name: Cardiogenic shock
+  description: Extensive ischemia or left main/proximal-vessel dissection can present with cardiogenic shock.
+  phenotype_term:
+    preferred_term: Cardiogenic shock
+    term:
+      id: HP:0030149
+      label: Cardiogenic shock
+  evidence:
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The most common clinical presentation is ST-segment elevation myocardial infarction (STEMI) or non-STEMI, followed by cardiogenic shock (∼2%), sudden cardiac death (0.8% in autopsy series), cardiac arrest, ventricular arrhythmias (∼5%), and Takotsubo syndrome."
+    explanation: Review explicitly identifies cardiogenic shock among less common but severe SCAD presentations.
+genetic:
+- name: Rare connective-tissue genetic predisposition
+  features: >-
+    Most idiopathic SCAD is not explained by a single high-penetrance genetic
+    diagnosis, but a small subset occurs in syndromic or non-syndromic
+    connective-tissue disease contexts that imply inherited vessel-wall
+    fragility.
+  evidence:
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The few cases with a precise genetic aetiology occur in the context of syndromic and non-syndromic connective tissue diseases."
+    explanation: Review supports rare genetic etiologies in connective-tissue disease contexts rather than a common Mendelian cause.
+environmental:
+- name: Pregnancy, postpartum state, and hormonal exposures
+  effect: Predisposes to SCAD in susceptible patients
+  evidence:
+  - reference: PMID:41776338
+    reference_title: "Spontaneous coronary artery dissection: a clinically oriented narrative review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It is also associated with pregnancy, delivery, and the post-partum period."
+    explanation: Narrative review supports pregnancy, delivery, and postpartum association.
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oral contraceptives, post-menopausal therapy, and infertility treatments are recognized associated factors."
+    explanation: Review supports hormonal exposures as associated factors in SCAD.
+- name: Emotional stress
+  effect: Triggers SCAD in susceptible patients
+  evidence:
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The pathological substrates (fibromuscular dysplasia) and triggers (especially emotional stress) are commonly present in affected women."
+    explanation: Review supports emotional stress as a recognized trigger in affected women.
+diagnosis:
+- name: Coronary angiography with selective intracoronary imaging
+  description: >-
+    Diagnosis is usually made by coronary angiography; optical coherence
+    tomography or intravascular ultrasound may clarify intramural hematoma or an
+    intimal flap when angiographic findings are uncertain and the procedure is
+    clinically safe.
+  results: Findings may include long smooth stenosis, contrast staining, multiple radiolucent lumens, or intramural hematoma.
+  evidence:
+  - reference: PMID:38089767
+    reference_title: "Contemporary review on spontaneous coronary artery dissection: insights into the angiographic finding and differential diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "So far, invasive coronary angiography remains the most important diagnostic tool in suspected SCAD."
+    explanation: Review supports invasive coronary angiography as the central diagnostic test for suspected SCAD.
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "the gold standard diagnostic exam for SCAD is an invasive coronary angiography (ICA) due to its increased sensitivity and disease characterization."
+    explanation: Review supports ICA as the gold-standard diagnostic exam.
+treatments:
+- name: Conservative medical management
+  description: >-
+    Hemodynamically stable patients are often managed conservatively because
+    spontaneous healing of dissected segments is common, while invasive
+    revascularization can be technically difficult.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: PMID:38298759
+    reference_title: "Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "CONCLUSION: Our results highlight that conservative treatment should be the preferred method of treatment in patients with SCAD."
+    explanation: Systematic review supports conservative treatment as the preferred strategy for many SCAD patients.
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Concerning its management, the preferred approach is conservative due to the high rates of spontaneous healing in the first months and the low rate of revascularization success (high complexity percutaneous coronary intervention (PCI) with dissection/hematoma extension risk)."
+    explanation: "Review explains the rationale for conservative management: spontaneous healing and difficult revascularization."
+- name: Percutaneous coronary intervention for high-risk SCAD
+  description: >-
+    Percutaneous coronary intervention may be required when conservative
+    management is unsafe because of ongoing ischemia, left main or multivessel
+    involvement, hemodynamic instability, recurrent chest pain, or persistent ST
+    elevation.
+  treatment_term:
+    preferred_term: coronary stent insertion
+    term:
+      id: MAXO:0009038
+      label: coronary stent insertion
+  evidence:
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Revascularization is recommended in the presence of high-risk features (such as left main or multivessel involvement, hemodynamic instability, recurrent chest pain, or ST elevation)."
+    explanation: Review supports revascularization for high-risk SCAD presentations.
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The first choice is PCI; coronary artery bypass graft (CABG) is considered only if PCI is not feasible or too hazardous according to the operators' and centers' experience."
+    explanation: Review supports PCI as first-choice revascularization when an invasive strategy is needed.
+- name: Coronary artery bypass grafting for selected high-risk SCAD
+  description: >-
+    Coronary artery bypass grafting is reserved for selected high-risk cases
+    when PCI is not feasible or carries excessive procedural risk.
+  evidence:
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The first choice is PCI; coronary artery bypass graft (CABG) is considered only if PCI is not feasible or too hazardous according to the operators' and centers' experience."
+    explanation: Review supports CABG as a fallback revascularization strategy in selected high-risk SCAD cases.

--- a/kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml
+++ b/kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml
@@ -1,6 +1,6 @@
 name: Idiopathic Spontaneous Coronary Artery Dissection
 creation_date: "2026-05-06T03:09:04Z"
-updated_date: "2026-05-06T03:09:04Z"
+updated_date: "2026-05-06T03:56:38Z"
 description: >-
   Idiopathic spontaneous coronary artery dissection is a non-traumatic,
   non-iatrogenic coronary arteriopathy in which separation of the coronary
@@ -293,6 +293,20 @@ environmental:
     evidence_source: HUMAN_CLINICAL
     snippet: "The pathological substrates (fibromuscular dysplasia) and triggers (especially emotional stress) are commonly present in affected women."
     explanation: Review supports emotional stress as a recognized trigger in affected women.
+epidemiology:
+- name: Fibromuscular dysplasia association
+  description: >-
+    Fibromuscular dysplasia is a frequent associated extracoronary arteriopathy
+    in SCAD cohorts and is clinically relevant because its presence supports a
+    systemic vessel-wall vulnerability context rather than isolated
+    plaque-mediated coronary disease.
+  evidence:
+  - reference: PMID:37091648
+    reference_title: "Spontaneous coronary artery dissection: an unpredictable event."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The pathological substrates (fibromuscular dysplasia) and triggers (especially emotional stress) are commonly present in affected women."
+    explanation: Review supports fibromuscular dysplasia as a commonly present associated arteriopathy in affected SCAD patients.
 diagnosis:
 - name: Coronary angiography with selective intracoronary imaging
   description: >-
@@ -314,6 +328,18 @@ diagnosis:
     evidence_source: HUMAN_CLINICAL
     snippet: "the gold standard diagnostic exam for SCAD is an invasive coronary angiography (ICA) due to its increased sensitivity and disease characterization."
     explanation: Review supports ICA as the gold-standard diagnostic exam.
+- name: Screening for extracardiac arteriopathy and connective-tissue disease
+  description: >-
+    After SCAD diagnosis, clinicians commonly evaluate for extracardiac
+    arteriopathies and connective-tissue disease features, especially when FMD
+    or other systemic vessel-wall abnormalities are suspected.
+  evidence:
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Furthermore, screening for extracardiac arthropathies or connective tissue diseases is recommended due to the hypothesized association with SCAD."
+    explanation: Review supports screening for extracardiac arteriopathy/connective-tissue disease context after SCAD.
 treatments:
 - name: Conservative medical management
   description: >-
@@ -338,6 +364,25 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "Concerning its management, the preferred approach is conservative due to the high rates of spontaneous healing in the first months and the low rate of revascularization success (high complexity percutaneous coronary intervention (PCI) with dissection/hematoma extension risk)."
     explanation: "Review explains the rationale for conservative management: spontaneous healing and difficult revascularization."
+- name: Beta-blocker therapy for selected SCAD patients
+  description: >-
+    Beta-blockers are used as part of post-SCAD medical therapy, especially
+    when ventricular dysfunction is present, while the optimal antiplatelet
+    strategy remains uncertain in conservatively managed disease.
+  treatment_term:
+    preferred_term: beta-blocker therapy
+    term:
+      id: MAXO:0000187
+      label: beta-adrenergic antagonist therapy
+    therapeutic_agent:
+    - preferred_term: beta blockers
+  evidence:
+  - reference: PMID:39742239
+    reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Medical therapy includes beta blockers in cases of ventricular dysfunction; however, no clear data are available about antiplatelet treatment because of the supposed risk of intramural hematoma enlargement."
+    explanation: Review supports beta-blocker use in selected SCAD medical therapy while noting uncertainty around antiplatelet treatment.
 - name: Percutaneous coronary intervention for high-risk SCAD
   description: >-
     Percutaneous coronary intervention may be required when conservative
@@ -373,3 +418,37 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "The first choice is PCI; coronary artery bypass graft (CABG) is considered only if PCI is not feasible or too hazardous according to the operators' and centers' experience."
     explanation: Review supports CABG as a fallback revascularization strategy in selected high-risk SCAD cases.
+clinical_trials:
+- name: NCT04850417
+  phase: PHASE_IV
+  status: NOT_RECRUITING
+  description: >-
+    BA-SCAD is a randomized Phase 4 factorial trial evaluating beta-blocker use
+    and antiplatelet duration in patients with spontaneous coronary artery
+    dissection.
+  target_phenotypes:
+  - preferred_term: Coronary artery dissection
+    term:
+      id: HP:0006702
+      label: Coronary artery dissection
+  - preferred_term: Myocardial infarction
+    term:
+      id: HP:0001658
+      label: Myocardial infarction
+  evidence:
+  - reference: clinicaltrials:NCT04850417
+    reference_title: Randomized Clinical Trial Assessing the Value of Beta-Blockers and Antiplatelet Agents in Patients With Spontaneous Coronary Artery Dissection. (The BA-SCAD Randomized Clinical Trial)
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Using a factorial 2x2 design, patients will be randomized (1:1/1:1) to: 1) BB (yes/no) and 2) short AP regimen (1 month) vs prolonged dual AP therapy (DAPT) (12 months)."
+    explanation: ClinicalTrials.gov summary supports the randomized beta-blocker and antiplatelet treatment comparisons.
+  - reference: clinicaltrials:NCT04850417
+    reference_title: Randomized Clinical Trial Assessing the Value of Beta-Blockers and Antiplatelet Agents in Patients With Spontaneous Coronary Artery Dissection. (The BA-SCAD Randomized Clinical Trial)
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A total of 600 SCAD patients will be randomized within 2 years (300 per arm in a factorial 2x2 design)."
+    explanation: ClinicalTrials.gov summary supports the planned randomized enrollment scale for BA-SCAD.
+notes: >-
+  Fibromuscular dysplasia is represented in epidemiology and pathophysiology
+  because the current Disease schema does not provide a dedicated disease-level
+  comorbidities slot.

--- a/kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml
+++ b/kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml
@@ -375,7 +375,10 @@ treatments:
       id: MAXO:0000187
       label: beta-adrenergic antagonist therapy
     therapeutic_agent:
-    - preferred_term: beta blockers
+    - preferred_term: Beta-Adrenergic Antagonist
+      term:
+        id: NCIT:C29576
+        label: Beta-Adrenergic Antagonist
   evidence:
   - reference: PMID:39742239
     reference_title: "Spontaneous Coronary Dissection Review: A Complex Picture."

--- a/references_cache/PMID_37091648.md
+++ b/references_cache/PMID_37091648.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:37091648"
+title: "Spontaneous coronary artery dissection: an unpredictable event."
+authors:
+- Smirnova A
+- Aliberti F
+- Cavaliere C
+- Gatti I
+- Vilardo V
+- Giorgianni C
+- Cassani C
+- Repetto A
+- Narula N
+- Giuliani L
+- Urtis M
+- Ozaki Y
+- Prati F
+- Arbustini E
+- Ferrari M
+journal: Eur Heart J Suppl
+year: '2023'
+doi: 10.1093/eurheartjsupp/suad059
+content_type: abstract_only
+---
+
+# Spontaneous coronary artery dissection: an unpredictable event.
+**Authors:** Smirnova A, Aliberti F, Cavaliere C, Gatti I, Vilardo V, Giorgianni C, Cassani C, Repetto A, Narula N, Giuliani L, Urtis M, Ozaki Y, Prati F, Arbustini E, Ferrari M
+**Journal:** Eur Heart J Suppl (2023)
+**DOI:** [10.1093/eurheartjsupp/suad059](https://doi.org/10.1093/eurheartjsupp/suad059)
+
+## Content
+
+1. Eur Heart J Suppl. 2023 Apr 21;25(Suppl B):B7-B11. doi: 
+10.1093/eurheartjsupp/suad059. eCollection 2023 Apr.
+
+Spontaneous coronary artery dissection: an unpredictable event.
+
+Smirnova A(1), Aliberti F(1), Cavaliere C(1), Gatti I(1), Vilardo V(1), 
+Giorgianni C(1), Cassani C(2)(3), Repetto A(4), Narula N(5), Giuliani L(1), 
+Urtis M(1), Ozaki Y(6), Prati F(7)(8), Arbustini E(1), Ferrari M(1).
+
+Author information:
+(1)Transplant Research Area and Centre for Inherited Cardiovascular Diseases, 
+Scientific Department, Fondazione IRCCS Policlinico San Matteo, Pavia, Italy.
+(2)Department of Clinical, Surgical, Diagnostic and Pediatric Sciences, 
+University of Pavia, Pavia, Italy.
+(3)Unit of Obstetrics and Gynecology, IRCCS Policlinico S. Matteo Foundation, 
+Pavia, Italy.
+(4)Division of Cardiology, Fondazione IRCCS Policlinico S. Matteo, Pavia, Italy.
+(5)Division of Cardiology, Department of Medicine, Weill Cornell Medical 
+College, New York, USA.
+(6)Department of Cardiology, Fujita Health University Hospital, Toyoake, Japan.
+(7)UniCamillus, Saint Camillus International University of Health Sciences, 
+Rome, Italy.
+(8)Centro per la Lotta Contro L'Infarto-CLI Foundation, Rome, Italy.
+
+Spontaneous coronary artery dissection (SCAD) is an under-recognized cause of 
+acute coronary syndrome that predominantly affects women in adulthood and is the 
+leading cause of acute myocardial infarction in pregnancy. The most common 
+clinical presentation is ST-segment elevation myocardial infarction (STEMI) or 
+non-STEMI, followed by cardiogenic shock (∼2%), sudden cardiac death (0.8% in 
+autopsy series), cardiac arrest, ventricular arrhythmias (∼5%), and Takotsubo 
+syndrome. The prevalence of SCAD in the general population is largely uncertain 
+due to underdiagnosis. Oral contraceptives, post-menopausal therapy, and 
+infertility treatments are recognized associated factors. The pathological 
+substrates (fibromuscular dysplasia) and triggers (especially emotional stress) 
+are commonly present in affected women. The few cases with a precise genetic 
+aetiology occur in the context of syndromic and non-syndromic connective tissue 
+diseases. The only true certainty in SCAD is the overwhelming prevalence in 
+women. The first event as well as the recurrence (up to 30%, which varies 
+depending on the definition) is largely unpredictable. The treatment strategy is 
+highly individualized and requires extensive additional study in order to 
+optimize outcomes and prevent major adverse cardiovascular events in affected 
+individuals. We have known about SCAD for nearly a century, but we still do not 
+know how best to prevent, diagnose, and treat it, making SCAD a highly important 
+and unmet clinical need.
+
+© The Author(s) 2023. Published by Oxford University Press on behalf of the 
+European Society of Cardiology.
+
+DOI: 10.1093/eurheartjsupp/suad059
+PMCID: PMC10120938
+PMID: 37091648
+
+Conflict of interest statement: Conflict of interest: None declared.

--- a/references_cache/PMID_38089767.md
+++ b/references_cache/PMID_38089767.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:38089767"
+title: "Contemporary review on spontaneous coronary artery dissection: insights into the angiographic finding and differential diagnosis."
+authors:
+- Kovacevic M
+- Jarakovic M
+- Milovancev A
+- Cankovic M
+- Petrovic M
+- Bjelobrk M
+- Ilic A
+- Srdanovic I
+- Tadic S
+- Dabovic D
+- Crnomarkovic B
+- Komazec N
+- Dracina N
+- Apostolovic S
+- Stanojevic D
+- Kunadian V
+journal: Front Cardiovasc Med
+year: '2023'
+doi: 10.3389/fcvm.2023.1278453
+content_type: abstract_only
+---
+
+# Contemporary review on spontaneous coronary artery dissection: insights into the angiographic finding and differential diagnosis.
+**Authors:** Kovacevic M, Jarakovic M, Milovancev A, Cankovic M, Petrovic M, Bjelobrk M, Ilic A, Srdanovic I, Tadic S, Dabovic D, Crnomarkovic B, Komazec N, Dracina N, Apostolovic S, Stanojevic D, Kunadian V
+**Journal:** Front Cardiovasc Med (2023)
+**DOI:** [10.3389/fcvm.2023.1278453](https://doi.org/10.3389/fcvm.2023.1278453)
+
+## Content
+
+1. Front Cardiovasc Med. 2023 Nov 27;10:1278453. doi: 10.3389/fcvm.2023.1278453. 
+eCollection 2023.
+
+Contemporary review on spontaneous coronary artery dissection: insights into the 
+angiographic finding and differential diagnosis.
+
+Kovacevic M(1)(2), Jarakovic M(1)(2), Milovancev A(1)(2), Cankovic M(1)(2), 
+Petrovic M(1)(2), Bjelobrk M(1)(2), Ilic A(1)(2), Srdanovic I(1)(2), Tadic 
+S(1)(2), Dabovic D(1)(2), Crnomarkovic B(2), Komazec N(2), Dracina N(2), 
+Apostolovic S(3)(4), Stanojevic D(4), Kunadian V(5)(6).
+
+Author information:
+(1)Faculty of Medicine, University of Novi Sad, Serbia.
+(2)Cardiology Clinic, Institute of Cardiovascular Diseases of Vojvodina, Sremska 
+Kamenica, Novi Sad, Serbia.
+(3)Faculty of Medicine, University of Niš, Niš, Serbia.
+(4)Clinic for Cardiology, Clinical Center Niš, Niš, Serbia.
+(5)Faculty of Medical Sciences, Translational and Clinical Research Institute, 
+Newcastle University, Newcastle upon Tyne, United Kingdom.
+(6)Cardiothoracic Centre, Freeman Hospital, Newcastle upon Tyne Hospitals NHS 
+Foundation Trust, Newcastle upon Tyne, United Kingdom.
+
+Spontaneous coronary artery dissection (SCAD), although in the majority of cases 
+presents as an acute coronary syndrome (ACS), has different pathophysiology from 
+atherosclerosis that influences specific angiography findings and enables most 
+patients to be solved by optimal medical therapy rather than percutaneous 
+coronary intervention (PCI). Therefore, accurate diagnosis is essential for 
+adequate treatment of each patient as management of SCAD differs from that of 
+ACS of atherosclerotic aetiology. So far, invasive coronary angiography remains 
+the most important diagnostic tool in suspected SCAD. However, there are 
+ambiguous cases that can mimic SCAD. In this review, the authors summarize 
+current knowledge about the diagnostic algorithms, particularly angiographic 
+features of SCAD, pitfalls of angiography, and the role of intracoronary imaging 
+in the context of SCAD diagnosis. Finally, apart from the pathognomonic 
+angiographic features of SCAD that are thoroughly discussed in this review, the 
+authors focus on obscure angiography findings and findings that can mimic SCAD 
+as well. Differential diagnosis and the timely recognition of SCAD are crucial 
+as there are differences in the acute and long-term management of SCAD and other 
+causes of ACS.
+
+© 2023 Kovacevic, Jarakovic, Milovancev, Cankovic, Petrovic, Bjelobrk, Ilic, 
+Srdanovic, Tadic, Dabovic, Crnomarkovic, Komazec, Dracina, Apostolovic, 
+Stanojevic and Kunadian.
+
+DOI: 10.3389/fcvm.2023.1278453
+PMCID: PMC10711615
+PMID: 38089767
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_38298759.md
+++ b/references_cache/PMID_38298759.md
@@ -1,0 +1,105 @@
+---
+reference_id: "PMID:38298759"
+title: "Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature."
+authors:
+- Petrović M
+- Miljković T
+- Ilić A
+- Kovačević M
+- Čanković M
+- Dabović D
+- Stojšić Milosavljević A
+- Čemerlić Maksimović S
+- Jaraković M
+- Andrić D
+- Golubović M
+- Bjelobrk M
+- Bjelić S
+- Tadić S
+- Slankamenac J
+- Apostolović S
+- Djurović V
+- Milovančev A
+journal: Front Cardiovasc Med
+year: '2024'
+doi: 10.3389/fcvm.2024.1276521
+content_type: abstract_only
+---
+
+# Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature.
+**Authors:** Petrović M, Miljković T, Ilić A, Kovačević M, Čanković M, Dabović D, Stojšić Milosavljević A, Čemerlić Maksimović S, Jaraković M, Andrić D, Golubović M, Bjelobrk M, Bjelić S, Tadić S, Slankamenac J, Apostolović S, Djurović V, Milovančev A
+**Journal:** Front Cardiovasc Med (2024)
+**DOI:** [10.3389/fcvm.2024.1276521](https://doi.org/10.3389/fcvm.2024.1276521)
+
+## Content
+
+1. Front Cardiovasc Med. 2024 Jan 16;11:1276521. doi: 10.3389/fcvm.2024.1276521. 
+eCollection 2024.
+
+Management and outcomes of spontaneous coronary artery dissection: a systematic 
+review of the literature.
+
+Petrović M(1)(2), Miljković T(1)(2), Ilić A(1)(2), Kovačević M(1)(2), Čanković 
+M(1)(2), Dabović D(1)(2), Stojšić Milosavljević A(1)(2), Čemerlić Maksimović 
+S(2), Jaraković M(1)(2), Andrić D(1)(2), Golubović M(1)(2), Bjelobrk M(1)(2), 
+Bjelić S(1)(2), Tadić S(1)(2), Slankamenac J(3), Apostolović S(4)(5), Djurović 
+V(6), Milovančev A(1)(2).
+
+Author information:
+(1)Faculty of Medicine, University of Novi Sad, Novi Sad, Serbia.
+(2)Institute of Cardiovascular Diseases of Vojvodina, Sremska Kamenica, Serbia.
+(3)Faculty of Sport and Physical Education, University of Novi Sad, Novi Sad, 
+Serbia.
+(4)Medical Faculty, University of Niš, Niš, Serbia.
+(5)Clinical Center of Niš, Cardiology Clinic, Niš, Serbia.
+(6)Clinic of Nephrology and Clinical Immunology, University Clinical Center of 
+Vojvodina, Novi Sad, Serbia.
+
+BACKGROUND: Contemporary management of spontaneous coronary artery dissection 
+(SCAD) is still controversial. This systematic review of the literature aims to 
+explore outcomes in the patients treated with conservative management vs. 
+invasive strategy.
+METHODS: The PRISMA (Preferred Reporting Items for Systematic Reviews and 
+Meta-Analyses) guidelines were followed when we extensively searched three 
+electronic databases: PubMed, ScienceDirect, and Web of Science, for studies 
+that compared conservative vs. invasive revascularization treatment outcomes for 
+patients with SCAD from 2003 to 2023. The outcomes of interest were all-cause 
+death and major adverse cardiovascular events (MACE), including acute coronary 
+syndrome (ACS), heart failure (HF), need for additional revascularization, 
+target vessel revascularization (TVR), SCAD recurrence, and stroke.
+RESULTS: The systematic review included 13 observational studies evaluating 
+1,801 patients with SCAD. The overall mean age was 49.12 +/- 3.41, and 88% were 
+females. The overall prevalence of arterial hypertension was 33.2%, 
+hyperlipidemia, 26.9%, smoking, 17.8%, and diabetes, 3.9%. Approximately 48.5% 
+of the patients were diagnosed with non-ST elevated myocardial infarction 
+(NSTEMI), 36.8% with ST elevated myocardial infarction (STEMI), 3.41% with 
+unstable angina, 0.56% with stable angina, and 0.11% were diagnosed with various 
+types of arrhythmias. The left anterior descending artery (LAD) was the most 
+common culprit lesion in 51% of the patients. There were initially 65.2% of 
+conservatively treated patients vs. 33.4% that underwent percutaneous coronary 
+intervention (PCI) or 1.28% that underwent coronary artery bypass graft (CABG). 
+SCAD-PCI revascularization was associated with a variable range of PCI failure. 
+The most common complications were hematoma extension and iatrogenic dissection. 
+SCAD-PCI revascularization frequently required three or more stents and had 
+residual areas of dissection. The overall reported in-hospital and follow-up 
+mortality rates were 1.2% and 1.3%, respectively. The follow-up range across 
+studies was 7.3-75.6 months. The authors reported variable prevalence of MACE, 
+recurrent SCAD up to 31%, ACS up to 27.4%, TVR up to 30%, repeat 
+revascularization up to 14.7%, UA up to 13.3%, HF up to 17.4%, and stroke up to 
+3%.
+CONCLUSION: Our results highlight that conservative treatment should be the 
+preferred method of treatment in patients with SCAD. PCI revascularization is 
+associated with a high prevalence of periprocedural complications. SCAD poses a 
+considerable risk of MACE, mainly associated with TVR, ACS, and recurrent SCAD.
+
+© 2024 Petrović, Miljković, Ilić, Kovačević, Čanković, Dabović, Stojšić 
+Milosavljević, Čemerlić Maksimović, Jaraković, Andrić, Golubović, Bjelobrk, 
+Bjelić, Tadić, Slankamenac, Apostolović, Djurović and Milovančev.
+
+DOI: 10.3389/fcvm.2024.1276521
+PMCID: PMC10829101
+PMID: 38298759
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_38390446.md
+++ b/references_cache/PMID_38390446.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:38390446"
+title: "Spontaneous coronary artery dissection in women in the generative period: clinical characteristics, treatment, and outcome-a systematic review and meta-analysis."
+authors:
+- Apostolović S
+- Ignjatović A
+- Stanojević D
+- Radojković DD
+- Nikolić M
+- Milošević J
+- Filipović T
+- Kostić K
+- Miljković I
+- Djoković A
+- Krljanac G
+- Mehmedbegović Z
+- Ilić I
+- Aleksandrić S
+- Paradies V
+journal: Front Cardiovasc Med
+year: '2024'
+doi: 10.3389/fcvm.2024.1277604
+content_type: abstract_only
+---
+
+# Spontaneous coronary artery dissection in women in the generative period: clinical characteristics, treatment, and outcome-a systematic review and meta-analysis.
+**Authors:** Apostolović S, Ignjatović A, Stanojević D, Radojković DD, Nikolić M, Milošević J, Filipović T, Kostić K, Miljković I, Djoković A, Krljanac G, Mehmedbegović Z, Ilić I, Aleksandrić S, Paradies V
+**Journal:** Front Cardiovasc Med (2024)
+**DOI:** [10.3389/fcvm.2024.1277604](https://doi.org/10.3389/fcvm.2024.1277604)
+
+## Content
+
+1. Front Cardiovasc Med. 2024 Feb 8;11:1277604. doi: 10.3389/fcvm.2024.1277604. 
+eCollection 2024.
+
+Spontaneous coronary artery dissection in women in the generative period: 
+clinical characteristics, treatment, and outcome-a systematic review and 
+meta-analysis.
+
+Apostolović S(1)(2), Ignjatović A(2), Stanojević D(1), Radojković DD(1)(2), 
+Nikolić M(1), Milošević J(1), Filipović T(2), Kostić K(1), Miljković I(1), 
+Djoković A(3)(4), Krljanac G(4)(5), Mehmedbegović Z(4)(5), Ilić I(4)(6), 
+Aleksandrić S(4)(5), Paradies V(7).
+
+Author information:
+(1)Clinic for Cardiology, University Clinical Center Nis, Nis, Serbia.
+(2)Medical Faculty, University of Nis, Nis, Serbia.
+(3)Department of Cardiology, Clinical Hospital Bežanijska Kosa, Belgrade, 
+Serbia.
+(4)Medical Faculty, University of Belgrade, Belgrade, Serbia.
+(5)Clinic of Cardiology, University Clinical Center of Serbia, Belgrade, Serbia.
+(6)Department of Cardiology, Institute for Cardiovascular Diseases Dedinje, 
+Belgrade, Serbia.
+(7)Department of Cardiology, Maasstad Hospital, Rotterdam, Netherlands.
+
+INTRODUCTION: Spontaneous coronary artery dissection (SCAD) is a non-traumatic 
+and non-iatrogenic separation of the coronary arterial wall.
+MATERIALS AND METHODS: This systematic review and meta-analysis is reported 
+following the PRISMA guidelines and is registered in the PROSPERO database. A 
+literature search was focused on female patients in generative period (16-55 of 
+age) with acute coronary syndrome (ACS) caused by SCAD, and comparison from that 
+database NP-SCAD (spontaneous coronary artery dissection in non pregnant women) 
+and P-SCAD (spontaneous coronary artery dissection in pregnant women).
+RESULTS: 14 studies with 2,145 females in the generative period with ACS caused 
+by SCAD were analyzed. The median age was 41 years (33.4-52.3 years). The most 
+common risk factor was previous smoking history in 24.9% cases. The most common 
+clinical presentation of ACS was STEMI in 47.4%. Conservative treatment was 
+reported in 41.1%. PCI was performed in 32.7%, and 3.8% of patients had CABG 
+surgery. LAD was the most frequently affected (50.5%). The prevalence of 
+composite clinical outcomes including mortality, non-fatal MI and recurrent SCAD 
+was 3.3% (95% CI: 1.4-5.1), 37.7% (95% CI: 1.9-73.4) and 15.2% (95% CI: 
+9.1-21.3) of patients. P-SCAD compared to NP-SCAD patients more frequently had 
+STEMI (OR = 3.16; 95% CI: 2.30-4.34; I2 = 64%); with the left main and LAD more 
+frequently affected [(OR = 14.34; 95% CI: 7.71-26.67; I2 = 54%) and (OR = 1.57; 
+95% CI: 1.06-2.32; I2 = 23%)]; P-SCAD patients more frequently underwent CABG 
+surgery (OR = 6.29; 95% CI: 4.08-9.70; I2 = 0%). NP-SCAD compared to P-SCAD 
+patients were more frequently treated conservatevly (OR = 0.61; 95% CI: 
+0.37-0.98; I2 = 0%). In P-SCAD compared to NP-SCAD mortality rates (OR = 1.13; 
+95% CI: 0.06-21.16; I2 = not applicable) and reccurence of coronary artery 
+dissection (OR = 2.54; 95% CI: 0.97-6.61; I2 = 0%) were not more prevalent.
+CONCLUSION: The results of this meta-analysis indicated that patients with 
+P-SCAD more frequently had STEMI, and events more frequently involved left main 
+and LAD compared to NP-SCAD patients. Women with NP-SCAD were significantly more 
+often treated conservatively compared to P-SCAD patients. P-SCAD compared to 
+NP-SCAD patients did not have significantly higher mortality rates or recurrent 
+coronary dissection.
+
+© 2024 Apostolović, Ignjatović, Stanojević, Radojković, Nikolić, Milošević, 
+Filipović, Kostić, Miljković, Djoković, Krljanac, Mehmedbegović, Ilić, 
+Aleksandrić and Paradies.
+
+DOI: 10.3389/fcvm.2024.1277604
+PMCID: PMC10882101
+PMID: 38390446
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_39742239.md
+++ b/references_cache/PMID_39742239.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:39742239"
+title: "Spontaneous Coronary Dissection Review: A Complex Picture."
+authors:
+- Bollati M
+- Ercolano V
+- Mazzarotto P
+journal: Rev Cardiovasc Med
+year: '2024'
+doi: 10.31083/j.rcm2512448
+content_type: abstract_only
+---
+
+# Spontaneous Coronary Dissection Review: A Complex Picture.
+**Authors:** Bollati M, Ercolano V, Mazzarotto P
+**Journal:** Rev Cardiovasc Med (2024)
+**DOI:** [10.31083/j.rcm2512448](https://doi.org/10.31083/j.rcm2512448)
+
+## Content
+
+1. Rev Cardiovasc Med. 2024 Dec 23;25(12):448. doi: 10.31083/j.rcm2512448. 
+eCollection 2024 Dec.
+
+Spontaneous Coronary Dissection Review: A Complex Picture.
+
+Bollati M(1), Ercolano V(1), Mazzarotto P(1).
+
+Author information:
+(1)Cardiologia, Ospedale Maggiore, 26900 Lodi, Italy.
+
+Spontaneous coronary artery dissection (SCAD) represents a quite rare event but 
+with potentially serious prognostic implications. Meanwhile, SCAD typically 
+presents as an acute coronary syndrome (ACS). Despite the majority of SCAD 
+presentation being characterized by typical ACS signs and symptoms, young age at 
+presentation with an atypical atherosclerotic risk factor profile is responsible 
+for late medical contact and misdiagnosis. The diagnostic algorithm is similar 
+to that for ACS. Low-risk factors prevalence and young age would push toward 
+non-invasive imaging (such as coronary computed tomography (CT)); instead, the 
+gold standard diagnostic exam for SCAD is an invasive coronary angiography (ICA) 
+due to its increased sensitivity and disease characterization. Moreover, 
+intravascular imaging (IVI) improves ICA diagnostic performance, confirming the 
+diagnosis and clarifying the disease mechanism. A SCAD-ICA classification 
+recognizes four angiographic appearances according to lesion extension and 
+features (radiolucent lumen, long and diffuse narrowing, focal stenosis, and 
+vessel occlusion). Concerning its management, the preferred approach is 
+conservative due to the high rates of spontaneous healing in the first months 
+and the low rate of revascularization success (high complexity percutaneous 
+coronary intervention (PCI) with dissection/hematoma extension risk). 
+Revascularization is recommended in the presence of high-risk features (such as 
+left main or multivessel involvement, hemodynamic instability, recurrent chest 
+pain, or ST elevation). The first choice is PCI; coronary artery bypass graft 
+(CABG) is considered only if PCI is not feasible or too hazardous according to 
+the operators' and centers' experience. Medical therapy includes beta blockers 
+in cases of ventricular dysfunction; however, no clear data are available about 
+antiplatelet treatment because of the supposed risk of intramural hematoma 
+enlargement. Furthermore, screening for extracardiac arthropathies or connective 
+tissue diseases is recommended due to the hypothesized association with SCAD. 
+Eventually, SCAD follow-up is important, considering the risk of SCAD 
+recurrence. Considering the young age of patients with SCAD, subsequent care is 
+essential (including psychological support, also for relatives) with the aim of 
+safe and complete reintegration into a non-limited everyday life.
+
+Copyright: © 2024 The Author(s). Published by IMR Press.
+
+DOI: 10.31083/j.rcm2512448
+PMCID: PMC11683698
+PMID: 39742239
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_41776338.md
+++ b/references_cache/PMID_41776338.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:41776338"
+title: "Spontaneous coronary artery dissection: a clinically oriented narrative review."
+authors:
+- Dang Q
+- Burgess S
+- Psaltis PJ
+- Fairley S
+- Saw J
+- Zaman S
+journal: NPJ Cardiovasc Health
+year: '2024'
+doi: 10.1038/s44325-024-00004-y
+content_type: abstract_only
+---
+
+# Spontaneous coronary artery dissection: a clinically oriented narrative review.
+**Authors:** Dang Q, Burgess S, Psaltis PJ, Fairley S, Saw J, Zaman S
+**Journal:** NPJ Cardiovasc Health (2024)
+**DOI:** [10.1038/s44325-024-00004-y](https://doi.org/10.1038/s44325-024-00004-y)
+
+## Content
+
+1. NPJ Cardiovasc Health. 2024 May 10;1(1):4. doi: 10.1038/s44325-024-00004-y.
+
+Spontaneous coronary artery dissection: a clinically oriented narrative review.
+
+Dang Q(1), Burgess S(2)(3), Psaltis PJ(4)(5)(6), Fairley S(7), Saw J(8), Zaman 
+S(9)(10).
+
+Author information:
+(1)Westmead Applied Research Centre, Faculty of Medicine and Health, University 
+of Sydney, Sydney, Australia.
+(2)Department of Cardiology, Nepean hospital, Sydney, Australia.
+(3)University of Sydney, Sydney, Australia.
+(4)Vascular Research Centre, Lifelong Health Theme, South Australian Health and 
+Medical Research Institute, Adelaide, Australia.
+(5)Department of Cardiology, Central Adelaide Local Health Network, Adelaide, 
+Australia.
+(6)Adelaide Medical School, University of Adelaide, Adelaide, Australia.
+(7)Department of Cardiology, Wellington Hospital, Wellington, New Zealand.
+(8)Division of Cardiology, Vancouver General Hospital, University of British 
+Columbia, Vancouver, BC, Canada.
+(9)Westmead Applied Research Centre, Faculty of Medicine and Health, University 
+of Sydney, Sydney, Australia. sarah.zaman@sydney.edu.au.
+(10)Department of Cardiology, Westmead Hospital, Sydney, Australia. 
+sarah.zaman@sydney.edu.au.
+
+Spontaneous coronary artery dissection (SCAD) is an important cause of acute 
+coronary syndromes (ACS), with a higher incidence in younger female patients. It 
+is also associated with pregnancy, delivery, and the post-partum period. Despite 
+an exponential rise in the volume of SCAD-focused research and publications 
+within the past decade, SCAD is still a poorly understood condition, with a 
+paucity of randomised controlled trial data. This review discusses the 
+pathophysiology, clinical presentation, diagnosis and management of SCAD 
+alongside areas for future research.
+
+© 2024. The Author(s).
+
+DOI: 10.1038/s44325-024-00004-y
+PMCID: PMC12912391
+PMID: 41776338
+
+Conflict of interest statement: Competing interests: The authors declare no 
+competing interests.

--- a/references_cache/clinicaltrials_NCT04850417.md
+++ b/references_cache/clinicaltrials_NCT04850417.md
@@ -1,5 +1,5 @@
 ---
-reference_id: clinicaltrials:NCT04850417
+reference_id: "clinicaltrials:NCT04850417"
 title: Randomized Clinical Trial Assessing the Value of Beta-Blockers and Antiplatelet Agents in Patients With Spontaneous Coronary Artery Dissection. (The BA-SCAD Randomized Clinical Trial)
 content_type: summary
 ---

--- a/references_cache/clinicaltrials_NCT04850417.md
+++ b/references_cache/clinicaltrials_NCT04850417.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT04850417
+title: Randomized Clinical Trial Assessing the Value of Beta-Blockers and Antiplatelet Agents in Patients With Spontaneous Coronary Artery Dissection. (The BA-SCAD Randomized Clinical Trial)
+content_type: summary
+---
+
+# Randomized Clinical Trial Assessing the Value of Beta-Blockers and Antiplatelet Agents in Patients With Spontaneous Coronary Artery Dissection. (The BA-SCAD Randomized Clinical Trial)
+
+## Content
+
+Spontaneous coronary artery dissection (SCAD) is a cause of acute coronary syndrome (ACS). Most patients are treated with beta-blockers (BB) and antiplatelet drugs (AP) on empiric basis. The Beta-Blockers and Antiplatelet Agents in Patients with Spontaneous Coronary Artery Dissection (BA-SCAD) randomized clinical trial is an academic, pragmatic, nation-wide, prospective study developed under the auspices of the Spanish Society of Cardiology (SEC) that aims to assess the efficacy of medical therapy in SCAD patients. Using a factorial 2x2 design, patients will be randomized (1:1/1:1) to: 1) BB (yes/no) and 2) short AP regimen (1 month) vs prolonged dual AP therapy (DAPT) (12 months).Only patients with preserved left ventricular ejection fraction (LVEF) will be randomized to BB (yes/no) because patients with LVEF \<40% will receive BB according to current guidelines. Likewise, only medically managed patients will be randomized to short AP therapy vs 1-year DAPT. The study will have a pragmatic, open label, blind outcomes design (PROBE). A total of 600 SCAD patients will be randomized within 2 years (300 per arm in a factorial 2x2 design). The primary efficacy endpoint will include the composite of death, acute myocardial infarction (MI), stroke, coronary revascularization, recurrent SCAD, and unplanned hospitalization for ACS or heart failure at 1 year. The primary safety endpoint will be bleeding. All patients will be clinically followed yearly. The main study will be pragmatic but a comprehensive set of additional studies (clinical, imaging, biomarkers, inflammatory, immunologic, pharmacogenetic and genetic) will be organized to ensure an holistic view on this challenging condition.

--- a/research/Idiopathic_Spontaneous_Coronary_Artery_Dissection-deep-research-falcon.md
+++ b/research/Idiopathic_Spontaneous_Coronary_Artery_Dissection-deep-research-falcon.md
@@ -1,0 +1,1210 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-05T23:14:06.451693'
+end_time: '2026-05-05T23:25:05.911807'
+duration_seconds: 659.46
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Idiopathic Spontaneous Coronary Artery Dissection
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Idiopathic Spontaneous Coronary Artery Dissection
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Idiopathic Spontaneous Coronary Artery Dissection** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Idiopathic Spontaneous Coronary Artery Dissection
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Idiopathic Spontaneous Coronary Artery Dissection** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Idiopathic Spontaneous Coronary Artery Dissection (SCAD): Disease Characteristics Research Report
+
+## Executive summary
+Idiopathic spontaneous coronary artery dissection (SCAD) is a non-atherosclerotic cause of acute coronary syndrome (ACS) caused by separation within the coronary arterial wall that produces an intramural hematoma and/or intimal tear, compressing the true lumen and causing myocardial ischemia/infarction. Contemporary evidence supports conservative-first management for clinically stable patients due to high spontaneous healing rates, with selective revascularization for high-risk anatomy or ongoing ischemia; systematic screening for extracoronary arteriopathies—especially fibromuscular dysplasia (FMD)—is commonly recommended. Despite rapidly growing registry-based knowledge, randomized controlled trial (RCT) evidence remains limited, and many recommendations are based on expert consensus and observational studies. (morena2024advancesinthe pages 1-2, dang2024spontaneouscoronaryartery pages 6-6, smirnova2023spontaneouscoronaryartery pages 1-2, petrovic2024managementandoutcomes pages 1-2)
+
+## 1. Disease information
+### 1.1 Definition and overview
+SCAD is described as a non-atherosclerotic, non-traumatic, non-iatrogenic separation of the coronary arterial wall resulting in a false lumen and/or intramural hematoma that compresses the true lumen and presents as ACS. (morena2024advancesinthe pages 1-2, smirnova2023spontaneouscoronaryartery pages 1-2, pender2025spontaneouscoronaryartery pages 1-2)
+
+**Abstract-supported quotes**
+- “SCAD is caused by separation occurring within or between any of the three tunics of the coronary artery wall. This leads to intramural hematoma and/or formation of false lumen in the artery, which leads to ischemic changes or infarction of the myocardium.” (Frontiers review abstract) (dang2024spontaneouscoronaryartery pages 6-7)
+- “Spontaneous coronary artery dissection (SCAD) is a non-traumatic and non-iatrogenic separation of the coronary arterial wall.” (systematic review/meta-analysis abstract) (apostolovic2024spontaneouscoronaryartery pages 1-2)
+
+### 1.2 Key identifiers (from retrieved evidence)
+- **ICD-10-CM:** **I25.42** used to identify SCAD in U.S. administrative datasets. (mughal2022contemporarytrendsin pages 1-3, krittanawong2020recurrentspontaneouscoronary pages 1-2)
+- **ICD-9-CM:** **414.12** used to identify SCAD before the ICD-10 transition. (mughal2022contemporarytrendsin pages 1-3, krittanawong2020recurrentspontaneouscoronary pages 1-2)
+
+**Not confirmed in retrieved full texts:** MeSH term(s), MONDO ID, Orphanet ID, OMIM entry specifically for “idiopathic SCAD” (these identifiers exist in external ontologies but are not present in the retrieved documents and are not inferred here). (mughal2022contemporarytrendsin pages 1-3, krittanawong2020recurrentspontaneouscoronary pages 1-2)
+
+### 1.3 Synonyms / alternative names
+- Spontaneous coronary artery dissection (SCAD) (morena2024advancesinthe pages 1-2)
+- Non-atherosclerotic coronary artery dissection / non-iatrogenic coronary artery dissection (descriptive usage across reviews) (smirnova2023spontaneouscoronaryartery pages 1-2, pender2025spontaneouscoronaryartery pages 1-2)
+
+### 1.4 Evidence provenance
+The current understanding summarized here is derived largely from **aggregated disease-level evidence**: systematic reviews/meta-analyses, narrative reviews, and registry/administrative cohort analyses, with some mechanistic inference from intracoronary imaging and pathology discussions. (dang2024spontaneouscoronaryartery pages 6-6, petrovic2024managementandoutcomes pages 1-2)
+
+## 2. Etiology
+### 2.1 Disease causal factors (current mechanistic framing)
+SCAD is thought to arise via two nonexclusive mechanisms:
+1) **“Inside–out”**: an intimal tear allows blood to enter the arterial wall, forming a false lumen.
+2) **“Outside–in”**: spontaneous hemorrhage (e.g., from vasa vasorum) causes intramural hematoma within the media, compressing the lumen. (rusali2025spontaneouscoronaryartery pages 3-5, pender2025spontaneouscoronaryartery pages 1-2)
+
+### 2.2 Risk factors
+#### Predisposing conditions (non-exhaustive)
+- **Fibromuscular dysplasia (FMD)**: the most consistently associated extracoronary arteriopathy; prevalence among SCAD patients varies widely (in part due to screening modality/intensity). (dang2024spontaneouscoronaryartery pages 6-6, gori2023contemporaryreviewon pages 3-4)
+- **Pregnancy/peripartum state** (pregnancy-associated SCAD often more severe). (smirnova2023spontaneouscoronaryartery pages 1-2, gori2023contemporaryreviewon pages 3-4, apostolovic2024spontaneouscoronaryartery pages 1-2)
+- **Inherited connective tissue disorders** (rare; often in syndromic/non-syndromic connective tissue disease contexts). (smirnova2023spontaneouscoronaryartery pages 1-2, gori2023contemporaryreviewon pages 3-4)
+- **Hypertension** (frequent “traditional” risk factor reported in multiple reviews). (gori2023contemporaryreviewon pages 3-4)
+- **Migraine** and other neuropsychiatric conditions are reported in SCAD cohorts and may associate with recurrence risk. (dang2024spontaneouscoronaryartery pages 6-6, krittanawong2020recurrentspontaneouscoronary pages 1-2)
+
+#### Precipitating triggers
+Reviews report that **emotional stress** (more often in women) and **physical stress/exertion** (more often in men) commonly precede symptoms; stimulant exposure (e.g., cocaine/amphetamines) is also discussed as a precipitating factor in risk-factor reviews. (gori2023contemporaryreviewon pages 3-4)
+
+### 2.3 Protective factors
+No specific protective genetic variants or protective exposures were identified in the retrieved evidence set.
+
+### 2.4 Gene–environment interactions
+The retrieved evidence supports a conceptual model of **arterial vulnerability (predisposition) + trigger (stress/hemodynamic/hormonal changes)** but does not provide quantified gene–environment interaction estimates. (rusali2025spontaneouscoronaryartery pages 3-5, gori2023contemporaryreviewon pages 3-4)
+
+## 3. Phenotypes
+### 3.1 Clinical presentation
+SCAD most commonly presents as ACS with chest pain and biomarker/ECG changes consistent with MI.
+
+**Abstract-supported quote**
+- “Spontaneous coronary artery dissection (SCAD) represents a quite rare event but with potentially serious prognostic implications. Meanwhile, SCAD typically presents as an acute coronary syndrome (ACS).” (review abstract) (morena2024advancesinthe pages 1-2)
+
+#### Frequencies / ranges reported in recent syntheses
+- Systematic review (n=1,801): **NSTEMI ~48.5%**, **STEMI ~36.8%**, unstable angina ~3.4%, stable angina ~0.56%. (petrovic2024managementandoutcomes pages 1-2)
+- In women of reproductive age meta-analysis (n=2,145): **STEMI ~47.4%** (pooled). (apostolovic2024spontaneouscoronaryartery pages 1-2)
+
+#### Complications/severe presentations (examples)
+A 2023 review reports cardiogenic shock (~2%), sudden cardiac death (~0.8% in autopsy series), and ventricular arrhythmias (~5%) among reported presentations/complications, and notes Takotsubo syndrome overlap. (smirnova2023spontaneouscoronaryartery pages 1-2)
+
+### 3.2 Quality-of-life impacts
+Post-event psychological morbidity is common; a 2024 narrative review highlights depression/anxiety/PTSD and recommends mental-health screening and peer support as part of follow-up care. (dang2024spontaneouscoronaryartery pages 6-6)
+
+### 3.3 Suggested HPO terms (for knowledge base entry; not exhaustive)
+- Chest pain **HP:0100749**
+- Acute myocardial infarction **HP:0001658**
+- ST elevation **HP:0031557** / Abnormal ST segment **HP:0031425**
+- Elevated cardiac troponin **HP:0031195**
+- Ventricular arrhythmia **HP:0001663**
+- Cardiogenic shock **HP:0030144**
+- Dyspnea **HP:0002094**
+- Nausea **HP:0002018**
+
+(These HPO codes are provided as ontology suggestions; they were not explicitly enumerated in the retrieved articles.)
+
+## 4. Genetic / molecular information
+### 4.1 Current understanding
+SCAD is generally **not strongly inherited**; familial cases are uncommon in the reviewed literature, and monogenic causes are considered rare and more often linked to connective tissue disorders. (gori2023contemporaryreviewon pages 3-4, smirnova2023spontaneouscoronaryartery pages 1-2)
+
+A 2024 narrative review discusses reported genetic associations/case reports including **PHACTR1/EDN1 locus**, **SMAD3 mutation** cases, and variants in fibrillar collagens; however, the excerpted evidence does not provide a comprehensive gene list or variant-level frequencies. (dang2024spontaneouscoronaryartery pages 6-7)
+
+### 4.2 When to consider genetic testing (practice-oriented guidance)
+Genetic testing is described as **low-yield and not routine**, but may be considered in SCAD patients with recurrent SCAD, multivessel disease, extracoronary vascular abnormalities, or a family history/features suggestive of a heritable connective tissue disorder, with appropriate counselling and possible aortopathy/connective tissue gene panels. (dang2024spontaneouscoronaryartery pages 6-6)
+
+### 4.3 Variants/modifier genes/epigenetics/chromosomal abnormalities
+The retrieved evidence does not provide curated variant-level data (e.g., ACMG classifications, allele frequencies) or epigenetic/chromosomal abnormality findings specific to idiopathic SCAD.
+
+## 5. Environmental information
+### 5.1 Environmental/lifestyle factors
+The evidence set primarily emphasizes **stress-related triggers** (emotional/physical) rather than classic lifestyle risk factors; traditional atherosclerotic risk factors are often less prevalent, though hypertension is frequently reported. (gori2023contemporaryreviewon pages 3-4)
+
+### 5.2 Infectious agents
+No specific infectious agent etiology was identified in the retrieved evidence.
+
+## 6. Mechanism / pathophysiology
+### 6.1 Causal chain (high-level)
+**Predisposing arteriopathy/hormonal milieu/stress exposure** → **arterial wall vulnerability** → **intramural bleeding and/or intimal disruption** → **intramural hematoma/false lumen** → **true-lumen compression** → **myocardial ischemia/infarction** → **ACS presentation and complications**. (rusali2025spontaneouscoronaryartery pages 3-5, pender2025spontaneouscoronaryartery pages 1-2, smirnova2023spontaneouscoronaryartery pages 1-2)
+
+### 6.2 Cellular processes and tissue injury (conceptual mapping)
+- Vessel wall injury leading to intramural hematoma with downstream ischemia is central to SCAD pathophysiology. (rusali2025spontaneouscoronaryartery pages 3-5, pender2025spontaneouscoronaryartery pages 1-2)
+
+### 6.3 Suggested GO (biological process) and CL (cell type) terms (ontology suggestions)
+- GO:0001525 **angiogenesis** (vasa vasorum biology; conceptual)
+- GO:0007596 **blood coagulation** (intramural hemorrhage context; conceptual)
+- GO:0006954 **inflammatory response** (discussed as unclear/variable in reviews; conceptual) (rusali2025spontaneouscoronaryartery pages 3-5)
+- CL:0002131 **vascular smooth muscle cell**
+- CL:0002543 **endothelial cell**
+
+(These are ontology suggestions; the retrieved evidence does not provide explicit GO/CL annotations.)
+
+## 7. Anatomical structures affected
+### 7.1 Primary structures
+- **Coronary arteries** (often LAD as culprit). (petrovic2024managementandoutcomes pages 1-2, apostolovic2024spontaneouscoronaryartery pages 1-2)
+
+### 7.2 Secondary involvement/complications
+- **Myocardium** (ischemia/infarction); potential for heart failure, arrhythmias, cardiogenic shock. (smirnova2023spontaneouscoronaryartery pages 1-2, petrovic2024managementandoutcomes pages 1-2)
+
+### 7.3 Suggested UBERON terms (ontology suggestions)
+- Coronary artery **UBERON:0001621**
+- Left anterior descending coronary artery (LAD) (UBERON term varies by subset; provide as “LAD coronary artery” mapping in your implementation)
+- Myocardium **UBERON:0002349**
+
+## 8. Diagnostics
+### 8.1 Imaging and diagnostic approach
+- **Invasive coronary angiography (ICA)** is emphasized as the diagnostic gold standard, with adjunctive intracoronary imaging (**IVUS/OCT**) improving diagnostic performance and clarifying mechanism. (morena2024advancesinthe pages 1-2, bollati2024spontaneouscoronarydissection pages 4-7)
+- **Extracoronary vascular imaging**: head-to-pelvis CT angiography is described as a method for FMD screening; MRA is an alternative but may have lower spatial resolution. (dang2024spontaneouscoronaryartery pages 6-6)
+
+### 8.2 Angiographic classification (Saw types)
+Recent reviews describe an ICA-based SCAD classification (Types 1–4) used in practice; Table/Figure evidence is available from a 2024 review, including examples of Types 1, 2A, 3, and 4 and management flow-chart context. (bollati2024spontaneouscoronarydissection pages 4-7, bollati2024spontaneouscoronarydissection media ffbb95a5, bollati2024spontaneouscoronarydissection media 8d0f25c2, bollati2024spontaneouscoronarydissection media 8c541a8a, bollati2024spontaneouscoronarydissection media 353fb04a, bollati2024spontaneouscoronarydissection media 94fd0b42, bollati2024spontaneouscoronarydissection media df824cb3)
+
+### 8.3 Differential diagnosis
+SCAD can mimic atherosclerotic ACS and requires careful angiographic interpretation; intracoronary imaging can help in ambiguous cases. (gori2023contemporaryreviewon pages 3-4)
+
+## 9. Treatment
+### 9.1 Acute management strategy (current practice pattern)
+- **Conservative management is preferred** in clinically stable SCAD because spontaneous healing is common, while PCI success is limited by technical challenges and risks of propagation/iatrogenic dissection. (bollati2024spontaneouscoronarydissection pages 4-7, petrovic2024managementandoutcomes pages 1-2)
+- **Revascularization (PCI; CABG rarely)** is reserved for high-risk presentations (e.g., left main/proximal multivessel, TIMI 0/1 flow, hemodynamic/electrical instability, ongoing ischemia). (bollati2024spontaneouscoronarydissection pages 4-7, bollati2024spontaneouscoronarydissection pages 7-8)
+
+### 9.2 Medical therapy themes
+- Beta-blockers are commonly used; observational evidence associates beta-blockers with lower recurrence. (dang2024spontaneouscoronaryartery pages 6-6)
+- ACE inhibitor/ARB is recommended when LVEF is reduced after SCAD-related ACS. (dang2024spontaneouscoronaryartery pages 6-6)
+- Antiplatelet strategy in conservatively managed SCAD remains debated in reviews due to concern about intramural hematoma expansion; practice varies and RCT data are limited. (morena2024advancesinthe pages 1-2, bollati2024spontaneouscoronarydissection pages 4-7)
+- Statins are generally not routine unless indicated for dyslipidemia/atherosclerotic disease. (smirnova2023spontaneouscoronaryartery pages 1-2)
+
+### 9.3 Cardiac rehabilitation and psychosocial care
+Cardiac rehabilitation is described as safe and recommended for SCAD patients; low/moderate-intensity aerobic and low-resistance programs are favored, along with avoidance of high-intensity abrupt-movement activities, and psychological screening/support is emphasized. (dang2024spontaneouscoronaryartery pages 6-6)
+
+### 9.4 Current clinical trials (real-world implementations of evidence generation)
+- **NCT04850417**: “Randomized Study of Beta-Blockers and Antiplatelets in Patients With Spontaneous Coronary Artery Dissection” (Phase 4; planned enrollment 600; Spanish Society of Cardiology). (clinical trial record) (dang2024spontaneouscoronaryartery pages 6-6)
+- **NCT06955663**: Exercise support/rehabilitation after SCAD (planned enrollment 120). (dang2024spontaneouscoronaryartery pages 6-6)
+- **NCT04251039**: RESPONSE observational study in SCAD patients undergoing complex PCI. (dang2024spontaneouscoronaryartery pages 6-6)
+
+### 9.5 Suggested MAXO terms (ontology suggestions)
+- Conservative management / medical management (MAXO “medical therapy” class; implement with local MAXO mapping)
+- Percutaneous coronary intervention **PCI**
+- Coronary artery bypass grafting **CABG**
+- Cardiac rehabilitation
+- CT angiography screening for extracoronary arteriopathy
+
+## 10. Prevention
+### 10.1 Primary prevention
+No established primary prevention is supported by RCT evidence in the retrieved set; prevention is largely framed as managing predispositions (e.g., blood pressure), avoiding extreme triggers, and individualized counselling. (dang2024spontaneouscoronaryartery pages 6-6, gori2023contemporaryreviewon pages 3-4)
+
+### 10.2 Secondary/tertiary prevention
+- **Recurrence risk mitigation**: beta-blockers are associated with lower recurrence in observational data and are commonly used; follow-up and monitoring are emphasized. (dang2024spontaneouscoronaryartery pages 6-6)
+- **Screening for FMD and other extracoronary vascular abnormalities** is commonly recommended; FMD is associated with higher recurrence risk in review-level evidence. (dang2024spontaneouscoronaryartery pages 6-6)
+
+## 11. Outcomes / prognosis
+### 11.1 Mortality and major adverse cardiovascular events
+A 2024 systematic review (13 observational studies, n=1,801) reported **in-hospital mortality ~1.2%** and **follow-up mortality ~1.3%**, with MACE including recurrent SCAD up to 31% across studies and other events (ACS, target vessel revascularization, HF, stroke) reported variably. (petrovic2024managementandoutcomes pages 1-2)
+
+A 2024 meta-analysis in reproductive-age women reported pooled **recurrent SCAD ~15.2%** (95% CI 9.1–21.3). (apostolovic2024spontaneouscoronaryartery pages 1-2)
+
+### 11.2 Recurrence and prognostic factors
+- Reviews report recurrence risk persists for years and may vary widely depending on definitions and cohorts; recurrence has been reported up to ~30% historically, with more recent prospective series reporting lower values in certain follow-up windows. (smirnova2023spontaneouscoronaryartery pages 1-2)
+- FMD is linked to higher recurrence risk (RR 2.02 in review summary). (dang2024spontaneouscoronaryartery pages 6-6)
+
+## 12. Temporal development
+### 12.1 Onset
+SCAD often occurs in younger to middle-aged adults, with strong female predominance and particular relevance in peripartum settings. (smirnova2023spontaneouscoronaryartery pages 1-2, apostolovic2024spontaneouscoronaryartery pages 1-2)
+
+### 12.2 Course
+- Early in-hospital period: risk of early extension/worsening in the first days is noted in reviews (reported ~5–10% in one review summary). (bollati2024spontaneouscoronarydissection pages 4-7)
+- Longer term: recurrence risk and chronic symptoms (e.g., persistent chest pain syndromes discussed in later reviews) can require ongoing follow-up care. (rusali2025spontaneouscoronaryartery pages 14-16)
+
+## 13. Inheritance and population
+### 13.1 Epidemiology
+- SCAD is commonly cited as accounting for ~1–4% of ACS. (gori2023contemporaryreviewon pages 3-4)
+- Administrative incidence trend analysis (U.S. National Inpatient Sample) reported rising crude incidence per 1,000,000 discharges from ~4.95 (2010) to ~14.81 (2017), identified using ICD-9/10 SCAD codes. (mughal2022contemporarytrendsin pages 1-3)
+
+### 13.2 Demographics
+- Female predominance is consistently reported; many reviews cite ~80–90% of cases in women. (gori2023contemporaryreviewon pages 3-4, petrovic2024managementandoutcomes pages 1-2)
+
+### 13.3 Inheritance pattern
+The evidence supports **mostly complex/polygenic susceptibility with rare monogenic syndromic cases**, rather than a single Mendelian inheritance pattern for idiopathic SCAD. (smirnova2023spontaneouscoronaryartery pages 1-2, gori2023contemporaryreviewon pages 3-4)
+
+## 14. Other species / natural disease
+No evidence for naturally occurring SCAD as a defined veterinary disease entity was identified in the retrieved materials.
+
+## 15. Model organisms
+No SCAD-specific validated animal model descriptions were found in the retrieved evidence excerpts; current literature in this evidence set emphasizes human imaging/registry studies and connective-tissue disease genetics rather than experimental organism models. (dang2024spontaneouscoronaryartery pages 6-6, petrovic2024managementandoutcomes pages 1-2)
+
+## Visual evidence (angiographic types and management algorithm)
+The following extracted visuals provide practical depictions of SCAD angiographic types and a management flow chart from a 2024 review; they can be used to support knowledge base UI elements and clinician-facing summaries. (bollati2024spontaneouscoronarydissection media ffbb95a5, bollati2024spontaneouscoronarydissection media 8d0f25c2, bollati2024spontaneouscoronarydissection media df824cb3)
+
+## Structured evidence table
+| Domain | Compact summary | Key figures / structured items |
+|---|---|---|
+| Definition & epidemiology | SCAD is a **non-atherosclerotic, non-traumatic, non-iatrogenic** separation of the coronary arterial wall causing **intramural hematoma and/or intimal tear**, compression of the true lumen, myocardial ischemia, and ACS. It is increasingly recognized but still underdiagnosed. Women predominate, typically younger to middle-aged and often without classic atherosclerotic risk factors. (morena2024advancesinthe pages 1-2, singulane2025spontaneouscoronaryartery pages 1-2, smirnova2023spontaneouscoronaryartery pages 1-2, pender2025spontaneouscoronaryartery pages 1-2) | **ACS contribution:** ~1–4% overall; ~22–43% of AMI/ACS in younger women depending on cohort/age definition; up to ~35% of MI/ACS in women <50 in some summaries. **Sex:** ~88–91% female. **Typical age:** mean ~49–50 years; reviews cite onset often 44–55 years. **Culprit vessel:** LAD most common (~50–51%). (morena2024advancesinthe pages 1-2, smirnova2023spontaneouscoronaryartery pages 1-2, mughal2022contemporarytrendsin pages 1-3, krittanawong2020recurrentspontaneouscoronary pages 1-2) |
+| Risk factors / predisposition / triggers | Strongest associated arteriopathy is **fibromuscular dysplasia (FMD)**; other predispositions include inherited connective-tissue disorders, pregnancy/peripartum state, hormonal exposure, migraine, hypertension, and less commonly systemic inflammatory/autoimmune disease. Triggers differ by sex pattern in reviews: **emotional stress** commonly reported in women and **physical stress/exertion** in men; stimulant use (cocaine/amphetamines) also reported. (dang2024spontaneouscoronaryartery pages 6-7, rusali2025spontaneouscoronaryartery pages 3-5, smirnova2023spontaneouscoronaryartery pages 1-2, dang2024spontaneouscoronaryartery pages 6-6) | **FMD prevalence in SCAD:** ~25%–86% across studies/screening strategies. **Recurrence predictors:** FMD RR 2.02 (95% CI 1.03–3.94) in review; migraine HR 3.4 and FMD HR 5.1 for recurrent SCAD in one cohort. **Pregnancy-associated SCAD:** <5–17% of SCAD overall in reviews/meta-analyses; postpartum clustering recognized. (dang2024spontaneouscoronaryartery pages 6-6, pender2025spontaneouscoronaryartery pages 1-2, krittanawong2020recurrentspontaneouscoronary pages 1-2) |
+| Diagnostics & angiographic types | **Invasive coronary angiography (ICA)** is the diagnostic gold standard in suspected SCAD; **OCT** and **IVUS** help confirm intimal tear, false lumen, and intramural hematoma and guide PCI when needed. Extracoronary vascular imaging (often **head-to-pelvis CTA**, with MRA alternative) is recommended to detect FMD/other arteriopathies. (morena2024advancesinthe pages 1-2, dang2024spontaneouscoronaryartery pages 6-7, dang2024spontaneouscoronaryartery pages 6-6, bollati2024spontaneouscoronarydissection pages 4-7, bollati2024spontaneouscoronarydissection pages 7-8) | **Saw/ICA angiographic types:** **Type 1** = classic radiolucent lumen/contrast staining; **Type 2** = long diffuse smooth narrowing (most common; includes 2A/2B); **Type 3** = focal stenosis mimicking atherosclerosis; **Type 4** = distal vessel occlusion. Review cited Type 1 ~29% and Type 3 ~4%. ICA “golden rules”: gentle catheter handling, minimize injections, use nitro to distinguish spasm, consider OCT/IVUS. (morena2024advancesinthe pages 1-2, bollati2024spontaneouscoronarydissection pages 4-7, bollati2024spontaneouscoronarydissection media ffbb95a5) |
+| Management, recurrence & outcomes | **Conservative therapy** is preferred for clinically stable patients because spontaneous healing is common; **PCI** is reserved for ongoing ischemia, recurrent chest pain/ST elevation, hemodynamic/electrical instability, left main/proximal multivessel disease, or TIMI 0/1 flow. **CABG** is considered when PCI is not feasible/failed, especially left main or proximal disease. Beta-blockers are commonly used; ACEi/ARB for reduced LVEF; statins only for standard indications; antiplatelet strategy remains debated in conservatively managed SCAD. **Cardiac rehabilitation** and psychological support are recommended. (morena2024advancesinthe pages 1-2, smirnova2023spontaneouscoronaryartery pages 1-2, dang2024spontaneouscoronaryartery pages 6-6, bollati2024spontaneouscoronarydissection pages 4-7, bollati2024spontaneouscoronarydissection pages 7-8) | **Healing:** angiographic healing in ~70–97% over months. **Early extension/worsening:** ~5–10% in first days. **PCI technical failure/complexity:** Mayo series failure 53%; European series 27% technical failure and 9% emergency CABG. **Mortality:** in systematic review, in-hospital ~1.2% and follow-up ~1.3%; 3-year mortality 0.8% in one review. **Recurrence:** often ~10–20% within ~4 years; systematic review reported recurrent SCAD up to 31% across studies; one cohort 10.6% over median 4.7 years. **Rehab/screening uptake in meta-analysis:** antiplatelet 92.1%, beta-blocker 78.0%, FMD screening 54.4%, rehab referral 70.2%. (smirnova2023spontaneouscoronaryartery pages 1-2, dang2024spontaneouscoronaryartery pages 6-6, bollati2024spontaneouscoronarydissection pages 4-7, bollati2024spontaneouscoronarydissection pages 7-8) |
+| Coding identifiers & active trials | Administrative studies identify SCAD using **ICD-9-CM 414.12** and **ICD-10-CM I25.42**; iatrogenic coronary laceration/dissection is commonly excluded with **ICD-9-CM 998.2** / **ICD-10-CM I97.51** in database analyses. No explicit MONDO/Orphanet identifier was confirmed in the retrieved evidence. (mughal2022contemporarytrendsin pages 1-3, krittanawong2020recurrentspontaneouscoronary pages 1-2) | **Trial NCTs:** **NCT04850417** (BA-SCAD; randomized study of beta-blockers and antiplatelets in SCAD, phase 4, planned n=600); **NCT06955663** (exercise support/rehabilitation after SCAD, planned n=120); **NCT04251039** (RESPONSE observational study in SCAD patients undergoing complex PCI). (dang2024spontaneouscoronaryartery pages 6-6) |
+
+
+*Table: This table condenses high-yield evidence on spontaneous coronary artery dissection, including definition, epidemiology, risk factors, diagnostics, management, outcomes, coding, and current trial identifiers. It is useful as a compact reference for building a structured disease knowledge base entry.*
+
+## Recent developments and expert analysis (2023–2024 emphasis)
+- Registry-driven science has accelerated SCAD understanding, but reviews emphasize that **RCT evidence is still scarce**, prompting active trials such as BA-SCAD. (dang2024spontaneouscoronaryartery pages 6-6)
+- Reviews highlight **system-level care gaps and practice variation**, including incomplete FMD screening and variable rehabilitation referral; meta-analytic estimates suggest substantial heterogeneity across regions and eras. (petrovic2024managementandoutcomes pages 1-2)
+
+## URLs and publication dates (from retrieved sources)
+- Dang Q. et al. *npj Cardiovascular Health* (May 2024). https://doi.org/10.1038/s44325-024-00004-y (dang2024spontaneouscoronaryartery pages 6-6)
+- Petrović M. et al. *Frontiers in Cardiovascular Medicine* (Jan 2024). https://doi.org/10.3389/fcvm.2024.1276521 (petrovic2024managementandoutcomes pages 1-2)
+- Apostolović S. et al. *Frontiers in Cardiovascular Medicine* (Feb 2024). https://doi.org/10.3389/fcvm.2024.1277604 (apostolovic2024spontaneouscoronaryartery pages 1-2)
+- Smirnova A. et al. *European Heart Journal Supplements* (Apr 2023). https://doi.org/10.1093/eurheartjsupp/suad059 (smirnova2023spontaneouscoronaryartery pages 1-2)
+- Mughal M.S. et al. *Expert Review of Cardiovascular Therapy* (May 2022). https://doi.org/10.1080/14779072.2022.2080055 (mughal2022contemporarytrendsin pages 1-3)
+
+## Evidence gaps (important for knowledge base provenance)
+- **MONDO/MeSH/Orphanet/OMIM** identifiers were not extractable from the retrieved full texts; adding them will require direct ontology lookups outside this evidence set.
+- Variant-level genetics (ClinVar-style curation), epigenetic signatures, and experimental model organism evidence are not provided in the retrieved excerpts and remain incomplete here.
+
+
+References
+
+1. (morena2024advancesinthe pages 1-2): Arianna Morena, Federico Giacobbe, Ovidio De Filippo, Filippo Angelini, Francesco Bruno, Stefano Siliano, Giuseppe Giannino, Veronica Dusi, Matteo Bianco, Carloalberto Biolé, Ferdinando Varbella, Enrico Cerrato, Fabrizio D’Ascenzo, and Gaetano Maria De Ferrari. Advances in the management of spontaneous coronary artery dissection (scad): a comprehensive review. Reviews in Cardiovascular Medicine, Sep 2024. URL: https://doi.org/10.31083/j.rcm2509345, doi:10.31083/j.rcm2509345. This article has 11 citations and is from a peer-reviewed journal.
+
+2. (dang2024spontaneouscoronaryartery pages 6-6): Quan Dang, Sonya Burgess, Peter J. Psaltis, Sarah Fairley, Jacqueline Saw, and Sarah Zaman. Spontaneous coronary artery dissection: a clinically oriented narrative review. npj Cardiovascular Health, May 2024. URL: https://doi.org/10.1038/s44325-024-00004-y, doi:10.1038/s44325-024-00004-y. This article has 14 citations.
+
+3. (smirnova2023spontaneouscoronaryartery pages 1-2): Alexandra Smirnova, Flaminia Aliberti, Claudia Cavaliere, Ilaria Gatti, Viviana Vilardo, Carmelina Giorgianni, Chiara Cassani, Alessandra Repetto, Nupoor Narula, Lorenzo Giuliani, Mario Urtis, Yukio Ozaki, Francesco Prati, Eloisa Arbustini, and Michela Ferrari. Spontaneous coronary artery dissection: an unpredictable event. European Heart Journal Supplements : Journal of the European Society of Cardiology, 25:B7-B11, Apr 2023. URL: https://doi.org/10.1093/eurheartjsupp/suad059, doi:10.1093/eurheartjsupp/suad059. This article has 11 citations.
+
+4. (petrovic2024managementandoutcomes pages 1-2): Milovan Petrović, Tatjana Miljković, Aleksandra Ilić, Mila Kovačević, Milenko Čanković, Dragana Dabović, Anastazija Stojšić Milosavljević, Snežana Čemerlić Maksimović, Milana Jaraković, Dragica Andrić, Miodrag Golubović, Marija Bjelobrk, Snežana Bjelić, Snežana Tadić, Jelena Slankamenac, Svetlana Apostolović, Vladimir Djurović, and Aleksandra Milovančev. Management and outcomes of spontaneous coronary artery dissection: a systematic review of the literature. Frontiers in Cardiovascular Medicine, Jan 2024. URL: https://doi.org/10.3389/fcvm.2024.1276521, doi:10.3389/fcvm.2024.1276521. This article has 17 citations and is from a peer-reviewed journal.
+
+5. (pender2025spontaneouscoronaryartery pages 1-2): Patrick Pender, Mithila Zaheen, Quan M. Dang, Viet Dang, James Xu, Matthew Hollings, Sidney Lo, Kazuaki Negishi, and Sarah Zaman. Spontaneous coronary artery dissection: a narrative review of epidemiology and public health implications. Medicina, 61:650, Apr 2025. URL: https://doi.org/10.3390/medicina61040650, doi:10.3390/medicina61040650. This article has 7 citations.
+
+6. (dang2024spontaneouscoronaryartery pages 6-7): Quan Dang, Sonya Burgess, Peter J. Psaltis, Sarah Fairley, Jacqueline Saw, and Sarah Zaman. Spontaneous coronary artery dissection: a clinically oriented narrative review. npj Cardiovascular Health, May 2024. URL: https://doi.org/10.1038/s44325-024-00004-y, doi:10.1038/s44325-024-00004-y. This article has 14 citations.
+
+7. (apostolovic2024spontaneouscoronaryartery pages 1-2): Svetlana Apostolović, Aleksandra Ignjatović, Dragana Stanojević, Danijela Djordjević Radojković, Miroslav Nikolić, Jelena Milošević, Tamara Filipović, Katarina Kostić, Ivana Miljković, Aleksandra Djoković, Gordana Krljanac, Zlatko Mehmedbegović, Ivan Ilić, Srdjan Aleksandrić, and Valeria Paradies. Spontaneous coronary artery dissection in women in the generative period: clinical characteristics, treatment, and outcome—a systematic review and meta-analysis. Frontiers in Cardiovascular Medicine, Feb 2024. URL: https://doi.org/10.3389/fcvm.2024.1277604, doi:10.3389/fcvm.2024.1277604. This article has 16 citations and is from a peer-reviewed journal.
+
+8. (mughal2022contemporarytrendsin pages 1-3): Mohsin S Mughal, Hafsa Akbar, Ikwinder P Kaur, Ali R Ghani, Hasan Mirza, Weiyi Xia, Mohammed Haris Usman, Mahboob Alam, and Tarek Helmy. Contemporary trends in the incidence of spontaneous coronary artery dissection (scad) – ethnic and household income disparities. Expert Review of Cardiovascular Therapy, 20:485-489, May 2022. URL: https://doi.org/10.1080/14779072.2022.2080055, doi:10.1080/14779072.2022.2080055. This article has 9 citations and is from a peer-reviewed journal.
+
+9. (krittanawong2020recurrentspontaneouscoronary pages 1-2): Chayakrit Krittanawong, Anirudh Kumar, Hafeez Ul Hassan Virk, Zhen Wang, Kipp W. Johnson, Bing Yue, and Deepak L. Bhatt. Recurrent spontaneous coronary artery dissection in the united states. International Journal of Cardiology, 301:34-37, Feb 2020. URL: https://doi.org/10.1016/j.ijcard.2019.10.052, doi:10.1016/j.ijcard.2019.10.052. This article has 28 citations and is from a peer-reviewed journal.
+
+10. (rusali2025spontaneouscoronaryartery pages 3-5): Andrei Constantin Rusali, Ioana Caterina Lupu, Lavinia Maria Rusali, and Lucia Cojocaru. Spontaneous coronary artery dissection unveiled: pathophysiology, imaging, and evolving management strategies. Jun 2025. URL: https://doi.org/10.20944/preprints202506.0355.v1, doi:10.20944/preprints202506.0355.v1.
+
+11. (gori2023contemporaryreviewon pages 3-4): Tommaso Gori, Luca Bergamaschi, Jarakovic Milovancev Cankovic Petrovic Bjelobrk Ilic Srdanov Kovacevic, M. Kovačević, M. Jarakovic, A. Milovančev, M. Čanković, M. Petrovic, M. Bjelobrk, A. Ilić, I. Srdanović, S. Tadić, D. Dabović, B. Crnomarković, N. Komazec, N. Dračina, S. Apostolovic, D. Stanojević, and V. Kunadian. Contemporary review on spontaneous coronary artery dissection: insights into the angiographic finding and differential diagnosis. Frontiers in Cardiovascular Medicine, Nov 2023. URL: https://doi.org/10.3389/fcvm.2023.1278453, doi:10.3389/fcvm.2023.1278453. This article has 14 citations and is from a peer-reviewed journal.
+
+12. (bollati2024spontaneouscoronarydissection pages 4-7): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+13. (bollati2024spontaneouscoronarydissection media ffbb95a5): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+14. (bollati2024spontaneouscoronarydissection media 8d0f25c2): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+15. (bollati2024spontaneouscoronarydissection media 8c541a8a): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+16. (bollati2024spontaneouscoronarydissection media 353fb04a): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+17. (bollati2024spontaneouscoronarydissection media 94fd0b42): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+18. (bollati2024spontaneouscoronarydissection media df824cb3): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+19. (bollati2024spontaneouscoronarydissection pages 7-8): Mario Bollati, Vincenzo Ercolano, and Pietro Mazzarotto. Spontaneous coronary dissection review: a complex picture. Reviews in Cardiovascular Medicine, Dec 2024. URL: https://doi.org/10.31083/j.rcm2512448, doi:10.31083/j.rcm2512448. This article has 6 citations and is from a peer-reviewed journal.
+
+20. (rusali2025spontaneouscoronaryartery pages 14-16): Andrei Constantin Rusali, Ioana Caterina Lupu, Lavinia Maria Rusali, and Lucia Cojocaru. Spontaneous coronary artery dissection unveiled: pathophysiology, imaging, and evolving management strategies. Jun 2025. URL: https://doi.org/10.20944/preprints202506.0355.v1, doi:10.20944/preprints202506.0355.v1.
+
+21. (singulane2025spontaneouscoronaryartery pages 1-2): Cristiane C. Singulane, Shuo Wang, Kelsey Watts, Macy E. Stahl, LeAnn Denlinger, Rachel Lloyd, Pranavi Pallinti, Lauren Preston, Mohamed Morsy, Odayme Quesada, Angela Taylor, Randy K. Ramcharitar, Mete Civelek, and Patricia F. Rodriguez-Lozano. Spontaneous coronary artery dissection (scad): unveiling the enigma of the unexpected coronary event. Current Atherosclerosis Reports, Aug 2025. URL: https://doi.org/10.1007/s11883-025-01328-5, doi:10.1007/s11883-025-01328-5. This article has 8 citations and is from a peer-reviewed journal.

--- a/research/Idiopathic_Spontaneous_Coronary_Artery_Dissection-deep-research-falcon.md.citations.md
+++ b/research/Idiopathic_Spontaneous_Coronary_Artery_Dissection-deep-research-falcon.md.citations.md
@@ -1,0 +1,483 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Idiopathic Spontaneous Coronary Artery Dissection
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Idiopathic Spontaneous Coronary Artery Dissection** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-05T23:25:05.911807
+
+1. dang2024spontaneouscoronaryartery pages 6-7
+2. apostolovic2024spontaneouscoronaryartery pages 1-2
+3. morena2024advancesinthe pages 1-2
+4. gori2023contemporaryreviewon pages 3-4
+5. petrovic2024managementandoutcomes pages 1-2
+6. smirnova2023spontaneouscoronaryartery pages 1-2
+7. dang2024spontaneouscoronaryartery pages 6-6
+8. rusali2025spontaneouscoronaryartery pages 3-5
+9. bollati2024spontaneouscoronarydissection pages 4-7
+10. rusali2025spontaneouscoronaryartery pages 14-16
+11. mughal2022contemporarytrendsin pages 1-3
+12. pender2025spontaneouscoronaryartery pages 1-2
+13. krittanawong2020recurrentspontaneouscoronary pages 1-2
+14. bollati2024spontaneouscoronarydissection pages 7-8
+15. singulane2025spontaneouscoronaryartery pages 1-2
+16. https://doi.org/10.1038/s44325-024-00004-y
+17. https://doi.org/10.3389/fcvm.2024.1276521
+18. https://doi.org/10.3389/fcvm.2024.1277604
+19. https://doi.org/10.1093/eurheartjsupp/suad059
+20. https://doi.org/10.1080/14779072.2022.2080055
+21. https://doi.org/10.31083/j.rcm2509345,
+22. https://doi.org/10.1038/s44325-024-00004-y,
+23. https://doi.org/10.1093/eurheartjsupp/suad059,
+24. https://doi.org/10.3389/fcvm.2024.1276521,
+25. https://doi.org/10.3390/medicina61040650,
+26. https://doi.org/10.3389/fcvm.2024.1277604,
+27. https://doi.org/10.1080/14779072.2022.2080055,
+28. https://doi.org/10.1016/j.ijcard.2019.10.052,
+29. https://doi.org/10.20944/preprints202506.0355.v1,
+30. https://doi.org/10.3389/fcvm.2023.1278453,
+31. https://doi.org/10.31083/j.rcm2512448,
+32. https://doi.org/10.1007/s11883-025-01328-5,


### PR DESCRIPTION
## Summary
- Add idiopathic spontaneous coronary artery dissection (MONDO:0007385) disorder curation.
- Include Falcon deep-research report and citations.
- Add PMID-backed reference caches for all evidence snippets used in the YAML.

## Validation
- `just validate-schema kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml`
- `scripts/run_term_validator.sh validate-data kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml -s src/dismech/schema/dismech.yaml -t Disease --labels -c conf/oak_config.yaml`
- `just validate-references kb/disorders/Idiopathic_Spontaneous_Coronary_Artery_Dissection.yaml`
- custom cache-backed snippet check: 25 evidence snippets found in referenced cache files
- `just check-reference-cache-frontmatter`
- `git diff --check`
- `just check-research Idiopathic_Spontaneous_Coronary_Artery_Dissection`

## Note
- Full `just validate` reached the repository-wide enum-cache precheck, but that precheck is currently blocked by a generated OAK NCIT cache download/decompression failure unrelated to this disorder file. The disorder-level schema, term, reference, snippet, frontmatter, and whitespace checks above passed.