### PR TITLE
Fix Bartter snippet audit mismatches

### DIFF
--- a/kb/disorders/Bartter_Syndrome.yaml
+++ b/kb/disorders/Bartter_Syndrome.yaml
@@ -377,7 +377,7 @@ pathophysiology:
     evidence_source: OTHER
     snippet: >-
       The main ion channel at the luminal membrane is NKCC2
-      (furosemide-sensitive sodium-potassium-chloride cotransporter), which
+      (furosemide-sensitive sodium–potassium–chloride cotransporter), which
       belongs to a family of sodium-coupled electrolyte transporters, encoded
       by the solute carrier family of SLC12A genes. NKCC2 is responsible for
       carrying sodium from the tubular lumen into the cell coupled with
@@ -536,7 +536,7 @@ pathophysiology:
     supports: SUPPORT
     evidence_source: OTHER
     snippet: >-
-      Henle's loop has another important role in the reabsorption of divalent
+      Henle’s loop has another important role in the reabsorption of divalent
       cations such as calcium (Ca2+) and magnesium (Mg2+), which are
       reabsorbed by a passive paracellular mechanism secondary to the driving
       force produced by active salt reabsorption.
@@ -1369,14 +1369,14 @@ references:
   found_in:
   - Bartter_Syndrome-deep-research-falcon.md
   findings:
-  - statement: and Bartter syndrome (BS) is a rare group of autosomal-recessive disorders that usually presents with hypokalemic metabolic alkalosis, occasionally with hyponatremia and hypochloremia.
-    supporting_text: and Bartter syndrome (BS) is a rare group of autosomal-recessive disorders that usually presents with hypokalemic metabolic alkalosis, occasionally with hyponatremia and hypochloremia.
+  - statement: Bartter syndrome (BS) is a rare group of autosomal-recessive disorders that usually presents with hypokalemic metabolic alkalosis, occasionally with hyponatremia and hypochloremia.
+    supporting_text: Bartter syndrome (BS) is a rare group of autosomal-recessive disorders that usually presents with hypokalemic metabolic alkalosis, occasionally with hyponatremia and hypochloremia.
     evidence:
     - reference: DOI:10.3390/medicina59091638
       reference_title: 'Bartter Syndrome: A Systematic Review of Case Reports and Case Series'
       supports: SUPPORT
       evidence_source: OTHER
-      snippet: and Bartter syndrome (BS) is a rare group of autosomal-recessive disorders that usually presents with hypokalemic metabolic alkalosis, occasionally with hyponatremia and hypochloremia.
+      snippet: Bartter syndrome (BS) is a rare group of autosomal-recessive disorders that usually presents with hypokalemic metabolic alkalosis, occasionally with hyponatremia and hypochloremia.
       explanation: Deep research cited this publication as relevant literature for Bartter Syndrome.
 - reference: DOI:10.7759/cureus.36120
   title: 'A Rare Presentation of Adult-Onset Bartter Syndrome: A Case Report'


### PR DESCRIPTION
## Summary

- Fix three Bartter snippets/derived research text entries that did not match the generated reference caches exactly after #2132 merged.
- Keep this follow-up YAML-only; no generated cache edits.

## Validation

- `just validate kb/disorders/Bartter_Syndrome.yaml`
- Custom Bartter snippet audit: 99 checks, 0 failures
- Custom Bartter graph audit: 0 failures
- `git diff --check`