### PR TITLE
Connect Citrullinemia Type I respiratory alkalosis phenotype

### DIFF
--- a/kb/disorders/Citrullinemia_Type_I.yaml
+++ b/kb/disorders/Citrullinemia_Type_I.yaml
@@ -1,7 +1,7 @@
 name: Citrullinemia Type I
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-05T20:42:36Z'
+updated_date: '2026-05-06T16:07:45Z'
 synonyms:
 - Classic citrullinemia
 - CTLN1
@@ -439,6 +439,18 @@ phenotypes:
       evidence_source: HUMAN_CLINICAL
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews links hyperammonemia and glutamine accumulation to increased ICP.
+  - target: Respiratory alkalosis
+    description: Acute hyperammonemia can present with tachypnea and respiratory alkalosis during neonatal metabolic decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Ammonia-associated central respiratory stimulation causes tachypnea and hypocapnia.
+    evidence:
+    - reference: PMID:33113778
+      reference_title: "Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Their first gas analysis revealed respiratory alkalosis. Hyperammonemia was confirmed, and three different enzymatic blocks in the urea cycle were diagnosed.
+      explanation: Newborn UCD case-series evidence links hyperammonemia to respiratory alkalosis during metabolic emergency presentation.
 - name: Encephalopathy
   frequency: VERY_FREQUENT
   description: 'Acute or recurrent encephalopathy due to ammonia neurotoxicity, manifesting as progressive lethargy, poor feeding, vomiting, and signs of increased intracranial pressure in neonatal-onset disease.
@@ -703,7 +715,13 @@ phenotypes:
     term:
       id: HP:0001950
       label: Respiratory alkalosis
-  notes: Respiratory alkalosis is a recognized hyperammonemic crisis finding in UCDs, but the current curated abstracts do not provide a direct CTLN1-specific quote.
+  evidence:
+  - reference: PMID:33113778
+    reference_title: "Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: This report aims to highlight the importance of suspecting urea cycle disorders in newborns with aspecific signs of hyperammonemia and respiratory alkalosis
+    explanation: Human newborn UCD cases support respiratory alkalosis as a hyperammonemic crisis feature relevant to CTLN1.
 biochemical:
 - name: Citrulline
   presence: INCREASED

--- a/references_cache/PMID_33113778.md
+++ b/references_cache/PMID_33113778.md
@@ -1,0 +1,62 @@
+---
+reference_id: "PMID:33113778"
+title: "Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management."
+authors:
+- Del Re S
+- Empain A
+- Vicinanza A
+- Balasel O
+- Johansson AB
+- Stalens JP
+- De Laet C
+journal: Pediatr Rep
+year: '2020'
+doi: 10.3390/pediatric12030019
+content_type: abstract_only
+---
+
+# Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management.
+**Authors:** Del Re S, Empain A, Vicinanza A, Balasel O, Johansson AB, Stalens JP, De Laet C
+**Journal:** Pediatr Rep (2020)
+**DOI:** [10.3390/pediatric12030019](https://doi.org/10.3390/pediatric12030019)
+
+## Content
+
+1. Pediatr Rep. 2020 Oct 25;12(3):77-85. doi: 10.3390/pediatric12030019.
+
+Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about
+Metabolic Emergencies. A Brief Summary of Hyperammonemia Management.
+
+Del Re S(1), Empain A(2), Vicinanza A(3), Balasel O(1), Johansson AB(1), Stalens
+JP(4), De Laet C(2).
+
+Author information:
+(1)Neonatal Intensive Care Unit, Hôpital Universitaire des Enfants Reine
+Fabiola, Université Libre de Bruxelles, 1020 Brussels, Belgium.
+(2)Department of Nutrition and Metabolism, Hôpital Universitaire des Enfants
+Reine Fabiola, Université Libre de Bruxelles, 1020 Brussels, Belgium.
+(3)Pediatric Intensive Care Unit, Hôpital Universitaire des Enfants Reine
+Fabiola, Université Libre de Bruxelles, 1020 Brussels, Belgium.
+(4)Neonatal Non-Intensive Care Unit, Centre Hospitalier de Wallonie Picarde
+(Site Union), 7500 Tournai, Belgium.
+
+The urea cycle is a series of metabolic reactions that convert ammonia into urea
+in order to eliminate it from the body. Urea cycle disorders are characterized
+by hyperammonemia, which can cause irreversible damages in central nervous
+system. We report a series of three newborns presenting irritability, poor
+feeding and tachypnea. Their first gas analysis revealed respiratory alkalosis.
+Hyperammonemia was confirmed, and three different enzymatic blocks in the urea
+cycle were diagnosed. Immediate treatment consisted in the removal of ammonia by
+reduction of the catabolic state, dietary adjustments, use of nitrogen
+scavenging agents and ultimately hemodiafiltration. Hyperammonemia is a medical
+emergency whose treatment should not be delayed. This report aims to highlight
+the importance of suspecting urea cycle disorders in newborns with aspecific
+signs of hyperammonemia and respiratory alkalosis, and to sum up the broad lines
+of hyperammonemia management.
+
+DOI: 10.3390/pediatric12030019
+PMCID: PMC7717652
+PMID: 33113778
+
+Conflict of interest statement: The authors have no competing interests to
+declare.


### PR DESCRIPTION
## Summary
- add evidence-backed respiratory alkalosis support for Citrullinemia Type I using generated PMID:33113778 cache
- connect Hyperammonemia to Respiratory alkalosis so the path graph has no untargeted phenotypes
- update curated timestamp

## Validation
- just validate kb/disorders/Citrullinemia_Type_I.yaml
- manual normalized snippet audit: 82 checks, 0 failures, 0 missing caches
- graph audit: 5 pathophysiology nodes, 13 phenotypes, 16 downstream edges, 9 phenotype sequelae, 0 untargeted phenotypes
- just check-reference-cache-frontmatter
- focused subagent review: no blockers