### PR TITLE
Add Congenital Total Pulmonary Venous Return Anomaly

### DIFF
--- a/kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml
+++ b/kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml
@@ -203,6 +203,25 @@ phenotypes:
     explanation: >-
       The review names cyanosis as a clinical manifestation of unobstructed
       TAPVR and severe compromise in obstructed TAPVR.
+- name: Respiratory Distress
+  category: Respiratory
+  phenotype_term:
+    preferred_term: Respiratory distress
+    term:
+      id: HP:0002098
+      label: Respiratory distress
+  description: >-
+    Obstructed TAPVR can present with severe respiratory compromise due to
+    pulmonary venous hypertension and pulmonary edema.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The clinical presentation is different if the pulmonary venous drainage is unobstructed (heart failure, mild cyanosis) or obstructed (respiratory failure, severe heart failure)."
+    explanation: >-
+      The surgical review directly identifies respiratory failure as a
+      presenting feature of obstructed total anomalous pulmonary venous return.
 - name: Pulmonary Arterial Hypertension
   category: Cardiovascular
   phenotype_term:

--- a/kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml
+++ b/kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml
@@ -10,11 +10,24 @@ disease_term:
   term:
     id: MONDO:0007130
     label: congenital total pulmonary venous return anomaly
+mappings:
+  icd10cm_mappings:
+  - term:
+      id: ICD10CM:Q26.2
+      label: Total anomalous pulmonary venous connection
+    mapping_predicate: skos:exactMatch
+    mapping_source: ICD-10-CM
+    mapping_justification: ICD-10-CM Q26.2 is the diagnosis code for total anomalous pulmonary venous connection, the clinical synonym of this MONDO disease.
 description: >-
   Congenital total pulmonary venous return anomaly, also called total anomalous
   pulmonary venous return, is a congenital pulmonary venous malformation in
   which all pulmonary veins drain to the right atrium or systemic venous
   circulation instead of the left atrium.
+synonyms:
+- Total anomalous pulmonary venous connection
+- Total anomalous pulmonary venous return
+- TAPVC
+- TAPVR
 has_subtypes:
 - name: Supracardiac
   display_name: Supracardiac TAPVR
@@ -70,6 +83,26 @@ pathophysiology:
     Total anomalous drainage returns oxygenated pulmonary venous blood to the
     right-sided circulation, creating obligatory right-to-left mixing at the
     atrial level and abnormal pulmonary blood flow.
+  cell_types:
+  - preferred_term: blood vessel endothelial cell
+    term:
+      id: CL:0000071
+      label: blood vessel endothelial cell
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  biological_processes:
+  - preferred_term: pulmonary vein morphogenesis
+    term:
+      id: GO:0060577
+      label: pulmonary vein morphogenesis
+    modifier: ABNORMAL
+  - preferred_term: vasculature development
+    term:
+      id: GO:0001944
+      label: vasculature development
+    modifier: ABNORMAL
   evidence:
   - reference: PMID:16638546
     reference_title: Surgical repair of total anomalous pulmonary venous connection.
@@ -87,11 +120,29 @@ pathophysiology:
     explanation: >-
       The imaging case review describes the embryologic failure and resulting
       redirection of pulmonary venous return.
+  downstream:
+  - target: Pulmonary Venous Obstruction
+    description: Abnormal anomalous drainage pathways can be narrowed or obstructed, raising pulmonary venous pressure and worsening postnatal compromise.
 - name: Pulmonary Venous Obstruction
   description: >-
     Narrowed or obstructed anomalous venous pathways can elevate pulmonary
     venous pressure, worsening cyanosis, pulmonary edema, and pulmonary
     hypertension.
+  cell_types:
+  - preferred_term: blood vessel endothelial cell
+    term:
+      id: CL:0000071
+      label: blood vessel endothelial cell
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  biological_processes:
+  - preferred_term: blood vessel morphogenesis
+    term:
+      id: GO:0048514
+      label: blood vessel morphogenesis
+    modifier: ABNORMAL
   evidence:
   - reference: PMID:16638546
     reference_title: Surgical repair of total anomalous pulmonary venous connection.
@@ -109,6 +160,9 @@ pathophysiology:
     explanation: >-
       The postoperative cohort supports pulmonary vein obstruction as an
       important post-repair risk marker requiring follow-up.
+  downstream:
+  - target: Cyanosis
+    description: Obstructed pulmonary venous return worsens systemic desaturation and respiratory compromise.
 phenotypes:
 - name: Total Anomalous Pulmonary Venous Return
   category: Cardiovascular
@@ -190,16 +244,21 @@ phenotypes:
       obstructed.
 genetic:
 - name: TBX5
+  gene_term:
+    preferred_term: TBX5
+    term:
+      id: hgnc:11604
+      label: TBX5
   association: Associated
   evidence:
   - reference: PMID:35514310
-    reference_title: "TBX5 variant with the novel phenotype of mixed-type total anomalous pulmonary venous return in Holt-Oram Syndrome and variable intrafamilial heart defects."
+    reference_title: "TBX5 variant with the novel phenotype of mixed‑type total anomalous pulmonary venous return in Holt‑Oram Syndrome and variable intrafamilial heart defects."
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: "The present findings extended the phenotypic cardiac defects associated with HOS; to the best of our knowledge, this is the first association of mixed-type TAPVR with TBX5."
+    snippet: "The present findings extended the phenotypic cardiac defects associated with HOS; to the best of our knowledge, this is the first association of mixed‑type TAPVR with TBX5."
     explanation: >-
       This family-based report supports TBX5 as a syndromic association for
-      mixed-type TAPVR, not as a universal cause of isolated TAPVR.
+      mixed‑type TAPVR, not as a universal cause of isolated TAPVR.
 treatments:
 - name: Surgical Repair
   treatment_term:
@@ -248,5 +307,5 @@ references:
   title: "Assessing the risk of reoperation for mild pulmonary vein obstruction post-TAPVC repair: a retrospective cohort study."
   findings: []
 - reference: PMID:35514310
-  title: "TBX5 variant with the novel phenotype of mixed-type total anomalous pulmonary venous return in Holt-Oram Syndrome and variable intrafamilial heart defects."
+  title: "TBX5 variant with the novel phenotype of mixed‑type total anomalous pulmonary venous return in Holt‑Oram Syndrome and variable intrafamilial heart defects."
   findings: []

--- a/kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml
+++ b/kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml
@@ -1,0 +1,252 @@
+name: Congenital Total Pulmonary Venous Return Anomaly
+creation_date: "2026-05-06T03:15:55Z"
+updated_date: "2026-05-06T03:15:55Z"
+category: Congenital Cardiovascular Disorder
+parents:
+- Heart Disorder
+- Vascular Disorder
+disease_term:
+  preferred_term: congenital total pulmonary venous return anomaly
+  term:
+    id: MONDO:0007130
+    label: congenital total pulmonary venous return anomaly
+description: >-
+  Congenital total pulmonary venous return anomaly, also called total anomalous
+  pulmonary venous return, is a congenital pulmonary venous malformation in
+  which all pulmonary veins drain to the right atrium or systemic venous
+  circulation instead of the left atrium.
+has_subtypes:
+- name: Supracardiac
+  display_name: Supracardiac TAPVR
+  description: Pulmonary venous drainage connects above the heart.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It constitutes between 1% and 1.5% of all children with congenital heart disease and can be categorized by the site of drainage into the systemic circulation (supracardiac, 45%; infracardiac, 25%; cardiac, 25%; mixed, 5%)."
+    explanation: >-
+      The surgical review lists supracardiac TAPVR as one of the standard
+      anatomic drainage-site categories.
+- name: Cardiac
+  display_name: Cardiac TAPVR
+  description: Pulmonary venous drainage connects at the heart, commonly to the coronary sinus or right atrium.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It constitutes between 1% and 1.5% of all children with congenital heart disease and can be categorized by the site of drainage into the systemic circulation (supracardiac, 45%; infracardiac, 25%; cardiac, 25%; mixed, 5%)."
+    explanation: >-
+      The surgical review lists cardiac TAPVR as one of the standard anatomic
+      drainage-site categories.
+- name: Infracardiac
+  display_name: Infracardiac TAPVR
+  description: Pulmonary venous drainage connects below the diaphragm.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It constitutes between 1% and 1.5% of all children with congenital heart disease and can be categorized by the site of drainage into the systemic circulation (supracardiac, 45%; infracardiac, 25%; cardiac, 25%; mixed, 5%)."
+    explanation: >-
+      The surgical review lists infracardiac TAPVR as one of the standard
+      anatomic drainage-site categories.
+- name: Mixed
+  display_name: Mixed TAPVR
+  description: Pulmonary veins drain through more than one anomalous pathway.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It constitutes between 1% and 1.5% of all children with congenital heart disease and can be categorized by the site of drainage into the systemic circulation (supracardiac, 45%; infracardiac, 25%; cardiac, 25%; mixed, 5%)."
+    explanation: >-
+      The surgical review lists mixed TAPVR as one of the standard anatomic
+      drainage-site categories.
+pathophysiology:
+- name: Anomalous Pulmonary Venous Drainage
+  description: >-
+    Total anomalous drainage returns oxygenated pulmonary venous blood to the
+    right-sided circulation, creating obligatory right-to-left mixing at the
+    atrial level and abnormal pulmonary blood flow.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The diagnosis of total anomalous pulmonary venous connection (TAPVC) is made when all four pulmonary veins drain anomalously to the right atrium or to a tributary of the systemic veins."
+    explanation: >-
+      This review statement directly supports the defining anomalous pulmonary
+      venous drainage mechanism.
+  - reference: PMID:27594934
+    reference_title: Computed tomography features of supracardiac total anomalous pulmonary venous connection in an infant.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "TAPVC is caused by nonfusion of pulmonary venous confluence with LA, thus, the oxygenated pulmonary blood is redirected to right heart and pumped once again to the lungs"
+    explanation: >-
+      The imaging case review describes the embryologic failure and resulting
+      redirection of pulmonary venous return.
+- name: Pulmonary Venous Obstruction
+  description: >-
+    Narrowed or obstructed anomalous venous pathways can elevate pulmonary
+    venous pressure, worsening cyanosis, pulmonary edema, and pulmonary
+    hypertension.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The clinical presentation is different if the pulmonary venous drainage is unobstructed (heart failure, mild cyanosis) or obstructed (respiratory failure, severe heart failure)."
+    explanation: >-
+      The review distinguishes obstructed from unobstructed TAPVR and links
+      obstruction to more severe clinical compromise.
+  - reference: PMID:38988666
+    reference_title: "Assessing the risk of reoperation for mild pulmonary vein obstruction post-TAPVC repair: a retrospective cohort study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Our results suggest that a pre-discharge echocardiography Doppler velocity threshold of 1.2 m/s could serve as a critical predictor for reoperation, emphasizing the need for targeted follow-up strategies for at-risk patients."
+    explanation: >-
+      The postoperative cohort supports pulmonary vein obstruction as an
+      important post-repair risk marker requiring follow-up.
+phenotypes:
+- name: Total Anomalous Pulmonary Venous Return
+  category: Cardiovascular
+  frequency: OBLIGATE
+  phenotype_term:
+    preferred_term: Total anomalous pulmonary venous return
+    term:
+      id: HP:0005160
+      label: Total anomalous pulmonary venous return
+  description: >-
+    All pulmonary veins drain anomalously rather than connecting normally to
+    the left atrium.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The diagnosis of total anomalous pulmonary venous connection (TAPVC) is made when all four pulmonary veins drain anomalously to the right atrium or to a tributary of the systemic veins."
+    explanation: >-
+      This directly supports total anomalous pulmonary venous return as the
+      defining phenotype.
+- name: Cyanosis
+  category: Cardiovascular
+  phenotype_term:
+    preferred_term: Cyanosis
+    term:
+      id: HP:0000961
+      label: Cyanosis
+  description: >-
+    Systemic desaturation results from obligatory mixing of pulmonary and
+    systemic venous blood.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The clinical presentation is different if the pulmonary venous drainage is unobstructed (heart failure, mild cyanosis) or obstructed (respiratory failure, severe heart failure)."
+    explanation: >-
+      The review names cyanosis as a clinical manifestation of unobstructed
+      TAPVR and severe compromise in obstructed TAPVR.
+- name: Pulmonary Arterial Hypertension
+  category: Cardiovascular
+  phenotype_term:
+    preferred_term: Pulmonary arterial hypertension
+    term:
+      id: HP:0002092
+      label: Pulmonary arterial hypertension
+  description: >-
+    Increased pulmonary blood flow and venous obstruction can raise pulmonary
+    arterial pressure.
+  evidence:
+  - reference: PMID:27594934
+    reference_title: Computed tomography features of supracardiac total anomalous pulmonary venous connection in an infant.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Based on its type and degree of pulmonary venous obstruction, TAPVC may result in pulmonary hypertension and congestive heart failure"
+    explanation: >-
+      The imaging case review links TAPVR severity and obstruction to pulmonary
+      hypertension.
+- name: Congestive Heart Failure
+  category: Cardiovascular
+  phenotype_term:
+    preferred_term: Congestive heart failure
+    term:
+      id: HP:0001635
+      label: Congestive heart failure
+  description: >-
+    Pulmonary overcirculation and obstructed venous drainage can contribute to
+    heart failure, particularly in infancy.
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The clinical presentation is different if the pulmonary venous drainage is unobstructed (heart failure, mild cyanosis) or obstructed (respiratory failure, severe heart failure)."
+    explanation: >-
+      The surgical review explicitly links TAPVR presentation to heart failure,
+      particularly severe heart failure when pulmonary venous drainage is
+      obstructed.
+genetic:
+- name: TBX5
+  association: Associated
+  evidence:
+  - reference: PMID:35514310
+    reference_title: "TBX5 variant with the novel phenotype of mixed-type total anomalous pulmonary venous return in Holt-Oram Syndrome and variable intrafamilial heart defects."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The present findings extended the phenotypic cardiac defects associated with HOS; to the best of our knowledge, this is the first association of mixed-type TAPVR with TBX5."
+    explanation: >-
+      This family-based report supports TBX5 as a syndromic association for
+      mixed-type TAPVR, not as a universal cause of isolated TAPVR.
+treatments:
+- name: Surgical Repair
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  description: >-
+    Surgical redirection of pulmonary venous drainage to the left atrium is the
+    definitive treatment, with urgent repair required when venous obstruction is
+    present.
+  target_phenotypes:
+  - preferred_term: Total anomalous pulmonary venous return
+    term:
+      id: HP:0005160
+      label: Total anomalous pulmonary venous return
+  evidence:
+  - reference: PMID:16638546
+    reference_title: Surgical repair of total anomalous pulmonary venous connection.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Obstructed TAPVC requires urgent surgical intervention, whereas unobstructed TAPVC can be dealt with electively; although this is usually operated on once the diagnosis is made."
+    explanation: >-
+      The review supports surgical repair as definitive management and
+      distinguishes urgent management of obstructed TAPVR.
+  - reference: PMID:36713670
+    reference_title: "Total anomalous pulmonary venous connection in 80 patients: Primary sutureless repair and outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The primary sutureless technique may eliminate the differences between subtypes while decrease the postoperative PVO rate, which makes it applicable in any subtypes of TAPVC."
+    explanation: >-
+      The 80-patient surgical series supports modern operative repair and
+      postoperative obstruction prevention strategies.
+references:
+- reference: PMID:16638546
+  title: Surgical repair of total anomalous pulmonary venous connection.
+  findings: []
+- reference: PMID:27594934
+  title: Computed tomography features of supracardiac total anomalous pulmonary
+    venous connection in an infant.
+  findings: []
+- reference: PMID:36713670
+  title: "Total anomalous pulmonary venous connection in 80 patients: Primary sutureless repair and outcomes."
+  findings: []
+- reference: PMID:38988666
+  title: "Assessing the risk of reoperation for mild pulmonary vein obstruction post-TAPVC repair: a retrospective cohort study."
+  findings: []
+- reference: PMID:35514310
+  title: "TBX5 variant with the novel phenotype of mixed-type total anomalous pulmonary venous return in Holt-Oram Syndrome and variable intrafamilial heart defects."
+  findings: []

--- a/references_cache/PMID_16638546.md
+++ b/references_cache/PMID_16638546.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:16638546"
+title: Surgical repair of total anomalous pulmonary venous connection.
+authors:
+- Kanter KR
+journal: Semin Thorac Cardiovasc Surg Pediatr Card Surg Annu
+year: '2006'
+doi: 10.1053/j.pcsu.2006.02.015
+keywords:
+- Adult
+- "Anastomosis, Surgical/adverse effects"
+- "Cardiac Surgical Procedures/adverse effects, methods"
+- Child
+- "Circulatory Arrest, Deep Hypothermia Induced"
+- Heart Atria/surgery
+- "Heart Defects, Congenital/surgery"
+- Humans
+- "Hypertension, Pulmonary/etiology, therapy"
+- Infant
+- "Pulmonary Veins/abnormalities, surgery"
+content_type: abstract_only
+---
+
+# Surgical repair of total anomalous pulmonary venous connection.
+**Authors:** Kanter KR
+**Journal:** Semin Thorac Cardiovasc Surg Pediatr Card Surg Annu (2006)
+**DOI:** [10.1053/j.pcsu.2006.02.015](https://doi.org/10.1053/j.pcsu.2006.02.015)
+
+## Content
+
+1. Semin Thorac Cardiovasc Surg Pediatr Card Surg Annu. 2006:40-4. doi: 
+10.1053/j.pcsu.2006.02.015.
+
+Surgical repair of total anomalous pulmonary venous connection.
+
+Kanter KR(1).
+
+Author information:
+(1)Division of Cardio-Thoracic Surgery, Department of Surgery, Emory University 
+School of Medicine and Children's Healthcare of Atlanta at Egleston, Atlanta, GA 
+30322, USA. kkanter@emory.edu
+
+The diagnosis of total anomalous pulmonary venous connection (TAPVC) is made 
+when all four pulmonary veins drain anomalously to the right atrium or to a 
+tributary of the systemic veins. It constitutes between 1% and 1.5% of all 
+children with congenital heart disease and can be categorized by the site of 
+drainage into the systemic circulation (supracardiac, 45%; infracardiac, 25%; 
+cardiac, 25%; mixed, 5%). The clinical presentation is different if the 
+pulmonary venous drainage is unobstructed (heart failure, mild cyanosis) or 
+obstructed (respiratory failure, severe heart failure). Surgical management 
+depends on the anatomic type. Obstructed TAPVC requires urgent surgical 
+intervention, whereas unobstructed TAPVC can be dealt with electively; although 
+this is usually operated on once the diagnosis is made. Postoperative pulmonary 
+artery hypertension can be problematic. Recent surgical results with isolated 
+TAPVC have improved, with operative mortality consistently at less than 10%. A 
+particularly challenging group of patients are those with single ventricle 
+physiology and TAPVC with high operative mortality and poor long-term survival.
+
+DOI: 10.1053/j.pcsu.2006.02.015
+PMID: 16638546 [Indexed for MEDLINE]

--- a/references_cache/PMID_27594934.md
+++ b/references_cache/PMID_27594934.md
@@ -1,0 +1,105 @@
+---
+reference_id: "PMID:27594934"
+title: Computed tomography features of supracardiac total anomalous pulmonary venous connection in an infant.
+authors:
+- Alam T
+- Hamidi H
+- Hoshang MM
+journal: Radiol Case Rep
+year: '2016'
+doi: 10.1016/j.radcr.2016.04.005
+content_type: full_text_xml
+---
+
+# Computed tomography features of supracardiac total anomalous pulmonary venous connection in an infant.
+**Authors:** Alam T, Hamidi H, Hoshang MM
+**Journal:** Radiol Case Rep (2016)
+**DOI:** [10.1016/j.radcr.2016.04.005](https://doi.org/10.1016/j.radcr.2016.04.005)
+
+## Content
+
+1. Radiol Case Rep. 2016 May 14;11(3):134-7. doi: 10.1016/j.radcr.2016.04.005. 
+eCollection 2016 Sep.
+
+Computed tomography features of supracardiac total anomalous pulmonary venous 
+connection in an infant.
+
+Alam T(1), Hamidi H(2), Hoshang MM(2).
+
+Author information:
+(1)Department of Radiology, Northwest General Hospital Peshawar, KPK, Pakistan.
+(2)Department of Radiology, French Medical University for Children (FMIC), 
+Kabul, Fifth district, 1006 Kabul, Afghanistan.
+
+Total anomalous pulmonary venous connection (TAPVC) is a rare congenital anomaly 
+of the pulmonary veins drainage. In this entity, the pulmonary veins, instead of 
+draining to left atrium, connect abnormally to the systemic venous circulation. 
+A right-to-left shunt is obligatory for survival. Based on its type and degree 
+of pulmonary venous obstruction, TAPVC may result in pulmonary hypertension and 
+congestive heart failure. In severe cases, urgent diagnosis and surgical 
+correction is essential to reduce morbidity and mortality. Echocardiography as 
+the first and safest imaging modality for cardiovascular abnormalities may fail 
+in complete depiction of some complex feature of TAPVC. Computed tomography 
+angiography is then a noninvasive and sensitive choice for mapping the pulmonary 
+veins without the need for invasive cardiac catheterization. Contrast-enhanced 
+MR angiography can be a radiation-free alternative. Authors present a computed 
+tomography-detected supracardiac TAPVC with small patent ductus arteriosus in a 
+2 months cyanotic infant.
+
+DOI: 10.1016/j.radcr.2016.04.005
+PMCID: PMC4996912
+PMID: 27594934
+
+A 2-month-old female infant was sent to radiology department to undergo chest computed tomography (CT) angiography for evaluation of pulmonary veins (PVs). The child developed cyanosis in her first week of life. Unfortunately, neither prenatal ultrasound nor postnatal echocardiography reports were available.
+
+Chest CT angiography was performed with 128-slice Siemens scanner after administration of 8 mL of nonionic water-soluble contrast material.
+
+The CT findings were as follows:
+
+All 4 PVs were joining together behind the small left atrium (LA; Fig. 1) and their confluence converging to a large vertical vein (VV) that was ascending lateral to the pulmonary trunk. LA was smaller in size and no PV entrance was noted into it (Fig. 2). The VV was draining into the dilated left innominate vein and subsequently to enlarged superior vena cava (SVC) and right atrium (RA; Fig. 3). The RA and right ventricle (RV) were also dilated (Fig. 3).
+
+A small (approximately 6.5 mm) atrial septal defect (ASD) was detected (Fig. 2). The small ASD was functioning as right-to-left shunt and made this supracardiac total anomalous pulmonary venous connection (TAPVC) compatible with life.
+
+No evidence of patent ductus arteriosus (PDA) or ventricular septal defect (VSD) was observed.
+
+TAPVC is a rare congenital anomaly of the PVs drainage that connects abnormally to the systemic venous circulation instead of LA. [1] The incidence of this rare entity is approximately 1 of 17,000 live births [2] or 1%-5% of all cardiovascular congenital anomalies [3].
+
+TAPVC is caused by nonfusion of pulmonary venous confluence with LA, thus, the oxygenated pulmonary blood is redirected to right heart and pumped once again to the lungs [4]. A right-to-left shunt is obligatory for survival that typically occurs at atrial level through either an ASD, patent foramen ovale [3] complete absence of the atrial septum [4] or less commonly a PDA [3]. Some of the mixed blood of the RA crosses through this shunt to the left heart to supply the systemic circulation [4].
+
+Cases of tetralogy of Fallot and double-outlet RV are reported in association with TAPVC [5]. Higher frequency of TAPVC is observed in patients with heterotaxy syndromes especially asplenia [6].
+
+TAPVC is a cause of neonatal cyanosis, and if right-to-left shunt is not present, it may rapidly result in death [3]; hence, being a surgical emergency in neonates [2].
+
+In severe cases, urgent diagnosis and surgical correction is essential to reduce morbidity and mortality [2]. However, if there is no obstruction and a sufficient shunt is present, patients may not present to clinic urgently [7].
+
+TAPVC can occasionally be misdiagnosed as persistent pulmonary hypertension of the newborn and even echocardiographic findings may overlap [7].
+
+Based on the location of pulmonary venous drainage, TAPVC is classified into 4 major types [1], [3], [4]. In all 4 types, complete drainage of pulmonary venous blood is directed to the right heart [4].
+
+Type I: supracardiac (approximately 50%): As in our case, PVs coalesce in the midline, forming a transverse confluence just behind and slightly above the small LA. The confluence drains into the remnant of left cardinal vein (VV), then into the left innominate vein, subsequently crossing the midline toward SVC and finally flows in to the RA [4].
+
+Rarely the confluence may drain directly to right SVC, left SVC, or azygous system [8].
+
+Type II: cardiac (approximately 25%): the pulmonary venous confluence drains either to the coronary sinus or directly into the RA [3], [4].
+
+Type III: infracardiac (approximately 25%): the pulmonary venous confluence may drain into IVC, hepatic vein, azygous system, or portal venous system [3], [4].
+
+Type IV: mixed type (approximately 9%) [3]: usually no midline pulmonary confluence is present; thus, the right and left PVs may have different drainages. Almost any combination of drainage may occur into SVC, innominate veins, coronary sinus, RA, azygous vein [4], or infradiaphragmatic veins [3].
+
+Pulmonary venous obstruction may occur in any type, but it is most commonly seen in infracardiac type which may be present in up to 78% of cases [3], [8].
+
+The diagnostic imaging findings are those described previously corresponding to each type.
+
+Echocardiography as the first and safest imaging modality for cardiovascular abnormalities may fail in complete depiction of some complex feature of TAPVC [3]. CT angiography is then a noninvasive and sensitive choice for mapping the PVs without need for invasive cardiac catheterization [2], [9].
+
+Contrast-enhanced magnetic resonance (MR) angiography [3] is the radiation-free alternative for CT angiography but needs general anesthesia in younger children.
+
+In a case report, Masaki Ogawa et al suggested that electrocardiography-gated CT and phase-contrast cine MR imaging (PC-MRI) are more useful than non–electrocardiography-gated CT for differentiating the VV in TAPVC from persistent left SVC in adult patients [1].
+
+Based on its type and degree of pulmonary venous obstruction, TAPVC may result in pulmonary hypertension and congestive heart failure [1]. Approximately 50% of patients develop symptoms in neonatal period and the majority may expire during infancy without surgical repair [10].
+
+Unobstructed type I TAPVC has very similar pathophysiology to a large ASD, so lesions not detected in infancy may be discovered later [4]. Several cases of adult untreated TAPVC have been reported, even few cases were diagnosed after 60 years of age [1], [11], [12].
+
+Generally, patients with type I and II TAPVC can live for older age than those with type III and IV lesions [13]. The most important factors affecting the survival period are large ASDs and normal to near normal pulmonary artery pressure [1].
+
+As precise diagnosis is essential and surgery is the mainstay of treatment, improvements in diagnostic imaging resulted in accurate depiction of this complex entity and advanced surgical techniques decreased the postoperative mortality rates. [3]

--- a/references_cache/PMID_35514310.md
+++ b/references_cache/PMID_35514310.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:35514310"
+title: TBX5 variant with the novel phenotype of mixed‑type total anomalous pulmonary venous return in Holt‑Oram Syndrome and variable intrafamilial heart defects.
+authors:
+- Azab B
+- Aburizeg D
+- Ji W
+- Jeffries L
+- Isbeih NJ
+- Al-Akily AS
+- Mohammad H
+- Osba YA
+- Shahin MA
+- Dardas Z
+- Hatmal MM
+- Al-Ammouri I
+- Lakhani S
+journal: Mol Med Rep
+year: '2022'
+doi: 10.3892/mmr.2022.12726
+keywords:
+- "Abnormalities, Multiple"
+- Female
+- "Heart Defects, Congenital/diagnosis, genetics, pathology"
+- "Heart Septal Defects, Atrial/diagnosis, genetics"
+- Humans
+- "Lower Extremity Deformities, Congenital"
+- Phenotype
+- Scimitar Syndrome/genetics
+- T-Box Domain Proteins/genetics
+- "Upper Extremity Deformities, Congenital"
+content_type: abstract_only
+---
+
+# TBX5 variant with the novel phenotype of mixed‑type total anomalous pulmonary venous return in Holt‑Oram Syndrome and variable intrafamilial heart defects.
+**Authors:** Azab B, Aburizeg D, Ji W, Jeffries L, Isbeih NJ, Al-Akily AS, Mohammad H, Osba YA, Shahin MA, Dardas Z, Hatmal MM, Al-Ammouri I, Lakhani S
+**Journal:** Mol Med Rep (2022)
+**DOI:** [10.3892/mmr.2022.12726](https://doi.org/10.3892/mmr.2022.12726)
+
+## Content
+
+1. Mol Med Rep. 2022 Jun;25(6):210. doi: 10.3892/mmr.2022.12726. Epub 2022 May 6.
+
+TBX5 variant with the novel phenotype of mixed‑type total anomalous pulmonary 
+venous return in Holt‑Oram Syndrome and variable intrafamilial heart defects.
+
+Azab B(#)(1), Aburizeg D(#)(2), Ji W(3), Jeffries L(3), Isbeih NJ(2), Al-Akily 
+AS(2), Mohammad H(2), Osba YA(2), Shahin MA(2), Dardas Z(4), Hatmal MM(5), 
+Al-Ammouri I(6), Lakhani S(3).
+
+Author information:
+(1)Department of Pathology and Cell Biology, Columbia University Irving Medical 
+Center, New York, NY 10032, USA.
+(2)Department of Pathology and Microbiology and Forensic Medicine, School of 
+Medicine, The University of Jordan, Amman 11942, Jordan.
+(3)Pediatric Genomics Discovery Program, Department of Pediatrics, Yale 
+University School of Medicine, New Haven, CT 06504, USA.
+(4)Department of Molecular and Human Genetics, Baylor College of Medicine, 
+Houston, TX 77030, USA.
+(5)Department of Medical Laboratory Sciences, Faculty of Applied Medical 
+Sciences, The Hashemite University, Zarqa 13133, Jordan.
+(6)Department of Pediatrics, School of Medicine, The University of Jordan, Amman 
+11942, Jordan.
+(#)Contributed equally
+
+Variants in T‑box transcription factor 5 (TBX5) can result in a wide phenotypic 
+spectrum, specifically in the heart and the limbs. TBX5 has been implicated in 
+causing non‑syndromic cardiac defects and Holt‑Oram syndrome (HOS). The present 
+study investigated the underlying molecular etiology of a family with 
+heterogeneous heart defects. The proband had mixed‑type total anomalous 
+pulmonary venous return (mixed‑type TAPVR), whereas her mother had an atrial 
+septal defect. Genetic testing through trio‑based whole‑exome sequencing was 
+used to reveal the molecular etiology. A nonsense variant was identified in TBX5 
+(c.577G>T; p.Gly193*) initially showing co‑segregation with a presumably 
+non‑syndromic presentation of congenital heart disease. Subsequent genetic 
+investigations and more complete phenotyping led to the correct diagnosis of 
+HOS, documenting the novel association of mixed‑type TAPVR with HOS. Finally, 
+protein modeling of the mutant TBX5 protein that harbored this pathogenic 
+nonsense variant (p.Gly193*) revealed a substantial drop in the quantity of 
+non‑covalent bonds. The decrease in the number of non‑covalent bonds suggested 
+that the resultant mutant dimer was less stable compared with the wild‑type 
+protein, consequently affecting the protein's ability to bind DNA. The present 
+findings extended the phenotypic cardiac defects associated with HOS; to the 
+best of our knowledge, this is the first association of mixed‑type TAPVR with 
+TBX5. Prior to the current analysis, the molecular association of TAPVR with HOS 
+had never been documented; hence, this is the first genetic investigation to 
+report the association between TAPVR and HOS. Furthermore, it was demonstrated 
+that the null‑variants reported in the T‑box domain of TBX5 were associated with 
+a wide range of cardiac and/or skeletal anomalies on both the inter‑and 
+intrafamilial levels. In conclusion, genetic testing was highlighted as a 
+potentially powerful approach in the prognostication of the proper diagnosis.
+
+DOI: 10.3892/mmr.2022.12726
+PMCID: PMC9133962
+PMID: 35514310 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_36713670.md
+++ b/references_cache/PMID_36713670.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:36713670"
+title: "Total anomalous pulmonary venous connection in 80 patients: Primary sutureless repair and outcomes."
+authors:
+- Li G
+- Meng B
+- Zhang C
+- Zhang W
+- Zhou X
+- Zhang Q
+- Ding Y
+journal: Front Surg
+year: '2022'
+doi: 10.3389/fsurg.2022.1086596
+content_type: abstract_only
+---
+
+# Total anomalous pulmonary venous connection in 80 patients: Primary sutureless repair and outcomes.
+**Authors:** Li G, Meng B, Zhang C, Zhang W, Zhou X, Zhang Q, Ding Y
+**Journal:** Front Surg (2022)
+**DOI:** [10.3389/fsurg.2022.1086596](https://doi.org/10.3389/fsurg.2022.1086596)
+
+## Content
+
+1. Front Surg. 2023 Jan 11;9:1086596. doi: 10.3389/fsurg.2022.1086596.
+eCollection  2022.
+
+Total anomalous pulmonary venous connection in 80 patients: Primary sutureless 
+repair and outcomes.
+
+Li G(1), Meng B(1), Zhang C(2), Zhang W(2), Zhou X(2), Zhang Q(1), Ding Y(2).
+
+Author information:
+(1)Department of Pediatric Cardiothoracic Surgery, Shenzhen Children's Hospital, 
+Shenzhen, China.
+(2)Department of Pediatric Cardiology, The University of Hong Kong-Shenzhen 
+Hospital, Shenzhen, China.
+
+INTRODUCTION: Total anomalous pulmonary venous connection (TAPVC) is a rare but 
+critical cardiac anomaly, in which pulmonary veins are connected to an abnormal 
+location rather than the left atrium. The prognosis can be extremely poor 
+without intervention, with a mortality of 80% during infancy. The purpose of 
+this research is to summarize the outcomes and relevant risk factors of 80 total 
+anomalous pulmonary venous connection (TAPVC) patients who underwent primary 
+TAPVC sutureless repair and discuss the indications and benefits of primary 
+sutureless repair.
+METHODS: This retrospective review included 80 patients with TAPVC who underwent 
+primary sutureless repair at a single institution between January 2015 and 
+December 2020. Patients were subdivided into 4 groups according to Darling's 
+classification. Risk factors that increase the postoperative pulmonary vein flow 
+velocity were explored by Multiple Linear regression.
+RESULTS: Anatomic TAPVC subtypes included supracardiac 35 (43.8%), cardiac 24 
+(30%), infracardiac 17 (21.2%), and mixed 4 (5%). Median age at repair was 16.5 
+days and median weight was 3.5 kg. Preoperative pulmonary venous obstruction 
+(PVO)was presented in 20 (25%) patients. There were 2 early deaths and 1 late 
+death. 2 patients developed postoperative PVO and none required reintervention. 
+Prolonged cardiopulmonary bypass time (CPB) (p = 0.009), preoperative pneumonia 
+(p = 0.022) and gender (p = 0.041) were found to be associated with the increase 
+of postoperative pulmonary vein flow velocity.
+DISCUSSION: Under the primary sutureless technique, no statistical difference 
+was observed among the 4 subgroups in terms of postoperative pulmonary vein flow 
+velocity (p = 0.589). The primary sutureless technique may eliminate the 
+differences between subtypes while decrease the postoperative PVO rate, which 
+makes it applicable in any subtypes of TAPVC. Following the favorable outcomes 
+in preventing postoperative PVO in all subtypes in this study, we advocate the 
+indications for primary sutureless repair may expand further to all the TAPVC 
+patients.
+
+© 2023 Li, Meng, Zhang, Zhang, Zhou, Zhang and Ding.
+
+DOI: 10.3389/fsurg.2022.1086596
+PMCID: PMC9874290
+PMID: 36713670
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_38988666.md
+++ b/references_cache/PMID_38988666.md
@@ -1,0 +1,62 @@
+---
+reference_id: "PMID:38988666"
+title: "Assessing the risk of reoperation for mild pulmonary vein obstruction post-TAPVC repair: a retrospective cohort study."
+authors:
+- Alifu A
+- Wang H
+- Chen R
+journal: Front Cardiovasc Med
+year: '2024'
+doi: 10.3389/fcvm.2024.1399659
+content_type: abstract_only
+---
+
+# Assessing the risk of reoperation for mild pulmonary vein obstruction post-TAPVC repair: a retrospective cohort study.
+**Authors:** Alifu A, Wang H, Chen R
+**Journal:** Front Cardiovasc Med (2024)
+**DOI:** [10.3389/fcvm.2024.1399659](https://doi.org/10.3389/fcvm.2024.1399659)
+
+## Content
+
+1. Front Cardiovasc Med. 2024 Jun 26;11:1399659. doi: 10.3389/fcvm.2024.1399659. 
+eCollection 2024.
+
+Assessing the risk of reoperation for mild pulmonary vein obstruction post-TAPVC 
+repair: a retrospective cohort study.
+
+Alifu A(1), Wang H(1), Chen R(1).
+
+Author information:
+(1)Department of Cardiothoracic Surgery, Hainan Women and Children's Medical 
+Center, Haikou, Hainan, China.
+
+OBJECTIVE: This study investigates the impact of mild pulmonary vein 
+obstruction, detected via echocardiography before hospital discharge, on the 
+likelihood of reoperation in patients who have undergone repair for Total 
+Anomalous Pulmonary Venous Connection (TAPVC).
+METHOD: Utilizing a single-center, retrospective cohort approach, we analyzed 38 
+cases from October 2017 to December 2023, excluding patients with functionally 
+univentricular circulations or atrial isomerism. Our primary outcome was the 
+necessity for reoperation within one year due to anatomical issues related to 
+the initial TAPVC repair. Mild obstruction was defined as a pulmonary vein flow 
+velocity ≥1.2 m/s.
+RESULT: Our findings revealed that 31.6% of patients exhibited pre-discharge 
+mild obstruction. During the median follow-up of 10 months, reoperations were 
+notably higher in the mild obstruction group compared to the normal group, with 
+a significant association between pre-discharge mild obstruction and increased 
+risk of reoperation. Specifically, in the fully adjusted model, mild obstruction 
+was linked to a 13.9-fold increased risk of reoperation.
+CONCLUSION: Our results suggest that a pre-discharge echocardiography Doppler 
+velocity threshold of 1.2 m/s could serve as a critical predictor for 
+reoperation, emphasizing the need for targeted follow-up strategies for at-risk 
+patients.
+
+© 2024 Alifu, Wang and Chen.
+
+DOI: 10.3389/fcvm.2024.1399659
+PMCID: PMC11233719
+PMID: 38988666
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/research/Congenital_Total_Pulmonary_Venous_Return_Anomaly-deep-research-falcon.md
+++ b/research/Congenital_Total_Pulmonary_Venous_Return_Anomaly-deep-research-falcon.md
@@ -1,0 +1,1197 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-05T23:17:41.968655'
+end_time: '2026-05-05T23:38:55.696400'
+duration_seconds: 1273.73
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Congenital Total Pulmonary Venous Return Anomaly
+  mondo_id: ''
+  category: Congenital Cardiovascular Disorder
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 36
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Congenital Total Pulmonary Venous Return Anomaly
+- **MONDO ID:**  (if available)
+- **Category:** Congenital Cardiovascular Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Congenital Total Pulmonary Venous Return Anomaly** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Congenital Total Pulmonary Venous Return Anomaly
+- **MONDO ID:**  (if available)
+- **Category:** Congenital Cardiovascular Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Congenital Total Pulmonary Venous Return Anomaly** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Congenital Total Pulmonary Venous Return Anomaly (Total Anomalous Pulmonary Venous Connection/Return; TAPVC/TAPVR)
+
+**Scope note:** In contemporary clinical literature, “congenital total pulmonary venous return anomaly” corresponds to **total anomalous pulmonary venous connection/return (TAPVC/TAPVR)**, a congenital cardiovascular malformation where **all pulmonary veins fail to connect to the left atrium** and instead drain to the right atrium or systemic venous circulation. (cheng2024clinicaldiagnosisand pages 1-4, xue2023prenataldiagnosisand pages 1-2)
+
+## 1. Disease Information
+
+### 1.1 Overview (current understanding)
+TAPVC/TAPVR is a **rare cyanotic congenital heart disease** in which **oxygenated pulmonary venous blood returns to the right-sided circulation/systemic veins** rather than the left atrium, causing systemic desaturation and abnormal pulmonary/systemic blood flow patterns. (cheng2024clinicaldiagnosisand pages 1-4, xue2023prenataldiagnosisand pages 1-2)
+
+A major determinant of early clinical deterioration is **pulmonary venous obstruction (PVO)** along the anomalous venous pathway, which increases pulmonary venous pressure, drives pulmonary edema, and worsens hypoxemia/hemodynamic compromise. (xue2023prenataldiagnosisand pages 2-3, cheng2024clinicaldiagnosisand pages 4-6)
+
+### 1.2 Key identifiers and coding systems
+- **ICD-10 (registry definition):** Q262 / Q26.2 “Total anomalous pulmonary venous connection” used to identify TAPVC in a nationwide registry study. (henningsen2025nationwideregistrystudy pages 2-3)
+- **Prenatal classification system:** Commonly described using the historical **Darling classification** into four anatomic types: supracardiac, intracardiac/cardiac, infracardiac, and mixed. (cheng2024clinicaldiagnosisand pages 4-6, xue2023prenataldiagnosisand pages 1-2)
+- **MONDO / Orphanet / OMIM / MeSH:** Not retrievable from the currently available full-text corpus in this run; therefore **not reported here**.
+
+### 1.3 Common synonyms and alternative names
+- Total anomalous pulmonary venous **connection** (TAPVC)
+- Total anomalous pulmonary venous **return** (TAPVR)
+- Total anomalous pulmonary venous **drainage** (TAPVD) (terminology varies across fetal imaging literature) (azab2022tbx5variantwith pages 1-2)
+
+### 1.4 Evidence provenance (patient-level vs aggregated)
+Most information below is derived from **aggregated cohorts** (fetal cohorts and surgical cohorts), **retrospective registries**, and **review-level synthesis**, supplemented by smaller case series. (xue2023prenataldiagnosisand pages 1-2, li2023totalanomalouspulmonary pages 1-2, henningsen2025nationwideregistrystudy pages 2-3)
+
+## 2. Etiology
+
+### 2.1 Primary causal factors (mechanistic)
+Clinical and surgical literature describes TAPVC/TAPVR as arising from **abnormal embryologic development/remodeling of pulmonary venous connections** and venous pole structures, with contributions from **genetic variation** in some patients. (cheng2024clinicaldiagnosisand pages 4-6, xue2023prenataldiagnosisand pages 1-2)
+
+### 2.2 Genetic risk factors (genes and syndromic associations)
+**TBX5 (Holt–Oram syndrome expansion):**
+- A pathogenic **TBX5 nonsense variant** (c.577G>T; p.Gly193*) was reported in a family where the proband had **mixed-type TAPVR**, and subsequent phenotyping supported Holt–Oram syndrome. This report is described as the *first genetic investigation* reporting this association. (azab2022tbx5variantwith pages 1-2)
+
+**ANKRD1 (candidate gene; gain-of-function signal; mechanistic animal model):**
+- A mechanistic study reports that increased ANKRD1 levels (including gain-of-function contexts) have been associated in humans with TAPVR and motivated creation of a **myocardial ANKRD1 overexpression mouse model**. In transgenic mice, myocardial ANKRD1 overexpression caused **sinus venosus/venous pole remodeling defects** with **abnormal pulmonary vein–systemic venous communications**, linking a plausible developmental mechanism to anomalous venous return phenotypes. (piroddi2020myocardialoverexpressionof pages 1-3, piroddi2020myocardialoverexpressionof pages 7-9, piroddi2020myocardialoverexpressionof pages 3-4)
+
+**Associated laterality/heterotaxy context (clinical association):**
+In fetal cohorts, TAPVC frequently co-occurs with complex congenital heart disease and laterality disorders such as right atrial isomerism (a heterotaxy phenotype). (xue2023prenataldiagnosisand pages 7-7, xue2023prenataldiagnosisand pages 8-10)
+
+### 2.3 Environmental risk/protective factors; GxE
+No TAPVC-specific, well-supported protective factors or gene–environment interaction evidence was identified in the retrieved corpus. Environmental teratogen evidence is not established in the extracted TAPVC-focused texts.
+
+## 3. Phenotypes
+
+### 3.1 Core clinical presentation (typical)
+Neonatal/infant presentations in clinical series commonly include **respiratory distress/shortness of breath**, **cyanosis**, recurrent respiratory infections/pneumonia, and heart failure/poor growth—particularly in obstructed forms. (cheng2024clinicaldiagnosisand pages 1-4, cheng2024clinicaldiagnosisand pages 4-6)
+
+### 3.2 Fetal imaging phenotypes and prenatal “suspicious signs”
+A structured fetal echocardiography approach highlighted suspicious ultrasound findings such as:
+- “**a small LA**,” “**an increased distance from the LA to the descending aorta**,” “**a smooth posterior wall of the LA**,” “**unobservable orifices of the PV**,” “**evident extra vessels and centrifugal venous flow**,” and “**an abnormal dilated vein (e.g., SVC, INN, AZV, IVC, or CS)**.” (xue2023prenataldiagnosisand pages 2-3)
+
+### 3.3 Suggested HPO terms (examples)
+*Note: HPO IDs are suggested based on phenotype labels; they were not retrieved from an ontology database in this run.*
+- Cyanosis (HP:0000969)
+- Respiratory distress (HP:0002098)
+- Tachypnea (HP:0002789)
+- Recurrent pneumonia (HP:0006532)
+- Pulmonary venous obstruction/stenosis (concept; may map to Pulmonary vein stenosis (HP:0012728))
+- Failure to thrive (HP:0001508)
+
+### 3.4 Quality of life impact
+No TAPVC-specific validated QoL instrument results (e.g., PedsQL, SF-36) were found in the retrieved TAPVC-focused corpus.
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes and pathogenic variants (evidence-supported in retrieved corpus)
+- **TBX5**: c.577G>T; p.Gly193* (nonsense; loss-of-function) associated with mixed-type TAPVR in a Holt–Oram syndrome context (family-based trio exome sequencing). (azab2022tbx5variantwith pages 1-2)
+
+### 4.2 Candidate genes / functional mechanisms
+- **ANKRD1**: gain-of-function/dysregulation implicated as a candidate driver of venous pole remodeling defects relevant to anomalous pulmonary venous return; transgenic overexpression produces congenital sinus venosus defects and later diastolic dysfunction. (piroddi2020myocardialoverexpressionof pages 1-3, piroddi2020myocardialoverexpressionof pages 7-9)
+
+### 4.3 Variant class and origin
+- TBX5 variant reported: nonsense (likely pathogenic in the report’s interpretation). (azab2022tbx5variantwith pages 1-2)
+- ANKRD1 evidence in retrieved corpus: gain-of-function/dysregulation signal and experimental overexpression model; specific human variant nomenclature is not fully extractable from the limited snippets provided. (piroddi2020myocardialoverexpressionof pages 3-4, piroddi2020myocardialoverexpressionof pages 1-3)
+
+### 4.4 Modifier genes, epigenetics, chromosomal abnormalities
+No specific, TAPVC-focused modifier gene sets, epigenetic signatures, or recurrent CNVs could be extracted from the retrieved full-text corpus in this run.
+
+## 5. Environmental Information
+No TAPVC-specific environmental, lifestyle, occupational, or infectious causal triggers were identified in the retrieved TAPVC-focused literature.
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Causal chain (integrated clinical + developmental model)
+1. **Developmental misconnection/remodeling failure** results in absent direct pulmonary vein–left atrium connection and anomalous drainage to systemic venous pathways/right atrium. (xue2023prenataldiagnosisand pages 1-2, cheng2024clinicaldiagnosisand pages 1-4)
+2. Mixing of oxygenated pulmonary venous blood with systemic venous blood in the right atrium leads to **cyanosis/hypoxemia** and abnormal loading conditions. (cheng2024clinicaldiagnosisand pages 1-4)
+3. **Pulmonary venous obstruction** (when present) increases pulmonary venous pressure, aggravating pulmonary congestion and worsening hypoxemia and hemodynamics; obstruction status strongly influences prognosis and urgency of intervention. (xue2023prenataldiagnosisand pages 2-3, cheng2024clinicaldiagnosisand pages 4-6)
+4. Post-repair, some patients develop **pulmonary vein stenosis (PVS)/recurrent obstruction**, a major driver of reintervention, morbidity, and mortality. (wen2024insightintothe pages 12-14, alifu2024assessingtherisk pages 3-5)
+
+### 6.2 Molecular/cellular processes (evidence-linked)
+**ANKRD1 gain-of-function model (mouse):** myocardial overexpression causes sinus venosus defects originating from impaired embryonic remodeling, with early transcriptional perturbations involving **GATA4 and NKX2-5** and downstream sarcomeric/titin modulation; embryos show abnormal venous pole connections, and adults develop progressive diastolic dysfunction. (piroddi2020myocardialoverexpressionof pages 1-3, piroddi2020myocardialoverexpressionof pages 7-9)
+
+### 6.3 Suggested ontology mappings
+**GO (Biological Process) suggestions:**
+- Heart morphogenesis (GO:0003007)
+- Cardiovascular system development (GO:0072358)
+- Pulmonary vein development (term exists conceptually; exact GO ID not retrieved in this run)
+- Blood vessel morphogenesis (GO:0048514)
+
+**CL (Cell Ontology) suggestions:**
+- Cardiomyocyte (CL:0000746)
+- Endothelial cell (CL:0000115)
+- Cardiac fibroblast (CL term exists; exact ID not retrieved in this run)
+
+**UBERON (Anatomy) suggestions:**
+- Pulmonary vein (UBERON term)
+- Left atrium (UBERON term)
+- Sinus venosus / venous pole region (UBERON term)
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/system level
+- **Primary:** pulmonary veins and their confluence, left atrium (failed connection), right atrium/systemic venous pathways receiving pulmonary venous return. (xue2023prenataldiagnosisand pages 1-2, cheng2024clinicaldiagnosisand pages 1-4)
+- **Secondary functional involvement:** lungs (pulmonary congestion/edema, especially with obstruction), pulmonary vasculature (risk of pulmonary hypertension), and systemic oxygen delivery (cyanosis). (cheng2024clinicaldiagnosisand pages 4-6, cheng2024clinicaldiagnosisand pages 1-4)
+
+## 8. Temporal Development
+- **Onset:** congenital; often clinically apparent in the neonatal period, especially in obstructed TAPVC. (cheng2024clinicaldiagnosisand pages 4-6)
+- **Course:** without surgery, high early mortality is reported; after repair, risk of postoperative pulmonary vein stenosis/obstruction often appears within months and can progress rapidly. (cheng2024clinicaldiagnosisand pages 4-6, wen2024insightintothe pages 12-14)
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology (selected recent/representative statistics)
+- TAPVC is described as approximately **2% of congenital heart disease** in a recent clinical summary. (cheng2024clinicaldiagnosisand pages 4-6)
+- In a TBX5-associated report, TAPVR is described as ~**7 per 100,000 live births** (and ~1–3% of CHD). (azab2022tbx5variantwith pages 1-2)
+
+### 9.2 Sex ratio / demographics
+A clinical summary notes TAPVC is reported more frequently in males than females. (cheng2024clinicaldiagnosisand pages 4-6)
+
+### 9.3 Inheritance
+The retrieved corpus supports **heterogeneous genetic architecture**: sporadic cases predominate, but rare **monogenic syndromic** associations (e.g., TBX5 in Holt–Oram) and candidate gene mechanisms (ANKRD1 gain-of-function contexts) exist. (azab2022tbx5variantwith pages 1-2, piroddi2020myocardialoverexpressionof pages 1-3)
+
+## 10. Diagnostics
+
+### 10.1 Prenatal diagnosis (real-world implementation)
+A fetal cohort describes a **four-step prenatal ultrasonography** workflow:
+1) demonstrate absent PV–LA connections; 2) identify common pulmonary vein and drainage route for subtype classification; 3) assess obstruction (turbulence and max velocity >50 cm/s suggested); 4) assess associated malformations. (xue2023prenataldiagnosisand pages 2-3)
+
+**Performance (2023 fetal cohort):** diagnostic accuracy by type was reported as **95% (supracardiac), 75% (intracardiac), 95% (infracardiac), 77% (mixed)**; among isolated TAPVC (n=21), **6 were missed** and **1 misclassified** prenatally. (xue2023prenataldiagnosisand pages 8-10, xue2023prenataldiagnosisand pages 1-2)
+
+**Figure/Table evidence (classification + drainage routes + obstruction):** Table 5 from the fetal cohort provides structured subtype and drainage-route detail along with obstruction findings. (xue2023prenataldiagnosisand media 1a8f0ae4)
+
+### 10.2 Postnatal diagnosis
+- **Transthoracic echocardiography (TTE)** is typically first-line but can have mis-/underdiagnosis in some settings.
+- **Computed tomographic angiography (CTA)** can increase anatomic diagnostic clarity and can also be used for surgical planning, but introduces radiation/contrast considerations. (cheng2024clinicaldiagnosisand pages 4-6, matsuhisa2020computedtomographybasedsurgical pages 1-2)
+
+### 10.3 Differential diagnosis (not exhaustively captured in retrieved corpus)
+Differentials for cyanotic neonatal CHD with pulmonary overcirculation/respiratory distress may include transposition physiology, obstructed left-sided lesions, and other complex CHD; specific differential algorithms were not retrievable from society guidelines in the current corpus.
+
+## 11. Outcome / Prognosis
+
+### 11.1 Natural history without intervention
+A clinical summary reports very poor natural prognosis without timely surgical intervention (e.g., mortality up to **48.8% in infancy** and high mortality in the first year in severe physiologic circumstances). (cheng2024clinicaldiagnosisand pages 4-6)
+
+### 11.2 Contemporary surgical outcomes and complications
+- Review-level synthesis describes **early postoperative mortality** in published series commonly ranging from **<10% to ~20%**, with **postoperative pulmonary vein stenosis (PVS)** as the most common complication and an incidence often cited around **10–20%**. (wen2024insightintothe pages 12-14)
+- In a single-center 2023 series using **primary sutureless repair** (n=80), there were **2 early deaths** and **1 late death**, and **2 patients developed postoperative PVO** with **no reintervention** required. (li2023totalanomalouspulmonary pages 1-2)
+
+### 11.3 Reoperation risk stratification (2024 evidence)
+A 2024 cohort found that **pre-discharge mild PVO** (Doppler velocity **>1.2 m/s**) was associated with substantially higher reoperation rates; in the fully adjusted model, HR **13.90** (95% CI 1.16–166.5) for reoperation within 1 year. (alifu2024assessingtherisk pages 3-5, alifu2024assessingtherisk pages 5-6)
+
+## 12. Treatment
+
+### 12.1 Surgical/interventional treatment (current practice)
+**Definitive management is surgical repair**, typically in the neonatal period when clinically indicated. (cheng2024clinicaldiagnosisand pages 4-6)
+
+**Primary sutureless repair (2023 outcomes):** In a single-center series (2015–2020), primary sutureless repair across all Darling subtypes showed low postoperative PVO incidence (2/80) and no reintervention, supporting the view that sutureless approaches may reduce anastomotic-level restenosis risk across subtypes. (li2023totalanomalouspulmonary pages 1-2)
+
+**Imaging-guided surgical planning (CTA era effect):** A 112-patient era comparison reported marked improvement in 5-year survival with a CTA-based strategy (biventricular: 69%→97%; single-ventricle: 21%→70%) and reduced/managed PVS burden with aggressive reintervention. (matsuhisa2020computedtomographybasedsurgical pages 1-2)
+
+**Technique comparisons:** For supracardiac TAPVC, a modified L-shaped incision approach was associated with improved freedom from death/postoperative PVO versus the posterior technique, especially in those with preoperative obstruction. (feng2020midtermresultsof pages 1-2)
+
+### 12.2 Supportive perioperative management
+Postoperative management may include intensive care strategies and **pulmonary hypertension-directed therapies** (e.g., inhaled nitric oxide, endothelin receptor antagonists, PDE-5 inhibitors, prostacyclin) as adjuncts when pulmonary hypertension is present. (cheng2024clinicaldiagnosisand pages 4-6)
+
+### 12.3 Pharmacotherapy / advanced therapeutics
+No TAPVC-specific disease-modifying pharmacotherapy trials, gene therapy, or RNA therapeutics were identified in the retrieved corpus.
+
+### 12.4 Suggested MAXO terms (examples)
+*Note: MAXO IDs not retrieved in this run; terms suggested as labels.*
+- Surgical repair of congenital heart defect (e.g., “TAPVC repair”)
+- Sutureless pulmonary venous anastomosis
+- Computed tomography angiography for preoperative planning
+- Echocardiographic surveillance / follow-up
+
+## 13. Prevention
+
+Primary prevention of TAPVC is not established. Practical prevention focuses on:
+- **Secondary prevention via prenatal detection** and perinatal planning (delivery at tertiary center; timely neonatal stabilization/surgery). (xue2023prenataldiagnosisand pages 8-10)
+- **Genetic counseling/testing** when syndromic features or familial recurrence is suspected (e.g., TBX5/Holt–Oram context). (azab2022tbx5variantwith pages 1-2)
+
+## 14. Other Species / Natural Disease
+No naturally occurring veterinary TAPVC disease series were identified in the retrieved corpus.
+
+## 15. Model Organisms
+A transgenic mouse model with **myocardial ANKRD1 overexpression** demonstrates congenital venous pole defects (sinus venosus defects; abnormal PV–systemic venous communications) and progressive functional deterioration, providing a mechanistic model relevant to anomalous pulmonary venous return. (piroddi2020myocardialoverexpressionof pages 1-3, piroddi2020myocardialoverexpressionof pages 7-9)
+
+## Recent developments (2023–2024 highlights)
+- **Structured fetal diagnostic protocols** with quantified type-specific accuracy and documentation that **isolated TAPVC is more likely to be missed** than syndromic/heterotaxy-associated TAPVC. (xue2023prenataldiagnosisand pages 8-10, xue2023prenataldiagnosisand pages 1-2)
+- **Expansion of sutureless repair evidence** showing low postoperative obstruction rates in a 2023 single-center cohort. (li2023totalanomalouspulmonary pages 1-2)
+- **Quantitative echocardiographic risk stratification** immediately prior to discharge (1.2 m/s threshold) associated with markedly increased reoperation risk within 1 year. (alifu2024assessingtherisk pages 3-5)
+
+## Evidence map of key studies
+| Topic | Key findings with quantitative stats | Population/Design | Year | Publication (journal) | Identifier (DOI and PMID if available) | URL |
+|---|---|---|---|---|---|---|
+| Classification / prenatal diagnosis | Four-step prenatal ultrasonography in 62 confirmed fetal TAPVC cases; subtype distribution: supracardiac 20/62 (32%), intracardiac 12/62 (19%), infracardiac 21/62 (34%), mixed 9/62 (15%); prenatal diagnostic accuracy by type: 95%, 75%, 95%, 77%, respectively; among 21 isolated TAPVC cases, 6 were missed and 1 was misclassified prenatally; literature cited in-study reported prenatal PVO prevalence 34.1% (95% CI 22.7%–47.7%); suspicious signs included small LA, increased LA–descending aorta distance, smooth posterior LA wall, absent PV orifices, extra vessels/centrifugal venous flow, and dilated systemic veins; obstruction marker on Doppler: turbulent flow or max velocity >50 cm/s (xue2023prenataldiagnosisand pages 8-10, xue2023prenataldiagnosisand pages 2-3, xue2023prenataldiagnosisand pages 1-2) | Retrospective fetal cohort; prenatal US with postnatal echo/surgery/autopsy confirmation | 2023 | Frontiers in Pediatrics | DOI: 10.3389/fped.2023.1206032; PMID: not available in context | https://doi.org/10.3389/fped.2023.1206032 |
+| Surgery / outcomes | Primary sutureless repair in 80 TAPVC patients: supracardiac 35 (43.8%), cardiac 24 (30%), infracardiac 17 (21.2%), mixed 4 (5%); median age at repair 16.5 days, median weight 3.5 kg; preoperative PVO 20/80 (25%); early deaths 2, late death 1; postoperative PVO in 2 patients, none required reintervention; prolonged CPB time (p=0.009), preoperative pneumonia (p=0.022), and gender (p=0.041) associated with higher postoperative PV flow velocity; authors argue primary sutureless repair may reduce subtype-related differences in postoperative obstruction (li2023totalanomalouspulmonary pages 1-2) | Single-center retrospective surgical series (2015–2020) | 2023 | Frontiers in Surgery | DOI: 10.3389/fsurg.2022.1086596; PMID: not available in context | https://doi.org/10.3389/fsurg.2022.1086596 |
+| Postoperative obstruction predictors | Mild pre-discharge pulmonary vein obstruction defined as Doppler velocity >1.2 m/s; postoperative mild obstruction present in 12/38 (31.6%); median follow-up 10.0 months; reoperation within 1 year was higher with mild obstruction (33.3% vs 7.7%); fully adjusted HR for reoperation 13.90 (95% CI 1.16–166.5), with threshold analysis supporting 1.2 m/s as a practical cutoff for intensified follow-up; routine follow-up echo at 1, 3, 6, and 12 months (alifu2024assessingtherisk pages 1-2, alifu2024assessingtherisk pages 5-6, alifu2024assessingtherisk pages 3-5, alifu2024assessingtherisk pages 2-3) | Single-center retrospective cohort after TAPVC repair | 2024 | Frontiers in Cardiovascular Medicine | DOI: 10.3389/fcvm.2024.1399659; PMID: not available in context | https://doi.org/10.3389/fcvm.2024.1399659 |
+| Surgery / outcomes / imaging-guided planning | CTA-based surgical planning in 112 repaired TAPVC patients comparing era 1 (1996–2010, n=56) vs era 2 (2011–2018, n=56); 5-year survival in biventricular hearts improved from 69% to 97% (P=0.0024); in single-ventricle hearts from 21% to 70% (P=0.0007); post-repair PVS in biventricular hearts fell from 23% to 13%, and in single-ventricle hearts from 60% to 36%; since 2011, 12 patients with post-repair PVS had multiple reinterventions with 5-year survival 88%; preoperative CTA associated with improved survival and PVS-free survival (matsuhisa2020computedtomographybasedsurgical pages 1-2) | Retrospective era-comparison cohort | 2020 | European Journal of Cardio-Thoracic Surgery | DOI: 10.1093/ejcts/ezaa028; PMID: not available in context | https://doi.org/10.1093/ejcts/ezaa028 |
+| Surgery / technique comparison | Modified L-shaped incision vs posterior technique for supracardiac TAPVC in 121 patients (53 vs 68; matched 52 pairs); median follow-up 33 months; operative mortality 5/121 (4.1%), late mortality 12/121 (9.9%); postoperative PVO in 21 patients overall; in matched patients with preoperative PVO, freedom from death and postoperative PVO at 1 and 3 years was 100% and 85.7% in L-shaped group vs 90% and 22.9% in posterior-technique group (P=0.002); posterior technique independently increased risk of death/PVO (HR 4.12, 95% CI 1.12–15.16; P=0.03) (feng2020midtermresultsof pages 1-2) | Single-center retrospective comparative study with propensity matching | 2020 | European Journal of Cardio-Thoracic Surgery | DOI: 10.1093/ejcts/ezaa264; PMID: not available in context | https://doi.org/10.1093/ejcts/ezaa264 |
+| Genetics / molecular | First genetically confirmed association of mixed-type TAPVR with Holt-Oram syndrome due to TBX5 nonsense variant c.577G>T (p.Gly193*); trio WES identified cosegregating variant; study notes TAPVR accounts for ~1–3% of CHD and ~7 per 100,000 live births; protein modeling indicated reduced non-covalent bonding and impaired DNA-binding stability of mutant TBX5; expands cardiac phenotype spectrum for TBX5/HOS (azab2022tbx5variantwith pages 1-2) | Family-based human genetic case report with trio exome sequencing | 2022 | Molecular Medicine Reports | DOI: 10.3892/mmr.2022.12726; PMID: not available in context | https://doi.org/10.3892/mmr.2022.12726 |
+| Genetics / molecular / model organism | ANKRD1 gain-of-function/overexpression linked to anomalous pulmonary venous return biology: prior human evidence cited TAPVR patients with ANKRD1 dysregulation (3–4-fold transcript increase or 10–20% protein-stability increase); myocardial ANKRD1-overexpressing transgenic mice developed sinus venosus defects with anomalous PV–systemic venous communications, venous-pole remodeling defects, early GATA4/Nkx2.5 upregulation, and progressive diastolic dysfunction/heart failure; provides mechanistic support for ANKRD1 as a TAPVR candidate gene (piroddi2020myocardialoverexpressionof pages 3-4, piroddi2020myocardialoverexpressionof pages 12-13, piroddi2020myocardialoverexpressionof pages 1-3, piroddi2020myocardialoverexpressionof pages 7-9) | Transgenic mouse model with supporting human candidate-gene context | 2020 | Cardiovascular Research | DOI: 10.1093/cvr/cvz291; PMID: not available in context | https://doi.org/10.1093/cvr/cvz291 |
+
+
+*Table: This table condenses high-value recent and foundational studies on TAPVC/TAPVR across prenatal diagnosis, operative strategy, postoperative obstruction risk, and genetics. It is useful as a quick-reference evidence map for building a disease knowledge base entry.*
+
+## Key visual evidence
+The following table image (from a 2023 fetal cohort) summarizes TAPVC anatomic subtypes, drainage routes, and obstruction findings, supporting the classification and prenatal evaluation sections. (xue2023prenataldiagnosisand media 1a8f0ae4)
+
+## Limitations of this report (data availability)
+- MONDO/Orphanet/OMIM/MeSH identifiers, formal guideline documents, and TAPVC-specific QoL datasets were not retrievable in the accessible corpus for this run; therefore, these elements are flagged as unavailable rather than inferred.
+- Some epidemiology estimates are study-/setting-specific; population-level prevalence estimates vary by ascertainment method and inclusion criteria.
+
+
+References
+
+1. (cheng2024clinicaldiagnosisand pages 1-4): Weiping Cheng, Junzhao Zhu, Youbo Xu, Yingqiang Guo, and Lexiang Shi. Clinical diagnosis and treatment of 5 cases of tapcv in infants. Unknown journal, Oct 2024. URL: https://doi.org/10.21203/rs.3.rs-3480976/v1, doi:10.21203/rs.3.rs-3480976/v1.
+
+2. (xue2023prenataldiagnosisand pages 1-2): Xiaoying Xue, Qiumei Wu, Mingtao Xiong, Wen Ling, Shan Guo, Hong Ma, Biying Huang, Min Liu, Xiuqing Qiu, and Zongjie Weng. Prenatal diagnosis and postnatal verification in fetuses with total anomalous pulmonary venous connection. Frontiers in Pediatrics, Jun 2023. URL: https://doi.org/10.3389/fped.2023.1206032, doi:10.3389/fped.2023.1206032. This article has 6 citations.
+
+3. (xue2023prenataldiagnosisand pages 2-3): Xiaoying Xue, Qiumei Wu, Mingtao Xiong, Wen Ling, Shan Guo, Hong Ma, Biying Huang, Min Liu, Xiuqing Qiu, and Zongjie Weng. Prenatal diagnosis and postnatal verification in fetuses with total anomalous pulmonary venous connection. Frontiers in Pediatrics, Jun 2023. URL: https://doi.org/10.3389/fped.2023.1206032, doi:10.3389/fped.2023.1206032. This article has 6 citations.
+
+4. (cheng2024clinicaldiagnosisand pages 4-6): Weiping Cheng, Junzhao Zhu, Youbo Xu, Yingqiang Guo, and Lexiang Shi. Clinical diagnosis and treatment of 5 cases of tapcv in infants. Unknown journal, Oct 2024. URL: https://doi.org/10.21203/rs.3.rs-3480976/v1, doi:10.21203/rs.3.rs-3480976/v1.
+
+5. (henningsen2025nationwideregistrystudy pages 2-3): Maj Beldring Henningsen, Cathrine Bohnstedt, Therese Risom Vestergaard, Morten Holdgaard Smerup, Pi Vejsig Madsen, and Lone Graff Stensballe. Nationwide registry study of long term survival and comorbidities in total anomalous pulmonary venous connection in denmark. Scientific Reports, Aug 2025. URL: https://doi.org/10.1038/s41598-025-15769-0, doi:10.1038/s41598-025-15769-0. This article has 3 citations and is from a peer-reviewed journal.
+
+6. (azab2022tbx5variantwith pages 1-2): Bilal Azab, Dunia Aburizeg, Weizhen Ji, Lauren Jeffries, Nooredeen Isbeih, Amal Al‑Akily, Hashim Mohammad, Yousef Osba, Mohammad Shahin, Zain Dardas, Ma'mon Hatmal, Iyad Al‑Ammouri, and Saquib Lakhani. Tbx5 variant with the novel phenotype of mixed-type total anomalous pulmonary venous return in holt-oram syndrome and variable intrafamilial heart defects. Molecular Medicine Reports, May 2022. URL: https://doi.org/10.3892/mmr.2022.12726, doi:10.3892/mmr.2022.12726. This article has 11 citations and is from a peer-reviewed journal.
+
+7. (li2023totalanomalouspulmonary pages 1-2): Gefei Li, Baoying Meng, Cheng Zhang, Weimin Zhang, Xiaodong Zhou, Qing Zhang, and Yiqun Ding. Total anomalous pulmonary venous connection in 80 patients: primary sutureless repair and outcomes. Frontiers in Surgery, Jan 2023. URL: https://doi.org/10.3389/fsurg.2022.1086596, doi:10.3389/fsurg.2022.1086596. This article has 5 citations.
+
+8. (piroddi2020myocardialoverexpressionof pages 1-3): Nicoletta Piroddi, Paola Pesce, Beatrice Scellini, Stefano Manzini, Giulia S Ganzetti, Ileana Badi, Michela Menegollo, Virginia Cora, Simone Tiso, Raffaella Cinquetti, Laura Monti, Giulia Chiesa, Steven B Bleyl, Marco Busnelli, Federica Dellera, Daniele Bruno, Federico Caicci, Annalisa Grimaldi, Roberto Taramelli, Lucia Manni, David Sacerdoti, Chiara Tesi, Corrado Poggesi, Simonetta Ausoni, Francesco Acquati, and Marina Campione. Myocardial overexpression of ankrd1 causes sinus venosus defects and progressive diastolic dysfunction. Cardiovascular research, 116:1458-1472, Nov 2020. URL: https://doi.org/10.1093/cvr/cvz291, doi:10.1093/cvr/cvz291. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+9. (piroddi2020myocardialoverexpressionof pages 7-9): Nicoletta Piroddi, Paola Pesce, Beatrice Scellini, Stefano Manzini, Giulia S Ganzetti, Ileana Badi, Michela Menegollo, Virginia Cora, Simone Tiso, Raffaella Cinquetti, Laura Monti, Giulia Chiesa, Steven B Bleyl, Marco Busnelli, Federica Dellera, Daniele Bruno, Federico Caicci, Annalisa Grimaldi, Roberto Taramelli, Lucia Manni, David Sacerdoti, Chiara Tesi, Corrado Poggesi, Simonetta Ausoni, Francesco Acquati, and Marina Campione. Myocardial overexpression of ankrd1 causes sinus venosus defects and progressive diastolic dysfunction. Cardiovascular research, 116:1458-1472, Nov 2020. URL: https://doi.org/10.1093/cvr/cvz291, doi:10.1093/cvr/cvz291. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+10. (piroddi2020myocardialoverexpressionof pages 3-4): Nicoletta Piroddi, Paola Pesce, Beatrice Scellini, Stefano Manzini, Giulia S Ganzetti, Ileana Badi, Michela Menegollo, Virginia Cora, Simone Tiso, Raffaella Cinquetti, Laura Monti, Giulia Chiesa, Steven B Bleyl, Marco Busnelli, Federica Dellera, Daniele Bruno, Federico Caicci, Annalisa Grimaldi, Roberto Taramelli, Lucia Manni, David Sacerdoti, Chiara Tesi, Corrado Poggesi, Simonetta Ausoni, Francesco Acquati, and Marina Campione. Myocardial overexpression of ankrd1 causes sinus venosus defects and progressive diastolic dysfunction. Cardiovascular research, 116:1458-1472, Nov 2020. URL: https://doi.org/10.1093/cvr/cvz291, doi:10.1093/cvr/cvz291. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+11. (xue2023prenataldiagnosisand pages 7-7): Xiaoying Xue, Qiumei Wu, Mingtao Xiong, Wen Ling, Shan Guo, Hong Ma, Biying Huang, Min Liu, Xiuqing Qiu, and Zongjie Weng. Prenatal diagnosis and postnatal verification in fetuses with total anomalous pulmonary venous connection. Frontiers in Pediatrics, Jun 2023. URL: https://doi.org/10.3389/fped.2023.1206032, doi:10.3389/fped.2023.1206032. This article has 6 citations.
+
+12. (xue2023prenataldiagnosisand pages 8-10): Xiaoying Xue, Qiumei Wu, Mingtao Xiong, Wen Ling, Shan Guo, Hong Ma, Biying Huang, Min Liu, Xiuqing Qiu, and Zongjie Weng. Prenatal diagnosis and postnatal verification in fetuses with total anomalous pulmonary venous connection. Frontiers in Pediatrics, Jun 2023. URL: https://doi.org/10.3389/fped.2023.1206032, doi:10.3389/fped.2023.1206032. This article has 6 citations.
+
+13. (wen2024insightintothe pages 12-14): Chen Wen, Geng Shen, Chenhao Fang, and Lan Tian. Insight into the research history and trends of total anomalous pulmonary venous connection: a bibliometric analysis. Journal of Cardiothoracic Surgery, May 2024. URL: https://doi.org/10.1186/s13019-024-02787-8, doi:10.1186/s13019-024-02787-8. This article has 6 citations and is from a peer-reviewed journal.
+
+14. (alifu2024assessingtherisk pages 3-5): Ailixiati Alifu, Haifan Wang, and Renwei Chen. Assessing the risk of reoperation for mild pulmonary vein obstruction post-tapvc repair: a retrospective cohort study. Frontiers in Cardiovascular Medicine, Jun 2024. URL: https://doi.org/10.3389/fcvm.2024.1399659, doi:10.3389/fcvm.2024.1399659. This article has 2 citations and is from a peer-reviewed journal.
+
+15. (xue2023prenataldiagnosisand media 1a8f0ae4): Xiaoying Xue, Qiumei Wu, Mingtao Xiong, Wen Ling, Shan Guo, Hong Ma, Biying Huang, Min Liu, Xiuqing Qiu, and Zongjie Weng. Prenatal diagnosis and postnatal verification in fetuses with total anomalous pulmonary venous connection. Frontiers in Pediatrics, Jun 2023. URL: https://doi.org/10.3389/fped.2023.1206032, doi:10.3389/fped.2023.1206032. This article has 6 citations.
+
+16. (matsuhisa2020computedtomographybasedsurgical pages 1-2): Hironori Matsuhisa, Yoshihiro Oshima, Tomonori Higuma, Shunsuke Matsushima, Shota Hasegawa, Yuson Wada, Michio Matsuoka, and Toshikatsu Tanaka. Computed tomography-based surgical strategy for total anomalous pulmonary venous connection. European journal of cardio-thoracic surgery : official journal of the European Association for Cardio-thoracic Surgery, 58:237-245, Feb 2020. URL: https://doi.org/10.1093/ejcts/ezaa028, doi:10.1093/ejcts/ezaa028. This article has 8 citations.
+
+17. (alifu2024assessingtherisk pages 5-6): Ailixiati Alifu, Haifan Wang, and Renwei Chen. Assessing the risk of reoperation for mild pulmonary vein obstruction post-tapvc repair: a retrospective cohort study. Frontiers in Cardiovascular Medicine, Jun 2024. URL: https://doi.org/10.3389/fcvm.2024.1399659, doi:10.3389/fcvm.2024.1399659. This article has 2 citations and is from a peer-reviewed journal.
+
+18. (feng2020midtermresultsof pages 1-2): Zicong Feng, Yang Yang, Fengpu He, Kunjing Pang, Kai Ma, Sen Zhang, Lei Qi, Guanxi Wang, Fengqun Mao, Jianhui Yuan, and Shoujun Li. Mid-term results of modified l-shaped incision technique for supracardiac total anomalous pulmonary venous connection. European journal of cardio-thoracic surgery : official journal of the European Association for Cardio-thoracic Surgery, 58:1261-1268, Sep 2020. URL: https://doi.org/10.1093/ejcts/ezaa264, doi:10.1093/ejcts/ezaa264. This article has 9 citations.
+
+19. (alifu2024assessingtherisk pages 1-2): Ailixiati Alifu, Haifan Wang, and Renwei Chen. Assessing the risk of reoperation for mild pulmonary vein obstruction post-tapvc repair: a retrospective cohort study. Frontiers in Cardiovascular Medicine, Jun 2024. URL: https://doi.org/10.3389/fcvm.2024.1399659, doi:10.3389/fcvm.2024.1399659. This article has 2 citations and is from a peer-reviewed journal.
+
+20. (alifu2024assessingtherisk pages 2-3): Ailixiati Alifu, Haifan Wang, and Renwei Chen. Assessing the risk of reoperation for mild pulmonary vein obstruction post-tapvc repair: a retrospective cohort study. Frontiers in Cardiovascular Medicine, Jun 2024. URL: https://doi.org/10.3389/fcvm.2024.1399659, doi:10.3389/fcvm.2024.1399659. This article has 2 citations and is from a peer-reviewed journal.
+
+21. (piroddi2020myocardialoverexpressionof pages 12-13): Nicoletta Piroddi, Paola Pesce, Beatrice Scellini, Stefano Manzini, Giulia S Ganzetti, Ileana Badi, Michela Menegollo, Virginia Cora, Simone Tiso, Raffaella Cinquetti, Laura Monti, Giulia Chiesa, Steven B Bleyl, Marco Busnelli, Federica Dellera, Daniele Bruno, Federico Caicci, Annalisa Grimaldi, Roberto Taramelli, Lucia Manni, David Sacerdoti, Chiara Tesi, Corrado Poggesi, Simonetta Ausoni, Francesco Acquati, and Marina Campione. Myocardial overexpression of ankrd1 causes sinus venosus defects and progressive diastolic dysfunction. Cardiovascular research, 116:1458-1472, Nov 2020. URL: https://doi.org/10.1093/cvr/cvz291, doi:10.1093/cvr/cvz291. This article has 40 citations and is from a domain leading peer-reviewed journal.

--- a/research/Congenital_Total_Pulmonary_Venous_Return_Anomaly-deep-research-falcon.md.citations.md
+++ b/research/Congenital_Total_Pulmonary_Venous_Return_Anomaly-deep-research-falcon.md.citations.md
@@ -1,0 +1,487 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Congenital Total Pulmonary Venous Return Anomaly
+- **MONDO ID:**  (if available)
+- **Category:** Congenital Cardiovascular Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Congenital Total Pulmonary Venous Return Anomaly** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-05T23:38:55.696400
+
+1. henningsen2025nationwideregistrystudy pages 2-3
+2. xue2023prenataldiagnosisand pages 2-3
+3. cheng2024clinicaldiagnosisand pages 1-4
+4. cheng2024clinicaldiagnosisand pages 4-6
+5. wen2024insightintothe pages 12-14
+6. li2023totalanomalouspulmonary pages 1-2
+7. matsuhisa2020computedtomographybasedsurgical pages 1-2
+8. feng2020midtermresultsof pages 1-2
+9. xue2023prenataldiagnosisand pages 8-10
+10. alifu2024assessingtherisk pages 3-5
+11. xue2023prenataldiagnosisand pages 1-2
+12. piroddi2020myocardialoverexpressionof pages 1-3
+13. piroddi2020myocardialoverexpressionof pages 7-9
+14. piroddi2020myocardialoverexpressionof pages 3-4
+15. xue2023prenataldiagnosisand pages 7-7
+16. alifu2024assessingtherisk pages 5-6
+17. alifu2024assessingtherisk pages 1-2
+18. alifu2024assessingtherisk pages 2-3
+19. piroddi2020myocardialoverexpressionof pages 12-13
+20. https://doi.org/10.3389/fped.2023.1206032
+21. https://doi.org/10.3389/fsurg.2022.1086596
+22. https://doi.org/10.3389/fcvm.2024.1399659
+23. https://doi.org/10.1093/ejcts/ezaa028
+24. https://doi.org/10.1093/ejcts/ezaa264
+25. https://doi.org/10.3892/mmr.2022.12726
+26. https://doi.org/10.1093/cvr/cvz291
+27. https://doi.org/10.21203/rs.3.rs-3480976/v1,
+28. https://doi.org/10.3389/fped.2023.1206032,
+29. https://doi.org/10.1038/s41598-025-15769-0,
+30. https://doi.org/10.3892/mmr.2022.12726,
+31. https://doi.org/10.3389/fsurg.2022.1086596,
+32. https://doi.org/10.1093/cvr/cvz291,
+33. https://doi.org/10.1186/s13019-024-02787-8,
+34. https://doi.org/10.3389/fcvm.2024.1399659,
+35. https://doi.org/10.1093/ejcts/ezaa028,
+36. https://doi.org/10.1093/ejcts/ezaa264,


### PR DESCRIPTION
## Summary

Adds a new curated disorder page for **Congenital Total Pulmonary Venous Return Anomaly** / TAPVR.

## Evidence Sources

- `PMID:16638546` - surgical review covering definition, subtype classification, clinical presentation, and urgency of repair.
- `PMID:27594934` - CT case review describing pathophysiology and complications.
- `PMID:36713670` - 80-patient surgical repair/outcomes series.
- `PMID:38988666` - postoperative pulmonary vein obstruction and reoperation risk cohort.
- `PMID:35514310` - TBX5/Holt-Oram family report with mixed-type TAPVR association.

## Validation

- `just validate-schema kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml`
- `scripts/run_term_validator.sh validate-data kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml -s src/dismech/schema/dismech.yaml -t Disease --labels -c conf/oak_config.yaml`
- `just validate-references kb/disorders/Congenital_Total_Pulmonary_Venous_Return_Anomaly.yaml`
- `just check-reference-cache-frontmatter`
- `git diff --cached --check -- . ':(exclude)references_cache/*.md'`

I did not include term cache changes from validation.
