### PR TITLE
Add Juvenile Temporal Arteritis disorder page

### DIFF
--- a/kb/disorders/Juvenile_Temporal_Arteritis.yaml
+++ b/kb/disorders/Juvenile_Temporal_Arteritis.yaml
@@ -1,0 +1,414 @@
+name: Juvenile Temporal Arteritis
+creation_date: "2026-05-06T11:57:06Z"
+updated_date: "2026-05-06T12:14:00Z"
+category: Complex
+parents:
+- Vascular disorder
+- Vasculitis
+disease_term:
+  preferred_term: juvenile temporal arteritis
+  term:
+    id: MONDO:0016848
+    label: juvenile temporal arteritis
+synonyms:
+- JTA
+- non-giant cell granulomatous temporal arteritis with eosinophilia
+- juvenile cranial arteritis
+- juvenile temporal vasculitis
+description: >-
+  Juvenile temporal arteritis is a rare localized arteritis of the superficial
+  temporal artery, usually reported in people younger than 45-50 years. It is
+  defined clinicopathologically by temporal nodules or prominent temporal
+  arteries, eosinophil-rich nongranulomatous arterial inflammation, and intimal
+  hyperplasia, with absent or limited systemic inflammatory features. The usual
+  course is benign and localized, contrasting with classic giant cell arteritis
+  in older adults.
+epidemiology:
+- name: Extreme rarity with young-adult male predominance in published cases
+  description: >-
+    Published evidence is dominated by case reports, reviews, and a small
+    multicenter clinicopathologic aggregation. The largest abstract-indexed
+    synthesis identified 44 total cases with median age 30 years and male
+    predominance.
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We included 12 patients and the literature review identified 32 cases
+      described in 27 articles, thus a total of 44 patients - 34 men and 10
+      women - with a median age of 30 and a maximum of 44.
+    explanation: >-
+      This multicenter series plus literature review gives the best compact
+      demographic summary available in an abstract-backed source.
+pathophysiology:
+- name: Localized Eosinophilic Temporal Arteritis
+  description: >-
+    JTA is a localized eosinophilic arteritis confined to the temporal arteries.
+    Human biopsy series describe inflammatory cells in the arterial wall and
+    perivascular tissues, with eosinophil-rich inflammation rather than the
+    systemic granulomatous large-vessel process typical of older-onset giant
+    cell arteritis.
+  cell_types:
+  - preferred_term: eosinophil
+    term:
+      id: CL:0000771
+      label: eosinophil
+  - preferred_term: lymphocyte
+    term:
+      id: CL:0000542
+      label: lymphocyte
+  locations:
+  - preferred_term: superficial temporal artery
+    term:
+      id: UBERON:0001614
+      label: superficial temporal artery
+  biological_processes:
+  - preferred_term: inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+    modifier: INCREASED
+  - preferred_term: eosinophil activation
+    term:
+      id: GO:0043307
+      label: eosinophil activation
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:18538831
+    reference_title: Vasculitis of the temporal arteries in the young.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      juvenile temporal arteritis, a localized eosinophilic arteritis confined
+      to the temporal arteries, seems unique to this age group.
+    explanation: >-
+      This review defines the central localized eosinophilic temporal-artery
+      mechanism.
+  - reference: PMID:21183315
+    reference_title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histologic findings were compatible with JTV (nongranulomatous
+      panarteritis with mononuclear cells and eosinophils).
+    explanation: >-
+      This case report gives direct biopsy evidence for nongranulomatous
+      panarteritis with eosinophils and mononuclear cells.
+- name: Intimal Hyperplasia and Luminal Narrowing
+  description: >-
+    Affected temporal arteries can show marked intimal hyperplasia, causing
+    luminal stenosis or occlusion. This vascular remodeling explains prominent
+    or nodular temporal arteries and supports surgical excision as both a
+    diagnostic and therapeutic intervention.
+  locations:
+  - preferred_term: superficial temporal artery
+    term:
+      id: UBERON:0001614
+      label: superficial temporal artery
+  biological_processes:
+  - preferred_term: cell population proliferation
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:32873218
+    reference_title: "Is Kimura's disease associated with juvenile temporal arteritis? A case report and literature review of all juvenile temporal arteritis cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histopathology of a biopsy of the left temporal artery revealed
+      inflammatory findings with marked eosinophil infiltration and significant
+      intimal hyperplasia with stenosis of the vascular lumen, indicating JTA.
+    explanation: >-
+      This human biopsy report directly links eosinophilic inflammation with
+      intimal hyperplasia and luminal stenosis.
+phenotypes:
+- category: Cardiovascular
+  name: Temporal artery nodule or prominence
+  diagnostic: true
+  description: >-
+    Localized temporal-region lumps, nodules, or prominent temporal arteries
+    are the cardinal presentation in published JTA cases.
+  phenotype_term:
+    preferred_term: temporal-region subcutaneous nodule
+    term:
+      id: HP:0001482
+      label: Subcutaneous nodule
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All patients presented either a lump in the temporal region or prominent
+      temporal arteries, and 47.7% of patients suffered from headaches.
+    explanation: >-
+      The largest clinicopathologic synthesis identifies local temporal
+      lumps/prominent temporal arteries as universal presenting findings in
+      the assembled cohort.
+  - reference: PMID:39180526
+    reference_title: "Bilateral juvenile temporal arteritis: a case-based review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Findings indicate that JTA typically presents as painless or painful
+      temporal nodules, rarely accompanied by other non-specific symptoms,
+      making histopathological examination crucial for accurate diagnosis.
+    explanation: >-
+      The 2024 systematic review supports temporal nodules as the typical
+      clinical presentation.
+- category: Neurological
+  name: Headache
+  frequency: FREQUENT
+  description: >-
+    Headache occurs in a substantial subset, but JTA may also present as an
+    isolated temporal lump without systemic cranial ischemic symptoms.
+  phenotype_term:
+    preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All patients presented either a lump in the temporal region or prominent
+      temporal arteries, and 47.7% of patients suffered from headaches.
+    explanation: >-
+      The 47.7% headache rate falls in the DISMECH frequent frequency band.
+biochemical:
+- name: Peripheral blood eosinophilia
+  presence: Present in subset
+  context: >-
+    Peripheral eosinophilia is reported in a subset of cases and aligns with
+    the eosinophil-rich tissue inflammation, but it is not universal.
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Only 11.4% of patients presented general symptoms and 6.8% a biological
+      inflammatory syndrome; 34.1% had peripheral blood eosinophilia; 83.7%
+      presented a single episode and complete excision without further treatment
+      was documented for 72.7%.
+    explanation: >-
+      The multicenter synthesis quantifies eosinophilia and shows that systemic
+      inflammatory features are uncommon.
+histopathology:
+- name: Nongranulomatous lymphoeosinophilic panarteritis
+  diagnostic: true
+  description: >-
+    Diagnostic biopsy typically shows nongranulomatous temporal panarteritis
+    with mononuclear and eosinophilic inflammation.
+  finding_term:
+    preferred_term: nongranulomatous lymphoeosinophilic panarteritis
+  evidence:
+  - reference: PMID:21183315
+    reference_title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histologic findings were compatible with JTV (nongranulomatous
+      panarteritis with mononuclear cells and eosinophils).
+    explanation: >-
+      This biopsy-supported case gives the core histopathologic pattern.
+- name: Arterial wall infiltrate with perivascular extension and lymphoid follicles
+  diagnostic: true
+  description: >-
+    Published pathology series also report arterial-wall inflammation,
+    perivascular extension, and lymphoid follicles or germinal centers; sparse
+    giant cells or granulomas can be seen but are not defining.
+  finding_term:
+    preferred_term: arterial wall inflammatory infiltrate
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pathology analysis revealed infiltrate of inflammatory cells in the
+      arterial wall in 97.6% of patients but also sparse giant cells for 25%
+      and granuloma for 22.9%, perivascular extension of the inflammation for
+      82.6%, and presence of lymphoid follicles or germinal centres for 60%.
+    explanation: >-
+      The multicenter pathology synthesis supports the arterial-wall and
+      perivascular inflammatory pattern and clarifies that giant cells or
+      granulomas may occur sparsely.
+progression:
+- phase: Localized single-episode course
+  duration: Often a single localized episode
+  notes: >-
+    Most published patients have a single localized episode, and local relapse
+    is reported in a minority.
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Only 11.4% of patients presented general symptoms and 6.8% a biological
+      inflammatory syndrome; 34.1% had peripheral blood eosinophilia; 83.7%
+      presented a single episode and complete excision without further treatment
+      was documented for 72.7%.
+    explanation: >-
+      This directly supports the usual single-episode, localized clinical
+      course.
+diagnosis:
+- name: Temporal artery biopsy and histopathologic correlation
+  description: >-
+    Diagnosis relies on clinical recognition of a temporal artery lesion in a
+    young patient and histopathologic confirmation on temporal artery biopsy or
+    excision. Laboratory and imaging findings may help exclude systemic or
+    secondary vasculitis.
+  diagnosis_term:
+    preferred_term: temporal artery biopsy
+  results: >-
+    Biopsy/excision showing localized eosinophilic nongranulomatous
+    panarteritis, intimal hyperplasia, and absence of an alternative systemic
+    vasculitis supports JTA.
+  evidence:
+  - reference: PMID:39180526
+    reference_title: "Bilateral juvenile temporal arteritis: a case-based review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Findings indicate that JTA typically presents as painless or painful
+      temporal nodules, rarely accompanied by other non-specific symptoms,
+      making histopathological examination crucial for accurate diagnosis.
+    explanation: >-
+      The 2024 systematic review states the central role of histopathology in
+      accurate diagnosis.
+  - reference: PMID:18538831
+    reference_title: Vasculitis of the temporal arteries in the young.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The final diagnosis of the different conditions causing TAV in the young
+      is based on a combination of clinical findings, relevant laboratory data,
+      imaging studies, and histological findings.
+    explanation: >-
+      This review supports integrating clinical, laboratory, imaging, and
+      histologic information when diagnosing temporal-artery vasculitis in
+      young patients.
+treatments:
+- name: Local surgical excision or excisional biopsy
+  description: >-
+    Surgical excision of the affected temporal artery segment is commonly both
+    diagnostic and therapeutic, and most reported cases do not require ongoing
+    systemic therapy after complete local excision.
+  treatment_term:
+    preferred_term: surgical excision
+    term:
+      id: MAXO:0000447
+      label: surgical excision
+  evidence:
+  - reference: PMID:30844551
+    reference_title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Only 11.4% of patients presented general symptoms and 6.8% a biological
+      inflammatory syndrome; 34.1% had peripheral blood eosinophilia; 83.7%
+      presented a single episode and complete excision without further treatment
+      was documented for 72.7%.
+    explanation: >-
+      The largest clinicopathologic synthesis documents complete excision
+      without further treatment in most cases.
+  - reference: PMID:21183315
+    reference_title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In these rare JTVs, excision of the involved section of temporal artery is
+      often curative and corticosteroid therapy is not required.
+    explanation: >-
+      This abstract explicitly supports excision as often curative and argues
+      against routine corticosteroid therapy.
+differential_diagnoses:
+- name: Giant Cell Arteritis
+  disease_term:
+    preferred_term: Giant Cell Arteritis
+    term:
+      id: MONDO:0008538
+      label: temporal arteritis
+  description: >-
+    Classic giant cell arteritis overlaps anatomically but usually affects
+    adults older than 50 years and carries greater concern for systemic
+    inflammation and ischemic complications.
+  distinguishing_features:
+  - JTA is typically localized to temporal arteries in younger patients.
+  - Classic giant cell arteritis is an older-adult disease and usually prompts urgent systemic corticosteroid therapy.
+  evidence:
+  - reference: PMID:21183315
+    reference_title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Classic giant cell arteritis affects older adults who are aged >50 years.
+      Temporal arteritis is uncommon in young adults but juvenile temporal
+      vasculitis (JTV) is the most frequent form found in young people.
+    explanation: >-
+      This abstract contrasts the age distribution of classic giant cell
+      arteritis with juvenile temporal vasculitis.
+- name: Kimura disease and angiolymphoid hyperplasia with eosinophilia
+  description: >-
+    Eosinophil-rich mass-forming disorders such as Kimura disease and
+    angiolymphoid hyperplasia with eosinophilia can mimic or accompany JTA,
+    making tissue diagnosis important.
+  distinguishing_features:
+  - Kimura disease and ALHE are eosinophil-rich mass-forming mimics rather than isolated temporal-artery panarteritis.
+  - Co-occurrence with JTA has been reported, especially in Asian cases, so biopsy context is required.
+  evidence:
+  - reference: PMID:18538831
+    reference_title: Vasculitis of the temporal arteries in the young.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In addition, other conditions such as Kimura disease and angiolymphoid
+      hyperplasia with eosinophilia may resemble temporal arteritis in the
+      young.
+    explanation: >-
+      This review identifies Kimura disease and ALHE as important mimics of
+      temporal arteritis in young patients.
+  - reference: PMID:32873218
+    reference_title: "Is Kimura's disease associated with juvenile temporal arteritis? A case report and literature review of all juvenile temporal arteritis cases."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In conclusion, this case and the literature review suggest that JTA can
+      be accompanied by another eosinophilic inflammation-based disorder,
+      Kimura's disease, particularly in Asians.
+    explanation: >-
+      This supports possible co-occurrence with Kimura disease, but does not
+      establish Kimura disease as the cause of all JTA.
+- name: Polyarteritis nodosa and other systemic vasculitides
+  description: >-
+    Systemic or secondary vasculitides can involve temporal arteries in young
+    patients and should be excluded when clinical, laboratory, imaging, or
+    histopathologic findings are not typical for localized JTA.
+  distinguishing_features:
+  - Multisystem involvement, fibrinoid necrosis, ANCA-associated features, or systemic inflammatory disease argue against isolated JTA.
+  - PAN and other systemic vasculitides require different evaluation and treatment from localized JTA.
+  evidence:
+  - reference: PMID:18538831
+    reference_title: Vasculitis of the temporal arteries in the young.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other vasculitides, such as polyarteritis nodosa, Churg-Strauss syndrome,
+      and thrombangiitis obliterans may involve the temporal arteries in young
+      patients.
+    explanation: >-
+      This review supports systemic vasculitides as key alternative diagnoses
+      when temporal arteries are involved in young patients.
+notes: >-
+  No validated causal gene, inheritance pattern, environmental trigger, clinical
+  trial, or model organism was identified in the Falcon report. The current
+  entry therefore avoids genetic, environmental, clinical-trial, and model
+  sections until primary evidence supports them.

--- a/kb/disorders/Juvenile_Temporal_Arteritis.yaml
+++ b/kb/disorders/Juvenile_Temporal_Arteritis.yaml
@@ -1,6 +1,6 @@
 name: Juvenile Temporal Arteritis
 creation_date: "2026-05-06T11:57:06Z"
-updated_date: "2026-05-06T12:14:00Z"
+updated_date: "2026-05-06T12:25:48Z"
 category: Complex
 parents:
 - Vascular disorder
@@ -75,6 +75,11 @@ pathophysiology:
       id: GO:0043307
       label: eosinophil activation
     modifier: INCREASED
+  downstream:
+  - target: Intimal Hyperplasia and Luminal Narrowing
+    description: >-
+      Local eosinophilic arterial inflammation is followed by intimal
+      hyperplasia and luminal stenosis in affected temporal artery segments.
   evidence:
   - reference: PMID:18538831
     reference_title: Vasculitis of the temporal arteries in the young.
@@ -296,6 +301,27 @@ diagnosis:
       This review supports integrating clinical, laboratory, imaging, and
       histologic information when diagnosing temporal-artery vasculitis in
       young patients.
+- name: Doppler ultrasonography for localized temporal arteritis
+  description: >-
+    Doppler ultrasonography can support pre-biopsy localization of temporal
+    artery inflammation, but tissue diagnosis remains important for excluding
+    mimics and systemic vasculitis.
+  diagnosis_term:
+    preferred_term: Doppler ultrasonography
+  results: >-
+    Localized inflammatory arteritis on Doppler ultrasound supports targeted
+    temporal artery biopsy or excision in the appropriate clinical context.
+  evidence:
+  - reference: PMID:21183315
+    reference_title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Doppler ultrasonography suggested a localized inflammatory arteritis.
+      Temporal biopsy was performed.
+    explanation: >-
+      This case report supports Doppler ultrasonography as a localizing
+      diagnostic tool before biopsy.
 treatments:
 - name: Local surgical excision or excisional biopsy
   description: >-
@@ -330,6 +356,47 @@ treatments:
     explanation: >-
       This abstract explicitly supports excision as often curative and argues
       against routine corticosteroid therapy.
+- name: Selective corticosteroid pharmacotherapy
+  description: >-
+    Corticosteroid therapy is not routine for most localized JTA cases after
+    complete excision, but it is a documented pharmacologic option when disease
+    is persistent, recurrent, bilateral, or initially difficult to distinguish
+    from systemic vasculitis.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: corticosteroid
+      term:
+        id: CHEBI:50858
+        label: corticosteroid
+  evidence:
+  - reference: PMID:21183315
+    reference_title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In these rare JTVs, excision of the involved section of temporal artery is
+      often curative and corticosteroid therapy is not required.
+    explanation: >-
+      This supports corticosteroid therapy as a recognized treatment context
+      while emphasizing that it is usually unnecessary after curative local
+      excision.
+  - reference: PMID:39180526
+    reference_title: "Bilateral juvenile temporal arteritis: a case-based review."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main takeaway from this review is the variable nature of JTA and the
+      importance of histopathology in diagnosis, which helps clinicians avoid
+      excessive testing and overtreatment and anticipate possible spontaneous
+      resolution.
+    explanation: >-
+      The systematic review reinforces conservative use of systemic treatment
+      by highlighting variable course, possible spontaneous resolution, and
+      risk of overtreatment.
 differential_diagnoses:
 - name: Giant Cell Arteritis
   disease_term:

--- a/references_cache/PMID_18538831.md
+++ b/references_cache/PMID_18538831.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:18538831"
+title: Vasculitis of the temporal arteries in the young.
+authors:
+- Nesher G
+- Oren S
+- Lijovetzky G
+- Nesher R
+journal: Semin Arthritis Rheum
+year: '2009'
+doi: 10.1016/j.semarthrit.2008.03.001
+keywords:
+- Adolescent
+- Adult
+- Age Factors
+- Female
+- "Giant Cell Arteritis/diagnosis, physiopathology, therapy"
+- Humans
+- Male
+- "Temporal Arteries/pathology, physiopathology"
+- Young Adult
+content_type: abstract_only
+---
+
+# Vasculitis of the temporal arteries in the young.
+**Authors:** Nesher G, Oren S, Lijovetzky G, Nesher R
+**Journal:** Semin Arthritis Rheum (2009)
+**DOI:** [10.1016/j.semarthrit.2008.03.001](https://doi.org/10.1016/j.semarthrit.2008.03.001)
+
+## Content
+
+1. Semin Arthritis Rheum. 2009 Oct;39(2):96-107. doi:
+10.1016/j.semarthrit.2008.03.001. Epub 2008 Jun 9.
+
+Vasculitis of the temporal arteries in the young.
+
+Nesher G(1), Oren S, Lijovetzky G, Nesher R.
+
+Author information:
+(1)Department of Internal Medicine, Rheumatology Service, Shaare-Zedek Medical
+Center, Jerusalem, Israel. nesher@inter.net.il
+
+OBJECTIVE: Temporal artery vasculitis (TAV) in patients younger than 50 years is
+extremely rare. A case of TAV in an 18-year-old man is described here, followed
+by a literature review regarding cases of all types of vasculitic involvement of
+the temporal arteries in the young.
+METHODS: Review of the English literature on vasculitis involving the temporal
+arteries in young patients, based on a PubMed search.
+RESULTS: Less than 40 cases of vasculitic involvement of temporal arteries in
+the young have been described. TAV in the young may be divided into 3 groups:
+juvenile temporal arteritis, a localized eosinophilic arteritis confined to the
+temporal arteries, seems unique to this age group. Fifteen patients with
+juvenile temporal arteritis were described. Other vasculitides, such as
+polyarteritis nodosa, Churg-Strauss syndrome, and thrombangiitis obliterans may
+involve the temporal arteries in young patients. The literature search revealed
+12 such cases. The least common group is arteritis in young patients,
+histologically resembling elderly type temporal arteritis, featuring 5 cases. In
+addition, other conditions such as Kimura disease and angiolymphoid hyperplasia
+with eosinophilia may resemble temporal arteritis in the young.
+CONCLUSIONS: TAV in the young is rare and differs from the classical temporal
+arteritis of older adults. There is an apparent overlap among several vasculitic
+conditions involving the temporal arteries in the young, and histological
+distinction may be difficult at times. The final diagnosis of the different
+conditions causing TAV in the young is based on a combination of clinical
+findings, relevant laboratory data, imaging studies, and histological findings.
+
+DOI: 10.1016/j.semarthrit.2008.03.001
+PMID: 18538831 [Indexed for MEDLINE]

--- a/references_cache/PMID_21183315.md
+++ b/references_cache/PMID_21183315.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:21183315"
+title: "Juvenile temporal vasculitis: a rare case in a middle-aged woman."
+authors:
+- Durant C
+- Connault J
+- Graveleau J
+- Toquet C
+- Brisseau JM
+- Hamidou M
+journal: Ann Vasc Surg
+year: '2011'
+doi: 10.1016/j.avsg.2010.10.006
+keywords:
+- Adult
+- Age Factors
+- Biopsy
+- Female
+- "Giant Cell Arteritis/complications, diagnosis, surgery"
+- Headache/etiology
+- Humans
+- "Temporal Arteries/diagnostic imaging, pathology, surgery"
+- Treatment Outcome
+- "Ultrasonography, Doppler"
+- Vascular Surgical Procedures
+content_type: abstract_only
+---
+
+# Juvenile temporal vasculitis: a rare case in a middle-aged woman.
+**Authors:** Durant C, Connault J, Graveleau J, Toquet C, Brisseau JM, Hamidou M
+**Journal:** Ann Vasc Surg (2011)
+**DOI:** [10.1016/j.avsg.2010.10.006](https://doi.org/10.1016/j.avsg.2010.10.006)
+
+## Content
+
+1. Ann Vasc Surg. 2011 Apr;25(3):384.e5-7. doi: 10.1016/j.avsg.2010.10.006. Epub
+2010 Dec 23.
+
+Juvenile temporal vasculitis: a rare case in a middle-aged woman.
+
+Durant C(1), Connault J, Graveleau J, Toquet C, Brisseau JM, Hamidou M.
+
+Author information:
+(1)Department of Internal Medecine, CHU Hôtel Dieu, Nantes, France.
+cecile.durant@sls.aphp.fr
+
+BACKGROUND: Classic giant cell arteritis affects older adults who are aged >50
+years. Temporal arteritis is uncommon in young adults but juvenile temporal
+vasculitis (JTV) is the most frequent form found in young people. Clinical
+presentation is usually poor, with localized temporal inflammatory changes
+without consistent systemic manifestations. Generally, the patients have a
+benign clinical course, without ophthalmic or ischemic manifestations. In these
+rare JTVs, excision of the involved section of temporal artery is often curative
+and corticosteroid therapy is not required.
+METHOD: The present study reports a case of JTV in a middle-aged woman.
+RESULTS: A 44-year-old woman complained of violent temporal headache, with a
+slight inflammatory syndrome. She had no vascular systemic manifestation and no
+cause of secondary vasculitis. Doppler ultrasonography suggested a localized
+inflammatory arteritis. Temporal biopsy was performed. Histologic findings were
+compatible with JTV (nongranulomatous panarteritis with mononuclear cells and
+eosinophils). All the symptoms disappeared after excision. One year later, she
+remains well and reports neither systemic manifestation nor recurrence.
+CONCLUSION: Vasculitis of the temporal arteries in young people is uncommon and
+JTV is rare in middle-aged people. It is necessary to search for systemic or
+secondary vasculitis. In contrast to giant cell arteritis, steroids are not
+required.
+
+Copyright © 2011 Annals of Vascular Surgery Inc. Published by Elsevier Inc. All
+rights reserved.
+
+DOI: 10.1016/j.avsg.2010.10.006
+PMID: 21183315 [Indexed for MEDLINE]

--- a/references_cache/PMID_30844551.md
+++ b/references_cache/PMID_30844551.md
@@ -1,0 +1,103 @@
+---
+reference_id: "PMID:30844551"
+title: "Juvenile temporal arteritis: A clinicopathological multicentric experience."
+authors:
+- Journeau L
+- Pistorius MA
+- Michon-Pasturel U
+- Lambert M
+- Lapébie FX
+- Bura-Riviere A
+- de Faucal P
+- Jego P
+- Didier Q
+- Durant C
+- Urbanski G
+- Hervier B
+- Toquet C
+- Agard C
+- Espitia O
+- "Groupe d'Étude Français des Artérites des gros Vaisseaux"
+journal: Autoimmun Rev
+year: '2019'
+doi: 10.1016/j.autrev.2019.03.007
+keywords:
+- Adolescent
+- Adult
+- Female
+- Humans
+- Male
+- Young Adult
+- Biopsy
+- France/epidemiology
+- "Giant Cell Arteritis/diagnosis, epidemiology, pathology, therapy"
+- "Headache/diagnosis, etiology, therapy"
+- Retrospective Studies
+- Syndrome
+- Temporal Arteries/pathology
+content_type: abstract_only
+---
+
+# Juvenile temporal arteritis: A clinicopathological multicentric experience.
+**Authors:** Journeau L, Pistorius MA, Michon-Pasturel U, Lambert M, Lapébie FX, Bura-Riviere A, de Faucal P, Jego P, Didier Q, Durant C, Urbanski G, Hervier B, Toquet C, Agard C, Espitia O, Groupe d'Étude Français des Artérites des gros Vaisseaux
+**Journal:** Autoimmun Rev (2019)
+**DOI:** [10.1016/j.autrev.2019.03.007](https://doi.org/10.1016/j.autrev.2019.03.007)
+
+## Content
+
+1. Autoimmun Rev. 2019 May;18(5):476-483. doi: 10.1016/j.autrev.2019.03.007. Epub
+ 2019 Mar 4.
+
+Juvenile temporal arteritis: A clinicopathological multicentric experience.
+
+Journeau L(1), Pistorius MA(1), Michon-Pasturel U(2), Lambert M(3), Lapébie
+FX(4), Bura-Riviere A(4), de Faucal P(5), Jego P(6), Didier Q(1), Durant C(1),
+Urbanski G(7), Hervier B(8), Toquet C(9), Agard C(1), Espitia O(10); Groupe
+d'Étude Français des Artérites des gros Vaisseaux.
+
+Author information:
+(1)Department of internal medicine, Hôtel-Dieu, CHU Nantes, Nantes, France.
+(2)Department of internal medicine, Centre Hospitalier Universitaire de Lille,
+Lille, France.
+(3)Department of vascular medicine, Hôpital Saint-Joseph, Paris, France.
+(4)Department of vascular medicine, Hôpital Rangueil, CHU de Toulouse, Toulouse,
+France.
+(5)Department of internal medicine, Hôpital privé du Confluent, Nantes, France.
+(6)Department of internal medicine, Hôpital Sud, CHU de Rennes, Rennes, France.
+(7)Department of internal medicine and vascular diseases, CHU d'Angers, Angers,
+France.
+(8)Department of internal medicine, Hôpital Pitié-Salpêtrière (AP-HP), Paris,
+France.
+(9)Departement of pathology, Hôtel-Dieu, CHU Nantes, Nantes, France.
+(10)Department of internal medicine, Hôtel-Dieu, CHU Nantes, Nantes, France.
+Electronic address: olivier.espitia@chu-nantes.fr.
+
+INTRODUCTION: Juvenile temporal arteritis (JTA) is a recently-described and
+little-known inflammatory disease and its etiology is undetermined. Less than
+forty cases have been published. This paper is aimed at reporting the largest
+JTA series and to compare it to literature data to better evaluate its
+characteristics at diagnosis, its evolution and treatment options.
+MATERIAL AND METHODS: We conducted a retrospective and descriptive multicentric
+study in France by identifying adult patients under the age of 50 which had a
+pathological temporal artery biopsy owing to the presence of a temporal
+arteritis. Patients with temporal arteritis as a manifestation of systemic
+vasculitis were excluded.
+RESULTS: We included 12 patients and the literature review identified 32 cases
+described in 27 articles, thus a total of 44 patients - 34 men and 10 women -
+with a median age of 30 and a maximum of 44. All patients presented either a
+lump in the temporal region or prominent temporal arteries, and 47.7% of
+patients suffered from headaches. Only 11.4% of patients presented general
+symptoms and 6.8% a biological inflammatory syndrome; 34.1% had peripheral blood
+eosinophilia; 83.7% presented a single episode and complete excision without
+further treatment was documented for 72.7%. Pathology analysis revealed
+infiltrate of inflammatory cells in the arterial wall in 97.6% of patients but
+also sparse giant cells for 25% and granuloma for 22.9%, perivascular extension
+of the inflammation for 82.6%, and presence of lymphoid follicles or germinal
+centres for 60%. Clinical relapses were present in 16.3% of cases.
+CONCLUSION: JTA is a rare, localized and benign disease. The majority of cases
+have only one episode which is cured by local surgery.
+
+Copyright © 2019 Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.autrev.2019.03.007
+PMID: 30844551 [Indexed for MEDLINE]

--- a/references_cache/PMID_32873218.md
+++ b/references_cache/PMID_32873218.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:32873218"
+title: "Is Kimura's disease associated with juvenile temporal arteritis? A case report and literature review of all juvenile temporal arteritis cases."
+authors:
+- Tomizuka T
+- Kikuchi H
+- Asako K
+- Tsukui D
+- Kimura Y
+- Kikuchi Y
+- Sasajima Y
+- Kono H
+journal: Mod Rheumatol Case Rep
+year: '2021'
+doi: 10.1080/24725625.2020.1818366
+keywords:
+- Adult
+- Asian People
+- Ear Auricle/pathology
+- "Giant Cell Arteritis/complications, pathology"
+- Humans
+- "Kimura Disease/complications, pathology"
+- Male
+- Temporal Arteries/pathology
+content_type: abstract_only
+---
+
+# Is Kimura's disease associated with juvenile temporal arteritis? A case report and literature review of all juvenile temporal arteritis cases.
+**Authors:** Tomizuka T, Kikuchi H, Asako K, Tsukui D, Kimura Y, Kikuchi Y, Sasajima Y, Kono H
+**Journal:** Mod Rheumatol Case Rep (2021)
+**DOI:** [10.1080/24725625.2020.1818366](https://doi.org/10.1080/24725625.2020.1818366)
+
+## Content
+
+1. Mod Rheumatol Case Rep. 2021 Jan;5(1):123-129. doi:
+10.1080/24725625.2020.1818366. Epub 2020 Sep 28.
+
+Is Kimura's disease associated with juvenile temporal arteritis? A case report
+and literature review of all juvenile temporal arteritis cases.
+
+Tomizuka T(1), Kikuchi H(1), Asako K(1), Tsukui D(1), Kimura Y(1), Kikuchi Y(2),
+Sasajima Y(2), Kono H(1).
+
+Author information:
+(1)Department of Internal Medicine, Teikyo University School of Medicine, Tokyo,
+Japan.
+(2)Department of Pathology, Teikyo University School of Medicine, Tokyo, Japan.
+
+Both juvenile temporal arteritis (JTA) and Kimura's disease are eosinophilic
+inflammatory conditions but exhibit different clinical manifestations. Here, we
+describe a case involving a 40-year-old man who developed JTA secondary to
+Kimura's disease. Approximately 3 years before admission, masses appeared on
+both posterior auricles. A biopsy of the right posterior auricle mass led to a
+diagnosis of Kimura's disease. Approximately 4 months before admission, both
+masses increased in size, and almost simultaneously, the left temporal artery
+became distended. Histopathology of a biopsy of the left temporal artery
+revealed inflammatory findings with marked eosinophil infiltration and
+significant intimal hyperplasia with stenosis of the vascular lumen, indicating
+JTA. An analysis of the 48 reported cases of JTA, identified in a literature
+review, and the present case, revealed that Kimura's disease was detected in 6
+cases, all of which involved Asians. In conclusion, this case and the literature
+review suggest that JTA can be accompanied by another eosinophilic
+inflammation-based disorder, Kimura's disease, particularly in Asians. This
+newly highlighted relationship between JTA and Kimura's disease could lead to a
+better understanding of JTA, which is an extremely rare disease.
+
+DOI: 10.1080/24725625.2020.1818366
+PMID: 32873218 [Indexed for MEDLINE]

--- a/references_cache/PMID_39180526.md
+++ b/references_cache/PMID_39180526.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:39180526"
+title: "Bilateral juvenile temporal arteritis: a case-based review."
+authors:
+- Marques-Soares J
+- Garcia-Domingo MI
+- Leal CB
+- Alijotas-Reig J
+journal: Rheumatol Int
+year: '2024'
+doi: 10.1007/s00296-024-05624-2
+keywords:
+- Adult
+- Female
+- Humans
+- Biopsy
+- "Giant Cell Arteritis/diagnosis, drug therapy, pathology"
+- Temporal Arteries/pathology
+content_type: abstract_only
+---
+
+# Bilateral juvenile temporal arteritis: a case-based review.
+**Authors:** Marques-Soares J, Garcia-Domingo MI, Leal CB, Alijotas-Reig J
+**Journal:** Rheumatol Int (2024)
+**DOI:** [10.1007/s00296-024-05624-2](https://doi.org/10.1007/s00296-024-05624-2)
+
+## Content
+
+1. Rheumatol Int. 2024 Oct;44(10):2253-2261. doi: 10.1007/s00296-024-05624-2.
+Epub  2024 Aug 24.
+
+Bilateral juvenile temporal arteritis: a case-based review.
+
+Marques-Soares J(1)(2), Garcia-Domingo MI(3), Leal CB(4), Alijotas-Reig J(5)(6).
+
+Author information:
+(1)Systemic Autoimmune Diseases Unit, Department of Internal Medicine, Hospital
+Universitari Vall d'Hebron and Systemic Autoimmune Research Unit, Vall d'Hebron
+Research Institute, Universitat Autònoma de Barcelona, Passeig Vall d'Hebron
+119-29, 08035-Barcelona, Catalonia, Barcelona, Spain.
+(2)Department of Medicine, Faculty of Medicine, Universitat Autònoma de
+Barcelona, Barcelona, Spain.
+(3)Department of General Surgery, Hospital Universitari Mútua Terrassa,
+Universitat de Barcelona, Terrassa, Spain.
+(4)Department of Pathology, Hospital Universitari Mútua Terrassa, Universitat de
+Barcelona, Terrassa, Spain.
+(5)Systemic Autoimmune Diseases Unit, Department of Internal Medicine, Hospital
+Universitari Vall d'Hebron and Systemic Autoimmune Research Unit, Vall d'Hebron
+Research Institute, Universitat Autònoma de Barcelona, Passeig Vall d'Hebron
+119-29, 08035-Barcelona, Catalonia, Barcelona, Spain. jaime.alijotas@uab.cat.
+(6)Department of Medicine, Faculty of Medicine, Universitat Autònoma de
+Barcelona, Barcelona, Spain. jaime.alijotas@uab.cat.
+
+Juvenile Temporal Arteritis (JTA) is a rare non-granulomatous vasculitis
+affecting the superficial temporal arteries, mostly in individuals under 45
+years old. It is often misdiagnosed due to its benign nature and the absence of
+systemic symptoms. Herein, we present a case report of a 40-year-old woman who
+initially presented with painless nodules in the left temporal area. Following a
+biopsy, the patient developed additional nodules not only in the same temple but
+also on the contralateral side. Remarkably, these nodules underwent spontaneous
+regression without further treatment, highlighting the variability in JTA's
+course and distinctive response to intervention. In addition, through a
+systematic literature review of 43 case reports - 17 with bilateral involvement
+- we aimed to thoroughly understand the clinical and histopathological findings,
+diagnostic processes, and treatment responses in JTA, with an emphasis on cases
+with bilateral involvement. Findings indicate that JTA typically presents as
+painless or painful temporal nodules, rarely accompanied by other non-specific
+symptoms, making histopathological examination crucial for accurate diagnosis.
+Collectively, our work provides the most extensive account of bilateral JTA
+cases to date. It emphasizes the need for clinical awareness of this condition,
+contributes valuable data to the limited information available on this rare
+condition and serves as a stepping-stone for further inquiry. The main takeaway
+from this review is the variable nature of JTA and the importance of
+histopathology in diagnosis, which helps clinicians avoid excessive testing and
+overtreatment and anticipate possible spontaneous resolution.
+
+© 2024. The Author(s).
+
+DOI: 10.1007/s00296-024-05624-2
+PMCID: PMC11393210
+PMID: 39180526 [Indexed for MEDLINE]
+
+Conflict of interest statement: All authors declare that they have no conflict
+of interest.

--- a/research/Juvenile_Temporal_Arteritis-deep-research-falcon.md
+++ b/research/Juvenile_Temporal_Arteritis-deep-research-falcon.md
@@ -1,0 +1,1196 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T07:58:45.985580'
+end_time: '2026-05-06T08:07:56.312063'
+duration_seconds: 550.33
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Juvenile Temporal Arteritis
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 24
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Juvenile Temporal Arteritis
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Juvenile Temporal Arteritis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Juvenile Temporal Arteritis
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Juvenile Temporal Arteritis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Juvenile Temporal Arteritis (JTA): Disease Characteristics Research Report (2024 update)
+
+## 1. Disease information
+
+### 1.1 Overview (current understanding)
+Juvenile temporal arteritis (JTA) is a rare, localized vasculitis/arteritis confined to the superficial temporal artery (STA) and its branches, characterized most often by non-granulomatous, eosinophil-rich panarteritis and intimal hyperplasia that presents clinically as temporal nodules or a temporal “lump,” usually without systemic symptoms. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+
+Direct abstract support (2024 systematic review): “Juvenile Temporal Arteritis (JTA) is a rare non-granulomatous vasculitis affecting the superficial temporal arteries, mostly in individuals under 45 years old.” (Published online 2024-08-24; DOI: https://doi.org/10.1007/s00296-024-05624-2) (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+Direct abstract support (2019 multicenter series): “Juvenile temporal arteritis (JTA) is a recently-described and little-known inflammatory disease and its etiology is undetermined. Less than forty cases have been published.” (Available online 2019-03-04; DOI: https://doi.org/10.1016/j.autrev.2019.03.007) (journeau2019juveniletemporalarteritis pages 1-2)
+
+### 1.2 Key identifiers and terminology
+- **Preferred name:** Juvenile temporal arteritis (JTA). (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+- **Common synonym(s):** juvenile temporal vasculitis (used in case literature). (durant2011juveniletemporalvasculitis pages 1-2)
+- **Orphanet:** Juvenile temporal arteritis **Orphanet:26137** (as cited by Marques-Soares et al., 2024; accessed 2024-04-26). URL: https://www.orpha.net/en/disease/detail/26137 (marquessoares2024bilateraljuveniletemporal pages 8-9)
+- **GARD (NIH):** juvenile temporal arteritis (cited as a reference/resource by Marques-Soares et al., 2024; accessed 2024-04-26). URL: https://rarediseases.info.nih.gov/diseases/3068/index (marquessoares2024bilateraljuveniletemporal pages 8-9)
+- **MONDO / MeSH / ICD-10/ICD-11 / OMIM:** Not identified in the retrieved full-text evidence. The 2024 review explicitly notes that comprehensive hereditary data are lacking, consistent with JTA being primarily defined clinicopathologically rather than genetically. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+### 1.3 Evidence type note
+Most knowledge about JTA comes from **aggregated disease-level synthesis of case reports/series** (e.g., systematic reviews, multicenter clinicopathologic series), rather than population cohorts or EHR-scale studies. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+The etiology of JTA remains **undetermined/unknown** in major reviews/series. (journeau2019juveniletemporalarteritis pages 1-2)
+
+### 2.2 Risk factors
+Evidence supports demographic and laboratory correlates more than causal risk factors:
+- **Age:** typically young adults/“under 45–50.” (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+- **Sex:** male predominance reported across aggregated case data (e.g., 77.3% male in a 44-patient combined cohort+literature dataset). (journeau2019juveniletemporalarteritis pages 1-2)
+- **Eosinophilia / IgE:** peripheral blood eosinophilia is common in subsets and may point toward overlap with eosinophil-associated conditions (see §6). (journeau2019juveniletemporalarteritis pages 1-2, marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+No gene–environment interactions were identified in the retrieved evidence.
+
+## 3. Phenotypes (with ontology suggestions)
+
+### 3.1 Core clinical phenotype (from largest clinicopathologic aggregation)
+In the 44-patient synthesis (12 French cases + 32 literature), all patients presented “either a lump in the temporal region or prominent temporal arteries,” and **47.7%** had headache; **11.4%** had general symptoms. (journeau2019juveniletemporalarteritis pages 1-2)
+
+### 3.2 Phenotype list with suggested HPO terms
+Below are phenotype items supported by retrieved evidence:
+- **Temporal lump / temporal nodules (often unilateral; sometimes bilateral)**
+  - Evidence: temporal lump 72.7% in 44-patient dataset; bilateral involvement 25.0% at presentation in that dataset; the 2024 bilateral-focused review emphasizes frequent bilateral disease in that selected subset. (journeau2019juveniletemporalarteritis pages 1-2, marquessoares2024bilateraljuveniletemporal pages 7-8)
+  - HPO suggestions: **HP:0002056** (Subcutaneous nodule), **HP:0025464** (Mass), **HP:0100259** (Localized swelling).
+- **Headache / temporal headache**
+  - Evidence: 47.7% headache in the 44-patient dataset; ~28.6% in the bilateral-case subset analyzed by Marques-Soares et al. (journeau2019juveniletemporalarteritis pages 1-2, marquessoares2024bilateraljuveniletemporal pages 6-7)
+  - HPO suggestions: **HP:0002315** (Headache).
+- **Temporal artery tenderness / pain in temple region**
+  - Evidence: painful nodules reported; “not particularly painful” is typical in the image-gallery case description but painful cases exist. (espitia2018imagegallerybilateral pages 1-1, marquessoares2024bilateraljuveniletemporal pages 7-8)
+  - HPO suggestions: **HP:0030834** (Scalp tenderness), **HP:0012531** (Pain).
+- **Pruritus (temporal itching)**
+  - Evidence: temporal itching in 11.4% (4/35) in the 2019 compilation. (journeau2019juveniletemporalarteritis pages 1-2)
+  - HPO suggestions: **HP:0000989** (Pruritus).
+- **Visual symptoms (rare): visual blurring/phosphenes**
+  - Evidence: 9.8% in 2019 compilation. (journeau2019juveniletemporalarteritis pages 1-2)
+  - HPO suggestions: **HP:0000648** (Blurred vision), **HP:0001109** (Photopsia).
+- **Attenuated temporal pulse / local ischemic signs**
+  - Evidence: attenuated temporal pulse in the 2024 case report. (marquessoares2024bilateraljuveniletemporal pages 2-4)
+  - HPO suggestions: **HP:0005305** (Decreased peripheral pulses).
+- **Occasional systemic symptoms (malaise/fatigue/fever)**
+  - Evidence: general symptoms 11.4% in 2019 compilation; bilateral-case subset described systemic involvement 22.2% in that selected set. (journeau2019juveniletemporalarteritis pages 1-2, marquessoares2024bilateraljuveniletemporal pages 7-8)
+  - HPO suggestions: **HP:0012378** (Fatigue), **HP:0001945** (Fever).
+
+### 3.3 Quality of life impact
+Formal QoL instruments (e.g., SF-36/EQ-5D) were not reported in the retrieved evidence. Clinically, the primary burden appears to be local pain, cosmetic/structural temporal nodules, and diagnostic uncertainty (misdiagnosis leading to unnecessary testing/overtreatment). (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes and pathogenic variants
+No causal genes, pathogenic variants, or inherited patterns were identified in the retrieved primary literature. The 2024 review states that, given rarity, “comprehensive data on the hereditary patterns of JTA is lacking.” (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+### 4.2 Modifier genes / epigenetics / chromosomal abnormalities
+Not reported in retrieved evidence.
+
+## 5. Environmental information
+
+No specific environmental exposures, lifestyle factors, or infectious triggers were identified as established contributors in the retrieved evidence. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Clinicopathologic concept
+JTA is generally modeled as a **localized eosinophil-rich panarteritis** of the STA with **intimal hyperplasia/proliferation**, **disruption of the internal elastic lamina (IEL)**, and variable thrombosis/microaneurysmal changes; it differs from classic giant cell arteritis (GCA) by typical absence/minimal systemic inflammation and rare/absent giant cells and granulomas. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2, nesher2009vasculitisofthe pages 2-4)
+
+### 6.2 Immune cell involvement (human pathology)
+- In the 2019 combined dataset, arterial-wall inflammatory infiltrate occurred in **97.6%**; perivascular extension in **82.6%**; lymphoid follicles/germinal centers in **60%**; “sparse giant cells” in **25%** and granuloma in **22.9%** (indicating giant cells can occur but are not defining). (journeau2019juveniletemporalarteritis pages 1-2)
+- The 2024 review emphasizes a “lymphoeosinophilic” infiltrate and notes that giant cells/granulomas are absent or nominal in many JTA cases and help distinguish JTA from GCA. (marquessoares2024bilateraljuveniletemporal pages 2-4)
+
+### 6.3 Proposed nosologic overlap (expert interpretation)
+Marques-Soares et al. (2024) highlight overlap features with **Kimura disease (KD)** and **angiolymphoid hyperplasia with eosinophilia (ALHE)**, especially because both can show eosinophilia/IgE elevation and perivascular eosinophilic infiltrates. The paper notes the hypothesis that JTA may start as a vascular inflammatory process that can extend to neighboring tissues and lead to lymphoid follicles. (marquessoares2024bilateraljuveniletemporal pages 2-4)
+
+### 6.4 Differential-pathology “red flags”
+The 2024 review notes that **fibrinoid necrosis** should prompt alternative diagnoses, including **ANCA-associated vasculitis** and **polyarteritis nodosa**, rather than JTA. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+### 6.5 Suggested ontology terms (mechanisms)
+- **GO Biological Process (suggestions):** arteritis; inflammatory response; eosinophil chemotaxis/activation; intimal hyperplasia; thrombus formation; extracellular matrix organization.
+- **Cell Ontology (CL) (suggestions):** eosinophil; CD4-positive T cell; B cell; plasma cell; macrophage/monocyte.
+
+## 7. Anatomical structures affected
+
+### 7.1 Organ/tissue level
+- Primary site: **superficial temporal arteries** and branches of the **external carotid artery** system. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+### 7.2 Suggested UBERON terms
+- **Superficial temporal artery** (UBERON term exists; exact identifier not available from retrieved evidence; recommended to map in ontology pipeline).
+- **Temporal region of head**; **scalp**.
+
+### 7.3 Subcellular level
+Not characterized in retrieved evidence.
+
+## 8. Temporal development (natural history)
+
+### 8.1 Onset
+Typically presents in late childhood through early adulthood; commonly operationalized as <45 years or <50 years in series and reviews. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+
+### 8.2 Course/progression
+JTA is often described as **benign** and localized. In the 44-patient dataset, **83.7%** had a single episode and local relapse occurred in **~16%**. (journeau2019juveniletemporalarteritis pages 1-2)
+
+The 2024 case report highlights potential **spontaneous regression** without further treatment following biopsy and emphasizes variability in disease course. (marquessoares2024bilateraljuveniletemporal pages 2-4)
+
+## 9. Inheritance and population
+
+### 9.1 Epidemiology
+Robust incidence/prevalence estimates are not available due to rarity. The 2024 review cites “prevalence estimates under 1 per 1,000,000 individuals.” (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+Case-count statistics (proxy epidemiology):
+- 2019 multicenter series states “Less than forty cases have been published” (at that time), and analyzed 44 total cases by combining new cases and literature. (journeau2019juveniletemporalarteritis pages 1-2)
+- 2009 review similarly emphasizes extreme rarity and notes <40 young temporal-artery vasculitis cases, including 15 JTA patients described in that review’s framing. (nesher2009vasculitisofthe pages 1-2)
+
+### 9.2 Demographics
+- Sex ratio: male predominance. Example: 34/44 (77.3%) male in 2019 compilation. (journeau2019juveniletemporalarteritis pages 1-2)
+- Age distribution: median age 30 (range 7–44) in 2019 compilation; median 34.5 (range 21–49) in 2024 bilateral-case subset synthesis. (journeau2019juveniletemporalarteritis pages 1-2, marquessoares2024bilateraljuveniletemporal pages 6-7)
+
+### 9.3 Inheritance
+No established inheritance pattern; hereditary data are lacking. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+## 10. Diagnostics
+
+### 10.1 Clinical suspicion
+Key clinical pattern is a localized temporal nodule/lump in a young patient, typically without systemic inflammatory syndrome. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+
+### 10.2 Laboratory tests
+A distinguishing feature from GCA is often normal acute-phase reactants (ESR/CRP) in many cases. (marquessoares2024bilateraljuveniletemporal pages 1-2, nesher2009vasculitisofthe pages 2-4)
+
+However, eosinophilia can be present:
+- 2019 compilation: eosinophilia >500/mm³ in 34.1% (14/41). (journeau2019juveniletemporalarteritis pages 1-2)
+- 2024 bilateral-case subset: peripheral blood eosinophilia 69.2% (9/13) and elevated IgE 66.7% (4/6) where measured. (marquessoares2024bilateraljuveniletemporal pages 7-8)
+
+### 10.3 Imaging
+- **Doppler/duplex ultrasound:** can show the “halo sign” (which also occurs in GCA) and can show segmental thickening and microaneurysms. (marquessoares2024bilateraljuveniletemporal pages 1-2, espitia2018imagegallerybilateral pages 1-1)
+- **PET-CT/CT:** the 2024 review states PET-CT/CT “reveal no indications of vasculitis in other arterial regions” in contrast to GCA. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+### 10.4 Biopsy / histopathology (diagnostic cornerstone)
+Histopathology is repeatedly emphasized as crucial for diagnosis and for distinguishing from mimics (GCA, KD, ALHE, systemic vasculitides). (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2)
+
+Canonical features include:
+- Lymphoeosinophilic arteritis/panarteritis. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+- Intimal hyperplasia/proliferation with luminal occlusion. (marquessoares2024bilateraljuveniletemporal pages 2-4)
+- IEL disruption/disorganization. (marquessoares2024bilateraljuveniletemporal pages 2-4)
+- Thrombosis and/or microaneurysmal lesions in some cases. (marquessoares2024bilateraljuveniletemporal pages 1-2, espitia2018imagegallerybilateral pages 1-1)
+
+**Histopathology figure evidence:** Figure 2 from Marques-Soares et al. (2024) shows STA cross-sections with luminal obliteration/intimal hyperplasia, transmural inflammatory infiltrate with abundant eosinophils, and elastic fiber disorganization on Verhoeff-Van Gieson stain. (marquessoares2024bilateraljuveniletemporal media 84a68dfb)
+
+### 10.5 Differential diagnosis (expert consensus)
+- **Giant cell arteritis (GCA):** typically >50 years, systemic symptoms and elevated ESR/CRP more common; treated urgently with corticosteroids to prevent ischemic complications. JTA is younger, usually localized/benign, and excision often curative; giant cells/granulomas are often absent in JTA but may occur sparsely. (marquessoares2024bilateraljuveniletemporal pages 1-2, journeau2019juveniletemporalarteritis pages 1-2, espitia2018imagegallerybilateral pages 1-1)
+- **Kimura disease / ALHE:** may mimic clinically and share eosinophilia/IgE and perivascular inflammation; histology and anatomic distribution aid distinction. (marquessoares2024bilateraljuveniletemporal pages 1-2, marquessoares2024bilateraljuveniletemporal pages 2-4)
+- **Systemic vasculitides involving temporal arteries:** PAN, ANCA-associated vasculitis; fibrinoid necrosis should raise suspicion for these rather than JTA. (marquessoares2024bilateraljuveniletemporal pages 1-2, nesher2009vasculitisofthe pages 1-2)
+- **Non-vascular mimics:** lipoma, sebaceous/dermoid cysts, aneurysm/AVM. (marquessoares2024bilateraljuveniletemporal pages 1-2)
+
+## 11. Outcome / prognosis
+
+### 11.1 Prognosis
+JTA is generally favorable/benign:
+- 2019 conclusion: “JTA is a rare, localized and benign disease… cured by local surgery.” (journeau2019juveniletemporalarteritis pages 1-2)
+- 2018 image-case: “The course is favourable; relapses are rare. Unlike giant-cell arteritis, excision is curative in JTA.” (espitia2018imagegallerybilateral pages 1-1)
+
+### 11.2 Relapse
+Local relapses were ~16% in the 2019 aggregated dataset. (journeau2019juveniletemporalarteritis pages 1-2)
+
+## 12. Treatment
+
+### 12.1 Real-world management patterns
+**Surgical biopsy/excision** is the most common approach and often curative.
+- In 2019 compilation: “complete excision without further treatment was documented for 72.7%.” (journeau2019juveniletemporalarteritis pages 1-2)
+- In 2018 image-case: excision followed by favorable course without treatment and no relapse in 3 years. (espitia2018imagegallerybilateral pages 1-1)
+
+**Corticosteroids** are used in a minority of cases (often when symptoms persist, bilateral disease complicates excision, or when diagnosis is uncertain):
+- 2019: corticosteroids used in 18.6% (8/43). (journeau2019juveniletemporalarteritis pages 1-2)
+- 2024 bilateral-case subset: corticosteroid therapy used in 33.3% (6/18) with resolution in 66.7% (4/6) of treated cases. (marquessoares2024bilateraljuveniletemporal pages 7-8)
+
+Other sporadically used therapies in the 2024 synthesis include **colchicine, methotrexate, aspirin, suplatast tosilate, tocopherol nicotinamide**, typically in anecdotal contexts. (marquessoares2024bilateraljuveniletemporal pages 7-8)
+
+### 12.2 MAXO (Medical Action Ontology) suggestions
+- Surgical excision of affected artery / excisional biopsy (MAXO: procedure terms to be mapped in ontology pipeline). (journeau2019juveniletemporalarteritis pages 1-2)
+- Systemic corticosteroid therapy (MAXO mapping recommended). (journeau2019juveniletemporalarteritis pages 1-2)
+
+### 12.3 Clinical trials
+A ClinicalTrials.gov search did not identify trials specifically targeting JTA; retrieved trials related to GCA/vasculitis broadly or imaging methods, consistent with JTA’s rarity and lack of dedicated interventional research. (clinical trials tool output; no JTA-relevant trial chunks met relevance criteria)
+
+## 13. Prevention
+
+No JTA-specific primary/secondary prevention strategies are established in the retrieved literature; prevention is not emphasized, consistent with unclear etiology and rarity.
+
+## 14. Other species / natural disease
+
+No naturally occurring JTA analog in other species was identified in retrieved evidence.
+
+## 15. Model organisms
+
+No established model organisms for JTA were identified in retrieved evidence.
+
+## Recent developments (2023–2024 priority)
+
+The most substantive recent development in the retrieved corpus is the **2024 Rheumatology International case-based systematic review** that focuses on bilateral JTA and provides updated quantitative synthesis, emphasizing: (i) rarity with cited prevalence <1/1,000,000, (ii) importance of histopathology, (iii) frequency of eosinophilia/IgE elevation in bilateral-case reports, and (iv) possibility of spontaneous regression and need to avoid overtreatment. (Published online 2024-08-24; DOI: https://doi.org/10.1007/s00296-024-05624-2) (marquessoares2024bilateraljuveniletemporal pages 1-2, marquessoares2024bilateraljuveniletemporal pages 7-8)
+
+## Key data/statistics (most directly supported)
+- 44-patient clinicopathologic synthesis (2019): male 77.3%; headache 47.7%; general symptoms 11.4%; eosinophilia 34.1%; excision alone 72.7%; relapse ~16%. (journeau2019juveniletemporalarteritis pages 1-2)
+- Bilateral-case subset synthesis (2024): median age 34.5 (21–49); painful nodules 44.4%; headache 28.6%; elevated ESR 11.1%; peripheral eosinophilia ~69%; elevated IgE 66.7% (measured subset); recurrence after biopsy 16.7%. (marquessoares2024bilateraljuveniletemporal pages 6-7, marquessoares2024bilateraljuveniletemporal pages 7-8)
+
+## Evidence summary table (key sources)
+| Citation | PMID | Publication type | Population / case count | Key clinical features | Labs (ESR/CRP/eosinophilia/IgE) | Histopathology highlights | Management / outcome | URL / DOI |
+|---|---|---|---|---|---|---|---|---|
+| Nesher 2009 |  | Review + case report | Review of temporal-artery vasculitis in patients <50; states 15 JTA patients described and <40 young temporal-artery vasculitis cases overall | Typical JTA presents as palpable temporal nodule/swelling, painless or tender; usually no ophthalmic or cranial ischemic symptoms; review case had pulsatile tender swelling | Case: ESR 3 mm/h, CRP 0.1 mg/dL, no peripheral eosinophilia; review notes eosinophilia may be present and normal ESR is common | Nongranulomatous panarteritis with mononuclear infiltrate and numerous eosinophils; intimal thickening/hyperplasia, severe internal elastic lamina disruption, luminal thrombosis; no multinucleated giant cells in the case | Excision considered curative in the case; no systemic therapy beyond mild analgesics; review emphasizes clinicopathologic correlation and distinction from systemic vasculitides | https://doi.org/10.1016/j.semarthrit.2008.03.001 (nesher2009vasculitisofthe pages 1-2, nesher2009vasculitisofthe pages 2-4, nesher2009vasculitisofthe pages 4-5) |
+| Journeau 2019 |  | Multicenter series + literature review | 12 new French cases + 32 literature cases = 44 total patients (34 men, 10 women), median age 30 years | Temporal lump/prominent temporal arteries in all patients; headache in 47.7%; general symptoms uncommon (11.4%); initial bilateral involvement 25.0% | Biological inflammatory syndrome 6.8%; eosinophilia >500/mm3 in 34.1% | Inflammatory infiltrate in arterial wall 97.6%; perivascular extension 82.6%; lymphoid follicles/germinal centres 60%; sparse giant cells 25%; granuloma 22.9% | Complete excision without further treatment in 72.7%; corticosteroids in 18.6%; majority had a single episode; local relapses 16.3%; authors conclude JTA is rare, localized, benign, and usually cured by local surgery | https://doi.org/10.1016/j.autrev.2019.03.007 (journeau2019juveniletemporalarteritis pages 1-2) |
+| Espitia 2018 |  | Image-based case report | 1 case, 23-year-old man with bilateral disease | Bilateral temporal nodules with “horn growth” appearance; often unilateral in JTA generally; lacked systemic symptoms | Hypereosinophilia noted; inflammatory syndrome absent | Segmental thickening and microaneurysms on duplex US; histology showed intimal hyperplasia with panarteritis and eosinophilic/lymphocytic infiltrate extending to perivascular tissue | Temporal artery excision; favorable course without treatment; no relapse within 3 years; note states excision is treatment of choice over steroids | https://doi.org/10.1111/bjd.17008 (espitia2018imagegallerybilateral pages 1-1) |
+| Durant 2011 |  | Case report | 1 middle-aged woman; article notes JTV/JTA median age 23 years, range 7–39, and <40 cases reported | Localized temporal nodules/swelling rather than full GCA syndrome | Example case: CRP 12 mg/L, ESR 15 mm/h, no hypereosinophilia | Nongranulomatous panarteritis with mononuclear cells and eosinophils; intimal hyperplasia; partial loss of internal elastic lamina; no giant cells | Excision of involved artery often curative; steroids not required | https://doi.org/10.1016/j.avsg.2010.10.006 (durant2011juveniletemporalvasculitis pages 1-2) |
+| Marques-Soares 2024 |  | Case report + systematic review | 43 case reports reviewed, including 17 with bilateral involvement; presented case was a 40-year-old woman | JTA defined as rare localized non-granulomatous eosinophilic arteritis of superficial temporal arteries, usually <45 years; presents as painful or painless temporal nodules; bilateral cases emphasized; prevalence estimate <1 per 1,000,000 | Acute-phase reactants typically normal; hypereosinophilia and elevated IgE described as common; in bilateral-case synthesis: elevated ESR 11.1%, peripheral blood eosinophilia 69.2%, elevated IgE 66.7% where measured; index case had normal eosinophils and normal ESR/CRP | Lymphoeosinophilic arteritis/panarteritis, intraluminal thrombosis, possible parietal microaneurysms, disruption of internal elastic lamina, intimal proliferation/hyperplasia; giant cells/granulomas absent or rare; fibrinoid necrosis should prompt alternate diagnosis | Biopsy often diagnostic and therapeutic; bilateral-case review: corticosteroids used in 33.3% with resolution in 66.7% of treated cases; recurrence after biopsy 16.7%; some cases, including index case, had spontaneous regression without treatment | https://doi.org/10.1007/s00296-024-05624-2 (marquessoares2024bilateraljuveniletemporal pages 1-2, marquessoares2024bilateraljuveniletemporal pages 4-6, marquessoares2024bilateraljuveniletemporal pages 2-4, marquessoares2024bilateraljuveniletemporal pages 6-7, marquessoares2024bilateraljuveniletemporal pages 7-8, marquessoares2024bilateraljuveniletemporal pages 8-9) |
+
+
+*Table: This table summarizes major published sources on juvenile temporal arteritis, emphasizing clinical presentation, laboratory patterns, histopathology, and management/outcomes. It is useful for quickly comparing how case reports, reviews, and multicenter data define and distinguish JTA from other temporal vasculitides.*
+
+## Limitations of current evidence base
+The evidence base is dominated by case reports/series and retrospective synthesis, with limited longitudinal follow-up standardization, scarce population-level epidemiology, and minimal molecular/genetic investigation; these limitations are explicitly noted as motivations for future research in the 2024 review. (marquessoares2024bilateraljuveniletemporal pages 7-8)
+
+
+References
+
+1. (marquessoares2024bilateraljuveniletemporal pages 1-2): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.
+
+2. (journeau2019juveniletemporalarteritis pages 1-2): Louis Journeau, Marc-Antoine Pistorius, Ulrique Michon-Pasturel, Marc Lambert, Francois-Xavier Lapébie, Alessandra Bura-Riviere, Philippe de Faucal, Patrick Jego, Quentin Didier, Cécile Durant, Geoffrey Urbanski, Baptiste Hervier, Claire Toquet, Christian Agard, and Olivier Espitia. Juvenile temporal arteritis: a clinicopathological multicentric experience. Autoimmunity reviews, 18 5:476-483, May 2019. URL: https://doi.org/10.1016/j.autrev.2019.03.007, doi:10.1016/j.autrev.2019.03.007. This article has 23 citations and is from a peer-reviewed journal.
+
+3. (durant2011juveniletemporalvasculitis pages 1-2): Cecile Durant, Jérome Connault, Julie Graveleau, Claire Toquet, Jean M. Brisseau, and Mohamed Hamidou. Juvenile temporal vasculitis: a rare case in a middle-aged woman. Annals of vascular surgery, 25 3:384.e5-7, Apr 2011. URL: https://doi.org/10.1016/j.avsg.2010.10.006, doi:10.1016/j.avsg.2010.10.006. This article has 16 citations and is from a peer-reviewed journal.
+
+4. (marquessoares2024bilateraljuveniletemporal pages 8-9): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.
+
+5. (marquessoares2024bilateraljuveniletemporal pages 7-8): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.
+
+6. (marquessoares2024bilateraljuveniletemporal pages 6-7): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.
+
+7. (espitia2018imagegallerybilateral pages 1-1): O. Espitia, C. Agard, and Marc-Antoine Pistorius. Image gallery: bilateral juvenile temporal arteritis. British Journal of Dermatology, 179:e168-e168, Oct 2018. URL: https://doi.org/10.1111/bjd.17008, doi:10.1111/bjd.17008. This article has 3 citations and is from a highest quality peer-reviewed journal.
+
+8. (marquessoares2024bilateraljuveniletemporal pages 2-4): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.
+
+9. (nesher2009vasculitisofthe pages 2-4): Gideon Nesher, Shirly Oren, Graciela Lijovetzky, and Ronit Nesher. Vasculitis of the temporal arteries in the young. Seminars in arthritis and rheumatism, 39 2:96-107, Oct 2009. URL: https://doi.org/10.1016/j.semarthrit.2008.03.001, doi:10.1016/j.semarthrit.2008.03.001. This article has 52 citations and is from a peer-reviewed journal.
+
+10. (nesher2009vasculitisofthe pages 1-2): Gideon Nesher, Shirly Oren, Graciela Lijovetzky, and Ronit Nesher. Vasculitis of the temporal arteries in the young. Seminars in arthritis and rheumatism, 39 2:96-107, Oct 2009. URL: https://doi.org/10.1016/j.semarthrit.2008.03.001, doi:10.1016/j.semarthrit.2008.03.001. This article has 52 citations and is from a peer-reviewed journal.
+
+11. (marquessoares2024bilateraljuveniletemporal media 84a68dfb): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.
+
+12. (nesher2009vasculitisofthe pages 4-5): Gideon Nesher, Shirly Oren, Graciela Lijovetzky, and Ronit Nesher. Vasculitis of the temporal arteries in the young. Seminars in arthritis and rheumatism, 39 2:96-107, Oct 2009. URL: https://doi.org/10.1016/j.semarthrit.2008.03.001, doi:10.1016/j.semarthrit.2008.03.001. This article has 52 citations and is from a peer-reviewed journal.
+
+13. (marquessoares2024bilateraljuveniletemporal pages 4-6): Joana Marques-Soares, Mª Isabel Garcia-Domingo, Cinthya Báez Leal, and Jaume Alijotas-Reig. Bilateral juvenile temporal arteritis: a case-based review. Rheumatology International, 44:2253-2261, Aug 2024. URL: https://doi.org/10.1007/s00296-024-05624-2, doi:10.1007/s00296-024-05624-2. This article has 0 citations and is from a peer-reviewed journal.

--- a/research/Juvenile_Temporal_Arteritis-deep-research-falcon.md.citations.md
+++ b/research/Juvenile_Temporal_Arteritis-deep-research-falcon.md.citations.md
@@ -1,0 +1,475 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Juvenile Temporal Arteritis
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Juvenile Temporal Arteritis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T08:07:56.312063
+
+1. marquessoares2024bilateraljuveniletemporal pages 1-2
+2. journeau2019juveniletemporalarteritis pages 1-2
+3. durant2011juveniletemporalvasculitis pages 1-2
+4. marquessoares2024bilateraljuveniletemporal pages 8-9
+5. marquessoares2024bilateraljuveniletemporal pages 2-4
+6. nesher2009vasculitisofthe pages 1-2
+7. marquessoares2024bilateraljuveniletemporal pages 7-8
+8. espitia2018imagegallerybilateral pages 1-1
+9. marquessoares2024bilateraljuveniletemporal pages 6-7
+10. nesher2009vasculitisofthe pages 2-4
+11. nesher2009vasculitisofthe pages 4-5
+12. marquessoares2024bilateraljuveniletemporal pages 4-6
+13. https://doi.org/10.1007/s00296-024-05624-2
+14. https://doi.org/10.1016/j.autrev.2019.03.007
+15. https://www.orpha.net/en/disease/detail/26137
+16. https://rarediseases.info.nih.gov/diseases/3068/index
+17. https://doi.org/10.1016/j.semarthrit.2008.03.001
+18. https://doi.org/10.1111/bjd.17008
+19. https://doi.org/10.1016/j.avsg.2010.10.006
+20. https://doi.org/10.1007/s00296-024-05624-2,
+21. https://doi.org/10.1016/j.autrev.2019.03.007,
+22. https://doi.org/10.1016/j.avsg.2010.10.006,
+23. https://doi.org/10.1111/bjd.17008,
+24. https://doi.org/10.1016/j.semarthrit.2008.03.001,


### PR DESCRIPTION
## Summary

Adds a new DISMECH disorder page for Juvenile Temporal Arteritis (`MONDO:0016848`) with Falcon deep-research provenance, PubMed reference caches, and source-faithful curation for localized eosinophilic temporal arteritis.

## Curation Notes

- Created `kb/disorders/Juvenile_Temporal_Arteritis.yaml` after confirming the file was absent on `origin/main`.
- Ran Falcon via `just research-disorder falcon Juvenile_Temporal_Arteritis` with `EDISON_API_KEY` from `/home/harry/dismech/edison_tok`.
- Added pathophysiology, phenotypes, biochemical eosinophilia, histopathology, diagnosis, treatment, progression, epidemiology, and differentials supported by exact PubMed abstract snippets.
- Populated cited references via `just fetch-reference` only; applied mechanical trailing-whitespace normalization to generated cache bodies so diff whitespace checks pass.

## Validation

- `just validate kb/disorders/Juvenile_Temporal_Arteritis.yaml`
- `just validate-references kb/disorders/Juvenile_Temporal_Arteritis.yaml`
- `just check-reference-cache-frontmatter`
- `git diff --check -- kb/disorders/Juvenile_Temporal_Arteritis.yaml research references_cache`
- `git diff --cached --check -- kb/disorders/Juvenile_Temporal_Arteritis.yaml research references_cache`
