### PR TITLE
Add aortitis disorder curation

### DIFF
--- a/kb/disorders/Aortitis.yaml
+++ b/kb/disorders/Aortitis.yaml
@@ -79,9 +79,31 @@ has_subtypes:
     explanation: >-
       This literature review supports G-CSF exposure as a drug-induced aortitis
       subtype, especially in chemotherapy care.
+- name: IgG4-related aortitis/periaortitis
+  description: >-
+    Aortitis or periaortitis occurring in the context of IgG4-related disease,
+    characterized by IgG4-bearing plasma-cell infiltration and fibrotic
+    inflammation that predominantly affects the abdominal aorta and iliac
+    arteries.
+  evidence:
+  - reference: DOI:10.3389/fimmu.2025.1625456
+    reference_title: "Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "IgG4-related disease (IgG4-RD) is a chronic fibrotic inflammatory condition characterized by elevated serum IgG4 levels and the infiltration of IgG4-bearing plasma cells in affected organs."
+    explanation: >-
+      The review defines IgG4-related disease by IgG4-bearing plasma-cell
+      infiltration and fibrotic inflammation.
+  - reference: DOI:10.3389/fimmu.2025.1625456
+    reference_title: "Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "IgG4-related aortitis/periaortitis and periarteritis (IgG4-related PAO/PA) predominantly affect the abdominal aorta and iliac arteries, with a higher prevalence in elderly males."
+    explanation: >-
+      This directly supports IgG4-related aortitis/periaortitis as a distinct
+      vascular manifestation.
 prevalence:
-- subtype: Histology-confirmed aortitis in major aortic surgery
-  population: Single-center major aortic surgery cohort with high histology sampling
+- population: Single-center major aortic surgery cohort with high histology sampling
   percentage: 10.6%
   evidence:
   - reference: DOI:10.3390/jcdd11120405
@@ -285,6 +307,43 @@ pathophysiology:
     explanation: >-
       Localizes G-CSF-associated aortitis most often to the aortic arch and
       branch vessels in reported cases.
+- name: IgG4-related plasma-cell fibrotic vascular inflammation
+  description: >-
+    IgG4-related aortitis/periaortitis involves chronic fibrotic inflammation
+    with IgG4-bearing plasma-cell infiltration in large-vessel tissue.
+  cell_types:
+  - preferred_term: plasma cell
+    term:
+      id: CL:0000786
+      label: plasma cell
+  biological_processes:
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  - preferred_term: extracellular matrix organization
+    modifier: ABNORMAL
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  locations:
+  - preferred_term: aorta
+    term:
+      id: UBERON:0000947
+      label: aorta
+  evidence:
+  - reference: DOI:10.3389/fimmu.2025.1625456
+    reference_title: "Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "IgG4-related disease (IgG4-RD) is a chronic fibrotic inflammatory condition characterized by elevated serum IgG4 levels and the infiltration of IgG4-bearing plasma cells in affected organs."
+    explanation: >-
+      Supports a fibrotic inflammatory and IgG4-bearing plasma-cell mechanism
+      for IgG4-related large-vessel disease.
+  downstream:
+  - target: Aortic wall remodeling and structural complications
+    description: Fibrotic inflammatory large-vessel disease can contribute to aneurysm, dissection, or rupture.
 - name: Aortic wall remodeling and structural complications
   description: >-
     Inflammatory injury can weaken and remodel the aortic wall, producing
@@ -378,14 +437,6 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Aortitis, defined as inflammation of the aorta, can lead to aneurysms and dissections."
     explanation: The abstract directly names dissection as a complication of aortitis.
-  - reference: DOI:10.3389/fphar.2024.1487501
-    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Most patients had a good prognosis, but 3 cases developed complications."
-    explanation: >-
-      The G-CSF case-review abstract documents that serious complications occur
-      in a minority of reported G-CSF-associated aortitis cases.
 - category: Cardiovascular
   name: Aortic regurgitation
   description: Aortic root or ascending aortic inflammation can impair aortic valve competence.
@@ -403,6 +454,83 @@ phenotypes:
     explanation: >-
       This case report links giant cell aortitis with severe aortic
       regurgitation and aortic root aneurysm.
+- category: Constitutional
+  name: Fever
+  description: >-
+    Fever is a common presentation in symptomatic G-CSF-associated aortitis and
+    can trigger evaluation for drug-induced aortic inflammation.
+  subtype: G-CSF-associated drug-induced aortitis
+  phenotype_term:
+    preferred_term: Fever
+    term:
+      id: HP:0001945
+      label: Fever
+  evidence:
+  - reference: PMID:40272133
+    reference_title: Aortitis triggered by granulocyte-colony stimulating factor.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The diagnosis of G-CSF-induced aortitis should be considered in patients with fever after G-CSF treatment, particularly if adequate antibiotic treatment does not lead to improvement."
+    explanation: >-
+      The case report interpretation explicitly links fever after G-CSF
+      exposure to consideration of G-CSF-induced aortitis.
+  - reference: PMID:34448091
+    reference_title: "Drug-induced aortitis of the subclavian artery caused by pegfilgrastim: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "If a patient develops a persistent high fever of unknown origin after pegfilgrastim administration, drug-induced aortitis should be considered during investigations for causes of fever."
+    explanation: >-
+      The case-report conclusion supports persistent high fever as a key
+      clinical clue for pegfilgrastim-induced aortitis.
+- category: Laboratory
+  name: Elevated C-reactive protein
+  description: >-
+    C-reactive protein may be markedly elevated in drug-induced aortitis and is
+    used clinically as an inflammatory activity marker.
+  subtype: G-CSF-associated drug-induced aortitis
+  phenotype_term:
+    preferred_term: Elevated circulating C-reactive protein concentration
+    term:
+      id: HP:0011227
+      label: Elevated circulating C-reactive protein concentration
+  evidence:
+  - reference: PMID:40272133
+    reference_title: Aortitis triggered by granulocyte-colony stimulating factor.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "After four days, C-reactive protein (CRP) had increased from 104 to 331, but the patient's condition was largely unchanged."
+    explanation: >-
+      The case report documents marked CRP increase during G-CSF-associated
+      aortitis evaluation.
+  - reference: PMID:34448091
+    reference_title: "Drug-induced aortitis of the subclavian artery caused by pegfilgrastim: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Therefore, C-reactive protein (CRP) is currently used to assess disease activity in clinical practice."
+    explanation: >-
+      The full-text case report notes CRP use for assessing G-CSF-associated
+      aortitis activity.
+- category: Laboratory
+  name: Elevated erythrocyte sedimentation rate
+  description: >-
+    Elevated erythrocyte sedimentation rate can accompany large-vessel
+    vasculitis-associated aortitis presentations and supports inflammatory
+    activity assessment.
+  subtype: Large-vessel vasculitis-associated aortitis
+  phenotype_term:
+    preferred_term: Elevated erythrocyte sedimentation rate
+    term:
+      id: HP:0003565
+      label: Elevated erythrocyte sedimentation rate
+  evidence:
+  - reference: PMID:36843728
+    reference_title: "From Temporal Cell Arteritis to Giant Cell Aortitis Presenting as a Constitutional Syndrome: A Case Report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The erythrocyte sedimentation rate (ESR) and C-reactive protein (CRP) were elevated, and he also had inflammatory anemia with a hemoglobin of 11.7 g/L."
+    explanation: >-
+      This giant-cell-aortitis case report documents elevated ESR and CRP in the
+      inflammatory presentation.
 histopathology:
 - name: Aortic wall inflammatory infiltrates
   description: >-
@@ -544,6 +672,51 @@ diagnosis:
       Supports vascular imaging as a central diagnostic tool when evaluating
       aortitis and large-vessel vasculitis.
 treatments:
+- name: Glucocorticoid therapy for noninfectious aortitis
+  description: >-
+    Glucocorticoids are a first-line immunosuppressive treatment backbone for
+    noninfectious large-vessel aortitis contexts, including giant cell arteritis
+    and IgG4-related aortitis/periaortitis.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: glucocorticoid
+      term:
+        id: CHEBI:24261
+        label: glucocorticoid
+    - preferred_term: prednisolone
+      term:
+        id: CHEBI:8378
+        label: prednisolone
+  evidence:
+  - reference: DOI:10.1186/s13063-024-07905-4
+    reference_title: "The Meteoritics Trial: efficacy of methotrexate after remission-induction with tocilizumab and glucocorticoids in giant cell arteritis—study protocol for a randomized, double-blind, placebo-controlled, parallel-group phase II study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Glucocorticoids (GC) are the standard treatment for giant cell arteritis (GCA), even though they are associated with adverse side effects and high relapse rates."
+    explanation: >-
+      Giant cell arteritis is a major large-vessel vasculitis context for
+      aortitis, and this trial protocol identifies glucocorticoids as standard
+      treatment.
+  - reference: PMID:36843728
+    reference_title: "From Temporal Cell Arteritis to Giant Cell Aortitis Presenting as a Constitutional Syndrome: A Case Report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Treatment with high-dose steroids should be initiated as soon as possible to rapidly control the inflammatory symptoms and prevent ischemic complications"
+    explanation: >-
+      This giant-cell-arteritis/aortitis case report supports high-dose steroid
+      treatment for inflammatory large-vessel disease.
+  - reference: DOI:10.3389/fimmu.2025.1625456
+    reference_title: "Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Glucocorticoids (GCs) are the mainstay of treatment, often combined with immunosuppressants (IMs), while B- and T-cell-targeted therapies are under investigation."
+    explanation: >-
+      The IgG4-related aortitis review directly supports glucocorticoids as a
+      mainstay treatment for IgG4-related aortitis/periaortitis.
 - name: Empiric antimicrobial therapy for infectious aortitis
   description: >-
     Infectious aortitis requires early antimicrobial therapy, initially empiric
@@ -645,6 +818,20 @@ references:
   findings:
   - statement: G-CSF-induced aortitis is a serious adverse event most often reported in oncology supportive care.
     supporting_text: "Recombinant human granulocyte-colony stimulating factors (G-CSF)-induced aortitis is a rare but particularly serious adverse event, commonly seen in cancer patients undergoing chemotherapy."
+- reference: DOI:10.3389/fimmu.2025.1625456
+  title: "Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice"
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: IgG4-related aortitis/periaortitis is a distinct fibrotic inflammatory large-vessel manifestation.
+    supporting_text: "IgG4-related aortitis/periaortitis and periarteritis (IgG4-related PAO/PA) predominantly affect the abdominal aorta and iliac arteries, with a higher prevalence in elderly males."
+- reference: DOI:10.1186/s13063-024-07905-4
+  title: "The Meteoritics Trial: efficacy of methotrexate after remission-induction with tocilizumab and glucocorticoids in giant cell arteritis—study protocol for a randomized, double-blind, placebo-controlled, parallel-group phase II study"
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Glucocorticoids are standard treatment for giant cell arteritis, a major large-vessel aortitis context.
+    supporting_text: "Glucocorticoids (GC) are the standard treatment for giant cell arteritis (GCA), even though they are associated with adverse side effects and high relapse rates."
 - reference: DOI:10.1093/cid/ciac560
   title: Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis
   found_in:
@@ -687,4 +874,19 @@ references:
   findings:
   - statement: Aortic wall tissue in Takayasu arteritis contains inflammatory infiltrates and multiple immune cell populations.
     supporting_text: "All specimens showed distinctive histologic features of Takayasu's arteritis and contained inflammatory infiltrates"
+- reference: PMID:40272133
+  title: Aortitis triggered by granulocyte-colony stimulating factor.
+  findings:
+  - statement: G-CSF-associated aortitis should be considered in patients with fever after G-CSF treatment.
+    supporting_text: "The diagnosis of G-CSF-induced aortitis should be considered in patients with fever after G-CSF treatment, particularly if adequate antibiotic treatment does not lead to improvement."
+- reference: PMID:34448091
+  title: "Drug-induced aortitis of the subclavian artery caused by pegfilgrastim: a case report."
+  findings:
+  - statement: Persistent high fever and CRP can support evaluation for pegfilgrastim-induced aortitis.
+    supporting_text: "She was hospitalized on day 15 when CRP increased to 21.5 mg/dL and the high fever continued."
+- reference: PMID:36843728
+  title: "From Temporal Cell Arteritis to Giant Cell Aortitis Presenting as a Constitutional Syndrome: A Case Report."
+  findings:
+  - statement: Giant cell aortitis can present with constitutional symptoms and elevated ESR/CRP.
+    supporting_text: "The erythrocyte sedimentation rate (ESR) and C-reactive protein (CRP) were elevated, and he also had inflammatory anemia with a hemoglobin of 11.7 g/L."
 datasets: []

--- a/kb/disorders/Aortitis.yaml
+++ b/kb/disorders/Aortitis.yaml
@@ -1,0 +1,690 @@
+name: Aortitis
+creation_date: "2026-05-06T03:09:08Z"
+updated_date: "2026-05-06T03:53:30Z"
+description: >-
+  Aortitis is inflammation of the aortic wall, spanning noninfectious
+  large-vessel vasculitis, clinically isolated surgical-pathology aortitis,
+  infectious aortitis, and drug-induced forms such as G-CSF-associated
+  aortitis. The shared disease axis is aortic wall inflammation with risk for
+  aneurysm, dissection, stenotic or occlusive disease, ischemic complications,
+  and aortic valve involvement, but the required management differs sharply by
+  etiology.
+category: Complex
+disease_term:
+  preferred_term: aortitis
+  term:
+    id: MONDO:0006656
+    label: aortitis
+parents:
+- Vascular disorder
+- Vasculitis
+- Inflammatory disorder
+synonyms:
+- Aorta inflammation
+- Inflammation of aorta
+- Aortic wall inflammation
+has_subtypes:
+- name: Clinically isolated aortitis
+  description: >-
+    Histology-confirmed aortitis without known systemic inflammatory or
+    infectious disease; many cases are discovered incidentally during aortic
+    surgery.
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The prevalence of aortitis was 10.6% (n = 57), of which 75% were clinically isolated."
+    explanation: >-
+      This surgical cohort identifies clinically isolated aortitis as the
+      majority subtype among histology-confirmed aortitis cases.
+- name: Large-vessel vasculitis-associated aortitis
+  description: >-
+    Aortitis associated with giant cell arteritis, Takayasu arteritis, or other
+    large- and variable-vessel vasculitides.
+  evidence:
+  - reference: DOI:10.3390/jcm13216364
+    reference_title: "Imaging in Large Vessel Vasculitis-A Narrative Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Large vessel vasculitis (LVV), particularly giant cell arteritis (GCA) and Takayasu arteritis (TAK), has garnered attention due to its significant morbidity and mortality."
+    explanation: >-
+      This review anchors GCA and Takayasu arteritis as major large-vessel
+      vasculitis contexts relevant to aortitis.
+- name: Infectious aortitis
+  description: >-
+    Aortitis caused by microbial infection of the aortic wall, often presenting
+    with aneurysm or structural aortic abnormalities and requiring urgent
+    antimicrobial and vascular-surgery evaluation.
+  evidence:
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One hundred eighty-three patients were included. Of these, 66 had IA (36.1%); the causative organism was Enterobacterales and streptococci in 18.2% each"
+    explanation: >-
+      This multicenter aortitis cohort identifies infectious aortitis cases and
+      their causative organisms.
+- name: G-CSF-associated drug-induced aortitis
+  description: >-
+    A rare adverse event after granulocyte-colony stimulating factor exposure,
+    most often reported in oncology supportive-care settings and occasionally in
+    healthy stem-cell donors.
+  evidence:
+  - reference: DOI:10.3389/fphar.2024.1487501
+    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Recombinant human granulocyte-colony stimulating factors (G-CSF)-induced aortitis is a rare but particularly serious adverse event, commonly seen in cancer patients undergoing chemotherapy."
+    explanation: >-
+      This literature review supports G-CSF exposure as a drug-induced aortitis
+      subtype, especially in chemotherapy care.
+prevalence:
+- subtype: Histology-confirmed aortitis in major aortic surgery
+  population: Single-center major aortic surgery cohort with high histology sampling
+  percentage: 10.6%
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The prevalence of aortitis was 10.6% (n = 57), of which 75% were clinically isolated."
+    explanation: >-
+      Provides the observed prevalence of histology-confirmed aortitis in a
+      high-sampling surgical cohort.
+epidemiology:
+- name: Infectious versus noninfectious aortitis distribution
+  description: >-
+    In a French multicenter comparison, infectious aortitis accounted for about
+    one-third of included aortitis cases and had distinct microbiologic and
+    aneurysm patterns.
+  factors:
+  - microbial etiology
+  - abdominal aortic involvement
+  - aneurysm at presentation
+  evidence:
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One hundred eighty-three patients were included. Of these, 66 had IA (36.1%); the causative organism was Enterobacterales and streptococci in 18.2% each"
+    explanation: >-
+      Quantifies infectious aortitis frequency and key organisms in a mixed
+      infectious/noninfectious cohort.
+- name: G-CSF-induced aortitis case-review profile
+  description: >-
+    The published case-review dataset is enriched for older women and oncology
+    patients, with pegfilgrastim the most frequently implicated G-CSF agent.
+  factors:
+  - G-CSF exposure
+  - cancer chemotherapy
+  - pegfilgrastim exposure
+  evidence:
+  - reference: DOI:10.3389/fphar.2024.1487501
+    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A total of 72 patients were enrolled, including 14 males and 58 females"
+    explanation: >-
+      Summarizes the demographic profile of reported G-CSF-associated aortitis
+      cases.
+pathophysiology:
+- name: Immune-mediated aortic wall inflammation in large-vessel vasculitis
+  description: >-
+    Large-vessel vasculitis-associated aortitis involves immune-mediated
+    inflammation of the vascular wall, including inflammatory cell accumulation
+    in aortic tissue in Takayasu arteritis.
+  cell_types:
+  - preferred_term: T cell
+    term:
+      id: CL:0000084
+      label: T cell
+  - preferred_term: macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
+  - preferred_term: granulocyte
+    term:
+      id: CL:0000094
+      label: granulocyte
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: smooth muscle cell
+    term:
+      id: CL:0000192
+      label: smooth muscle cell
+  biological_processes:
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  - preferred_term: adaptive immune response
+    modifier: ABNORMAL
+    term:
+      id: GO:0002250
+      label: adaptive immune response
+  locations:
+  - preferred_term: aorta
+    term:
+      id: UBERON:0000947
+      label: aorta
+  evidence:
+  - reference: DOI:10.3390/jcm13216364
+    reference_title: "Imaging in Large Vessel Vasculitis-A Narrative Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Both conditions involve immune-mediated inflammation of the vascular wall, despite differing in epidemiology and presentation."
+    explanation: >-
+      Supports immune-mediated vascular-wall inflammation as a shared mechanism
+      in the GCA/TAK large-vessel vasculitis context.
+  - reference: DOI:10.1177/000331970005100705
+    reference_title: "Accumulation of Lymphocytes, Dendritic Cells, and Granulocytes in the Aortic Wall Affected by Takayasu's Disease"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "CD68 (macrophages), CD15 (granulocytes), von Willebrand factor (endothelial cells), and alpha-smooth muscle actin (smooth muscle cells)."
+    explanation: >-
+      Directly supports macrophage and granulocyte involvement in affected
+      aortic wall tissue in Takayasu arteritis.
+  - reference: DOI:10.1177/000331970005100705
+    reference_title: "Accumulation of Lymphocytes, Dendritic Cells, and Granulocytes in the Aortic Wall Affected by Takayasu's Disease"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "(endothelial cells), and alpha-smooth muscle actin (smooth muscle cells)."
+    explanation: >-
+      Supports endothelial-cell and smooth-muscle-cell assessment in affected
+      aortic wall tissue.
+  downstream:
+  - target: Aortic wall remodeling and structural complications
+    description: >-
+      Persistent vascular inflammation contributes to later remodeling and
+      structural complications such as aneurysm, dissection, or ischemia.
+- name: Infectious aortic wall infection and aneurysmal injury
+  description: >-
+    Infectious aortitis is initiated by microbial infection of native aortic
+    tissue, producing wall thickening or aneurysmal distortion and a higher
+    mortality-risk phenotype than noninfectious aortitis.
+  biological_processes:
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  locations:
+  - preferred_term: aorta
+    term:
+      id: UBERON:0000947
+      label: aorta
+  evidence:
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One hundred eighty-three patients were included. Of these, 66 had IA (36.1%); the causative organism was Enterobacterales and streptococci in 18.2% each"
+    explanation: >-
+      Identifies causative organisms in infectious aortitis and supports
+      microbial infection as the upstream etiology.
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "IA was more frequently associated with aortic aneurysms compared with NIA (78.8% vs 17.6%, P &lt; .001), especially located in the abdominal aorta (69.7% vs 23.1%, P &lt; .001)."
+    explanation: >-
+      Links infectious aortitis to aneurysmal aortic injury more strongly than
+      noninfectious aortitis in the comparison cohort.
+  downstream:
+  - target: Aortic aneurysm
+    description: Infectious wall injury commonly presents with aneurysmal aortic disease.
+    evidence:
+    - reference: DOI:10.1093/cid/ciac560
+      reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "IA was more frequently associated with aortic aneurysms compared with NIA (78.8% vs 17.6%, P &lt; .001), especially located in the abdominal aorta (69.7% vs 23.1%, P &lt; .001)."
+      explanation: >-
+        Provides cohort-level evidence that infectious aortitis is strongly
+        associated with aneurysm.
+- name: G-CSF-associated aortic inflammation
+  description: >-
+    Exogenous G-CSF exposure can trigger aortitis as a serious adverse event,
+    most often detected by CT in the aortic arch and branch vessels.
+  biological_processes:
+  - preferred_term: cytokine-mediated signaling pathway
+    modifier: ABNORMAL
+    term:
+      id: GO:0019221
+      label: cytokine-mediated signaling pathway
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  locations:
+  - preferred_term: aorta
+    term:
+      id: UBERON:0000947
+      label: aorta
+  triggers:
+  - preferred_term: granulocyte-colony stimulating factor exposure
+  evidence:
+  - reference: DOI:10.3389/fphar.2024.1487501
+    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The G-CSF type with the highest frequency of occurrence of aortitis is pegfilgrastim."
+    explanation: >-
+      Identifies G-CSF exposure, particularly pegfilgrastim, as the most common
+      trigger in the case-review dataset.
+  - reference: DOI:10.3389/fphar.2024.1487501
+    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "CT scan showed that aortitis most commonly occured in the aortic arch and its branches."
+    explanation: >-
+      Localizes G-CSF-associated aortitis most often to the aortic arch and
+      branch vessels in reported cases.
+- name: Aortic wall remodeling and structural complications
+  description: >-
+    Inflammatory injury can weaken and remodel the aortic wall, producing
+    aneurysm or dissection and driving the need for long-term aortic follow-up.
+  cell_types:
+  - preferred_term: smooth muscle cell
+    term:
+      id: CL:0000192
+      label: smooth muscle cell
+  - preferred_term: fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    modifier: ABNORMAL
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  locations:
+  - preferred_term: aorta
+    term:
+      id: UBERON:0000947
+      label: aorta
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Aortitis, defined as inflammation of the aorta, can lead to aneurysms and dissections."
+    explanation: >-
+      Directly links aortic inflammation to the principal structural
+      complications of aneurysm and dissection.
+  downstream:
+  - target: Aortic aneurysm
+    description: Aortic wall remodeling can present as aneurysmal dilation.
+  - target: Aortic dissection
+    description: Weakened and inflamed aortic wall can dissect.
+phenotypes:
+- category: Cardiovascular
+  name: Aortitis
+  diagnostic: true
+  description: Inflammation of the aortic wall is the defining feature of aortitis.
+  phenotype_term:
+    preferred_term: Aortitis
+    term:
+      id: HP:6001461
+      label: Aortitis
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Aortitis, defined as inflammation of the aorta, can lead to aneurysms and dissections."
+    explanation: The abstract defines aortitis as inflammation of the aorta.
+- category: Cardiovascular
+  name: Aortic aneurysm
+  description: Aortic wall inflammation can weaken the vessel wall and contribute to aneurysmal dilation.
+  phenotype_term:
+    preferred_term: Aortic aneurysm
+    term:
+      id: HP:0004942
+      label: Aortic aneurysm
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Aortitis, defined as inflammation of the aorta, can lead to aneurysms and dissections."
+    explanation: The abstract directly names aneurysm as a complication of aortitis.
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "IA was more frequently associated with aortic aneurysms compared with NIA (78.8% vs 17.6%, P &lt; .001), especially located in the abdominal aorta (69.7% vs 23.1%, P &lt; .001)."
+    explanation: >-
+      The infectious/noninfectious comparison shows a strong association between
+      infectious aortitis and aortic aneurysm.
+- category: Cardiovascular
+  name: Aortic dissection
+  description: Severe inflammatory weakening of the aorta can predispose to dissection.
+  phenotype_term:
+    preferred_term: Aortic dissection
+    term:
+      id: HP:0002647
+      label: Aortic dissection
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Aortitis, defined as inflammation of the aorta, can lead to aneurysms and dissections."
+    explanation: The abstract directly names dissection as a complication of aortitis.
+  - reference: DOI:10.3389/fphar.2024.1487501
+    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Most patients had a good prognosis, but 3 cases developed complications."
+    explanation: >-
+      The G-CSF case-review abstract documents that serious complications occur
+      in a minority of reported G-CSF-associated aortitis cases.
+- category: Cardiovascular
+  name: Aortic regurgitation
+  description: Aortic root or ascending aortic inflammation can impair aortic valve competence.
+  phenotype_term:
+    preferred_term: Aortic regurgitation
+    term:
+      id: HP:0001659
+      label: Aortic regurgitation
+  evidence:
+  - reference: DOI:10.62186/001c.146456
+    reference_title: "Stroke, Aortic Regurgitation and Aortic Aneurysm in Younger Female: Case of Giant Cell Aortitis and Discussion"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Due to severe aortic regurgitation limiting her activity and aortic root aneurysm"
+    explanation: >-
+      This case report links giant cell aortitis with severe aortic
+      regurgitation and aortic root aneurysm.
+histopathology:
+- name: Aortic wall inflammatory infiltrates
+  description: >-
+    Aortitis can show inflammatory infiltrates in the aortic wall, with
+    lymphocytes, dendritic cells, macrophages, granulocytes, endothelial cells,
+    and smooth muscle cells characterized in Takayasu aortic tissue.
+  diagnostic: true
+  context: Large-vessel vasculitis-associated aortitis
+  evidence:
+  - reference: DOI:10.1177/000331970005100705
+    reference_title: "Accumulation of Lymphocytes, Dendritic Cells, and Granulocytes in the Aortic Wall Affected by Takayasu's Disease"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All specimens showed distinctive histologic features of Takayasu's arteritis and contained inflammatory infiltrates"
+    explanation: >-
+      Histologic inflammatory infiltrates in aortic wall tissue support this
+      microscopic aortitis feature.
+- name: Histology-confirmed clinically isolated aortitis
+  description: >-
+    Clinically isolated aortitis is often diagnosed through intra-operative
+    aortic sampling rather than through preoperative clinical symptoms.
+  diagnostic: true
+  context: Major aortic surgery
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Intra-operative sampling is essential for diagnosis, with many cases presenting asymptomatically as clinically isolated aortitis."
+    explanation: >-
+      Supports intra-operative histologic sampling as a key diagnostic route for
+      clinically isolated aortitis.
+environmental:
+- name: Granulocyte-colony stimulating factor exposure
+  presence: Positive
+  description: >-
+    G-CSF exposure, particularly pegfilgrastim in reported cases, can trigger
+    drug-induced aortitis.
+  evidence:
+  - reference: DOI:10.3389/fphar.2024.1487501
+    reference_title: "Literature review analysis of aortitis induced by granulocyte-colony stimulating factor"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The G-CSF type with the highest frequency of occurrence of aortitis is pegfilgrastim."
+    explanation: >-
+      Identifies pegfilgrastim as the most frequently reported G-CSF exposure in
+      G-CSF-associated aortitis.
+- name: Current tobacco smoking
+  presence: Positive
+  description: >-
+    Current smoking was associated with histology-confirmed aortitis in a major
+    aortic surgery cohort.
+  exposure_term:
+    preferred_term: exposure to tobacco smoking
+    term:
+      id: ECTO:6000029
+      label: exposure to tobacco smoking
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Multivariate logistic regression identified increased age, female sex, current smoking, and other inflammatory diseases as significantly associated with aortitis"
+    explanation: >-
+      Supports current smoking as a clinical risk association in the surgical
+      aortitis cohort.
+diagnosis:
+- name: Histologic aortic wall assessment
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  description: >-
+    Intra-operative aortic sampling can diagnose clinically isolated aortitis
+    that may be missed clinically.
+  results: Aortic wall inflammation on histology supports the diagnosis.
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Intra-operative sampling is essential for diagnosis, with many cases presenting asymptomatically as clinically isolated aortitis."
+    explanation: >-
+      Supports histologic assessment as a diagnostic approach in surgical
+      aortitis and clinically isolated aortitis.
+- name: Large-vessel vascular imaging
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  description: >-
+    CTA, ultrasound, MRI, and FDG-PET are used to detect large-vessel vasculitis
+    activity, wall thickening, and aortic or branch-vessel involvement.
+  results: Vessel-wall thickening or FDG uptake supports active vascular inflammation.
+  evidence:
+  - reference: DOI:10.3390/jcm13216364
+    reference_title: "Imaging in Large Vessel Vasculitis-A Narrative Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Vascular imaging, including computed tomography angiography (CTA), ultrasound (US), magnetic resonance imaging (MRI), and positron emission tomography-computed tomography (PET-CT), is key in diagnosing vasculitis, revealing vessel wall thickening and other suggestive features."
+    explanation: >-
+      Supports vascular imaging as a diagnostic method for large-vessel
+      vasculitis-associated aortitis.
+  - reference: DOI:10.1136/rmdopen-2023-003379
+    reference_title: "Imaging in diagnosis, monitoring and outcome prediction of large vessel vasculitis: a systematic literature review and meta-analysis informing the 2023 update of the EULAR recommendations"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Ultrasound, MRI and FDG-PET revealed a good performance for the diagnosis of GCA."
+    explanation: >-
+      Supports ultrasound, MRI, and FDG-PET as evidence-backed imaging tools in
+      giant-cell-arteritis large-vessel disease.
+- name: Infectious versus noninfectious etiology assessment
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  description: >-
+    Evaluation should distinguish infectious aortitis from noninfectious
+    aortitis because treatment and mortality risk differ.
+  results: Microbiologic evidence and aortic imaging pattern help classify etiology.
+  evidence:
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Determining the etiology of aortitis is often challenging, in particular to distinguish infectious aortitis (IA) and noninfectious aortitis (NIA)."
+    explanation: >-
+      Supports explicit infectious/noninfectious etiologic assessment during
+      aortitis diagnosis.
+  - reference: DOI:10.3390/jcm13216364
+    reference_title: "Imaging in Large Vessel Vasculitis-A Narrative Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Vascular imaging, including computed tomography angiography (CTA), ultrasound (US), magnetic resonance imaging (MRI), and positron emission tomography-computed tomography (PET-CT), is key in diagnosing vasculitis, revealing vessel wall thickening and other suggestive features."
+    explanation: >-
+      Supports vascular imaging as a central diagnostic tool when evaluating
+      aortitis and large-vessel vasculitis.
+treatments:
+- name: Empiric antimicrobial therapy for infectious aortitis
+  description: >-
+    Infectious aortitis requires early antimicrobial therapy, initially empiric
+    when microbiologic documentation is pending and then adapted to organism and
+    susceptibility data.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  evidence:
+  - reference: DOI:10.1093/cid/ciac560
+    reference_title: "Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Effective empiric antimicrobial therapy, initiated before any microbial documentation, was associated with a decreased mortality"
+    explanation: >-
+      Supports early empiric antimicrobial therapy as a mortality-associated
+      protective intervention in infectious aortitis.
+- name: Tocilizumab for LVV-associated aortitis contexts
+  description: >-
+    Tocilizumab may be used for large-vessel vasculitis phenotypes associated
+    with aortitis, with clinical remission and glucocorticoid-sparing effects
+    reported in LV-GCA and Takayasu arteritis cohorts.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  evidence:
+  - reference: DOI:10.3390/sci7010012
+    reference_title: "Tocilizumab in Extracranial Giant-Cell Arteritis and Takayasu Arteritis: A Multicentric Observational Comparative Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Tocilizumab (TCZ) has demonstrated potential efficacy in managing large-vessel (LV) vasculitis such as giant-cell arteritis (GCA) and Takayasu arteritis (TAK)."
+    explanation: >-
+      Supports tocilizumab as a treatment option in the LVV contexts that can
+      include aortitis.
+  - reference: DOI:10.3390/sci7010012
+    reference_title: "Tocilizumab in Extracranial Giant-Cell Arteritis and Takayasu Arteritis: A Multicentric Observational Comparative Study"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "complete imaging resolution was observed in only 18.9% of LV-GCA patients and 21.1% of TAK patients."
+    explanation: >-
+      The clinical benefit is tempered by incomplete imaging resolution,
+      supporting a partial rather than complete effect on vascular inflammation.
+- name: Specialist multidisciplinary follow-up and aortic surveillance
+  description: >-
+    Patients with aortitis require specialist follow-up because of increased
+    re-intervention risk and late aortic complications.
+  treatment_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Due to the increased re-intervention in aortitis, specialist multi-disciplinary follow-up and aortitis centres should be formed."
+    explanation: >-
+      Supports specialist multidisciplinary follow-up for aortitis after major
+      aortic surgery.
+progression:
+- phase: Asymptomatic discovery during aortic surgery
+  subtype: Clinically isolated aortitis
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Intra-operative sampling is essential for diagnosis, with many cases presenting asymptomatically as clinically isolated aortitis."
+    explanation: >-
+      Supports asymptomatic surgical discovery as an important presentation mode
+      for clinically isolated aortitis.
+- phase: Re-intervention after aortitis-associated aortic surgery
+  notes: Re-operation risk is higher in aortitis than in non-aortitis surgical comparators.
+  evidence:
+  - reference: DOI:10.3390/jcdd11120405
+    reference_title: "Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The re-operation rate in aortitis was twice that of non-aortitis patients (17.5% vs. 9.4%, p = 0.054)."
+    explanation: >-
+      Quantifies higher post-surgical re-operation rates in the aortitis cohort.
+references:
+- reference: DOI:10.3390/jcdd11120405
+  title: Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Histology-confirmed aortitis occurred in 10.6% of a high-sampling major aortic surgery cohort.
+    supporting_text: "The prevalence of aortitis was 10.6% (n = 57), of which 75% were clinically isolated."
+- reference: DOI:10.3389/fphar.2024.1487501
+  title: Literature review analysis of aortitis induced by granulocyte-colony stimulating factor
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: G-CSF-induced aortitis is a serious adverse event most often reported in oncology supportive care.
+    supporting_text: "Recombinant human granulocyte-colony stimulating factors (G-CSF)-induced aortitis is a rare but particularly serious adverse event, commonly seen in cancer patients undergoing chemotherapy."
+- reference: DOI:10.1093/cid/ciac560
+  title: Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Infectious aortitis had higher aneurysm association and lower survival than noninfectious aortitis.
+    supporting_text: "IA was more frequently associated with aortic aneurysms compared with NIA (78.8% vs 17.6%, P &lt; .001), especially located in the abdominal aorta (69.7% vs 23.1%, P &lt; .001)."
+- reference: DOI:10.1136/rmdopen-2023-003379
+  title: "Imaging in diagnosis, monitoring and outcome prediction of large vessel vasculitis: a systematic literature review and meta-analysis informing the 2023 update of the EULAR recommendations"
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Ultrasound, MRI, and FDG-PET have good diagnostic performance for giant cell arteritis.
+    supporting_text: "Ultrasound, MRI and FDG-PET revealed a good performance for the diagnosis of GCA."
+- reference: DOI:10.3390/jcm13216364
+  title: Imaging in Large Vessel Vasculitis-A Narrative Review
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Large-vessel vasculitis involves immune-mediated inflammation of the vascular wall.
+    supporting_text: "Both conditions involve immune-mediated inflammation of the vascular wall, despite differing in epidemiology and presentation."
+- reference: DOI:10.3390/sci7010012
+  title: "Tocilizumab in Extracranial Giant-Cell Arteritis and Takayasu Arteritis: A Multicentric Observational Comparative Study"
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Tocilizumab has clinical activity in LV-GCA and Takayasu arteritis but imaging resolution may lag.
+    supporting_text: "complete imaging resolution was observed in only 18.9% of LV-GCA patients and 21.1% of TAK patients."
+- reference: DOI:10.62186/001c.146456
+  title: "Stroke, Aortic Regurgitation and Aortic Aneurysm in Younger Female: Case of Giant Cell Aortitis and Discussion"
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Giant cell aortitis can present with aortic regurgitation and aortic root aneurysm.
+    supporting_text: "Due to severe aortic regurgitation limiting her activity and aortic root aneurysm"
+- reference: DOI:10.1177/000331970005100705
+  title: "Accumulation of Lymphocytes, Dendritic Cells, and Granulocytes in the Aortic Wall Affected by Takayasu's Disease"
+  found_in:
+  - Aortitis-deep-research-falcon.md
+  findings:
+  - statement: Aortic wall tissue in Takayasu arteritis contains inflammatory infiltrates and multiple immune cell populations.
+    supporting_text: "All specimens showed distinctive histologic features of Takayasu's arteritis and contained inflammatory infiltrates"
+datasets: []

--- a/references_cache/DOI_10.1093_cid_ciac560.md
+++ b/references_cache/DOI_10.1093_cid_ciac560.md
@@ -1,0 +1,58 @@
+---
+reference_id: "DOI:10.1093/cid/ciac560"
+title: Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis
+authors:
+- Mathilde Carrer
+- Carole Vignals
+- Xavier Berard
+- Caroline Caradu
+- Anne-Sophie Battut
+- Katherine Stenson
+- Didier Neau
+- Estibaliz Lazaro
+- Maxime Mehlen
+- Amaury Barret
+- Elsa Nyamankolly
+- François Lifermann
+- Patrick Rispal
+- Gabriela Illes
+- Nicolas Rouanes
+- Olivier Caubet
+- Stéphane Poirot-Mazeres
+- Marc-Olivier Vareil
+- Laure Alleman
+- Antoine Millon
+- Ugo Huvelle
+- Florent Valour
+- Tristan Ferry
+- Charles Cazanave
+- Mathilde Puges
+journal: Clinical Infectious Diseases
+year: '2023'
+doi: 10.1093/cid/ciac560
+content_type: abstract_only
+---
+
+# Retrospective Multicenter Study Comparing Infectious and Noninfectious Aortitis
+**Authors:** Mathilde Carrer, Carole Vignals, Xavier Berard, Caroline Caradu, Anne-Sophie Battut, Katherine Stenson, Didier Neau, Estibaliz Lazaro, Maxime Mehlen, Amaury Barret, Elsa Nyamankolly, François Lifermann, Patrick Rispal, Gabriela Illes, Nicolas Rouanes, Olivier Caubet, Stéphane Poirot-Mazeres, Marc-Olivier Vareil, Laure Alleman, Antoine Millon, Ugo Huvelle, Florent Valour, Tristan Ferry, Charles Cazanave, Mathilde Puges
+**Journal:** Clinical Infectious Diseases (2023)
+**DOI:** [10.1093/cid/ciac560](https://doi.org/10.1093/cid/ciac560)
+
+## Content
+
+Abstract
+
+Background
+Determining the etiology of aortitis is often challenging, in particular to distinguish infectious aortitis (IA) and noninfectious aortitis (NIA). This study aims to describe and compare the clinical, biological, and radiological characteristics of IA and NIA and their outcomes.
+
+
+Methods
+A multicenter retrospective study was performed in 10 French centers, including patients with aortitis between 1 January 2014 and 31 December 2019.
+
+
+Results
+One hundred eighty-three patients were included. Of these, 66 had IA (36.1%); the causative organism was Enterobacterales and streptococci in 18.2% each, Staphylococcus aureus in 13.6%, and Coxiella burnetii in 10.6%. NIA was diagnosed in 117 patients (63.9%), mainly due to vasculitides (49.6%), followed by idiopathic aortitis (39.3%). IA was more frequently associated with aortic aneurysms compared with NIA (78.8% vs 17.6%, P &lt; .001), especially located in the abdominal aorta (69.7% vs 23.1%, P &lt; .001). Crude and adjusted survival were significantly lower in IA compared to NIA (P &lt; .001 and P = .006, respectively). In the IA cohort, high American Society of Anesthesiologists score (hazard ratio [HR], 2.47 [95% confidence interval {CI}, 1.08–5.66]; P = .033) and free aneurysm rupture (HR, 9.54 [95% CI, 1.04–87.11]; P = .046) were significantly associated with mortality after adjusting for age, sex, and Charlson comorbidity score. Effective empiric antimicrobial therapy, initiated before any microbial documentation, was associated with a decreased mortality (HR, 0.23, 95% CI, .08–.71]; P = .01).
+
+
+Conclusions
+IA was complicated by significantly higher mortality rates compared with NIA. An appropriate initial antibiotic therapy appeared as a protective factor in IA.

--- a/references_cache/DOI_10.1136_rmdopen-2023-003379.md
+++ b/references_cache/DOI_10.1136_rmdopen-2023-003379.md
@@ -1,0 +1,39 @@
+---
+reference_id: "DOI:10.1136/rmdopen-2023-003379"
+title: "Imaging in diagnosis, monitoring and outcome prediction of large vessel vasculitis: a systematic literature review and meta-analysis informing the 2023 update of the EULAR recommendations"
+authors:
+- Philipp Bosch
+- Milena Bond
+- Christian Dejaco
+- Cristina Ponte
+- Sarah Louise Mackie
+- Louise Falzon
+- Wolfgang A Schmidt
+- Sofia Ramiro
+journal: RMD Open
+year: '2023'
+doi: 10.1136/rmdopen-2023-003379
+content_type: abstract_only
+---
+
+# Imaging in diagnosis, monitoring and outcome prediction of large vessel vasculitis: a systematic literature review and meta-analysis informing the 2023 update of the EULAR recommendations
+**Authors:** Philipp Bosch, Milena Bond, Christian Dejaco, Cristina Ponte, Sarah Louise Mackie, Louise Falzon, Wolfgang A Schmidt, Sofia Ramiro
+**Journal:** RMD Open (2023)
+**DOI:** [10.1136/rmdopen-2023-003379](https://doi.org/10.1136/rmdopen-2023-003379)
+
+## Content
+
+Objectives
+To update the evidence on imaging for diagnosis, monitoring and outcome prediction in large vessel vasculitis (LVV) to inform the 2023 update of the European Alliance of Associations for Rheumatology recommendations on imaging in LVV.
+
+
+Methods
+Systematic literature review (SLR) (2017–2022) including prospective cohort and cross-sectional studies (>20 participants) on diagnostic, monitoring, outcome prediction and technical aspects of LVV imaging. Diagnostic accuracy data were meta-analysed in combination with data from an earlier (2017) SLR.
+
+
+Results
+The update retrieved 38 studies, giving a total of 81 studies when combined with the 2017 SLR. For giant cell arteritis (GCA), and taking clinical diagnosis as a reference standard, low risk of bias (RoB) studies yielded pooled sensitivities and specificities (95% CI) of 88% (82% to 92%) and 96% (95% CI 86% to 99%) for ultrasound (n=8 studies), 81% (95% CI 71% to 89%) and 98% (95% CI 89% to 100%) for MRI (n=3) and 76% (95% CI 67% to 83%) and 95% (95% CI 71% to 99%) for fluorodeoxyglucose positron emission tomography (FDG-PET, n=4), respectively. Compared with studies assessing cranial arteries only, low RoB studies with ultrasound assessing both cranial and extracranial arteries revealed a higher sensitivity (93% (95% CI 88% to 96%) vs 80% (95% CI 71% to 87%)) with comparable specificity (94% (95% CI 83% to 98%) vs 97% (95% CI 71% to 100%)). No new studies on diagnostic imaging for Takayasu arteritis (TAK) were found. Some monitoring studies in GCA or TAK reported associations of imaging with clinical signs of inflammation. No evidence was found to determine whether imaging severity might predict worse clinical outcomes.
+
+
+Conclusion
+Ultrasound, MRI and FDG-PET revealed a good performance for the diagnosis of GCA. Cranial and extracranial vascular ultrasound had a higher pooled sensitivity with similar specificity compared with limited cranial ultrasound.

--- a/references_cache/DOI_10.1177_000331970005100705.md
+++ b/references_cache/DOI_10.1177_000331970005100705.md
@@ -1,0 +1,24 @@
+---
+reference_id: "DOI:10.1177/000331970005100705"
+title: "Accumulation of Lymphocytes, Dendritic Cells, and Granulocytes in the Aortic Wall Affected by Takayasu's Disease"
+authors:
+- Stephanie Jane Inder
+- Yuri Veniaminovich Bobryshev
+- Sanjay Mammen Cherian
+- Reginald Sidney Albert Lord
+- Kazuyoshi Masuda
+- Chikao Yutani
+journal: Angiology
+year: '2000'
+doi: 10.1177/000331970005100705
+content_type: abstract_only
+---
+
+# Accumulation of Lymphocytes, Dendritic Cells, and Granulocytes in the Aortic Wall Affected by Takayasu's Disease
+**Authors:** Stephanie Jane Inder, Yuri Veniaminovich Bobryshev, Sanjay Mammen Cherian, Reginald Sidney Albert Lord, Kazuyoshi Masuda, Chikao Yutani
+**Journal:** Angiology (2000)
+**DOI:** [10.1177/000331970005100705](https://doi.org/10.1177/000331970005100705)
+
+## Content
+
+The aim of this study was to analyze the cellular composition of the arterial wall in Takayasu's disease and to investigate the contribution of the various cell types to the immunoinflammatory processes and degenerative alterations of the vessel wall in this disease. Specimens of aorta were obtained at operation from 10 patients with Takayasu's arteritis. The duration of disease ranged from 2 months to 13 years. Immunohisto chemical investigation was carried out using the antibodies CD3 (to identify T-cells), CD20 (B-cells), S-100 (dendritic cells), CD68 (macrophages), CD15 (granulocytes), von Willebrand factor (endothelial cells), and alpha-smooth muscle actin (smooth muscle cells). All specimens showed distinctive histologic features of Takayasu's arteritis and contained inflammatory infiltrates, but the degree of their accumulation within the aortic wall varied. Inflammatory infiltrates within the deep part of the intima, around areas of neovascularization and within the adventitia contained T-cells colocalizing with dendritic cells. Nodules formed by large numbers of intermingling T-cells and B-cells enriched with dendritic cells were observed in the adventitia. Massive accumulation of granulo- ( continued on next page) cytes and their destruction within the adventitia were prominent in all cases. This is the first study that establishes the presence of dendritic cells and granulocytes in Takayasu's disease. Dendritic cells are probably involved in the immunoinflammatory processes through their interaction with T-cells and B-cells. The present observations may help understanding of the pathogenesis of Takayasu's disease.

--- a/references_cache/DOI_10.1186_s13063-024-07905-4.md
+++ b/references_cache/DOI_10.1186_s13063-024-07905-4.md
@@ -1,0 +1,41 @@
+---
+reference_id: "DOI:10.1186/s13063-024-07905-4"
+title: "The Meteoritics Trial: efficacy of methotrexate after remission-induction with tocilizumab and glucocorticoids in giant cell arteritis—study protocol for a randomized, double-blind, placebo-controlled, parallel-group phase II study"
+authors:
+- Lena Kreis
+- Christian Dejaco
+- Wolfgang Andreas Schmidt
+- Robert Németh
+- Nils Venhoff
+- Valentin Sebastian Schäfer
+journal: Trials
+year: '2024'
+doi: 10.1186/s13063-024-07905-4
+content_type: abstract_only
+---
+
+# The Meteoritics Trial: efficacy of methotrexate after remission-induction with tocilizumab and glucocorticoids in giant cell arteritis—study protocol for a randomized, double-blind, placebo-controlled, parallel-group phase II study
+**Authors:** Lena Kreis, Christian Dejaco, Wolfgang Andreas Schmidt, Robert Németh, Nils Venhoff, Valentin Sebastian Schäfer
+**Journal:** Trials (2024)
+**DOI:** [10.1186/s13063-024-07905-4](https://doi.org/10.1186/s13063-024-07905-4)
+
+## Content
+
+Abstract
+
+Background
+Glucocorticoids (GC) are the standard treatment for giant cell arteritis (GCA), even though they are associated with adverse side effects and high relapse rates. Tocilizumab (TCZ), an interleukin-6 receptor antagonist, has shown promise in sustaining remission and reducing the cumulative GC dosage, but it increases the risk of infections and is expensive. After discontinuation of TCZ, only about half of patients remain in remission. Additionally, only few studies have been conducted looking at remission maintenance, highlighting the need for alternative strategies to maintain remission in GCA. Methotrexate (MTX) has been shown to significantly decrease the risk of relapse in new-onset GCA and is already a proven safe drug in many rheumatologic diseases.
+
+
+Methods
+This study aims to evaluate the efficacy and safety of MTX in maintaining remission in patients with GCA who have previously been treated with GC and at least 6 months with TCZ. We hypothesize that MTX can maintain remission in GCA patients, who have achieved stable remission after treatment with GC and TCZ, and prevent the occurrence of relapses. The study design is a monocentric, randomized, double-blind, placebo-controlled, parallel-group phase II trial randomizing 40 GCA patients 1:1 into a MTX or placebo arm. Patients will receive 17.5 mg MTX/matching placebo weekly by subcutaneous injection for 12 months, with the possibility of dose reduction if clinically needed. A 6-month follow-up will take place. The primary endpoint is the time to first relapse in the MTX group versus placebo during the 12-month treatment period. Secondary outcomes include patient- and investigator-reported outcomes and laboratory findings, as well as the prevalence of aortitis, number of vasculitic vessels, and change in intima-media thickness during the study.
+
+
+Discussion
+This is the first clinical trial evaluating remission maintenance of GCA with MTX after a previous treatment cycle with TCZ. Following the discontinuation of TCZ in GCA, MTX could be a safe and inexpensive drug.
+
+
+Trial registration
+ClinicalTrials.gov, NCT05623592. Registered on 21 November 2022.
+EU Clinical Trials Register, 2022-501058-12-00.
+German Clinical Trials Register DRKS00030571.

--- a/references_cache/DOI_10.3389_fimmu.2025.1625456.md
+++ b/references_cache/DOI_10.3389_fimmu.2025.1625456.md
@@ -1,0 +1,21 @@
+---
+reference_id: "DOI:10.3389/fimmu.2025.1625456"
+title: "Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice"
+authors:
+- Yan Wang
+- Feng Tian
+- Hui Li
+journal: Frontiers in Immunology
+year: '2025'
+doi: 10.3389/fimmu.2025.1625456
+content_type: abstract_only
+---
+
+# Unraveling the complexity of IgG4-related aortitis and periarteritis: from pathogenesis to clinical practice
+**Authors:** Yan Wang, Feng Tian, Hui Li
+**Journal:** Frontiers in Immunology (2025)
+**DOI:** [10.3389/fimmu.2025.1625456](https://doi.org/10.3389/fimmu.2025.1625456)
+
+## Content
+
+IgG4-related disease (IgG4-RD) is a chronic fibrotic inflammatory condition characterized by elevated serum IgG4 levels and the infiltration of IgG4-bearing plasma cells in affected organs. It can involve various organs, particularly large vessels. IgG4-related aortitis/periaortitis and periarteritis (IgG4-related PAO/PA) predominantly affect the abdominal aorta and iliac arteries, with a higher prevalence in elderly males. This condition exhibits distinct clinical, histologic, and radiological features compared to IgG4-RD without vascular involvement and other immune-associated vasculitides. IgG4-related PAO/PA diagnosis primarily relies on histopathological findings and imaging studies. Glucocorticoids (GCs) are the mainstay of treatment, often combined with immunosuppressants (IMs), while B- and T-cell-targeted therapies are under investigation. Although most patients respond well to treatment, the disease can be life-threatening due to complications such as myocardial infarction, aortic dissection, and aneurysmal rupture. Therefore, understanding these characteristics is crucial for clinicians to make accurate diagnoses and implement effective treatment strategies. This review provides a comprehensive overview of the current understanding of the pathogenesis, histopathological characteristics, clinical features, diagnosis, treatment, and prognosis of IgG4-related PAO/PA.

--- a/references_cache/DOI_10.3389_fphar.2024.1487501.md
+++ b/references_cache/DOI_10.3389_fphar.2024.1487501.md
@@ -1,0 +1,20 @@
+---
+reference_id: "DOI:10.3389/fphar.2024.1487501"
+title: Literature review analysis of aortitis induced by granulocyte-colony stimulating factor
+authors:
+- Ting Zhao
+- Huanhuan Xu
+journal: Frontiers in Pharmacology
+year: '2024'
+doi: 10.3389/fphar.2024.1487501
+content_type: abstract_only
+---
+
+# Literature review analysis of aortitis induced by granulocyte-colony stimulating factor
+**Authors:** Ting Zhao, Huanhuan Xu
+**Journal:** Frontiers in Pharmacology (2024)
+**DOI:** [10.3389/fphar.2024.1487501](https://doi.org/10.3389/fphar.2024.1487501)
+
+## Content
+
+BackgroundRecombinant human granulocyte-colony stimulating factors (G-CSF)-induced aortitis is a rare but particularly serious adverse event, commonly seen in cancer patients undergoing chemotherapy. The aim of this article is to clarify the clinical characteristics of G-CSF- induced aortitis and provide effective references for clinical diagnosis and intervention.MethodsCase reports of adverse reactions of aortitis induced by G-CSF were collected from the relevant databases. The patients’ basic information and adverse reaction process were recorded and subjected to descriptive analysis.ResultsA total of 72 patients were enrolled, including 14 males and 58 females, with a mean age of 61.83 ± 10.30 years. The G-CSF type with the highest frequency of occurrence of aortitis is pegfilgrastim. Apart from three healthy stem cell donors, G-CSF-induced aortitis was primarily found in patients with underlying malignancies, especially in patients with breast cancer. The most common anticancer drugs used at onset were docetaxel, cyclophosphamide, and doxorubicin. CT scan showed that aortitis most commonly occured in the aortic arch and its branches. Most patients had a good prognosis, but 3 cases developed complications. Importantly, G-CSF-induced aortitis was also found in 4 asymptomatic patients.ConclusionThis article found that G-CSF-induced aortitis not only occured in cancer patients undergoing chemotherapy as previously reported in literature, but also in healthy stem cell donors. Especially, asymptomatic patients with G-CSF-induced aortitis faced a greater risk of being missed by the attending physician.

--- a/references_cache/DOI_10.3390_jcdd11120405.md
+++ b/references_cache/DOI_10.3390_jcdd11120405.md
@@ -1,0 +1,27 @@
+---
+reference_id: "DOI:10.3390/jcdd11120405"
+title: Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery
+authors:
+- Edward Staniforth
+- Shirish Dubey
+- Iakovos Ttofi
+- Vanitha Perinparajah
+- Jasmina Ttofi
+- Rohit Vijjhalwar
+- Raman Uberoi
+- Ediri Sideso
+- George Krasopoulos
+journal: Journal of Cardiovascular Development and Disease
+year: '2024'
+doi: 10.3390/jcdd11120405
+content_type: abstract_only
+---
+
+# Aortitis Increases the Risk of Surgical Complications and Re-Operations After Major Aortic Surgery
+**Authors:** Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, George Krasopoulos
+**Journal:** Journal of Cardiovascular Development and Disease (2024)
+**DOI:** [10.3390/jcdd11120405](https://doi.org/10.3390/jcdd11120405)
+
+## Content
+
+Aortitis, defined as inflammation of the aorta, can lead to aneurysms and dissections. Intra-operative sampling is essential for diagnosis, with many cases presenting asymptomatically as clinically isolated aortitis. Previous studies investigating aortitis in major aortic surgery have been limited by low intra-operative sampling. We performed an 11-year, retrospective, cross-sectional study to investigate the true prevalence of aortitis in thoracic aortic aneurysms and dissections by analysing all major aortic operations performed in a single centre. We collected medical histories, histological reports, post-operative outcomes and follow-up data; 537 patients met the inclusion criteria, representing an 88% histological sampling rate. The prevalence of aortitis was 10.6% (n = 57), of which 75% were clinically isolated. The re-operation rate in aortitis was twice that of non-aortitis patients (17.5% vs. 9.4%, p = 0.054). Multivariate logistic regression identified increased age, female sex, current smoking, and other inflammatory diseases as significantly associated with aortitis, with a bicuspid aortic valve associated with a significantly decreased likelihood of aortitis. The true prevalence of aortitis is likely higher than reported in previous studies, with our study showing twice the prevalence found in previous studies with lower sampling rates. Due to the increased re-intervention in aortitis, specialist multi-disciplinary follow-up and aortitis centres should be formed.

--- a/references_cache/DOI_10.3390_jcm13216364.md
+++ b/references_cache/DOI_10.3390_jcm13216364.md
@@ -1,0 +1,32 @@
+---
+reference_id: "DOI:10.3390/jcm13216364"
+title: Imaging in Large Vessel Vasculitis—A Narrative Review
+authors:
+- Ioana Popescu
+- Roxana Pintican
+- Luminita Cocarla
+- Benjamin Burger
+- Irina Sandu
+- George Popa
+- Alexandra Dadarlat
+- Raluca Rancea
+- Alexandru Oprea
+- Alexandru Goicea
+- Laura Damian
+- Alexandru Manea
+- Ruben Mateas
+- Simona Manole
+journal: Journal of Clinical Medicine
+year: '2024'
+doi: 10.3390/jcm13216364
+content_type: abstract_only
+---
+
+# Imaging in Large Vessel Vasculitis—A Narrative Review
+**Authors:** Ioana Popescu, Roxana Pintican, Luminita Cocarla, Benjamin Burger, Irina Sandu, George Popa, Alexandra Dadarlat, Raluca Rancea, Alexandru Oprea, Alexandru Goicea, Laura Damian, Alexandru Manea, Ruben Mateas, Simona Manole
+**Journal:** Journal of Clinical Medicine (2024)
+**DOI:** [10.3390/jcm13216364](https://doi.org/10.3390/jcm13216364)
+
+## Content
+
+Vasculitis refers to a group of rare conditions characterized by the inflammation of blood vessels, affecting multiple systems. It presents a diagnostic and therapeutic challenge due to its broad clinical manifestations. Vasculitis is classified based on the size of the affected vessels: small, medium, large, or variable-sized. Large vessel vasculitis (LVV), particularly giant cell arteritis (GCA) and Takayasu arteritis (TAK), has garnered attention due to its significant morbidity and mortality. Both conditions involve immune-mediated inflammation of the vascular wall, despite differing in epidemiology and presentation. Early identification is crucial to prevent complications like organ ischemia and hemorrhage. Diagnostic accuracy can be hampered by false negative results, making comprehensive investigation essential. Vascular imaging, including computed tomography angiography (CTA), ultrasound (US), magnetic resonance imaging (MRI), and positron emission tomography-computed tomography (PET-CT), is key in diagnosing vasculitis, revealing vessel wall thickening and other suggestive features. This article reviews typical and atypical CT and CTA findings in LVV, discusses imaging modalities, and highlights their role in therapeutic management and prognosis. It emphasizes the importance of a multidisciplinary approach and the critical role of radiologists in improving patient outcomes in LVV.

--- a/references_cache/DOI_10.3390_sci7010012.md
+++ b/references_cache/DOI_10.3390_sci7010012.md
@@ -1,0 +1,30 @@
+---
+reference_id: "DOI:10.3390/sci7010012"
+title: "Tocilizumab in Extracranial Giant-Cell Arteritis and Takayasu Arteritis: A Multicentric Observational Comparative Study"
+authors:
+- Carmen Lasa-Teja
+- Javier Loricera
+- Diana Prieto-Peña
+- Fernando López-Gutiérrez
+- Pilar Bernabéu
+- María Mercedes Freire-González
+- Beatriz González-Alvarez
+- Roser Solans-Laqué
+- Mauricio Mínguez
+- Iván Ferraz-Amaro
+- Santos Castañeda
+- Ricardo Blanco
+journal: Sci
+year: '2025'
+doi: 10.3390/sci7010012
+content_type: abstract_only
+---
+
+# Tocilizumab in Extracranial Giant-Cell Arteritis and Takayasu Arteritis: A Multicentric Observational Comparative Study
+**Authors:** Carmen Lasa-Teja, Javier Loricera, Diana Prieto-Peña, Fernando López-Gutiérrez, Pilar Bernabéu, María Mercedes Freire-González, Beatriz González-Alvarez, Roser Solans-Laqué, Mauricio Mínguez, Iván Ferraz-Amaro, Santos Castañeda, Ricardo Blanco
+**Journal:** Sci (2025)
+**DOI:** [10.3390/sci7010012](https://doi.org/10.3390/sci7010012)
+
+## Content
+
+Tocilizumab (TCZ) has demonstrated potential efficacy in managing large-vessel (LV) vasculitis such as giant-cell arteritis (GCA) and Takayasu arteritis (TAK). Despite the shared characteristics between the LV-GCA phenotype and TAK, there are differences between both entities that may affect therapeutic responses to TCZ. We aim to assess and compare the effectiveness and safety of TCZ in patients with LV-GCA and TAK. Multicenter, observational study on 70 LV-GCA patients and 57 TAK patients treated with TCZ. Outcomes were assessed at baseline and at 1, 3, 6 and 12 months post-treatment initiation. The variables analyzed included the following: (a) the achievement of clinical remission and improvement in laboratory markers; (b) imaging-based disease activity; (c) a glucocorticoid (GC)-sparing effect; and (d) side events and a safety profile. At the treatment initiation, TAK patients were younger, exhibited longer disease duration, had received more prior biologics, and were on higher doses of prednisone compared to LV-GCA patients. While TAK patients showed a slower initial clinical response, remission rates at 12 months were comparable between groups (74.5% for LV-GCA vs. 76.9% for TAK). Both groups experienced rapid laboratory marker improvement and a significant GC-sparing effect. However, complete imaging resolution was observed in only 18.9% of LV-GCA patients and 21.1% of TAK patients. The safety profile was similar in both groups, with severe infections leading to TCZ discontinuation in four LV-GCA and three TAK patients. In clinical practice, TCZ demonstrates similar efficacy in promoting remission and reducing GC dependency in both LV-GCA and TAK patients. Nonetheless, discrepancies between clinical outcomes and imaging improvement highlight the need for further investigation into disease monitoring and management strategies.

--- a/references_cache/DOI_10.62186_001c.146456.md
+++ b/references_cache/DOI_10.62186_001c.146456.md
@@ -1,0 +1,19 @@
+---
+reference_id: "DOI:10.62186/001c.146456"
+title: "Stroke, Aortic Regurgitation and Aortic Aneurysm in Younger Female: Case of Giant Cell Aortitis and Discussion"
+authors:
+- Elizabeth Chan
+journal: "Academic Medicine &amp; Surgery"
+year: '2025'
+doi: 10.62186/001c.146456
+content_type: abstract_only
+---
+
+# Stroke, Aortic Regurgitation and Aortic Aneurysm in Younger Female: Case of Giant Cell Aortitis and Discussion
+**Authors:** Elizabeth Chan
+**Journal:** Academic Medicine &amp; Surgery (2025)
+**DOI:** [10.62186/001c.146456](https://doi.org/10.62186/001c.146456)
+
+## Content
+
+The author presents the case of a middle-aged woman who had a left parietal lobe infarct. Due to severe aortic regurgitation limiting her activity and aortic root aneurysm, the patient underwent aortic valve and aortic graft replacement, in addition to PFO closure. During this hospitalization, aortic root pathology was noted, leading to an ultimate diagnosis of giant cell aortitis.

--- a/references_cache/PMID_34448091.md
+++ b/references_cache/PMID_34448091.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:34448091"
+title: "Drug-induced aortitis of the subclavian artery caused by pegfilgrastim: a case report."
+authors:
+- Jimbo H
+- Horimoto Y
+- Okazaki M
+- Ishizuka Y
+- Kido H
+- Saito M
+journal: Surg Case Rep
+year: '2021'
+doi: 10.1186/s40792-021-01282-9
+content_type: full_text_xml
+---
+
+# Drug-induced aortitis of the subclavian artery caused by pegfilgrastim: a case report.
+**Authors:** Jimbo H, Horimoto Y, Okazaki M, Ishizuka Y, Kido H, Saito M
+**Journal:** Surg Case Rep (2021)
+**DOI:** [10.1186/s40792-021-01282-9](https://doi.org/10.1186/s40792-021-01282-9)
+
+## Content
+
+1. Surg Case Rep. 2021 Aug 26;7(1):197. doi: 10.1186/s40792-021-01282-9.
+
+Drug-induced aortitis of the subclavian artery caused by pegfilgrastim: a case 
+report.
+
+Jimbo H(1), Horimoto Y(2), Okazaki M(1), Ishizuka Y(1), Kido H(3), Saito M(1).
+
+Author information:
+(1)Department of Breast Oncology, Juntendo University School of Medicine, 2-1-1 
+Hongo, Bunkyo-ku, Tokyo, 113-0033, Japan.
+(2)Department of Breast Oncology, Juntendo University School of Medicine, 2-1-1 
+Hongo, Bunkyo-ku, Tokyo, 113-0033, Japan. horimoto@juntendo.ac.jp.
+(3)Department of Medical Oncology, Juntendo University School of Medicine, 2-1-1 
+Hongo, Bunkyo-ku, Tokyo, 113-0033, Japan.
+
+BACKGROUND: Pegfilgrastim is a modified version of granulocyte-colony 
+stimulating factor (G-CSF), with a polyethylene glycol (PEG) that prolongs its 
+half-life in peripheral blood. It is prophylactically administered during 
+chemotherapy to prevent severe febrile neutropenia. G-CSF-related aortitis is a 
+rare side effect but reports of this disease have been increasing in recent 
+years, probably due to PEGylation. Herein, we report a case who developed 
+pegfilgrastim-induced aortitis, localized to the right subclavian artery, during 
+adjuvant chemotherapy. Her condition recovered without the use of steroids.
+CASE PRESENTATION: A 58-year-old woman was diagnosed with invasive ductal 
+carcinoma of the left breast. She had a medical history of contralateral breast 
+cancer and pyelonephritis. Following curative surgery for her left breast 
+cancer, she received adjuvant chemotherapy. Two days after the first course of 
+dose-dense paclitaxel, pegfilgrastim was used as planned. Eight days after the 
+administration of pegfilgrastim, she developed a high fever of 38 °C and visited 
+the emergency outpatient clinic 3 days after. Blood tests revealed an increased 
+inflammatory response, and contrast-enhanced computed tomography (CT) revealed a 
+wall thickening of the subclavian artery, suggesting aortitis caused by 
+pegfilgrastim. She was hospitalized on day 15 when CRP increased to 21.5 mg/dL 
+and the high fever continued. Blood and urine culture tests were negative 
+throughout. Pegfilgrastim-induced aortitis was suspected and she was observed 
+without the use of steroids. Seven days later, her fever abated. A 
+contrast-enhanced CT scan on day 26 showed the subclavian artery wall thickening 
+had disappeared. The patient continues to be afebrile and is currently on weekly 
+paclitaxel without use of G-CSF.
+CONCLUSIONS: The onset of this disease is known to usually occur within 2 weeks 
+after the first pegfilgrastim administration. Aortitis localized to the 
+subclavian artery is relatively rare with the most frequent site being the 
+aortic arch. Clinicians should be aware of the timing and location of onset of 
+this disease.
+
+© 2021. The Author(s).
+
+DOI: 10.1186/s40792-021-01282-9
+PMCID: PMC8390717
+PMID: 34448091
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests in this case.
+
+Granulocyte-colony stimulating factor (G-CSF) binds to its receptors on neutrophil progenitors in the bone marrow and increases neutrophil number in peripheral blood by promoting the differentiation of neutrophil progenitors into neutrophils [1]. It has long been used in chemotherapies that cause myelosuppression. Pegfilgrastim is a modified version of G-CSF, with a polyethylene glycol (PEG) conjugated to the N-terminus of filgrastim to prolong its half-life in peripheral blood [1]. As a sustained form, it can be administered prophylactically during chemotherapy to prevent severe febrile neutropenia. It is widely used for a variety of malignancies.
+
+G-CSF-related aortitis is a rare side effect of G-CSF treatment, with an incidence rate of 0.0014% in the United States and 0.47% in Japan, indicating a slightly higher incidence in Asian patients [2]. It is also known to occur more frequently in women [2, 3]. The key findings for diagnosis are the presence of aortic wall thickening and surrounding soft tissue infiltration on contrast-enhanced CT scan [2–5]. There are no specific markers for G-CSF-associated aortitis and general markers for autoimmune disease, such as PR3-ANCA (proteinase3-anti-neutrophil cytoplasmic antibody), MPO (myeloperoxidase)-ANCA, antinuclear antibodies and IgG, are usually negative [2, 3]. Therefore, C-reactive protein (CRP) is currently used to assess disease activity in clinical practice. Treatment for this disease has not yet been established, as the benefit of steroids in patient remission, in a similar manner to Takayasu’s disease, is equivocal [2–7].
+
+Reports of G-CSF-associated aortitis have been increasing in recent years, probably due to PEGylation [2, 3, 6]. Here, we report a case who developed pegfilgrastim-induced aortitis, localized to the right subclavian artery, during adjuvant chemotherapy. Her condition recovered without the use of steroids.
+
+A 58-year-old woman found a lump on her left breast and was diagnosed with invasive ductal carcinoma (IDC) by her previous doctor, who referred her to our department for further treatment. Fourteen years prior she had undergone curative surgery for contralateral right breast cancer at another hospital (IDC, triple negative, pT2N0M0). Postoperatively, she received six cycles of CEF (C: cyclophosphamide 500 mg/m2, E: epirubicin 75 mg/m2, F: 5-fluorouracil: 500 mg/m2). She had a history of pyelonephritis. Her family history includes esophageal cancer in her father, cerebral infarction in her mother, and colon cancer in her grandfather.
+
+At our hospital, she underwent left mastectomy and sentinel node biopsy for left breast cancer. The final pathological diagnosis was IDC, ER (−), PgR (+), HER2 (−), pT2N0M0 (stage IIA). After starting TC (docetaxel plus cyclophosphamide) as adjuvant chemotherapy, a rash appeared all over her body. A drug-induced lymphocyte stimulation test (DLST) was positive for docetaxel and palonosetron hydrochloride, so this chemotherapy was discontinued. Instead, she received dose-dense paclitaxel (ddPTX, 175 mg/m2 bi-weekly) therapy. Two days after the first course, pegfilgrastim (3.6 mg) was administered as a scheduled regimen. Eight days after the administration of pegfilgrastim, she developed high fever of 38 °C and took levofloxacin (LVFX). As the fever did not decrease within 3 days, the patient visited the emergency outpatient clinic (day 11 after pegfilgrastim administration). Figure 1 shows the clinical course of the patient. Blood tests, contrast-enhanced computed tomography (CT), and various culture tests (blood, urine and sputum) were performed, and an increased inflammatory response was observed with white blood cell (WBC) 22,600/μL (neutrophil: 93%) and CRP 13.7 mg/dL.Fig. 1Clinical course of the case patient. The clinical course of this patient after pegfilgrastim administration is shown. Blue, orange and grey lines indicate body temperature (BT), white blood cell (WBC) and CRP, respectively. Down arrowheads indicate the use of acetaminophen. ddPTX dose-dense paclitaxel, LVFX levofloxacin, ST sulfamethoxazole–trimethoprim combination, MEPM meropenem, CT computed tomography
+
+Clinical course of the case patient. The clinical course of this patient after pegfilgrastim administration is shown. Blue, orange and grey lines indicate body temperature (BT), white blood cell (WBC) and CRP, respectively. Down arrowheads indicate the use of acetaminophen. ddPTX dose-dense paclitaxel, LVFX levofloxacin, ST sulfamethoxazole–trimethoprim combination, MEPM meropenem, CT computed tomography
+
+Contrast-enhanced CT revealed wall thickening of the subclavian artery, suggesting the possibility of pegfilgrastim-induced aortitis (Fig. 2A). However, pyelonephritis could not be ruled out due to the observation of some poorly contrasted areas in the renal cortex. As a result, she was given an additional sulfamethoxazole–trimethoprim combination, however, the fever did not abate and the patient returned to the outpatient clinic on day 15. At this point CRP had increased to 21.5 mg/dL, and following strong complaints of malaise and anorexia she was hospitalized that day. While blood and urine culture tests were negative, meropenem (MEPM) was given since an anaerobic bacterial infection could not be ruled out. At this point, the possibility of pegfilgrastim-induced aortitis was considered more likely than infection, and the patient was observed without steroids. Acetaminophen was used as needed during admission. On day 21 (7 days after admission) her fever abated, and blood tests showed improvement on day 23 (WBC 5600/μL and CRP 1.95 mg/dL). A contrast-enhanced CT scan was performed again on day 26, and an improvement of the subclavian artery wall thickening was confirmed (Fig. 2B).Fig. 2CT scan findings: the right subclavian artery. A Wall thickening and peri-aortic soft tissue infiltration of the right subclavian artery on day 11 after pegfilgrastim administration (orange arrowheads). These findings were improved on day 26 (B)
+
+CT scan findings: the right subclavian artery. A Wall thickening and peri-aortic soft tissue infiltration of the right subclavian artery on day 11 after pegfilgrastim administration (orange arrowheads). These findings were improved on day 26 (B)
+
+Following discharge from hospital, the patient remains afebrile and is currently on weekly paclitaxel without the use of G-CSF.
+
+This report describes our experience with a case of aortitis localized to the subclavian artery where fever was exhibited 8 days after pegfilgrastim administration. The onset of this disease is known to usually occur within 2 weeks after the first administration of pegfilgrastim [3]. G-CSF-induced aortitis can occur in the thoracic to abdominal aorta and its branches, but the most frequent site is the aortic arch, reported to occur in approximately 70% of cases (11 of 16) [3–12]. Aortitis localized to the subclavian artery is relatively rare.
+
+When our case patient visited an emergency outpatient clinic, her blood test showed high neutrophil rate (93%), despite no infectious disease. In clinical practice, an increase in the WBC neutrophil rate is frequently observed after pegfilgrastim administration. However, to the best of our knowledge, there are no reports on changes in leukocyte fractions after pegfilgrastim administration, but only one old report on conventional G-CSF [13]. For reference, we retrospectively investigated changes in neutrophils after the first administration of pegfilgrastim. We examined patients who received dose-dense EC (E: epirubicin 90 mg/m2, C: cyclophosphamide 600 mg/m2) as neo-adjuvant therapy during the December 2019 through March 2021 period (n = 21), this being the most common regimen for pegfilgrastim use. As shown in Table 1, the neutrophil rate did significantly increase over 2 weeks after the first administration of pegfilgrastim, as well as WBC, absolute count of neutrophils and CRP. Therefore, it is difficult to determine an existence of infection based on a differential white blood count, although the presence of a severe infection may reduce the neutrophil count.Table 1Changes in neutrophils after the first pegfilgrastim administration (n = 21)a,bDay 0c,dDay 14c,dP valueWBC5395 (2700–8500)10,838 (5500–19,200)< 0.001Neutrophil rate57.3% (41.8–67.1)77.2% (59.2–84.2)< 0.001Absolute neutrophil count3126 (1463–5542)8492 (3300–15,110)< 0.001CRP0.10 (0.03–0.63)0.37 (0.02–1.45)0.011aMean age was 49.8 (range 33–64). bAll patients were given dose-dense EC (E: epirubicin 90 mg/m2, C: cyclophosphamide 600 mg/m2) and pegfilgrastim (3.6 mg) was administered 1–3 days later. cThe day of the first dose-dense EC administration was counted as Day 0. dMean (range)
+
+Changes in neutrophils after the first pegfilgrastim administration (n = 21)a,b
+
+aMean age was 49.8 (range 33–64). bAll patients were given dose-dense EC (E: epirubicin 90 mg/m2, C: cyclophosphamide 600 mg/m2) and pegfilgrastim (3.6 mg) was administered 1–3 days later. cThe day of the first dose-dense EC administration was counted as Day 0. dMean (range)
+
+The treatment for drug-induced arteritis has not yet been established. As to the application of steroids, in cases such as this case where the vasculitis is localized and systemic symptoms are minimal, omission of steroid administration might be possible. However, it is clearly necessary to establish a treatment strategy for this disease by accumulating more cases.
+
+If a patient develops a persistent high fever of unknown origin after pegfilgrastim administration, drug-induced aortitis should be considered during investigations for causes of fever. It is also crucial for clinicians to be aware of the timing and location of onset of this disease.

--- a/references_cache/PMID_36843728.md
+++ b/references_cache/PMID_36843728.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:36843728"
+title: "From Temporal Cell Arteritis to Giant Cell Aortitis Presenting as a Constitutional Syndrome: A Case Report."
+authors:
+- Lopes M
+- Rocha M
+- Fonseca M
+- Monteiro A
+journal: Cureus
+year: '2023'
+doi: 10.7759/cureus.34181
+content_type: abstract_only
+---
+
+# From Temporal Cell Arteritis to Giant Cell Aortitis Presenting as a Constitutional Syndrome: A Case Report.
+**Authors:** Lopes M, Rocha M, Fonseca M, Monteiro A
+**Journal:** Cureus (2023)
+**DOI:** [10.7759/cureus.34181](https://doi.org/10.7759/cureus.34181)
+
+## Content
+
+1. Cureus. 2023 Jan 25;15(1):e34181. doi: 10.7759/cureus.34181. eCollection 2023 
+Jan.
+
+From Temporal Cell Arteritis to Giant Cell Aortitis Presenting as a 
+Constitutional Syndrome: A Case Report.
+
+Lopes M(1), Rocha M(1), Fonseca M(2), Monteiro A(1).
+
+Author information:
+(1)Internal Medicine, Hospital Professor Doutor Fernando Fonseca, Amadora, PRT.
+(2)Internal Medicine, Hospital Professor Doutor Fernando Fonseca, Lisboa, PRT.
+
+Giant cell arteritis (GCA) is the most common form of systemic vasculitis in 
+adults, especially in patients over the age of 50. It manifests most commonly 
+with an intense headache and visual symptoms. Although constitutional symptoms 
+are also frequent in GCA, these can be dominant in 15% of patients at first 
+presentation and 20% of patients when relapsing. Treatment with high-dose 
+steroids should be initiated as soon as possible to rapidly control the 
+inflammatory symptoms and prevent ischemic complications, the most feared being 
+blindness from anterior ischemic optic neuropathy. We present a case of a 
+72-year-old man who presented to the emergency department with a right temporal 
+headache with retroocular radiation associated with scalp hyperesthesia, without 
+any visual symptoms. The patient also reported low-grade fever, night sweats, 
+anorexia, and weight loss over the last two months. The physical exam revealed a 
+tortuous and indurated right superficial temporal artery, which was tender to 
+palpation. The ophthalmological examination was normal. The erythrocyte 
+sedimentation rate (ESR) and C-reactive protein (CRP) were elevated, and he also 
+had inflammatory anemia with a hemoglobin of 11.7 g/L. Due to this clinical 
+presentation as well as the elevation of inflammatory markers, the diagnosis of 
+temporal arteritis was suspected, and the patient was started on prednisolone (1 
+mg/kg). A right temporal artery biopsy was performed on the first week after the 
+initiation of corticotherapy and was negative. After treatment initiation, there 
+was a remission of symptoms accompanied by a decrease and normalization of 
+inflammatory markers. However, after steroid tapering, there was a reappearance 
+of constitutional symptoms but without any other organ-specific symptoms, such 
+as headache, visual loss, arthralgia, or other. The corticosteroid dose was 
+increased to the initial dosage, but there was no improvement in the symptoms 
+this time. After the exclusion of other causes of the constitutional syndrome, a 
+positron-emission tomography (PET) scan was performed, which showed a grade 2 
+aortitis. The diagnosis of giant cell aortitis was assumed, and given the lack 
+of clinical response to corticotherapy, tocilizumab was initiated with a 
+resolution of constitutional symptoms as well as a normalization of inflammatory 
+markers. In conclusion, we report a case of temporal cell arteritis that further 
+progressed to aortitis manifesting solely with constitutional symptoms. 
+Furthermore, there was no optimal response to corticotherapy and no improvement 
+with tocilizumab, therefore making this a case with a unique and infrequent 
+clinical course. GCA is characterized by a wide variety of symptoms and organ 
+involvement, and although it most frequently affects temporal arteries, it can 
+be associated with aortic involvement that can cause life-threatening structural 
+complications, highlighting the need for a high suspicion index for this 
+condition.
+
+Copyright © 2023, Lopes et al.
+
+DOI: 10.7759/cureus.34181
+PMCID: PMC9951122
+PMID: 36843728
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_40272133.md
+++ b/references_cache/PMID_40272133.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:40272133"
+title: Aortitis triggered by granulocyte-colony stimulating factor.
+authors:
+- Gaustad A
+- Liff MH
+- Nørgaard AN
+- Fremo KK
+- Brudevold R
+journal: Tidsskr Nor Laegeforen
+year: '2025'
+doi: 10.4045/tidsskr.24.0466
+keywords:
+- Humans
+- Male
+- "Granulocyte Colony-Stimulating Factor/adverse effects, therapeutic use, administration & dosage"
+- "Aortitis/chemically induced, drug therapy, diagnostic imaging"
+- "Tomography, X-Ray Computed"
+- "Lymphoma, Large B-Cell, Diffuse/drug therapy"
+- Prednisolone/therapeutic use
+- Tongue Neoplasms/drug therapy
+- Middle Aged
+- C-Reactive Protein/analysis
+content_type: abstract_only
+---
+
+# Aortitis triggered by granulocyte-colony stimulating factor.
+**Authors:** Gaustad A, Liff MH, Nørgaard AN, Fremo KK, Brudevold R
+**Journal:** Tidsskr Nor Laegeforen (2025)
+**DOI:** [10.4045/tidsskr.24.0466](https://doi.org/10.4045/tidsskr.24.0466)
+
+## Content
+
+1. Tidsskr Nor Laegeforen. 2025 Apr 10;145(5). doi: 10.4045/tidsskr.24.0466.
+Print  2025 Apr 22.
+
+Aortitis triggered by granulocyte-colony stimulating factor.
+
+[Article in English, Norwegian]
+
+Gaustad A(1), Liff MH(2), Nørgaard AN(3), Fremo KK(4), Brudevold R(5).
+
+Author information:
+(1)Medisinsk avdeling, Diakonhjemmet sykehus, Oslo.
+(2)Rehabiliteringsklinikken, St. Olavs hospital, Universitetssykehuset i 
+Trondheim, Trondheim.
+(3)Radiologisk avdeling, Ullevål sykehus, Oslo.
+(4)Anestesiavdelingen, Ålesund sjukehus, Ålesund.
+(5)Medisinsk avdeling, Ålesund sjukehus, Ålesund.
+
+BACKGROUND: A man in his sixties was diagnosed with diffuse large B-cell 
+lymphoma localised in the base of his tongue.
+CASE PRESENTATION: The patient was admitted to the emergency department with a 
+fever, generalised muscle aches and lethargy 12 days atter receiving his first 
+chemotherapy treatment with granulocyte-colony stimulating factor (G-CSF) 
+supplementation. There were no focal signs of infection. The patient was started 
+on empiric antibiotic treatment. After four days, C-reactive protein (CRP) had 
+increased from 104 to 331, but the patient's condition was largely unchanged. A 
+computer tomography (CT) scan showed aortitis, most likely caused by G-CSF. The 
+patient was treated with prednisolone and rapidly improved.
+INTERPRETATION: The diagnosis of G-CSF-induced aortitis should be considered in 
+patients with fever after G-CSF treatment, particularly if adequate antibiotic 
+treatment does not lead to improvement. Advanced imaging is often indicated. The 
+most important measure is to discontinue G-CSF supplementation.
+
+DOI: 10.4045/tidsskr.24.0466
+PMID: 40272133 [Indexed for MEDLINE]

--- a/research/Aortitis-deep-research-falcon.md
+++ b/research/Aortitis-deep-research-falcon.md
@@ -1,0 +1,1286 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-05T23:13:52.374666'
+end_time: '2026-05-05T23:44:14.822781'
+duration_seconds: 1822.45
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Aortitis
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 45
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Aortitis
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Aortitis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Aortitis
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Aortitis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Disease Characteristics Research Report: Aortitis
+
+### Scope note and evidence constraints
+Aortitis is an umbrella term covering multiple etiologies (infectious and noninfectious). The evidence retrieved for this run is strongest for (i) **large-vessel vasculitis (LVV)-associated aortitis** (GCA, Takayasu) and imaging guidance (EULAR 2023 systematic review/meta-analysis), (ii) **clinically isolated aortitis (CIA)** detected on surgical histology (single-center cohort 2024), (iii) **infectious aortitis** as a diagnostic/treatment “mimicker” (case-based review 2025), and (iv) **drug-induced aortitis** (G-CSF-associated, 2024 systematic case review). Explicit ICD-10/ICD-11, MeSH Unique IDs, MONDO and Orphanet identifiers were **not present** in the retrieved full texts; therefore, ontology coding in this report is limited to **ontology term suggestions** (HPO/GO/CL/UBERON/MAXO) rather than confirmed IDs from those ontologies. (staniforth2024aortitisincreasesthe pages 9-11, staniforth2024aortitisincreasesthe pages 2-4)
+
+---
+
+## 1. Disease Information
+
+### 1.1 Overview / definition
+**Aortitis** is explicitly defined as **“inflammation of the aorta”**. (staniforth2024aortitisincreasesthe pages 1-2)
+
+Clinically, it is best conceptualized as a **syndrome** with divergent causes and management imperatives (e.g., immunosuppression for inflammatory aortitis vs antimicrobials ± surgery for infectious aortitis). (arcilla2025thegreatvasculitis pages 7-9, staniforth2024aortitisincreasesthe pages 1-2)
+
+### 1.2 Key identifiers (requested: OMIM/Orphanet/ICD/MeSH/MONDO)
+- **Not found in retrieved texts:** ICD-10/ICD-11 codes, MeSH headings/unique IDs, MONDO IDs, Orphanet IDs. (staniforth2024aortitisincreasesthe pages 9-11, staniforth2024aortitisincreasesthe pages 2-4)
+- **Common literature labels/synonyms used in retrieved texts** (non-exhaustive):
+  - Aortitis; **infectious aortitis**; **noninfectious aortitis**; **inflammatory aortitis**; **clinically isolated aortitis (CIA)**; “idiopathic aortitis”; “giant cell aortitis”. (staniforth2024aortitisincreasesthe pages 1-2, staniforth2024aortitisincreasesthe pages 9-11, staniforth2024aortitisincreasesthe pages 2-4)
+
+### 1.3 Evidence sources
+The information here is derived from **aggregated disease-level resources** (systematic reviews, narrative reviews, cohort studies) and **case-based reviews**; several sources are surgical-cohort based (histology from aortic resections) and thus reflect a selected population (patients undergoing major aortic surgery). (staniforth2024aortitisincreasesthe pages 1-2, bosch2023imagingindiagnosis pages 1-2, arcilla2025thegreatvasculitis pages 7-9)
+
+---
+
+## 2. Etiology
+
+### 2.1 Major causal categories
+1. **Noninfectious (immune-mediated) aortitis**
+   - Large-vessel vasculitis: **Giant cell arteritis (GCA)**, **Takayasu arteritis (TAK)**, and variable-vessel vasculitis such as **Behçet disease** can involve the aorta/major branches. (popescu2024imaginginlarge pages 4-5)
+   - **Clinically isolated aortitis (CIA)**: defined as aortitis **without systemic vasculitis or other inflammatory conditions**, often detected on histology after aortic surgery. (staniforth2024aortitisincreasesthe pages 1-2)
+   - IgG4-related periaortitis/aortitis is a distinct fibro-inflammatory entity (review evidence retrieved is 2025). (wang2025unravelingthecomplexity pages 6-7)
+
+2. **Infectious aortitis**
+   - Pathogens include **Salmonella**, **Staphylococcus aureus**, **Streptococcus spp.**, **Enterococcus**, **Haemophilus influenzae**, **Mycobacterium tuberculosis**, **Treponema pallidum**, fungi, and others; infection can seed damaged aortic wall (e.g., atherosclerosis) with pseudoaneurysm formation and high rupture risk. (arcilla2025thegreatvasculitis pages 7-9, arcilla2025thegreatvasculitis pages 6-7)
+
+3. **Drug-induced aortitis**
+   - **G-CSF–induced aortitis** has been characterized through systematic case aggregation, particularly in chemotherapy settings. (zhao2024literaturereviewanalysis pages 1-2, zhao2024literaturereviewanalysis pages 5-7)
+
+### 2.2 Risk factors
+- **CIA/noninfectious surgical aortitis (surgical cohort):** increased age, female sex, current smoking, and prior inflammatory disease were associated with histologic aortitis; bicuspid aortic valve was associated with reduced odds in that cohort. (staniforth2024aortitisincreasesthe pages 6-8)
+- **Infectious aortitis:** risk factors include trauma, atherosclerotic plaques, congenital malformations, immunosuppression, infections, and malignancy. (arcilla2025thegreatvasculitis pages 1-3)
+- **G-CSF–induced:** predominantly older women; common setting is breast cancer chemotherapy; geographic clustering in East Asia reported in the case-review dataset. (zhao2024literaturereviewanalysis pages 1-2, zhao2024literaturereviewanalysis pages 2-3)
+
+### 2.3 Protective factors
+A bicuspid aortic valve was associated with **lower likelihood** of histologic aortitis in a surgical cohort (association, not necessarily causal protection). (staniforth2024aortitisincreasesthe pages 6-8)
+
+### 2.4 Gene–environment interactions
+Direct gene–environment interaction studies specific to “aortitis” were not retrieved. However, TAK genetic susceptibility (e.g., MLX variant; HLA associations) plausibly interacts with inflammatory triggers; infectious mimics can also induce autoantibodies and confound immune phenotyping. (tamura2018singlenucleotidepolymorphismof pages 6-7, arcilla2025thegreatvasculitis pages 7-9)
+
+---
+
+## 3. Phenotypes (with HPO suggestions)
+
+Aortitis phenotypes vary by etiology and vascular territory involved. A curated phenotype-to-HPO mapping table is provided below.
+
+| Phenotype (plain) | HPO term(s) suggestion | Evidence details (including onset/course, frequencies, quantitative lab values) | Major etiologies/subtypes where seen | Key citations (pqac ids) |
+|---|---|---|---|---|
+| Constitutional symptoms / malaise / fatigue / weight loss | HP:0012378 Fatigue; HP:0004305 Malaise; HP:0001824 Weight loss | Aortitis often presents nonspecifically with fatigue, feeling generally ill, and weight loss; GCA usually has gradual onset over weeks to months; TAK has a prodromal constitutional phase; IgG4-related PAO/PA also includes fatigue/weight loss/malaise; Behçet often relapsing-remitting | General aortitis, GCA, TAK, IgG4-related aortitis, Behçet disease | (staniforth2024aortitisincreasesthe pages 1-2, popescu2024imaginginlarge pages 4-5, wang2025unravelingthecomplexity pages 6-7) |
+| Fever | HP:0001945 Fever | Fever is common in GCA and TAK constitutional phases; in G-CSF-induced aortitis, 68/72 (96%) were symptomatic, commonly with fever; mean temperatures around 38.6°C; infectious aortitis also commonly presents with systemic inflammatory illness | GCA, TAK, G-CSF-induced aortitis, infectious aortitis | (popescu2024imaginginlarge pages 4-5, zhao2024literaturereviewanalysis pages 5-7, arcilla2025thegreatvasculitis pages 7-9) |
+| Pain (chest, back, abdominal, neck, sore throat) | HP:0100749 Chest pain; HP:0002027 Abdominal pain; HP:0003418 Back pain; HP:0003202 Cervical pain | G-CSF-induced aortitis commonly caused fever plus pain (chest, back, abdominal, neck, sore throat); IgG4-related PAO/PA commonly causes abdominal or back pain; thoracic involvement may cause chest pain and dyspnea | G-CSF-induced aortitis, IgG4-related aortitis/periaortitis | (zhao2024literaturereviewanalysis pages 5-7, wang2025unravelingthecomplexity pages 6-7) |
+| Polymyalgia-type proximal stiffness | HP:0002829 Arthralgia; HP:0003326 Myalgia | Noninfectious aortitis may include polymyalgic symptoms with proximal shoulder/pelvic girdle stiffness; polymyalgia rheumatica co-occurs in 40–60% of GCA | Noninfectious aortitis, especially GCA-associated aortitis | (staniforth2024aortitisincreasesthe pages 1-2, popescu2024imaginginlarge pages 4-5) |
+| Headache | HP:0002315 Headache | GCA cranial phenotype includes headache; onset usually gradual over weeks to months, though ~20% may be abrupt | GCA-associated aortitis/large-vessel GCA | (popescu2024imaginginlarge pages 4-5) |
+| Jaw or tongue claudication | HP:0200044 Jaw claudication | Characteristic cranial ischemic symptom in GCA; occurs with chewing and supports cranial involvement in patients who may also have aortitis/large-vessel disease | GCA-associated aortitis | (popescu2024imaginginlarge pages 4-5) |
+| Visual loss / ischemic optic neuropathy | HP:0000572 Visual loss; HP:0000648 Optic atrophy (suggestive downstream term if chronic) | In GCA, vascular occlusion can cause cranial ischemia and ischemic optic neuropathy; vision loss is typically painless and irreversible; ischemic optic neuropathy reported in ~14% in imaging review context | GCA-associated aortitis/large-vessel GCA | (popescu2024imaginginlarge pages 4-5) |
+| Limb claudication / arm or leg claudication | HP:0004936 Intermittent claudication | Aortic or main-branch involvement in GCA can cause limb claudication; TAK vascular phase includes arm or leg claudication; IgG4 iliac/femoral disease can also cause claudication | GCA, TAK, IgG4-related aortitis | (popescu2024imaginginlarge pages 4-5, chan2025strokeaorticregurgitation pages 2-4, wang2025unravelingthecomplexity pages 6-7) |
+| Pulseless vascular phase / pulse deficits | HP:0031808 Abnormality of peripheral pulse | TAK classically progresses from a constitutional “pre-pulseless” phase to a “pulseless” vascular phase with stenotic lesions in >90% | TAK-associated aortitis | (popescu2024imaginginlarge pages 4-5) |
+| Hypertension | HP:0000822 Hypertension | Common in TAK (30–90%); IgG4-related renal artery involvement can also cause hypertension | TAK, IgG4-related aortitis | (popescu2024imaginginlarge pages 4-5, wang2025unravelingthecomplexity pages 6-7) |
+| Stroke / transient ischemic attack | HP:0001297 Stroke; HP:0002326 Transient ischemic attack | TIAs/strokes occur in 2–7% of GCA and 10–20% of TAK; aortitis cohorts also report increased stroke risk during follow-up | GCA, TAK, general aortitis complications | (popescu2024imaginginlarge pages 4-5, staniforth2024aortitisincreasesthe pages 8-9) |
+| Mucocutaneous ulcers | HP:0000197 Oral ulcer; HP:0000135 Genital ulcer | Behçet disease phenotype includes oral and genital ulcers with frequent relapses/remissions and potential large-vessel aortitis/aneurysm/thrombosis | Behçet disease-associated aortitis | (popescu2024imaginginlarge pages 4-5) |
+| Uveitis / ocular inflammation | HP:0000554 Uveitis | Behçet disease includes uveitis as a key systemic phenotype accompanying possible large-vessel complications | Behçet disease-associated aortitis | (popescu2024imaginginlarge pages 4-5) |
+| Thrombosis / occlusion | HP:0004930 Venous thrombosis; HP:0012393 Arterial thrombosis; HP:0004417 Vascular occlusion | Behçet large-vessel involvement may include thrombosis and occlusion; aortitis overall can cause stenosis/occlusion; infectious aortitis can present with pseudoaneurysm and occlusive thrombus | Behçet disease, infectious aortitis, general aortitis | (popescu2024imaginginlarge pages 4-5, staniforth2024aortitisincreasesthe pages 1-2, arcilla2025thegreatvasculitis pages 7-9) |
+| Elevated CRP / ESR / inflammatory markers | HP:0011227 Elevated C-reactive protein level; HP:0003565 Increased erythrocyte sedimentation rate | Aortitis workup commonly shows high inflammatory markers; G-CSF-induced cases had CRP means ~26.06 ± 15.39 mg/dL (filgrastim), 24.81 ± 9.65 mg/dL (pegfilgrastim), 10.45 ± 9.91 mg/dL (lenograstim); giant cell aortitis case had CRP 82 mg/L and ESR 140 mm/h | General aortitis, G-CSF-induced aortitis, giant cell aortitis case, IgG4-related aortitis | (staniforth2024aortitisincreasesthe pages 1-2, zhao2024literaturereviewanalysis pages 5-7, chan2025strokeaorticregurgitation pages 2-4, wang2025unravelingthecomplexity pages 6-7) |
+| Leukocytosis | HP:0001974 Leukocytosis | Reported as a common laboratory abnormality in infectious/inflammatory aortitis differential workup | Infectious aortitis and mimics | (arcilla2025thegreatvasculitis pages 7-9) |
+| Thrombocytosis | HP:0001873 Thrombocytosis | Mild-to-moderate thrombocytosis reported in infectious/inflammatory aortitis differential workup | Infectious aortitis and mimics | (arcilla2025thegreatvasculitis pages 7-9) |
+| Normocytic/normochromic anemia | HP:0001877 Abnormality of erythrocytes; HP:0001892 Normocytic anemia | Normochromic/normocytic anemia described among laboratory abnormalities in infectious/inflammatory aortitis evaluation | Infectious aortitis and mimics | (arcilla2025thegreatvasculitis pages 7-9) |
+| Hypoalbuminemia | HP:0003073 Hypoalbuminemia | Reported among laboratory abnormalities in infectious/inflammatory aortitis differential workup | Infectious aortitis and mimics | (arcilla2025thegreatvasculitis pages 7-9) |
+| Polyclonal hypergammaglobulinemia | HP:0003237 Hypergammaglobulinemia | Reported in inflammatory/infectious aortitis differential workup | Infectious/inflammatory aortitis | (arcilla2025thegreatvasculitis pages 7-9) |
+| Aortic aneurysm | HP:0002617 Aortic aneurysm | A major downstream complication across aortitis subtypes. In surgical cohort, re-operations for new aneurysm formation were increased (14% with aortitis vs 3.8% without); GCA CT study reported >20% (12/54) developing aneurysm after 4–10 years; Behçet and infectious aortitis also associated with aneurysms | General aortitis, GCA, Behçet, infectious aortitis, IgG4-related aortitis | (staniforth2024aortitisincreasesthe pages 4-6, popescu2024imaginginlarge pages 7-9, popescu2024imaginginlarge pages 4-5, arcilla2025thegreatvasculitis pages 7-9, wang2025unravelingthecomplexity pages 6-7) |
+| Aortic dissection | HP:0002647 Aortic dissection | Aortitis may present as dissection; G-CSF-induced review documented dissections among complications; giant cell aortitis case involved aneurysmal/root pathology; infectious/IgG4-related disease can also progress to dissection | General aortitis, G-CSF-induced, giant cell aortitis, IgG4-related aortitis | (staniforth2024aortitisincreasesthe pages 1-2, zhao2024literaturereviewanalysis pages 5-7, chan2025strokeaorticregurgitation pages 2-4, wang2025unravelingthecomplexity pages 6-7) |
+| Stenosis / arterial narrowing / occlusion | HP:0005290 Arterial stenosis; HP:0004417 Vascular occlusion | Aortitis can cause wall thickening, loss of elasticity, stenosis, and occlusion; TAK has stenotic lesions in >90%; CTA shows luminal stenosis/narrowing | General aortitis, TAK, infectious aortitis | (staniforth2024aortitisincreasesthe pages 1-2, popescu2024imaginginlarge pages 4-5, popescu2024imaginginlarge pages 5-7) |
+| Aortic regurgitation | HP:0001659 Aortic valve regurgitation | Case report of giant cell aortitis described severe aortic regurgitation with aortic root aneurysm and destructive transmural inflammation; MLX variant study in TAK linked severity with aortic regurgitation morbidity | Giant cell aortitis case, Takayasu arteritis | (chan2025strokeaorticregurgitation pages 2-4) |
+| Dyspnea / compressive thoracic symptoms | HP:0002094 Dyspnea | Thoracic IgG4-related lesions may cause chest pain, dyspnea, and mediastinal compression; may reflect advanced local disease | IgG4-related aortitis/periaortitis | (wang2025unravelingthecomplexity pages 6-7) |
+| Abdominal angina / bowel ischemia | HP:0031106 Intestinal ischemia; HP:0002574 Abdominal pain | Mesenteric involvement in IgG4-related disease may cause abdominal angina or bowel ischemia | IgG4-related aortitis/periaortitis | (wang2025unravelingthecomplexity pages 6-7) |
+| Renal ischemia / hydronephrosis / renal injury | HP:0000105 Renal insufficiency; HP:0000126 Hydronephrosis | IgG4-related renal artery/periaortic involvement can cause ischemic nephropathy, post-obstructive hydronephrosis, and potentially permanent renal injury | IgG4-related aortitis/periaortitis | (wang2025unravelingthecomplexity pages 6-7) |
+
+
+*Table: This table summarizes key clinical, laboratory, and complication phenotypes reported for aortitis across major etiologic subtypes, with suggested HPO mappings. It is useful for disease knowledge-base curation because it links observed features to onset/course details, frequencies where available, and source-backed evidence.*
+
+Key phenotype highlights with quantitative data (when available):
+- **GCA:** gradual onset over weeks–months (≈20% abrupt), cranial/constitutional symptoms; polymyalgia rheumatica in **40–60%**; TIAs/strokes **2–7%**; aortic/major branch involvement **27%**. (popescu2024imaginginlarge pages 4-5)
+- **TAK:** constitutional phase → pulseless vascular phase; stenotic lesions **>90%**; aneurysms ≈**25%**; hypertension **30–90%**; stroke/TIA **10–20%**. (popescu2024imaginginlarge pages 4-5)
+- **Behçet:** large vascular involvement up to **40%**; mortality ≈**4%**; frequent relapsing course. (popescu2024imaginginlarge pages 4-5)
+- **G-CSF–induced aortitis:** symptomatic in **96% (68/72)**; fever and pain common; CRP markedly elevated; blood cultures uniformly negative in the compiled case series. (zhao2024literaturereviewanalysis pages 5-7)
+
+Quality-of-life measures (EQ-5D/SF-36/PROMIS) were not reported in the retrieved texts; QoL impact is inferred from chronicity/relapse and major vascular complications rather than quantified. (popescu2024imaginginlarge pages 4-5, staniforth2024aortitisincreasesthe pages 8-9)
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Genetic susceptibility (human)
+- **GCA:** HLA association reported with **HLA-DRB*04**; non-HLA polymorphisms noted in a narrative imaging review include **PTPN22, NOS2, ERAP1, REL, PRKQC**. (popescu2024imaginginlarge pages 4-5)
+- **TAK:** persistent genetic risk at **HLA-B*52:01** and susceptibility loci (HLA-B/MICA; HLA-DQB1/HLA-DRB1) were reported in review; a mechanistic genetics study links **MLX rs665268 (Q139R)** to TAK severity and aortic regurgitation. (popescu2024imaginginlarge pages 4-5, tamura2018singlenucleotidepolymorphismof pages 2-3)
+- **Behçet disease:** susceptibility at MHC class I, notably **HLA-B51**. (popescu2024imaginginlarge pages 4-5)
+
+### 4.2 Mechanistic pathways and causal chains
+- **TAK MLX-Q139R → inflammasome axis (primary research):** MLX-Q139R increases MondoA–MLX activity, upregulates **TXNIP**, and promotes **NLRP3 inflammasome** activation with increased IL-1β, oxidative stress, and impaired autophagy (mTOR axis), supporting a causal chain from genotype to macrophage-driven vascular inflammation. (tamura2018singlenucleotidepolymorphismof pages 6-7, tamura2018singlenucleotidepolymorphismof pages 2-3)
+- **GCA vascular immunopathology (review evidence retrieved is 2026):** initiation includes activation of arterial-wall dendritic cells, T cell invasion enabled by monocyte-derived MMP-9, NETs, macrophage polarization, and tertiary lymphoid organ signals (CXCL13/BAFF/APRIL/LT-β), implicating innate and adaptive immune circuits and stromal remodeling. (muratore2026treatmentstrategiesin pages 29-33)
+
+### 4.3 Suggested GO biological processes and CL cell types
+(These are **suggested ontology mappings** based on mechanisms described in retrieved sources.)
+- **GO terms (suggested):** inflammatory response; granulomatous inflammatory response; leukocyte migration; cytokine-mediated signaling pathway; inflammasome complex assembly; autophagy; extracellular matrix organization; angiogenesis/neovascularization. (popescu2024imaginginlarge pages 4-5, tamura2018singlenucleotidepolymorphismof pages 6-7, muratore2026treatmentstrategiesin pages 29-33)
+- **CL terms (suggested):** macrophage / monocyte-derived macrophage; CD4-positive T cell; CD8-positive T cell; dendritic cell (arterial wall); neutrophil; B cell; vascular endothelial cell; vascular smooth muscle cell; fibroblast. (tamura2018singlenucleotidepolymorphismof pages 6-7, muratore2026treatmentstrategiesin pages 29-33)
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Infectious agents
+Infectious aortitis pathogens frequently cited include **Salmonella**, **Staphylococcus aureus**, **Streptococcus spp.**, **Enterococcus**, **Haemophilus influenzae**, **Mycobacterium tuberculosis**, **Treponema pallidum**, fungi, and others. (arcilla2025thegreatvasculitis pages 7-9, arcilla2025thegreatvasculitis pages 6-7)
+
+### 5.2 Drug exposure
+G-CSF exposure (notably pegfilgrastim) is associated with rare aortitis, most commonly presenting within days after dosing in the compiled case series (agent-dependent mean onset times). (zhao2024literaturereviewanalysis pages 5-7)
+
+Lifestyle/environmental risks (e.g., smoking) were associated with surgical-cohort aortitis risk. (staniforth2024aortitisincreasesthe pages 6-8)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Upstream-to-downstream causal chain (integrated)
+Aortitis pathophysiology can be summarized as:
+1. **Trigger/etiology** (autoimmune LVV, infection, drug-induced immune activation) →
+2. **Aortic wall inflammation** (granulomatous inflammation in GCA/TAK; neutrophil-predominant infiltration in infection; IgG4+ lymphoplasmacytic infiltration with storiform fibrosis in IgG4-RD) →
+3. **Structural remodeling** (intimal hyperplasia, neovascularization, fibrosis; medial degradation) →
+4. **Clinical consequences**: aneurysm, dissection, stenosis/occlusion, ischemia, stroke, valve involvement (aortic regurgitation), rupture. (popescu2024imaginginlarge pages 4-5, arcilla2025thegreatvasculitis pages 7-9, wang2025unravelingthecomplexity pages 6-7, staniforth2024aortitisincreasesthe pages 1-2)
+
+### 6.2 Tissue damage mechanisms
+- **Stenosis/occlusion** and **aneurysm/dissection** arise from wall thickening, loss of elasticity, and inflammatory destruction/remodeling. (staniforth2024aortitisincreasesthe pages 1-2, popescu2024imaginginlarge pages 4-5)
+- **Infectious aortitis** often produces pseudoaneurysm and saccular morphology, with rupture risk heightened by wall necrosis and gas/edema/fat stranding in periaortic tissues. (arcilla2025thegreatvasculitis pages 7-9)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/system level
+- Primary: aorta and major branches (cardiovascular system). (staniforth2024aortitisincreasesthe pages 1-2, popescu2024imaginginlarge pages 4-5)
+- Secondary/complications: heart valves (aortic regurgitation), brain (stroke), kidneys (renal ischemia/hydronephrosis in IgG4-related disease), bowel (mesenteric ischemia). (chan2025strokeaorticregurgitation pages 2-4, popescu2024imaginginlarge pages 4-5, wang2025unravelingthecomplexity pages 6-7)
+
+### 7.2 Suggested UBERON terms (not exhaustive; suggestions)
+- UBERON:0000947 (aorta), plus segment-level (thoracic aorta, abdominal aorta), and branch arteries (subclavian, axillary, carotid) depending on phenotype. Imaging reviews emphasize aorta and its branches. (popescu2024imaginginlarge pages 1-2, popescu2024imaginginlarge pages 7-9)
+
+---
+
+## 8. Temporal Development
+
+- **GCA:** typically subacute onset over weeks–months; may be abrupt (~20%). (popescu2024imaginginlarge pages 4-5)
+- **TAK:** constitutional “pre-pulseless” phase progressing to “pulseless” vascular phase with chronic stenosis/aneurysm complications. (popescu2024imaginginlarge pages 4-5)
+- **CIA:** frequently asymptomatic until incidentally found on surgical pathology; requires prolonged surveillance due to late complications. (staniforth2024aortitisincreasesthe pages 1-2, staniforth2024aortitisincreasesthe pages 8-9)
+- **G-CSF-induced:** onset typically within days after exposure (agent-specific mean onset times in case review). (zhao2024literaturereviewanalysis pages 5-7)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology (selected quantitative data from retrieved sources)
+- **Histology-confirmed aortitis in major aortic surgery:** prevalence **10.6% (57/537)** with **75% CIA**, in a single-center cohort with high sampling rate (88%). (staniforth2024aortitisincreasesthe pages 1-2)
+- **GCA:** incidence about **44 per 100,000 persons >50** (Northern Europe) and prevalence estimates in another PET-focused review as 9–25 per 100,000 (>50). (popescu2024imaginginlarge pages 1-2, nassarmadji202318fluorodeoxyglucosepositronemission pages 1-2)
+- **TAK:** annual incidence **0.4–3.4 per 1,000,000**. (popescu2024imaginginlarge pages 1-2)
+
+### 9.2 Population/sex patterns
+- CIA/surgical cohort aortitis associated with female sex. (staniforth2024aortitisincreasesthe pages 6-8)
+- G-CSF-induced aortitis: ~81% female with mean age ~62 years in compiled case series. (zhao2024literaturereviewanalysis pages 1-2)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Laboratory evaluation (common elements)
+- In aortitis evaluation, inflammatory markers (ESR/CRP) are commonly used, but may be insensitive/nonspecific for vascular inflammation; infectious workup includes cultures and broad serologies. (ahlman2023advancedmolecularimaging pages 1-2, arcilla2025thegreatvasculitis pages 7-9)
+- Infectious/inflammatory mimics: leucocytosis, thrombocytosis, normocytic anemia, hypoalbuminemia, polyclonal hypergammaglobulinemia. (arcilla2025thegreatvasculitis pages 7-9)
+
+### 10.2 Imaging: current standards and performance
+**EULAR 2023 evidence base (systematic review/meta-analysis) for GCA imaging**:
+- Ultrasound, MRI, and FDG-PET have “good performance” for GCA diagnosis; in low risk-of-bias studies, ultrasound sensitivity/specificity **88% / 96%** and pooled LR+ **20.07**, LR− **0.13**. (bosch2023imagingindiagnosis pages 3-4)
+- Ultrasound assessing both cranial and extracranial arteries improves sensitivity (**93% vs 80%**) with similar specificity. (bosch2023imagingindiagnosis pages 1-2)
+- FDG-PET pooled sensitivity/specificity reported as **76% / 95%** (context: GCA imaging studies in the SLR). (bosch2023imagingindiagnosis pages 1-2)
+
+**Practical CTA/MRI/PET criteria from narrative imaging review (2024):**
+- Active inflammation suggested by wall thickening **>2 mm (aorta)** and **>1 mm (branch vessels)** on CTA/MRI. (popescu2024imaginginlarge pages 7-9)
+- Arterial wall enhancement defined as **>20 HU** increase compared to unenhanced CT. (popescu2024imaginginlarge pages 7-9)
+- PET positivity criterion: **segmental FDG uptake ≥ liver**. (popescu2024imaginginlarge pages 7-9)
+
+**FDG-PET/CT in clinical practice (2023 review):**
+- For cranial artery involvement (when performed before/≤72h after glucocorticoids), sensitivity **82–92%** and specificity **85–100%** reported. (nassarmadji202318fluorodeoxyglucosepositronemission pages 1-2)
+
+### 10.3 Histopathology
+- Surgical series highlight the importance of intra-operative sampling: aortitis diagnosis often relies on histology, and CIA may be missed without routine sampling. (staniforth2024aortitisincreasesthe pages 1-2)
+- Infectious aortitis may show neutrophilic infiltration but biopsy may be risky in fragile walls. (arcilla2025thegreatvasculitis pages 7-9)
+
+### 10.4 Differential diagnosis
+A key diagnostic principle is to **exclude infection and malignancy** before immunosuppression; infectious aortitis can induce autoantibodies (ANCA/MPO/PR3), mimicking primary vasculitis. (arcilla2025thegreatvasculitis pages 6-7, arcilla2025thegreatvasculitis pages 7-9)
+
+---
+
+## 11. Outcome / Prognosis
+
+- **Surgical cohort outcomes:** aortitis increased re-operation risk; re-operation rate was roughly doubled (17.5% vs 9.4%). (staniforth2024aortitisincreasesthe pages 1-2)
+- **Long-term complications:** vascular stenosis, stroke risk, and new aneurysm formation are emphasized, with cited studies reporting 58% 5-year vascular complication rates in a French series and new aneurysm development in CIA cohorts (as cited in the surgical paper). (staniforth2024aortitisincreasesthe pages 8-9)
+- **Infectious aortitis:** high mortality noted for thoracic infectious aortitis (reported up to 30–50% in a case-based review). (arcilla2025thegreatvasculitis pages 1-3)
+
+---
+
+## 12. Treatment
+
+### 12.1 Noninfectious/CIA and LVV-associated aortitis
+- **Center practice regimen (CIA/noninfectious):** prednisolone **0.75–1 mg/kg** plus methotrexate **20–25 mg/week**; refractory cases may use pulsed IV cyclophosphamide **15 mg/kg**; tocilizumab **162 mg SC weekly** used for relapsing/refractory disease after failure of two conventional strategies. (staniforth2024aortitisincreasesthe pages 8-9)
+
+- **Tocilizumab real-world effectiveness (extracranial GCA/LV-GCA and TAK; 2025 observational):** at 12 months, remission **74.5% (LV-GCA)** and **76.9% (TAK)**; imaging-complete resolution only **18.9%** and **21.1%**, respectively; severe infections led to discontinuation in 4 LV-GCA and 3 TAK patients. (lasateja2025tocilizumabinextracranial pages 1-2)
+
+- **GC + TCZ RCT benchmark (GiACTA; summarized in 2024 trial protocol):** sustained remission at 52 weeks **56%/53%** (weekly/q2w TCZ) vs **14%/18%** (GC alone). (kreis2024themeteoriticstrial pages 1-2)
+
+### 12.2 Infectious aortitis
+- Early empiric broad-spectrum antibiotics covering Gram-positive cocci and Gram-negative rods; ampicillin/cephalosporins suggested empirically for Salmonella; prolonged therapy often required (≥6–8 weeks), especially with endovascular repair; surgery/endovascular (TEVAR/EVAR) indicated for rapid expansion/large aneurysm but with infection-related complication risk. (arcilla2025thegreatvasculitis pages 7-9)
+
+### 12.3 MAXO term suggestions (examples)
+- Glucocorticoid therapy; methotrexate therapy; cyclophosphamide therapy; IL-6 receptor antagonist therapy (tocilizumab); antimicrobial therapy; endovascular aortic repair; open surgical aortic repair; imaging surveillance. (staniforth2024aortitisincreasesthe pages 8-9, arcilla2025thegreatvasculitis pages 7-9, lasateja2025tocilizumabinextracranial pages 1-2)
+
+---
+
+## 13. Prevention
+
+Evidence retrieved is limited. Practical prevention/mitigation approaches include:
+- **Secondary prevention of complications** via long-term surveillance imaging (annual CT aortogram ≥5 years in one center protocol) and cardiovascular risk modification measures (statins, beta-blockers, ACE inhibitors, antithrombotics) used in clinical practice. (staniforth2024aortitisincreasesthe pages 8-9)
+- For biologic therapy: **TB screening** (PPD/QuantiFERON, chest X-ray) and isoniazid prophylaxis for latent infection before biologics in one multicenter observational practice description. (lasateja2025tocilizumabinextracranial pages 2-4)
+
+---
+
+## 14. Other Species / Natural Disease
+
+No retrieved evidence in this run addressed naturally occurring aortitis across non-human species or zoonotic considerations.
+
+---
+
+## 15. Model Organisms
+
+No direct “aortitis model organism” papers were retrieved in this run. Mechanistic TAK genetics work used immune cell systems and vascular cells (e.g., PBMC-derived macrophages; human aortic smooth muscle cells) supporting in vitro mechanistic modeling. (tamura2018singlenucleotidepolymorphismof pages 6-7)
+
+---
+
+## Recent developments (priority 2023–2024)
+
+1. **Imaging evidence synthesis informing EULAR 2023 update:** pooled diagnostic performance metrics for ultrasound/MRI/FDG-PET in GCA and evidence supporting inclusion of extracranial (axillary) ultrasound to increase sensitivity. (Aug 2023; https://doi.org/10.1136/rmdopen-2023-003379) (bosch2023imagingindiagnosis pages 1-2, bosch2023imagingindiagnosis pages 3-4)
+2. **High-sampling surgical cohort redefining CIA prevalence and postoperative risk:** histology-sampled prevalence 10.6% with 75% CIA; higher re-operation risk and identified risk associations (age, female sex, smoking, inflammatory disease). (Dec 2024; https://doi.org/10.3390/jcdd11120405) (staniforth2024aortitisincreasesthe pages 1-2, staniforth2024aortitisincreasesthe pages 6-8, staniforth2024aortitisincreasesthe media bd38afdc)
+3. **Drug-induced aortitis (G-CSF) systematic case synthesis:** 72-case dataset describing demographics, lesion distribution, complication rate (~4.2%), and recurrence on rechallenge, emphasizing diagnostic vigilance. (Dec 2024; https://doi.org/10.3389/fphar.2024.1487501) (zhao2024literaturereviewanalysis pages 1-2, zhao2024literaturereviewanalysis pages 5-7)
+
+---
+
+## Key quantitative summary table (etiology/risk statistics)
+
+| Category | Typical patient profile | Key statistics | Diagnostic clues (labs/imaging) | Notes/quotes | Key citations |
+|---|---|---|---|---|---|
+| Noninfectious: overall surgically identified aortitis / clinically isolated aortitis (CIA) | Often older adults; more common in women; associated with smoking and prior inflammatory disease; many cases asymptomatic until aneurysm/dissection surgery | In a major aortic surgery cohort, histology-confirmed aortitis prevalence was **10.6% (57/537)**; **75%** of aortitis cases were CIA; CIA prevalence **8.0% (43/537)**; re-operation **17.5% vs 9.4%** in non-aortitis; multivariable associations: age OR **1.03**, female sex OR **4.10**, current smoking OR **3.43**, prior inflammatory disease OR **9.01**; bicuspid aortic valve associated with lower odds OR **0.34** | Elevated inflammatory markers; PET-CT to map inflammation; intra-operative histology is essential; annual CT aortogram suggested in follow-up | “**Aortitis, defined as inflammation of the aorta**”; “**75% were clinically isolated**” | (staniforth2024aortitisincreasesthe pages 1-2, staniforth2024aortitisincreasesthe pages 6-8, staniforth2024aortitisincreasesthe media bd38afdc) |
+| Noninfectious: giant cell arteritis (GCA)-associated aortitis | Usually adults >50 years; Northern European populations higher incidence; can coexist with PMR; risk factors for aneurysmal complications include male sex, smoking, hypertension, hyperlipidemia/coronary disease | GCA incidence about **44/100,000 persons >50** in Northern Europe; aorta or major branch involvement in about **27%** of GCA; in large-vessel GCA, aortic involvement **45–65%**; thoracic aortic aneurysm/dissection incidence reported **8.2–33%**; meta-analysis suggests ~**3-fold** increased TAA risk; one cohort found **3.1%** TAA among 2,344 GCA patients; >**20% (12/54)** developed aortic aneurysm after 4–10 years in one CT study | CTA/MRA/PET-CT/US; CTA/MRI wall-thickness thresholds suggesting active disease: **>2 mm aorta**, **>1 mm branch vessels**; PET uptake may identify higher-risk patients for future aneurysm | “**a granulomatous vasculitis**”; “**Imaging is essential**”; “**The literature review disclosed an increased incidence and relative risk of TAA among patients with GCA**” | (popescu2024imaginginlarge pages 4-5, strachan2025thoracicaorticaneurysm pages 2-4, popescu2024imaginginlarge pages 7-9, popescu2024imaginginlarge pages 1-2) |
+| Noninfectious: Takayasu arteritis (TAK)-associated aortitis | Typically younger individuals; often women; systemic large-vessel vasculitis affecting aorta and branches | Annual incidence **0.4–3.4 per 1,000,000**; TAK is “the primary cause of aortitis in younger individuals”; aorta/major branches involved in about **65%**; coronary arteries **44%**; pulmonary arteries **63%**; stenotic lesions in **>90%**; aneurysms in about **25%**; hypertension **30–90%**; stroke/TIA **10–20%** | MRI first-line in suspected TAK; CTA shows circumferential wall thickening in active disease, later stenosis/occlusion; PET-CT can complement luminal imaging by showing active inflammation | “**characterized by variable degrees of inflammation... of all arterial layers (panarteritis)**” | (popescu2024imaginginlarge pages 4-5, popescu2024imaginginlarge pages 7-9, popescu2024imaginginlarge pages 1-2) |
+| Noninfectious: Behçet disease-associated aortitis/large-vessel vasculitis | Often younger to middle-aged adults; autoinflammatory/systemic vasculitis phenotype; HLA-B51 association noted in review | Up to **40%** may experience large vascular complications; mortality around **4%** | CTA/MRA/PET-CT/US depending territory; evaluate aneurysm, thrombosis, arterial wall inflammation | “**mainly considered an auto-inflammatory systemic vasculitis**” | (popescu2024imaginginlarge pages 4-5) |
+| Noninfectious: drug-induced aortitis (G-CSF-associated) | Predominantly older women receiving chemotherapy; especially breast cancer; also reported in healthy stem-cell donors; majority reported from Asian populations | Review of **72** patients: **58 female/14 male (80.6% female)**, mean age **61.83 ± 10.30** years; pegfilgrastim implicated most often (**63.4%**); lesion distribution: aortic arch **36.11%**, abdominal aorta **26.39%**, thoracic aorta **22.22%**; **4/72** asymptomatic; complications in **3/72 (~4.2%)** including dissection/aneurysm; recurrence after rechallenge reported | Typically fever/pain with elevated CRP and negative blood cultures; CT most often identifies aortic arch/branch involvement | “**Most patients had a good prognosis, but 3 cases developed complications**”; “**G-CSF-induced aortitis was also found in 4 asymptomatic patients**” | (zhao2024literaturereviewanalysis pages 1-2, zhao2024literaturereviewanalysis pages 5-7, zhao2024literaturereviewanalysis pages 7-8, zhao2024literaturereviewanalysis pages 2-3) |
+| Infectious aortitis: overall bacterial/fungal/mycobacterial/spirochetal | Often patients with atherosclerosis, damaged vessel wall, immunosuppression, infection, trauma, congenital abnormalities, or malignancy; may present with aneurysm, pseudoaneurysm, or sepsis-like syndrome | Thoracic aortitis mortality reported **30–50%**; blood cultures positive in only **50–82%**; mycotic aneurysms account for **0.6–2%** of all aortic aneurysms in Western populations; infectious aortitis more often abdominal (**56%** in cited series) | Labs: leukocytosis, thrombocytosis, normocytic anemia, elevated inflammatory markers/CRP (often >100 mg/L in cited review); imaging: CTA/MRA/PET-CT/US; infected aneurysm clues include saccular morphology, peri-aortic edema/fat stranding, wall thickening, loss of contour, gas in wall | “**Differentiating between infectious and inflammatory cases is crucial**”; “**blood cultures (positive in only 50% to 82%) are recommended**” | (arcilla2025thegreatvasculitis pages 7-9, arcilla2025thegreatvasculitis pages 1-3, arcilla2025thegreatvasculitis pages 6-7) |
+| Infectious aortitis: common pathogens / microbiology | Bacterial predominance; consider bacteremia/endovascular seeding via vasa vasorum or damaged wall | Gram-positive organisms about **44%** in one review; Gram-negative rods **33%**; intracellular/fastidious organisms **43%**; Cox review notes Gram-positive bacteria account for about **60%** of thoracic infections; common pathogens include **Staphylococcus aureus, Streptococcus spp., Enterococcus, Salmonella, Haemophilus influenzae, Mycobacterium tuberculosis, Treponema pallidum**, fungi | Obtain repeated blood cultures, tissue culture/PCR/serologies; histology often shows neutrophilic infiltration; CTA/PET-CT used to define extent and plan intervention | “**Gram positive bacteria such as Staphylococcus, Enterococcus and Streptococcus accounting for approximately 60% of the infections**” | (arcilla2025thegreatvasculitis pages 7-9, arcilla2025thegreatvasculitis pages 6-7) |
+| Infectious aortitis: management-relevant clues | Patients may initially mimic primary vasculitis; wrong early immunosuppression can be harmful | No large comparative trials; prolonged antibiotics typically **at least 6–8 weeks** with TEVAR/EVAR/open repair depending anatomy and infection control | Broad-spectrum bactericidal therapy first; defer steroids/biologics until infection excluded; CTA gives high-resolution 3D anatomy, PET may help distinguish infection/inflammation and occult extent | “**Steroids and biological therapy were held until comprehensive investigations were completed**”; “**optimal approach must be decided on a case-by-case basis**” | (arcilla2025thegreatvasculitis pages 7-9, arcilla2025thegreatvasculitis pages 6-7) |
+
+
+*Table: This table summarizes major noninfectious and infectious aortitis categories, highlighting patient profiles, quantitative epidemiology, diagnostic clues, and brief source-supported notes from the current evidence set. It is designed as a compact reference for comparing causes of aortitis and the numbers most relevant to diagnosis and risk stratification.*
+
+---
+
+## Real-world implementations / workflows
+
+- **Surgical pathology workflow:** routine intra-operative aortic sampling can uncover aortitis/CIA otherwise missed, changing follow-up intensity and rheumatology referral patterns. (staniforth2024aortitisincreasesthe pages 1-2)
+- **Clinical imaging workflow:** many centers increasingly integrate FDG-PET with CTA/MRA/US for LVV/aortitis assessment; reimbursement changes (CMS 2021) and guideline incorporation have accelerated PET use in some health systems. (ahlman2023advancedmolecularimaging pages 1-2)
+- **Long-term monitoring:** annual CT aortogram surveillance for at least 5 years after diagnosis is used in at least one specialized center pathway for CIA/noninfectious aortitis. (staniforth2024aortitisincreasesthe pages 8-9)
+
+---
+
+## Items requested but not fully retrievable in this run
+
+- **MONDO/Orphanet/ICD-10/ICD-11/MeSH identifiers:** not present in retrieved full texts. (staniforth2024aortitisincreasesthe pages 9-11, staniforth2024aortitisincreasesthe pages 2-4)
+- **PMIDs preferred:** Several retrieved items are identified by DOI within text extracts but PMIDs were not consistently present in the extracted evidence snippets; therefore, DOI-based URLs are provided where available.
+- **Model organism literature and cross-species natural disease:** not retrieved.
+
+
+
+References
+
+1. (staniforth2024aortitisincreasesthe pages 9-11): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+2. (staniforth2024aortitisincreasesthe pages 2-4): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+3. (staniforth2024aortitisincreasesthe pages 1-2): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+4. (arcilla2025thegreatvasculitis pages 7-9): Cristine Kuzhuppilly Arcilla, Tomas Marek, and Gurjit Kaeley. The great vasculitis pretenders: mycotic pseudoaneurysm, aortitis with occlusive iliac thrombus, and paraneoplastic aortitis. a case-based review. Mediterranean Journal of Rheumatology, 36:488, Sep 2025. URL: https://doi.org/10.31138/mjr.220125.era, doi:10.31138/mjr.220125.era. This article has 0 citations.
+
+5. (bosch2023imagingindiagnosis pages 1-2): Philipp Bosch, Milena Bond, Christian Dejaco, Cristina Ponte, Sarah Louise Mackie, Louise Falzon, Wolfgang A Schmidt, and Sofia Ramiro. Imaging in diagnosis, monitoring and outcome prediction of large vessel vasculitis: a systematic literature review and meta-analysis informing the 2023 update of the eular recommendations. RMD Open, 9:e003379, Aug 2023. URL: https://doi.org/10.1136/rmdopen-2023-003379, doi:10.1136/rmdopen-2023-003379. This article has 108 citations and is from a peer-reviewed journal.
+
+6. (popescu2024imaginginlarge pages 4-5): Ioana Popescu, Roxana Pintican, Luminita Cocarla, Benjamin Burger, Irina Sandu, George Popa, Alexandra Dadarlat, Raluca Rancea, Alexandru Oprea, Alexandru Goicea, Laura Damian, Alexandru Manea, Ruben Mateas, and Simona Manole. Imaging in large vessel vasculitis—a narrative review. Journal of Clinical Medicine, 13:6364, Oct 2024. URL: https://doi.org/10.3390/jcm13216364, doi:10.3390/jcm13216364. This article has 6 citations.
+
+7. (wang2025unravelingthecomplexity pages 6-7): Yan Wang, Feng Tian, and Hui Li. Unraveling the complexity of igg4-related aortitis and periarteritis: from pathogenesis to clinical practice. Frontiers in Immunology, Jul 2025. URL: https://doi.org/10.3389/fimmu.2025.1625456, doi:10.3389/fimmu.2025.1625456. This article has 0 citations and is from a peer-reviewed journal.
+
+8. (arcilla2025thegreatvasculitis pages 6-7): Cristine Kuzhuppilly Arcilla, Tomas Marek, and Gurjit Kaeley. The great vasculitis pretenders: mycotic pseudoaneurysm, aortitis with occlusive iliac thrombus, and paraneoplastic aortitis. a case-based review. Mediterranean Journal of Rheumatology, 36:488, Sep 2025. URL: https://doi.org/10.31138/mjr.220125.era, doi:10.31138/mjr.220125.era. This article has 0 citations.
+
+9. (zhao2024literaturereviewanalysis pages 1-2): Ting Zhao and Huanhuan Xu. Literature review analysis of aortitis induced by granulocyte-colony stimulating factor. Frontiers in Pharmacology, Dec 2024. URL: https://doi.org/10.3389/fphar.2024.1487501, doi:10.3389/fphar.2024.1487501. This article has 11 citations.
+
+10. (zhao2024literaturereviewanalysis pages 5-7): Ting Zhao and Huanhuan Xu. Literature review analysis of aortitis induced by granulocyte-colony stimulating factor. Frontiers in Pharmacology, Dec 2024. URL: https://doi.org/10.3389/fphar.2024.1487501, doi:10.3389/fphar.2024.1487501. This article has 11 citations.
+
+11. (staniforth2024aortitisincreasesthe pages 6-8): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+12. (arcilla2025thegreatvasculitis pages 1-3): Cristine Kuzhuppilly Arcilla, Tomas Marek, and Gurjit Kaeley. The great vasculitis pretenders: mycotic pseudoaneurysm, aortitis with occlusive iliac thrombus, and paraneoplastic aortitis. a case-based review. Mediterranean Journal of Rheumatology, 36:488, Sep 2025. URL: https://doi.org/10.31138/mjr.220125.era, doi:10.31138/mjr.220125.era. This article has 0 citations.
+
+13. (zhao2024literaturereviewanalysis pages 2-3): Ting Zhao and Huanhuan Xu. Literature review analysis of aortitis induced by granulocyte-colony stimulating factor. Frontiers in Pharmacology, Dec 2024. URL: https://doi.org/10.3389/fphar.2024.1487501, doi:10.3389/fphar.2024.1487501. This article has 11 citations.
+
+14. (tamura2018singlenucleotidepolymorphismof pages 6-7): Natsuko Tamura, Yasuhiro Maejima, Takayoshi Matsumura, Rick B. Vega, Eisuke Amiya, Yusuke Ito, Yuka Shiheido-Watanabe, Takashi Ashikaga, Issei Komuro, Daniel P. Kelly, Kenzo Hirao, and Mitsuaki Isobe. Single-nucleotide polymorphism of the mlx gene is associated with takayasu arteritis. Circulation: Genomic and Precision Medicine, 11:e002296, Oct 2018. URL: https://doi.org/10.1161/circgen.118.002296, doi:10.1161/circgen.118.002296. This article has 19 citations.
+
+15. (chan2025strokeaorticregurgitation pages 2-4): Elizabeth Chan. Stroke, aortic regurgitation and aortic aneurysm in younger female: case of giant cell aortitis and discussion. Academic Medicine &amp; Surgery, Nov 2025. URL: https://doi.org/10.62186/001c.146456, doi:10.62186/001c.146456. This article has 0 citations.
+
+16. (staniforth2024aortitisincreasesthe pages 8-9): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+17. (staniforth2024aortitisincreasesthe pages 4-6): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+18. (popescu2024imaginginlarge pages 7-9): Ioana Popescu, Roxana Pintican, Luminita Cocarla, Benjamin Burger, Irina Sandu, George Popa, Alexandra Dadarlat, Raluca Rancea, Alexandru Oprea, Alexandru Goicea, Laura Damian, Alexandru Manea, Ruben Mateas, and Simona Manole. Imaging in large vessel vasculitis—a narrative review. Journal of Clinical Medicine, 13:6364, Oct 2024. URL: https://doi.org/10.3390/jcm13216364, doi:10.3390/jcm13216364. This article has 6 citations.
+
+19. (popescu2024imaginginlarge pages 5-7): Ioana Popescu, Roxana Pintican, Luminita Cocarla, Benjamin Burger, Irina Sandu, George Popa, Alexandra Dadarlat, Raluca Rancea, Alexandru Oprea, Alexandru Goicea, Laura Damian, Alexandru Manea, Ruben Mateas, and Simona Manole. Imaging in large vessel vasculitis—a narrative review. Journal of Clinical Medicine, 13:6364, Oct 2024. URL: https://doi.org/10.3390/jcm13216364, doi:10.3390/jcm13216364. This article has 6 citations.
+
+20. (tamura2018singlenucleotidepolymorphismof pages 2-3): Natsuko Tamura, Yasuhiro Maejima, Takayoshi Matsumura, Rick B. Vega, Eisuke Amiya, Yusuke Ito, Yuka Shiheido-Watanabe, Takashi Ashikaga, Issei Komuro, Daniel P. Kelly, Kenzo Hirao, and Mitsuaki Isobe. Single-nucleotide polymorphism of the mlx gene is associated with takayasu arteritis. Circulation: Genomic and Precision Medicine, 11:e002296, Oct 2018. URL: https://doi.org/10.1161/circgen.118.002296, doi:10.1161/circgen.118.002296. This article has 19 citations.
+
+21. (muratore2026treatmentstrategiesin pages 29-33): F Muratore, KJ Warrington, and C Dejaco. Treatment strategies in giant cell arteritis and polymyalgia rheumatica: beyond glucocorticoids. Unknown journal, 2026.
+
+22. (popescu2024imaginginlarge pages 1-2): Ioana Popescu, Roxana Pintican, Luminita Cocarla, Benjamin Burger, Irina Sandu, George Popa, Alexandra Dadarlat, Raluca Rancea, Alexandru Oprea, Alexandru Goicea, Laura Damian, Alexandru Manea, Ruben Mateas, and Simona Manole. Imaging in large vessel vasculitis—a narrative review. Journal of Clinical Medicine, 13:6364, Oct 2024. URL: https://doi.org/10.3390/jcm13216364, doi:10.3390/jcm13216364. This article has 6 citations.
+
+23. (nassarmadji202318fluorodeoxyglucosepositronemission pages 1-2): Kladoum Nassarmadji, Anthony Vanjak, Venceslas Bourdin, Karine Champion, Ruxandra Burlacu, Stéphane Mouly, Damien Sène, and Cloé Comarmond. 18-fluorodeoxyglucose positron emission tomography/computed tomography for large vessel vasculitis in clinical practice. Frontiers in Medicine, Jan 2023. URL: https://doi.org/10.3389/fmed.2023.1103752, doi:10.3389/fmed.2023.1103752. This article has 7 citations.
+
+24. (ahlman2023advancedmolecularimaging pages 1-2): Mark A. Ahlman and Peter C. Grayson. Advanced molecular imaging in large-vessel vasculitis: adopting fdg-pet into a clinical workflow. Best practice & research. Clinical rheumatology, 37:101856, Jul 2023. URL: https://doi.org/10.1016/j.berh.2023.101856, doi:10.1016/j.berh.2023.101856. This article has 11 citations.
+
+25. (bosch2023imagingindiagnosis pages 3-4): Philipp Bosch, Milena Bond, Christian Dejaco, Cristina Ponte, Sarah Louise Mackie, Louise Falzon, Wolfgang A Schmidt, and Sofia Ramiro. Imaging in diagnosis, monitoring and outcome prediction of large vessel vasculitis: a systematic literature review and meta-analysis informing the 2023 update of the eular recommendations. RMD Open, 9:e003379, Aug 2023. URL: https://doi.org/10.1136/rmdopen-2023-003379, doi:10.1136/rmdopen-2023-003379. This article has 108 citations and is from a peer-reviewed journal.
+
+26. (lasateja2025tocilizumabinextracranial pages 1-2): Carmen Lasa-Teja, Javier Loricera, Diana Prieto-Peña, Fernando López-Gutiérrez, Pilar Bernabéu, María Mercedes Freire-González, Beatriz González-Alvarez, Roser Solans-Laqué, Mauricio Mínguez, Iván Ferraz-Amaro, Santos Castañeda, and Ricardo Blanco. Tocilizumab in extracranial giant-cell arteritis and takayasu arteritis: a multicentric observational comparative study. Sci, 7:12, Jan 2025. URL: https://doi.org/10.3390/sci7010012, doi:10.3390/sci7010012. This article has 0 citations.
+
+27. (kreis2024themeteoriticstrial pages 1-2): Lena Kreis, Christian Dejaco, Wolfgang Andreas Schmidt, Robert Németh, Nils Venhoff, and Valentin Sebastian Schäfer. The meteoritics trial: efficacy of methotrexate after remission-induction with tocilizumab and glucocorticoids in giant cell arteritis—study protocol for a randomized, double-blind, placebo-controlled, parallel-group phase ii study. Trials, Jan 2024. URL: https://doi.org/10.1186/s13063-024-07905-4, doi:10.1186/s13063-024-07905-4. This article has 14 citations and is from a peer-reviewed journal.
+
+28. (lasateja2025tocilizumabinextracranial pages 2-4): Carmen Lasa-Teja, Javier Loricera, Diana Prieto-Peña, Fernando López-Gutiérrez, Pilar Bernabéu, María Mercedes Freire-González, Beatriz González-Alvarez, Roser Solans-Laqué, Mauricio Mínguez, Iván Ferraz-Amaro, Santos Castañeda, and Ricardo Blanco. Tocilizumab in extracranial giant-cell arteritis and takayasu arteritis: a multicentric observational comparative study. Sci, 7:12, Jan 2025. URL: https://doi.org/10.3390/sci7010012, doi:10.3390/sci7010012. This article has 0 citations.
+
+29. (staniforth2024aortitisincreasesthe media bd38afdc): Edward Staniforth, Shirish Dubey, Iakovos Ttofi, Vanitha Perinparajah, Jasmina Ttofi, Rohit Vijjhalwar, Raman Uberoi, Ediri Sideso, and George Krasopoulos. Aortitis increases the risk of surgical complications and re-operations after major aortic surgery. Journal of Cardiovascular Development and Disease, 11:405, Dec 2024. URL: https://doi.org/10.3390/jcdd11120405, doi:10.3390/jcdd11120405. This article has 1 citations.
+
+30. (strachan2025thoracicaorticaneurysm pages 2-4): Sebastien Strachan, Mohammad A. Zafar, Sudhir Perincheri, Awab Ahmad, Nafiye Busra Celik, Mah I. Kan Changez, Bulat A. Ziganshin, and John A. Elefteriades. Thoracic aortic aneurysm and giant cell arteritis: clarifying the link. AORTA, 13:072-078, Jun 2025. URL: https://doi.org/10.1055/a-2765-8610, doi:10.1055/a-2765-8610. This article has 1 citations and is from a peer-reviewed journal.
+
+31. (zhao2024literaturereviewanalysis pages 7-8): Ting Zhao and Huanhuan Xu. Literature review analysis of aortitis induced by granulocyte-colony stimulating factor. Frontiers in Pharmacology, Dec 2024. URL: https://doi.org/10.3389/fphar.2024.1487501, doi:10.3389/fphar.2024.1487501. This article has 11 citations.

--- a/research/Aortitis-deep-research-falcon.md.citations.md
+++ b/research/Aortitis-deep-research-falcon.md.citations.md
@@ -1,0 +1,496 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Aortitis
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Aortitis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-05T23:44:14.822781
+
+1. staniforth2024aortitisincreasesthe pages 1-2
+2. popescu2024imaginginlarge pages 4-5
+3. wang2025unravelingthecomplexity pages 6-7
+4. staniforth2024aortitisincreasesthe pages 6-8
+5. arcilla2025thegreatvasculitis pages 1-3
+6. arcilla2025thegreatvasculitis pages 7-9
+7. chan2025strokeaorticregurgitation pages 2-4
+8. zhao2024literaturereviewanalysis pages 5-7
+9. muratore2026treatmentstrategiesin pages 29-33
+10. popescu2024imaginginlarge pages 1-2
+11. zhao2024literaturereviewanalysis pages 1-2
+12. bosch2023imagingindiagnosis pages 3-4
+13. bosch2023imagingindiagnosis pages 1-2
+14. popescu2024imaginginlarge pages 7-9
+15. staniforth2024aortitisincreasesthe pages 8-9
+16. lasateja2025tocilizumabinextracranial pages 1-2
+17. kreis2024themeteoriticstrial pages 1-2
+18. lasateja2025tocilizumabinextracranial pages 2-4
+19. tamura2018singlenucleotidepolymorphismof pages 6-7
+20. ahlman2023advancedmolecularimaging pages 1-2
+21. staniforth2024aortitisincreasesthe pages 9-11
+22. staniforth2024aortitisincreasesthe pages 2-4
+23. arcilla2025thegreatvasculitis pages 6-7
+24. zhao2024literaturereviewanalysis pages 2-3
+25. staniforth2024aortitisincreasesthe pages 4-6
+26. popescu2024imaginginlarge pages 5-7
+27. tamura2018singlenucleotidepolymorphismof pages 2-3
+28. strachan2025thoracicaorticaneurysm pages 2-4
+29. zhao2024literaturereviewanalysis pages 7-8
+30. https://doi.org/10.1136/rmdopen-2023-003379
+31. https://doi.org/10.3390/jcdd11120405
+32. https://doi.org/10.3389/fphar.2024.1487501
+33. https://doi.org/10.3390/jcdd11120405,
+34. https://doi.org/10.31138/mjr.220125.era,
+35. https://doi.org/10.1136/rmdopen-2023-003379,
+36. https://doi.org/10.3390/jcm13216364,
+37. https://doi.org/10.3389/fimmu.2025.1625456,
+38. https://doi.org/10.3389/fphar.2024.1487501,
+39. https://doi.org/10.1161/circgen.118.002296,
+40. https://doi.org/10.62186/001c.146456,
+41. https://doi.org/10.3389/fmed.2023.1103752,
+42. https://doi.org/10.1016/j.berh.2023.101856,
+43. https://doi.org/10.3390/sci7010012,
+44. https://doi.org/10.1186/s13063-024-07905-4,
+45. https://doi.org/10.1055/a-2765-8610,


### PR DESCRIPTION
## Summary

- Add `kb/disorders/Aortitis.yaml` for MONDO:0006656.
- Include Falcon deep-research artifacts and cited reference caches generated with `just fetch-reference`.
- Curate clinically isolated, LVV-associated, infectious, and G-CSF-associated aortitis evidence with exact cached snippets.

## Validation

- `just validate-schema kb/disorders/Aortitis.yaml`
- `scripts/run_term_validator.sh validate-data kb/disorders/Aortitis.yaml -s src/dismech/schema/dismech.yaml -t Disease --labels -c conf/oak_config.yaml`
- `just validate-references kb/disorders/Aortitis.yaml`
- `just check-reference-cache-frontmatter`
- `git diff --check`
- Manual exact-snippet check against generated reference caches
