### PR TITLE
Phase 1 batch: migrate Satoyoshi pharmacologic-substance qualifiers to therapeutic_agent (#1613)

### DIFF
--- a/kb/disorders/Satoyoshi_Syndrome.yaml
+++ b/kb/disorders/Satoyoshi_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Satoyoshi Syndrome
 creation_date: "2026-02-23T00:00:00Z"
-updated_date: "2026-04-22T20:13:21Z"
+updated_date: "2026-05-06T00:00:00Z"
 category: Autoimmune
 synonyms:
 - Komuragaeri disease
@@ -893,27 +893,15 @@ treatments:
     term:
       id: MAXO:0000640
       label: corticosteroid agent therapy
-    qualifiers:
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: prednisone
-        term:
-          id: CHEBI:8382
-          label: prednisone
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: prednisolone
-        term:
-          id: CHEBI:8378
-          label: prednisolone
+    therapeutic_agent:
+    - preferred_term: prednisone
+      term:
+        id: CHEBI:8382
+        label: prednisone
+    - preferred_term: prednisolone
+      term:
+        id: CHEBI:8378
+        label: prednisolone
   evidence:
   - reference: PMID:31217029
     reference_title: "Treatment of Satoyoshi syndrome: a systematic review."
@@ -955,17 +943,11 @@ treatments:
     term:
       id: MAXO:0000324
       label: skeletal muscle relaxant agent therapy
-    qualifiers:
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: dantrolene
-        term:
-          id: CHEBI:4317
-          label: dantrolene
+    therapeutic_agent:
+    - preferred_term: dantrolene
+      term:
+        id: CHEBI:4317
+        label: dantrolene
   evidence:
   - reference: PMID:31217029
     reference_title: "Treatment of Satoyoshi syndrome: a systematic review."
@@ -987,67 +969,31 @@ treatments:
     term:
       id: MAXO:0000297
       label: immune suppressant agent therapy
-    qualifiers:
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: cyclosporine
-        term:
-          id: CHEBI:4031
-          label: cyclosporin A
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: mycophenolate mofetil
-        term:
-          id: CHEBI:8764
-          label: mycophenolate mofetil
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: azathioprine
-        term:
-          id: CHEBI:2948
-          label: azathioprine
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: methotrexate
-        term:
-          id: CHEBI:44185
-          label: methotrexate
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: tacrolimus
-        term:
-          id: CHEBI:61049
-          label: tacrolimus (anhydrous)
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: cyclophosphamide
-        term:
-          id: CHEBI:4027
-          label: cyclophosphamide
+    therapeutic_agent:
+    - preferred_term: cyclosporine
+      term:
+        id: CHEBI:4031
+        label: cyclosporin A
+    - preferred_term: mycophenolate mofetil
+      term:
+        id: CHEBI:8764
+        label: mycophenolate mofetil
+    - preferred_term: azathioprine
+      term:
+        id: CHEBI:2948
+        label: azathioprine
+    - preferred_term: methotrexate
+      term:
+        id: CHEBI:44185
+        label: methotrexate
+    - preferred_term: tacrolimus
+      term:
+        id: CHEBI:61049
+        label: tacrolimus (anhydrous)
+    - preferred_term: cyclophosphamide
+      term:
+        id: CHEBI:4027
+        label: cyclophosphamide
   evidence:
   - reference: PMID:31217029
     reference_title: "Treatment of Satoyoshi syndrome: a systematic review."
@@ -1069,17 +1015,11 @@ treatments:
     term:
       id: MAXO:0001480
       label: immunoglobulin infusion therapy
-    qualifiers:
-    - predicate:
-        preferred_term: pharmacologic substance
-        term:
-          id: NCIT:C1909
-          label: Pharmacologic Substance
-      value:
-        preferred_term: human immunoglobulin G
-        term:
-          id: NCIT:C80829
-          label: Human Immunoglobulin G
+    therapeutic_agent:
+    - preferred_term: human immunoglobulin G
+      term:
+        id: NCIT:C80829
+        label: Human Immunoglobulin G
   evidence:
   - reference: PMID:31217029
     reference_title: "Treatment of Satoyoshi syndrome: a systematic review."


### PR DESCRIPTION
## Summary

Phase 1 follow-up to merged PR #2057. Migrates the 10 remaining `qualifiers[predicate=pharmacologic substance]` rows in `kb/disorders/Satoyoshi_Syndrome.yaml` to the prescribed `therapeutic_agent:` slot — completing the entire `pharmacologic substance` predicate slice of issue #1613.

After this lands, the `pharmacologic substance` row count across `kb/disorders/` is **0**.

## Migration applied

| Treatment | Action term (unchanged) | Agents migrated to `therapeutic_agent:` |
|---|---|---|
| Corticosteroids | `MAXO:0000640` | prednisone (`CHEBI:8382`), prednisolone (`CHEBI:8378`) |
| Dantrolene | `MAXO:0000324` | dantrolene (`CHEBI:4317`) |
| Immunosuppressive Agents | `MAXO:0000297` | cyclosporine (`CHEBI:4031`), mycophenolate mofetil (`CHEBI:8764`), azathioprine (`CHEBI:2948`), methotrexate (`CHEBI:44185`), tacrolimus (`CHEBI:61049`), cyclophosphamide (`CHEBI:4027`) |
| Intravenous Immunoglobulin (IVIG) | `MAXO:0001480` | human immunoglobulin G (`NCIT:C80829`) |

Total: **10 qualifier rows → 10 `therapeutic_agent[]` items across 4 treatments**.

## Pattern

Same structural transform as approved/merged PR #2057:

```yaml
# Before
qualifiers:
- predicate:
    preferred_term: pharmacologic substance
    term:
      id: NCIT:C1909
      label: Pharmacologic Substance
  value:
    preferred_term: prednisone
    term:
      id: CHEBI:8382
      label: prednisone

# After
therapeutic_agent:
- preferred_term: prednisone
  term:
    id: CHEBI:8382
    label: prednisone
```

The predicate (`NCIT:C1909` / "Pharmacologic Substance") is dropped because `therapeutic_agent` already encodes that semantics. Per `CLAUDE.md`'s Therapeutic Agent Pattern: *"Do NOT put the drug name in `preferred_term` on `treatment_term` — `preferred_term` describes the action (pharmacotherapy), `therapeutic_agent.preferred_term` describes the agent."*

No ontology terms changed; all CHEBI/NCIT IDs were already in the file.

## Validation

- `just validate kb/disorders/Satoyoshi_Syndrome.yaml` — ✅ schema + terms + references all pass
- Cache normalization side-effects from validation were reverted to keep the diff scoped to the actual content migration, matching PR #2057's approach.

## Intentionally NOT changed

- The remaining ~124 `therapeutic agent` qualifier rows across the rest of `kb/disorders/` (the other half of Phase 1). Those are the natural follow-up batch once this lands.
- All Phase 2 predicates (surgical procedure, diagnostic procedure, route of administration, medical device, has participant, has input — ~312 rows). Those need a schema-design discussion per the 2026-04-23 / 2026-04-28 triage on #1613 and stay in `qualifiers:` as `CLAUDE.md`'s explicit escape hatch.

## Test plan

- [x] `just validate kb/disorders/Satoyoshi_Syndrome.yaml` passes
- [x] No new ontology terms introduced
- [x] No new evidence / PMIDs introduced
- [x] Diff scoped to single file; no cache CSV churn

cc @cmungall

🤖 Generated with [Claude Code](https://claude.com/claude-code)