### PR TITLE
Add PVOD/PCH disorder curation

### DIFF
--- a/kb/disorders/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis.yaml
+++ b/kb/disorders/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis.yaml
@@ -1,0 +1,766 @@
+name: Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis
+creation_date: "2026-05-06T17:25:51Z"
+updated_date: "2026-05-06T17:25:51Z"
+description: >-
+  Pulmonary veno-occlusive disease and/or pulmonary capillary haemangiomatosis
+  (PVOD/PCH) is a rare pulmonary arterial hypertension spectrum disorder with
+  overt pulmonary venous and capillary involvement. It is characterized by
+  progressive pulmonary venous and capillary remodeling, impaired gas exchange,
+  increased pulmonary vascular resistance, and risk of right ventricular failure.
+category: Cardiovascular Disorder
+disease_term:
+  preferred_term: pulmonary veno-occlusive disease and/or pulmonary capillary haemangiomatosis
+  term:
+    id: MONDO:0018554
+    label: pulmonary veno-occlusive disease and/or pulmonary capillary haemangiomatosis
+parents:
+- Pulmonary arterial hypertension
+- Respiratory system disorder
+synonyms:
+- PVOD and/or PCH
+- PVOD/PCH
+- Pulmonary veno-occlusive disease
+- Pulmonary capillary haemangiomatosis
+- Pulmonary capillary hemangiomatosis
+prevalence:
+- population: Global
+  percentage: Ultra-rare
+  notes: >-
+    PVOD/PCH is repeatedly described as a rare cause or subtype of pulmonary
+    arterial hypertension; exact population prevalence estimates remain limited.
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      rare cause of PAH characterised by substantial small pulmonary vein and capillary involvement
+    explanation: >-
+      This recent review supports PVOD/PCH as a rare PAH-associated disease.
+progression:
+- phase: Progressive pulmonary vascular disease
+  notes: >-
+    The disease often progresses rapidly with severe hypoxemia, right ventricular
+    failure, poor response to conventional PAH therapy, and need for early
+    transplant referral.
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PVOD is a progressive and fatal disease requiring early recognition and specific management.
+    explanation: >-
+      This review summarizes the progressive and high-risk clinical course.
+inheritance:
+- name: Autosomal recessive inheritance
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  penetrance: COMPLETE
+  description: >-
+    Heritable PVOD/PCH is caused by biallelic EIF2AK4 pathogenic variants and
+    follows autosomal recessive inheritance.
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      hereditary autosomal recessive condition with biallelic eukaryotic translation initiation factor 2 alpha kinase 4
+    explanation: >-
+      The review directly identifies autosomal recessive inheritance due to
+      biallelic EIF2AK4 variants.
+pathophysiology:
+- name: Pulmonary venous and capillary remodeling
+  description: >-
+    PVOD/PCH involves small pulmonary veins, venules, and capillaries rather
+    than isolated arterial remodeling, leading to increased pulmonary vascular
+    resistance and right ventricular strain.
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  locations:
+  - preferred_term: pulmonary vein
+    term:
+      id: UBERON:0002016
+      label: pulmonary vein
+  - preferred_term: pulmonary venule
+    term:
+      id: UBERON:8600024
+      label: pulmonary venule
+  - preferred_term: pulmonary capillary
+    term:
+      id: UBERON:0016405
+      label: pulmonary capillary
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:24292273
+    reference_title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      widespread fibrous intimal proliferation of septal veins and preseptal venules
+    explanation: >-
+      Histologic evidence supports the pulmonary venous remodeling component.
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      substantial small pulmonary vein and capillary involvement, leading to increased pulmonary vascular resistance and right ventricular failure
+    explanation: >-
+      The review connects venous/capillary involvement to pulmonary vascular
+      resistance and right ventricular failure.
+- name: EIF2AK4/GCN2 stress-response loss
+  description: >-
+    Biallelic EIF2AK4 loss impairs GCN2-mediated integrated stress-response
+    signaling and provides the established genetic mechanism for heritable
+    PVOD/PCH.
+  genes:
+  - preferred_term: EIF2AK4
+    term:
+      id: hgnc:19687
+      label: EIF2AK4
+  biological_processes:
+  - preferred_term: cellular response to amino acid starvation
+    term:
+      id: GO:0034198
+      label: cellular response to amino acid starvation
+    modifier: DECREASED
+  - preferred_term: response to amino acid starvation
+    term:
+      id: GO:1990928
+      label: response to amino acid starvation
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:24292273
+    reference_title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All mutations, either in a homozygous or compound-heterozygous state, disrupted the function of the gene.
+    explanation: >-
+      The founding human genetic study supports loss of EIF2AK4 function as a
+      causal mechanism.
+  - reference: PMID:36852942
+    reference_title: T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient rats in basal and stress conditions.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      The ISR was not activated after ASNase treatment in Gcn2-/- rat lungs, and apoptosis was increased.
+    explanation: >-
+      Gcn2-deficient rats model impaired stress-response activation and
+      stress-induced lung pathology relevant to heritable PVOD.
+- name: Immune inflammation in EIF2AK4/GCN2 deficiency
+  description: >-
+    Experimental Gcn2 deficiency produces inflammatory lung signatures that may
+    contribute to pulmonary vascular injury and remodeling.
+  cell_types:
+  - preferred_term: T cell
+    term:
+      id: CL:0000084
+      label: T cell
+  - preferred_term: neutrophil
+    term:
+      id: CL:0000775
+      label: neutrophil
+  locations:
+  - preferred_term: lung
+    term:
+      id: UBERON:0002048
+      label: lung
+  biological_processes:
+  - preferred_term: inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:36852942
+    reference_title: T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient rats in basal and stress conditions.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Several proinflammatory and innate immunity genes were overexpressed, and inflammatory cells infiltration was also observed in the perivascular area.
+    explanation: >-
+      This animal model supports immune dysregulation as a plausible downstream
+      consequence of GCN2 deficiency, not as a stand-alone proven human driver.
+- name: Macrophage ferroptosis and venous arterialization
+  description: >-
+    Recent translational work implicates macrophage ferroptosis and arterial
+    marker expression in venous endothelial cells as a potential mechanism of
+    pulmonary venous arterialization.
+  cell_types:
+  - preferred_term: macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  locations:
+  - preferred_term: pulmonary vein
+    term:
+      id: UBERON:0002016
+      label: pulmonary vein
+  biological_processes:
+  - preferred_term: ferroptosis
+    term:
+      id: GO:0097707
+      label: ferroptosis
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:40983649
+    reference_title: Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous arterialization.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Treatment with the specific ferroptosis inhibitor ferrostatin-1 (Fer-1) reverses the changes in haemodynamic indices observed in Eif2ak4K1488X/K1488X hypoxia mice and PVOD model rats.
+    explanation: >-
+      Animal model rescue data support macrophage ferroptosis as a candidate
+      targetable mechanism, while human causal relevance remains translational.
+  - reference: PMID:40983649
+    reference_title: Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous arterialization.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ferroptosis pathway-related genes are upregulated in lung macrophages of PVOD patients
+    explanation: >-
+      Human tissue transcriptomic evidence supports relevance of the macrophage
+      ferroptosis signal in PVOD lungs.
+phenotypes:
+- category: Cardiovascular
+  name: Pulmonary arterial hypertension
+  diagnostic: true
+  description: >-
+    PVOD/PCH belongs to the pulmonary arterial hypertension spectrum, with
+    pre-capillary pulmonary hypertension and venous/capillary involvement.
+  phenotype_term:
+    preferred_term: Pulmonary arterial hypertension
+    term:
+      id: HP:0002092
+      label: Pulmonary arterial hypertension
+  evidence:
+  - reference: PMID:40104258
+    reference_title: "Pulmonary veno-occlusive disease: a clinical review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PVOD is classified under group 1 pulmonary arterial hypertension (PAH) as subgroup 1.5
+    explanation: >-
+      The clinical review supports pulmonary arterial hypertension as the
+      diagnostic classification framework.
+- category: Respiratory
+  name: Hypoxemia
+  diagnostic: true
+  description: >-
+    Severe hypoxemia is a distinguishing clinical clue and reflects impaired gas
+    exchange from venous and capillary disease.
+  phenotype_term:
+    preferred_term: Hypoxemia
+    term:
+      id: HP:0012418
+      label: Hypoxemia
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PVOD is characterized by progressive pulmonary venous and capillary remodelling, severe hypoxemia, and right ventricular failure.
+    explanation: >-
+      The review explicitly lists severe hypoxemia among core PVOD features.
+- category: Respiratory
+  name: Decreased DLCO
+  diagnostic: true
+  description: >-
+    Reduced lung diffusion capacity for carbon monoxide is a key noninvasive
+    clue that helps distinguish PVOD/PCH from other PAH presentations.
+  phenotype_term:
+    preferred_term: Decreased DLCO
+    term:
+      id: HP:0045051
+      label: Decreased DLCO
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      low lung diffusion capacity for carbon monoxide (DLCO), and genetic testing can aid differentiation
+    explanation: >-
+      The review supports reduced DLCO as part of the diagnostic differentiation
+      from PAH.
+  - reference: PMID:28972005
+    reference_title: Phenotypic Characterization of EIF2AK4 Mutation Carriers in a Large Cohort of Patients Diagnosed Clinically With Pulmonary Arterial Hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These patients had a reduced transfer coefficient for carbon monoxide
+    explanation: >-
+      A large PAH/PVOD cohort found reduced carbon monoxide transfer in
+      biallelic EIF2AK4 carriers.
+- category: Cardiovascular
+  name: Right ventricular failure
+  description: >-
+    Progressive pulmonary vascular resistance can culminate in right ventricular
+    failure.
+  phenotype_term:
+    preferred_term: Right ventricular failure
+    term:
+      id: HP:0001708
+      label: Right ventricular failure
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      leading to increased pulmonary vascular resistance and right ventricular failure
+    explanation: >-
+      The review links venous/capillary involvement to increased resistance and
+      right ventricular failure.
+- category: Treatment complication
+  name: Pulmonary edema with pulmonary vasodilator therapy
+  diagnostic: true
+  description: >-
+    Pulmonary edema after PAH vasodilator exposure is a recognized and
+    clinically important clue to PVOD/PCH.
+  phenotype_term:
+    preferred_term: Pulmonary edema
+    term:
+      id: HP:0100598
+      label: Pulmonary edema
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Life-threatening pulmonary oedema is a complication of pulmonary vasodilator therapy that can occur with any class of PAH drugs in PVOD.
+    explanation: >-
+      The review supports pulmonary edema after vasodilator therapy as a major
+      management risk and diagnostic clue.
+- category: Imaging
+  name: Interlobular septal thickening
+  diagnostic: true
+  description: >-
+    Interlobular septal thickening is part of the characteristic chest CT
+    pattern used to distinguish PVOD/PCH from other PAH forms.
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Chest computed tomography typically displays interlobular septal thickening, ground-glass opacities and mediastinal lymphadenopathy.
+    explanation: >-
+      The review directly supports this CT finding as part of the typical PVOD
+      imaging pattern.
+- category: Imaging
+  name: Ground-glass opacities
+  diagnostic: true
+  description: >-
+    Centrilobular ground-glass opacities are part of the typical CT pattern for
+    PVOD/PCH.
+  evidence:
+  - reference: PMID:31178067
+    reference_title: "Computed tomographic and clinical features of pulmonary veno-occlusive disease: raising the radiologist's awareness."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Potential distinguishing CT features between PVOD and other subtypes of PAH include interlobular septal thickening, mediastinal lymphadenopathy, and centrilobular ground-glass opacities.
+    explanation: >-
+      The radiology review supports ground-glass opacities as part of the
+      differentiating CT pattern.
+- category: Imaging
+  name: Mediastinal lymphadenopathy
+  diagnostic: true
+  description: >-
+    Mediastinal lymphadenopathy is another CT feature that supports PVOD/PCH
+    over idiopathic PAH in the right clinical context.
+  evidence:
+  - reference: PMID:31178067
+    reference_title: "Computed tomographic and clinical features of pulmonary veno-occlusive disease: raising the radiologist's awareness."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Potential distinguishing CT features between PVOD and other subtypes of PAH include interlobular septal thickening, mediastinal lymphadenopathy, and centrilobular ground-glass opacities.
+    explanation: >-
+      The radiology review supports mediastinal lymphadenopathy as a
+      distinguishing CT feature.
+histopathology:
+- name: Fibrous intimal proliferation of septal veins and preseptal venules
+  diagnostic: true
+  description: >-
+    The classic histologic lesion is fibrous intimal proliferation affecting
+    septal veins and preseptal venules.
+  evidence:
+  - reference: PMID:24292273
+    reference_title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      widespread fibrous intimal proliferation of septal veins and preseptal venules
+    explanation: >-
+      This founding genetic study also summarizes the defining PVOD
+      histopathology.
+- name: Pulmonary capillary dilatation and proliferation
+  diagnostic: true
+  description: >-
+    PVOD is frequently accompanied by pulmonary capillary dilatation and
+    proliferation, explaining its overlap with PCH.
+  evidence:
+  - reference: PMID:24292273
+    reference_title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      frequently associated with pulmonary capillary dilatation and proliferation
+    explanation: >-
+      This supports the PVOD/PCH spectrum concept.
+- name: Fibrous veno-occlusive lesions on explant pathology
+  diagnostic: true
+  description: >-
+    Lung explant pathology can reveal microvascular remodeling and fibrous
+    veno-occlusive lesions, but biopsy is generally avoided clinically due to
+    risk in pulmonary hypertension.
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histopathological analysis of lung explants reveals microvascular remodelling with typical fibrous veno-occlusive lesions.
+    explanation: >-
+      The review supports the explant histopathology pattern.
+genetic:
+- name: EIF2AK4
+  association: >-
+    Biallelic pathogenic EIF2AK4 variants cause heritable PVOD/PCH and may also
+    identify patients clinically classified as PAH who have PVOD/PCH biology.
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  gene_term:
+    preferred_term: EIF2AK4
+    term:
+      id: hgnc:19687
+      label: EIF2AK4
+  inheritance:
+  - name: Autosomal recessive inheritance
+    inheritance_term:
+      preferred_term: Autosomal recessive inheritance
+      term:
+        id: HP:0000007
+        label: Autosomal recessive inheritance
+  evidence:
+  - reference: PMID:24292273
+    reference_title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      recessive mutations in EIF2AK4 (also called GCN2) that cosegregated with PVOD in all 13 families studied
+    explanation: >-
+      This founding study established EIF2AK4 as a causal recessive PVOD gene.
+  - reference: PMID:24292273
+    reference_title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      biallelic EIF2AK4 mutations in 5 of 20 histologically confirmed sporadic cases of PVOD
+    explanation: >-
+      Biallelic EIF2AK4 variants were also observed in sporadic
+      histologically confirmed PVOD.
+  - reference: PMID:28972005
+    reference_title: Phenotypic Characterization of EIF2AK4 Mutation Carriers in a Large Cohort of Patients Diagnosed Clinically With Pulmonary Arterial Hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Genetic testing can identify these misclassified patients, allowing appropriate management and early referral for lung transplantation.
+    explanation: >-
+      EIF2AK4 testing can reclassify PAH-labeled patients and alter management.
+  - reference: PMID:38776952
+    reference_title: Functional validation of EIF2AK4 (GCN2) missense variants associated with pulmonary arterial hypertension.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Biallelic mutations of EIF2AK4, which encodes the kinase GCN2, are causal in two ultra-rare subtypes of PAH, pulmonary veno-occlusive disease and pulmonary capillary haemangiomatosis.
+    explanation: >-
+      Functional variant work reinforces the causal role of biallelic EIF2AK4
+      variants and the importance of testing rare missense alleles.
+environmental:
+- name: Organic solvent exposure
+  description: >-
+    Occupational organic solvent exposure, particularly trichloroethylene, is a
+    reported environmental risk factor for PVOD.
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Known risk factors include specific drug/toxin and environmental exposures, such as mitomycin C and trichloroethylene, respectively.
+    explanation: >-
+      The review identifies trichloroethylene as an environmental exposure
+      associated with PVOD.
+- name: Mitomycin C and chemotherapy exposure
+  description: >-
+    Chemotherapy exposure, notably mitomycin C, is a reported iatrogenic risk
+    factor for PVOD.
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Environmental risk factors have been associated with the development of PVOD, such as occupational exposure to organic solvents and chemotherapy, notably mitomycin.
+    explanation: >-
+      This review supports chemotherapy, especially mitomycin, as an associated
+      exposure.
+diagnosis:
+- name: High-resolution chest computed tomography
+  description: >-
+    Chest CT supports noninvasive diagnosis when the characteristic pattern of
+    septal thickening, ground-glass opacities, and mediastinal lymphadenopathy
+    appears in a patient with pre-capillary pulmonary hypertension.
+  diagnosis_term:
+    preferred_term: computed tomography procedure
+    term:
+      id: MAXO:0000571
+      label: computed tomography procedure
+  evidence:
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Chest computed tomography typically displays interlobular septal thickening, ground-glass opacities and mediastinal lymphadenopathy.
+    explanation: >-
+      This supports the HRCT triad as a key diagnostic pattern.
+- name: Pulmonary function testing for DLCO
+  description: >-
+    Reduced DLCO helps distinguish PVOD/PCH from other PAH presentations and
+    should be interpreted alongside hypoxemia, CT findings, and hemodynamics.
+  diagnosis_term:
+    preferred_term: pulmonary function testing
+    term:
+      id: MAXO:0035078
+      label: pulmonary function testing
+  evidence:
+  - reference: PMID:40104258
+    reference_title: "Pulmonary veno-occlusive disease: a clinical review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the presence of hypoxia and reduced diffusion capacity of the lung may be required for a clinical diagnosis of PVOD
+    explanation: >-
+      The clinical review supports diffusion-capacity testing as part of
+      clinical PVOD diagnosis.
+- name: EIF2AK4 molecular genetic testing
+  description: >-
+    Molecular testing for biallelic EIF2AK4 variants can support or establish
+    heritable PVOD/PCH diagnosis and guide family testing and transplant
+    evaluation.
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+  evidence:
+  - reference: PMID:28972005
+    reference_title: Phenotypic Characterization of EIF2AK4 Mutation Carriers in a Large Cohort of Patients Diagnosed Clinically With Pulmonary Arterial Hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Genetic testing can identify these misclassified patients, allowing appropriate management and early referral for lung transplantation.
+    explanation: >-
+      The cohort study supports EIF2AK4 testing as a clinically actionable
+      diagnostic tool.
+- name: Avoidance of diagnostic lung biopsy when PVOD/PCH is suspected
+  description: >-
+    Lung biopsy can provide definitive histopathology but is hazardous in
+    pulmonary hypertension; diagnosis is generally pursued with clinical,
+    radiologic, physiologic, and genetic data.
+  evidence:
+  - reference: PMID:31178067
+    reference_title: "Computed tomographic and clinical features of pulmonary veno-occlusive disease: raising the radiologist's awareness."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Lung biopsy is required for definitive diagnosis, but this is hazardous, and ideally, should be avoided in pulmonary hypertension.
+    explanation: >-
+      The radiology review supports avoiding lung biopsy when noninvasive
+      diagnostic evidence is sufficient.
+treatments:
+- name: Lung transplantation
+  description: >-
+    Lung transplantation is the only established curative option for eligible
+    patients, so early referral is emphasized once PVOD/PCH is suspected.
+  treatment_term:
+    preferred_term: organ transplantation
+    term:
+      id: MAXO:0010039
+      label: organ transplantation
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Lung transplantation remains the only curative treatment, with posttransplant survival rates comparable to idiopathic PAH.
+    explanation: >-
+      This review supports transplant as the curative therapy.
+  - reference: PMID:38232988
+    reference_title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Early referral to a lung transplant centre is essential due to the poor response to therapy when compared with other forms of PAH.
+    explanation: >-
+      This supports early transplant-center referral.
+- name: Cautious PAH-approved pharmacotherapy as bridge or individualized care
+  description: >-
+    PAH-approved pulmonary vasodilator therapy is not reliably effective in
+    PVOD/PCH and can precipitate pulmonary edema, so it requires expert-center
+    monitoring and individualized risk assessment.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  evidence:
+  - reference: PMID:40471666
+    reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Initiation of PAH-approved drugs in patients with PVOD requires careful consideration due to limited evidence of long-term clinical benefits and the high risk of developing pulmonary oedema in this population.
+    explanation: >-
+      This supports only cautious, individualized pharmacotherapy rather than
+      routine disease-modifying use.
+  - reference: PMID:40104258
+    reference_title: "Pulmonary veno-occlusive disease: a clinical review."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The development of pulmonary oedema with pulmonary vasodilator therapy limits therapeutic options for PVOD.
+    explanation: >-
+      The clinical review supports pulmonary edema risk as a limiting factor for
+      vasodilator therapy.
+animal_models:
+- species: Rat
+  genotype: Gcn2 loss-of-function rat lines
+  category: Genetic and amino-acid-deprivation stress model
+  description: >-
+    Biallelic Gcn2 mutant rats do not spontaneously develop full PVOD, but
+    amino-acid deprivation reveals impaired lung stress-response activation,
+    apoptosis, and inflammatory signatures relevant to heritable PVOD.
+  associated_phenotypes:
+  - Impaired integrated stress-response activation
+  - Perivascular inflammatory cell infiltration
+  evidence:
+  - reference: PMID:36852942
+    reference_title: T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient rats in basal and stress conditions.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Three rat lines carrying biallelic Gcn2 mutation were generated and found phenotypically normal and did not spontaneously develop a PVOD-related disease.
+    explanation: >-
+      This model is informative for stress-response biology but is not a
+      spontaneous full-disease model.
+- species: Mouse and rat
+  genotype: Eif2ak4K1488X/K1488X hypoxia mice and PVOD model rats
+  category: GCN2-deficiency and PVOD vascular remodeling models
+  description: >-
+    Eif2ak4 mutant hypoxic mice and PVOD model rats support a macrophage
+    ferroptosis and pulmonary venous arterialization mechanism.
+  associated_phenotypes:
+  - Altered hemodynamic indices
+  - Pulmonary venous arterialization
+  evidence:
+  - reference: PMID:40983649
+    reference_title: Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous arterialization.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Treatment with the specific ferroptosis inhibitor ferrostatin-1 (Fer-1) reverses the changes in haemodynamic indices observed in Eif2ak4K1488X/K1488X hypoxia mice and PVOD model rats.
+    explanation: >-
+      This model supports a targetable ferroptosis mechanism in experimental
+      PVOD/PCH biology.
+clinical_trials:
+- name: NCT03902353
+  phase: NOT_APPLICABLE
+  status: UNKNOWN
+  description: >-
+    DELPHI-4 is a diagnostic/screening study of adults carrying heterozygous
+    EIF2AK4 variants, using clinical, functional, echocardiographic, radiologic,
+    and exercise testing to assess early PVOD risk.
+  evidence:
+  - reference: clinicaltrials:NCT03902353
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      It appears essential to determine the clinical, functional, echocardiographic and radiologics characteristics of these persons, and their risk of developping Pulmonary veino occlusive disease
+    explanation: >-
+      ClinicalTrials.gov describes a PVOD-focused screening study for
+      heterozygous EIF2AK4 carriers.
+references:
+- reference: DOI:10.1183/16000617.0156-2023
+  title: "Pulmonary veno-occlusive disease: illustrative cases and literature review"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1183/20734735.0098-2024
+  title: "Pulmonary veno-occlusive disease: a clinical review"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.18093/0869-0189-2024-34-4-595-598
+  title: "Rare clinical case: pulmonary venoocclusive disease"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1172/jci.insight.181877
+  title: "Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.3390/arm93060048
+  title: "Pulmonary Veno-Occlusive Disease: A Comprehensive Review of Diagnostic Challenges, Therapeutic Limitations, and Evolving Management"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1159/000527524
+  title: "Differential Diagnosis of Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Hemangiomatosis after Identification of Two Novel EIF2AK4 Variants by Whole-Exome Sequencing"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.17863/cam.108223
+  title: "Functional validation of EIF2AK4 (GCN2) missense variants associated with pulmonary arterial hypertension."
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1152/ajplung.00460.2021
+  title: "T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient rats in basal and stress conditions"
+  found_in:
+  - Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+  findings: []
+review_notes: >-
+  Falcon deep research was run on 2026-05-06 for this disorder. Imaging
+  findings were intentionally left without HPO identifiers because local OAK
+  lookup did not confirm reliable HPO bindings for the suggested IDs.

--- a/kb/disorders/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis.yaml
+++ b/kb/disorders/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis.yaml
@@ -59,10 +59,11 @@ inheritance:
     term:
       id: HP:0000007
       label: Autosomal recessive inheritance
-  penetrance: COMPLETE
+  penetrance: INCOMPLETE
   description: >-
     Heritable PVOD/PCH is caused by biallelic EIF2AK4 pathogenic variants and
-    follows autosomal recessive inheritance.
+    follows autosomal recessive inheritance with nearly complete, but not
+    literally complete, penetrance in current clinical reviews.
   evidence:
   - reference: PMID:40471666
     reference_title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
@@ -165,6 +166,45 @@ pathophysiology:
     explanation: >-
       Gcn2-deficient rats model impaired stress-response activation and
       stress-induced lung pathology relevant to heritable PVOD.
+  - reference: PMID:29108819
+    reference_title: Pulmonary vascular remodeling patterns and expression of general control nonderepressible 2 (GCN2) in pulmonary veno-occlusive disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      GCN2 expression was abolished in heritable PVOD (p < 0.0001), but also importantly decreased in sporadic PVOD (p = 0.03)
+    explanation: >-
+      This supports reduced GCN2 expression beyond inherited EIF2AK4-carrier
+      disease, including sporadic PVOD.
+- name: Mitomycin C PKR/ISR endothelial barrier dysfunction
+  description: >-
+    Mitomycin C exposure can drive PVOD-like disease in rats through PKR and
+    integrated stress-response activation, converging on endothelial junctional
+    and barrier impairment.
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  locations:
+  - preferred_term: pulmonary vein
+    term:
+      id: UBERON:0002016
+      label: pulmonary vein
+  biological_processes:
+  - preferred_term: integrated stress response
+    modifier: INCREASED
+  - preferred_term: endothelial barrier dysfunction
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:39269983
+    reference_title: Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      mitomycin C (MMC) in rats mediates PVOD through the activation of the eukaryotic initiation factor 2 (eIF2) kinase protein kinase R (PKR) and the integrated stress response (ISR), resulting in the impairment of vascular endothelial junctional structure and barrier function.
+    explanation: >-
+      This experimental study supports an iatrogenic/environmental convergence
+      mechanism distinct from inherited EIF2AK4 loss.
 - name: Immune inflammation in EIF2AK4/GCN2 deficiency
   description: >-
     Experimental Gcn2 deficiency produces inflammatory lung signatures that may
@@ -265,6 +305,26 @@ phenotypes:
     explanation: >-
       The clinical review supports pulmonary arterial hypertension as the
       diagnostic classification framework.
+- category: Respiratory
+  name: Dyspnea
+  description: >-
+    Dyspnea, often exertional, is a common presenting respiratory symptom in
+    PVOD/PCH and may be clinically indistinguishable from PAH symptoms.
+  phenotype_term:
+    preferred_term: Dyspnea
+    term:
+      id: HP:0002094
+      label: Dyspnea
+  evidence:
+  - reference: DOI:10.1159/000527524
+    reference_title: Differential Diagnosis of Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Hemangiomatosis after Identification of Two Novel EIF2AK4 Variants by Whole-Exome Sequencing
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A 19-year-old man who was previously diagnosed with idiopathic PAH suffered from dyspnea on exertion for 2 months.
+    explanation: >-
+      This PVOD/PCH case report supports exertional dyspnea as a presenting
+      clinical feature.
 - category: Respiratory
   name: Hypoxemia
   diagnostic: true
@@ -420,6 +480,15 @@ histopathology:
     explanation: >-
       This founding genetic study also summarizes the defining PVOD
       histopathology.
+  - reference: PMID:29108819
+    reference_title: Pulmonary vascular remodeling patterns and expression of general control nonderepressible 2 (GCN2) in pulmonary veno-occlusive disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histology of EIF2AK4 mutation carriers was distinctive from non-carriers regarding (1) arterial remodeling, with significantly more severe intimal fibrosis (p = 0.001)
+    explanation: >-
+      This cohort links EIF2AK4-carrier PVOD to more severe intimal fibrosis,
+      refining the histopathology of heritable disease.
 - name: Pulmonary capillary dilatation and proliferation
   diagnostic: true
   description: >-
@@ -633,6 +702,27 @@ treatments:
       Early referral to a lung transplant centre is essential due to the poor response to therapy when compared with other forms of PAH.
     explanation: >-
       This supports early transplant-center referral.
+- name: Supportive care and early multidisciplinary management
+  description: >-
+    Supportive care is used for symptom management and risk reduction while
+    definitive transplant evaluation is pursued, especially because inappropriate
+    PAH-specific vasodilators may be harmful.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: DOI:10.3390/arm93060048
+    reference_title: "Pulmonary Veno-Occlusive Disease: A Comprehensive Review of Diagnostic Challenges, Therapeutic Limitations, and Evolving Management"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      management strategies emphasizing early recognition, supportive care, avoidance of inappropriate PAH therapies due to poor response, and timely referral for lung transplantation
+    explanation: >-
+      This review supports supportive care as part of PVOD management, while
+      specific oxygen and diuretic MAXO bindings were not used because the
+      suggested local MAXO IDs resolve to unrelated labels in this checkout.
 - name: Cautious PAH-approved pharmacotherapy as bridge or individualized care
   description: >-
     PAH-approved pulmonary vasodilator therapy is not reliably effective in
@@ -687,12 +777,24 @@ animal_models:
   genotype: Eif2ak4K1488X/K1488X hypoxia mice and PVOD model rats
   category: GCN2-deficiency and PVOD vascular remodeling models
   description: >-
-    Eif2ak4 mutant hypoxic mice and PVOD model rats support a macrophage
-    ferroptosis and pulmonary venous arterialization mechanism.
+    Eif2ak4 mutant hypoxic mice, mitomycin C-treated rats, and PVOD model rats
+    support stress-response, macrophage ferroptosis, and pulmonary venous
+    arterialization mechanisms.
   associated_phenotypes:
   - Altered hemodynamic indices
+  - Right ventricular hypertrophy
+  - Endothelial barrier dysfunction
   - Pulmonary venous arterialization
   evidence:
+  - reference: PMID:39269983
+    reference_title: Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease.
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      aged rats over 1 year exhibit more severe vascular remodeling and RV hypertrophy than young adult rats following MMC treatment.
+    explanation: >-
+      This supports the mitomycin C rat model and age-associated worsening of
+      PVOD-like vascular and right ventricular phenotypes.
   - reference: PMID:40983649
     reference_title: Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous arterialization.
     supports: PARTIAL
@@ -762,5 +864,10 @@ references:
   findings: []
 review_notes: >-
   Falcon deep research was run on 2026-05-06 for this disorder. Imaging
-  findings were intentionally left without HPO identifiers because local OAK
-  lookup did not confirm reliable HPO bindings for the suggested IDs.
+  findings were intentionally left without HPO identifiers because repeated
+  local OAK lookup did not confirm reliable HPO bindings for the suggested IDs:
+  HP:0031969 resolved to Reduced blood urea nitrogen, HP:0031944 resolved to
+  Pleural thickening, and HP:0030111 resolved to Reduced muscle fiber delta
+  sarcoglycan. Likewise, suggested MAXO IDs for oxygen therapy, diuretic
+  therapy, and lung transplantation resolved locally to unrelated labels, so
+  broader validated MAXO terms were retained.

--- a/references_cache/DOI_10.1152_ajplung.00460.2021.md
+++ b/references_cache/DOI_10.1152_ajplung.00460.2021.md
@@ -1,0 +1,31 @@
+---
+reference_id: "DOI:10.1152/ajplung.00460.2021"
+title: "T-cell dysregulation and inflammatory process in <i>Gcn2</i> (<i>Eif2ak4</i><sup>−/−</sup>)-deficient rats in basal and stress conditions"
+authors:
+- Juliette Bignard
+- Fabrice Atassi
+- Olivier Claude
+- Maria-Rosa Ghigna
+- Nathalie Mougenot
+- Bahgat Soilih Abdoulkarim
+- Florence Deknuydt
+- Aurélie Gestin
+- Virginie Monceau
+- David Montani
+- Sophie Nadaud
+- Florent Soubrier
+- Frédéric Perros
+journal: American Journal of Physiology-Lung Cellular and Molecular Physiology
+year: '2023'
+doi: 10.1152/ajplung.00460.2021
+content_type: abstract_only
+---
+
+# T-cell dysregulation and inflammatory process in <i>Gcn2</i> (<i>Eif2ak4</i><sup>−/−</sup>)-deficient rats in basal and stress conditions
+**Authors:** Juliette Bignard, Fabrice Atassi, Olivier Claude, Maria-Rosa Ghigna, Nathalie Mougenot, Bahgat Soilih Abdoulkarim, Florence Deknuydt, Aurélie Gestin, Virginie Monceau, David Montani, Sophie Nadaud, Florent Soubrier, Frédéric Perros
+**Journal:** American Journal of Physiology-Lung Cellular and Molecular Physiology (2023)
+**DOI:** [10.1152/ajplung.00460.2021](https://doi.org/10.1152/ajplung.00460.2021)
+
+## Content
+
+Hereditary pulmonary veno-occlusive disease (hPVOD) is a severe form of autosomal recessive pulmonary hypertension and is due to biallelic loss of function of the EIF2AK4 gene (alias GCN2) coding for GCN2. GCN2 is a stress kinase that belongs to the integrated stress response pathway (ISR). Three rat lines carrying biallelic Gcn2 mutation were generated and found phenotypically normal and did not spontaneously develop a PVOD-related disease. We submitted these rats to amino acid deprivation to document the molecular and cellular response of the lungs and to identify phenotypic changes that could be involved in PVOD pathophysiology. Gcn2−/− rat lungs were analyzed under basal conditions and 3 days after a single administration of PEG-asparaginase (ASNase). Lung mRNAs were analyzed by RNAseq and single-cell RNAseq (scRNA-seq), flow cytometry, tissue imaging, and Western blots. The ISR was not activated after ASNase treatment in Gcn2−/− rat lungs, and apoptosis was increased. Several proinflammatory and innate immunity genes were overexpressed, and inflammatory cells infiltration was also observed in the perivascular area. Under basal conditions, scRNA-seq analysis of Gcn2−/− rat lungs revealed increases in two T-cell populations, a LAG3+ T-cell population and a proliferative T-cell population. Following ASNase administration, we observed an increase in calprotectin expression involved in TLR pathway activation and neutrophil infiltration. In conclusion, under basal and asparagine and glutamine deprivation induced by asparaginase administration, Gcn2−/− rats display molecular and cellular signatures in the lungs that may indicate a role for Gcn2 in immune homeostasis and provide further clues to the mechanisms of hPVOD development.

--- a/references_cache/DOI_10.1159_000527524.md
+++ b/references_cache/DOI_10.1159_000527524.md
@@ -1,0 +1,24 @@
+---
+reference_id: "DOI:10.1159/000527524"
+title: Differential Diagnosis of Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Hemangiomatosis after Identification of Two Novel EIF2AK4 Variants by Whole-Exome Sequencing
+authors:
+- Jong Eun Park
+- Sung-A Chang
+- Shin Yi Jang
+- Kyung Soo Lee
+- Duk-Kyung Kim
+- Chang-Seok Ki
+journal: Molecular Syndromology
+year: '2023'
+doi: 10.1159/000527524
+content_type: abstract_only
+---
+
+# Differential Diagnosis of Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Hemangiomatosis after Identification of Two Novel EIF2AK4 Variants by Whole-Exome Sequencing
+**Authors:** Jong Eun Park, Sung-A Chang, Shin Yi Jang, Kyung Soo Lee, Duk-Kyung Kim, Chang-Seok Ki
+**Journal:** Molecular Syndromology (2023)
+**DOI:** [10.1159/000527524](https://doi.org/10.1159/000527524)
+
+## Content
+
+Background: Pulmonary veno-occlusive disease (PVOD) and/or pulmonary capillary hemangiomatosis (PCH) are rare causes of pulmonary hypertension. Pulmonary arterial hypertension (PAH) and PVOD/PCH are clinically similar, but there is a risk of drug-induced pulmonary edema when PCH patients receive the PAH therapy. Therefore, early diagnosis of PVOD/PCH is important. Objectives: We report the first case in Korea of PVOD/PCH in a patient carrying compound heterozygous pathogenic variants in the EIF2AK4 gene. Case Description and Method: A 19-year-old man who was previously diagnosed with idiopathic PAH suffered from dyspnea on exertion for 2 months. He had a reduced lung diffusion capacity for carbon monoxide (25% predicted). Chest computed tomography images showed diffusely scattered ground-glass opacity nodules in both lungs with an enlarged main pulmonary artery. For the molecular diagnosis of PVOD/PCH, whole-exome sequencing was performed for the proband. Results: Exome sequencing identified two novel EIF2AK4 variants, c.2137_2138dup (p.Ser714Leufs*78) and c.3358-1G>A. These two variants were classified as pathogenic variants according to the 2015 American College of Medical Genetics and Genomics  guidelines. Conclusions: We identified two novel pathogenic variants (c.2137_2138dup and c.3358-1G>A) in the EIF2AK4 gene. Identification of possible pathogenic gene variants by whole-exome sequencing or panel sequencing is recommended as a guide to adequate treatment of patients with pulmonary hypertension.

--- a/references_cache/DOI_10.1172_jci.insight.181877.md
+++ b/references_cache/DOI_10.1172_jci.insight.181877.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.1172/jci.insight.181877"
+title: Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease
+authors:
+- Amit Prabhakar
+- Meetu Wadhwa
+- Rahul Kumar
+- Prajakta Ghatpande
+- Aneta Gandjeva
+- Rubin M. Tuder
+- Brian B. Graham
+- Giorgio Lagna
+- Akiko Hata
+journal: JCI Insight
+year: '2024'
+doi: 10.1172/jci.insight.181877
+content_type: unavailable
+---
+
+# Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease
+**Authors:** Amit Prabhakar, Meetu Wadhwa, Rahul Kumar, Prajakta Ghatpande, Aneta Gandjeva, Rubin M. Tuder, Brian B. Graham, Giorgio Lagna, Akiko Hata
+**Journal:** JCI Insight (2024)
+**DOI:** [10.1172/jci.insight.181877](https://doi.org/10.1172/jci.insight.181877)
+
+## Content

--- a/references_cache/DOI_10.1183_16000617.0156-2023.md
+++ b/references_cache/DOI_10.1183_16000617.0156-2023.md
@@ -1,0 +1,26 @@
+---
+reference_id: "DOI:10.1183/16000617.0156-2023"
+title: "Pulmonary veno-occlusive disease: illustrative cases and literature review"
+authors:
+- Benoit Lechartier
+- Athénaïs Boucly
+- Sabina Solinas
+- Deepa Gopalan
+- Peter Dorfmüller
+- Teodora Radonic
+- Olivier Sitbon
+- David Montani
+journal: European Respiratory Review
+year: '2024'
+doi: 10.1183/16000617.0156-2023
+content_type: abstract_only
+---
+
+# Pulmonary veno-occlusive disease: illustrative cases and literature review
+**Authors:** Benoit Lechartier, Athénaïs Boucly, Sabina Solinas, Deepa Gopalan, Peter Dorfmüller, Teodora Radonic, Olivier Sitbon, David Montani
+**Journal:** European Respiratory Review (2024)
+**DOI:** [10.1183/16000617.0156-2023](https://doi.org/10.1183/16000617.0156-2023)
+
+## Content
+
+Pulmonary veno-occlusive disease (PVOD), also known as “pulmonary arterial hypertension (PAH) with overt features of venous/capillary involvement”, is a rare cause of PAH characterised by substantial small pulmonary vein and capillary involvement, leading to increased pulmonary vascular resistance and right ventricular failure. Environmental risk factors have been associated with the development of PVOD, such as occupational exposure to organic solvents and chemotherapy, notably mitomycin. PVOD may also be associated with a mutation in theEIF2AK4gene in heritable forms of disease. Distinguishing PVOD from PAH is critical for guiding appropriate management. Chest computed tomography typically displays interlobular septal thickening, ground-glass opacities and mediastinal lymphadenopathy. Life-threatening pulmonary oedema is a complication of pulmonary vasodilator therapy that can occur with any class of PAH drugs in PVOD. Early referral to a lung transplant centre is essential due to the poor response to therapy when compared with other forms of PAH. Histopathological analysis of lung explants reveals microvascular remodelling with typical fibrous veno-occlusive lesions. This review covers the main features distinguishing PVOD from PAH and two clinical cases that illustrate the challenges of PVOD management.

--- a/references_cache/DOI_10.1183_20734735.0098-2024.md
+++ b/references_cache/DOI_10.1183_20734735.0098-2024.md
@@ -1,0 +1,22 @@
+---
+reference_id: "DOI:10.1183/20734735.0098-2024"
+title: "Pulmonary veno-occlusive disease: a clinical review"
+authors:
+- Himanshu Deshwal
+- Sauradeep Sarkar
+- Atreyee Basu
+- Bilal A. Jalil
+journal: Breathe
+year: '2025'
+doi: 10.1183/20734735.0098-2024
+content_type: abstract_only
+---
+
+# Pulmonary veno-occlusive disease: a clinical review
+**Authors:** Himanshu Deshwal, Sauradeep Sarkar, Atreyee Basu, Bilal A. Jalil
+**Journal:** Breathe (2025)
+**DOI:** [10.1183/20734735.0098-2024](https://doi.org/10.1183/20734735.0098-2024)
+
+## Content
+
+Pulmonary vasculopathy presents as a spectrum of diseases affecting the precapillary pulmonary arterioles, the capillaries and the venules. Pulmonary veno-occlusive disease (PVOD) is classified under group 1 pulmonary arterial hypertension (PAH) as subgroup 1.5 (PAH with features of capillary/venous involvement), and represents a progressive and fatal spectrum of pulmonary vascular disorders. PVOD and pulmonary capillary haemangiomatosis (PCH) can be clinically indistinguishable and often coexist, along with the same risk factors and genetic alterations; they are referred to together as PVOD/PCH in the literature. For brevity, we use the clinical term PVOD in this article. PVOD cannot be distinguished from other forms of PAH based on symptoms and haemodynamics. Risk factors include exposure to toxins/chemotherapeutic drugs and genetic mutation in theEIF2AK4gene. Radiographic features such as mediastinal adenopathy, centrilobular ground-glass opacities, and interlobular septal thickening, along with the presence of hypoxia and reduced diffusion capacity of the lung may be required for a clinical diagnosis of PVOD, as lung biopsy carries a high risk for bleeding. Characteristic histological findings include narrowing/occlusion of small pulmonary veins. The development of pulmonary oedema with pulmonary vasodilator therapy limits therapeutic options for PVOD. With limited treatment options, lung transplantation remains the only curative treatment.

--- a/references_cache/DOI_10.17863_cam.108223.md
+++ b/references_cache/DOI_10.17863_cam.108223.md
@@ -1,0 +1,36 @@
+---
+reference_id: "DOI:10.17863/cam.108223"
+title: Functional validation of EIF2AK4 (GCN2) missense variants associated with pulmonary arterial hypertension.
+authors:
+- "Emanuelli, Giulia"
+- "Zhu, JiaYi"
+- "Li, Wei"
+- "Morrell, Nicholas W"
+- "Marciniak, Stefan J"
+journal: Oxford University Press (OUP)
+year: '2024'
+doi: 10.17863/cam.108223
+keywords:
+- EIF2AK4
+- GCN2
+- PVOD
+- missense variants
+- pulmonary hypertension
+- Humans
+- Protein Serine-Threonine Kinases
+- "Mutation, Missense"
+- Pulmonary Arterial Hypertension
+- Genetic Predisposition to Disease
+- "Hypertension, Pulmonary"
+- Computational Biology
+content_type: abstract_only
+---
+
+# Functional validation of EIF2AK4 (GCN2) missense variants associated with pulmonary arterial hypertension.
+**Authors:** Emanuelli, Giulia, Zhu, JiaYi, Li, Wei, Morrell, Nicholas W, Marciniak, Stefan J
+**Journal:** Oxford University Press (OUP) (2024)
+**DOI:** [10.17863/cam.108223](https://doi.org/10.17863/cam.108223)
+
+## Content
+
+Pulmonary arterial hypertension (PAH) is a disorder with a large genetic component. Biallelic mutations of EIF2AK4, which encodes the kinase GCN2, are causal in two ultra-rare subtypes of PAH, pulmonary veno-occlusive disease and pulmonary capillary haemangiomatosis. EIF2AK4 variants of unknown significance have also been identified in patients with classical PAH, though their relationship to disease remains unclear. To provide patients with diagnostic information and enable family testing, the functional consequences of such rare variants must be determined, but existing computational methods are imperfect. We applied a suite of bioinformatic and experimental approaches to sixteen EIF2AK4 variants that had been identified in patients. By experimentally testing the functional integrity of the integrated stress response (ISR) downstream of GCN2, we determined that existing computational tools have insufficient sensitivity to reliably predict impaired kinase function. We determined experimentally that several EIF2AK4 variants identified in patients with classical PAH had preserved function and are therefore likely to be non-pathogenic. The dysfunctional variants of GCN2 that we identified could be subclassified into three groups: misfolded, kinase-dead, and hypomorphic. Intriguingly, members of the hypomorphic group were amenable to paradoxical activation by a type-1½ GCN2 kinase inhibitor. This experiment approach may aid in the clinical stratification of EIF2AK4 variants and potentially identify hypomorophic alleles receptive to pharmacological activation.

--- a/references_cache/DOI_10.18093_0869-0189-2024-34-4-595-598.md
+++ b/references_cache/DOI_10.18093_0869-0189-2024-34-4-595-598.md
@@ -1,0 +1,20 @@
+---
+reference_id: "DOI:10.18093/0869-0189-2024-34-4-595-598"
+title: "Rare clinical case: pulmonary venoocclusive disease"
+authors:
+- V. A. Stener
+- N. A. Tsareva
+journal: PULMONOLOGIYA
+year: '2024'
+doi: 10.18093/0869-0189-2024-34-4-595-598
+content_type: abstract_only
+---
+
+# Rare clinical case: pulmonary venoocclusive disease
+**Authors:** V. A. Stener, N. A. Tsareva
+**Journal:** PULMONOLOGIYA (2024)
+**DOI:** [10.18093/0869-0189-2024-34-4-595-598](https://doi.org/10.18093/0869-0189-2024-34-4-595-598)
+
+## Content
+
+Pulmonary veno-occlusive disease (PVOD) is a rare pathology of unknown etiology when the development and progression of pulmonary arterial hypertension (PAH) is associated with damage to small pulmonary veins and venules, including thrombotic lesions. The prevalence of the disease is 1 – 2 cases per 10 million people. PVOD is characterized by rapid progression and poor prognosis. The aim of the work was to demonstrate a rare clinical case of PVOD in a 43-year-old woman who had a predisposing risk factor for the development of the disease and a verified mutation in the EIF2AK4 gene. Conclusion. This clinical case illustrates the difficulties of diagnosing PVOD and choosing the further patient management. It is noted that timely diagnosis and initiation of therapy are critically important for patients with PVOD, while the use of PAH-specific therapy might complicate course of the disease by provoking pulmonary edema.

--- a/references_cache/DOI_10.3390_arm93060048.md
+++ b/references_cache/DOI_10.3390_arm93060048.md
@@ -1,0 +1,22 @@
+---
+reference_id: "DOI:10.3390/arm93060048"
+title: "Pulmonary Veno-Occlusive Disease: A Comprehensive Review of Diagnostic Challenges, Therapeutic Limitations, and Evolving Management"
+authors:
+- Brian Foster
+- Sikandar Khan
+- Ana Suarez Gonzalez
+- Samantha Gillenwater
+journal: Advances in Respiratory Medicine
+year: '2025'
+doi: 10.3390/arm93060048
+content_type: abstract_only
+---
+
+# Pulmonary Veno-Occlusive Disease: A Comprehensive Review of Diagnostic Challenges, Therapeutic Limitations, and Evolving Management
+**Authors:** Brian Foster, Sikandar Khan, Ana Suarez Gonzalez, Samantha Gillenwater
+**Journal:** Advances in Respiratory Medicine (2025)
+**DOI:** [10.3390/arm93060048](https://doi.org/10.3390/arm93060048)
+
+## Content
+
+Pulmonary veno-occlusive disease (PVOD) is a rare and under-recognized cause of pulmonary hypertension. It is characterized by fibrotic obstruction of small pulmonary veins and venules. Its clinical presentation closely mimics pulmonary arterial hypertension (PAH), leading to frequent misdiagnosis, delayed recognition, and potentially harmful exposure to PAH-specific vasodilator therapy. This review aims to synthesize our evolving understanding of PVOD, discussing its etiologies, role of genetic underpinnings, histopathologic features, pathophysiology, clinical presentation, and characteristic imaging findings. It then discusses management strategies emphasizing early recognition, supportive care, avoidance of inappropriate PAH therapies due to poor response, and timely referral for lung transplantation. Despite advances in identification and management, PVOD remains a fatal condition with a median survival of less than two years, underscoring the importance of early recognition and multidisciplinary care.

--- a/references_cache/PMID_24292273.md
+++ b/references_cache/PMID_24292273.md
@@ -1,0 +1,108 @@
+---
+reference_id: "PMID:24292273"
+title: "EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension."
+authors:
+- Eyries M
+- Montani D
+- Girerd B
+- Perret C
+- Leroy A
+- Lonjou C
+- Chelghoum N
+- Coulet F
+- Bonnet D
+- Dorfmüller P
+- Fadel E
+- Sitbon O
+- Simonneau G
+- Tregouët DA
+- Humbert M
+- Soubrier F
+journal: Nat Genet
+year: '2014'
+doi: 10.1038/ng.2844
+keywords:
+- Adult
+- Chromosome Mapping
+- Female
+- Homozygote
+- Humans
+- "Hypertension, Pulmonary/physiopathology"
+- Male
+- Middle Aged
+- Mutation
+- Pedigree
+- "Protein Serine-Threonine Kinases/genetics, metabolism"
+- "Pulmonary Veno-Occlusive Disease/genetics, physiopathology"
+- Young Adult
+content_type: abstract_only
+---
+
+# EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of pulmonary hypertension.
+**Authors:** Eyries M, Montani D, Girerd B, Perret C, Leroy A, Lonjou C, Chelghoum N, Coulet F, Bonnet D, Dorfmüller P, Fadel E, Sitbon O, Simonneau G, Tregouët DA, Humbert M, Soubrier F
+**Journal:** Nat Genet (2014)
+**DOI:** [10.1038/ng.2844](https://doi.org/10.1038/ng.2844)
+
+## Content
+
+1. Nat Genet. 2014 Jan;46(1):65-9. doi: 10.1038/ng.2844. Epub 2013 Dec 1.
+
+EIF2AK4 mutations cause pulmonary veno-occlusive disease, a recessive form of 
+pulmonary hypertension.
+
+Eyries M(1), Montani D(2), Girerd B(2), Perret C(3), Leroy A(4), Lonjou C(5), 
+Chelghoum N(5), Coulet F(6), Bonnet D(7), Dorfmüller P(8), Fadel E(9), Sitbon 
+O(2), Simonneau G(2), Tregouët DA(3), Humbert M(2), Soubrier F(1).
+
+Author information:
+(1)1] Unité Mixte de Recherche en Santé (UMR_S 956), Université Pierre and Marie 
+Curie Université Paris 06 (UPMC) and Institut National de la Santé et de la 
+Recherche Médicale (INSERM), Paris, France. [2] Genetics Department, Hôpital 
+Pitié-Salpêtrière, Assistance Publique-Hôpitaux de Paris (AP-HP), Paris, France. 
+[3] Institute for Cardiometabolism and Nutrition (ICAN), Paris, France.
+(2)1] Université Paris-Sud, Faculté de Médecine, Le Kremlin Bicêtre, France. [2] 
+Département Hospitalo-Universitaire (DHU) Thorax Innovation (TORINO), Service de 
+Pneumologie, Hôpital Bicêtre, AP-HP, Le Kremlin Bicêtre, France. [3] INSERM 
+UMR_S 999, Laboratoire d'Excellence en Recherche sur le Médicament et 
+l'Innovation Thérapeutique (LERMIT), Centre Chirurgical Marie Lannelongue, Le 
+Plessis Robinson, France.
+(3)1] Institute for Cardiometabolism and Nutrition (ICAN), Paris, France. [2] 
+UMR_S 937, UPMC, INSERM, Paris, France.
+(4)Genetics Department, Hôpital Pitié-Salpêtrière, Assistance Publique-Hôpitaux 
+de Paris (AP-HP), Paris, France.
+(5)Post-Genomic Platform (P3S), UPMC, INSERM, Paris, France.
+(6)1] Genetics Department, Hôpital Pitié-Salpêtrière, Assistance 
+Publique-Hôpitaux de Paris (AP-HP), Paris, France. [2] Institute for 
+Cardiometabolism and Nutrition (ICAN), Paris, France.
+(7)1] Cardiac Surgery Department, Hôpital Necker-Enfants Malades, AP-HP, Paris, 
+France. [2] UMR_S 765, INSERM and Université Paris Descartes, Paris, France.
+(8)1] INSERM UMR_S 999, Laboratoire d'Excellence en Recherche sur le Médicament 
+et l'Innovation Thérapeutique (LERMIT), Centre Chirurgical Marie Lannelongue, Le 
+Plessis Robinson, France. [2] Department of Pathology, Centre Chirurgical Marie 
+Lannelongue, Le Plessis-Robinson, France.
+(9)1] INSERM UMR_S 999, Laboratoire d'Excellence en Recherche sur le Médicament 
+et l'Innovation Thérapeutique (LERMIT), Centre Chirurgical Marie Lannelongue, Le 
+Plessis Robinson, France. [2] Thoracic Surgery Department, Centre Chirurgical 
+Marie Lannelongue, Le Plessis-Robinson, France.
+
+Comment in
+    Clin Genet. 2014 Sep;86(3):218-9. doi: 10.1111/cge.12446.
+
+Pulmonary veno-occlusive disease (PVOD) is a rare and devastating cause of 
+pulmonary hypertension that is characterized histologically by widespread 
+fibrous intimal proliferation of septal veins and preseptal venules and is 
+frequently associated with pulmonary capillary dilatation and proliferation. 
+PVOD is categorized into a separate pulmonary arterial hypertension-related 
+group in the current classification of pulmonary hypertension. PVOD presents 
+either sporadically or as familial cases with a seemingly recessive mode of 
+transmission. Using whole-exome sequencing, we detected recessive mutations in 
+EIF2AK4 (also called GCN2) that cosegregated with PVOD in all 13 families 
+studied. We also found biallelic EIF2AK4 mutations in 5 of 20 histologically 
+confirmed sporadic cases of PVOD. All mutations, either in a homozygous or 
+compound-heterozygous state, disrupted the function of the gene. These findings 
+point to EIF2AK4 as the major gene that is linked to PVOD development and 
+contribute toward an understanding of the complex genetic architecture of 
+pulmonary hypertension.
+
+DOI: 10.1038/ng.2844
+PMID: 24292273 [Indexed for MEDLINE]

--- a/references_cache/PMID_28972005.md
+++ b/references_cache/PMID_28972005.md
@@ -1,0 +1,226 @@
+---
+reference_id: "PMID:28972005"
+title: Phenotypic Characterization of EIF2AK4 Mutation Carriers in a Large Cohort of Patients Diagnosed Clinically With Pulmonary Arterial Hypertension.
+authors:
+- Hadinnapola C
+- Bleda M
+- Haimel M
+- Screaton N
+- Swift A
+- Dorfmüller P
+- Preston SD
+- Southwood M
+- Hernandez-Sanchez J
+- Martin J
+- Treacy C
+- Yates K
+- Bogaard H
+- Church C
+- Coghlan G
+- Condliffe R
+- Corris PA
+- Gibbs S
+- Girerd B
+- Holden S
+- Humbert M
+- Kiely DG
+- Lawrie A
+- Machado R
+- MacKenzie Ross R
+- Moledina S
+- Montani D
+- Newnham M
+- Peacock A
+- Pepke-Zaba J
+- Rayner-Matthews P
+- Shamardina O
+- Soubrier F
+- Southgate L
+- Suntharalingam J
+- Toshner M
+- Trembath R
+- Vonk Noordegraaf A
+- Wilkins MR
+- Wort SJ
+- Wharton J
+- NIHR BioResource–Rare Diseases Consortium; UK National Cohort Study of Idiopathic and Heritable PAH
+- Gräf S
+- Morrell NW
+journal: Circulation
+year: '2017'
+doi: 10.1161/CIRCULATIONAHA.117.028351
+keywords:
+- Adult
+- Aged
+- Arterial Pressure/genetics
+- "Bone Morphogenetic Protein Receptors, Type II/genetics"
+- DNA Mutational Analysis
+- Europe
+- Female
+- Gene Frequency
+- Genetic Association Studies
+- Genetic Predisposition to Disease
+- Heredity
+- Humans
+- "Hypertension, Pulmonary/diagnosis, enzymology, genetics, physiopathology"
+- Male
+- Middle Aged
+- Mutation
+- Pedigree
+- Phenotype
+- Predictive Value of Tests
+- Prospective Studies
+- Protein Serine-Threonine Kinases/genetics
+- Pulmonary Artery/physiopathology
+- Retrospective Studies
+- Risk Factors
+- "Tomography, X-Ray Computed"
+- Young Adult
+content_type: abstract_only
+---
+
+# Phenotypic Characterization of EIF2AK4 Mutation Carriers in a Large Cohort of Patients Diagnosed Clinically With Pulmonary Arterial Hypertension.
+**Authors:** Hadinnapola C, Bleda M, Haimel M, Screaton N, Swift A, Dorfmüller P, Preston SD, Southwood M, Hernandez-Sanchez J, Martin J, Treacy C, Yates K, Bogaard H, Church C, Coghlan G, Condliffe R, Corris PA, Gibbs S, Girerd B, Holden S, Humbert M, Kiely DG, Lawrie A, Machado R, MacKenzie Ross R, Moledina S, Montani D, Newnham M, Peacock A, Pepke-Zaba J, Rayner-Matthews P, Shamardina O, Soubrier F, Southgate L, Suntharalingam J, Toshner M, Trembath R, Vonk Noordegraaf A, Wilkins MR, Wort SJ, Wharton J, NIHR BioResource–Rare Diseases Consortium; UK National Cohort Study of Idiopathic and Heritable PAH, Gräf S, Morrell NW
+**Journal:** Circulation (2017)
+**DOI:** [10.1161/CIRCULATIONAHA.117.028351](https://doi.org/10.1161/CIRCULATIONAHA.117.028351)
+
+## Content
+
+1. Circulation. 2017 Nov 21;136(21):2022-2033. doi: 
+10.1161/CIRCULATIONAHA.117.028351. Epub 2017 Sep 28.
+
+Phenotypic Characterization of EIF2AK4 Mutation Carriers in a Large Cohort of 
+Patients Diagnosed Clinically With Pulmonary Arterial Hypertension.
+
+Hadinnapola C(1), Bleda M(1), Haimel M(1)(2), Screaton N(3), Swift A(4), 
+Dorfmüller P(5), Preston SD(3), Southwood M(3), Hernandez-Sanchez J(3), Martin 
+J(1)(2), Treacy C(1), Yates K(1)(2), Bogaard H(6), Church C(7), Coghlan G(8), 
+Condliffe R(9), Corris PA(10), Gibbs S(11), Girerd B(5), Holden S(12), Humbert 
+M(5), Kiely DG(9), Lawrie A(4), Machado R(13), MacKenzie Ross R(14), Moledina 
+S(15), Montani D(5), Newnham M(1), Peacock A(7), Pepke-Zaba J(3), 
+Rayner-Matthews P(2), Shamardina O(2), Soubrier F(16), Southgate L(17)(18), 
+Suntharalingam J(14), Toshner M(1)(3), Trembath R(17), Vonk Noordegraaf A(6), 
+Wilkins MR(11), Wort SJ(19), Wharton J(11); NIHR BioResource–Rare Diseases 
+Consortium; UK National Cohort Study of Idiopathic and Heritable PAH; Gräf 
+S(1)(2)(20), Morrell NW(21)(2).
+
+Collaborators: Aitman T, Bennett D, Caulfield M, Chinnery P, Gale D, Koziell A, 
+Kuijpers TW, Laffan MA, Maher E, Markus HS, Ouwehand WH, Perry D, Raymond FL, 
+Roberts I, Smith K, Thrasher A, Watkins H, Williamson C, Woods G, Ashford S, 
+Bradley JR, Fletcher D, Hammerton T, James R, Kingston N, Ouwehand WH, Penkett 
+CJ, Raymond FL, Stirrups K, Veltman M, Young T, Ashford S, Brown M, 
+Clements-Brod N, Davis J, Dewhurst E, Erwood M, Frary A, Linger R, Papadia S, 
+Rehnstrom K, Stark H, Allsup D, Austin S, Bakchoul T, Bariana TK, Bolton-Maggs 
+P, Chalmers E, Collins P, Erber WN, Everington T, Favier R, Freson K, Furie B, 
+Gattens M, Gomez K, Greene D, Greinacher A, Hart D, Heemskerk JW, Henskens Y, 
+Kazmi R, Keeling D, Kelly AM, Laffan MA, Lambert MP, Lentaigne C, Liesner R, 
+Mangles S, Mathias M, Millar CM, Mumford A, Nurden P, Ouwehand WH, Papadia S, 
+Payne J, Pasi J, Perry DJ, Peerlinck K, Richards M, Rondina M, Roughley C, 
+Schulman S, Schulze H, Scully M, Sivapalaratnam S, Tait RC, Talks K, Thachil J, 
+Turro E, Toh CH, Van Geet C, De Vries M, Warner TQ, Westbury S, Furnell A, 
+Mapeta R, Simeoni I, Staines S, Stephens J, Stirrups K, Whitehorn D, Watt C, 
+Attwood A, Daugherty L, Deevi SV, Halmagyi C, Hu F, James R, Matser V, Meacham 
+S, Megy K, Penkett CJ, Stirrups K, Titterton C, Tuna S, Yu P, von Ziegenweldt J, 
+Astle W, Carss K, Greene D, Lango-Allen H, Turro E, Astle W, Greene D, 
+Richardson S, Turro E, Calleja P, Rankin S, Turek W, Bryson C, Anderson J, 
+Fletcher D, McJannet C, Stock S, Young T, Wassmer E, Sohal A, Santra S, Vogt J, 
+Chitre M, Krishnakumar D, Ambegaonkar G, Maw A, Armstrong R, Park SM, Mehta S, 
+Paterson J, Carmichael J, Allen L, Hensiek A, Firth H, Stein P, Deegan P, 
+Doffinger R, Parker A, Bitner-Glindzicz M, Scott R, Hurst J, Rosser E, Lees M, 
+Clement E, Henderson R, Thompson D, Gardham A, Gissen P, Josifova D, Thomas E, 
+Patch C, Deshpande C, Flinter F, Holder M, Canham N, Wakeling E, Holder S, Ghali 
+N, Brady A, Clowes V, MacLaren R, Webster A, Moore A, Arno G, Michaelides M, 
+Rankin J, Kurian M, Murphy E, Carss K, Sanchis-Juan A, Erwood M, Dewhurst E, 
+Grozeva D, Raymond FL, Reid E, Woods G, Tischkowitz M, Sandford R, Ali S, 
+Creaser-Myers A, Cookson V, DaCosta R, Dormand N, Ghataorhe PK, Greenhalgh A, 
+Huis In't Veld A, Kennedy F, Mackenzie Ross R, Masati L, Meehan S, Othman S, 
+Pollock V, Polwarth G, Rhodes CJ, Rue-Albrecht K, Schotte G, Shipley D, Tan Y, 
+Wanjiku I, Wort J, Smith K, Kuijpers T, Thrasher A, Thaventhiran J, Brown M, 
+Lango Allen H, Simeoni I, Staples E, Samarghitean C, Alachkar H, Antrobus R, 
+Arumugakani G, Bacchelli C, Baxendale H, Bethune C, Bibi S, Booth C, Browning M, 
+Burns S, Chandra A, Cooper N, Davies S, Devlin L, Doffinger R, Drewe E, Edgar D, 
+Egner W, Ghurye R, Gilmour K, Goddard S, Gordins P, Grigoriadou S, Hackett S, 
+Hague R, Hayman G, Herwadkar A, Huissoon A, Jolles S, Kelleher P, Kumararatne D, 
+Lear S, Longhurst H, Lorenzo L, Maimaris J, Manson A, McDermott E, Murng S, 
+Nejentsev S, Noorani S, Oksenhendler E, Ponsford M, Qasim W, Quinti I, Richter 
+A, Sargur R, Savic S, Seneviratne S, Sewell C, Stauss H, Thomas M, Welch S, 
+Willcocks L, Yeatman N, Yong P.
+
+Author information:
+(1)Department of Medicine, University of Cambridge, UK (C.H., M.B., M.H., J.M., 
+C.T., K.Y., M.N., M.T., S. Gräf, N.W.M.).
+(2)NIHR BioResource-Rare Diseases (M.H., J.M., K.Y., P.R.-M., O.S., S. Gräf, 
+N.W.M.).
+(3)Papworth Hospital, Cambridge, UK (N.S., S.D.P., M.S., J.H.-S., J.P.-Z., 
+M.T.).
+(4)Sheffield University, UK (A.S., A.L.).
+(5)Université Paris-Sud, France (P.D., B.G., M.H., D.M.).
+(6)VU University Medical Centre, Amsterdam, the Netherlands (H.B., A.V.N.).
+(7)Golden Jubilee Hospital, Glasgow, UK (C.C., A.P.).
+(8)Royal Free Hospital, London, UK (G.C.).
+(9)Royal Hallamshire Hospital, Sheffield, UK (R.C., D.G.K.).
+(10)Newcastle University, UK (P.A.C.).
+(11)Imperial College London, UK (S. Gibbs, M.R.W., J.W.).
+(12)Addenbrooke's Hospital, Cambridge, UK (S.H.).
+(13)University of Lincoln, UK (R.M.).
+(14)Royal United Hospitals Bath NHS Foundation Trust, UK (R.M.R., J.S.).
+(15)Great Ormond Street Hospital, London, UK (S.M.).
+(16)Hôpital Pitié Salpétrière, Paris, France (F.S.).
+(17)King's College London, UK (L.S., R.T.).
+(18)St George's, University of London, UK (L.S.).
+(19)Royal Brompton Hospital, London, UK (S.J.W.).
+(20)Department of Haematology, University of Cambridge, UK (S. Gräf).
+(21)Department of Medicine, University of Cambridge, UK (C.H., M.B., M.H., J.M., 
+C.T., K.Y., M.N., M.T., S. Gräf, N.W.M.) nmw23@cam.ac.uk.
+
+Comment in
+    Circulation. 2017 Nov 21;136(21):2034-2036. doi: 
+10.1161/CIRCULATIONAHA.117.031158.
+    Circulation. 2018 May 29;137(22):2411-2412. doi: 
+10.1161/CIRCULATIONAHA.118.033641.
+    Circulation. 2018 May 29;137(22):2413-2414. doi: 
+10.1161/CIRCULATIONAHA.118.033970.
+
+BACKGROUND: Pulmonary arterial hypertension (PAH) is a rare disease with an 
+emerging genetic basis. Heterozygous mutations in the gene encoding the bone 
+morphogenetic protein receptor type 2 (BMPR2) are the commonest genetic cause of 
+PAH, whereas biallelic mutations in the eukaryotic translation initiation factor 
+2 alpha kinase 4 gene (EIF2AK4) are described in pulmonary veno-occlusive 
+disease/pulmonary capillary hemangiomatosis. Here, we determine the frequency of 
+these mutations and define the genotype-phenotype characteristics in a large 
+cohort of patients diagnosed clinically with PAH.
+METHODS: Whole-genome sequencing was performed on DNA from patients with 
+idiopathic and heritable PAH and with pulmonary veno-occlusive disease/pulmonary 
+capillary hemangiomatosis recruited to the National Institute of Health Research 
+BioResource-Rare Diseases study. Heterozygous variants in BMPR2 and biallelic 
+EIF2AK4 variants with a minor allele frequency of <1:10 000 in control data sets 
+and predicted to be deleterious (by combined annotation-dependent depletion, 
+PolyPhen-2, and sorting intolerant from tolerant predictions) were identified as 
+potentially causal. Phenotype data from the time of diagnosis were also 
+captured.
+RESULTS: Eight hundred sixty-four patients with idiopathic or heritable PAH and 
+16 with pulmonary veno-occlusive disease/pulmonary capillary hemangiomatosis 
+were recruited. Mutations in BMPR2 were identified in 130 patients (14.8%). 
+Biallelic mutations in EIF2AK4 were identified in 5 patients with a clinical 
+diagnosis of pulmonary veno-occlusive disease/pulmonary capillary 
+hemangiomatosis. Furthermore, 9 patients with a clinical diagnosis of PAH 
+carried biallelic EIF2AK4 mutations. These patients had a reduced transfer 
+coefficient for carbon monoxide (Kco; 33% [interquartile range, 30%-35%] 
+predicted) and younger age at diagnosis (29 years; interquartile range, 23-38 
+years) and more interlobular septal thickening and mediastinal lymphadenopathy 
+on computed tomography of the chest compared with patients with PAH without 
+EIF2AK4 mutations. However, radiological assessment alone could not accurately 
+identify biallelic EIF2AK4 mutation carriers. Patients with PAH with biallelic 
+EIF2AK4 mutations had a shorter survival.
+CONCLUSIONS: Biallelic EIF2AK4 mutations are found in patients classified 
+clinically as having idiopathic and heritable PAH. These patients cannot be 
+identified reliably by computed tomography, but a low Kco and a young age at 
+diagnosis suggests the underlying molecular diagnosis. Genetic testing can 
+identify these misclassified patients, allowing appropriate management and early 
+referral for lung transplantation.
+
+© 2017 The Authors.
+
+DOI: 10.1161/CIRCULATIONAHA.117.028351
+PMCID: PMC5700414
+PMID: 28972005 [Indexed for MEDLINE]

--- a/references_cache/PMID_29108819.md
+++ b/references_cache/PMID_29108819.md
@@ -1,0 +1,135 @@
+---
+reference_id: "PMID:29108819"
+title: Pulmonary vascular remodeling patterns and expression of general control nonderepressible 2 (GCN2) in pulmonary veno-occlusive disease.
+authors:
+- Nossent EJ
+- Antigny F
+- Montani D
+- Bogaard HJ
+- Ghigna MR
+- Lambert M
+- Thomas de Montpréville V
+- Girerd B
+- Jaïs X
+- Savale L
+- Mercier O
+- Fadel E
+- Soubrier F
+- Sitbon O
+- Simonneau G
+- Vonk Noordegraaf A
+- Humbert M
+- Perros F
+- Dorfmüller P
+journal: J Heart Lung Transplant
+year: '2018'
+doi: 10.1016/j.healun.2017.09.022
+keywords:
+- Adult
+- Female
+- Gene Expression Regulation
+- Humans
+- Male
+- "Protein Serine-Threonine Kinases/genetics, physiology"
+- "Pulmonary Veno-Occlusive Disease/genetics, pathology, physiopathology"
+- Retrospective Studies
+- Vascular Remodeling
+- Young Adult
+content_type: abstract_only
+---
+
+# Pulmonary vascular remodeling patterns and expression of general control nonderepressible 2 (GCN2) in pulmonary veno-occlusive disease.
+**Authors:** Nossent EJ, Antigny F, Montani D, Bogaard HJ, Ghigna MR, Lambert M, Thomas de Montpréville V, Girerd B, Jaïs X, Savale L, Mercier O, Fadel E, Soubrier F, Sitbon O, Simonneau G, Vonk Noordegraaf A, Humbert M, Perros F, Dorfmüller P
+**Journal:** J Heart Lung Transplant (2018)
+**DOI:** [10.1016/j.healun.2017.09.022](https://doi.org/10.1016/j.healun.2017.09.022)
+
+## Content
+
+1. J Heart Lung Transplant. 2018 May;37(5):647-655. doi: 
+10.1016/j.healun.2017.09.022. Epub 2017 Oct 4.
+
+Pulmonary vascular remodeling patterns and expression of general control 
+nonderepressible 2 (GCN2) in pulmonary veno-occlusive disease.
+
+Nossent EJ(1), Antigny F(2), Montani D(3), Bogaard HJ(4), Ghigna MR(5), Lambert 
+M(6), Thomas de Montpréville V(7), Girerd B(3), Jaïs X(3), Savale L(3), Mercier 
+O(8), Fadel E(8), Soubrier F(9), Sitbon O(3), Simonneau G(3), Vonk Noordegraaf 
+A(4), Humbert M(3), Perros F(6), Dorfmüller P(10).
+
+Author information:
+(1)Department of Pulmonary Diseases, Vrije Universiteit University Medical 
+Center, Institute for Cardiovascular Research, Amsterdam, The Netherlands; 
+Institut National de la Santé et de la Recherche Unités Mixtes de Recherche_S 
+999, Pulmonary Hypertension: Pathophysiology and Novel Therapies, Hôpital Marie 
+Lannelongue, Le Plessis-Robinson, Paris, France.
+(2)Institut National de la Santé et de la Recherche Unités Mixtes de Recherche_S 
+999, Pulmonary Hypertension: Pathophysiology and Novel Therapies, Hôpital Marie 
+Lannelongue, Le Plessis-Robinson, Paris, France.
+(3)Institut National de la Santé et de la Recherche Unités Mixtes de Recherche_S 
+999, Pulmonary Hypertension: Pathophysiology and Novel Therapies, Hôpital Marie 
+Lannelongue, Le Plessis-Robinson, Paris, France; Faculty of Medicine, 
+Paris-South University, Kremlin-Bicêtre, Paris, France; National Reference 
+Center of Pulmonary Hypertension, Department of Pulmonology and Intensive Care 
+Unit for Respiratory Diseases, Hôpital Bicêtre, Assistance Publique-Hôpitaux de 
+Paris, Kremlin-Bicêtre, Paris, France.
+(4)Department of Pulmonary Diseases, Vrije Universiteit University Medical 
+Center, Institute for Cardiovascular Research, Amsterdam, The Netherlands.
+(5)Institut National de la Santé et de la Recherche Unités Mixtes de Recherche_S 
+999, Pulmonary Hypertension: Pathophysiology and Novel Therapies, Hôpital Marie 
+Lannelongue, Le Plessis-Robinson, Paris, France; Faculty of Medicine, 
+Paris-South University, Kremlin-Bicêtre, Paris, France; Department of Pathology, 
+Hôpital Marie Lannelongue, Le Plessis-Robinson, Paris, France.
+(6)Institut National de la Santé et de la Recherche Unités Mixtes de Recherche_S 
+999, Pulmonary Hypertension: Pathophysiology and Novel Therapies, Hôpital Marie 
+Lannelongue, Le Plessis-Robinson, Paris, France; Faculty of Medicine, 
+Paris-South University, Kremlin-Bicêtre, Paris, France.
+(7)Department of Pathology, Hôpital Marie Lannelongue, Le Plessis-Robinson, 
+Paris, France.
+(8)Faculty of Medicine, Paris-South University, Kremlin-Bicêtre, Paris, France; 
+Department of Thoracic and Vascular Surgery, Hôpital Marie Lannelongue, Le 
+Plessis-Robinson, Paris, France.
+(9)Department of Clinical Genetics, Hôpital Pitié-Salpêtrière, Assistance 
+Publique-Hôpitaux de Paris and Unités Mixtes de Recherche_S 1166-ICAN, Institut 
+National De La Santé Et De La Recherche Unités Mixtes De Recherche, Université 
+Pierre et Marie Curie Sorbonne Universités, Paris, France.
+(10)Institut National de la Santé et de la Recherche Unités Mixtes de 
+Recherche_S 999, Pulmonary Hypertension: Pathophysiology and Novel Therapies, 
+Hôpital Marie Lannelongue, Le Plessis-Robinson, Paris, France; Faculty of 
+Medicine, Paris-South University, Kremlin-Bicêtre, Paris, France; Department of 
+Pathology, Hôpital Marie Lannelongue, Le Plessis-Robinson, Paris, France. 
+Electronic address: peter.dorfmuller@u-psud.fr.
+
+BACKGROUND: Heritable pulmonary veno-occlusive disease (PVOD) is linked to 
+mutations in the eukaryotic initiation factor 2 alpha kinase 4 (EIF2AK4) gene, 
+leading to a loss of general control nonderepressible 2 (GCN2). The role of GCN2 
+expression in pulmonary vascular remodeling remains obscure. We sought to 
+identify specific histologic and biologic features in heritable PVOD.
+METHODS: Clinical data and lung histology of 24 PVOD patients (12 EIF2AK4 
+mutation carriers, 12 non-carriers) were submitted to systematic histologic 
+analysis and semiautomated morphometry. GCN2 expression was quantified by 
+Western blotting in 24 PVOD patients, 44 patients with pulmonary arterial 
+hypertension (PAH; 23 bone morphogenetic protein receptor type II [BMPR2] 
+mutation carriers, 21 non-carriers), and 3 experimental pulmonary hypertension 
+models.
+RESULTS: PVOD patients showed a significant decrease of pulmonary arterial 
+patency (p < 0.0001) compared with healthy controls. Histology of EIF2AK4 
+mutation carriers was distinctive from non-carriers regarding (1) arterial 
+remodeling, with significantly more severe intimal fibrosis (p = 0.001), less 
+severe medial hypertrophy (p = 0.001), and (2) stronger muscular hyperplasia of 
+interlobular septal veins (p = 0.002). GCN2 expression was abolished in 
+heritable PVOD (p < 0.0001), but also importantly decreased in sporadic PVOD (p 
+= 0.03) as well as in heritable (p = 0.002) and idiopathic PAH (p = 0.003); 
+moreover, GCN2 was abolished in 2 experimental pulmonary hypertension models and 
+importantly decreased in 1 model (p < 0.0001 for all models).
+CONCLUSIONS: Pulmonary arterial remodeling in PVOD is present to an important 
+extent. A significant decrease of GCN2 expression is a common denominator of all 
+tested groups of PVOD and PAH, including their respective experimental models. 
+Our results underline specific morphologic and biologic similarities between PAH 
+and PVOD and let us consider both conditions rather in one large spectrum of 
+disease than as two distinct and clear-cut entities.
+
+Copyright © 2017 International Society for the Heart and Lung Transplantation. 
+Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.healun.2017.09.022
+PMID: 29108819 [Indexed for MEDLINE]

--- a/references_cache/PMID_31178067.md
+++ b/references_cache/PMID_31178067.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:31178067"
+title: "Computed tomographic and clinical features of pulmonary veno-occlusive disease: raising the radiologist's awareness."
+authors:
+- Ali N
+- Loughborough WW
+- Rodrigues JCL
+- Suntharalingam J
+- Hudson B
+- Hall T
+- Augustine D
+- Mackenzie R
+- Robinson G
+journal: Clin Radiol
+year: '2019'
+doi: 10.1016/j.crad.2019.04.023
+keywords:
+- Biopsy
+- "Diagnosis, Differential"
+- Humans
+- Prognosis
+- Pulmonary Veno-Occlusive Disease/diagnostic imaging
+- "Tomography, X-Ray Computed/methods"
+content_type: abstract_only
+---
+
+# Computed tomographic and clinical features of pulmonary veno-occlusive disease: raising the radiologist's awareness.
+**Authors:** Ali N, Loughborough WW, Rodrigues JCL, Suntharalingam J, Hudson B, Hall T, Augustine D, Mackenzie R, Robinson G
+**Journal:** Clin Radiol (2019)
+**DOI:** [10.1016/j.crad.2019.04.023](https://doi.org/10.1016/j.crad.2019.04.023)
+
+## Content
+
+1. Clin Radiol. 2019 Sep;74(9):655-662. doi: 10.1016/j.crad.2019.04.023. Epub
+2019  Jun 6.
+
+Computed tomographic and clinical features of pulmonary veno-occlusive disease: 
+raising the radiologist's awareness.
+
+Ali N(1), Loughborough WW(2), Rodrigues JCL(1), Suntharalingam J(1), Hudson 
+B(1), Hall T(1), Augustine D(1), Mackenzie R(1), Robinson G(3).
+
+Author information:
+(1)Royal United Hospital, Combe Park, Avon BA13NG, UK.
+(2)The Royal Marsden NHS Foundation Trust, Fulham Road, SW36JJ London, UK.
+(3)Royal United Hospital, Combe Park, Avon BA13NG, UK. Electronic address: 
+grobinson1@nhs.net.
+
+Pulmonary veno-occlusive disease (PVOD) is a rare subtype of pulmonary arterial 
+hypertension (PAH) characterised by preferential remodelling of the pulmonary 
+venules. Differentiation from other subtypes of PAH is essential as the 
+management can differ significantly; for example, initiation of vasodilator 
+therapy may cause fatal pulmonary oedema in a patient with PVOD misdiagnosed 
+with idiopathic PAH. PVOD also carries a substantially worse prognosis. Lung 
+biopsy is required for definitive diagnosis, but this is hazardous, and ideally, 
+should be avoided in pulmonary hypertension. Computed tomography (CT) may 
+suggest the diagnosis, directing the patient towards specialist review. 
+Potential distinguishing CT features between PVOD and other subtypes of PAH 
+include interlobular septal thickening, mediastinal lymphadenopathy, and 
+centrilobular ground-glass opacities. No evidence-based medical therapy exists 
+for PVOD at present and lung transplantation remains the definitive treatment 
+for eligible patients. Therefore, early radiological identification of this 
+challenging diagnosis facilitates timely referral for transplant.
+
+Crown Copyright © 2019. Published by Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/j.crad.2019.04.023
+PMID: 31178067 [Indexed for MEDLINE]

--- a/references_cache/PMID_36852942.md
+++ b/references_cache/PMID_36852942.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:36852942"
+title: T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient rats in basal and stress conditions.
+authors:
+- Bignard J
+- Atassi F
+- Claude O
+- Ghigna MR
+- Mougenot N
+- Abdoulkarim BS
+- Deknuydt F
+- Gestin A
+- Monceau V
+- Montani D
+- Nadaud S
+- Soubrier F
+- Perros F
+journal: Am J Physiol Lung Cell Mol Physiol
+year: '2023'
+doi: 10.1152/ajplung.00460.2021
+keywords:
+- Animals
+- Rats
+- "Hypertension, Pulmonary"
+- Lung/metabolism
+- "Protein Serine-Threonine Kinases/genetics, metabolism"
+- Pulmonary Veno-Occlusive Disease/genetics
+- "RNA, Messenger"
+- Protein Kinases
+content_type: abstract_only
+---
+
+# T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient rats in basal and stress conditions.
+**Authors:** Bignard J, Atassi F, Claude O, Ghigna MR, Mougenot N, Abdoulkarim BS, Deknuydt F, Gestin A, Monceau V, Montani D, Nadaud S, Soubrier F, Perros F
+**Journal:** Am J Physiol Lung Cell Mol Physiol (2023)
+**DOI:** [10.1152/ajplung.00460.2021](https://doi.org/10.1152/ajplung.00460.2021)
+
+## Content
+
+1. Am J Physiol Lung Cell Mol Physiol. 2023 May 1;324(5):L609-L624. doi: 
+10.1152/ajplung.00460.2021. Epub 2023 Feb 28.
+
+T-cell dysregulation and inflammatory process in Gcn2 (Eif2ak4(-/-))-deficient 
+rats in basal and stress conditions.
+
+Bignard J(1), Atassi F(1), Claude O(1), Ghigna MR(2)(3), Mougenot N(4), 
+Abdoulkarim BS(3), Deknuydt F(5), Gestin A(5), Monceau V(1), Montani D(3)(6), 
+Nadaud S(1), Soubrier F(1), Perros F(3)(7).
+
+Author information:
+(1)UMR_S 1166, Sorbonne Université, INSERM, Paris, France.
+(2)Department of Pathology, Institut Gustave Roussy, Villejuif, France.
+(3)UMR_S999, Université Paris-Saclay, INSERM, Hôpital Marie Lannelongue, Le 
+Plessis Robinson, France.
+(4)UMS28, Sorbonne Université, Plateforme d'Expérimentation Cœur, Muscles, 
+Vaisseaux (PECMV), Paris, France.
+(5)Flow Cytometry Core Cyto-ICAN, Institute of Cardiometabolism and Nutrition, 
+Hôpital Pitié-Salpêtrière, Paris, France.
+(6)Service de Pneumologie et Soins Intensifs Respiratoires, Hôpital de Bicêtre, 
+Assistance Publique Hôpitaux de paris, Le Kremlin Bicêtre, France.
+(7)Laboratoire CarMeN, UMR INSERM U1060/INRA U1397, Université Claude Bernard 
+Lyon1, Pierre-Bénite and Bron, France.
+
+Hereditary pulmonary veno-occlusive disease (hPVOD) is a severe form of 
+autosomal recessive pulmonary hypertension and is due to biallelic loss of 
+function of the EIF2AK4 gene (alias GCN2) coding for GCN2. GCN2 is a stress 
+kinase that belongs to the integrated stress response pathway (ISR). Three rat 
+lines carrying biallelic Gcn2 mutation were generated and found phenotypically 
+normal and did not spontaneously develop a PVOD-related disease. We submitted 
+these rats to amino acid deprivation to document the molecular and cellular 
+response of the lungs and to identify phenotypic changes that could be involved 
+in PVOD pathophysiology. Gcn2-/- rat lungs were analyzed under basal conditions 
+and 3 days after a single administration of PEG-asparaginase (ASNase). Lung 
+mRNAs were analyzed by RNAseq and single-cell RNAseq (scRNA-seq), flow 
+cytometry, tissue imaging, and Western blots. The ISR was not activated after 
+ASNase treatment in Gcn2-/- rat lungs, and apoptosis was increased. Several 
+proinflammatory and innate immunity genes were overexpressed, and inflammatory 
+cells infiltration was also observed in the perivascular area. Under basal 
+conditions, scRNA-seq analysis of Gcn2-/- rat lungs revealed increases in two 
+T-cell populations, a LAG3+ T-cell population and a proliferative T-cell 
+population. Following ASNase administration, we observed an increase in 
+calprotectin expression involved in TLR pathway activation and neutrophil 
+infiltration. In conclusion, under basal and asparagine and glutamine 
+deprivation induced by asparaginase administration, Gcn2-/- rats display 
+molecular and cellular signatures in the lungs that may indicate a role for Gcn2 
+in immune homeostasis and provide further clues to the mechanisms of hPVOD 
+development.
+
+DOI: 10.1152/ajplung.00460.2021
+PMID: 36852942 [Indexed for MEDLINE]

--- a/references_cache/PMID_38232988.md
+++ b/references_cache/PMID_38232988.md
@@ -1,0 +1,105 @@
+---
+reference_id: "PMID:38232988"
+title: "Pulmonary veno-occlusive disease: illustrative cases and literature review."
+authors:
+- Lechartier B
+- Boucly A
+- Solinas S
+- Gopalan D
+- Dorfmüller P
+- Radonic T
+- Sitbon O
+- Montani D
+journal: Eur Respir Rev
+year: '2024'
+doi: 10.1183/16000617.0156-2023
+keywords:
+- Humans
+- "Pulmonary Veno-Occlusive Disease/etiology, genetics"
+- Lung/diagnostic imaging
+- Familial Primary Pulmonary Hypertension
+- "Tomography, X-Ray Computed/methods"
+- Lung Transplantation/adverse effects
+- Pulmonary Arterial Hypertension
+- Protein Serine-Threonine Kinases
+content_type: abstract_only
+---
+
+# Pulmonary veno-occlusive disease: illustrative cases and literature review.
+**Authors:** Lechartier B, Boucly A, Solinas S, Gopalan D, Dorfmüller P, Radonic T, Sitbon O, Montani D
+**Journal:** Eur Respir Rev (2024)
+**DOI:** [10.1183/16000617.0156-2023](https://doi.org/10.1183/16000617.0156-2023)
+
+## Content
+
+1. Eur Respir Rev. 2024 Jan 17;33(171):230156. doi: 10.1183/16000617.0156-2023. 
+Print 2024 Jan 31.
+
+Pulmonary veno-occlusive disease: illustrative cases and literature review.
+
+Lechartier B(1)(2)(3)(4), Boucly A(1)(2)(3), Solinas S(1)(2)(3), Gopalan D(5), 
+Dorfmüller P(6)(7), Radonic T(8), Sitbon O(1)(2)(3), Montani D(9)(2)(3).
+
+Author information:
+(1)Assistance Publique - Hôpitaux de Paris (AP-HP), Department of Respiratory 
+and Intensive Care Medicine, Pulmonary Hypertension National Referral Center, 
+DMU 5 Thorinno, Hôpital Bicêtre, Le Kremlin-Bicêtre, France.
+(2)Université Paris-Saclay, School of Medicine, Le Kremlin-Bicêtre, France.
+(3)INSERM UMR_S 999 "Pulmonary Hypertension: Pathophysiology and Novel 
+Therapies", Hôpital Marie Lannelongue, Le Plessis-Robinson, France.
+(4)Respiratory Division, Lausanne University Hospital (CHUV), Lausanne, 
+Switzerland.
+(5)Department of Radiology, Imperial College Hospital NHS Trust, London, UK.
+(6)Institut für Pathologie, Universitätsklinikum Giessen/Marburg, Giessen, 
+Germany.
+(7)Deutsches Zentrum für Lungenforschung (DZL), Giessen, Germany.
+(8)Amsterdam UMC location Vrije Universiteit Amsterdam, Department of Pathology, 
+Boelelaan Amsterdam, The Netherlands Cancer Centre Amsterdam, Amsterdam, The 
+Netherlands.
+(9)Assistance Publique - Hôpitaux de Paris (AP-HP), Department of Respiratory 
+and Intensive Care Medicine, Pulmonary Hypertension National Referral Center, 
+DMU 5 Thorinno, Hôpital Bicêtre, Le Kremlin-Bicêtre, France 
+david.montani@aphp.fr.
+
+Comment in
+    doi: 10.1183/16000617.0237-2023.
+
+Comment in
+    doi: 10.1183/16000617.0138-2023.
+    doi: 10.1183/16000617.0119-2023.
+    doi: 10.1183/16000617.0149-2023.
+
+Pulmonary veno-occlusive disease (PVOD), also known as "pulmonary arterial 
+hypertension (PAH) with overt features of venous/capillary involvement", is a 
+rare cause of PAH characterised by substantial small pulmonary vein and 
+capillary involvement, leading to increased pulmonary vascular resistance and 
+right ventricular failure. Environmental risk factors have been associated with 
+the development of PVOD, such as occupational exposure to organic solvents and 
+chemotherapy, notably mitomycin. PVOD may also be associated with a mutation in 
+the EIF2AK4 gene in heritable forms of disease. Distinguishing PVOD from PAH is 
+critical for guiding appropriate management. Chest computed tomography typically 
+displays interlobular septal thickening, ground-glass opacities and mediastinal 
+lymphadenopathy. Life-threatening pulmonary oedema is a complication of 
+pulmonary vasodilator therapy that can occur with any class of PAH drugs in 
+PVOD. Early referral to a lung transplant centre is essential due to the poor 
+response to therapy when compared with other forms of PAH. Histopathological 
+analysis of lung explants reveals microvascular remodelling with typical fibrous 
+veno-occlusive lesions. This review covers the main features distinguishing PVOD 
+from PAH and two clinical cases that illustrate the challenges of PVOD 
+management.
+
+Copyright ©The authors 2024.
+
+DOI: 10.1183/16000617.0156-2023
+PMCID: PMC10792437
+PMID: 38232988 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of interest: B. Lechartier reports 
+travel support from Janssen and advisory board participation with MSD, outside 
+the submitted work. A. Boucly reports grants from Acceleron, Janssen and MSD; 
+lecture honoraria from Janssen, MSD, AOP Orphan and Ferrer; and travel support 
+from Janssen, MSD and Ferrer, outside the submitted work. D. Montani reports 
+grants from Acceleron, Janssen and MSD; consulting fees from Acceleron, Merck 
+MSD, Janssen and Ferrer; and lecture honoraria from Bayer, Janssen, Boehringer, 
+Chiesi, GSK, Ferrer and Merck MSD, outside the submitted work. All other authors 
+have nothing to disclose.

--- a/references_cache/PMID_38776952.md
+++ b/references_cache/PMID_38776952.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:38776952"
+title: Functional validation of EIF2AK4 (GCN2) missense variants associated with pulmonary arterial hypertension.
+authors:
+- Emanuelli G
+- Zhu J
+- Li W
+- Morrell NW
+- Marciniak SJ
+journal: Hum Mol Genet
+year: '2024'
+doi: 10.1093/hmg/ddae082
+keywords:
+- Humans
+- Protein Serine-Threonine Kinases/genetics
+- "Mutation, Missense/genetics"
+- Pulmonary Arterial Hypertension/genetics
+- Genetic Predisposition to Disease
+- "Hypertension, Pulmonary/genetics"
+- Computational Biology/methods
+content_type: abstract_only
+---
+
+# Functional validation of EIF2AK4 (GCN2) missense variants associated with pulmonary arterial hypertension.
+**Authors:** Emanuelli G, Zhu J, Li W, Morrell NW, Marciniak SJ
+**Journal:** Hum Mol Genet (2024)
+**DOI:** [10.1093/hmg/ddae082](https://doi.org/10.1093/hmg/ddae082)
+
+## Content
+
+1. Hum Mol Genet. 2024 Aug 18;33(17):1495-1505. doi: 10.1093/hmg/ddae082.
+
+Functional validation of EIF2AK4 (GCN2) missense variants associated with 
+pulmonary arterial hypertension.
+
+Emanuelli G(1), Zhu J(1), Li W(2)(3), Morrell NW(2)(3)(4), Marciniak 
+SJ(1)(3)(4).
+
+Author information:
+(1)Cambridge Institute for Medical Research (CIMR), University of Cambridge, 
+Keith Peters Building, Biomedical Campus, Hills Rd, Cambridge CB2 0XY, United 
+Kingdom.
+(2)Victor Phillip Dahdaleh Heart and Lung Research Institute, University of 
+Cambridge, Papworth Road, Trumpington, Cambridge CB2 0BB, United Kingdom.
+(3)Department of Medicine, University of Cambridge, Addenbrooke's Hospital (Box 
+157), Hills Road, Cambridge CB2 2QQ, United Kingdom.
+(4)Royal Papworth Hospital NHS Foundation Trust, Papworth Rd, Trumpington, 
+Cambridge CB2 0AY, United Kingdom.
+
+Pulmonary arterial hypertension (PAH) is a disorder with a large genetic 
+component. Biallelic mutations of EIF2AK4, which encodes the kinase GCN2, are 
+causal in two ultra-rare subtypes of PAH, pulmonary veno-occlusive disease and 
+pulmonary capillary haemangiomatosis. EIF2AK4 variants of unknown significance 
+have also been identified in patients with classical PAH, though their 
+relationship to disease remains unclear. To provide patients with diagnostic 
+information and enable family testing, the functional consequences of such rare 
+variants must be determined, but existing computational methods are imperfect. 
+We applied a suite of bioinformatic and experimental approaches to sixteen 
+EIF2AK4 variants that had been identified in patients. By experimentally testing 
+the functional integrity of the integrated stress response (ISR) downstream of 
+GCN2, we determined that existing computational tools have insufficient 
+sensitivity to reliably predict impaired kinase function. We determined 
+experimentally that several EIF2AK4 variants identified in patients with 
+classical PAH had preserved function and are therefore likely to be 
+non-pathogenic. The dysfunctional variants of GCN2 that we identified could be 
+subclassified into three groups: misfolded, kinase-dead, and hypomorphic. 
+Intriguingly, members of the hypomorphic group were amenable to paradoxical 
+activation by a type-1½ GCN2 kinase inhibitor. This experiment approach may aid 
+in the clinical stratification of EIF2AK4 variants and potentially identify 
+hypomorophic alleles receptive to pharmacological activation.
+
+© The Author(s) 2024. Published by Oxford University Press.
+
+DOI: 10.1093/hmg/ddae082
+PMCID: PMC11336063
+PMID: 38776952 [Indexed for MEDLINE]

--- a/references_cache/PMID_39269983.md
+++ b/references_cache/PMID_39269983.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:39269983"
+title: Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease.
+authors:
+- Prabhakar A
+- Wadhwa M
+- Kumar R
+- Ghatpande P
+- Gandjeva A
+- Tuder RM
+- Graham BB
+- Lagna G
+- Hata A
+journal: JCI Insight
+year: '2024'
+doi: 10.1172/jci.insight.181877
+keywords:
+- Animals
+- Rats
+- Pulmonary Veno-Occlusive Disease/pathology
+- Male
+- Protein Phosphatase 1/metabolism
+- eIF-2 Kinase/metabolism
+- "Disease Models, Animal"
+- Mitomycin/pharmacology
+- Eukaryotic Initiation Factor-2/metabolism
+- Vascular Remodeling/drug effects
+- Phosphorylation
+- Age Factors
+- Aging/pathology
+- "Hypertrophy, Right Ventricular/pathology, etiology"
+- Humans
+- "Rats, Sprague-Dawley"
+content_type: abstract_only
+---
+
+# Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease.
+**Authors:** Prabhakar A, Wadhwa M, Kumar R, Ghatpande P, Gandjeva A, Tuder RM, Graham BB, Lagna G, Hata A
+**Journal:** JCI Insight (2024)
+**DOI:** [10.1172/jci.insight.181877](https://doi.org/10.1172/jci.insight.181877)
+
+## Content
+
+1. JCI Insight. 2024 Sep 5;9(19):e181877. doi: 10.1172/jci.insight.181877.
+
+Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive 
+disease.
+
+Prabhakar A(1), Wadhwa M(2)(3), Kumar R(4), Ghatpande P(1), Gandjeva A(5), Tuder 
+RM(5), Graham BB(4), Lagna G(1), Hata A(1)(6).
+
+Author information:
+(1)Cardiovascular Research Institute.
+(2)Department of Anesthesia and Perioperative Care, and.
+(3)Department of Radiology, UCSF, San Francisco, California, USA.
+(4)Lung Biology Center, Pulmonary and Critical Care Medicine, Zuckerberg San 
+Francisco General Hospital, California, USA.
+(5)Department of Medicine, University of Colorado School of Medicine, Aurora, 
+Colorado, USA.
+(6)Department of Biochemistry and Biophysics, University of California, San 
+Francisco, San Francisco, California, USA.
+
+Pulmonary veno-occlusive disease (PVOD) is a rare but severe form of pulmonary 
+hypertension characterized by the obstruction of pulmonary arteries and veins, 
+causing increased pulmonary artery pressure and leading to right ventricular 
+(RV) heart failure. PVOD is often resistant to conventional pulmonary arterial 
+hypertension (PAH) treatments and has a poor prognosis, with a median survival 
+time of 2-3 years after diagnosis. We previously showed that the administration 
+of a chemotherapy agent mitomycin C (MMC) in rats mediates PVOD through the 
+activation of the eukaryotic initiation factor 2 (eIF2) kinase protein kinase R 
+(PKR) and the integrated stress response (ISR), resulting in the impairment of 
+vascular endothelial junctional structure and barrier function. Here, we 
+demonstrate that aged rats over 1 year exhibit more severe vascular remodeling 
+and RV hypertrophy than young adult rats following MMC treatment. This is 
+attributed to an age-associated elevation of basal ISR activity and depletion of 
+protein phosphatase 1, leading to prolonged eIF2 phosphorylation and sustained 
+ISR activation. Pharmacological blockade of PKR or ISR mitigates PVOD phenotypes 
+in both age groups, suggesting that targeting the PKR/ISR axis could be a 
+potential therapeutic strategy for PVOD.
+
+DOI: 10.1172/jci.insight.181877
+PMCID: PMC11466196
+PMID: 39269983 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of interest: The authors have declared 
+that no conflict of interest exists.

--- a/references_cache/PMID_40104258.md
+++ b/references_cache/PMID_40104258.md
@@ -1,0 +1,66 @@
+---
+reference_id: "PMID:40104258"
+title: "Pulmonary veno-occlusive disease: a clinical review."
+authors:
+- Deshwal H
+- Sarkar S
+- Basu A
+- Jalil BA
+journal: Breathe (Sheff)
+year: '2025'
+doi: 10.1183/20734735.0098-2024
+content_type: abstract_only
+---
+
+# Pulmonary veno-occlusive disease: a clinical review.
+**Authors:** Deshwal H, Sarkar S, Basu A, Jalil BA
+**Journal:** Breathe (Sheff) (2025)
+**DOI:** [10.1183/20734735.0098-2024](https://doi.org/10.1183/20734735.0098-2024)
+
+## Content
+
+1. Breathe (Sheff). 2025 Mar 18;21(1):240098. doi: 10.1183/20734735.0098-2024. 
+eCollection 2025 Jan.
+
+Pulmonary veno-occlusive disease: a clinical review.
+
+Deshwal H(1), Sarkar S(1), Basu A(2), Jalil BA(3).
+
+Author information:
+(1)Division of Pulmonary, Sleep and Critical Care Medicine, Department of 
+Medicine, West Virginia University School of Medicine, Morgantown, WV, USA.
+(2)Cardiothoracic and Surgical Pathology, Department of Anatomic Pathology, 
+Tufts Medical Center, Boston, MA, USA.
+(3)Heart and Vascular Institute, West Virginia University School of Medicine, 
+Morgantown, WV, USA.
+
+Pulmonary vasculopathy presents as a spectrum of diseases affecting the 
+precapillary pulmonary arterioles, the capillaries and the venules. Pulmonary 
+veno-occlusive disease (PVOD) is classified under group 1 pulmonary arterial 
+hypertension (PAH) as subgroup 1.5 (PAH with features of capillary/venous 
+involvement), and represents a progressive and fatal spectrum of pulmonary 
+vascular disorders. PVOD and pulmonary capillary haemangiomatosis (PCH) can be 
+clinically indistinguishable and often coexist, along with the same risk factors 
+and genetic alterations; they are referred to together as PVOD/PCH in the 
+literature. For brevity, we use the clinical term PVOD in this article. PVOD 
+cannot be distinguished from other forms of PAH based on symptoms and 
+haemodynamics. Risk factors include exposure to toxins/chemotherapeutic drugs 
+and genetic mutation in the EIF2AK4 gene. Radiographic features such as 
+mediastinal adenopathy, centrilobular ground-glass opacities, and interlobular 
+septal thickening, along with the presence of hypoxia and reduced diffusion 
+capacity of the lung may be required for a clinical diagnosis of PVOD, as lung 
+biopsy carries a high risk for bleeding. Characteristic histological findings 
+include narrowing/occlusion of small pulmonary veins. The development of 
+pulmonary oedema with pulmonary vasodilator therapy limits therapeutic options 
+for PVOD. With limited treatment options, lung transplantation remains the only 
+curative treatment.
+
+Copyright ©ERS 2025.
+
+DOI: 10.1183/20734735.0098-2024
+PMCID: PMC11915124
+PMID: 40104258
+
+Conflict of interest statement: Conflict of interest: H. Deshwal, S. Sarkar, A. 
+Basu and B.A. Jalil have no conflict of interest or financial disclosures to 
+declare for this manuscript.

--- a/references_cache/PMID_40471666.md
+++ b/references_cache/PMID_40471666.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:40471666"
+title: "Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension."
+authors:
+- Aguado B
+- Grynblat J
+- Budhram B
+- Ghigna MR
+- Boucly A
+- Antigny F
+- Jaïs X
+- Sitbon O
+- Savale L
+- Humbert M
+- Montani D
+journal: Curr Opin Pulm Med
+year: '2025'
+doi: 10.1097/MCP.0000000000001184
+keywords:
+- Humans
+- "Pulmonary Veno-Occlusive Disease/diagnosis, therapy, genetics"
+- "Hypertension, Pulmonary/diagnosis, therapy, etiology"
+- Lung Transplantation
+- Risk Factors
+- "Tomography, X-Ray Computed"
+- Mutation
+- Genetic Testing
+- Protein Serine-Threonine Kinases
+content_type: abstract_only
+---
+
+# Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic challenges in pulmonary hypertension.
+**Authors:** Aguado B, Grynblat J, Budhram B, Ghigna MR, Boucly A, Antigny F, Jaïs X, Sitbon O, Savale L, Humbert M, Montani D
+**Journal:** Curr Opin Pulm Med (2025)
+**DOI:** [10.1097/MCP.0000000000001184](https://doi.org/10.1097/MCP.0000000000001184)
+
+## Content
+
+1. Curr Opin Pulm Med. 2025 Sep 1;31(5):443-455. doi:
+10.1097/MCP.0000000000001184.  Epub 2025 Jun 5.
+
+Pulmonary veno-occlusive disease: a paradigm of diagnosis and therapeutic 
+challenges in pulmonary hypertension.
+
+Aguado B(1), Grynblat J(1)(2), Budhram B(1)(3), Ghigna MR(1)(4), Boucly A(1), 
+Antigny F(1), Jaïs X(1), Sitbon O(1), Savale L(1), Humbert M(1), Montani D(1).
+
+Author information:
+(1)Université Paris-Saclay, INSERM, UMR_S 999, Hypertension Pulmonaire: 
+Physiopathologie and Innovation Therapeutique (HPPIT); Assistance Publique 
+Hôpitaux de Paris, Hôpital Bicêtre, ERN-LUNG, FHU André Cournand, Le 
+Kremlin-Bicêtre.
+(2)M3C-Necker, Hôpital Necker-Enfants malades, AP-HP Université de Paris Cité, 
+Cardiologie Congénitale et Pédiatrique, Paris, France.
+(3)Division of Respirology, Department of Medicine, University of Calgary, 
+Calgary, Alberta, Canada.
+(4)Biopathology Department Gustave Roussy Cancer Campus, Villejuif, France.
+
+PURPOSE OF REVIEW: Pulmonary veno-occlusive disease (PVOD) is a rare and 
+life-threatening form of precapillary pulmonary hypertension. This review aims 
+to outline its genetic and environmental risk factors, highlight key diagnostic 
+challenges, and discuss current treatment options.
+RECENT FINDINGS: PVOD can occur sporadically or as a hereditary autosomal 
+recessive condition with biallelic eukaryotic translation initiation factor 2 
+alpha kinase 4 ( EIF2AK4) mutations, leading to nearly complete disease 
+penetrance. Known risk factors include specific drug/toxin and environmental 
+exposures, such as mitomycin C and trichloroethylene, respectively. PVOD is 
+characterized by progressive pulmonary venous and capillary remodelling, severe 
+hypoxemia, and right ventricular failure. Diagnosis remains difficult due to 
+overlapping features with pulmonary arterial hypertension (PAH), but 
+high-resolution computed tomography (HRCT) findings, low lung diffusion capacity 
+for carbon monoxide (DLCO), and genetic testing can aid differentiation. 
+Initiation of PAH-approved drugs in patients with PVOD requires careful 
+consideration due to limited evidence of long-term clinical benefits and the 
+high risk of developing pulmonary oedema in this population. Lung 
+transplantation remains the only curative treatment, with posttransplant 
+survival rates comparable to idiopathic PAH.
+SUMMARY: PVOD is a progressive and fatal disease requiring early recognition and 
+specific management. Due to its poor prognosis and lack of effective medical 
+therapies, early referral for lung transplantation is crucial. Advances in 
+genetic and molecular research may lead to novel treatment strategies.
+
+Copyright © 2025 Wolters Kluwer Health, Inc. All rights reserved.
+
+DOI: 10.1097/MCP.0000000000001184
+PMID: 40471666 [Indexed for MEDLINE]

--- a/references_cache/PMID_40983649.md
+++ b/references_cache/PMID_40983649.md
@@ -1,0 +1,100 @@
+---
+reference_id: "PMID:40983649"
+title: Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous arterialization.
+authors:
+- Zhang J
+- Mao P
+- Zhou T
+- Yue B
+- Li Y
+- Qiu Y
+- Ying K
+- Wang F
+- Chen J
+- Yang J
+journal: Nat Commun
+year: '2025'
+doi: 10.1038/s41467-025-64035-4
+keywords:
+- Animals
+- "Ferroptosis/genetics, drug effects"
+- Mice
+- Humans
+- Male
+- Macrophages/metabolism
+- "Pulmonary Veno-Occlusive Disease/genetics, metabolism, pathology"
+- Endothelial Cells/metabolism
+- Rats
+- "Pulmonary Veins/pathology, metabolism"
+- Female
+- Cyclohexylamines/pharmacology
+- "Disease Models, Animal"
+- "Mice, Inbred C57BL"
+- Heme Oxygenase-1/metabolism
+- Iron/metabolism
+- Phenylenediamines
+- Protein Serine-Threonine Kinases
+content_type: abstract_only
+---
+
+# Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous arterialization.
+**Authors:** Zhang J, Mao P, Zhou T, Yue B, Li Y, Qiu Y, Ying K, Wang F, Chen J, Yang J
+**Journal:** Nat Commun (2025)
+**DOI:** [10.1038/s41467-025-64035-4](https://doi.org/10.1038/s41467-025-64035-4)
+
+## Content
+
+1. Nat Commun. 2025 Sep 22;16(1):8335. doi: 10.1038/s41467-025-64035-4.
+
+Macrophage ferroptosis potentiates GCN2 deficiency induced pulmonary venous 
+arterialization.
+
+Zhang J(#)(1)(2), Mao P(#)(1)(2), Zhou T(#)(1)(2), Yue B(2)(3), Li Y(1)(2), Qiu 
+Y(4), Ying K(4), Wang F(5), Chen J(2)(3), Yang J(6)(7).
+
+Author information:
+(1)Department of Physiology and Department of Cardiology of the Second 
+Affiliated Hospital, Zhejiang University School of Medicine, Hangzhou, China.
+(2)State Key Laboratory of Transvascular Implantation Devices of the Second 
+Affiliated Hospital, Zhejiang University School of Medicine, Hangzhou, China.
+(3)Center for Lung Transplantation of the Second Affiliated Hospital, Zhejiang 
+University School of Medicine, Hangzhou, China.
+(4)Department of Pulmonary and Critical Care Medicine of Sir Run Run Shaw 
+Hospital, Zhejiang University School of Medicine, Hangzhou, China.
+(5)Department of Public Health of Zhejiang University School of Medicine, 
+Hangzhou, China.
+(6)Department of Physiology and Department of Cardiology of the Second 
+Affiliated Hospital, Zhejiang University School of Medicine, Hangzhou, China. 
+yang_jun@zju.edu.cn.
+(7)State Key Laboratory of Transvascular Implantation Devices of the Second 
+Affiliated Hospital, Zhejiang University School of Medicine, Hangzhou, China. 
+yang_jun@zju.edu.cn.
+(#)Contributed equally
+
+Pulmonary veno-occlusive disease (PVOD) is a fatal disease characterized by the 
+remodelling of pulmonary veins and haemosiderin accumulation in macrophages. 
+Although (General Control Nonderepressible 2) GCN2 deficiency has been reported 
+in PVOD patients, the underlying mechanism by which GCN2 deficiency affects the 
+pulmonary venous cells and the surrounding cells, remains unclear. Here, we 
+perform immunohistochemistry and scRNA-sequencing analyses to show that 
+macrophages are the major population affected by GCN2 deficiency and ferroptosis 
+pathway-related genes are upregulated in lung macrophages of PVOD patients. 
+Treatment with the specific ferroptosis inhibitor ferrostatin-1 (Fer-1) reverses 
+the changes in haemodynamic indices observed in Eif2ak4K1488X/K1488X hypoxia 
+mice and PVOD model rats. Furthermore, GCN2 deficiency increases HMOX1 and iron 
+levels to facilitate ferroptosis in macrophages, and enhances arterial marker 
+expression in venous endothelial cells (VECs). Specifically, spatial 
+transcriptome analysis shows increased expression of NRP1, KDR and EFNB2 through 
+ETS1 in VECs from PVOD patients. Our findings suggest the potential of targeting 
+macrophage ferroptosis as a therapeutic strategy for treating related vascular 
+diseases, and of using NRP1/KDR/EFNB2 expression as a specific marker set for 
+venous arterialization.
+
+© 2025. The Author(s).
+
+DOI: 10.1038/s41467-025-64035-4
+PMCID: PMC12454641
+PMID: 40983649 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: The authors declare no 
+competing interests.

--- a/references_cache/clinicaltrials_NCT03902353.md
+++ b/references_cache/clinicaltrials_NCT03902353.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT03902353
+title: Screening of Pulmonary Veino Occlusive Disease in Heterozygous EIF2AK4 Mutation Carriers
+content_type: summary
+---
+
+# Screening of Pulmonary Veino Occlusive Disease in Heterozygous EIF2AK4 Mutation Carriers
+
+## Content
+
+Pulmonary Veino Occlusive Disease (PVOD) is a rare form of pulmonary arterial hypertension, characterised by a poor prognosis. Recent studies demonstrated that heritable form of pulmonary veino occlusive diseaseis due to bi-allelic mutations in EIF2AK4 gene. heritable pulmonary veino occlusive disease is an autosomal recessive disease. In the french referal center of severe PH, ulmonary veino occlusive disease patients carriers of bi-allelic mutations in EIF2AK4 gene were identified. Genetic counselling in these families allowed to identified herozygous carriers of a single mutation in EIF2AK4 gene. However, to date, nothing is known about the risk of these persons of developping pulmonary diseases. It appears essential to determine the clinical, functional, echocardiographic and radiologics characteristics of these persons, and their risk of developping Pulmonary veino occlusive disease

--- a/research/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
+++ b/research/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md
@@ -1,0 +1,1324 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T13:28:51.734367'
+end_time: '2026-05-06T13:49:08.544779'
+duration_seconds: 1216.82
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis
+  mondo_id: ''
+  category: Cardiovascular Disorder
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 40
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis
+- **MONDO ID:**  (if available)
+- **Category:** Cardiovascular Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis
+- **MONDO ID:**  (if available)
+- **Category:** Cardiovascular Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Comprehensive Disease Characteristics Report: Pulmonary Veno-Occlusive Disease (PVOD) and Pulmonary Capillary Haemangiomatosis (PCH)
+
+**Target disease:** Pulmonary veno-occlusive disease and/or pulmonary capillary haemangiomatosis (PVOD/PCH)
+**Category:** Cardiovascular disorder → pulmonary vascular disease (pulmonary hypertension)
+**Evidence note:** The retrieved corpus contains strong peer‑reviewed clinical reviews and primary mechanistic/genetic studies, but it did **not** include OMIM/Orphanet/ICD/MeSH/MONDO identifier pages; therefore, identifier fields are flagged as **not available from current retrieved sources**.
+
+| Domain | Key facts (concise) | Quantitative data | Evidence/source (author year + URL) | Citation id(s) |
+|---|---|---|---|---|
+| Identifiers / classification / synonyms | PVOD and PCH are now generally treated as a spectrum of **PAH with overt venous/capillary involvement**; reviews note they are often clinically indistinguishable and commonly grouped as **PVOD/PCH**. PVOD is a rare cause of precapillary pulmonary hypertension with fibrotic obstruction of small pulmonary veins/venules; PCH reflects prominent capillary congestion/proliferation. | Classified within Group 1 PAH; recent reviews describe subgroup **1.5** / “PAH with features of venous/capillary involvement.” | Lechartier et al. 2024, European Respiratory Review. https://doi.org/10.1183/16000617.0156-2023; Deshwal et al. 2025, Breathe. https://doi.org/10.1183/20734735.0098-2024 | (lechartier2024pulmonaryvenoocclusivedisease pages 1-2, deshwal2025pulmonaryvenoocclusivedisease pages 1-2, deshwal2025pulmonaryvenoocclusivedisease pages 2-3) |
+| Epidemiology | PVOD/PCH is ultra-rare and likely under-recognized; cases are often initially labeled as PAH. Affected patients can present from childhood to late adulthood, but heritable cases tend to be younger. | Incidence **0.1–0.5 per million/year**; prevalence **1–2 per million** (or **1–2 per 10 million** in one 2024 case report). Some reviews estimate **5–25%** of patients labeled PAH may have PVOD features. | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023; Deshwal et al. 2025. https://doi.org/10.1183/20734735.0098-2024; Stener & Tsareva 2024. https://doi.org/10.18093/0869-0189-2024-34-4-595-598 | (lechartier2024pulmonaryvenoocclusivedisease pages 1-2, deshwal2025pulmonaryvenoocclusivedisease pages 1-2) |
+| Prognosis | Natural history is poor, with rapid progression to right-heart failure and frequent need for lung transplantation. Outcomes are generally worse than idiopathic PAH. | **1-year mortality ~72%**; mean time from diagnosis to death or transplant **11.8 months**; mean time from first symptoms to death/transplant **24.4 months**; median survival often cited as **2–3 years** after diagnosis. | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023; Prabhakar et al. 2024. https://doi.org/10.1172/jci.insight.181877 | (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, prabhakar2024mechanismsunderlyingageassociated pages 1-2) |
+| Diagnostic clues: CT / physiology / hemodynamics | Noninvasive diagnosis relies on a characteristic **HRCT triad** plus severe gas-exchange impairment and precapillary PH. Typical clues are **centrilobular ground-glass opacities**, **smooth interlobular septal thickening**, and **mediastinal lymphadenopathy**; many patients also have marked hypoxemia and very low DLCO. | Suggested confirmatory pattern in one review: at least **2 HRCT features**, **PaO2 <70 mmHg**, **DLCO <55% predicted**. RHC shows precapillary PH: **mPAP >20 mmHg**, **PAWP/PCWP ≤15 mmHg**, **PVR >2 WU**. Markedly reduced DLCO often **<40%** in some series. | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023; Deshwal et al. 2025. https://doi.org/10.1183/20734735.0098-2024; Foster et al. 2025. https://doi.org/10.3390/arm93060048 | (lechartier2024pulmonaryvenoocclusivedisease pages 2-3, lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 8-9, deshwal2025pulmonaryvenoocclusivedisease pages 7-8, foster2025pulmonaryvenoocclusivedisease pages 4-6) |
+| Diagnostic workflow / procedures to avoid | Lung biopsy is the histologic gold standard but is generally **not recommended** in routine suspected PVOD/PCH because of bleeding/perioperative risk in pulmonary hypertension. Diagnosis is instead based on clinical-radiologic-genetic synthesis. Development of pulmonary edema after vasodilator exposure is a major diagnostic red flag. | 2022 ESC/ERS recommendation table states diagnosis should rely on **clinical + radiological findings** and that **lung biopsy is not recommended**. | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023 | (lechartier2024pulmonaryvenoocclusivedisease pages 5-6, lechartier2024pulmonaryvenoocclusivedisease media a49a6475) |
+| Causal gene / inheritance | **EIF2AK4 (GCN2)** is the established causal gene for heritable PVOD/PCH. Disease is caused by **biallelic** pathogenic variants, typically autosomal recessive / compound heterozygous or homozygous. Detection of biallelic pathogenic EIF2AK4 variants can establish diagnosis without histology. | Biallelic EIF2AK4 variants reported in **all 13 familial** PVOD cases and **5/20 (25%)** sporadic cases in foundational series; another review cites **9% (7/81)** in suspected sporadic cases. EIF2AK4 carriers present younger: median **26 vs 60 years**. | Park et al. 2023. https://doi.org/10.1159/000527524; Emanuelli et al. 2024. https://doi.org/10.17863/cam.108223; Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023 | (park2023differentialdiagnosisof pages 2-3, park2023differentialdiagnosisof pages 1-2, emanuelli2024functionalvalidationof pages 3-5, lechartier2024pulmonaryvenoocclusivedisease pages 2-3, lechartier2024pulmonaryvenoocclusivedisease pages 1-2) |
+| Variant examples / molecular data | Reported pathogenic EIF2AK4 examples include truncating, splice, missense, and frameshift alleles. Park 2023 identified two novel compound-heterozygous variants; Emanuelli 2024 functionally classified multiple missense variants and showed not all rare missense alleles are pathogenic. | Park 2023: **NM_001013703.3:c.2137_2138dup (p.Ser714Leufs*78)** and **c.3358-1G>A**, both absent from **gnomAD**. Emanuelli 2024: pathogenic/likely pathogenic examples include **p.R585Q, p.G599R, p.V607G, p.L643R, p.S909R, p.G1109R, p.P1115L, p.H1202L, p.L1295R**; common polymorphisms include **p.I441L, p.E556G, p.G1306C**. | Park et al. 2023. https://doi.org/10.1159/000527524; Emanuelli et al. 2024. https://doi.org/10.17863/cam.108223 | (park2023differentialdiagnosisof pages 2-3, park2023differentialdiagnosisof pages 1-2, emanuelli2024functionalvalidationof pages 1-3, emanuelli2024functionalvalidationof pages 3-5) |
+| Environmental / occupational risk factors | Strongest reported non-genetic associations are **organic solvents** (especially **trichloroethylene**) and **chemotherapy**, particularly alkylating agents such as **mitomycin C**, cyclophosphamide, and cisplatin. Tobacco may be additive with solvent exposure. | Organic solvents: adjusted OR **12.8**; trichloroethylene exposure in **42% of PVOD vs 3% of PAH**, adjusted OR **8.2**. Chemotherapy-associated PVOD in anal-cancer cohort estimated at **3.9/1000 patient-years** vs idiopathic PVOD **0.5/million/year**. | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023; Deshwal et al. 2025. https://doi.org/10.1183/20734735.0098-2024 | (lechartier2024pulmonaryvenoocclusivedisease pages 2-3, deshwal2025pulmonaryvenoocclusivedisease pages 2-3) |
+| Mechanistic highlights | Pathobiology centers on venular/capillary remodeling with endothelial injury and stress-response dysfunction. Recent work implicates **EIF2AK4/GCN2**, **PKR**, and the **integrated stress response (ISR)**, with endothelial barrier failure (VE-cadherin/Rad51 disruption), inflammation, and age-related amplification. | Aging increased endothelial ISR markers in rat lungs: p-PKR **2.7-fold**, total PKR **1.6-fold**, p-eIF2α **1.8-fold**, ATF4 **2.3-fold**. In MMC model, RVSP rose from **25.0→34.1 mmHg** (young) and **24.4→34.6 mmHg** (aged); RV/LV+S from **0.21→0.31** and **0.21→0.34**. | Prabhakar et al. 2024. https://doi.org/10.1172/jci.insight.181877; Bignard et al. 2023. https://doi.org/10.1152/ajplung.00460.2021 | (prabhakar2024mechanismsunderlyingageassociated pages 1-2, prabhakar2024mechanismsunderlyingageassociated pages 2-4, bignard2023tcelldysregulationand pages 1-5, bignard2023tcelldysregulationand pages 16-19) |
+| Management recommendations | Management emphasizes **early referral to PH/transplant expert centers**, oxygen and diuretics, cautious rehabilitation/immunization, and genetic counseling/testing. **Bilateral lung transplantation** is the only established curative therapy. Routine anticoagulation is generally not recommended unless another indication exists. | Post-transplant survival reported as similar to PAH in review summaries; one study cited higher pre-transplant mortality in PVOD (**22.6% vs 11% at 6 months**). | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023; Deshwal et al. 2025. https://doi.org/10.1183/20734735.0098-2024; Foster et al. 2025. https://doi.org/10.3390/arm93060048 | (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 8-9, deshwal2025pulmonaryvenoocclusivedisease pages 9-10, foster2025pulmonaryvenoocclusivedisease pages 10-12, lechartier2024pulmonaryvenoocclusivedisease pages 1-2) |
+| PAH-targeted therapy and pulmonary edema risk | PAH drugs may occasionally be used cautiously as a **bridge to transplant**, but evidence is limited and pulmonary edema risk is the central limitation. Reviews emphasize careful monitoring of symptoms and gas exchange if vasodilators are tried. | Large cohort/review estimates: drug-induced pulmonary edema in **>20%** of treated patients; systematic review found edema in about **30/64** patients; older series reported edema in **20–50%** with PAH therapy and about **70%** with CCBs. One epoprostenol bridge series had **1/12** mild edema, with **9/12** transplanted. | Lechartier et al. 2024. https://doi.org/10.1183/16000617.0156-2023; Deshwal et al. 2025. https://doi.org/10.1183/20734735.0098-2024 | (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 9-10, lechartier2024pulmonaryvenoocclusivedisease pages 5-6) |
+| Current real-world studies / implementation | Active real-world efforts include registries and targeted screening of **EIF2AK4 carriers**. These studies operationalize surveillance with CT, DLCO, echo, CPET, and genomics to define penetrance and natural history. | **NCT03902353** screens **20** heterozygous EIF2AK4 carriers; **NCT03169010** is a rare-PH registry with target enrollment **2000** including PVOD/PCH; **NCT01907295** UK cohort enrolls PAH/PVOD/PCH cases and relatives with deep phenotyping and sequencing. | ClinicalTrials.gov: NCT03902353; NCT03169010; NCT01907295 | (NCT03902353 chunk 1, NCT03169010 chunk 1, NCT01907295 chunk 1) |
+
+
+*Table: This table condenses the highest-yield disease characteristics for PVOD/PCH from the gathered evidence, including classification, epidemiology, diagnostics, genetics, risk factors, mechanisms, and management. It is designed as a database-ready summary with quantitative findings and direct context citations.*
+
+---
+
+## 1. Disease Information
+
+### 1.1 Concise overview
+PVOD is an ultra‑rare pulmonary microvascular vasculopathy characterized by fibrotic obstruction/obliteration of small pulmonary veins and venules, producing **pre‑capillary pulmonary hypertension**, severe gas‑exchange impairment, and progressive right‑heart failure. PCH (pulmonary capillary haemangiomatosis) is characterized by prominent pulmonary capillary congestion/proliferation and is widely regarded as part of the same clinicopathologic spectrum as PVOD; the entities often coexist and are frequently grouped as **PVOD/PCH**. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 2-3)
+
+A recent authoritative ERS review explicitly frames PVOD as “pulmonary arterial hypertension (PAH) with overt features of venous/capillary involvement” and stresses that distinguishing PVOD from idiopathic PAH is critical because of **poor response and risk of life‑threatening pulmonary edema with PAH vasodilators**. (lechartier2024pulmonaryvenoocclusivedisease pages 1-2, lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+
+**Direct abstract quotes (for definition/importance):**
+- Lechartier et al. (Jan 2024) state PVOD is “a rare cause of PAH characterised by substantial small pulmonary vein and capillary involvement, leading to increased pulmonary vascular resistance and right ventricular failure.” (Published 2024‑01; https://doi.org/10.1183/16000617.0156-2023) (lechartier2024pulmonaryvenoocclusivedisease pages 1-2)
+- Deshwal et al. (Jan 2025) describe PVOD as “a progressive and fatal spectrum of pulmonary vascular disorders” and note PVOD and PCH “can be clinically indistinguishable and often coexist… referred to together as PVOD/PCH.” (Published 2025‑01; https://doi.org/10.1183/20734735.0098-2024) (deshwal2025pulmonaryvenoocclusivedisease pages 1-2)
+
+### 1.2 Key identifiers (availability)
+Not available in the retrieved full‑text evidence for this run:
+- **MONDO ID:** not retrieved
+- **OMIM / Orphanet / ICD‑10 / ICD‑11 / MeSH IDs:** not retrieved
+
+### 1.3 Common synonyms / alternative names (from literature)
+- “PAH with features of venous/capillary involvement” (classification term used in ESC/ERS context) (lechartier2024pulmonaryvenoocclusivedisease pages 1-2, lechartier2024pulmonaryvenoocclusivedisease pages 5-6)
+- “PVOD/PCH” (combined term used in multiple reviews) (deshwal2025pulmonaryvenoocclusivedisease pages 1-2, deshwal2025pulmonaryvenoocclusivedisease pages 2-3)
+
+### 1.4 Evidence source type
+- Aggregated disease‑level resources: ERS/European Respiratory Review and Breathe clinical reviews (lechartier2024pulmonaryvenoocclusivedisease pages 1-2, deshwal2025pulmonaryvenoocclusivedisease pages 1-2)
+- Individual patient evidence: genetic case report with compound heterozygous EIF2AK4 variants (park2023differentialdiagnosisof pages 2-3)
+- Experimental/model organism evidence: rat and mouse mechanistic models (mitomycin C; amino‑acid deprivation) including RNA‑seq/scRNA‑seq (bignard2023tcelldysregulationand pages 1-5, prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+**Genetic (causal): EIF2AK4 (GCN2) biallelic pathogenic variants** cause heritable PVOD/PCH. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3, emanuelli2024functionalvalidationof pages 3-5)
+
+**Direct abstract quote (genetic causality):**
+- Emanuelli et al. (Apr 2024) state: “Biallelic mutations of EIF2AK4… are causal in… pulmonary veno-occlusive disease and pulmonary capillary haemangiomatosis.” (Published 2024‑04; https://doi.org/10.17863/cam.108223) (emanuelli2024functionalvalidationof pages 1-3)
+
+**Environmental/iatrogenic:** Epidemiologic associations include occupational exposure to organic solvents (notably trichloroethylene) and chemotherapy (notably **mitomycin C** and other alkylating agents). (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+### 2.2 Risk factors (with quantitative data)
+- **Occupational organic solvents / trichloroethylene:** Lechartier et al. report strong association; trichloroethylene exposure occurred in **42% of PVOD vs 3% of PAH** with adjusted OR **8.2**, and organic solvents overall had adjusted OR **12.8**. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+- **Chemotherapy (alkylating agents):** Mitomycin C (MMC), cyclophosphamide, cisplatin are repeatedly associated; MMC has experimental support for endothelial toxicity and PVOD induction in rats. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+- **Tobacco:** Tobacco co‑exposure is common and may be additive with solvent exposure, with permeability effects. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+The 2024 ERS review links solvent exposure (trichloroethylene), tobacco, and chemotherapy to **endothelial permeability/barrier injury**, and separately identifies EIF2AK4 (GCN2) as a stress‑response kinase—supporting a convergent model in which genetically reduced stress‑response capacity and/or environmentally induced endothelial injury contribute to PVOD/PCH pathogenesis. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotypes (with suggested HPO terms)
+PVOD/PCH cannot be reliably distinguished from idiopathic PAH on symptoms or routine hemodynamics alone; diagnostic suspicion rests on gas‑exchange impairment and imaging patterns. (deshwal2025pulmonaryvenoocclusivedisease pages 1-2, lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+
+**Symptoms/signs**
+- Progressive exertional dyspnea → **Dyspnea (HP:0002094)** (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+- Hypoxemia (often disproportionate) → **Hypoxemia (HP:0012418)**; severe resting hypoxemia highlighted as a red flag (foster2025pulmonaryvenoocclusivedisease pages 4-6)
+- Right‑heart failure manifestations (peripheral edema, hepatomegaly, ascites) → **Peripheral edema (HP:0000969)**; **Hepatomegaly (HP:0002240)**; **Ascites (HP:0001541)** (foster2025pulmonaryvenoocclusivedisease pages 4-6)
+
+**Pulmonary function / lab abnormalities**
+- Markedly reduced diffusion capacity → **Decreased DLCO (HP:0045051)** (threshold examples below) (deshwal2025pulmonaryvenoocclusivedisease pages 8-9)
+
+**Radiology/pathology manifestations**
+- HRCT: centrilobular ground‑glass opacities → **Ground-glass opacity on pulmonary imaging (HP:0031969)**
+- Smooth interlobular septal thickening → **Interlobular septal thickening (HP:0031944)**
+- Mediastinal lymphadenopathy → **Mediastinal lymphadenopathy (HP:0030111)** (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 8-9)
+
+### 3.2 Phenotype characteristics (age, severity, progression)
+- Age of onset: heritable EIF2AK4‑associated cases present younger (median **26** vs **60** years in one series) (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+- Course: rapid progression with poor prognosis; median survival often cited as **2–3 years after diagnosis** (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+
+### 3.3 Frequencies / quantitative thresholds reported
+- Suggested clinical criteria in one review include **PaO2 <70 mmHg** and **DLCO <55% predicted** along with ≥2 HRCT features. (deshwal2025pulmonaryvenoocclusivedisease pages 8-9)
+- Another review notes DLCO often “below **40% predicted**” and mean ≈35% in studies. (foster2025pulmonaryvenoocclusivedisease pages 4-6)
+
+### 3.4 Quality-of-life impact
+No disease‑specific QoL instrument results (e.g., SF‑36/EQ‑5D) were identified in the retrieved evidence; functional limitation is implied by severe dyspnea, hypoxemia, and CPET impairment. (deshwal2025pulmonaryvenoocclusivedisease pages 7-8)
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes
+- **EIF2AK4 (GCN2)**: biallelic pathogenic variants are causal for PVOD/PCH and can establish diagnosis without histology. (emanuelli2024functionalvalidationof pages 3-5, emanuelli2024functionalvalidationof pages 1-3)
+
+### 4.2 Pathogenic variant examples (HGVS where available)
+**Case‑level PVOD/PCH genetic diagnosis (whole‑exome sequencing):**
+- Park et al. 2023 reported **compound heterozygous** EIF2AK4 variants: **NM_001013703.3:c.2137_2138dup (p.Ser714Leufs*78)** and **c.3358-1G>A**, both described as absent from gnomAD; parental segregation supported biallelic inheritance. (Published 2023‑02; https://doi.org/10.1159/000527524) (park2023differentialdiagnosisof pages 2-3)
+
+**Variant spectrum and functional interpretation (2024):**
+Emanuelli et al. 2024 list pathogenic/likely pathogenic EIF2AK4 missense examples (protein notation) including **p.R585Q, p.G599R, p.V607G, p.L643R, p.S909R, p.G1109R, p.P1115L, p.H1202L, p.L1295R** and also note that some alleles represent common polymorphisms (e.g., **I441L, E556G, G1306C**), highlighting the need for functional validation of VUS. (emanuelli2024functionalvalidationof pages 1-3)
+
+**Direct quote (diagnostic impact of biallelic EIF2AK4):**
+- Emanuelli et al. 2024: “Detection of biallelic pathogenic EIF2AK4 mutations establishes the diagnosis of PVOD or PCH without the need for histological confirmation.” (emanuelli2024functionalvalidationof pages 3-5)
+
+### 4.3 Inheritance
+Autosomal recessive/biallelic inheritance is supported by:
+- Parent‑of‑origin segregation consistent with compound heterozygosity (Park 2023) (park2023differentialdiagnosisof pages 2-3)
+- Statement that PVOD due to EIF2AK4 is a “recessive form of pulmonary hypertension” (park2023differentialdiagnosisof pages 4-4)
+
+### 4.4 Modifier genes / epigenetics / chromosomal abnormalities
+Not identified in the retrieved evidence.
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Environmental factors
+- Organic solvents, especially **trichloroethylene** (occupational exposure) (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+### 5.2 Lifestyle factors
+- Tobacco exposure is commonly reported and may act cumulatively with solvent exposure, potentially via permeability effects. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+### 5.3 Infectious agents
+No specific infectious etiologies were identified in the retrieved evidence.
+
+---
+
+## 6. Mechanism / Pathophysiology (with causal chains and ontology suggestions)
+
+### 6.1 Pathologic substrate (vascular remodeling)
+PVOD is defined pathologically by diffuse fibrous thickening/obliteration of septal veins and pre‑septal venules, with characteristic involvement of small venules (<100 µm). PCH is part of the same spectrum with capillary congestion/proliferation. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+
+**Causal chain (high‑level):**
+Trigger(s) (biallelic EIF2AK4 loss and/or endothelial toxic exposures such as MMC/solvents) → endothelial stress response/barrier dysfunction → increased permeability, microvascular remodeling and venular obstruction → increased pulmonary vascular resistance → pre‑capillary PH → RV hypertrophy/failure and hypoxemia due to impaired gas exchange. (prabhakar2024mechanismsunderlyingageassociated pages 2-4, lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+### 6.2 Integrated stress response (ISR) and PKR/PP1 axis (recent 2023–2024 developments)
+A key 2024 mechanistic study reports that MMC induces PVOD‑like disease in rats via activation of **PKR** and the **integrated stress response (ISR)**, with sustained **eIF2α phosphorylation** due to reduced **protein phosphatase 1 (PP1)**, leading to endothelial junction disruption and barrier dysfunction. (prabhakar2024mechanismsunderlyingageassociated pages 1-2, prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+
+Quantitative findings in the MMC rat model include increased RV systolic pressure and RV hypertrophy after MMC, with greater severity in aged animals; pharmacologic PKR or ISR blockade mitigated PVOD phenotypes. (prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+
+**Direct abstract quote (2024):**
+- Prabhakar et al. 2024: “We previously showed that… mitomycin C (MMC) in rats mediates PVOD through the activation of… protein kinase R (PKR) and the integrated stress response (ISR), resulting in the impairment of vascular endothelial junctional structure and barrier function.” (Published 2024‑09; https://doi.org/10.1172/jci.insight.181877) (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+
+**GO term suggestions (processes):**
+- Integrated stress response → **GO:0140749 (integrated stress response)** (conceptually aligned with eIF2α‑ATF4 pathway described) (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+- Regulation of endothelial barrier / permeability → **GO:0035633 (maintenance of barrier function)** (conceptual) (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+- Vascular remodeling/fibrosis → **GO:0001525 (angiogenesis)**; **GO:0045766 (positive regulation of angiogenesis)** (supported by angiogenesis mentions and remodeling) (bignard2023tcelldysregulationand pages 16-19)
+
+**Cell Ontology (CL) suggestions (cell types implicated):**
+- Pulmonary vascular endothelial cells → **Endothelial cell (CL:0000115)**, supported by CD31+ endothelial localization of ISR markers (prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+- T cells (LAG3+ and proliferative populations) → **T cell (CL:0000084)**; regulatory/exhausted‑like subsets conceptually consistent with LAG3+ population (bignard2023tcelldysregulationand pages 1-5)
+- Neutrophils → **Neutrophil (CL:0000775)** (bignard2023tcelldysregulationand pages 1-5)
+- Macrophages/mononuclear phagocytes involved in inflammation signals (supported by infiltration language) → **Macrophage (CL:0000235)** (bignard2023tcelldysregulationand pages 1-5)
+
+### 6.3 Immune dysregulation in EIF2AK4/GCN2 deficiency (2023)
+In a 2023 rat model, Gcn2 (Eif2ak4) deficiency did not spontaneously cause PVOD but produced immune dysregulation and inflammatory signatures under metabolic stress (asparaginase‑induced amino‑acid deprivation), including expansion of specific T‑cell populations at baseline and neutrophil infiltration plus innate immune gene upregulation after stress; scRNA‑seq and RNA‑seq were used. (bignard2023tcelldysregulationand pages 1-5)
+
+**Direct abstract quote (2023):**
+- Bignard et al. 2023: “Hereditary pulmonary veno-occlusive disease… is… due to biallelic loss-of-function of the EIF2AK4 gene… Lung mRNAS were analyzed by RNASeq and single cell RNASeq (scRNA-seq)… Under basal conditions, scRNA-seq analysis… revealed increases in two T cell populations…” (Published 2023‑05; https://doi.org/10.1152/ajplung.00460.2021) (bignard2023tcelldysregulationand pages 1-5)
+
+### 6.4 Anatomical localization (UBERON suggestions)
+- Lung (primary) → **lung (UBERON:0002048)**
+- Pulmonary venules/small pulmonary veins (microvasculature) → **pulmonary vein (UBERON:0002017)** (approximate macro term; microvenules not explicitly mapped in retrieved evidence)
+- Right ventricle (secondary) → **right ventricle (UBERON:0002080)** (supported by RV hypertrophy/failure) (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ level
+- Primary: lung microvasculature (pulmonary venules/veins and capillary bed) (lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+- Secondary: right ventricle/right heart due to increased pulmonary vascular resistance (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+
+### 7.2 Tissue/cell level
+- Vascular endothelium (CD31+ endothelial cells implicated in ISR signaling) (prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+- Perivascular inflammatory infiltrates (T cells and neutrophils highlighted in Gcn2 deficiency models) (bignard2023tcelldysregulationand pages 1-5)
+
+### 7.3 Subcellular level (GO cellular component suggestions)
+Not directly specified in retrieved evidence; however, ISR signaling implies involvement of cytosolic translation machinery and stress‑kinase signaling complexes.
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset
+- Broad: children/young adults to older ages; EIF2AK4 carriers present younger (median 26 vs 60 years in one series). (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+### 8.2 Progression / stages
+PVOD/PCH is described as rapidly progressive with poor prognosis; quantitative endpoints reported include time from diagnosis to death/transplant and 1‑year mortality. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology
+- Incidence ~0.1–0.5 per million/year; prevalence ~1–2 per million (rare). (lechartier2024pulmonaryvenoocclusivedisease pages 1-2)
+
+### 9.2 Inheritance
+- EIF2AK4‑associated PVOD/PCH is recessive/biallelic (compound heterozygous or homozygous), supported by segregation in Park 2023 and explicit “recessive form” statement. (park2023differentialdiagnosisof pages 2-3, park2023differentialdiagnosisof pages 4-4)
+
+### 9.3 Demographics
+- In one cohort description, EIF2AK4 carriers had a near‑equal sex ratio and younger age. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical tests and biomarkers
+**Hemodynamics (gold standard for PH diagnosis):** pre‑capillary PH with mPAP >20 mmHg, PAWP/PCWP ≤15 mmHg, PVR >2 WU. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3, deshwal2025pulmonaryvenoocclusivedisease pages 8-9)
+
+**Pulmonary function:** reduced DLCO is a key clue (e.g., <55% predicted in one suggested clinical pattern). (deshwal2025pulmonaryvenoocclusivedisease pages 8-9)
+
+### 10.2 Imaging
+**HRCT diagnostic triad:** centrilobular ground‑glass opacities + smooth interlobular septal thickening + mediastinal lymphadenopathy; parenchymal changes may precede overt PH. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+
+### 10.3 Genetic testing
+Genetic testing for **EIF2AK4** is recommended in suggestive cases; biallelic pathogenic variants can confirm heritable PVOD/PCH without histology. (lechartier2024pulmonaryvenoocclusivedisease pages 5-6, emanuelli2024functionalvalidationof pages 3-5)
+
+### 10.4 Biopsy and procedure risk
+ESC/ERS‑referenced guidance emphasizes clinical‑radiologic diagnosis and recommends against lung biopsy for confirmation. (lechartier2024pulmonaryvenoocclusivedisease pages 5-6, lechartier2024pulmonaryvenoocclusivedisease media a49a6475)
+
+### 10.5 Differential diagnosis
+Differential diagnoses include idiopathic PAH, ILD‑associated PH, and CTEPH (with V/Q scanning as key screen for CTEPH). (foster2025pulmonaryvenoocclusivedisease pages 10-12, deshwal2025pulmonaryvenoocclusivedisease pages 7-8)
+
+---
+
+## 11. Outcome / Prognosis
+
+PVOD/PCH carries a very poor prognosis:
+- 1‑year mortality ~72% and mean time from diagnosis to death/transplant 11.8 months (lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+- Median survival often reported as 2–3 years after diagnosis (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+
+A major adverse management outcome is **pulmonary edema precipitated by PAH vasodilators**, reported as >20% in a cohort and ~30/64 in a systematic review summarized in a clinical review. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 9-10)
+
+---
+
+## 12. Treatment
+
+### 12.1 Supportive care (real‑world standard)
+- Supplemental oxygen and diuretics are commonly recommended supportive measures. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+- Routine anticoagulation is not recommended unless another indication exists. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, foster2025pulmonaryvenoocclusivedisease pages 10-12)
+
+**MAXO suggestions:**
+- Oxygen therapy → **MAXO:0000861 (oxygen therapy)** (conceptual)
+- Diuretic therapy → **MAXO:0000930 (diuretic therapy)** (conceptual)
+
+### 12.2 PAH‑targeted therapies (caution)
+PAH‑approved drugs “may be considered with careful monitoring of clinical symptoms and gas exchange” in guideline‑summarized recommendations, reflecting risk–benefit uncertainty; pulmonary edema can occur with any PAH drug class and can be life‑threatening. (lechartier2024pulmonaryvenoocclusivedisease pages 5-6, lechartier2024pulmonaryvenoocclusivedisease pages 3-5)
+
+- Pulmonary edema incidence: >20% in a large cohort summary; systematic review summary indicates ~30/64 with edema; older series suggest 20–50% with PAH therapies and ~70% with calcium channel blockers. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, deshwal2025pulmonaryvenoocclusivedisease pages 9-10)
+
+**MAXO suggestions:**
+- Pulmonary vasodilator therapy → **MAXO:0001298 (vasodilator therapy)** (conceptual)
+
+### 12.3 Definitive therapy
+**Bilateral lung transplantation** is consistently described as the definitive/curative option; early referral to a transplant center is emphasized due to rapid progression. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, lechartier2024pulmonaryvenoocclusivedisease pages 1-2)
+
+**MAXO suggestion:**
+- Lung transplantation → **MAXO:0000602 (lung transplantation)** (conceptual)
+
+### 12.4 Emerging/experimental (mechanism‑based)
+Recent mechanistic work suggests that pharmacologic blockade of PKR/ISR pathways can mitigate disease phenotypes in MMC models, supporting investigational therapeutic directions; this is preclinical/experimental. (prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+
+---
+
+## 13. Prevention
+
+No established primary prevention strategies were identified in the retrieved evidence. Practical prevention in high‑risk contexts is best framed as:
+- Avoidance/mitigation of exposures (occupational solvents; high‑risk chemotherapies when alternatives exist) consistent with risk association evidence. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3)
+- Genetic counseling and cascade testing in families with EIF2AK4‑associated disease. (lechartier2024pulmonaryvenoocclusivedisease pages 1-2)
+
+---
+
+## 14. Other Species / Natural Disease
+
+Not identified in the retrieved evidence.
+
+---
+
+## 15. Model Organisms
+
+### 15.1 Genetic models
+- **Gcn2 (Eif2ak4)‑deficient rats**: phenotypically normal at baseline but show immune/inflammatory dysregulation under amino‑acid deprivation, analyzed with bulk RNA‑seq and scRNA‑seq. (bignard2023tcelldysregulationand pages 1-5)
+
+### 15.2 Induced models
+- **Mitomycin C (MMC) rat model**: induces PVOD‑like remodeling via PKR/ISR activation; aged rats show more severe remodeling and RV hypertrophy. (prabhakar2024mechanismsunderlyingageassociated pages 1-2, prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+
+### 15.3 Model limitations
+Gcn2‑deficient rats did not spontaneously develop PVOD, suggesting additional triggers/factors are required to reproduce human disease fully. (bignard2023tcelldysregulationand pages 1-5)
+
+---
+
+## Current applications / real-world implementations (registries and carrier screening)
+Clinical implementation is active in longitudinal registries and carrier surveillance:
+- **NCT03902353** (2019; ClinicalTrials.gov): screening of **heterozygous EIF2AK4 carriers** using CT, DLCO, echo, CPET, and biomarkers to identify early abnormalities and predictors of PVOD development. (NCT03902353 chunk 1)
+- **NCT03169010** (2017; ClinicalTrials.gov): long‑term rare pulmonary hypertension registry explicitly including PVOD and PCH with planned sequencing/biobank and survival/transplant outcomes. (NCT03169010 chunk 1)
+- **NCT01907295** (2014; ClinicalTrials.gov): UK national cohort/biorepository including PVOD/PCH, deep phenotyping, and next‑generation sequencing for natural history and predictors. (NCT01907295 chunk 1)
+
+---
+
+## Visual evidence (guideline table)
+The ESC/ERS 2022 PVOD/PCH recommendation summary table (diagnosis based on clinical+radiologic findings, lung biopsy not recommended, PAH drugs may be considered with careful monitoring) was retrieved as an image from Lechartier et al. 2024. (lechartier2024pulmonaryvenoocclusivedisease media a49a6475)
+
+---
+
+## Expert synthesis (authoritative interpretation grounded in cited sources)
+1) **PVOD/PCH is best approached as a distinct PAH spectrum disorder** with venous/capillary involvement, where accurate early identification matters because common PAH vasodilator strategies can be dangerous (pulmonary edema) and the therapeutic window for transplant referral is short. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5, lechartier2024pulmonaryvenoocclusivedisease pages 1-2)
+
+2) **Genetic confirmation is increasingly central**: biallelic EIF2AK4 pathogenic variants can establish diagnosis without lung biopsy, enabling family testing and earlier care pathway decisions (e.g., transplant evaluation, exposure avoidance). (emanuelli2024functionalvalidationof pages 3-5, park2023differentialdiagnosisof pages 2-3)
+
+3) **2023–2024 mechanistic advances converge on stress-response and barrier biology** (ISR/PKR/PP1 axis; endothelial junction disruption) and suggest tractable therapeutic targets, but these remain preclinical and not yet standard of care. (prabhakar2024mechanismsunderlyingageassociated pages 2-4)
+
+---
+
+## URLs and publication dates (key sources used)
+- Lechartier B. et al. **2024‑01**. *European Respiratory Review.* https://doi.org/10.1183/16000617.0156-2023 (lechartier2024pulmonaryvenoocclusivedisease pages 1-2)
+- Park J.E. et al. **2023‑02**. *Molecular Syndromology.* https://doi.org/10.1159/000527524 (park2023differentialdiagnosisof pages 2-3)
+- Prabhakar A. et al. **2024‑09**. *JCI Insight.* https://doi.org/10.1172/jci.insight.181877 (prabhakar2024mechanismsunderlyingageassociated pages 1-2)
+- Bignard J. et al. **2023‑05**. *AJP-Lung.* https://doi.org/10.1152/ajplung.00460.2021 (bignard2023tcelldysregulationand pages 1-5)
+- Emanuelli G. et al. **2024‑04**. https://doi.org/10.17863/cam.108223 (emanuelli2024functionalvalidationof pages 1-3)
+
+---
+
+## Limitations of this report (evidence availability)
+- Standard identifiers (OMIM/Orphanet/ICD/MeSH/MONDO) and some phenotype frequency statistics were not present in the retrieved corpus for this run; the report therefore focuses on high‑confidence clinical, genetic, imaging, mechanistic, and guideline‑linked evidence available in the provided texts. (lechartier2024pulmonaryvenoocclusivedisease pages 1-2, deshwal2025pulmonaryvenoocclusivedisease pages 1-2)
+
+References
+
+1. (lechartier2024pulmonaryvenoocclusivedisease pages 1-2): Benoit Lechartier, Athénaïs Boucly, Sabina Solinas, Deepa Gopalan, Peter Dorfmüller, Teodora Radonic, Olivier Sitbon, and David Montani. Pulmonary veno-occlusive disease: illustrative cases and literature review. European Respiratory Review, 33:230156, Jan 2024. URL: https://doi.org/10.1183/16000617.0156-2023, doi:10.1183/16000617.0156-2023. This article has 28 citations and is from a peer-reviewed journal.
+
+2. (deshwal2025pulmonaryvenoocclusivedisease pages 1-2): Himanshu Deshwal, Sauradeep Sarkar, Atreyee Basu, and Bilal A. Jalil. Pulmonary veno-occlusive disease: a clinical review. Breathe, 21:240098, Jan 2025. URL: https://doi.org/10.1183/20734735.0098-2024, doi:10.1183/20734735.0098-2024. This article has 4 citations.
+
+3. (deshwal2025pulmonaryvenoocclusivedisease pages 2-3): Himanshu Deshwal, Sauradeep Sarkar, Atreyee Basu, and Bilal A. Jalil. Pulmonary veno-occlusive disease: a clinical review. Breathe, 21:240098, Jan 2025. URL: https://doi.org/10.1183/20734735.0098-2024, doi:10.1183/20734735.0098-2024. This article has 4 citations.
+
+4. (lechartier2024pulmonaryvenoocclusivedisease pages 3-5): Benoit Lechartier, Athénaïs Boucly, Sabina Solinas, Deepa Gopalan, Peter Dorfmüller, Teodora Radonic, Olivier Sitbon, and David Montani. Pulmonary veno-occlusive disease: illustrative cases and literature review. European Respiratory Review, 33:230156, Jan 2024. URL: https://doi.org/10.1183/16000617.0156-2023, doi:10.1183/16000617.0156-2023. This article has 28 citations and is from a peer-reviewed journal.
+
+5. (prabhakar2024mechanismsunderlyingageassociated pages 1-2): Amit Prabhakar, Meetu Wadhwa, Rahul Kumar, Prajakta Ghatpande, Aneta Gandjeva, Rubin M. Tuder, Brian B. Graham, Giorgio Lagna, and Akiko Hata. Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease. JCI Insight, Sep 2024. URL: https://doi.org/10.1172/jci.insight.181877, doi:10.1172/jci.insight.181877. This article has 7 citations and is from a domain leading peer-reviewed journal.
+
+6. (lechartier2024pulmonaryvenoocclusivedisease pages 2-3): Benoit Lechartier, Athénaïs Boucly, Sabina Solinas, Deepa Gopalan, Peter Dorfmüller, Teodora Radonic, Olivier Sitbon, and David Montani. Pulmonary veno-occlusive disease: illustrative cases and literature review. European Respiratory Review, 33:230156, Jan 2024. URL: https://doi.org/10.1183/16000617.0156-2023, doi:10.1183/16000617.0156-2023. This article has 28 citations and is from a peer-reviewed journal.
+
+7. (deshwal2025pulmonaryvenoocclusivedisease pages 8-9): Himanshu Deshwal, Sauradeep Sarkar, Atreyee Basu, and Bilal A. Jalil. Pulmonary veno-occlusive disease: a clinical review. Breathe, 21:240098, Jan 2025. URL: https://doi.org/10.1183/20734735.0098-2024, doi:10.1183/20734735.0098-2024. This article has 4 citations.
+
+8. (deshwal2025pulmonaryvenoocclusivedisease pages 7-8): Himanshu Deshwal, Sauradeep Sarkar, Atreyee Basu, and Bilal A. Jalil. Pulmonary veno-occlusive disease: a clinical review. Breathe, 21:240098, Jan 2025. URL: https://doi.org/10.1183/20734735.0098-2024, doi:10.1183/20734735.0098-2024. This article has 4 citations.
+
+9. (foster2025pulmonaryvenoocclusivedisease pages 4-6): Brian Foster, Sikandar Khan, Ana Suarez Gonzalez, and Samantha Gillenwater. Pulmonary veno-occlusive disease: a comprehensive review of diagnostic challenges, therapeutic limitations, and evolving management. Advances in Respiratory Medicine, 93:48, Oct 2025. URL: https://doi.org/10.3390/arm93060048, doi:10.3390/arm93060048. This article has 2 citations.
+
+10. (lechartier2024pulmonaryvenoocclusivedisease pages 5-6): Benoit Lechartier, Athénaïs Boucly, Sabina Solinas, Deepa Gopalan, Peter Dorfmüller, Teodora Radonic, Olivier Sitbon, and David Montani. Pulmonary veno-occlusive disease: illustrative cases and literature review. European Respiratory Review, 33:230156, Jan 2024. URL: https://doi.org/10.1183/16000617.0156-2023, doi:10.1183/16000617.0156-2023. This article has 28 citations and is from a peer-reviewed journal.
+
+11. (lechartier2024pulmonaryvenoocclusivedisease media a49a6475): Benoit Lechartier, Athénaïs Boucly, Sabina Solinas, Deepa Gopalan, Peter Dorfmüller, Teodora Radonic, Olivier Sitbon, and David Montani. Pulmonary veno-occlusive disease: illustrative cases and literature review. European Respiratory Review, 33:230156, Jan 2024. URL: https://doi.org/10.1183/16000617.0156-2023, doi:10.1183/16000617.0156-2023. This article has 28 citations and is from a peer-reviewed journal.
+
+12. (park2023differentialdiagnosisof pages 2-3): Jong Eun Park, Sung-A Chang, Shin Yi Jang, Kyung Soo Lee, Duk-Kyung Kim, and Chang-Seok Ki. Differential diagnosis of pulmonary veno-occlusive disease and/or pulmonary capillary hemangiomatosis after identification of two novel eif2ak4 variants by whole-exome sequencing. Molecular Syndromology, 14:254-257, Feb 2023. URL: https://doi.org/10.1159/000527524, doi:10.1159/000527524. This article has 6 citations and is from a peer-reviewed journal.
+
+13. (park2023differentialdiagnosisof pages 1-2): Jong Eun Park, Sung-A Chang, Shin Yi Jang, Kyung Soo Lee, Duk-Kyung Kim, and Chang-Seok Ki. Differential diagnosis of pulmonary veno-occlusive disease and/or pulmonary capillary hemangiomatosis after identification of two novel eif2ak4 variants by whole-exome sequencing. Molecular Syndromology, 14:254-257, Feb 2023. URL: https://doi.org/10.1159/000527524, doi:10.1159/000527524. This article has 6 citations and is from a peer-reviewed journal.
+
+14. (emanuelli2024functionalvalidationof pages 3-5): Giulia Emanuelli, JiaYi Zhu, Wei Li, Nicholas W Morrell, and Stefan J Marciniak. Functional validation of eif2ak4 (gcn2) missense variants associated with pulmonary arterial hypertension. JournalArticle, Apr 2024. URL: https://doi.org/10.17863/cam.108223, doi:10.17863/cam.108223. This article has 14 citations.
+
+15. (emanuelli2024functionalvalidationof pages 1-3): Giulia Emanuelli, JiaYi Zhu, Wei Li, Nicholas W Morrell, and Stefan J Marciniak. Functional validation of eif2ak4 (gcn2) missense variants associated with pulmonary arterial hypertension. JournalArticle, Apr 2024. URL: https://doi.org/10.17863/cam.108223, doi:10.17863/cam.108223. This article has 14 citations.
+
+16. (prabhakar2024mechanismsunderlyingageassociated pages 2-4): Amit Prabhakar, Meetu Wadhwa, Rahul Kumar, Prajakta Ghatpande, Aneta Gandjeva, Rubin M. Tuder, Brian B. Graham, Giorgio Lagna, and Akiko Hata. Mechanisms underlying age-associated exacerbation of pulmonary veno-occlusive disease. JCI Insight, Sep 2024. URL: https://doi.org/10.1172/jci.insight.181877, doi:10.1172/jci.insight.181877. This article has 7 citations and is from a domain leading peer-reviewed journal.
+
+17. (bignard2023tcelldysregulationand pages 1-5): Juliette Bignard, Fabrice Atassi, Olivier Claude, Maria-Rosa Ghigna, Nathalie Mougenot, Bahgat Soilih Abdoulkarim, Florence Deknuydt, Aurélie Gestin, Virginie Monceau, David Montani, Sophie Nadaud, Florent Soubrier, and Frédéric Perros. T-cell dysregulation and inflammatory process in <i>gcn2</i> (<i>eif2ak4</i><sup>−/−</sup>)-deficient rats in basal and stress conditions. American Journal of Physiology-Lung Cellular and Molecular Physiology, 324:L609-L624, May 2023. URL: https://doi.org/10.1152/ajplung.00460.2021, doi:10.1152/ajplung.00460.2021. This article has 5 citations.
+
+18. (bignard2023tcelldysregulationand pages 16-19): Juliette Bignard, Fabrice Atassi, Olivier Claude, Maria-Rosa Ghigna, Nathalie Mougenot, Bahgat Soilih Abdoulkarim, Florence Deknuydt, Aurélie Gestin, Virginie Monceau, David Montani, Sophie Nadaud, Florent Soubrier, and Frédéric Perros. T-cell dysregulation and inflammatory process in <i>gcn2</i> (<i>eif2ak4</i><sup>−/−</sup>)-deficient rats in basal and stress conditions. American Journal of Physiology-Lung Cellular and Molecular Physiology, 324:L609-L624, May 2023. URL: https://doi.org/10.1152/ajplung.00460.2021, doi:10.1152/ajplung.00460.2021. This article has 5 citations.
+
+19. (deshwal2025pulmonaryvenoocclusivedisease pages 9-10): Himanshu Deshwal, Sauradeep Sarkar, Atreyee Basu, and Bilal A. Jalil. Pulmonary veno-occlusive disease: a clinical review. Breathe, 21:240098, Jan 2025. URL: https://doi.org/10.1183/20734735.0098-2024, doi:10.1183/20734735.0098-2024. This article has 4 citations.
+
+20. (foster2025pulmonaryvenoocclusivedisease pages 10-12): Brian Foster, Sikandar Khan, Ana Suarez Gonzalez, and Samantha Gillenwater. Pulmonary veno-occlusive disease: a comprehensive review of diagnostic challenges, therapeutic limitations, and evolving management. Advances in Respiratory Medicine, 93:48, Oct 2025. URL: https://doi.org/10.3390/arm93060048, doi:10.3390/arm93060048. This article has 2 citations.
+
+21. (NCT03902353 chunk 1):  Screening of Pulmonary Veino Occlusive Disease in Heterozygous EIF2AK4 Mutation Carriers. Assistance Publique - Hôpitaux de Paris. 2019. ClinicalTrials.gov Identifier: NCT03902353
+
+22. (NCT03169010 chunk 1): Zhi-Cheng JING, MD. Registration Study for Rare Type of Pulmonary Hypertension. China National Center for Cardiovascular Diseases. 2017. ClinicalTrials.gov Identifier: NCT03169010
+
+23. (NCT01907295 chunk 1): Nick Morrell. National Cohort Study of Idiopathic and Heritable Pulmonary Arterial Hypertension. University of Cambridge. 2014. ClinicalTrials.gov Identifier: NCT01907295
+
+24. (park2023differentialdiagnosisof pages 4-4): Jong Eun Park, Sung-A Chang, Shin Yi Jang, Kyung Soo Lee, Duk-Kyung Kim, and Chang-Seok Ki. Differential diagnosis of pulmonary veno-occlusive disease and/or pulmonary capillary hemangiomatosis after identification of two novel eif2ak4 variants by whole-exome sequencing. Molecular Syndromology, 14:254-257, Feb 2023. URL: https://doi.org/10.1159/000527524, doi:10.1159/000527524. This article has 6 citations and is from a peer-reviewed journal.

--- a/research/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md.citations.md
+++ b/research/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis-deep-research-falcon.md.citations.md
@@ -1,0 +1,491 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis
+- **MONDO ID:**  (if available)
+- **Category:** Cardiovascular Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Pulmonary Veno-Occlusive Disease and/or Pulmonary Capillary Haemangiomatosis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T13:49:08.544779
+
+1. lechartier2024pulmonaryvenoocclusivedisease pages 1-2
+2. deshwal2025pulmonaryvenoocclusivedisease pages 1-2
+3. park2023differentialdiagnosisof pages 2-3
+4. emanuelli2024functionalvalidationof pages 1-3
+5. lechartier2024pulmonaryvenoocclusivedisease pages 2-3
+6. foster2025pulmonaryvenoocclusivedisease pages 4-6
+7. deshwal2025pulmonaryvenoocclusivedisease pages 8-9
+8. prabhakar2024mechanismsunderlyingageassociated pages 1-2
+9. deshwal2025pulmonaryvenoocclusivedisease pages 7-8
+10. emanuelli2024functionalvalidationof pages 3-5
+11. park2023differentialdiagnosisof pages 4-4
+12. lechartier2024pulmonaryvenoocclusivedisease pages 3-5
+13. prabhakar2024mechanismsunderlyingageassociated pages 2-4
+14. bignard2023tcelldysregulationand pages 16-19
+15. bignard2023tcelldysregulationand pages 1-5
+16. deshwal2025pulmonaryvenoocclusivedisease pages 2-3
+17. lechartier2024pulmonaryvenoocclusivedisease pages 5-6
+18. park2023differentialdiagnosisof pages 1-2
+19. deshwal2025pulmonaryvenoocclusivedisease pages 9-10
+20. foster2025pulmonaryvenoocclusivedisease pages 10-12
+21. https://doi.org/10.1183/16000617.0156-2023;
+22. https://doi.org/10.1183/20734735.0098-2024
+23. https://doi.org/10.1183/20734735.0098-2024;
+24. https://doi.org/10.18093/0869-0189-2024-34-4-595-598
+25. https://doi.org/10.1172/jci.insight.181877
+26. https://doi.org/10.3390/arm93060048
+27. https://doi.org/10.1183/16000617.0156-2023
+28. https://doi.org/10.1159/000527524;
+29. https://doi.org/10.17863/cam.108223;
+30. https://doi.org/10.17863/cam.108223
+31. https://doi.org/10.1172/jci.insight.181877;
+32. https://doi.org/10.1152/ajplung.00460.2021
+33. https://doi.org/10.1159/000527524
+34. https://doi.org/10.1183/16000617.0156-2023,
+35. https://doi.org/10.1183/20734735.0098-2024,
+36. https://doi.org/10.1172/jci.insight.181877,
+37. https://doi.org/10.3390/arm93060048,
+38. https://doi.org/10.1159/000527524,
+39. https://doi.org/10.17863/cam.108223,
+40. https://doi.org/10.1152/ajplung.00460.2021,


### PR DESCRIPTION
## Summary
- Adds a new DISMECH disorder page for pulmonary veno-occlusive disease and/or pulmonary capillary haemangiomatosis (MONDO:0018554).
- Incorporates Falcon deep research into evidence-backed pathophysiology, phenotypes, histopathology, EIF2AK4 genetics, environmental risks, diagnosis, treatments, animal models, and an EIF2AK4-carrier screening study.
- Adds the Falcon report, citation file, and reference-cache entries generated with `just fetch-reference`.

## Validation
- `just validate kb/disorders/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis.yaml` passed.
- `just validate-references kb/disorders/Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis.yaml` passed; the validator reported `Total checks: 0`.
- `just check-reference-cache-frontmatter` passed.
- `just qc-deep-research --only Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis --target-providers falcon` passed for missing reference/cache/found_in coverage. It reports no second provider because this curation batch requested Falcon.
- `just check-research Pulmonary_Veno_Occlusive_Disease_And_Or_Pulmonary_Capillary_Haemangiomatosis` listed the Falcon report and citations file.
- `git diff --cached --check -- . ':!references_cache/*.md'` passed. Generated `references_cache/*.md` files contain fetcher-produced trailing whitespace, and were not hand-edited.

## Notes
- Imaging findings are intentionally preferred-term-only because local OAK lookup did not confirm reliable HPO bindings for the suggested imaging IDs.
