### PR TITLE
Add Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy

### DIFF
--- a/kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml
+++ b/kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml
@@ -1,0 +1,214 @@
+name: Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy
+creation_date: "2026-05-06T03:14:37Z"
+updated_date: "2026-05-06T03:14:37Z"
+category: Neurodegenerative Disease
+parents:
+- Neurodegenerative Disease
+disease_term:
+  preferred_term: adult-onset autosomal dominant demyelinating leukodystrophy
+  term:
+    id: MONDO:0008215
+    label: adult-onset autosomal dominant demyelinating leukodystrophy
+description: >-
+  Adult-onset autosomal dominant demyelinating leukodystrophy is a rare,
+  slowly progressive neurodegenerative leukodystrophy characterized by central
+  nervous system demyelination with autonomic dysfunction, pyramidal signs,
+  ataxia, and variable cognitive impairment.
+pathophysiology:
+- name: Lamin B1-Associated Demyelination
+  description: >-
+    Increased LMNB1 dosage is associated with disrupted nuclear lamina function
+    and progressive central nervous system white matter degeneration.
+  evidence:
+  - reference: PMID:28769756
+    reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Duplication or over expression of the lamin B1 (LMNB1) gene causes ADLD."
+    explanation: >-
+      The family study directly links LMNB1 duplication/overexpression with
+      adult-onset autosomal dominant leukodystrophy.
+  - reference: PMID:25701871
+    reference_title: "A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Chromosomal rearrangements with duplication of the lamin B1 (LMNB1) gene underlie autosomal dominant adult-onset demyelinating leukodystrophy (ADLD), a rare neurological disorder in which overexpression of LMNB1 causes progressive central nervous system demyelination."
+    explanation: >-
+      The structural-variant study supports LMNB1 overexpression as the shared
+      mechanism driving progressive CNS demyelination.
+- name: Enhancer Adoption From Upstream Deletion
+  description: >-
+    Some families lack an LMNB1 coding duplication and instead have upstream
+    deletions that disrupt regulatory boundaries, allowing ectopic enhancer
+    activity to increase LMNB1 expression.
+  evidence:
+  - reference: PMID:25701871
+    reference_title: "A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The deletion eliminates a genome topological domain boundary, allowing normally forbidden interactions between at least three forebrain-directed enhancers and the LMNB1 promoter, in line with the observed mainly cerebral localization of lamin B1 overexpression and myelin degeneration."
+    explanation: >-
+      This supports a noncoding structural variant mechanism that converges on
+      LMNB1 overexpression.
+phenotypes:
+- name: Leukodystrophy
+  category: Neurologic
+  phenotype_term:
+    preferred_term: Leukodystrophy
+    term:
+      id: HP:0002415
+      label: Leukodystrophy
+  description: >-
+    Progressive central nervous system white matter disease is the core
+    radiologic and clinical substrate.
+  evidence:
+  - reference: PMID:28769756
+    reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autosomal dominant adult-onset demyelinating leukodystrophy (ADLD) is a very rare neurological disorder featured with late onset, slowly progressive central nervous system demyelination."
+    explanation: >-
+      This describes the defining adult-onset leukodystrophy phenotype and
+      progressive CNS demyelination.
+- name: Spasticity
+  category: Neurologic
+  phenotype_term:
+    preferred_term: Spasticity
+    term:
+      id: HP:0001257
+      label: Spasticity
+  description: >-
+    Upper motor neuron dysfunction may produce progressive spasticity.
+  evidence:
+  - reference: PMID:26053668
+    reference_title: "LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Motor signs developed ascending from spastic paraplegia to tetraplegia and pseudobulbar palsy in the seventh decade."
+    explanation: >-
+      The longitudinal cohort supports spastic motor involvement during
+      progression.
+- name: Ataxia
+  category: Neurologic
+  phenotype_term:
+    preferred_term: Ataxia
+    term:
+      id: HP:0001251
+      label: Ataxia
+  description: >-
+    Cerebellar or long-tract involvement can cause progressive gait and limb
+    incoordination.
+  evidence:
+  - reference: PMID:26053668
+    reference_title: "LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Duplication of the LMNB1 gene encoding lamin B1 causes adult-onset autosomal-dominant leukodystrophy (ADLD) starting with autonomic symptoms, which are followed by pyramidal signs and ataxia."
+    explanation: >-
+      The longitudinal study identifies ataxia as a later motor feature after
+      autonomic symptoms.
+- name: Autonomic Dysfunction
+  category: Neurologic
+  phenotype_term:
+    preferred_term: Autonomic dysfunction
+    term:
+      id: HP:0012332
+      label: Abnormal autonomic nervous system physiology
+  description: >-
+    Autonomic involvement commonly appears early and may include bladder,
+    bowel, sweating, erectile, or orthostatic symptoms.
+  evidence:
+  - reference: PMID:26053668
+    reference_title: "LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autonomic dysfunction appeared in the fifth to sixth decade, preceding or together with gait and coordination difficulties."
+    explanation: >-
+      The longitudinal cohort supports autonomic dysfunction as an early
+      clinical feature.
+genetic:
+- name: LMNB1
+  association: Causative
+  inheritance:
+  - name: Autosomal dominant inheritance
+    evidence:
+    - reference: PMID:26053668
+      reference_title: "LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Duplication of the LMNB1 gene encoding lamin B1 causes adult-onset autosomal-dominant leukodystrophy (ADLD) starting with autonomic symptoms, which are followed by pyramidal signs and ataxia."
+      explanation: >-
+        The title and abstract support autosomal-dominant inheritance in
+        LMNB1-related ADLD.
+  evidence:
+  - reference: PMID:28769756
+    reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "However, Multiplex ligand-dependent probe amplification (MLPA) showed whole duplication of LMNB1 gene which is co-segregated with the disease phenotype in this family."
+    explanation: >-
+      The family study supports LMNB1 duplication as a causative structural
+      variant.
+diagnosis:
+- name: LMNB1 Copy-Number Testing
+  diagnosis_term:
+    preferred_term: genetic testing
+    term:
+      id: MAXO:0000127
+      label: genetic testing
+  description: >-
+    Targeted LMNB1 deletion/duplication analysis, MLPA, array-CGH, or other
+    validated copy-number methods are needed when the phenotype and MRI pattern
+    suggest LMNB1-related ADLD.
+  results: >-
+    Heterozygous LMNB1 duplication or an upstream regulatory deletion supports
+    the molecular diagnosis.
+  evidence:
+  - reference: PMID:28769756
+    reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In order to understand the genetic cause of the disease in this family, target exome capture based next generation sequencing has been done, but no causative variants or possibly pathogenic variants has been identified."
+    explanation: >-
+      The study shows that sequence-focused testing can miss the diagnosis.
+  - reference: PMID:28769756
+    reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "However, Multiplex ligand-dependent probe amplification (MLPA) showed whole duplication of LMNB1 gene which is co-segregated with the disease phenotype in this family."
+    explanation: >-
+      MLPA copy-number testing identified the familial LMNB1 duplication after
+      exome sequencing was unrevealing.
+treatments:
+- name: Allele-Specific RNA Interference
+  treatment_term:
+    preferred_term: RNA interference therapy
+    term:
+      id: MAXO:0001592
+      label: RNA interference therapy
+  description: >-
+    LMNB1-lowering RNA interference is a preclinical disease-targeted strategy
+    intended to reduce excess LMNB1 expression while avoiding excessive
+    suppression of the normal allele.
+  evidence:
+  - reference: PMID:31143934
+    reference_title: "Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy."
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: "Three of the small interfering RNAs were highly selective for the target allele and restored both LMNB1 mRNA and protein levels close to control levels."
+    explanation: >-
+      This supports a mechanistically targeted but preclinical RNAi approach in
+      patient-derived and disease-relevant cellular models.
+references:
+- reference: PMID:28769756
+  title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+  findings: []
+- reference: PMID:26053668
+  title: "LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course."
+  findings: []
+- reference: PMID:25701871
+  title: "A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD)."
+  findings: []
+- reference: PMID:31143934
+  title: "Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy."
+  findings: []

--- a/kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml
+++ b/kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml
@@ -14,11 +14,46 @@ description: >-
   slowly progressive neurodegenerative leukodystrophy characterized by central
   nervous system demyelination with autonomic dysfunction, pyramidal signs,
   ataxia, and variable cognitive impairment.
-pathophysiology:
-- name: Lamin B1-Associated Demyelination
+synonyms:
+- LMNB1-related autosomal dominant leukodystrophy
+- Autosomal dominant adult-onset demyelinating leukodystrophy
+- ADLD
+external_assertions:
+- name: OMIM adult-onset autosomal dominant leukodystrophy record
+  source: OMIM
+  assertion_type: disease_record
+  external_id: OMIM:169500
+  description: OMIM disease identifier for adult-onset autosomal dominant leukodystrophy.
+has_subtypes:
+- name: LMNB1 Duplication-Related ADLD
   description: >-
-    Increased LMNB1 dosage is associated with disrupted nuclear lamina function
-    and progressive central nervous system white matter degeneration.
+    The classic molecular subtype caused by heterozygous LMNB1 duplication,
+    producing lamin B1 overexpression and the typical autonomic, pyramidal,
+    ataxic, and leukodystrophy phenotype.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All eight patients had LMNB1 duplication."
+    explanation: Supports LMNB1 duplication as the molecular finding across the Mayo Clinic ADLD cohort.
+- name: Upstream Deletion-Related ADLD
+  description: >-
+    A regulatory structural-variant subtype in which heterozygous upstream
+    deletion removes a topological boundary and drives LMNB1 enhancer adoption
+    without whole-gene duplication.
+  evidence:
+  - reference: PMID:25701871
+    reference_title: "A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This second route to LMNB1 overexpression and ADLD is a new example of the relevance of regulatory landscape modifications in determining Mendelian phenotypes."
+    explanation: Supports upstream regulatory deletion and enhancer adoption as a distinct molecular route to ADLD.
+pathophysiology:
+- name: LMNB1 Overexpression
+  description: >-
+    Whole-gene duplication or upstream regulatory deletion increases LMNB1
+    expression, establishing lamin B1 excess as the proximal molecular driver.
   evidence:
   - reference: PMID:28769756
     reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
@@ -36,6 +71,9 @@ pathophysiology:
     explanation: >-
       The structural-variant study supports LMNB1 overexpression as the shared
       mechanism driving progressive CNS demyelination.
+  downstream:
+  - target: Nuclear Lamina Structural Dysregulation
+    description: Lamin B1 excess perturbs nuclear-lamina and chromatin-associated functions in CNS cells.
 - name: Enhancer Adoption From Upstream Deletion
   description: >-
     Some families lack an LMNB1 coding duplication and instead have upstream
@@ -50,6 +88,90 @@ pathophysiology:
     explanation: >-
       This supports a noncoding structural variant mechanism that converges on
       LMNB1 overexpression.
+  downstream:
+  - target: LMNB1 Overexpression
+    description: Enhancer adoption increases LMNB1 promoter activity and converges on lamin B1 overexpression.
+- name: Nuclear Lamina Structural Dysregulation
+  description: >-
+    Lamin B1 overexpression perturbs nuclear lamina structure and chromatin
+    regulatory functions, providing a cellular bridge from structural variants
+    to altered CNS cell morphology and function.
+  biological_processes:
+  - preferred_term: chromatin organization
+    term:
+      id: GO:0006325
+      label: chromatin organization
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:37450245
+    reference_title: "Understanding the Ultra-Rare Disease Autosomal Dominant Leukodystrophy: an Updated Review on Morpho-Functional Alterations Found in Experimental Models."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "LMNB1 encodes for Lamin B1, a protein of the nuclear lamina. Lamin B1 regulates many cellular processes such as DNA replication, chromatin organization, and senescence."
+    explanation: Supports nuclear-lamina and chromatin organization disruption as a proximal molecular consequence of LMNB1 overexpression.
+  - reference: PMID:37450245
+    reference_title: "Understanding the Ultra-Rare Disease Autosomal Dominant Leukodystrophy: an Updated Review on Morpho-Functional Alterations Found in Experimental Models."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Nevertheless, Lamin B1 together with the other lamins that constitute the nuclear lamina has firstly the key role of maintaining the nuclear structure."
+    explanation: Supports nuclear structural homeostasis as a relevant lamin B1-dependent process.
+  downstream:
+  - target: Oligodendrocyte Myelin Dysfunction
+    description: Nuclear and gene-regulatory disruption in disease-relevant CNS cells contributes to impaired myelin maintenance.
+- name: Oligodendrocyte Myelin Dysfunction
+  description: >-
+    Disease-relevant LMNB1-overexpressing models implicate oligodendrocytes and
+    CNS myelin maintenance as vulnerable downstream targets of lamin B1 excess.
+  cell_types:
+  - preferred_term: oligodendrocyte
+    term:
+      id: CL:0000128
+      label: oligodendrocyte
+  biological_processes:
+  - preferred_term: myelination
+    term:
+      id: GO:0042552
+      label: myelination
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:31143934
+    reference_title: "Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "studied autosomal dominant adult-onset demyelinating leukodystrophy (ADLD) due to lamin B1 (LMNB1) duplication, a hereditary, progressive and fatal disorder affecting myelin in the CNS."
+    explanation: Supports CNS myelin as the affected tissue-level target of LMNB1-duplication ADLD.
+  - reference: PMID:31143934
+    reference_title: "Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "in two disease-relevant cellular models: murine oligodendrocytes overexpressing human LMNB1, and neurons directly reprogrammed from patients' fibroblasts."
+    explanation: Supports oligodendrocytes as a disease-relevant cellular model for LMNB1 overexpression.
+  downstream:
+  - target: Central Nervous System Demyelination
+    description: Oligodendrocyte and myelin dysfunction manifests as progressive CNS demyelination.
+- name: Central Nervous System Demyelination
+  description: >-
+    Progressive central nervous system demyelination and white matter loss are
+    the downstream tissue-level outputs of LMNB1 overexpression.
+  biological_processes:
+  - preferred_term: myelination
+    term:
+      id: GO:0042552
+      label: myelination
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:25701871
+    reference_title: "A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "overexpression of LMNB1 causes progressive central nervous system demyelination."
+    explanation: Directly links LMNB1 overexpression to progressive CNS demyelination.
+  - reference: PMID:28769756
+    reference_title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Autosomal dominant adult-onset demyelinating leukodystrophy (ADLD) is a very rare neurological disorder featured with late onset, slowly progressive central nervous system demyelination."
+    explanation: Supports slowly progressive CNS demyelination as the defining downstream phenotype.
 phenotypes:
 - name: Leukodystrophy
   category: Neurologic
@@ -126,9 +248,50 @@ phenotypes:
     explanation: >-
       The longitudinal cohort supports autonomic dysfunction as an early
       clinical feature.
+- name: Cognitive Impairment
+  category: Neurologic
+  frequency: VERY_FREQUENT
+  phenotype_term:
+    preferred_term: Cognitive impairment
+    term:
+      id: HP:0100543
+      label: Cognitive impairment
+  description: Cognitive difficulties are frequent in recent LMNB1-related ADLD cohorts.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: Supports cognitive impairment as very frequent in the eight-patient Mayo Clinic cohort.
+- name: Fatigue
+  category: Neurologic
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Fatigue
+    term:
+      id: HP:0012378
+      label: Fatigue
+  description: Fatigue is common in recent LMNB1-related ADLD cohorts.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: Supports fatigue as frequent in the eight-patient Mayo Clinic cohort.
 genetic:
 - name: LMNB1
+  gene_term:
+    preferred_term: LMNB1
+    term:
+      id: hgnc:6637
+      label: LMNB1
   association: Causative
+  features: >-
+    LMNB1 causes ADLD through gain of expression, most often by whole-gene
+    tandem duplication and more rarely by upstream regulatory deletion with
+    enhancer adoption.
   inheritance:
   - name: Autosomal dominant inheritance
     evidence:
@@ -149,6 +312,12 @@ genetic:
     explanation: >-
       The family study supports LMNB1 duplication as a causative structural
       variant.
+  - reference: PMID:40046440
+    reference_title: "Case report: LMNB1 duplication-mediated autosomal dominant adult leukodystrophy in a Chinese family and literature review of Chinese patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Currently, two genetic alterations have been identified in association with the pathogenesis of ADLD: LMNB1 gene tandem duplication and LMNB1 gene upstream deletions."
+    explanation: Supports the two major LMNB1 gain-of-expression structural variant classes represented in this entry.
 diagnosis:
 - name: LMNB1 Copy-Number Testing
   diagnosis_term:
@@ -179,7 +348,86 @@ diagnosis:
     explanation: >-
       MLPA copy-number testing identified the familial LMNB1 duplication after
       exome sequencing was unrevealing.
+- name: Characteristic Brain and Spine MRI Pattern
+  diagnosis_term:
+    preferred_term: magnetic resonance imaging procedure
+    term:
+      id: MAXO:0000424
+      label: magnetic resonance imaging procedure
+  description: >-
+    Brain and spine MRI can show the characteristic symmetric white-matter and
+    spinal cord involvement that should prompt LMNB1 copy-number testing.
+  results: >-
+    Symmetric confluent T2-weighted deep cerebral and periventricular white
+    matter hyperintensities with internal capsule, corpus callosum, brainstem
+    corticospinal tract, cerebellar peduncle, and spinal cord atrophy patterns.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All showed symmetric confluent T2W deep cerebral and periventricular white matter hyperintensities with involvement of the posterior limb of the internal capsule, corpus callosum, corticospinal tract in brain stem, and superior and middle cerebellar peduncles."
+    explanation: Supports the hallmark brain MRI pattern in molecularly confirmed LMNB1-related ADLD.
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Seven spine MRIs from six patients showed moderate diffuse atrophy of the spinal cord."
+    explanation: Supports spinal cord atrophy as part of the MRI diagnostic pattern.
 treatments:
+- name: Symptom-Directed Supportive Care
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  description: >-
+    Management is supportive and symptom-directed, with attention to autonomic
+    dysfunction, spasticity, mobility decline, fatigue, and cognitive or mood
+    symptoms while disease-targeted therapy remains investigational.
+  target_phenotypes:
+  - preferred_term: Autonomic dysfunction
+    term:
+      id: HP:0012332
+      label: Abnormal autonomic nervous system physiology
+  - preferred_term: Spasticity
+    term:
+      id: HP:0001257
+      label: Spasticity
+  - preferred_term: Fatigue
+    term:
+      id: HP:0012378
+      label: Fatigue
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: Supports the clinical symptom targets for supportive management in the Mayo Clinic cohort.
+  - reference: PMID:37564735
+    reference_title: "Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions."
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: "Comprehensive evaluation and molecular confirmation when available helps in prognostication, early initiation of treatment in certain disorders, enrollment in clinical trials, and provides valuable information for the family for reproductive counseling."
+    explanation: Supports anticipatory management, treatment consideration when available, trial enrollment, and family counseling in adult-onset leukodystrophy care.
+- name: Genetic Counseling
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  description: >-
+    Genetic counseling is appropriate after molecular confirmation because the
+    disease is autosomal dominant and familial risk and reproductive decisions
+    are central to care.
+  evidence:
+  - reference: PMID:37564735
+    reference_title: "Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Comprehensive evaluation and molecular confirmation when available helps in prognostication, early initiation of treatment in certain disorders, enrollment in clinical trials, and provides valuable information for the family for reproductive counseling."
+    explanation: Supports genetic and reproductive counseling after molecular diagnosis in adult-onset leukodystrophies.
 - name: Allele-Specific RNA Interference
   treatment_term:
     preferred_term: RNA interference therapy
@@ -199,6 +447,25 @@ treatments:
     explanation: >-
       This supports a mechanistically targeted but preclinical RNAi approach in
       patient-derived and disease-relevant cellular models.
+clinical_trials:
+- name: NCT06816498
+  phase: PHASE_I
+  status: ACTIVE_NOT_RECRUITING
+  description: >-
+    Open-label single-participant phase 1/2 personalized antisense
+    oligonucleotide study for LMNB1 mutation-associated ADLD.
+  target_phenotypes:
+  - preferred_term: Leukodystrophy
+    term:
+      id: HP:0002415
+      label: Leukodystrophy
+  evidence:
+  - reference: clinicaltrials:NCT06816498
+    reference_title: "An Open-label, Single-center, Single-participant Study of an Experimental Antisense Oligonucleotide Treatment for a Patient With LMNB1 Mutation Associated Autosomal Dominant Leukodystrophy (ADLD)"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This research project entails delivery of a personalized antisense oligonucleotide (ASO) drug designed for a single participant with Autosomal Dominant Leukodystrophy (ADLD) due to LMNB1 mutation"
+    explanation: Supports an active personalized ASO clinical trial for LMNB1-associated ADLD.
 references:
 - reference: PMID:28769756
   title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
@@ -211,4 +478,16 @@ references:
   findings: []
 - reference: PMID:31143934
   title: "Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy."
+  findings: []
+- reference: DOI:10.1007/s44162-024-00055-w
+  title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+  findings: []
+- reference: PMID:37450245
+  title: "Understanding the Ultra-Rare Disease Autosomal Dominant Leukodystrophy: an Updated Review on Morpho-Functional Alterations Found in Experimental Models."
+  findings: []
+- reference: PMID:37564735
+  title: "Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions."
+  findings: []
+- reference: PMID:40046440
+  title: "Case report: LMNB1 duplication-mediated autosomal dominant adult leukodystrophy in a Chinese family and literature review of Chinese patients."
   findings: []

--- a/kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml
+++ b/kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml
@@ -96,6 +96,11 @@ pathophysiology:
     Lamin B1 overexpression perturbs nuclear lamina structure and chromatin
     regulatory functions, providing a cellular bridge from structural variants
     to altered CNS cell morphology and function.
+  cell_types:
+  - preferred_term: oligodendrocyte
+    term:
+      id: CL:0000128
+      label: oligodendrocyte
   biological_processes:
   - preferred_term: chromatin organization
     term:
@@ -266,7 +271,7 @@ phenotypes:
     explanation: Supports cognitive impairment as very frequent in the eight-patient Mayo Clinic cohort.
 - name: Fatigue
   category: Neurologic
-  frequency: FREQUENT
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Fatigue
     term:
@@ -280,6 +285,72 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
     explanation: Supports fatigue as frequent in the eight-patient Mayo Clinic cohort.
+- name: Sleep Disturbance
+  category: Neurologic
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Sleep disturbance
+    term:
+      id: HP:0002360
+      label: Sleep disturbance
+  description: Sleep disturbance is reported in recent LMNB1-related ADLD cohorts.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: Supports sleep disturbance in half of the eight-patient Mayo Clinic cohort.
+- name: Mood Disturbance
+  category: Psychiatric
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Depression
+    term:
+      id: HP:0000716
+      label: Depression
+  description: Mood disturbances are reported in recent LMNB1-related ADLD cohorts.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: >-
+      The cohort reports mood disturbances in most patients; the HPO binding is
+      to the available depression term and is therefore partial.
+- name: Tremor
+  category: Neurologic
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Tremor
+    term:
+      id: HP:0001337
+      label: Tremor
+  description: Tremor is reported in recent LMNB1-related ADLD cohorts.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: Supports tremor in half of the eight-patient Mayo Clinic cohort.
+- name: Migraine
+  category: Neurologic
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Migraine
+    term:
+      id: HP:0002076
+      label: Migraine
+  description: Migraine is reported in recent LMNB1-related ADLD cohorts.
+  evidence:
+  - reference: DOI:10.1007/s44162-024-00055-w
+    reference_title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8)."
+    explanation: Supports migraine in half of the eight-patient Mayo Clinic cohort.
 genetic:
 - name: LMNB1
   gene_term:

--- a/references_cache/DOI_10.1007_s44162-024-00055-w.md
+++ b/references_cache/DOI_10.1007_s44162-024-00055-w.md
@@ -1,0 +1,35 @@
+---
+reference_id: "DOI:10.1007/s44162-024-00055-w"
+title: A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+authors:
+- Judit M. Perez Ortiz
+- Karthik Muthusamy
+- W. Oliver Tobin
+- Ralitza Gavrilova
+- Margot A. Cousin
+- Radhika Dhamija
+journal: Journal of Rare Diseases
+year: '2024'
+doi: 10.1007/s44162-024-00055-w
+content_type: abstract_only
+---
+
+# A retrospective review of LMNB1-related autosomal dominant leukodystrophy
+**Authors:** Judit M. Perez Ortiz, Karthik Muthusamy, W. Oliver Tobin, Ralitza Gavrilova, Margot A. Cousin, Radhika Dhamija
+**Journal:** Journal of Rare Diseases (2024)
+**DOI:** [10.1007/s44162-024-00055-w](https://doi.org/10.1007/s44162-024-00055-w)
+
+## Content
+
+Abstract
+Introduction
+LMNB1-related autosomal dominant leukodystrophy (ADLD) is a slowly progressive neurodegenerative disorder caused by overexpression of LMNB1. We retrospectively reviewed charts of all ADLD patients seen at Mayo Clinic.
+
+Methods
+All available data from molecularly confirmed ADLD patients was reviewed.
+
+Results
+Of eight patients identified, three were male. Age at symptom onset ranged from 33 to 64 years. In males, the first symptom was erectile dysfunction (2/3) or neurogenic bladder (1/3) and, in females, weakness (3/5), bladder dysfunction (2/5), or depression (1/5). Diagnostic delay from symptom onset was a median of 6 (IQR 2.3–10) years. Other reported symptoms included cognitive difficulties (8/8), fatigue (7/8), sleep issues (4/8), mood disturbances (5/8), tremor (4/8), and migraine (4/8). Family history was positive in 6. All eight patients had LMNB1 duplication. Eighteen brain MRIs were reviewed from 7 patients. All showed symmetric confluent T2W deep cerebral and periventricular white matter hyperintensities with involvement of the posterior limb of the internal capsule, corpus callosum, corticospinal tract in brain stem, and superior and middle cerebellar peduncles. Seven spine MRIs from six patients showed moderate diffuse atrophy of the spinal cord.
+
+Conclusion
+Typical clinical symptoms and characteristic MRI changes should prompt genetic testing for ADLD.

--- a/references_cache/PMID_25701871.md
+++ b/references_cache/PMID_25701871.md
@@ -1,0 +1,112 @@
+---
+reference_id: "PMID:25701871"
+title: "A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD)."
+authors:
+- Giorgio E
+- Robyr D
+- Spielmann M
+- Ferrero E
+- Di Gregorio E
+- Imperiale D
+- Vaula G
+- Stamoulis G
+- Santoni F
+- Atzori C
+- Gasparini L
+- Ferrera D
+- Canale C
+- Guipponi M
+- Pennacchio LA
+- Antonarakis SE
+- Brussino A
+- Brusco A
+journal: Hum Mol Genet
+year: '2015'
+doi: 10.1093/hmg/ddv065
+keywords:
+- Animals
+- Base Sequence
+- "Cells, Cultured"
+- DNA Mutational Analysis
+- "Enhancer Elements, Genetic"
+- Female
+- Gene Expression
+- Gene Expression Regulation
+- Genetic Association Studies
+- Humans
+- "Lamin Type B/genetics, metabolism"
+- Male
+- "Mice, Transgenic"
+- Middle Aged
+- Molecular Sequence Data
+- Pedigree
+- Pelizaeus-Merzbacher Disease/genetics
+- Sequence Deletion
+content_type: abstract_only
+---
+
+# A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (ADLD).
+**Authors:** Giorgio E, Robyr D, Spielmann M, Ferrero E, Di Gregorio E, Imperiale D, Vaula G, Stamoulis G, Santoni F, Atzori C, Gasparini L, Ferrera D, Canale C, Guipponi M, Pennacchio LA, Antonarakis SE, Brussino A, Brusco A
+**Journal:** Hum Mol Genet (2015)
+**DOI:** [10.1093/hmg/ddv065](https://doi.org/10.1093/hmg/ddv065)
+
+## Content
+
+1. Hum Mol Genet. 2015 Jun 1;24(11):3143-54. doi: 10.1093/hmg/ddv065. Epub 2015
+Feb  20.
+
+A large genomic deletion leads to enhancer adoption by the lamin B1 gene: a 
+second path to autosomal dominant adult-onset demyelinating leukodystrophy 
+(ADLD).
+
+Giorgio E(1), Robyr D(2), Spielmann M(3), Ferrero E(1), Di Gregorio E(4), 
+Imperiale D(5), Vaula G(6), Stamoulis G(2), Santoni F(2), Atzori C(5), Gasparini 
+L(7), Ferrera D(7), Canale C(8), Guipponi M(2), Pennacchio LA(9), Antonarakis 
+SE(2), Brussino A(1), Brusco A(10).
+
+Author information:
+(1)Department of Medical Sciences, University of Torino, via Santena, 19, Torino 
+10126, Italy.
+(2)Department of Genetic Medicine and Development, University of Geneva Medical 
+School, Geneva 1211, Switzerland.
+(3)Max Planck Institute for Molecular Genetics, Ihnestr. 63-73, Berlin 14195, 
+Germany.
+(4)Department of Medical Sciences, University of Torino, via Santena, 19, Torino 
+10126, Italy Medical Genetics Unit and.
+(5)Centro Regionale Malattie Da Prioni - Domp (ASLTO2), Torino 10144, Italy.
+(6)Department of Neurology, Città della Salute e della Scienza University 
+Hospital, Torino 10126, Italy.
+(7)Department of Neuroscience and Brain Technologies and.
+(8)Department of Nanophysics, Istituto Italiano di Tecnologia, Genoa 16163, 
+Italy and.
+(9)Genomics Division, Lawrence Berkeley National Laboratory, MS 84-171, 
+Berkeley, CA 9472, USA.
+(10)Department of Medical Sciences, University of Torino, via Santena, 19, 
+Torino 10126, Italy Medical Genetics Unit and alfredo.brusco@unito.it.
+
+Chromosomal rearrangements with duplication of the lamin B1 (LMNB1) gene 
+underlie autosomal dominant adult-onset demyelinating leukodystrophy (ADLD), a 
+rare neurological disorder in which overexpression of LMNB1 causes progressive 
+central nervous system demyelination. However, we previously reported an ADLD 
+family (ADLD-1-TO) without evidence of duplication or other mutation in LMNB1 
+despite linkage to the LMNB1 locus and lamin B1 overexpression. By custom 
+array-CGH, we further investigated this family and report here that patients 
+carry a large (∼660 kb) heterozygous deletion that begins 66 kb upstream of the 
+LMNB1 promoter. Lamin B1 overexpression was confirmed in further ADLD-1-TO 
+tissues and in a postmortem brain sample, where lamin B1 was increased in the 
+frontal lobe. Through parallel studies, we investigated both loss of genetic 
+material and chromosomal rearrangement as possible causes of LMNB1 
+overexpression, and found that ADLD-1-TO plausibly results from an enhancer 
+adoption mechanism. The deletion eliminates a genome topological domain 
+boundary, allowing normally forbidden interactions between at least three 
+forebrain-directed enhancers and the LMNB1 promoter, in line with the observed 
+mainly cerebral localization of lamin B1 overexpression and myelin degeneration. 
+This second route to LMNB1 overexpression and ADLD is a new example of the 
+relevance of regulatory landscape modifications in determining Mendelian 
+phenotypes.
+
+© The Author 2015. Published by Oxford University Press.
+
+DOI: 10.1093/hmg/ddv065
+PMCID: PMC4424952
+PMID: 25701871 [Indexed for MEDLINE]

--- a/references_cache/PMID_26053668.md
+++ b/references_cache/PMID_26053668.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:26053668"
+title: "LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course."
+authors:
+- Finnsson J
+- Sundblom J
+- Dahl N
+- Melberg A
+- Raininko R
+journal: Ann Neurol
+year: '2015'
+doi: 10.1002/ana.24452
+keywords:
+- Adult
+- Aged
+- Brain/diagnostic imaging
+- Female
+- Humans
+- Lamin Type B/genetics
+- Longitudinal Studies
+- Male
+- Middle Aged
+- "Pelizaeus-Merzbacher Disease/diagnostic imaging, genetics, mortality"
+- Radiography
+- Spinal Cord/diagnostic imaging
+- Survival Rate/trends
+content_type: abstract_only
+---
+
+# LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological course.
+**Authors:** Finnsson J, Sundblom J, Dahl N, Melberg A, Raininko R
+**Journal:** Ann Neurol (2015)
+**DOI:** [10.1002/ana.24452](https://doi.org/10.1002/ana.24452)
+
+## Content
+
+1. Ann Neurol. 2015 Sep;78(3):412-25. doi: 10.1002/ana.24452. Epub 2015 Jul 27.
+
+LMNB1-related autosomal-dominant leukodystrophy: Clinical and radiological 
+course.
+
+Finnsson J(1), Sundblom J(2), Dahl N(3), Melberg A(2), Raininko R(1).
+
+Author information:
+(1)Department of Radiology, Uppsala University, Uppsala, Sweden.
+(2)Department of Neuroscience, Neurology, Uppsala University, Uppsala, Sweden.
+(3)Department of Immunology, Genetics and Pathology, Science for Life 
+Laboratory, Uppsala University, Uppsala, Sweden.
+
+OBJECTIVE: Duplication of the LMNB1 gene encoding lamin B1 causes adult-onset 
+autosomal-dominant leukodystrophy (ADLD) starting with autonomic symptoms, which 
+are followed by pyramidal signs and ataxia. Magnetic resonance imaging (MRI) of 
+the brain reveals characteristic findings. This is the first longitudinal study 
+on this disease. Our objective is to describe the natural clinical and 
+radiological course of LMNB1-related ADLD.
+METHODS: Twenty-three subjects in two families with LMNB1 duplications were 
+studied over two decades with clinical assessment and MRI of the brain and 
+spinal cord. They were 29 to 70 years old at their first MRI. Repeated MRIs were 
+performed in 14 subjects over a time period of up to 17 years.
+RESULTS: Pathological MRI findings were found in the brain and spinal cord in 
+all examinations (i.e., even preceding clinical symptoms). MRI changes and 
+clinical symptoms progressed in a definite order. Autonomic dysfunction appeared 
+in the fifth to sixth decade, preceding or together with gait and coordination 
+difficulties. Motor signs developed ascending from spastic paraplegia to 
+tetraplegia and pseudobulbar palsy in the seventh decade. There were clinical, 
+radiological, and neurophysiological signs of myelopathy. Survival lasted more 
+than two decades after clinical onset.
+INTERPRETATION: LMNB1-related ADLD is a slowly progressive neurological disease. 
+MRI abnormalities of the brain and spinal cord can precede clinical symptoms by 
+more than a decade and are extensive in all symptomatic patients. Spinal cord 
+involvement is a likely contributing factor to early autonomic symptoms and 
+spastic paraplegia.
+
+© 2015 American Neurological Association.
+
+DOI: 10.1002/ana.24452
+PMCID: PMC5054845
+PMID: 26053668 [Indexed for MEDLINE]

--- a/references_cache/PMID_28769756.md
+++ b/references_cache/PMID_28769756.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:28769756"
+title: "An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis."
+authors:
+- Dai Y
+- Ma Y
+- Li S
+- Banerjee S
+- Liang S
+- Liu Q
+- Yang Y
+- Peng B
+- Cui L
+- Jin L
+journal: Front Mol Neurosci
+year: '2017'
+doi: 10.3389/fnmol.2017.00215
+content_type: abstract_only
+---
+
+# An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis.
+**Authors:** Dai Y, Ma Y, Li S, Banerjee S, Liang S, Liu Q, Yang Y, Peng B, Cui L, Jin L
+**Journal:** Front Mol Neurosci (2017)
+**DOI:** [10.3389/fnmol.2017.00215](https://doi.org/10.3389/fnmol.2017.00215)
+
+## Content
+
+1. Front Mol Neurosci. 2017 Jul 18;10:215. doi: 10.3389/fnmol.2017.00215. 
+eCollection 2017.
+
+An LMNB1 Duplication Caused Adult-Onset Autosomal Dominant Leukodystrophy in 
+Chinese Family: Clinical Manifestations, Neuroradiology and Genetic Diagnosis.
+
+Dai Y(1), Ma Y(2), Li S(1), Banerjee S(3), Liang S(4), Liu Q(1), Yang Y(1), Peng 
+B(1), Cui L(1)(5), Jin L(1).
+
+Author information:
+(1)Department of Neurology, Peking Union Medical College Hospital, Chinese 
+Academy of Medical SciencesBeijing, China.
+(2)Department of Neurology, Suide Branch Hospital, Yulin First HospitalYulin, 
+China.
+(3)Department of Cell Biology and Medical Genetics, School of Medicine, Zhejiang 
+UniversityHangzhou, China.
+(4)School of Life Science and Biopharmaceutical, Guangdong Pharmaceutical 
+UniversityGuangzhou, China.
+(5)Neurosciences Center, Chinese Academy of Medical SciencesBeijing, China.
+
+Autosomal dominant adult-onset demyelinating leukodystrophy (ADLD) is a very 
+rare neurological disorder featured with late onset, slowly progressive central 
+nervous system demyelination. Duplication or over expression of the lamin B1 
+(LMNB1) gene causes ADLD. In this study, we undertook a comprehensive clinical 
+evaluation and genetic detection for a Chinese family with ADLD. The proband is 
+a 52-year old man manifested with autonomic abnormalities, pyramidal tract 
+dysfunction. MRI brain scan identified bilateral symmetric white matter (WM) 
+hyper-intensities in periventricular and semi-oval WM, cerebral peduncles and 
+middle cerebellar peduncles. The proband has a positive autosomal dominant 
+family history with similar clinical manifestations with a trend of genetic 
+anticipation. In order to understand the genetic cause of the disease in this 
+family, target exome capture based next generation sequencing has been done, but 
+no causative variants or possibly pathogenic variants has been identified. 
+However, Multiplex ligand-dependent probe amplification (MLPA) showed whole 
+duplication of LMNB1 gene which is co-segregated with the disease phenotype in 
+this family. This is the first genetically confirmed LMNB1 associated ADLD 
+pedigree from China.
+
+DOI: 10.3389/fnmol.2017.00215
+PMCID: PMC5513940
+PMID: 28769756

--- a/references_cache/PMID_31143934.md
+++ b/references_cache/PMID_31143934.md
@@ -1,0 +1,110 @@
+---
+reference_id: "PMID:31143934"
+title: "Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy."
+authors:
+- Giorgio E
+- Lorenzati M
+- Rivetti di Val Cervo P
+- Brussino A
+- Cernigoj M
+- Della Sala E
+- Bartoletti Stella A
+- Ferrero M
+- Caiazzo M
+- Capellari S
+- Cortelli P
+- Conti L
+- Cattaneo E
+- Buffo A
+- Brusco A
+journal: Brain
+year: '2019'
+doi: 10.1093/brain/awz139
+keywords:
+- Alleles
+- Animals
+- Case-Control Studies
+- "Cells, Cultured"
+- Fibroblasts/drug effects
+- Gene Duplication/drug effects
+- Gene Silencing
+- "Genetic Diseases, Inborn/drug therapy"
+- Genetic Vectors
+- Humans
+- Lamin Type B/metabolism
+- Lentivirus
+- Neurons/metabolism
+- Pelizaeus-Merzbacher Disease/drug therapy
+- "RNA, Small Interfering/therapeutic use"
+- Rats
+content_type: abstract_only
+---
+
+# Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy.
+**Authors:** Giorgio E, Lorenzati M, Rivetti di Val Cervo P, Brussino A, Cernigoj M, Della Sala E, Bartoletti Stella A, Ferrero M, Caiazzo M, Capellari S, Cortelli P, Conti L, Cattaneo E, Buffo A, Brusco A
+**Journal:** Brain (2019)
+**DOI:** [10.1093/brain/awz139](https://doi.org/10.1093/brain/awz139)
+
+## Content
+
+1. Brain. 2019 Jul 1;142(7):1905-1920. doi: 10.1093/brain/awz139.
+
+Allele-specific silencing as treatment for gene duplication disorders: 
+proof-of-principle in autosomal dominant leukodystrophy.
+
+Giorgio E(1), Lorenzati M(2), Rivetti di Val Cervo P(3), Brussino A(1), Cernigoj 
+M(3), Della Sala E(1), Bartoletti Stella A(4), Ferrero M(1), Caiazzo M(5)(6), 
+Capellari S(4)(7), Cortelli P(4)(7), Conti L(8), Cattaneo E(3)(9), Buffo A(2), 
+Brusco A(1)(10).
+
+Author information:
+(1)University of Torino, Department of Medical Sciences, Torino, Italy.
+(2)University of Torino, Department of Neuroscience Rita Levi Montalcini and 
+Neuroscience Institute Cavalieri Ottolenghi (NICO), Orbassano, Torino, Italy.
+(3)University of Milan, Department of Biosciences, Laboratory of Stem Cell 
+Biology and Pharmacology of Neurodegenerative Diseases, Milan, Italy.
+(4)IRCCS Istituto delle Scienze Neurologiche di Bologna, Bellaria Hospital, 
+Bologna, Italy.
+(5)Department of Pharmaceutics, Utrecht Institute for Pharmaceutical Sciences 
+(UIPS), Utrecht University, Universiteitsweg 99, CG, Utrecht, The Netherlands.
+(6)Department of Molecular Medicine and Medical Biotechnology, University of 
+Naples 'Federico II', Naples, Italy.
+(7)University of Bologna, Department of Biomedical and Neuromotor Sciences, 
+Bologna, Italy.
+(8)University of Trento, Centre for Integrative Biology (CIBIO), Laboratory of 
+Computational Oncology, Trento, Italy.
+(9)National Institute of Molecular Genetics (INGM) Romeo and Enrica Invernizzi, 
+Milano, Italy.
+(10)Città della Salute e della Scienza University Hospital, Medical Genetics 
+Unit, Torino, Italy.
+
+Allele-specific silencing by RNA interference (ASP-siRNA) holds promise as a 
+therapeutic strategy for downregulating a single mutant allele with minimal 
+suppression of the corresponding wild-type allele. This approach has been 
+effectively used to target autosomal dominant mutations and single nucleotide 
+polymorphisms linked with aberrantly expanded trinucleotide repeats. Here, we 
+propose ASP-siRNA as a preferable choice to target duplicated disease genes, 
+avoiding potentially harmful excessive downregulation. As a proof-of-concept, we 
+studied autosomal dominant adult-onset demyelinating leukodystrophy (ADLD) due 
+to lamin B1 (LMNB1) duplication, a hereditary, progressive and fatal disorder 
+affecting myelin in the CNS. Using a reporter system, we screened the most 
+efficient ASP-siRNAs preferentially targeting one of the alleles at rs1051644 
+(average minor allele frequency: 0.45) located in the 3' untranslated region of 
+the gene. We identified four siRNAs with a high efficacy and allele-specificity, 
+which were tested in ADLD patient-derived fibroblasts. Three of the small 
+interfering RNAs were highly selective for the target allele and restored both 
+LMNB1 mRNA and protein levels close to control levels. Furthermore, small 
+interfering RNA treatment abrogates the ADLD-specific phenotypes in fibroblasts 
+and in two disease-relevant cellular models: murine oligodendrocytes 
+overexpressing human LMNB1, and neurons directly reprogrammed from patients' 
+fibroblasts. In conclusion, we demonstrated that ASP-silencing by RNA 
+interference is a suitable and promising therapeutic option for ADLD. Moreover, 
+our results have a broad translational value extending to several pathological 
+conditions linked to gene-gain in copy number variations.
+
+© The Author(s) (2019). Published by Oxford University Press on behalf of the 
+Guarantors of Brain. All rights reserved. For Permissions, please email: 
+journals.permissions@oup.com.
+
+DOI: 10.1093/brain/awz139
+PMID: 31143934 [Indexed for MEDLINE]

--- a/references_cache/PMID_37450245.md
+++ b/references_cache/PMID_37450245.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:37450245"
+title: "Understanding the Ultra-Rare Disease Autosomal Dominant Leukodystrophy: an Updated Review on Morpho-Functional Alterations Found in Experimental Models."
+authors:
+- Neri I
+- Ramazzotti G
+- Mongiorgi S
+- Rusciano I
+- Bugiani M
+- Conti L
+- Cousin M
+- Giorgio E
+- Padiath QS
+- Vaula G
+- Cortelli P
+- Manzoli L
+- Ratti S
+journal: Mol Neurobiol
+year: '2023'
+doi: 10.1007/s12035-023-03461-1
+keywords:
+- Humans
+- Rare Diseases
+- Demyelinating Diseases/metabolism
+- Brain/metabolism
+- Lysosomal Storage Diseases
+- Neurodegenerative Diseases
+- "Models, Theoretical"
+content_type: abstract_only
+---
+
+# Understanding the Ultra-Rare Disease Autosomal Dominant Leukodystrophy: an Updated Review on Morpho-Functional Alterations Found in Experimental Models.
+**Authors:** Neri I, Ramazzotti G, Mongiorgi S, Rusciano I, Bugiani M, Conti L, Cousin M, Giorgio E, Padiath QS, Vaula G, Cortelli P, Manzoli L, Ratti S
+**Journal:** Mol Neurobiol (2023)
+**DOI:** [10.1007/s12035-023-03461-1](https://doi.org/10.1007/s12035-023-03461-1)
+
+## Content
+
+1. Mol Neurobiol. 2023 Nov;60(11):6362-6372. doi: 10.1007/s12035-023-03461-1.
+Epub  2023 Jul 14.
+
+Understanding the Ultra-Rare Disease Autosomal Dominant Leukodystrophy: an 
+Updated Review on Morpho-Functional Alterations Found in Experimental Models.
+
+Neri I(1), Ramazzotti G(1), Mongiorgi S(1), Rusciano I(1), Bugiani M(2), Conti 
+L(3), Cousin M(4), Giorgio E(5)(6), Padiath QS(7), Vaula G(8), Cortelli 
+P(9)(10), Manzoli L(1), Ratti S(11).
+
+Author information:
+(1)Cellular Signalling Laboratory, Anatomy Centre, Department of Biomedical and 
+Neuromotor Sciences (DIBINEM), University of Bologna, 40126, Bologna, Italy.
+(2)Department of Pathology, Amsterdam University Medical Centers, Vrije 
+Universiteit and Amsterdam Neuroscience, 1105, Amsterdam, The Netherlands.
+(3)Department of Cellular, Computational, and Integrative Biology (CIBIO), 
+Università Degli Studi Di Trento, 38123, Povo-Trento, Italy.
+(4)Center for Individualized Medicine and Department of Clinical Genomics, Mayo 
+Clinic, Rochester, MN, 55905, USA.
+(5)Department of Molecular Medicine, University of Pavia, 27100, Pavia, Italy.
+(6)Medical Genetics Unit, IRCCS Mondino Foundation, 27100, Pavia, Italy.
+(7)Department of Human Genetics, Graduate School of Public Health, University of 
+Pittsburgh, Pittsburgh, PA, 15261, USA.
+(8)Department of Neuroscience, Azienda Ospedaliera-Universitaria Città della 
+Salute e della Scienza, 10126, Turin, Italy.
+(9)IRCCS, Istituto Di Scienze Neurologiche Di Bologna, 40139, Bologna, Italy.
+(10)Department of Biomedical and Neuromotor Sciences (DIBINEM), University of 
+Bologna, 40126 , Bologna, Italy.
+(11)Cellular Signalling Laboratory, Anatomy Centre, Department of Biomedical and 
+Neuromotor Sciences (DIBINEM), University of Bologna, 40126, Bologna, Italy. 
+stefano.ratti@unibo.it.
+
+Autosomal dominant leukodystrophy (ADLD) is an ultra-rare, slowly progressive, 
+and fatal neurodegenerative disorder associated with the loss of white matter in 
+the central nervous system (CNS). Several years after its first clinical 
+description, ADLD was found to be caused by coding and non-coding variants in 
+the LMNB1 gene that cause its overexpression in at least the brain of patients. 
+LMNB1 encodes for Lamin B1, a protein of the nuclear lamina. Lamin B1 regulates 
+many cellular processes such as DNA replication, chromatin organization, and 
+senescence. However, its functions have not been fully characterized yet. 
+Nevertheless, Lamin B1 together with the other lamins that constitute the 
+nuclear lamina has firstly the key role of maintaining the nuclear structure. 
+Being the nucleus a dynamic system subject to both biochemical and mechanical 
+regulation, it is conceivable that changes to its structural homeostasis might 
+translate into functional alterations. Under this light, this review aims at 
+describing the pieces of evidence that to date have been obtained regarding the 
+effects of LMNB1 overexpression on cellular morphology and functionality. 
+Moreover, we suggest that further investigation on ADLD morpho-functional 
+consequences is essential to better understand this complex disease and, 
+possibly, other neurological disorders affecting CNS myelination.
+
+© 2023. The Author(s).
+
+DOI: 10.1007/s12035-023-03461-1
+PMCID: PMC10533580
+PMID: 37450245 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_37564735.md
+++ b/references_cache/PMID_37564735.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:37564735"
+title: "Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions."
+authors:
+- Muthusamy K
+- Sivadasan A
+- Dixon L
+- Sudhakar S
+- Thomas M
+- Danda S
+- Wszolek ZK
+- Wierenga K
+- Dhamija R
+- Gavrilova R
+journal: Front Neurol
+year: '2023'
+doi: 10.3389/fneur.2023.1219324
+content_type: abstract_only
+---
+
+# Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions.
+**Authors:** Muthusamy K, Sivadasan A, Dixon L, Sudhakar S, Thomas M, Danda S, Wszolek ZK, Wierenga K, Dhamija R, Gavrilova R
+**Journal:** Front Neurol (2023)
+**DOI:** [10.3389/fneur.2023.1219324](https://doi.org/10.3389/fneur.2023.1219324)
+
+## Content
+
+1. Front Neurol. 2023 Jul 26;14:1219324. doi: 10.3389/fneur.2023.1219324. 
+eCollection 2023.
+
+Adult-onset leukodystrophies: a practical guide, recent treatment updates, and 
+future directions.
+
+Muthusamy K(1), Sivadasan A(2), Dixon L(3), Sudhakar S(4), Thomas M(2), Danda 
+S(5), Wszolek ZK(6), Wierenga K(1), Dhamija R(7), Gavrilova R(8).
+
+Author information:
+(1)Department of Clinical Genomics, Mayo Clinic, Jacksonville, FL, United 
+States.
+(2)Department of Neurological Sciences, Christian Medical College, Tamil Nadu, 
+Vellore, India.
+(3)Department of Radiology, Imperial College, NHS Trust, London, United Kingdom.
+(4)Department of Radiology, Great Ormond Street Hospital, London, United 
+Kingdom.
+(5)Department of Medical Genetics, Christian Medical College, Vellore, Tamil 
+Nadu, India.
+(6)Department of Neurology, Mayo Clinic, Jacksonville, FL, United States.
+(7)Department of Clinical Genomics and Neurology, Mayo Clinic, Phoenix, AZ, 
+United States.
+(8)Department of Clinical Genomics and Neurology, Mayo Clinic, Rochester, MN, 
+United States.
+
+Adult-onset leukodystrophies though individually rare are not uncommon. This 
+group includes several disorders with isolated adult presentations, as well as 
+several childhood leukodystrophies with attenuated phenotypes that present at a 
+later age. Misdiagnoses often occur due to the clinical and radiological overlap 
+with common acquired disorders such as infectious, immune, inflammatory, 
+vascular, metabolic, and toxic etiologies. Increased prevalence of non-specific 
+white matter changes in adult population poses challenges during diagnostic 
+considerations. Clinico-radiological spectrum and molecular landscape of 
+adult-onset leukodystrophies have not been completely elucidated at this time. 
+Diagnostic approach is less well-standardized when compared to the childhood 
+counterpart. Absence of family history and reduced penetrance in certain 
+disorders frequently create a dilemma. Comprehensive evaluation and molecular 
+confirmation when available helps in prognostication, early initiation of 
+treatment in certain disorders, enrollment in clinical trials, and provides 
+valuable information for the family for reproductive counseling. In this review 
+article, we aimed to formulate an approach to adult-onset leukodystrophies that 
+will be useful in routine practice, discuss common adult-onset leukodystrophies 
+with usual and unusual presentations, neuroimaging findings, recent advances in 
+treatment, acquired mimics, and provide an algorithm for comprehensive clinical, 
+radiological, and genetic evaluation that will facilitate early diagnosis and 
+consider active treatment options when available. A high index of suspicion, 
+awareness of the clinico-radiological presentations, and comprehensive genetic 
+evaluation are paramount because treatment options are available for several 
+disorders when diagnosed early in the disease course.
+
+Copyright © 2023 Muthusamy, Sivadasan, Dixon, Sudhakar, Thomas, Danda, Wszolek, 
+Wierenga, Dhamija and Gavrilova.
+
+DOI: 10.3389/fneur.2023.1219324
+PMCID: PMC10410460
+PMID: 37564735
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_40046440.md
+++ b/references_cache/PMID_40046440.md
@@ -1,0 +1,66 @@
+---
+reference_id: "PMID:40046440"
+title: "Case report: LMNB1 duplication-mediated autosomal dominant adult leukodystrophy in a Chinese family and literature review of Chinese patients."
+authors:
+- Jiang Y
+- Han L
+- Li Y
+- Zhao Z
+- Xin Z
+- Zhu Z
+journal: Front Neurosci
+year: '2025'
+doi: 10.3389/fnins.2025.1531593
+content_type: abstract_only
+---
+
+# Case report: LMNB1 duplication-mediated autosomal dominant adult leukodystrophy in a Chinese family and literature review of Chinese patients.
+**Authors:** Jiang Y, Han L, Li Y, Zhao Z, Xin Z, Zhu Z
+**Journal:** Front Neurosci (2025)
+**DOI:** [10.3389/fnins.2025.1531593](https://doi.org/10.3389/fnins.2025.1531593)
+
+## Content
+
+1. Front Neurosci. 2025 Feb 19;19:1531593. doi: 10.3389/fnins.2025.1531593. 
+eCollection 2025.
+
+Case report: LMNB1 duplication-mediated autosomal dominant adult leukodystrophy 
+in a Chinese family and literature review of Chinese patients.
+
+Jiang Y(#)(1), Han L(#)(2), Li Y(1), Zhao Z(3), Xin Z(3), Zhu Z(1)(3).
+
+Author information:
+(1)Clinical College of Neurology, Neurosurgery, and Neurorehabilitation, Tianjin 
+Medical University, Tianjin, China.
+(2)Department of Electroencephalogram, Tianjin Huanhu Hospital, Tianjin, China.
+(3)Department of Neurology, Tianjin Huanhu Hospital, Tianjin, China.
+(#)Contributed equally
+
+Adult-onset autosomal dominant leukodystrophy (ADLD) is a rare, slowly 
+progressive, and fatal neurodegenerative disorder characterized by central 
+nervous system white matter loss due to LMNB1 gene abnormalities encoding 
+laminB1. However, not all LMNB1 mutations lead to ADLD. Currently, two genetic 
+alterations have been identified in association with the pathogenesis of ADLD: 
+LMNB1 gene tandem duplication and LMNB1 gene upstream deletions. We report a 
+case of a 60-year-old man diagnosed with ADLD, with pyramidal tract dysfunction 
+and autonomic abnormalities as the main clinical manifestations. MRI revealed 
+bilateral symmetric high signal intensities in the white matter of the medulla 
+oblongata, middle cerebellar peduncles, cerebral peduncle, periventricular white 
+matter, centrum semi vale, and the pressure region of the corpus callosum. Whole 
+exome sequencing results indicated 73.6Kb duplicate copy number variation 
+signals in the 5q23.2 region of the proband's chromosome. The Multiplex 
+ligation-dependent probe amplification (MLPA) experiment results indicate 
+recurrent mutations across all exons (exon1-11) of the LMNB1 gene. This is the 
+eighth ADLD pedigree from China. We conducted a literature review of all ADLD 
+pedigrees in China and summarized the characteristics of Chinese patients with 
+ADLD to raise awareness of ADLD disease.
+
+Copyright © 2025 Jiang, Han, Li, Zhao, Xin and Zhu.
+
+DOI: 10.3389/fnins.2025.1531593
+PMCID: PMC11880262
+PMID: 40046440
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/clinicaltrials_NCT06816498.md
+++ b/references_cache/clinicaltrials_NCT06816498.md
@@ -1,5 +1,5 @@
 ---
-reference_id: clinicaltrials:NCT06816498
+reference_id: "clinicaltrials:NCT06816498"
 title: "An Open-label, Single-center, Single-participant Study of an Experimental Antisense Oligonucleotide Treatment for a Patient With LMNB1 Mutation Associated Autosomal Dominant Leukodystrophy (ADLD)"
 content_type: summary
 ---

--- a/references_cache/clinicaltrials_NCT06816498.md
+++ b/references_cache/clinicaltrials_NCT06816498.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT06816498
+title: "An Open-label, Single-center, Single-participant Study of an Experimental Antisense Oligonucleotide Treatment for a Patient With LMNB1 Mutation Associated Autosomal Dominant Leukodystrophy (ADLD)"
+content_type: summary
+---
+
+# An Open-label, Single-center, Single-participant Study of an Experimental Antisense Oligonucleotide Treatment for a Patient With LMNB1 Mutation Associated Autosomal Dominant Leukodystrophy (ADLD)
+
+## Content
+
+This research project entails delivery of a personalized antisense oligonucleotide (ASO) drug designed for a single participant with Autosomal Dominant Leukodystrophy (ADLD) due to LMNB1 mutation

--- a/research/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy-deep-research-falcon.md
+++ b/research/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy-deep-research-falcon.md
@@ -1,0 +1,1306 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-05T23:15:34.814795'
+end_time: '2026-05-05T23:43:49.120226'
+duration_seconds: 1694.31
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy
+  mondo_id: ''
+  category: Neurodegenerative Disease
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 54
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Neurodegenerative Disease
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Neurodegenerative Disease
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Disease Characteristics Research Report
+### Target disease
+**Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy (ADLD; LMNB1-related autosomal dominant leukodystrophy)** — a rare, progressive adult-onset leukodystrophy caused by **LMNB1 overexpression**, leading to **central nervous system (CNS) demyelination** with a characteristic symmetric MRI pattern and prominent autonomic dysfunction. (ortiz2024aretrospectivereview pages 1-2, neri2023understandingtheultrarare pages 1-2)
+
+| Disease / synonyms | Key identifiers explicitly stated | Causal gene & mechanism | Typical age of onset | Core clinical features | Hallmark MRI findings | Natural history / prognosis | Source year & DOI URL | Best supporting citations |
+|---|---|---|---|---|---|---|---|---|
+| Adult-onset autosomal dominant demyelinating leukodystrophy (ADLD); LMNB1-related autosomal dominant leukodystrophy; adult-onset autosomal dominant leukodystrophy with autonomic symptoms | OMIM/MIM #169500 explicitly stated | **LMNB1** (5q23.2); heterozygous **LMNB1 duplication** causing Lamin B1 overexpression and CNS demyelination | Usually 4th-6th decade; mean/median onset around late 30s to 40s | Early autonomic dysfunction (bladder, erectile dysfunction, orthostatic hypotension, sweating abnormalities), then spasticity/pyramidal signs, ataxia/tremor, later cognitive decline | Symmetric confluent T2 white-matter hyperintensities involving deep/periventricular cerebral WM, corticospinal tracts, posterior limb of internal capsule, corpus callosum, brainstem, middle/superior cerebellar peduncles; spinal cord atrophy/thinning | Slowly progressive, fatal/life-limiting; survival often 10-20+ years after onset | 2024, https://doi.org/10.1007/s44162-024-00055-w ; 2019, https://doi.org/10.1136/jnnp-2018-319481 ; 2017, https://doi.org/10.3389/fnmol.2017.00215 | (ortiz2024aretrospectivereview pages 1-2, ortiz2024aretrospectivereview pages 2-3, dai2017anlmnb1duplication pages 1-2, lin2011adultonsetautosomaldominant pages 1-2) |
+| LMNB1-related ADLD due to **upstream noncoding deletion** | OMIM #169500 explicitly stated | **LMNB1**; large heterozygous **upstream deletion** (e.g., ~660 kb) removes a topological domain boundary, causing **enhancer adoption** and LMNB1 overexpression | 4th-5th decade typically; reported deletion cases 32-52 years | Progressive leukodystrophy with weakness, spasticity, hypophonia/dysarthria, cerebellar dysfunction; compared with duplication cases, may show less early dysautonomia and less cerebellar/spinal involvement | Widespread white-matter alterations; corticospinal tract involvement from upper frontal lobes to cerebral peduncles; spinal cord may be relatively less affected than duplication cases in some families | Fatal progressive course; death often 10-20 years after onset | 2015, https://doi.org/10.1093/hmg/ddv065 ; 2019, https://doi.org/10.1212/nxg.0000000000000305 | (giorgio2015alargegenomic pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2) |
+| Longitudinal LMNB1-duplication ADLD natural history | Not focused on identifier; disease is LMNB1-related ADLD | **LMNB1 duplication** | Symptoms usually begin in 5th-6th decade; MRI may be abnormal >10 years before symptoms and as early as age 29 in asymptomatic carriers | Autonomic dysfunction often precedes motor symptoms; ascending myelopathy pattern with gait impairment, spastic paraplegia progressing to tetraplegia/pseudobulbar palsy; mild early cognitive issues, dementia late | Extensive T2 hyperintensities in cerebellar peduncles and cerebral WM with relatively spared periventricular rim early; pyramidal tract extension; all carriers showed spinal cord WM abnormalities; no gadolinium enhancement | **EDSS 6** at mean 59 ± 8 years (**11 ± 5 years** from onset); **EDSS 8** at mean 61 ± 6 years (**14 ± 4 years** from onset); interval EDSS 6→8 **5 ± 2 years**; deaths at mean 66 ± 6 years (**17 ± 6 years** from onset); median survival **18 years** | 2015, https://doi.org/10.1002/ana.24452 | (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 1-2, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 7-9) |
+| Mayo Clinic retrospective LMNB1-related ADLD cohort | No additional identifier stated in excerpt beyond disease name | All 8 patients had **LMNB1 duplication** | Onset range **33-64 years**; median onset **38.5 years**; median diagnosis age **46 years** | Cognitive difficulties **8/8**, fatigue **7/8**, mood disturbances **5/8**, tremor **4/8**, migraine **4/8**; sex-specific first symptoms included erectile dysfunction/neurogenic bladder in men and weakness/bladder dysfunction/depression in women | All reviewed brain MRIs showed symmetric confluent T2 deep cerebral/periventricular WM hyperintensities with internal capsule, corpus callosum, brainstem corticospinal tract, superior/middle cerebellar peduncle involvement; spine MRI showed moderate diffuse cord atrophy | Median diagnostic delay **6 years** (IQR 2.3-10); white-matter MRI abnormalities can predate symptoms by **9-16 years** in examples; no cure, supportive management only | 2024, https://doi.org/10.1007/s44162-024-00055-w | (ortiz2024aretrospectivereview pages 1-2, ortiz2024aretrospectivereview pages 2-3, ortiz2024aretrospectivereview pages 3-5) |
+
+
+*Table: This table condenses the core disease-defining information for LMNB1-related adult-onset autosomal dominant demyelinating leukodystrophy, including identifiers, mechanisms, phenotype, imaging, and prognosis. It is useful as a quick-reference artifact for knowledge-base population and citation tracking.*
+
+| Domain | Key points for LMNB1-related ADLD | Practical implementation / test or treatment | Source year + URL | Evidence |
+|---|---|---|---|---|
+| Diagnostic clues: clinical phenotype | Adult-onset leukodystrophy, usually 4th-5th decade; early autonomic dysfunction is typical (bladder/bowel dysfunction, orthostatic hypotension, sweating abnormalities, erectile dysfunction), followed by gait impairment, pyramidal signs/spasticity, ataxia, and later cognitive decline; women may present with motor-predominant phenotypes and cases may be mistaken for multiple sclerosis or bvFTD-spectrum disease | Suspect LMNB1-related ADLD in adults with progressive dysautonomia plus spastic-ataxic syndrome and family history suggestive of autosomal dominant inheritance | 2024: https://doi.org/10.1007/s44162-024-00055-w ; 2023: https://doi.org/10.3389/fneur.2023.1219324 | (ortiz2024aretrospectivereview pages 3-5, muthusamy2023adultonsetleukodystrophiesa pages 10-11) |
+| Diagnostic clues: hallmark MRI | Stereotyped MRI pattern: symmetric confluent T2 white-matter hyperintensities involving deep/periventricular cerebral white matter, corticospinal tracts, posterior limb of the internal capsule, corpus callosum, brainstem, and middle/superior cerebellar peduncles; relative sparing of subcortical U-fibers and periventricular rim may help; spinal cord atrophy/thinning is common; no contrast enhancement is typical | Obtain brain MRI with T2/FLAIR and spine imaging; recognize that MRI abnormalities can predate symptoms by years and may be the earliest clue | 2024: https://doi.org/10.1007/s44162-024-00055-w ; 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2015: https://doi.org/10.1002/ana.24452 | (ortiz2024aretrospectivereview pages 2-3, muthusamy2023adultonsetleukodystrophiesa pages 10-11, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7) |
+| Recommended genetic confirmation | Disease is caused by LMNB1 dosage/expression abnormalities: usually heterozygous LMNB1 duplication, rarely upstream deletion causing LMNB1 overexpression | Order targeted LMNB1 copy-number / structural-variant testing when clinicoradiologic pattern is suggestive | 2024: https://doi.org/10.1007/s44162-024-00055-w ; 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2015: https://doi.org/10.1093/hmg/ddv065 | (ortiz2024aretrospectivereview pages 3-5, muthusamy2023adultonsetleukodystrophiesa pages 10-11, giorgio2015alargegenomic pages 1-2) |
+| Genetic methods to use | Copy-number focused methods are required; literature specifically supports targeted CNV/duplication testing and notes use of MLPA, gene-targeted microarray/aCGH, capillary-array methods, qPCR/other CNV assays in adult leukodystrophy workflows; custom array-CGH identified upstream LMNB1 deletion in one family | Preferred methods: LMNB1 deletion/duplication analysis, MLPA, array-CGH/gene-targeted microarray, or other validated CNV assays; consider single-gene LMNB1 testing first if phenotype is classic | 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2024: https://doi.org/10.1007/s44162-024-00055-w ; 2015: https://doi.org/10.1093/hmg/ddv065 | (muthusamy2023adultonsetleukodystrophiesa pages 23-24, ortiz2024aretrospectivereview pages 3-5, ortiz2024aretrospectivereview pages 2-3, giorgio2015alargegenomic pages 1-2) |
+| Limitation of standard NGS | Standard short-read NGS/WES/WGS may miss LMNB1 duplications/upstream deletions and other CNV/deep intronic/complex variants; relying only on routine NGS can delay diagnosis | If exome/genome is negative but MRI/phenotype strongly suggest ADLD, reflex to CNV-focused LMNB1 testing rather than stopping workup | 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2024: https://doi.org/10.1007/s44162-024-00055-w | (muthusamy2023adultonsetleukodystrophiesa pages 10-11, ortiz2024aretrospectivereview pages 3-5, muthusamy2023adultonsetleukodystrophiesa pages 21-23) |
+| Ancillary autonomic testing | Autonomic reflex screen, tilt table, QSART, thermoregulatory sweat testing, and urodynamics often show orthostatic hypotension, anhidrosis, and bladder dysfunction | Useful both for phenotype definition and longitudinal monitoring, especially in early dysautonomia | 2024: https://doi.org/10.1007/s44162-024-00055-w | (ortiz2024aretrospectivereview pages 2-3) |
+| Ancillary electrophysiology | EMG/NCS are often normal or do not show polyneuropathy; neurophysiology may instead support central myelopathy (e.g., SSEPs, motor conduction delay in some series) | Use EMG/NCS mainly to exclude peripheral neuropathy mimics rather than to confirm ADLD | 2024: https://doi.org/10.1007/s44162-024-00055-w ; 2015: https://doi.org/10.1002/ana.24452 | (ortiz2024aretrospectivereview pages 2-3, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7) |
+| General adult leukodystrophy workflow | First exclude acquired mimics (infectious, inflammatory, autoimmune, vascular, neoplastic, toxic, metabolic), then integrate family history, exam, MRI pattern recognition, biochemical testing, and genetics; advanced MRI and periodic reinterpretation improve yield | Practical workflow: history + 3-generation pedigree -> MRI pattern review -> targeted biochemical tests for treatable mimics -> targeted CNV/single-gene testing if classic -> broader panel/WES/WGS with reanalysis if unresolved | 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2019: https://doi.org/10.1148/rg.2019180081 ; 2018: https://doi.org/10.1038/nrneurol.2017.175 | (muthusamy2023adultonsetleukodystrophiesa pages 23-24, muthusamy2023adultonsetleukodystrophiesa pages 1-2, muthusamy2023adultonsetleukodystrophiesa pages 21-23, kohler2018adulthoodleukodystrophies pages 3-4, resende2019adultleukodystrophiesa pages 1-2) |
+| Key differential: multiple sclerosis / acquired inflammatory myeloleukoencephalopathy | ADLD can mimic MS, but ADLD typically has symmetric confluent white-matter disease, prominent dysautonomia, lack of gadolinium enhancement, and spinal cord atrophy rather than inflammatory lesions; acquired causes are suggested by rapid onset, steroid responsiveness, systemic features, enhancement | Use MRI symmetry/enhancement pattern, course, and inflammatory context to separate ADLD from MS and other acquired disorders | 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2019: https://doi.org/10.1136/jnnp-2018-319481 | (muthusamy2023adultonsetleukodystrophiesa pages 10-11, lynch2019practicalapproachto pages 2-3, muthusamy2023adultonsetleukodystrophiesa pages 21-23) |
+| Key differential: AMN / X-ALD and other inherited leukodystrophies | AMN may show normal brain MRI or pyramidal-tract changes with spinal cord atrophy; AMACR deficiency shows symmetric thalamic/midbrain/pons/cerebellar-tract changes and elevated pristanic acid; CSF1R disease may have early psychiatric syndrome and punctate calcifications on CT/gradient-echo; Gordon Holmes syndrome has prominent cerebellar atrophy/endocrine clues | Distinguish with VLCFA testing, pristanic acid, CT/gradient-echo for calcifications, endocrine evaluation, and disorder-specific gene testing | 2023: https://doi.org/10.3389/fneur.2023.1219324 ; 2019: https://doi.org/10.1136/jnnp-2018-319481 | (muthusamy2023adultonsetleukodystrophiesa pages 10-11, lynch2019practicalapproachto pages 2-3) |
+| Current standard treatment | No curative or approved disease-modifying therapy; management is supportive and symptomatic | Symptom-directed care may include bladder/autonomic management, spasticity relief, physical/functional exercise, cognitive support, dietary guidance/neurotrophic support in reported case series, and multidisciplinary follow-up | 2024: https://doi.org/10.1007/s44162-024-00055-w ; 2025: https://doi.org/10.3389/fnins.2025.1531593 | (ortiz2024aretrospectivereview pages 3-5, jiang2025casereportlmnb1 pages 4-5) |
+| Investigational therapy: allele-specific RNAi | Preclinical proof-of-concept supports allele-specific RNA interference to reduce LMNB1 toward physiologic levels without over-suppression; siRNA/shRNA targeting rs1051644 restored LMNB1 mRNA/protein near control levels and improved nuclear morphology and neurite growth in fibroblasts, directly reprogrammed neurons, and oligodendrocyte models | Experimental only; supports LMNB1-lowering as a rational targeted strategy for future translation | 2019: https://doi.org/10.1093/brain/awz139 | (giorgio2019allelespecificsilencingas pages 1-6, giorgio2019allelespecificsilencingas pages 6-10, giorgio2019allelespecificsilencingas pages 17-20, giorgio2019allelespecificsilencingas pages 20-23) |
+| Investigational therapy: personalized ASO clinical trial | ClinicalTrials.gov lists a personalized antisense oligonucleotide trial for a single participant with LMNB1-duplication ADLD: nL-LMNB1-001, open-label, phase 1/2, active-not-recruiting, sponsor n-Lorem Foundation with Mayo Clinic collaboration, enrollment 1 | Endpoints at baseline and 6/12/18/24 months include gait motion analysis, 6-minute walk, 25-feet walk, neurological functioning, MRI brain atrophy; secondary measures include urodynamics, autonomic testing, and safety/tolerability | 2025 registry entry: https://clinicaltrials.gov/study/NCT06816498 | (NCT06816498 chunk 1) |
+
+
+*Table: This table summarizes how LMNB1-related ADLD is recognized and confirmed in practice, including the MRI and autonomic phenotype, the need for CNV-focused LMNB1 testing beyond standard NGS, major differential diagnoses, and the current treatment landscape from supportive care to emerging gene-silencing therapies and the personalized ASO trial NCT06816498.*
+
+---
+
+## 1. Disease information
+### 1.1 Overview (current understanding)
+ADLD is a **slowly progressive, life-limiting/fatal** adult-onset leukodystrophy characterized by **progressive CNS white-matter loss/demyelination**, typically beginning with **autonomic dysfunction** and later evolving to **spasticity/pyramidal signs and ataxia**, with **cognitive decline** occurring later in the course in many patients. (ortiz2024aretrospectivereview pages 1-2, neri2023understandingtheultrarare pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+
+A key practical diagnostic observation from longitudinal cohorts is that **MRI can become abnormal many years before symptoms**, making imaging pattern recognition a major real-world entry point for diagnosis. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7, ortiz2024aretrospectivereview pages 3-5)
+
+### 1.2 Key identifiers
+* **OMIM/MIM:** **169500** (“ADLD”) is explicitly stated in multiple primary sources. (dai2017anlmnb1duplication pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+* **Other requested identifiers (Orphanet, ICD-10/11, MeSH, MONDO):** not present in the retrieved full-text excerpts used for this report; therefore they cannot be reported here with evidence-grade citation. (ortiz2024aretrospectivereview pages 1-2, neri2023understandingtheultrarare pages 1-2)
+
+### 1.3 Synonyms / alternative names
+Synonyms used in the cited literature include:
+* “**LMNB1-related autosomal dominant leukodystrophy**” (ortiz2024aretrospectivereview pages 1-2)
+* “**Adult-onset autosomal dominant leukodystrophy with autonomic symptoms**” (santos2012adultonsetautosomaldominant pages 3-3)
+* “**Autosomal Dominant Leukodystrophy with Autonomic Disease**” (educational materials) (gosky2021assessmentanddevelopment pages 92-96)
+
+### 1.4 Evidence provenance
+The information in this report is derived primarily from:
+* **Aggregated disease-level resources:** expert reviews and structured diagnostic guides for adult leukodystrophies (2023–2024 emphasized). (neri2023understandingtheultrarare pages 1-2, muthusamy2023adultonsetleukodystrophiesa pages 10-11)
+* **Human clinical cohorts/case series:** longitudinal natural history (Finnsson 2015) and a 2024 Mayo Clinic retrospective cohort. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7, ortiz2024aretrospectivereview pages 1-2)
+* **Mechanistic/model-organism studies:** transgenic mouse and cellular models summarized in the 2023 mechanistic review. (neri2023understandingtheultrarare pages 4-6, neri2023understandingtheultrarare pages 6-7)
+
+---
+
+## 2. Etiology
+### 2.1 Disease causal factors
+ADLD is fundamentally a **genetic dosage/regulatory disorder**: both coding and non-coding structural alterations at the **LMNB1** locus converge on **LMNB1 (lamin B1) overexpression**, which is considered causal for CNS demyelination. (neri2023understandingtheultrarare pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+
+Two established pathogenic alteration classes:
+1. **Tandem duplication spanning LMNB1** (most common) → increased LMNB1 gene dosage and expression. (dai2017anlmnb1duplication pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+2. **Upstream non-coding deletions** that cause **enhancer adoption** (disrupted 3D genomic boundary permitting forebrain enhancers to activate LMNB1) → LMNB1 overexpression without LMNB1 coding duplication. (giorgio2015alargegenomic pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+
+Quantitative tissue evidence for LMNB1 overexpression includes ~2–3-fold increased LMNB1 transcripts in one upstream-deletion family, and ~7-fold increased lamin B1 protein in frontal lobe compared with control in postmortem tissue. (giorgio2015alargegenomic pages 1-2)
+
+### 2.2 Risk factors
+**Primary risk factor: autosomal dominant inheritance** of a pathogenic LMNB1 structural variant. Family history is frequently present (e.g., 6/8 in one Mayo cohort). (ortiz2024aretrospectivereview pages 1-2)
+
+Non-genetic/environmental susceptibility factors are not established in the cited sources; the disorder is best understood as genetically driven. (neri2023understandingtheultrarare pages 1-2)
+
+### 2.3 Protective factors
+No protective genetic variants or protective environmental factors were identified in the retrieved evidence. (neri2023understandingtheultrarare pages 1-2)
+
+### 2.4 Gene–environment interaction
+Not clearly established in the retrieved evidence. Some clinical observations in longitudinal cohorts include **pseudoexacerbations with heat, fever, or infections**, suggesting that environmental stressors can transiently worsen symptoms, but these do not constitute validated causal gene–environment interactions. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+
+---
+
+## 3. Phenotypes
+### 3.1 Core phenotype spectrum (human)
+Across cohorts, the most characteristic phenotype is **early autonomic dysfunction**, followed by progressive motor system involvement:
+* **Autonomic dysfunction:** neurogenic bladder/urinary urgency, orthostatic hypotension, anhidrosis/sweating abnormalities; in a longitudinal cohort, bladder dysfunction was present in **100%** and orthostatic hypotension in **77%**. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7)
+* **Pyramidal tract dysfunction:** spasticity, progressive spastic paraparesis progressing caudal→rostral in advanced disease. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+* **Cerebellar involvement:** ataxia, tremor; in a Mayo cohort tremor occurred in **4/8**. (ortiz2024aretrospectivereview pages 1-2)
+* **Cognitive/psychiatric:** cognitive difficulties were reported in **8/8** in the Mayo cohort; mood disturbances **5/8**; sleep issues **4/8**. (ortiz2024aretrospectivereview pages 1-2)
+
+### 3.2 Phenotype characteristics (age of onset, progression)
+* **Onset:** commonly in the **4th–6th decade**; 2024 Mayo cohort onset range **33–64 years**. (ortiz2024aretrospectivereview pages 1-2)
+* **Progression:** slow, insidious progression over years with increasing disability; a characteristic ascending myelopathy pattern is described in the longitudinal study. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 1-2, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+
+### 3.3 Phenotype frequencies (recent quantitative cohort)
+From an 8-patient Mayo Clinic retrospective cohort (molecularly confirmed LMNB1 duplication):
+* cognitive difficulties **8/8**
+* fatigue **7/8**
+* sleep issues **4/8**
+* mood disturbances **5/8**
+* tremor **4/8**
+* migraine **4/8**
+* family history positive **6/8**
+* diagnostic delay: median **6 years** (IQR 2.3–10)
+(ortiz2024aretrospectivereview pages 1-2)
+
+### 3.4 Quality of life impact
+Direct standardized quality-of-life instruments (EQ-5D/SF-36/PROMIS) were not reported in the retrieved excerpts. However, progressive disability milestones (EDSS progression) and autonomic morbidity (urodynamic abnormalities) indicate substantial impairment in mobility and daily functioning. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7, ortiz2024aretrospectivereview pages 2-3)
+
+### 3.5 Suggested HPO terms (examples)
+Based on described clinical features, plausible HPO mappings include:
+* Autonomic dysfunction: **Neurogenic bladder (HP:0000010)**; **Orthostatic hypotension (HP:0001278)**; **Anhidrosis (HP:0000970)**; **Erectile dysfunction (HP:0100639)** (ortiz2024aretrospectivereview pages 1-2, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7)
+* Motor: **Spasticity (HP:0001257)**; **Spastic paraplegia (HP:0001258)**; **Ataxia (HP:0001251)**; **Tremor (HP:0001337)** (ortiz2024aretrospectivereview pages 1-2, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+* Cognitive/psychiatric: **Cognitive impairment (HP:0100543)**; **Depression (HP:0000716)** (ortiz2024aretrospectivereview pages 1-2)
+
+(These HPO IDs are suggested mappings; the retrieved sources did not explicitly list HPO codes.)
+
+---
+
+## 4. Genetic / molecular information
+### 4.1 Causal gene
+**LMNB1** (lamin B1) is the causal gene; disease results from **LMNB1 overexpression** rather than canonical loss-of-function. (neri2023understandingtheultrarare pages 1-2, lin2011adultonsetautosomaldominant pages 1-2)
+
+### 4.2 Pathogenic variant classes
+* **Structural duplication** of LMNB1 (copy-number gain), often spanning the full gene. (dai2017anlmnb1duplication pages 1-2, santos2012adultonsetautosomaldominant pages 3-3)
+* **Nonrecurrent upstream deletions** (regulatory structural variants) causing enhancer adoption. (giorgio2015alargegenomic pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+
+### 4.3 Functional consequence
+The convergent molecular consequence is **increased Lamin B1 levels** (gain-of-function by overexpression), perturbing nuclear lamina stoichiometry and downstream chromatin/transcription/splicing programs in myelin-relevant cells. (neri2023understandingtheultrarare pages 2-4, neri2023understandingtheultrarare pages 6-7)
+
+### 4.4 Modifier genes / epigenetics
+Direct human modifier genes were not identified in the retrieved excerpts. However, mechanistic work suggests epigenetic shifts in oligodendrocytes under LMNB1 overexpression, including **increased repressive histone marks (H3K9me3, H3K27me3)** and **reduced activating acetylation marks (AcH3, AcH4)** in aged oligodendrocytes in transgenic models. (neri2023understandingtheultrarare pages 6-7)
+
+---
+
+## 5. Environmental information
+No specific environmental toxins, lifestyle exposures, or infectious triggers were established as causal in the retrieved literature excerpts; ADLD is best understood as genetically caused. (neri2023understandingtheultrarare pages 1-2)
+
+---
+
+## 6. Mechanism / pathophysiology (current understanding)
+### 6.1 Causal chain (integrated model)
+1. **Upstream trigger:** LMNB1 structural variant (duplication or upstream deletion) → **LMNB1 overexpression**. (neri2023understandingtheultrarare pages 1-2, nmezi2019genomicdeletionsupstream pages 1-2)
+2. **Nuclear lamina/chromatin effects:** Lamin B1 excess disturbs nuclear lamina architecture (misshaped/folded nuclei; increased nuclear rigidity) and alters chromatin organization and transcriptional silencing at the nuclear periphery. (neri2023understandingtheultrarare pages 4-6, lin2011adultonsetautosomaldominant pages 1-2)
+3. **Myelin cell dysfunction (oligodendrocyte-centered mechanisms):** oligodendrocyte-targeted LMNB1 overexpression can cause premature differentiation arrest and repression of lipid synthesis pathways; in one spinal-cord transgenic model, multiple downregulated genes mapped to lipid synthesis and lipidomics showed reduced myelin lipids. (neri2023understandingtheultrarare pages 4-6)
+4. **Spliceopathy and myelin gene dysregulation:** LMNB1 increase is associated with upregulation of **RAVER2**, inhibiting PTB and contributing to abnormal splicing of PTB-target genes including **PLP1**, and PLP1 downregulation has been linked to reduced YY1 binding. (neri2023understandingtheultrarare pages 7-9, dai2017anlmnb1duplication pages 1-2)
+5. **Non-cell-autonomous contributions (astrocytopathy):** astrocyte LMNB1 accumulation can reduce **LIF/LIF-R signaling** and downstream PI3K/Akt/mTOR pathway activity, impairing support for oligodendrocytes; astrocytes show reduced viability and reactive changes. (neri2023understandingtheultrarare pages 6-7, neri2023understandingtheultrarare pages 7-9)
+6. **Downstream tissue outcome:** progressive, largely non-inflammatory CNS demyelination with vacuolated white matter and relative preservation of oligodendroglia in pathology descriptions. (lin2011adultonsetautosomaldominant pages 1-2)
+
+### 6.2 Immune involvement
+ADLD is generally described as lacking prominent inflammatory demyelination; neuropathology notes vacuolated white matter without significant inflammatory infiltrates, distinguishing it from autoimmune demyelination paradigms. (lin2011adultonsetautosomaldominant pages 1-2)
+
+### 6.3 Oxidative stress / inflammatory signaling
+Patient-derived cells show disturbed oxidative stress responses and increased ROS after oxidative challenge, and increased activation of inflammatory signaling markers (e.g., phosphorylated NF-κB) in fibroblast-based studies, though confirmation in patient CNS tissue remains an open need. (neri2023understandingtheultrarare pages 7-9)
+
+### 6.4 Suggested GO biological process terms (examples)
+Based on mechanisms discussed:
+* **Chromatin organization** and **negative regulation of transcription** (lin2011adultonsetautosomaldominant pages 1-2, neri2023understandingtheultrarare pages 6-7)
+* **Myelination** / **oligodendrocyte differentiation** (neri2023understandingtheultrarare pages 4-6)
+* **Lipid biosynthetic process** (myelin lipid synthesis dysregulation) (neri2023understandingtheultrarare pages 4-6)
+* **mRNA splicing** (RAVER2/PTB axis) (neri2023understandingtheultrarare pages 7-9)
+
+(GO IDs not explicitly provided in the sources; these are suggested mappings.)
+
+### 6.5 Suggested Cell Ontology (CL) terms (examples)
+Key implicated cell types include:
+* **Oligodendrocytes** (myelin-producing CNS glia) (neri2023understandingtheultrarare pages 4-6, oranburg2023establishingmodelsystems pages 27-31)
+* **Astrocytes** (LIF signaling and reactive changes) (neri2023understandingtheultrarare pages 7-9)
+* **Neurons** (nuclear morphology and neurite phenotypes in models) (giorgio2019allelespecificsilencingas pages 20-23)
+
+(CL IDs not explicitly provided; suggested mappings.)
+
+---
+
+## 7. Anatomical structures affected
+### 7.1 Organ/system level
+Primary: **central nervous system** white matter (brain and spinal cord), with prominent clinical contributions from autonomic pathways and long motor tracts. (ortiz2024aretrospectivereview pages 2-3, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7)
+
+### 7.2 Tissue/cell level
+Primary tissue: **CNS white matter** with demyelination; implicated cell types include **oligodendrocytes** (directly, via cell-specific overexpression models) and **astrocytes** (supportive signaling dysfunction). (neri2023understandingtheultrarare pages 4-6, neri2023understandingtheultrarare pages 6-7)
+
+### 7.3 Subcellular
+Core subcellular compartment implicated: **nuclear lamina / nuclear envelope** and its chromatin tethering domains. (lin2011adultonsetautosomaldominant pages 1-2)
+
+### 7.4 Suggested UBERON terms (examples)
+* **Brain white matter** and **spinal cord white matter** (ortiz2024aretrospectivereview pages 2-3, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+* **Internal capsule** and **corpus callosum** (ortiz2024aretrospectivereview pages 2-3)
+* **Cerebellar peduncles** (ortiz2024aretrospectivereview pages 2-3)
+
+(UBERON IDs not explicitly provided; suggested mappings.)
+
+---
+
+## 8. Temporal development
+### 8.1 Onset
+Onset is typically **insidious in mid-adulthood** (often 4th–6th decade), with MRI abnormalities potentially preceding symptoms by a decade or more in some individuals. (ortiz2024aretrospectivereview pages 1-2, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7)
+
+### 8.2 Progression and staging (data-supported milestones)
+Longitudinal natural history in LMNB1-duplication families provides disability and survival estimates:
+* EDSS 6 at mean age **59 ± 8** years, about **11 ± 5 years** from symptom onset.
+* EDSS 8 at mean age **61 ± 6** years, about **14 ± 4 years** from onset.
+* Deaths at mean age **66 ± 6** years, about **17 ± 6 years** from onset.
+* Median survival after onset **18 years**.
+(finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7, finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+
+### 8.3 Remission/relapse patterns
+A relapsing-remitting course is not typical; pseudoexacerbations with heat/infection can occur. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12)
+
+---
+
+## 9. Inheritance and population
+### 9.1 Inheritance
+Inheritance is **autosomal dominant**, consistent with structural variants that increase LMNB1 expression. (gosky2021assessmentanddevelopment pages 18-22, nmezi2019genomicdeletionsupstream pages 1-2)
+
+### 9.2 Epidemiology
+ADLD is **ultra-rare**; multiple sources state that **>30 families** have been reported worldwide and that **exact prevalence is unknown** due to rarity and diagnostic challenges. (neri2023understandingtheultrarare pages 1-2, ortiz2024aretrospectivereview pages 3-5)
+
+Educational materials summarize older literature counts as “at least **24 families**” and “**>70 individuals**,” and emphasize likely underdiagnosis. (gosky2021assessmentanddevelopment pages 18-22)
+
+No robust sex ratio, penetrance estimates, or population prevalence/incidence rates were identified in the retrieved excerpts. (ortiz2024aretrospectivereview pages 3-5)
+
+---
+
+## 10. Diagnostics
+### 10.1 Clinical and imaging diagnostics
+The practical, high-yield diagnostic pathway is:
+1. Recognize the **adult-onset dysautonomia + spastic-ataxic syndrome**.
+2. Identify the **characteristic symmetric MRI pattern**, including corticospinal tract involvement and cerebellar peduncle lesions; spine MRI may show cord thinning/atrophy.
+3. Confirm with **LMNB1 duplication/deletion testing**, using methods that detect CNVs/structural variants.
+(ortiz2024aretrospectivereview pages 3-5, muthusamy2023adultonsetleukodystrophiesa pages 10-11)
+
+MRI details in a 2024 cohort: all reviewed MRIs showed **symmetric confluent deep cerebral and periventricular T2 hyperintensities** with involvement of **posterior limb internal capsule**, **corpus callosum**, **brainstem corticospinal tracts**, **superior/middle cerebellar peduncles**, and spine MRI showed **diffuse spinal cord atrophy**. (ortiz2024aretrospectivereview pages 1-2, ortiz2024aretrospectivereview pages 2-3)
+
+### 10.2 Genetic testing strategy
+A critical real-world point from 2023–2024 expert sources is that **routine short-read NGS may not reliably detect LMNB1 duplications/upstream deletions**, so the clinician must order CNV/structural-variant assays (e.g., deletion/duplication analysis, MLPA, gene-targeted microarray/array-CGH) when the phenotype/MRI are classic. (muthusamy2023adultonsetleukodystrophiesa pages 21-23, ortiz2024aretrospectivereview pages 3-5)
+
+### 10.3 Differential diagnosis (key examples)
+Because adult leukodystrophies overlap with MS and other acquired leukoencephalopathies, reviews emphasize first excluding acquired mimics and using imaging patterns/biochemical testing to distinguish inherited conditions. (muthusamy2023adultonsetleukodystrophiesa pages 23-24, muthusamy2023adultonsetleukodystrophiesa pages 21-23)
+
+A 2023 practical guide explicitly highlights differentials and distinguishing tests, including AMN/X-ALD (VLCFA; spinal cord atrophy), AMACR deficiency (pristanic acid), CSF1R disease (calcifications on CT/gradient-echo), and emphasizes the LMNB1 ADLD MRI signature and CNV testing needs. (muthusamy2023adultonsetleukodystrophiesa pages 10-11)
+
+---
+
+## 11. Outcome / prognosis
+ADLD is slowly progressive but ultimately severe, with a multi-decade course in many patients. Quantified outcomes include EDSS milestone timing and survival described above (Section 8). (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7)
+
+Diagnostic delay is substantial in real-world practice: median **6 years** from symptom onset to diagnosis in one 2024 cohort. (ortiz2024aretrospectivereview pages 1-2)
+
+---
+
+## 12. Treatment
+### 12.1 Current standard of care (real-world)
+No established disease-modifying therapy was identified in the cited clinical literature; care is **supportive/symptomatic**, targeting dysautonomia (bladder and orthostatic intolerance), spasticity, mobility and functional decline, and cognitive/psychiatric symptoms. (ortiz2024aretrospectivereview pages 3-5, jiang2025casereportlmnb1 pages 4-5)
+
+### 12.2 Experimental / emerging therapeutics
+**LMNB1-lowering strategies** are the most mechanistically aligned targeted approaches:
+
+1. **Allele-specific RNA interference (preclinical proof-of-concept).** In patient fibroblasts and disease-relevant cellular models, allele-specific siRNA/shRNA targeting a common LMNB1 3′UTR SNP (rs1051644) reduced LMNB1 expression toward physiologic levels and improved ADLD-associated cellular phenotypes. In directly reprogrammed neurons, allele-specific shRNA produced ~**30%** Lamin B1 protein reduction with improved nuclear anomalies and neurite growth. (giorgio2019allelespecificsilencingas pages 17-20, giorgio2019allelespecificsilencingas pages 20-23)
+
+2. **Personalized antisense oligonucleotide (ASO) therapy clinical trial (single participant).** ClinicalTrials.gov lists an open-label phase 1/2 trial of a personalized ASO (nL-LMNB1-001) in a single participant with LMNB1-duplication ADLD (NCT06816498), started **2025-03-17**, ACTIVE_NOT_RECRUITING; endpoints include gait metrics (6-minute walk, 25-foot walk, motion analysis), neurological functioning, MRI brain atrophy, plus urodynamics and autonomic tests for secondary outcomes. (NCT06816498 chunk 1)
+
+### 12.3 Suggested MAXO terms (examples)
+Not explicitly provided in sources; suggested mappings include:
+* Genetic counseling (autosomal dominant inheritance) (gosky2021assessmentanddevelopment pages 18-22)
+* Symptomatic treatment of spasticity and autonomic dysfunction (jiang2025casereportlmnb1 pages 4-5)
+* Antisense oligonucleotide therapy / RNA interference (investigational) (NCT06816498 chunk 1, giorgio2019allelespecificsilencingas pages 17-20)
+
+---
+
+## 13. Prevention
+Primary prevention is not currently feasible because ADLD is a dominantly inherited genetic disorder. Prevention is best framed as:
+* **Secondary prevention:** early recognition via MRI/clinical features and confirmatory genetic testing to reduce diagnostic delay and enable anticipatory management and trial eligibility. (ortiz2024aretrospectivereview pages 3-5, muthusamy2023adultonsetleukodystrophiesa pages 21-23)
+* **Tertiary prevention:** management of complications (orthostatic hypotension, bladder dysfunction, spasticity) and supportive rehabilitation. (ortiz2024aretrospectivereview pages 2-3)
+
+Genetic counseling is central given autosomal dominant inheritance and 50% transmission risk to offspring of an affected parent. (gosky2021assessmentanddevelopment pages 18-22)
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring veterinary ADLD analogs were identified in the retrieved evidence; the literature retrieved emphasizes engineered model systems rather than naturally occurring cross-species disease. (neri2023understandingtheultrarare pages 2-4)
+
+---
+
+## 15. Model organisms
+Multiple model systems support mechanistic study and therapy development:
+* **Transgenic mouse models** with oligodendrocyte-specific LMNB1 overexpression (Plp1 promoter; PLP-FLAG-LMNB1) recapitulate age-dependent white matter degeneration and motor dysfunction, supporting oligodendrocytes as key vulnerability points. (oranburg2023establishingmodelsystems pages 27-31, henck2024singlecellsequencing pages 26-29)
+* **LMNB1BAC / PLP-LMNB1Tg mice** show age-dependent demyelination and neurological phenotypes (motor/cognitive/epileptic), summarized in the 2023 review. (neri2023understandingtheultrarare pages 2-4)
+* **Human cellular models** include patient-derived fibroblasts and directly reprogrammed neurons used for mechanistic assays and proof-of-concept gene silencing. (giorgio2019allelespecificsilencingas pages 17-20)
+
+Limitations emphasized across sources: cell-type specificity remains incompletely explained, mechanistic findings vary by model, and many molecular signatures require validation in patient CNS tissue. (neri2023understandingtheultrarare pages 2-4)
+
+---
+
+## Direct abstract quotes supporting key claims (from retrieved abstracts)
+* 2024 cohort definition: “**LMNB1-related autosomal dominant leukodystrophy (ADLD) is a slowly progressive neurodegenerative disorder caused by overexpression of LMNB1.**” (ortiz2024aretrospectivereview pages 1-2)
+* 2015 enhancer adoption mechanism: “**Chromosomal rearrangements with duplication of the lamin B1 (LMNB1) gene underlie autosomal dominant adult-onset demyelinating leukodystrophy (ADLD), a rare neurological disorder in which overexpression of LMNB1 causes progressive central nervous system demyelination.**” (giorgio2015alargegenomic pages 1-2)
+* 2025 trial registry summary (ClinicalTrials.gov): describes “**Personalized Antisense Oligonucleotide Therapy for A Single Participant With LMNB1 Mutation Associated Autosomal Dominant Leukodystrophy (ADLD)**” with endpoints including gait testing and MRI atrophy measures. (NCT06816498 chunk 1)
+
+---
+
+## Notes on missing template elements
+* **MONDO / Orphanet / ICD / MeSH codes:** not available in the retrieved excerpts; reporting them without evidence would require direct database querying not supported by the current tool evidence set. (neri2023understandingtheultrarare pages 1-2)
+* **Variant-level HGVS nomenclature, ClinVar classifications, gnomAD allele frequencies:** not present in the retrieved excerpts; ADLD is primarily associated with structural variants (duplications/deletions) that often require specialized CNV assays and may not be represented uniformly in variant databases. (muthusamy2023adultonsetleukodystrophiesa pages 21-23)
+
+
+
+References
+
+1. (ortiz2024aretrospectivereview pages 1-2): Judit M. Perez Ortiz, Karthik Muthusamy, W. Oliver Tobin, Ralitza Gavrilova, Margot A. Cousin, and Radhika Dhamija. A retrospective review of lmnb1-related autosomal dominant leukodystrophy. Journal of Rare Diseases, Oct 2024. URL: https://doi.org/10.1007/s44162-024-00055-w, doi:10.1007/s44162-024-00055-w. This article has 0 citations.
+
+2. (neri2023understandingtheultrarare pages 1-2): Irene Neri, Giulia Ramazzotti, Sara Mongiorgi, Isabella Rusciano, Marianna Bugiani, Luciano Conti, Margot Cousin, Elisa Giorgio, Quasar S. Padiath, Giovanna Vaula, Pietro Cortelli, Lucia Manzoli, and Stefano Ratti. Understanding the ultra-rare disease autosomal dominant leukodystrophy: an updated review on morpho-functional alterations found in experimental models. Molecular Neurobiology, 60:6362-6372, Jul 2023. URL: https://doi.org/10.1007/s12035-023-03461-1, doi:10.1007/s12035-023-03461-1. This article has 16 citations and is from a peer-reviewed journal.
+
+3. (ortiz2024aretrospectivereview pages 2-3): Judit M. Perez Ortiz, Karthik Muthusamy, W. Oliver Tobin, Ralitza Gavrilova, Margot A. Cousin, and Radhika Dhamija. A retrospective review of lmnb1-related autosomal dominant leukodystrophy. Journal of Rare Diseases, Oct 2024. URL: https://doi.org/10.1007/s44162-024-00055-w, doi:10.1007/s44162-024-00055-w. This article has 0 citations.
+
+4. (dai2017anlmnb1duplication pages 1-2): Yi Dai, Yaling Ma, Shengde Li, Santasree Banerjee, Shengran Liang, Qing Liu, Yinchang Yang, Bin Peng, Liying Cui, and Liri Jin. An lmnb1 duplication caused adult-onset autosomal dominant leukodystrophy in chinese family: clinical manifestations, neuroradiology and genetic diagnosis. Frontiers in Molecular Neuroscience, Jul 2017. URL: https://doi.org/10.3389/fnmol.2017.00215, doi:10.3389/fnmol.2017.00215. This article has 25 citations.
+
+5. (lin2011adultonsetautosomaldominant pages 1-2): Shu-Ting Lin, Louis J. Ptáček, and Ying-Hui Fu. Adult-onset autosomal dominant leukodystrophy: linking nuclear envelope to myelin. The Journal of Neuroscience, 31:1163-1166, Jan 2011. URL: https://doi.org/10.1523/jneurosci.5994-10.2011, doi:10.1523/jneurosci.5994-10.2011. This article has 33 citations.
+
+6. (giorgio2015alargegenomic pages 1-2): Elisa Giorgio, Daniel Robyr, Malte Spielmann, Enza Ferrero, Eleonora Di Gregorio, Daniele Imperiale, Giovanna Vaula, Georgios Stamoulis, Federico Santoni, Cristiana Atzori, Laura Gasparini, Denise Ferrera, Claudio Canale, Michel Guipponi, Len A. Pennacchio, Stylianos E. Antonarakis, Alessandro Brussino, and Alfredo Brusco. A large genomic deletion leads to enhancer adoption by the lamin b1 gene: a second path to autosomal dominant adult-onset demyelinating leukodystrophy (adld). Human Molecular Genetics, 24:3143-3154, Feb 2015. URL: https://doi.org/10.1093/hmg/ddv065, doi:10.1093/hmg/ddv065. This article has 178 citations and is from a domain leading peer-reviewed journal.
+
+7. (nmezi2019genomicdeletionsupstream pages 1-2): Bruce Nmezi, Elisa Giorgio, Raili Raininko, Anna Lehman, Malte Spielmann, Mary Kay Koenig, Rahmat Adejumo, Melissa Knight, Ralitza Gavrilova, Murad Alturkustani, Manas Sharma, Robert Hammond, William A. Gahl, Camilo Toro, Alfredo Brusco, and Quasar S. Padiath. Genomic deletions upstream of lamin b1 lead to atypical autosomal dominant leukodystrophy. Neurology Genetics, Feb 2019. URL: https://doi.org/10.1212/nxg.0000000000000305, doi:10.1212/nxg.0000000000000305. This article has 31 citations.
+
+8. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 1-2): Johannes Finnsson, Jimmy Sundblom, Niklas Dahl, Atle Melberg, and Raili Raininko. Lmnb1‐related autosomal‐dominant leukodystrophy: clinical and radiological course. Annals of Neurology, 78:412-425, Jul 2015. URL: https://doi.org/10.1002/ana.24452, doi:10.1002/ana.24452. This article has 61 citations and is from a highest quality peer-reviewed journal.
+
+9. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 6-7): Johannes Finnsson, Jimmy Sundblom, Niklas Dahl, Atle Melberg, and Raili Raininko. Lmnb1‐related autosomal‐dominant leukodystrophy: clinical and radiological course. Annals of Neurology, 78:412-425, Jul 2015. URL: https://doi.org/10.1002/ana.24452, doi:10.1002/ana.24452. This article has 61 citations and is from a highest quality peer-reviewed journal.
+
+10. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 9-12): Johannes Finnsson, Jimmy Sundblom, Niklas Dahl, Atle Melberg, and Raili Raininko. Lmnb1‐related autosomal‐dominant leukodystrophy: clinical and radiological course. Annals of Neurology, 78:412-425, Jul 2015. URL: https://doi.org/10.1002/ana.24452, doi:10.1002/ana.24452. This article has 61 citations and is from a highest quality peer-reviewed journal.
+
+11. (finnsson2015lmnb1‐relatedautosomal‐dominantleukodystrophy pages 7-9): Johannes Finnsson, Jimmy Sundblom, Niklas Dahl, Atle Melberg, and Raili Raininko. Lmnb1‐related autosomal‐dominant leukodystrophy: clinical and radiological course. Annals of Neurology, 78:412-425, Jul 2015. URL: https://doi.org/10.1002/ana.24452, doi:10.1002/ana.24452. This article has 61 citations and is from a highest quality peer-reviewed journal.
+
+12. (ortiz2024aretrospectivereview pages 3-5): Judit M. Perez Ortiz, Karthik Muthusamy, W. Oliver Tobin, Ralitza Gavrilova, Margot A. Cousin, and Radhika Dhamija. A retrospective review of lmnb1-related autosomal dominant leukodystrophy. Journal of Rare Diseases, Oct 2024. URL: https://doi.org/10.1007/s44162-024-00055-w, doi:10.1007/s44162-024-00055-w. This article has 0 citations.
+
+13. (muthusamy2023adultonsetleukodystrophiesa pages 10-11): Karthik Muthusamy, Ajith Sivadasan, Luke Dixon, Sniya Sudhakar, Maya Thomas, Sumita Danda, Zbigniew K. Wszolek, Klaas Wierenga, Radhika Dhamija, and Ralitza Gavrilova. Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1219324, doi:10.3389/fneur.2023.1219324. This article has 30 citations and is from a peer-reviewed journal.
+
+14. (muthusamy2023adultonsetleukodystrophiesa pages 23-24): Karthik Muthusamy, Ajith Sivadasan, Luke Dixon, Sniya Sudhakar, Maya Thomas, Sumita Danda, Zbigniew K. Wszolek, Klaas Wierenga, Radhika Dhamija, and Ralitza Gavrilova. Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1219324, doi:10.3389/fneur.2023.1219324. This article has 30 citations and is from a peer-reviewed journal.
+
+15. (muthusamy2023adultonsetleukodystrophiesa pages 21-23): Karthik Muthusamy, Ajith Sivadasan, Luke Dixon, Sniya Sudhakar, Maya Thomas, Sumita Danda, Zbigniew K. Wszolek, Klaas Wierenga, Radhika Dhamija, and Ralitza Gavrilova. Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1219324, doi:10.3389/fneur.2023.1219324. This article has 30 citations and is from a peer-reviewed journal.
+
+16. (muthusamy2023adultonsetleukodystrophiesa pages 1-2): Karthik Muthusamy, Ajith Sivadasan, Luke Dixon, Sniya Sudhakar, Maya Thomas, Sumita Danda, Zbigniew K. Wszolek, Klaas Wierenga, Radhika Dhamija, and Ralitza Gavrilova. Adult-onset leukodystrophies: a practical guide, recent treatment updates, and future directions. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1219324, doi:10.3389/fneur.2023.1219324. This article has 30 citations and is from a peer-reviewed journal.
+
+17. (kohler2018adulthoodleukodystrophies pages 3-4): Wolfgang Köhler, Julian Curiel, and Adeline Vanderver. Adulthood leukodystrophies. Nature Reviews Neurology, 14:94-105, Jan 2018. URL: https://doi.org/10.1038/nrneurol.2017.175, doi:10.1038/nrneurol.2017.175. This article has 169 citations and is from a highest quality peer-reviewed journal.
+
+18. (resende2019adultleukodystrophiesa pages 1-2): Lucas Lopes Resende, Anderson Rodrigues Brandão de Paiva, Fernando Kok, Claudia da Costa Leite, and Leandro Tavares Lucato. Adult leukodystrophies: a step-by-step diagnostic approach. Radiographics : a review publication of the Radiological Society of North America, Inc, 39 1:153-168, Jan 2019. URL: https://doi.org/10.1148/rg.2019180081, doi:10.1148/rg.2019180081. This article has 93 citations.
+
+19. (lynch2019practicalapproachto pages 2-3): David S Lynch, Charles Wade, Anderson Rodrigues Brandão de Paiva, Nevin John, Justin A Kinsella, Áine Merwick, Rebekah M Ahmed, Jason D Warren, Catherine J Mummery, Jonathan M Schott, Nick C Fox, Henry Houlden, Matthew E Adams, Indran Davagnanam, Elaine Murphy, and Jeremy Chataway. Practical approach to the diagnosis of adult-onset leukodystrophies: an updated guide in the genomic era. Journal of Neurology, Neurosurgery, and Psychiatry, 90:543-554, Nov 2019. URL: https://doi.org/10.1136/jnnp-2018-319481, doi:10.1136/jnnp-2018-319481. This article has 152 citations.
+
+20. (jiang2025casereportlmnb1 pages 4-5): Yumeng Jiang, Lu Han, Yaqi Li, Zhihong Zhao, Zikai Xin, and Zilong Zhu. Case report: lmnb1 duplication-mediated autosomal dominant adult leukodystrophy in a chinese family and literature review of chinese patients. Frontiers in Neuroscience, Feb 2025. URL: https://doi.org/10.3389/fnins.2025.1531593, doi:10.3389/fnins.2025.1531593. This article has 0 citations and is from a peer-reviewed journal.
+
+21. (giorgio2019allelespecificsilencingas pages 1-6): Elisa Giorgio, Martina Lorenzati, Pia Rivetti di Val Cervo, Alessandro Brussino, Manuel Cernigoj, Edoardo Della Sala, Anna Bartoletti Stella, Marta Ferrero, Massimiliano Caiazzo, Sabina Capellari, Pietro Cortelli, Luciano Conti, Elena Cattaneo, Annalisa Buffo, and Alfredo Brusco. Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy. Brain : a journal of neurology, 142:1905-1920, May 2019. URL: https://doi.org/10.1093/brain/awz139, doi:10.1093/brain/awz139. This article has 26 citations.
+
+22. (giorgio2019allelespecificsilencingas pages 6-10): Elisa Giorgio, Martina Lorenzati, Pia Rivetti di Val Cervo, Alessandro Brussino, Manuel Cernigoj, Edoardo Della Sala, Anna Bartoletti Stella, Marta Ferrero, Massimiliano Caiazzo, Sabina Capellari, Pietro Cortelli, Luciano Conti, Elena Cattaneo, Annalisa Buffo, and Alfredo Brusco. Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy. Brain : a journal of neurology, 142:1905-1920, May 2019. URL: https://doi.org/10.1093/brain/awz139, doi:10.1093/brain/awz139. This article has 26 citations.
+
+23. (giorgio2019allelespecificsilencingas pages 17-20): Elisa Giorgio, Martina Lorenzati, Pia Rivetti di Val Cervo, Alessandro Brussino, Manuel Cernigoj, Edoardo Della Sala, Anna Bartoletti Stella, Marta Ferrero, Massimiliano Caiazzo, Sabina Capellari, Pietro Cortelli, Luciano Conti, Elena Cattaneo, Annalisa Buffo, and Alfredo Brusco. Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy. Brain : a journal of neurology, 142:1905-1920, May 2019. URL: https://doi.org/10.1093/brain/awz139, doi:10.1093/brain/awz139. This article has 26 citations.
+
+24. (giorgio2019allelespecificsilencingas pages 20-23): Elisa Giorgio, Martina Lorenzati, Pia Rivetti di Val Cervo, Alessandro Brussino, Manuel Cernigoj, Edoardo Della Sala, Anna Bartoletti Stella, Marta Ferrero, Massimiliano Caiazzo, Sabina Capellari, Pietro Cortelli, Luciano Conti, Elena Cattaneo, Annalisa Buffo, and Alfredo Brusco. Allele-specific silencing as treatment for gene duplication disorders: proof-of-principle in autosomal dominant leukodystrophy. Brain : a journal of neurology, 142:1905-1920, May 2019. URL: https://doi.org/10.1093/brain/awz139, doi:10.1093/brain/awz139. This article has 26 citations.
+
+25. (NCT06816498 chunk 1):  Personalized Antisense Oligonucleotide Therapy for A Single Participant With LMNB1 Mutation Associated Autosomal Dominant Leukodystrophy (ADLD). n-Lorem Foundation. 2025. ClinicalTrials.gov Identifier: NCT06816498
+
+26. (santos2012adultonsetautosomaldominant pages 3-3): Michael M. Dos Santos, Caspar Grond-Ginsbach, Suna Su Aksay, Bowang Chen, Sandrine Tchatchou, Nicole I. Wolf, Marjo S. Knaap, and Armin J. Grau. Adult-onset autosomal dominant leukodystrophy due to lmnb1 gene duplication. Journal of Neurology, 259:579-581, Mar 2012. URL: https://doi.org/10.1007/s00415-011-6225-4, doi:10.1007/s00415-011-6225-4. This article has 37 citations and is from a domain leading peer-reviewed journal.
+
+27. (gosky2021assessmentanddevelopment pages 92-96): MD Gosky. Assessment and development of online educational materials for autosomal dominant leukodystrophy. Unknown journal, 2021.
+
+28. (neri2023understandingtheultrarare pages 4-6): Irene Neri, Giulia Ramazzotti, Sara Mongiorgi, Isabella Rusciano, Marianna Bugiani, Luciano Conti, Margot Cousin, Elisa Giorgio, Quasar S. Padiath, Giovanna Vaula, Pietro Cortelli, Lucia Manzoli, and Stefano Ratti. Understanding the ultra-rare disease autosomal dominant leukodystrophy: an updated review on morpho-functional alterations found in experimental models. Molecular Neurobiology, 60:6362-6372, Jul 2023. URL: https://doi.org/10.1007/s12035-023-03461-1, doi:10.1007/s12035-023-03461-1. This article has 16 citations and is from a peer-reviewed journal.
+
+29. (neri2023understandingtheultrarare pages 6-7): Irene Neri, Giulia Ramazzotti, Sara Mongiorgi, Isabella Rusciano, Marianna Bugiani, Luciano Conti, Margot Cousin, Elisa Giorgio, Quasar S. Padiath, Giovanna Vaula, Pietro Cortelli, Lucia Manzoli, and Stefano Ratti. Understanding the ultra-rare disease autosomal dominant leukodystrophy: an updated review on morpho-functional alterations found in experimental models. Molecular Neurobiology, 60:6362-6372, Jul 2023. URL: https://doi.org/10.1007/s12035-023-03461-1, doi:10.1007/s12035-023-03461-1. This article has 16 citations and is from a peer-reviewed journal.
+
+30. (neri2023understandingtheultrarare pages 2-4): Irene Neri, Giulia Ramazzotti, Sara Mongiorgi, Isabella Rusciano, Marianna Bugiani, Luciano Conti, Margot Cousin, Elisa Giorgio, Quasar S. Padiath, Giovanna Vaula, Pietro Cortelli, Lucia Manzoli, and Stefano Ratti. Understanding the ultra-rare disease autosomal dominant leukodystrophy: an updated review on morpho-functional alterations found in experimental models. Molecular Neurobiology, 60:6362-6372, Jul 2023. URL: https://doi.org/10.1007/s12035-023-03461-1, doi:10.1007/s12035-023-03461-1. This article has 16 citations and is from a peer-reviewed journal.
+
+31. (neri2023understandingtheultrarare pages 7-9): Irene Neri, Giulia Ramazzotti, Sara Mongiorgi, Isabella Rusciano, Marianna Bugiani, Luciano Conti, Margot Cousin, Elisa Giorgio, Quasar S. Padiath, Giovanna Vaula, Pietro Cortelli, Lucia Manzoli, and Stefano Ratti. Understanding the ultra-rare disease autosomal dominant leukodystrophy: an updated review on morpho-functional alterations found in experimental models. Molecular Neurobiology, 60:6362-6372, Jul 2023. URL: https://doi.org/10.1007/s12035-023-03461-1, doi:10.1007/s12035-023-03461-1. This article has 16 citations and is from a peer-reviewed journal.
+
+32. (oranburg2023establishingmodelsystems pages 27-31): TDF Oranburg. Establishing model systems to study mechanisms of cell specificity in autosomal dominant leukodystrophy. Unknown journal, 2023.
+
+33. (gosky2021assessmentanddevelopment pages 18-22): MD Gosky. Assessment and development of online educational materials for autosomal dominant leukodystrophy. Unknown journal, 2021.
+
+34. (henck2024singlecellsequencing pages 26-29): Jana Henck. Single cell sequencing as a phenotyping strategy to decipher the molecular mechanisms of developmental disorders. Text, Jan 2024. URL: https://doi.org/10.17169/refubium-43507, doi:10.17169/refubium-43507. This article has 0 citations and is from a peer-reviewed journal.

--- a/research/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy-deep-research-falcon.md.citations.md
+++ b/research/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy-deep-research-falcon.md.citations.md
@@ -1,0 +1,505 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Neurodegenerative Disease
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-05T23:43:49.120226
+
+1. ortiz2024aretrospectivereview pages 2-3
+2. ortiz2024aretrospectivereview pages 1-2
+3. santos2012adultonsetautosomaldominant pages 3-3
+4. gosky2021assessmentanddevelopment pages 92-96
+5. giorgio2015alargegenomic pages 1-2
+6. neri2023understandingtheultrarare pages 1-2
+7. neri2023understandingtheultrarare pages 6-7
+8. neri2023understandingtheultrarare pages 4-6
+9. lin2011adultonsetautosomaldominant pages 1-2
+10. neri2023understandingtheultrarare pages 7-9
+11. giorgio2019allelespecificsilencingas pages 20-23
+12. gosky2021assessmentanddevelopment pages 18-22
+13. ortiz2024aretrospectivereview pages 3-5
+14. muthusamy2023adultonsetleukodystrophiesa pages 10-11
+15. neri2023understandingtheultrarare pages 2-4
+16. giorgio2019allelespecificsilencingas pages 17-20
+17. muthusamy2023adultonsetleukodystrophiesa pages 21-23
+18. nmezi2019genomicdeletionsupstream pages 1-2
+19. muthusamy2023adultonsetleukodystrophiesa pages 23-24
+20. muthusamy2023adultonsetleukodystrophiesa pages 1-2
+21. kohler2018adulthoodleukodystrophies pages 3-4
+22. resende2019adultleukodystrophiesa pages 1-2
+23. lynch2019practicalapproachto pages 2-3
+24. giorgio2019allelespecificsilencingas pages 1-6
+25. giorgio2019allelespecificsilencingas pages 6-10
+26. oranburg2023establishingmodelsystems pages 27-31
+27. henck2024singlecellsequencing pages 26-29
+28. https://doi.org/10.1007/s44162-024-00055-w
+29. https://doi.org/10.1136/jnnp-2018-319481
+30. https://doi.org/10.3389/fnmol.2017.00215
+31. https://doi.org/10.1093/hmg/ddv065
+32. https://doi.org/10.1212/nxg.0000000000000305
+33. https://doi.org/10.1002/ana.24452
+34. https://doi.org/10.3389/fneur.2023.1219324
+35. https://doi.org/10.1148/rg.2019180081
+36. https://doi.org/10.1038/nrneurol.2017.175
+37. https://doi.org/10.3389/fnins.2025.1531593
+38. https://doi.org/10.1093/brain/awz139
+39. https://clinicaltrials.gov/study/NCT06816498
+40. https://doi.org/10.1007/s44162-024-00055-w,
+41. https://doi.org/10.1007/s12035-023-03461-1,
+42. https://doi.org/10.3389/fnmol.2017.00215,
+43. https://doi.org/10.1523/jneurosci.5994-10.2011,
+44. https://doi.org/10.1093/hmg/ddv065,
+45. https://doi.org/10.1212/nxg.0000000000000305,
+46. https://doi.org/10.1002/ana.24452,
+47. https://doi.org/10.3389/fneur.2023.1219324,
+48. https://doi.org/10.1038/nrneurol.2017.175,
+49. https://doi.org/10.1148/rg.2019180081,
+50. https://doi.org/10.1136/jnnp-2018-319481,
+51. https://doi.org/10.3389/fnins.2025.1531593,
+52. https://doi.org/10.1093/brain/awz139,
+53. https://doi.org/10.1007/s00415-011-6225-4,
+54. https://doi.org/10.17169/refubium-43507,


### PR DESCRIPTION
## Summary

Adds a new curated disorder page for **Adult-Onset Autosomal Dominant Demyelinating Leukodystrophy** / LMNB1-related ADLD.

## Evidence Sources

- `PMID:28769756` - LMNB1 duplication family with clinical, MRI, and genetic confirmation.
- `PMID:26053668` - longitudinal LMNB1-related ADLD clinical and radiological course.
- `PMID:25701871` - upstream deletion / enhancer adoption mechanism for LMNB1 overexpression.
- `PMID:31143934` - preclinical allele-specific RNA interference proof-of-principle.

## Validation

- `just validate-schema kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml`
- `scripts/run_term_validator.sh validate-data kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml -s src/dismech/schema/dismech.yaml -t Disease --labels -c conf/oak_config.yaml`
- `just validate-references kb/disorders/Adult-Onset_Autosomal_Dominant_Demyelinating_Leukodystrophy.yaml`
- `just check-reference-cache-frontmatter`
- `git diff --cached --check -- . ':(exclude)references_cache/*.md'`

I did not include term cache changes from validation.
