### PR TITLE
Curate arteriosclerotic retinopathy

### DIFF
--- a/kb/disorders/Arteriosclerotic_Retinopathy.yaml
+++ b/kb/disorders/Arteriosclerotic_Retinopathy.yaml
@@ -53,7 +53,7 @@ pathophysiology:
       id: GO:0001974
       label: blood vessel remodeling
   - preferred_term: endothelial cell proliferation
-    modifier: ABNORMAL
+    modifier: INCREASED
     term:
       id: GO:0001935
       label: endothelial cell proliferation
@@ -170,6 +170,11 @@ phenotypes:
   description: >-
     Narrowing of retinal arterioles is a characteristic ophthalmoscopic feature
     of arteriosclerotic remodeling.
+  phenotype_term:
+    preferred_term: Attenuation of retinal blood vessels
+    term:
+      id: HP:0007843
+      label: Attenuation of retinal blood vessels
   evidence:
   - reference: PMID:38793083
     reference_title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
@@ -251,6 +256,66 @@ environmental:
     explanation: >-
       The study explicitly frames Scheie retinopathy grading as a way to
       evaluate hypertension and atherosclerosis effects in the ocular fundus.
+- name: Heavy alcohol consumption
+  presence: Positive
+  description: >-
+    Heavy alcohol consumption was associated with marked enhanced retinal
+    arteriolar light reflex in the Blue Mountains Eye Study cohort.
+  evidence:
+  - reference: PMID:17070582
+    reference_title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Markedly enhanced light reflex was significantly associated with mean
+      arterial blood pressure (OR 1.24), heavy alcohol consumption (OR 2.66, >
+      or = 40 grams alcohol per day), and serum glucose (OR 1.16).
+    explanation: >-
+      This directly supports heavy alcohol consumption as a systemic risk factor
+      associated with marked enhanced retinal arteriolar light reflex.
+- name: Dyslipidemia
+  presence: Positive
+  description: >-
+    Lipid abnormalities, including higher total cholesterol, LDL cholesterol,
+    and triglycerides, were associated with enhanced retinal arteriolar light
+    reflex.
+  evidence:
+  - reference: PMID:17070582
+    reference_title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      mildly enhanced light reflex was significantly associated with serum
+      glucose (OR 1.11 per SD increase), total cholesterol (OR 1.11),
+      low-density lipoprotein (OR 1.55), triglycerides (OR 1.11)
+    explanation: >-
+      This supports dyslipidemia-related measures as risk correlates of
+      enhanced retinal arteriolar light reflex.
+- name: Serum glucose dysregulation
+  presence: Positive
+  description: >-
+    Higher serum glucose was associated with both mild and marked enhanced
+    retinal arteriolar light reflex, consistent with a metabolic vascular-risk
+    context.
+  evidence:
+  - reference: PMID:17070582
+    reference_title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      serum glucose (OR 1.11 per SD increase)
+    explanation: >-
+      This supports serum glucose as a metabolic factor associated with mildly
+      enhanced retinal arteriolar light reflex.
+  - reference: PMID:17070582
+    reference_title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      serum glucose (OR 1.16).
+    explanation: >-
+      This supports serum glucose as a metabolic factor associated with markedly
+      enhanced retinal arteriolar light reflex.
 - name: Chronic kidney disease on hemodialysis
   presence: Risk context
   description: >-

--- a/kb/disorders/Arteriosclerotic_Retinopathy.yaml
+++ b/kb/disorders/Arteriosclerotic_Retinopathy.yaml
@@ -1,0 +1,476 @@
+name: Arteriosclerotic Retinopathy
+creation_date: "2026-05-06T17:24:49Z"
+updated_date: "2026-05-06T17:54:50Z"
+description: >-
+  Arteriosclerotic retinopathy is a chronic retinal vascular disorder marked by
+  arteriosclerotic change in retinal arterioles. In clinical and epidemiologic
+  studies it overlaps with "retinal arteriosclerosis" or "fundus
+  arteriosclerosis" and is commonly operationalized with Scheie atherosclerotic
+  grades or related fundus-photographic grading systems. The disorder is
+  primarily an ocular manifestation and biomarker of systemic vascular disease,
+  including arterial stiffness, carotid atherosclerosis, and cardiovascular risk.
+category: Complex
+disease_term:
+  preferred_term: arteriosclerotic retinopathy
+  term:
+    id: MONDO:0042495
+    label: arteriosclerotic retinopathy
+synonyms:
+- retinal arteriosclerosis
+- arteriosclerosis disorder of retina
+- retinopathy, arteriosclerotic
+parents:
+- Arteriosclerosis disorder
+- Retinal vascular disorder
+pathophysiology:
+- name: Retinal arteriolar sclerosis
+  description: >-
+    The central disease process is sclerosis and remodeling of retinal
+    arterioles, visible as Scheie-defined atherosclerotic retinal changes and
+    related fundus arteriosclerosis signs.
+  locations:
+  - preferred_term: retina
+    term:
+      id: UBERON:0000966
+      label: retina
+  - preferred_term: arteriole
+    term:
+      id: UBERON:0001980
+      label: arteriole
+  cell_types:
+  - preferred_term: retinal blood vessel endothelial cell
+    term:
+      id: CL:0002585
+      label: retinal blood vessel endothelial cell
+  - preferred_term: smooth muscle cell
+    term:
+      id: CL:0000192
+      label: smooth muscle cell
+  biological_processes:
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  - preferred_term: endothelial cell proliferation
+    modifier: ABNORMAL
+    term:
+      id: GO:0001935
+      label: endothelial cell proliferation
+  evidence:
+  - reference: PMID:33239480
+    reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      retinopathy based on Scheie classification are often applied to evaluate
+      the impact of hypertension and atherosclerosis.
+    explanation: >-
+      This supports Scheie-classified atherosclerotic retinopathy as the
+      clinical retinal arteriolar sclerosis phenotype.
+  - reference: PMID:26133318
+    reference_title: Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Significant correlations were found between the presence of
+      arteriosclerotic retinopathy
+    explanation: >-
+      This hemodialysis cohort directly studied arteriosclerotic retinopathy
+      graded by Scheie S grade.
+  downstream:
+  - target: Retinopathy
+    description: Retinal arteriolar remodeling contributes to clinically visible retinopathy.
+    evidence:
+    - reference: PMID:33239480
+      reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        retinopathy based on Scheie classification are often applied to evaluate
+        the impact of hypertension and atherosclerosis.
+      explanation: >-
+        Scheie-classified atherosclerotic retinopathy links retinal arteriolar
+        sclerosis with visible retinopathy grading.
+- name: Systemic vascular stiffness and atherosclerosis association
+  description: >-
+    Arteriosclerotic retinal findings track with systemic vascular stiffness and
+    macrovascular atherosclerotic burden, supporting the use of retinal vascular
+    imaging as a noninvasive systemic vascular biomarker.
+  locations:
+  - preferred_term: retina
+    term:
+      id: UBERON:0000966
+      label: retina
+  biological_processes:
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  evidence:
+  - reference: PMID:33239480
+    reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      atherosclerotic retinopathy was significantly associated with CAVI and
+      carotid IMT.
+    explanation: >-
+      The study links Scheie-defined atherosclerotic retinal lesions with
+      functional and morphologic large-artery atherosclerosis measures.
+  - reference: PMID:37968750
+    reference_title: "Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      fundus arteriosclerosis was significantly associated with the risk of
+      carotid atherosclerosis.
+    explanation: >-
+      The large health-examination cohort supports a clinically relevant
+      fundus-arteriosclerosis association with carotid atherosclerosis.
+  downstream:
+  - target: Cardiovascular disease risk stratification
+    description: Retinal microvascular findings can contribute to systemic vascular risk assessment.
+    evidence:
+    - reference: PMID:26133318
+      reference_title: Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        ophthalmoscopic examination may be a useful tool for predicting arterial
+        stiffness
+      explanation: >-
+        The study supports using Scheie S grade as a noninvasive marker of
+        arterial stiffness and cardiovascular disease association.
+phenotypes:
+- category: Ophthalmologic
+  name: Retinopathy
+  description: >-
+    Noninflammatory retinal vascular abnormalities are the defining ocular
+    manifestation of arteriosclerotic retinopathy.
+  phenotype_term:
+    preferred_term: Retinopathy
+    term:
+      id: HP:0000488
+      label: Retinopathy
+  evidence:
+  - reference: PMID:33239480
+    reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The absence or presence and extent of retinopathy were characterized by
+      ophthalmologists
+    explanation: >-
+      The study operationalized both hypertensive and atherosclerotic retinal
+      lesions as retinopathy grades.
+- category: Ophthalmologic
+  name: Retinal arteriolar narrowing
+  description: >-
+    Narrowing of retinal arterioles is a characteristic ophthalmoscopic feature
+    of arteriosclerotic remodeling.
+  evidence:
+  - reference: PMID:38793083
+    reference_title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A narrower CRAE, wider CRVE and a lower AVR have been associated with
+      increased cardiovascular events.
+    explanation: >-
+      CRAE is an arteriolar-caliber metric; the review supports narrowed retinal
+      arterioles as a vascular-risk imaging feature, although not specific to
+      Scheie-defined arteriosclerotic retinopathy.
+- category: Ophthalmologic
+  name: Enhanced retinal arteriolar light reflex
+  description: >-
+    Increased retinal arteriolar light reflex, including classic copper- or
+    silver-wiring descriptions, is a visible retinal vessel wall sign associated
+    with vascular risk factors and retinal vascular disease.
+  evidence:
+  - reference: PMID:17070582
+    reference_title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The enhanced arteriolar light reflex sign was found in 1053 participants
+      (31.7%
+    explanation: >-
+      This population study supports enhanced arteriolar light reflex as a
+      common retinal arteriolar wall sign.
+- category: Ophthalmologic
+  name: Arteriovenous nicking
+  description: >-
+    Arteriovenous nicking is an arteriolar-venular crossing sign that commonly
+    clusters with enhanced arteriolar light reflex and retinopathy.
+  evidence:
+  - reference: PMID:17070582
+    reference_title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      arteriovenous nicking (OR 3.12) or retinopathy (OR 1.96).
+    explanation: >-
+      The study shows that enhanced arteriolar light reflex is strongly
+      associated with arteriovenous nicking and retinopathy.
+biochemical:
+- name: Serum uric acid trajectory
+  presence: Higher trajectory
+  biomarker_term:
+    preferred_term: serum uric acid trajectory
+  notes: >-
+    Longitudinal serum uric-acid trajectory is a sex-specific biochemical risk
+    marker for incident retinal arteriosclerosis in the reported cohort.
+  evidence:
+  - reference: PMID:36926048
+    reference_title: "Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in Chinese population: A population-based longitudinal study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Higher SUA trajectory groups were significantly associated with an
+      increased risk of incident retinal arteriosclerosis in men
+    explanation: >-
+      This longitudinal cohort supports higher serum uric acid trajectories as
+      a male-specific risk marker for incident retinal arteriosclerosis.
+genetic: []
+environmental:
+- name: Hypertension
+  presence: Positive
+  description: >-
+    Hypertension is a major systemic vascular context in which Scheie
+    retinopathy grading is applied and atherosclerotic retinal lesions are
+    evaluated.
+  evidence:
+  - reference: PMID:33239480
+    reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      evaluate the impact of hypertension and atherosclerosis.
+    explanation: >-
+      The study explicitly frames Scheie retinopathy grading as a way to
+      evaluate hypertension and atherosclerosis effects in the ocular fundus.
+- name: Chronic kidney disease on hemodialysis
+  presence: Risk context
+  description: >-
+    Chronic kidney disease requiring hemodialysis is a clinical context in which
+    retinal arterial sclerosis has been associated with arterial stiffness and
+    prior cardiovascular disease.
+  evidence:
+  - reference: PMID:26133318
+    reference_title: Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with chronic kidney disease (CKD) undergoing hemodialysis (HD)
+      have a high prevalence of cardiovascular diseases
+    explanation: >-
+      The study directly examined retinal arterial sclerosis in a CKD
+      hemodialysis cohort with high cardiovascular disease burden.
+diagnosis:
+- name: Fundus photography with Scheie or KWB grading
+  description: >-
+    Ophthalmologist-graded fundus photography is the core diagnostic and
+    epidemiologic method for identifying Scheie atherosclerotic grades and KWB
+    fundus arteriosclerosis categories.
+  diagnosis_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  results: Retinopathy grade, fundus arteriosclerosis grade, arteriolar light reflex, and arteriovenous crossing signs.
+  evidence:
+  - reference: PMID:33239480
+    reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      characterized by ophthalmologists as hypertensive (H0-4) and
+      atherosclerotic grades (S0-4)
+    explanation: >-
+      This supports ophthalmologist-graded Scheie H and S grades as a diagnostic
+      classification approach.
+  - reference: PMID:37968750
+    reference_title: "Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Two trained ophthalmologists analysed fundus arteriosclerosis based on
+      fundus photographs
+    explanation: >-
+      The study supports fundus photography reviewed by ophthalmologists for
+      identifying fundus arteriosclerosis.
+- name: OCT and OCTA retinal vascular biomarker assessment
+  description: >-
+    Optical coherence tomography and OCT angiography can quantify retinal
+    structural and vascular features used as systemic cardiovascular biomarkers,
+    complementing classic fundus grading rather than replacing it.
+  diagnosis_term:
+    preferred_term: optical coherence tomography
+    term:
+      id: MAXO:0000969
+      label: optical coherence tomography
+  results: Retinal thickness, choroidal thickness, vessel density, and foveal avascular zone measurements.
+  evidence:
+  - reference: PMID:38672719
+    reference_title: "Retinal Structural and Vascular Changes in Patients with Coronary Artery Disease: A Systematic Review and Meta-Analysis."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      retinal vasculature as a biomarker for diagnosis and monitoring of
+      patients with coronary artery disease
+    explanation: >-
+      This systematic review supports OCT/OCTA-derived retinal vascular
+      assessment as a cardiovascular biomarker; it is not specific to classic
+      Scheie arteriosclerotic retinopathy.
+  - reference: PMID:38793083
+    reference_title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      fundus images can be taken and analysed.
+    explanation: >-
+      This review supports noninvasive retinal vessel analysis for quantifying
+      cardiovascular microvascular changes.
+treatments:
+- name: Cardiovascular risk-factor management and retinal surveillance
+  description: >-
+    No disease-specific ocular pharmacotherapy was identified in the Falcon
+    report. Practical management is prevention-oriented: identify and treat
+    systemic vascular risk factors and monitor retinal vascular signs over time.
+  treatment_term:
+    preferred_term: cardiovascular risk-factor management
+  target_mechanisms:
+  - target: Systemic vascular stiffness and atherosclerosis association
+    treatment_effect: MODULATES
+    description: >-
+      Risk-factor control targets the systemic vascular disease context that is
+      associated with retinal arteriosclerosis rather than reversing established
+      retinal arteriolar sclerosis directly.
+    evidence:
+    - reference: PMID:33239480
+      reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        CAVI and carotid IMT are independent determinants of retinopathy.
+      explanation: >-
+        This supports targeting systemic arterial stiffness and atherosclerosis
+        risk as a management rationale, while not proving direct treatment
+        reversal of retinal lesions.
+  evidence:
+  - reference: PMID:33239480
+    reference_title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CAVI and carotid IMT are independent determinants of retinopathy.
+    explanation: >-
+      This supports a systemic vascular-risk management rationale, although it
+      is observational rather than an intervention trial.
+  - reference: PMID:38793083
+    reference_title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Retinal vascular imaging using AI may help identify the cardiovascular
+      risk
+    explanation: >-
+      This supports retinal vascular imaging as a prevention and surveillance
+      tool for cardiovascular risk.
+datasets: []
+animal_models: []
+references:
+- reference: DOI:10.5551/jat.59857
+  title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Scheie-defined atherosclerotic retinopathy is associated with CAVI and carotid IMT.
+    supporting_text: >-
+      atherosclerotic retinopathy was significantly associated with CAVI and
+      carotid IMT.
+- reference: DOI:10.5551/jat.30601
+  title: Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Scheie S grade correlates with arterial stiffness and prior cardiovascular disease in a hemodialysis cohort.
+    supporting_text: >-
+      Significant correlations were found between the presence of
+      arteriosclerotic retinopathy
+- reference: DOI:10.1016/j.ophtha.2006.06.046
+  title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Enhanced retinal arteriolar light reflex is common and associated with AV nicking and retinopathy.
+    supporting_text: >-
+      arteriovenous nicking (OR 3.12) or retinopathy (OR 1.96).
+- reference: DOI:10.3389/fcvm.2023.1116486
+  title: "Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in Chinese population: A population-based longitudinal study."
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Higher serum uric acid trajectories are associated with incident retinal arteriosclerosis in men.
+    supporting_text: >-
+      Higher SUA trajectory groups were significantly associated with an
+      increased risk of incident retinal arteriosclerosis in men
+- reference: DOI:10.1186/s40001-023-01508-6
+  title: "Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study."
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Fundus arteriosclerosis is associated with carotid atherosclerosis.
+    supporting_text: >-
+      fundus arteriosclerosis was significantly associated with the risk of
+      carotid atherosclerosis.
+- reference: DOI:10.1038/s41598-023-38378-1
+  title: "Association between total bilirubin and gender-specific incidence of fundus arteriosclerosis in a Chinese population: a retrospective cohort study"
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Serum total bilirubin was assessed as a sex-specific incident fundus arteriosclerosis risk marker.
+- reference: DOI:10.3390/life14040448
+  title: "Retinal Structural and Vascular Changes in Patients with Coronary Artery Disease: A Systematic Review and Meta-Analysis."
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: OCT/OCTA retinal vascular features can serve as cardiovascular biomarkers.
+    supporting_text: >-
+      retinal vasculature as a biomarker for diagnosis and monitoring of
+      patients with coronary artery disease
+- reference: DOI:10.3390/jpm14050501
+  title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Retinal vessel analysis can support cardiovascular risk identification and prevention.
+    supporting_text: >-
+      Retinal vascular imaging using AI may help identify the cardiovascular
+      risk
+- reference: DOI:10.1007/s00415-023-12171-6
+  title: "Retinal imaging for the assessment of stroke risk: a systematic review"
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Retinal imaging biomarkers were reviewed for prospective stroke-risk assessment.
+- reference: DOI:10.1167/tvst.12.7.14
+  title: A Systematic Review and Meta-Analysis of Applying Deep Learning in the Prediction of the Risk of Cardiovascular Diseases From Retinal Images
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Deep-learning models using retinal images were reviewed for cardiovascular risk prediction.
+- reference: DOI:10.3390/jpm13111564
+  title: "Retinal Findings and Cardiovascular Risk: Prognostic Conditions, Novel Biomarkers, and Emerging Image Analysis Techniques"
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Retinal findings and imaging biomarkers were reviewed as cardiovascular prognostic tools.
+- reference: DOI:10.3390/jcdd12060230
+  title: "Retinal Imaging as a Window into Cardiovascular Health: Towards Harnessing Retinal Analytics for Precision Cardiovascular Medicine"
+  found_in:
+  - Arteriosclerotic_Retinopathy-deep-research-falcon.md
+  findings:
+  - statement: Retinal analytics were reviewed as tools for precision cardiovascular medicine.

--- a/references_cache/DOI_10.1007_s00415-023-12171-6.md
+++ b/references_cache/DOI_10.1007_s00415-023-12171-6.md
@@ -1,0 +1,37 @@
+---
+reference_id: "DOI:10.1007/s00415-023-12171-6"
+title: "Retinal imaging for the assessment of stroke risk: a systematic review"
+authors:
+- Zain Girach
+- Arni Sarian
+- Cynthia Maldonado-García
+- Nishant Ravikumar
+- Panagiotis I. Sergouniotis
+- Peter M. Rothwell
+- Alejandro F. Frangi
+- Thomas H. Julian
+journal: Journal of Neurology
+year: '2024'
+doi: 10.1007/s00415-023-12171-6
+content_type: abstract_only
+---
+
+# Retinal imaging for the assessment of stroke risk: a systematic review
+**Authors:** Zain Girach, Arni Sarian, Cynthia Maldonado-García, Nishant Ravikumar, Panagiotis I. Sergouniotis, Peter M. Rothwell, Alejandro F. Frangi, Thomas H. Julian
+**Journal:** Journal of Neurology (2024)
+**DOI:** [10.1007/s00415-023-12171-6](https://doi.org/10.1007/s00415-023-12171-6)
+
+## Content
+
+Abstract
+Background
+Stroke is a leading cause of morbidity and mortality. Retinal imaging allows non-invasive assessment of the microvasculature. Consequently, retinal imaging is a technology which is garnering increasing attention as a means of assessing cardiovascular health and stroke risk.
+
+Methods
+A biomedical literature search was performed to identify prospective studies that assess the role of retinal imaging derived biomarkers as indicators of stroke risk.
+
+Results
+Twenty-four studies were included in this systematic review. The available evidence suggests that wider retinal venules, lower fractal dimension, increased arteriolar tortuosity, presence of retinopathy, and presence of retinal emboli are associated with increased likelihood of stroke. There is weaker evidence to suggest that narrower arterioles and the presence of individual retinopathy traits such as microaneurysms and arteriovenous nicking indicate increased stroke risk. Our review identified three models utilizing artificial intelligence algorithms for the analysis of retinal images to predict stroke. Two of these focused on fundus photographs, whilst one also utilized optical coherence tomography (OCT) technology images. The constructed models performed similarly to conventional risk scores but did not significantly exceed their performance. Only two studies identified in this review used OCT imaging, despite the higher dimensionality of this data.
+
+Conclusion
+Whilst there is strong evidence that retinal imaging features can be used to indicate stroke risk, there is currently no predictive model which significantly outperforms conventional risk scores. To develop clinically useful tools, future research should focus on utilization of deep learning algorithms, validation in external cohorts, and analysis of OCT images.

--- a/references_cache/DOI_10.1016_j.ophtha.2006.06.046.md
+++ b/references_cache/DOI_10.1016_j.ophtha.2006.06.046.md
@@ -1,0 +1,20 @@
+---
+reference_id: "DOI:10.1016/j.ophtha.2006.06.046"
+title: Prevalence and Associations of Enhanced Retinal Arteriolar Light Reflex
+authors:
+- Shweta Kaushik
+- Ava Grace Tan
+- Paul Mitchell
+- Jie Jin Wang
+journal: Ophthalmology
+year: '2007'
+doi: 10.1016/j.ophtha.2006.06.046
+content_type: unavailable
+---
+
+# Prevalence and Associations of Enhanced Retinal Arteriolar Light Reflex
+**Authors:** Shweta Kaushik, Ava Grace Tan, Paul Mitchell, Jie Jin Wang
+**Journal:** Ophthalmology (2007)
+**DOI:** [10.1016/j.ophtha.2006.06.046](https://doi.org/10.1016/j.ophtha.2006.06.046)
+
+## Content

--- a/references_cache/DOI_10.1038_s41598-023-38378-1.md
+++ b/references_cache/DOI_10.1038_s41598-023-38378-1.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.1038/s41598-023-38378-1"
+title: "Association between total bilirubin and gender-specific incidence of fundus arteriosclerosis in a Chinese population: a retrospective cohort study"
+authors:
+- Yongfei Dong
+- Chunxing Liu
+- Jieli Wang
+- Huijun Li
+- Qi Wang
+- Aicheng Feng
+- Zaixiang Tang
+journal: Scientific Reports
+year: '2023'
+doi: 10.1038/s41598-023-38378-1
+content_type: abstract_only
+---
+
+# Association between total bilirubin and gender-specific incidence of fundus arteriosclerosis in a Chinese population: a retrospective cohort study
+**Authors:** Yongfei Dong, Chunxing Liu, Jieli Wang, Huijun Li, Qi Wang, Aicheng Feng, Zaixiang Tang
+**Journal:** Scientific Reports (2023)
+**DOI:** [10.1038/s41598-023-38378-1](https://doi.org/10.1038/s41598-023-38378-1)
+
+## Content
+
+AbstractTo investigate the gender-specific relationship between total bilirubin (TBIL) and fundus arteriosclerosis in the general population, and to explore whether there is a dose–response relationship between them. In a retrospective cohort study, 27,477 participants were enrolled from 2006 to 2019. The TBIL was divided into four groups according to the quartile. The Cox proportional hazards model was used to estimate the HRs with 95% CIs of different TBIL level and fundus arteriosclerosis in men and women. The dose–response relationship between TBIL and fundus arteriosclerosis was estimated using restricted cubic splines method. In males, after adjusting for potential confounders, the Q2 to Q4 level of TBIL were significantly associated with the risk of fundus arteriosclerosis. The HRs with 95% CIs were 1.217 (1.095–1.354), 1.255 (1.128–1.396) and 1.396 (1.254–1.555), respectively. For females, TBIL level was not associated with the incidence of fundus arteriosclerosis. In addition, a linear relationship between TBIL and fundus arteriosclerosis in both genders (P < 0.0001 and P = 0.0047, respectively). In conclusion, the incidence of fundus arteriosclerosis is positively correlated with serum TBIL level in males, but not in females. In addition, there was a linear dose–response relationship between TBIL and incidence of fundus arteriosclerosis.

--- a/references_cache/DOI_10.1167_tvst.12.7.14.md
+++ b/references_cache/DOI_10.1167_tvst.12.7.14.md
@@ -1,0 +1,27 @@
+---
+reference_id: "DOI:10.1167/tvst.12.7.14"
+title: A Systematic Review and Meta-Analysis of Applying Deep Learning in the Prediction of the Risk of Cardiovascular Diseases From Retinal Images
+authors:
+- Wenyi Hu
+- Fabian S. L. Yii
+- Ruiye Chen
+- Xinyu Zhang
+- Xianwen Shang
+- Katerina Kiburg
+- Ekaterina Woods
+- Algis Vingrys
+- Lei Zhang
+- Zhuoting Zhu
+- Mingguang He
+journal: "Translational Vision Science &amp; Technology"
+year: '2023'
+doi: 10.1167/tvst.12.7.14
+content_type: unavailable
+---
+
+# A Systematic Review and Meta-Analysis of Applying Deep Learning in the Prediction of the Risk of Cardiovascular Diseases From Retinal Images
+**Authors:** Wenyi Hu, Fabian S. L. Yii, Ruiye Chen, Xinyu Zhang, Xianwen Shang, Katerina Kiburg, Ekaterina Woods, Algis Vingrys, Lei Zhang, Zhuoting Zhu, Mingguang He
+**Journal:** Translational Vision Science &amp; Technology (2023)
+**DOI:** [10.1167/tvst.12.7.14](https://doi.org/10.1167/tvst.12.7.14)
+
+## Content

--- a/references_cache/DOI_10.1186_s40001-023-01508-6.md
+++ b/references_cache/DOI_10.1186_s40001-023-01508-6.md
@@ -1,0 +1,40 @@
+---
+reference_id: "DOI:10.1186/s40001-023-01508-6"
+title: "Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study"
+authors:
+- Chunxing Liu
+- Xiaolong Yang
+- Mengmeng Ji
+- Xiaowei Zhang
+- Xiyun Bian
+- Tingli Chen
+- Yihan Li
+- Xing Qi
+- Jianfeng Wu
+- Jing Wang
+- Zaixiang Tang
+journal: European Journal of Medical Research
+year: '2023'
+doi: 10.1186/s40001-023-01508-6
+content_type: abstract_only
+---
+
+# Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study
+**Authors:** Chunxing Liu, Xiaolong Yang, Mengmeng Ji, Xiaowei Zhang, Xiyun Bian, Tingli Chen, Yihan Li, Xing Qi, Jianfeng Wu, Jing Wang, Zaixiang Tang
+**Journal:** European Journal of Medical Research (2023)
+**DOI:** [10.1186/s40001-023-01508-6](https://doi.org/10.1186/s40001-023-01508-6)
+
+## Content
+
+Abstract
+Objectives
+Vascular stiffening is highly predictive of major adverse cardiovascular events. It is not clear whether microangiopathy, such as fundus arteriosclerosis, is related to carotid atherosclerosis. Hence, this study was designed to investigate the relationship between carotid atherosclerosis and fundus arteriosclerosis among individuals of different sexes in the Chinese health-examination population.
+
+Methods
+This retrospective cross-sectional study involved 20,836 participants, including 13050 males and 7786 females. All participants underwent a detailed health examination, including medical history assessment, physical examination, assessment of lifestyle factors, fundus photography, Doppler ultrasound examination of the neck, and laboratory examinations. Two trained ophthalmologists analysed fundus arteriosclerosis based on fundus photographs, while carotid atherosclerosis was diagnosed using colour Doppler sonography of the neck. Binary logistic regression was used to analyse the relationship between carotid atherosclerosis and fundus arteriosclerosis.
+
+Results
+In participants with fundus arteriosclerosis, the incidence of carotid atherosclerosis was higher than that of participants without fundus arteriosclerosis (52.94% vs. 47.06%). After adjustments for potential confounding factors, fundus arteriosclerosis was significantly associated with the risk of carotid atherosclerosis. The OR with 95% CI for fundus arteriosclerosis was 1.17 (1.02, 1.34) with p = 0.0262, and individuals who did not have fundus arteriosclerosis were used as a reference in the total population. Fundus arteriosclerosis was associated with the incidence of carotid atherosclerosis in males (p = 0.0005) but not in females (p = 0.0746).
+
+Conclusions
+Fundus arteriosclerosis was closely associated with carotid atherosclerosis in the Chinese population. This association was found in males but not in females.

--- a/references_cache/DOI_10.3389_fcvm.2023.1116486.md
+++ b/references_cache/DOI_10.3389_fcvm.2023.1116486.md
@@ -1,0 +1,26 @@
+---
+reference_id: "DOI:10.3389/fcvm.2023.1116486"
+title: "Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in Chinese population: A population-based longitudinal study"
+authors:
+- Ruirui Geng
+- Qinbei Feng
+- Mengmeng Ji
+- Yongfei Dong
+- Shuanshuan Xu
+- Chunxing Liu
+- Yufeng He
+- Zaixiang Tang
+journal: Frontiers in Cardiovascular Medicine
+year: '2023'
+doi: 10.3389/fcvm.2023.1116486
+content_type: abstract_only
+---
+
+# Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in Chinese population: A population-based longitudinal study
+**Authors:** Ruirui Geng, Qinbei Feng, Mengmeng Ji, Yongfei Dong, Shuanshuan Xu, Chunxing Liu, Yufeng He, Zaixiang Tang
+**Journal:** Frontiers in Cardiovascular Medicine (2023)
+**DOI:** [10.3389/fcvm.2023.1116486](https://doi.org/10.3389/fcvm.2023.1116486)
+
+## Content
+
+BackgroundThe impact of serum uric acid (SUA) trajectories on the development of retinal arteriosclerosis is uncertain. The purpose of this study was to identify adult SUA trajectories by sex and determine their association with risk of retinal arteriosclerosis.MethodsIn this longitudinal study, 4,324 participants who were aged between 18 and 60 years without retinal arteriosclerosis at or before baseline (from January 1, 2010, through December 31, 2010) were included. Group-based trajectory modeling was used to identify SUA trajectories during the exposure period (from January 1, 2006, through December 31, 2010). Cox proportional-hazards models were applied to evaluate the associations between SUA trajectories and the risk of incident retinal arteriosclerosis during the outcome period (from January 1, 2011, through December 31, 2019).Results4 distinct SUA trajectories were identified in both women and men: low, moderate, moderate-high, and high. During a median follow-up of 9.54 years (IQR 9.53–9.56), 97 women and 295 men had developed retinal arteriosclerosis. In the fully adjusted model, a significant association between the moderate-high SUA trajectory group and incidence of retinal arteriosclerosis was observed only in men (HR: 1.76, 95% CI: 1.17–2.65) compared with the low trajectory group, but not in women (HR: 0.77, 95% CI: 0.39–1.52). Also, the high SUA trajectory group had the highest risk with an adjusted HR of 1.81 (95% CI, 1.04–3.17) in men. However, they did not exhibit a substantially increased risk in women.ConclusionHigher SUA trajectory groups were significantly associated with an increased risk of incident retinal arteriosclerosis in men but not in women.

--- a/references_cache/DOI_10.3390_jcdd12060230.md
+++ b/references_cache/DOI_10.3390_jcdd12060230.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.3390/jcdd12060230"
+title: "Retinal Imaging as a Window into Cardiovascular Health: Towards Harnessing Retinal Analytics for Precision Cardiovascular Medicine"
+authors:
+- Jay Bharatsingh Bisen
+- Hayden Sikora
+- Anushree Aneja
+- Sanjiv J. Shah
+- Rukhsana G. Mirza
+journal: Journal of Cardiovascular Development and Disease
+year: '2025'
+doi: 10.3390/jcdd12060230
+content_type: abstract_only
+---
+
+# Retinal Imaging as a Window into Cardiovascular Health: Towards Harnessing Retinal Analytics for Precision Cardiovascular Medicine
+**Authors:** Jay Bharatsingh Bisen, Hayden Sikora, Anushree Aneja, Sanjiv J. Shah, Rukhsana G. Mirza
+**Journal:** Journal of Cardiovascular Development and Disease (2025)
+**DOI:** [10.3390/jcdd12060230](https://doi.org/10.3390/jcdd12060230)
+
+## Content
+
+Rising morbidity and mortality from cardiovascular disease (CVD) have increased interest in precision and preventive management to reduce long-term sequelae. While retinal imaging has traditionally been recognized for identifying vascular changes in systemic conditions such as hypertension and type 2 diabetes mellitus, a new ophthalmologic field, cardiac-oculomics, has associated retinal biomarker changes with other cardiovascular diseases with retinal manifestations. Several imaging modalities visualize the retina, including color fundus photography (CFP), optical coherence tomography (OCT), and OCT angiography (OCTA), which visualize the retinal surface, the individual retinal layers, and the microvasculature within those layers, respectively. In these modalities, imaging-derived biomarkers can present due to CVD and have been linked to the presence, progression, or risk of developing a range of CVD, including hypertension, carotid artery disease, valvular heart disease, cerebral infarction, atrial fibrillation, and heart failure. Promising artificial intelligence (AI) models have been developed to complement existing risk-prediction tools, but standardization and clinical trials are needed for clinical adoption. Beyond risk estimation, there is growing interest in assessing real-time cardiovascular status to track vascular changes following pharmacotherapy, surgery, or acute decompensation. This review offers an up-to-date assessment of the cardiac-oculomics literature and aims to raise awareness among cardiologists and encourage interdepartmental collaboration.

--- a/references_cache/DOI_10.3390_jpm13111564.md
+++ b/references_cache/DOI_10.3390_jpm13111564.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.3390/jpm13111564"
+title: "Retinal Findings and Cardiovascular Risk: Prognostic Conditions, Novel Biomarkers, and Emerging Image Analysis Techniques"
+authors:
+- Joseph Colcombe
+- Rusdeep Mundae
+- Alexis Kaiser
+- Jacques Bijon
+- Yasha Modi
+journal: Journal of Personalized Medicine
+year: '2023'
+doi: 10.3390/jpm13111564
+content_type: abstract_only
+---
+
+# Retinal Findings and Cardiovascular Risk: Prognostic Conditions, Novel Biomarkers, and Emerging Image Analysis Techniques
+**Authors:** Joseph Colcombe, Rusdeep Mundae, Alexis Kaiser, Jacques Bijon, Yasha Modi
+**Journal:** Journal of Personalized Medicine (2023)
+**DOI:** [10.3390/jpm13111564](https://doi.org/10.3390/jpm13111564)
+
+## Content
+
+Many retinal diseases and imaging findings have pathophysiologic underpinnings in the function of the cardiovascular system. Myriad retinal conditions, new imaging biomarkers, and novel image analysis techniques have been investigated for their association with future cardiovascular risk or utility in cardiovascular risk prognostication. An intensive literature search was performed to identify relevant articles indexed in PubMed, Scopus, and Google Scholar for a targeted narrative review. This review investigates the literature on specific retinal disease states, such as retinal arterial and venous occlusions and cotton wool spots, that portend significantly increased risk of future cardiovascular events, such as stroke or myocardial infarction, and the implications for personalized patient counseling. Furthermore, conditions diagnosed primarily through retinal bioimaging, such as paracentral acute middle maculopathy and the newly discovered entity known as a retinal ischemic perivascular lesion, may be associated with future incident cardiovascular morbidity and are also discussed. As ever-more-sophisticated imaging biomarkers and analysis techniques are developed, the review concludes with a focused analysis of optical coherence tomography and optical coherence tomography angiography biomarkers under investigation for potential value in prognostication and personalized therapy in cardiovascular disease.

--- a/references_cache/DOI_10.3390_jpm14050501.md
+++ b/references_cache/DOI_10.3390_jpm14050501.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.3390/jpm14050501"
+title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease
+authors:
+- Raluca Eugenia Iorga
+- Damiana Costin
+- Răzvana Sorina Munteanu-Dănulescu
+- Elena Rezuș
+- Andreea Dana Moraru
+journal: Journal of Personalized Medicine
+year: '2024'
+doi: 10.3390/jpm14050501
+content_type: abstract_only
+---
+
+# Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease
+**Authors:** Raluca Eugenia Iorga, Damiana Costin, Răzvana Sorina Munteanu-Dănulescu, Elena Rezuș, Andreea Dana Moraru
+**Journal:** Journal of Personalized Medicine (2024)
+**DOI:** [10.3390/jpm14050501](https://doi.org/10.3390/jpm14050501)
+
+## Content
+
+Cardiovascular disease (CVD) is the most frequent cause of death worldwide. The alterations in the microcirculation may predict the cardiovascular mortality. The retinal vasculature can be used as a model to study vascular alterations associated with cardiovascular disease. In order to quantify microvascular changes in a non-invasive way, fundus images can be taken and analysed. The central retinal arteriolar (CRAE), the venular (CRVE) diameter and the arteriolar-to-venular diameter ratio (AVR) can be used as biomarkers to predict the cardiovascular mortality. A narrower CRAE, wider CRVE and a lower AVR have been associated with increased cardiovascular events. Dynamic retinal vessel analysis (DRVA) allows the quantification of retinal changes using digital image sequences in response to visual stimulation with flicker light. This article is not just a review of the current literature, it also aims to discuss the methodological benefits and to identify research gaps. It highlights the potential use of microvascular biomarkers for screening and treatment monitoring of cardiovascular disease. Artificial intelligence (AI), such as Quantitative Analysis of Retinal vessel Topology and size (QUARTZ), and SIVA–deep learning system (SIVA-DLS), seems efficient in extracting information from fundus photographs and has the advantage of increasing diagnosis accuracy and improving patient care by complementing the role of physicians. Retinal vascular imaging using AI may help identify the cardiovascular risk, and is an important tool in primary cardiovascular disease prevention. Further research should explore the potential clinical application of retinal microvascular biomarkers, in order to assess systemic vascular health status, and to predict cardiovascular events.

--- a/references_cache/DOI_10.3390_life14040448.md
+++ b/references_cache/DOI_10.3390_life14040448.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.3390/life14040448"
+title: "Retinal Structural and Vascular Changes in Patients with Coronary Artery Disease: A Systematic Review and Meta-Analysis"
+authors:
+- Alexandra Cristina Rusu
+- Karin Ursula Horvath
+- Grigore Tinica
+- Raluca Ozana Chistol
+- Andra-Irina Bulgaru-Iliescu
+- Ecaterina Tomaziu Todosia
+- Klara Brînzaniuc
+journal: Life
+year: '2024'
+doi: 10.3390/life14040448
+content_type: abstract_only
+---
+
+# Retinal Structural and Vascular Changes in Patients with Coronary Artery Disease: A Systematic Review and Meta-Analysis
+**Authors:** Alexandra Cristina Rusu, Karin Ursula Horvath, Grigore Tinica, Raluca Ozana Chistol, Andra-Irina Bulgaru-Iliescu, Ecaterina Tomaziu Todosia, Klara Brînzaniuc
+**Journal:** Life (2024)
+**DOI:** [10.3390/life14040448](https://doi.org/10.3390/life14040448)
+
+## Content
+
+Background: Retinal microvascular anomalies have been identified in patients with cardiovascular conditions such as arterial hypertension, diabetes mellitus, and carotid artery disease. We conducted a systematic review and meta-analysis (PROSPERO registration number CRD42024506589) to explore the potential of retinal vasculature as a biomarker for diagnosis and monitoring of patients with coronary artery disease (CAD) through optical coherence tomography (OCT) and optical coherence tomography angiography (OCTA). Methods: We systematically examined original articles in the Pubmed, Embase, and Web of Science databases from their inception up to November 2023, comparing retinal microvascular features between patients with CAD and control groups. Studies were included if they reported sample mean with standard deviation or median with range and/or interquartile range (which were computed into mean and standard deviation). Review Manager 5.4 (The Cochrane Collaboration, 2020) software was used to calculate the pooled effect size with weighted mean difference and 95% confidence intervals (CI) by random-effects inverse variance method. Results: Eleven studies meeting the inclusion criteria were incorporated into the meta-analysis. The findings indicated a significant decrease in the retinal nerve fiber layer (WMD −3.11 [−6.06, −0.16]), subfoveal choroid (WMD −58.79 [−64.65, −52.93]), and overall retinal thickness (WMD −4.61 [−7.05, −2.17]) among patients with CAD compared to controls (p < 0.05). Furthermore, vascular macular density was notably lower in CAD patients, particularly in the superficial capillary plexus (foveal vessel density WMD −2.19 [−3.02, −1.135], p < 0.0001). Additionally, the foveal avascular zone area was statistically larger in CAD patients compared to the control group (WMD 52.73 [8.79, 96.67], p = 0.02). Heterogeneity was significant (I2 > 50%) for most features except for subfoveal choroid thickness, retina thickness, and superficial foveal vessel density. Conclusion: The current meta-analysis suggests that retinal vascularization could function as a noninvasive biomarker, providing additional insights beyond standard routine examinations for assessing dysfunction in coronary arteries.

--- a/references_cache/DOI_10.5551_jat.30601.md
+++ b/references_cache/DOI_10.5551_jat.30601.md
@@ -1,0 +1,20 @@
+---
+reference_id: "DOI:10.5551/jat.30601"
+title: Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis
+authors:
+- Hirohiko Nokiba
+- Takashi Takei
+- Chikako Suto
+- Kosaku Nitta
+journal: Journal of Atherosclerosis and Thrombosis
+year: '2015'
+doi: 10.5551/jat.30601
+content_type: unavailable
+---
+
+# Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis
+**Authors:** Hirohiko Nokiba, Takashi Takei, Chikako Suto, Kosaku Nitta
+**Journal:** Journal of Atherosclerosis and Thrombosis (2015)
+**DOI:** [10.5551/jat.30601](https://doi.org/10.5551/jat.30601)
+
+## Content

--- a/references_cache/DOI_10.5551_jat.59857.md
+++ b/references_cache/DOI_10.5551_jat.59857.md
@@ -1,0 +1,28 @@
+---
+reference_id: "DOI:10.5551/jat.59857"
+title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals
+authors:
+- Tomonori Sugiura
+- Yasuaki Dohi
+- Yasuyuki Takagi
+- Takashi Yokochi
+- Naofumi Yoshikane
+- Kenji Suzuki
+- Takamasa Tomiishi
+- Takashi Nagami
+- Mitsunori Iwase
+- Hiroyuki Takase
+- Yoshihiro Seo
+- Nobuyuki Ohte
+journal: Journal of Atherosclerosis and Thrombosis
+year: '2022'
+doi: 10.5551/jat.59857
+content_type: unavailable
+---
+
+# Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals
+**Authors:** Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, Nobuyuki Ohte
+**Journal:** Journal of Atherosclerosis and Thrombosis (2022)
+**DOI:** [10.5551/jat.59857](https://doi.org/10.5551/jat.59857)
+
+## Content

--- a/references_cache/PMID_17070582.md
+++ b/references_cache/PMID_17070582.md
@@ -1,0 +1,97 @@
+---
+reference_id: "PMID:17070582"
+title: "Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign."
+authors:
+- Kaushik S
+- Tan AG
+- Mitchell P
+- Wang JJ
+journal: Ophthalmology
+year: '2007'
+doi: 10.1016/j.ophtha.2006.06.046
+keywords:
+- Aged
+- "Aged, 80 and over"
+- Arterioles/pathology
+- Blood Glucose/analysis
+- Blood Pressure/physiology
+- Cause of Death
+- Cholesterol/blood
+- "Cholesterol, LDL/blood"
+- Cross-Sectional Studies
+- Female
+- Humans
+- "Hypertension/diagnosis, etiology, mortality"
+- Light
+- Male
+- Middle Aged
+- Photography/methods
+- Prevalence
+- Prognosis
+- Reflex
+- Retinal Artery/pathology
+- "Retinal Diseases/diagnosis, etiology, mortality"
+- Risk Factors
+- Triglycerides/blood
+content_type: abstract_only
+---
+
+# Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign.
+**Authors:** Kaushik S, Tan AG, Mitchell P, Wang JJ
+**Journal:** Ophthalmology (2007)
+**DOI:** [10.1016/j.ophtha.2006.06.046](https://doi.org/10.1016/j.ophtha.2006.06.046)
+
+## Content
+
+1. Ophthalmology. 2007 Jan;114(1):113-20. doi: 10.1016/j.ophtha.2006.06.046. Epub
+ 2006 Oct 27.
+
+Prevalence and associations of enhanced retinal arteriolar light reflex: a new 
+look at an old sign.
+
+Kaushik S(1), Tan AG, Mitchell P, Wang JJ.
+
+Author information:
+(1)Department of Ophthalmology, Center for Vision Research, Westmead Millennium 
+Institute, University of Sydney, Sydney, Australia.
+
+PURPOSE: To assess the prevalence, associated risk factors and prognosis 
+(mortality) of the enhanced retinal arteriolar light reflex sign in an older 
+Australian population.
+DESIGN: Population-based cross-sectional study.
+PARTICIPANTS: Three thousand six hundred fifty-four participants (82.4% 
+response) ages >/=49 years from Australia's Blue Mountains region.
+METHODS: Retinal photographs of participants were graded for presence and 
+severity of the enhanced arteriolar light reflex sign by comparison with 
+standard photographs. Associations with systemic factors (subject-specific) and 
+ocular variables (eye-specific) were assessed by logistic regression. Mortality 
+data were obtained using the Australian National Death Index. Hazard ratios were 
+calculated using Cox regression.
+MAIN OUTCOME MEASURES: Prevalence of enhanced arteriolar light reflex and 
+associations with demographic variables (age, gender), blood pressure, blood 
+parameters, health risk behaviors, cataract, retinal vessel wall signs, 
+retinopathy, and 10-year incident mortality.
+RESULTS: The enhanced arteriolar light reflex sign was found in 1053 
+participants (31.7%, including 28.8% graded as mild and 2.9% as marked). 
+Prevalence decreased with age (36.0%, 37.7%, 28.0%, and 18.8% for age groups < 
+60, 60-69, 70-79 and > or = 80 years, respectively, P(trend)<0.0001); odds ratio 
+(OR) 0.78; and 95% confidence interval (CI) 0.72 to 0.85 per decade. Persons 
+with cataract were less likely to have mildly enhanced light reflex (OR, 0.74; 
+CI 0.64-0.87). After multivariate adjustment, mildly enhanced light reflex was 
+significantly associated with serum glucose (OR 1.11 per SD increase), total 
+cholesterol (OR 1.11), low-density lipoprotein (OR 1.55), triglycerides (OR 
+1.11), platelets (OR 0.89), and body mass index (OR 1.12). Markedly enhanced 
+light reflex was significantly associated with mean arterial blood pressure (OR 
+1.24), heavy alcohol consumption (OR 2.66, > or = 40 grams alcohol per day), and 
+serum glucose (OR 1.16). Strong associations were demonstrated between presence 
+of mildly enhanced light reflex and either arteriovenous nicking (OR 3.12) or 
+retinopathy (OR 1.96). There was no association between mildly or markedly 
+enhanced light reflex and either all-cause or vascular mortality.
+CONCLUSIONS: In this older population, the enhanced retinal arteriolar light 
+reflex sign was a relatively common finding. Although some associations of this 
+sign with vascular risk factors were found, only a marked level of enhanced 
+light reflex was correlated with elevated blood pressure, but not with poor 
+survival.
+
+DOI: 10.1016/j.ophtha.2006.06.046
+PMID: 17070582 [Indexed for MEDLINE]

--- a/references_cache/PMID_26133318.md
+++ b/references_cache/PMID_26133318.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:26133318"
+title: Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+authors:
+- Nokiba H
+- Takei T
+- Suto C
+- Nitta K
+journal: J Atheroscler Thromb
+year: '2015'
+doi: 10.5551/jat.30601
+keywords:
+- Aged
+- Arteriosclerosis/complications
+- Cardiovascular Diseases/complications
+- Eye Diseases/complications
+- Female
+- Humans
+- Hypertensive Retinopathy/complications
+- Male
+- Middle Aged
+- Pulse Wave Analysis
+- Renal Dialysis
+- "Renal Insufficiency, Chronic/complications, therapy"
+- Risk Factors
+- Treatment Outcome
+- Vascular Stiffness
+content_type: abstract_only
+---
+
+# Association between Ophthalmological Changes and Cardiovascular Diseases in Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+**Authors:** Nokiba H, Takei T, Suto C, Nitta K
+**Journal:** J Atheroscler Thromb (2015)
+**DOI:** [10.5551/jat.30601](https://doi.org/10.5551/jat.30601)
+
+## Content
+
+1. J Atheroscler Thromb. 2015;22(12):1248-54. doi: 10.5551/jat.30601. Epub 2015
+Jun  30.
+
+Association between Ophthalmological Changes and Cardiovascular Diseases in 
+Patients with Chronic Kidney Disease Undergoing Hemodialysis.
+
+Nokiba H(1), Takei T, Suto C, Nitta K.
+
+Author information:
+(1)Department of Medicine, Kidney Center, Tokyo Women's Medical University.
+
+AIMS: Patients with chronic kidney disease (CKD) undergoing hemodialysis (HD) 
+have a high prevalence of cardiovascular diseases (CVD). Arterial sclerosis 
+plays an important role in the pathogenesis of CVD. However, to date, there have 
+been no reports of assessment of the association between retinal arterial 
+sclerosis and CVD in patients with CKD on HD. The aim of this study was to 
+assess retinal arterial sclerosis and to investigate the relationship between 
+retinal arterial changes in patients with CKD on HD and arterial stiffness/past 
+history of CVD.
+METHODS: We examined the data of 44 patients (21 female, 23 male) with CKD 
+receiving HD treatment at Saiseikai Kurihashi Hospital. The relationship between 
+ophthalmological changes and arterial stiffness [pulse wave velocity (PWV)] or 
+past history of CVD was evaluated. All medications being taken were recorded, 
+and biochemical parameters were analyzed.
+RESULTS: Significant correlations were found between the presence of 
+arteriosclerotic retinopathy [Scheie classification S grade (grade 0: 7 
+patients, grade 1: 18 patients, grade 2: 14 patients, grade 3: 4 patients, and 
+grade 4: 1 patient)] and results of the evaluation of arterial stiffness (PWV) 
+and past history of CVD (p=0.001, p=0.045). Other ophthalmological findings were 
+not associated with a history of CVD or arterial stiffness.
+CONCLUSION: We showed that the classification (Scheie S grade) of retinopathy on 
+ophthalmoscopic examination may be a useful tool for predicting arterial 
+stiffness and its association with CVD.
+
+DOI: 10.5551/jat.30601
+PMID: 26133318 [Indexed for MEDLINE]

--- a/references_cache/PMID_33239480.md
+++ b/references_cache/PMID_33239480.md
@@ -1,0 +1,92 @@
+---
+reference_id: "PMID:33239480"
+title: Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+authors:
+- Sugiura T
+- Dohi Y
+- Takagi Y
+- Yokochi T
+- Yoshikane N
+- Suzuki K
+- Tomiishi T
+- Nagami T
+- Iwase M
+- Takase H
+- Seo Y
+- Ohte N
+journal: J Atheroscler Thromb
+year: '2022'
+doi: 10.5551/jat.59857
+keywords:
+- Adult
+- Age Factors
+- Ankle Brachial Index
+- "Atherosclerosis/complications, diagnosis, physiopathology"
+- Carotid Intima-Media Thickness
+- Cohort Studies
+- Female
+- Humans
+- "Hypertension/complications, diagnosis, physiopathology"
+- Male
+- Middle Aged
+- Regression Analysis
+- "Retinal Diseases/complications, diagnosis, physiopathology"
+content_type: abstract_only
+---
+
+# Examination of Large Artery Atherosclerosis could Reveal Small Artery Retinopathy in Untreated Middle-Aged Individuals.
+**Authors:** Sugiura T, Dohi Y, Takagi Y, Yokochi T, Yoshikane N, Suzuki K, Tomiishi T, Nagami T, Iwase M, Takase H, Seo Y, Ohte N
+**Journal:** J Atheroscler Thromb (2022)
+**DOI:** [10.5551/jat.59857](https://doi.org/10.5551/jat.59857)
+
+## Content
+
+1. J Atheroscler Thromb. 2022 Jan 1;29(1):11-23. doi: 10.5551/jat.59857. Epub
+2020  Nov 25.
+
+Examination of Large Artery Atherosclerosis could Reveal Small Artery 
+Retinopathy in Untreated Middle-Aged Individuals.
+
+Sugiura T(1)(2), Dohi Y(2)(3), Takagi Y(2)(4), Yokochi T(2)(5), Yoshikane N(2), 
+Suzuki K(2), Tomiishi T(2), Nagami T(2), Iwase M(4), Takase H(1)(6), Seo Y(1), 
+Ohte N(1).
+
+Author information:
+(1)Department of Cardiology, Nagoya City University Graduate School of Medical 
+Sciences.
+(2)Health Support Center WELPO, Toyota Motor Corporation.
+(3)Department of Internal Medicine, Faculty of Rehabilitation Sciences, Nagoya 
+Gakuin University.
+(4)Toyota Memorial Hospital.
+(5)Midtown Clinic Meieki.
+(6)Department of Internal Medicine, Enshu Hospital.
+
+AIMS: Small arteries can be visualized in the ocular fundus, and findings of 
+retinopathy based on Scheie classification are often applied to evaluate the 
+impact of hypertension and atherosclerosis. However, the relationship between 
+damage in the large and small arteries has not been investigated sufficiently, 
+especially in the early stages. The present study investigated possible 
+associations between large artery atherosclerosis and small artery retinopathy 
+in untreated middle-aged individuals.
+METHODS: Untreated middle-aged workers undergoing periodic health check-ups 
+(n=7,730, 45±8 years) were enrolled in this study. The absence or presence and 
+extent of retinopathy were characterized by ophthalmologists as hypertensive 
+(H0-4) and atherosclerotic grades (S0-4) based on Scheie classification. Large 
+artery atherosclerosis was examined based on functional assessment of the 
+cardio-ankle vascular index (CAVI) and morphological assessment of the carotid 
+intima-media thickness (IMT) by ultrasound.
+RESULTS: We found significant differences in CAVI and carotid IMT between 
+individuals with and without hypertensive or atherosclerotic retinopathy. 
+Multivariable regression analysis showed that the presence of hypertensive and 
+atherosclerotic retinopathy was significantly associated with CAVI and carotid 
+IMT. Logistic regression analysis with the endpoint of a hypertensive or 
+atherosclerotic lesion revealed that CAVI and carotid IMT are independent 
+determinants of retinopathy.
+CONCLUSIONS: CAVI and carotid IMT were significantly associated with the 
+presence of retinopathy based on Scheie classification in untreated middle-aged 
+subjects, implying that atherosclerotic examination in large arteries could 
+reveal early-stage small artery retinopathy.
+
+DOI: 10.5551/jat.59857
+PMCID: PMC8737076
+PMID: 33239480 [Indexed for MEDLINE]

--- a/references_cache/PMID_36926048.md
+++ b/references_cache/PMID_36926048.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:36926048"
+title: "Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in Chinese population: A population-based longitudinal study."
+authors:
+- Geng R
+- Feng Q
+- Ji M
+- Dong Y
+- Xu S
+- Liu C
+- He Y
+- Tang Z
+journal: Front Cardiovasc Med
+year: '2023'
+doi: 10.3389/fcvm.2023.1116486
+content_type: abstract_only
+---
+
+# Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in Chinese population: A population-based longitudinal study.
+**Authors:** Geng R, Feng Q, Ji M, Dong Y, Xu S, Liu C, He Y, Tang Z
+**Journal:** Front Cardiovasc Med (2023)
+**DOI:** [10.3389/fcvm.2023.1116486](https://doi.org/10.3389/fcvm.2023.1116486)
+
+## Content
+
+1. Front Cardiovasc Med. 2023 Feb 28;10:1116486. doi: 10.3389/fcvm.2023.1116486. 
+eCollection 2023.
+
+Sex-specific association of serum uric acid trajectories with risk of incident 
+retinal arteriosclerosis in Chinese population: A population-based longitudinal 
+study.
+
+Geng R(1)(2), Feng Q(3), Ji M(3), Dong Y(1)(2), Xu S(1)(2), Liu C(3), He Y(4), 
+Tang Z(1)(2).
+
+Author information:
+(1)Department of Biostatistics, School of Public Health, Suzhou Medical College 
+of Soochow University, Suzhou, China.
+(2)Jiangsu Key Laboratory of Preventive and Translational Medicine for Geriatric 
+Diseases, Suzhou Medical College of Soochow University, Suzhou, China.
+(3)Department of Laboratory, Hua Dong Sanatorium, Wuxi, China.
+(4)Department of Stomatology, Hua Dong Sanatorium, Wuxi, China.
+
+BACKGROUND: The impact of serum uric acid (SUA) trajectories on the development 
+of retinal arteriosclerosis is uncertain. The purpose of this study was to 
+identify adult SUA trajectories by sex and determine their association with risk 
+of retinal arteriosclerosis.
+METHODS: In this longitudinal study, 4,324 participants who were aged between 18 
+and 60 years without retinal arteriosclerosis at or before baseline (from 
+January 1, 2010, through December 31, 2010) were included. Group-based 
+trajectory modeling was used to identify SUA trajectories during the exposure 
+period (from January 1, 2006, through December 31, 2010). Cox 
+proportional-hazards models were applied to evaluate the associations between 
+SUA trajectories and the risk of incident retinal arteriosclerosis during the 
+outcome period (from January 1, 2011, through December 31, 2019).
+RESULTS: 4 distinct SUA trajectories were identified in both women and men: low, 
+moderate, moderate-high, and high. During a median follow-up of 9.54 years (IQR 
+9.53-9.56), 97 women and 295 men had developed retinal arteriosclerosis. In the 
+fully adjusted model, a significant association between the moderate-high SUA 
+trajectory group and incidence of retinal arteriosclerosis was observed only in 
+men (HR: 1.76, 95% CI: 1.17-2.65) compared with the low trajectory group, but 
+not in women (HR: 0.77, 95% CI: 0.39-1.52). Also, the high SUA trajectory group 
+had the highest risk with an adjusted HR of 1.81 (95% CI, 1.04-3.17) in men. 
+However, they did not exhibit a substantially increased risk in women.
+CONCLUSION: Higher SUA trajectory groups were significantly associated with an 
+increased risk of incident retinal arteriosclerosis in men but not in women.
+
+Copyright © 2023 Geng, Feng, Ji, Dong, Xu, Liu, He and Tang.
+
+DOI: 10.3389/fcvm.2023.1116486
+PMCID: PMC10011080
+PMID: 36926048
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_37968750.md
+++ b/references_cache/PMID_37968750.md
@@ -1,0 +1,95 @@
+---
+reference_id: "PMID:37968750"
+title: "Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study."
+authors:
+- Liu C
+- Yang X
+- Ji M
+- Zhang X
+- Bian X
+- Chen T
+- Li Y
+- Qi X
+- Wu J
+- Wang J
+- Tang Z
+journal: Eur J Med Res
+year: '2023'
+doi: 10.1186/s40001-023-01508-6
+keywords:
+- Male
+- Female
+- Humans
+- Retrospective Studies
+- Cross-Sectional Studies
+- Risk Factors
+- "Arteriosclerosis/diagnostic imaging, epidemiology, complications"
+- "Carotid Artery Diseases/complications, diagnostic imaging, epidemiology"
+content_type: abstract_only
+---
+
+# Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a Chinese population: a retrospective cross-sectional study.
+**Authors:** Liu C, Yang X, Ji M, Zhang X, Bian X, Chen T, Li Y, Qi X, Wu J, Wang J, Tang Z
+**Journal:** Eur J Med Res (2023)
+**DOI:** [10.1186/s40001-023-01508-6](https://doi.org/10.1186/s40001-023-01508-6)
+
+## Content
+
+1. Eur J Med Res. 2023 Nov 15;28(1):518. doi: 10.1186/s40001-023-01508-6.
+
+Sex-specific association between carotid atherosclerosis and fundus 
+arteriosclerosis in a Chinese population: a retrospective cross-sectional study.
+
+Liu C(#)(1), Yang X(#)(2), Ji M(#)(1), Zhang X(3), Bian X(2), Chen T(2), Li 
+Y(4), Qi X(4), Wu J(1), Wang J(5), Tang Z(6)(7).
+
+Author information:
+(1)Department of Laboratory, Hua Dong Sanatorium, Wuxi, 214065, China.
+(2)Department of Ophthalmology, Hua Dong Sanatorium, Wuxi, 214065, China.
+(3)Department of Nursing, Hua Dong Sanatorium, Wuxi, 214065, China.
+(4)Department of Otolaryngology, Hua Dong Sanatorium, Wuxi, 214065, China.
+(5)Department of Ophthalmology, Hua Dong Sanatorium, Wuxi, 214065, China. 
+wangjing2034@126.com.
+(6)Department of Biostatistics, School of Public Health, Suzhou Medical College 
+of Soochow University, Suzhou, 215123, China. tangzx@suda.edu.cn.
+(7)Jiangsu Key Laboratory of Preventive and Translational Medicine for Geriatric 
+Diseases, Suzhou Medical College of Soochow University, Suzhou, 215123, China. 
+tangzx@suda.edu.cn.
+(#)Contributed equally
+
+OBJECTIVES: Vascular stiffening is highly predictive of major adverse 
+cardiovascular events. It is not clear whether microangiopathy, such as fundus 
+arteriosclerosis, is related to carotid atherosclerosis. Hence, this study was 
+designed to investigate the relationship between carotid atherosclerosis and 
+fundus arteriosclerosis among individuals of different sexes in the Chinese 
+health-examination population.
+METHODS: This retrospective cross-sectional study involved 20,836 participants, 
+including 13050 males and 7786 females. All participants underwent a detailed 
+health examination, including medical history assessment, physical examination, 
+assessment of lifestyle factors, fundus photography, Doppler ultrasound 
+examination of the neck, and laboratory examinations. Two trained 
+ophthalmologists analysed fundus arteriosclerosis based on fundus photographs, 
+while carotid atherosclerosis was diagnosed using colour Doppler sonography of 
+the neck. Binary logistic regression was used to analyse the relationship 
+between carotid atherosclerosis and fundus arteriosclerosis.
+RESULTS: In participants with fundus arteriosclerosis, the incidence of carotid 
+atherosclerosis was higher than that of participants without fundus 
+arteriosclerosis (52.94% vs. 47.06%). After adjustments for potential 
+confounding factors, fundus arteriosclerosis was significantly associated with 
+the risk of carotid atherosclerosis. The OR with 95% CI for fundus 
+arteriosclerosis was 1.17 (1.02, 1.34) with p = 0.0262, and individuals who did 
+not have fundus arteriosclerosis were used as a reference in the total 
+population. Fundus arteriosclerosis was associated with the incidence of carotid 
+atherosclerosis in males (p = 0.0005) but not in females (p = 0.0746).
+CONCLUSIONS: Fundus arteriosclerosis was closely associated with carotid 
+atherosclerosis in the Chinese population. This association was found in males 
+but not in females.
+
+© 2023. The Author(s).
+
+DOI: 10.1186/s40001-023-01508-6
+PMCID: PMC10648731
+PMID: 37968750 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_38672719.md
+++ b/references_cache/PMID_38672719.md
@@ -1,0 +1,82 @@
+---
+reference_id: "PMID:38672719"
+title: "Retinal Structural and Vascular Changes in Patients with Coronary Artery Disease: A Systematic Review and Meta-Analysis."
+authors:
+- Rusu AC
+- Horvath KU
+- Tinica G
+- Chistol RO
+- Bulgaru-Iliescu AI
+- Todosia ET
+- Brînzaniuc K
+journal: Life (Basel)
+year: '2024'
+doi: 10.3390/life14040448
+content_type: abstract_only
+---
+
+# Retinal Structural and Vascular Changes in Patients with Coronary Artery Disease: A Systematic Review and Meta-Analysis.
+**Authors:** Rusu AC, Horvath KU, Tinica G, Chistol RO, Bulgaru-Iliescu AI, Todosia ET, Brînzaniuc K
+**Journal:** Life (Basel) (2024)
+**DOI:** [10.3390/life14040448](https://doi.org/10.3390/life14040448)
+
+## Content
+
+1. Life (Basel). 2024 Mar 28;14(4):448. doi: 10.3390/life14040448.
+
+Retinal Structural and Vascular Changes in Patients with Coronary Artery 
+Disease: A Systematic Review and Meta-Analysis.
+
+Rusu AC(1)(2), Horvath KU(2)(3), Tinica G(4)(5), Chistol RO(4)(5), 
+Bulgaru-Iliescu AI(4), Todosia ET(4), Brînzaniuc K(3).
+
+Author information:
+(1)Doctoral School of Medicine and Pharmacy, George Emil Palade University of 
+Medicine, Pharmacy, Science, and Technology of Targu Mures, 540142 Targu Mures, 
+Romania.
+(2)Department of Ophthalmology, Emergency County Hospital Targu Mures, 540136 
+Targu Mures, Romania.
+(3)Faculty of Medicine, George Emil Palade University of Medicine, Pharmacy, 
+Science, and Technology of Targu Mures, 540142 Targu Mures, Romania.
+(4)Faculty of Medicine, Grigore T. Popa University of Medicine and Pharmacy, 
+700115 Iasi, Romania.
+(5)Prof. Dr. George I.M. Georgescu Cardiovascular Diseases Institute, 700503 
+Iasi, Romania.
+
+BACKGROUND: Retinal microvascular anomalies have been identified in patients 
+with cardiovascular conditions such as arterial hypertension, diabetes mellitus, 
+and carotid artery disease. We conducted a systematic review and meta-analysis 
+(PROSPERO registration number CRD42024506589) to explore the potential of 
+retinal vasculature as a biomarker for diagnosis and monitoring of patients with 
+coronary artery disease (CAD) through optical coherence tomography (OCT) and 
+optical coherence tomography angiography (OCTA).
+METHODS: We systematically examined original articles in the Pubmed, Embase, and 
+Web of Science databases from their inception up to November 2023, comparing 
+retinal microvascular features between patients with CAD and control groups. 
+Studies were included if they reported sample mean with standard deviation or 
+median with range and/or interquartile range (which were computed into mean and 
+standard deviation). Review Manager 5.4 (The Cochrane Collaboration, 2020) 
+software was used to calculate the pooled effect size with weighted mean 
+difference and 95% confidence intervals (CI) by random-effects inverse variance 
+method.
+RESULTS: Eleven studies meeting the inclusion criteria were incorporated into 
+the meta-analysis. The findings indicated a significant decrease in the retinal 
+nerve fiber layer (WMD -3.11 [-6.06, -0.16]), subfoveal choroid (WMD -58.79 
+[-64.65, -52.93]), and overall retinal thickness (WMD -4.61 [-7.05, -2.17]) 
+among patients with CAD compared to controls (p < 0.05). Furthermore, vascular 
+macular density was notably lower in CAD patients, particularly in the 
+superficial capillary plexus (foveal vessel density WMD -2.19 [-3.02, -1.135], p 
+< 0.0001). Additionally, the foveal avascular zone area was statistically larger 
+in CAD patients compared to the control group (WMD 52.73 [8.79, 96.67], p = 
+0.02). Heterogeneity was significant (I2 > 50%) for most features except for 
+subfoveal choroid thickness, retina thickness, and superficial foveal vessel 
+density.
+CONCLUSION: The current meta-analysis suggests that retinal vascularization 
+could function as a noninvasive biomarker, providing additional insights beyond 
+standard routine examinations for assessing dysfunction in coronary arteries.
+
+DOI: 10.3390/life14040448
+PMCID: PMC11051177
+PMID: 38672719
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_38793083.md
+++ b/references_cache/PMID_38793083.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:38793083"
+title: Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+authors:
+- Iorga RE
+- Costin D
+- Munteanu-Dănulescu RS
+- Rezuș E
+- Moraru AD
+journal: J Pers Med
+year: '2024'
+doi: 10.3390/jpm14050501
+content_type: abstract_only
+---
+
+# Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+**Authors:** Iorga RE, Costin D, Munteanu-Dănulescu RS, Rezuș E, Moraru AD
+**Journal:** J Pers Med (2024)
+**DOI:** [10.3390/jpm14050501](https://doi.org/10.3390/jpm14050501)
+
+## Content
+
+1. J Pers Med. 2024 May 9;14(5):501. doi: 10.3390/jpm14050501.
+
+Non-Invasive Retinal Vessel Analysis as a Predictor for Cardiovascular Disease.
+
+Iorga RE(1), Costin D(2), Munteanu-Dănulescu RS(3), Rezuș E(4), Moraru AD(1).
+
+Author information:
+(1)Department of Surgery II, Discipline of Ophthalmology, "Grigore T. Popa" 
+University of Medicine and Pharmacy, Strada Universitatii No. 16, 700115 Iași, 
+Romania.
+(2)Doctoral School, "Grigore T. Popa" University of Medicine and Pharmacy, 
+700115 Iași, Romania.
+(3)Department of Gastroenterology, "L. Pasteur" Clinical Hospital, 28630 Le 
+Coudray, France.
+(4)Department of Internal Medicine II, Discipline of Reumathology, "Grigore T. 
+Popa" University of Medicine and Pharmacy, 700115 Iași, Romania.
+
+Cardiovascular disease (CVD) is the most frequent cause of death worldwide. The 
+alterations in the microcirculation may predict the cardiovascular mortality. 
+The retinal vasculature can be used as a model to study vascular alterations 
+associated with cardiovascular disease. In order to quantify microvascular 
+changes in a non-invasive way, fundus images can be taken and analysed. The 
+central retinal arteriolar (CRAE), the venular (CRVE) diameter and the 
+arteriolar-to-venular diameter ratio (AVR) can be used as biomarkers to predict 
+the cardiovascular mortality. A narrower CRAE, wider CRVE and a lower AVR have 
+been associated with increased cardiovascular events. Dynamic retinal vessel 
+analysis (DRVA) allows the quantification of retinal changes using digital image 
+sequences in response to visual stimulation with flicker light. This article is 
+not just a review of the current literature, it also aims to discuss the 
+methodological benefits and to identify research gaps. It highlights the 
+potential use of microvascular biomarkers for screening and treatment monitoring 
+of cardiovascular disease. Artificial intelligence (AI), such as Quantitative 
+Analysis of Retinal vessel Topology and size (QUARTZ), and SIVA-deep learning 
+system (SIVA-DLS), seems efficient in extracting information from fundus 
+photographs and has the advantage of increasing diagnosis accuracy and improving 
+patient care by complementing the role of physicians. Retinal vascular imaging 
+using AI may help identify the cardiovascular risk, and is an important tool in 
+primary cardiovascular disease prevention. Further research should explore the 
+potential clinical application of retinal microvascular biomarkers, in order to 
+assess systemic vascular health status, and to predict cardiovascular events.
+
+DOI: 10.3390/jpm14050501
+PMCID: PMC11122007
+PMID: 38793083
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/research/Arteriosclerotic_Retinopathy-deep-research-falcon.md
+++ b/research/Arteriosclerotic_Retinopathy-deep-research-falcon.md
@@ -1,0 +1,1247 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T13:31:04.419792'
+end_time: '2026-05-06T13:43:16.992744'
+duration_seconds: 732.58
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Arteriosclerotic Retinopathy
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 29
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Arteriosclerotic Retinopathy
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Arteriosclerotic Retinopathy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Arteriosclerotic Retinopathy
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Arteriosclerotic Retinopathy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Research Report: Arteriosclerotic Retinopathy (Fundus Arteriosclerosis / Retinal Arteriosclerosis)
+
+### Executive summary
+Arteriosclerotic retinopathy (often operationalized in modern epidemiology as **“fundus arteriosclerosis”** or **“retinal arteriosclerosis/atherosclerotic retinopathy”**) refers to chronic, structural **arteriolar wall changes** in the retinal circulation that are typically associated with aging and systemic vascular disease (e.g., hypertension, diabetes, chronic kidney disease, and atherosclerosis). Clinically it is recognized by ophthalmoscopic or fundus-photographic signs such as **increased arteriolar light reflex (copper/silver wiring)** and **arteriovenous (AV) crossing changes** and is commonly graded using **Scheie S0–S4** (atherosclerotic) and related grading systems. Histopathologic descriptors include medial hypertrophy, intimal hyalinization, and endothelial hyperplasia. (nokiba2015associationbetweenophthalmological pages 1-3, sugiura2022examinationoflarge media a2b302a2)
+
+Because the retina is a uniquely accessible microvascular bed, multiple recent studies (2023–2024) have used fundus photography and OCT/OCTA-derived metrics as **non-invasive correlates of systemic atherosclerosis burden** and predictors of cardiovascular/cerebrovascular risk. (liu2023sexspecificassociationbetween pages 3-4, rusu2024retinalstructuraland pages 1-2)
+
+---
+
+## 1. Disease Information
+
+### 1.1 Disease overview (current understanding)
+**Arteriosclerotic retinopathy** denotes chronic retinal arteriolar remodeling/“hardening” related to arteriosclerosis/atherosclerosis and long-standing vascular risk exposure. In one clinical definition used in CKD/hemodialysis research, arteriosclerotic retinopathy is described as a lesion characterized by **“medial layer hypertrophy, hyalinization of the intima, and hyperplasia of the endothelial layer of the vessel wall.”** (nokiba2015associationbetweenophthalmological pages 1-3)
+
+In practice, the term overlaps with chronic components of **hypertensive retinopathy** (arteriolar sclerosis) and with population screening terms such as **“fundus arteriosclerosis.”** (liu2023sexspecificassociationbetween pages 3-4, sugiura2022examinationoflarge media a2b302a2)
+
+### 1.2 Key identifiers (ontology/coding)
+* **MONDO / OMIM / Orphanet:** Not identified in the retrieved primary literature excerpts; this entity is commonly treated as a *clinical sign/phenotype complex* rather than a monogenic disorder. (No specific MONDO/OMIM/Orphanet identifier found in available texts.)
+* **MeSH / ICD-10/ICD-11:** Not extractable from the retrieved texts using available tools/evidence; many studies define the phenotype via **fundus grading systems** rather than billing codes. (liu2023sexspecificassociationbetween pages 3-4, sugiura2022examinationoflarge media a2b302a2)
+
+### 1.3 Synonyms / alternative names
+Commonly used overlapping terms in the retrieved literature:
+* **Fundus arteriosclerosis** (liu2023sexspecificassociationbetween pages 3-4)
+* **Retinal arteriosclerosis / atherosclerotic retinopathy** (Scheie S grading) (sugiura2022examinationoflarge pages 2-4, sugiura2022examinationoflarge media a2b302a2)
+* **Arteriolar light reflex enhancement** / **copper-wiring** / **silver-wiring** (as a sign within arteriosclerotic/hypertensive grading) (kaushik2007prevalenceandassociations pages 1-3, sugiura2022examinationoflarge media a2b302a2)
+
+### 1.4 Evidence sources
+The information above is derived from **aggregated disease-level resources in cohort studies, systematic reviews, and clinical definitions** rather than single case reports. (kaushik2007prevalenceandassociations pages 1-3, liu2023sexspecificassociationbetween pages 3-4, rusu2024retinalstructuraland pages 1-2, geng2023sexspecificassociationof pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Primary causal factors (multifactorial)
+Arteriosclerotic retinopathy is best understood as a **microvascular end-organ manifestation** of chronic systemic vascular stressors rather than a single causal gene disorder. Mechanistically, the phenotype reflects chronic arteriolar wall remodeling and sclerosis (see §6). (nokiba2015associationbetweenophthalmological pages 1-3)
+
+### 2.2 Risk factors (recent human evidence)
+**Metabolic and vascular risk factors** are consistently associated with arteriosclerotic retinal signs:
+
+* **Hypertension, diabetes, dyslipidemia, CKD:** In a cohort of untreated middle-aged workers (n=7,730), unadjusted odds ratios for atherosclerotic retinopathy (Scheie S1+S2) were elevated for CKD (OR 2.88), hypertension (OR 3.27), dyslipidemia (OR 1.26), and diabetes (OR 5.98). (sugiura2022examinationoflarge pages 12-13)
+* **Serum uric acid trajectory (sex-specific):** In a 2010 baseline cohort followed to 2019 (n=4,324), men in higher SUA trajectory groups had higher incidence of retinal arteriosclerosis (moderate-high vs low: HR 1.76; high vs low: HR 1.81), while women did not show the same pattern. (geng2023sexspecificassociationof pages 1-2)
+
+### 2.3 Protective factors
+Clear protective factors are less consistently reported; however, biomarkers sometimes proposed as protective against systemic atherosclerosis can show complex/sex-specific associations in retinal endpoints.
+
+* **Total bilirubin (TBIL):** A large retrospective cohort (n=27,477; 2006–2019) found *higher* TBIL quartiles were associated with *higher* risk of incident fundus arteriosclerosis in males (Q4 vs Q1 HR 1.396), with no significant association in females. This directionality suggests TBIL is not protective in this cohort/definition and underscores possible confounding or non-linear biology. (nokiba2015associationbetweenophthalmological pages 1-3)
+
+### 2.4 Gene–environment interactions
+Direct gene–environment interaction evidence specific to arteriosclerotic retinopathy was not captured in the retrieved texts. Some broader retinal microvascular biomarker literature acknowledges genetic influences on retinal traits, but disease-specific G×E results were not retrievable here. (iorga2024noninvasiveretinalvessel pages 5-7)
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Key clinical signs and grading (Scheie)
+The most widely operationalized phenotype definition in the retrieved sources is **Scheie atherosclerotic retinopathy S0–S4** and hypertensive retinopathy H0–H4, evaluated from fundus examination/photography.
+
+**Scheie atherosclerotic retinopathy (S) grading (definitions):**
+* **S0:** Normal
+* **S1:** Broadening of the light reflex from the arteriole with minimal/no AV compression
+* **S2:** Light reflex and crossing changes more prominent
+* **S3:** “Copper wire” appearance with more prominent AV compression
+* **S4:** “Silver” appearance with most severe AV crossing changes (sugiura2022examinationoflarge media a2b302a2)
+
+**Scheie hypertensive retinopathy (H) grading (definitions):**
+* **H0:** Normal
+* **H1:** Barely detectable arterial narrowing
+* **H2:** Obvious arterial narrowing with focal irregularities plus light reflex changes
+* **H3:** H2 plus retinal hemorrhages and/or exudates
+* **H4:** H3 plus papilledema (sugiura2022examinationoflarge media a2b302a2)
+
+A figure region containing the above grading definitions was retrieved from the Sugiura et al. paper (visual evidence). (sugiura2022examinationoflarge media a2b302a2)
+
+### 3.2 Population frequency (examples)
+* **Enhanced arteriolar light reflex (a related arteriosclerotic sign):** In the Blue Mountains Eye Study (n=3,654; ≥49 years), enhanced retinal arteriolar light reflex was common (31.7% overall; 28.8% mild, 2.9% marked). Mild enhancement was strongly associated with AV nicking (OR 3.12) and with retinopathy (OR 1.96). (kaushik2007prevalenceandassociations pages 1-3)
+* **Scheie-defined retinopathy prevalence in untreated middle-aged workers:** In Sugiura et al. (n=7,730; ages 35–61), hypertensive retinopathy (H1+H2) prevalence was 2.8%, while atherosclerotic retinopathy (S1+S2) prevalence was 13.6%. (sugiura2022examinationoflarge pages 12-13)
+
+### 3.3 Symptomatology and QoL impact
+Arteriosclerotic retinopathy is often **asymptomatic** until complications occur (e.g., occlusive disease, macular edema in related conditions). The retrieved evidence focused on imaging signs and systemic associations rather than patient-reported quality-of-life instruments; no EQ-5D/SF-36 metrics were found in the available texts. (liu2023sexspecificassociationbetween pages 3-4, rusu2024retinalstructuraland pages 1-2)
+
+### 3.4 Suggested HPO terms (phenotype mapping; best-fit suggestions)
+(These are ontology suggestions; exact HPO IDs should be verified in HPO.)
+* Retinal arteriolar narrowing (sign) (supported conceptually by Scheie H grades and retinal arteriolar narrowing) (sugiura2022examinationoflarge media a2b302a2)
+* Arteriovenous nicking (sign) (kaushik2007prevalenceandassociations pages 1-3, sugiura2022examinationoflarge media a2b302a2)
+* Increased retinal arteriolar light reflex / copper wiring / silver wiring (sign) (kaushik2007prevalenceandassociations pages 1-3, sugiura2022examinationoflarge media a2b302a2)
+* Retinal hemorrhage / hard exudates / cotton wool spots / papilledema (primarily severe hypertensive retinopathy features) (sugiura2022examinationoflarge media a2b302a2)
+
+---
+
+## 4. Genetic/Molecular Information
+
+### 4.1 Causal genes and pathogenic variants
+No causal genes or pathogenic variants were identified in the retrieved sources for arteriosclerotic retinopathy as a discrete genetic disorder. The current evidence base in this tool run supports arteriosclerotic retinopathy as a **complex trait/end-organ phenotype** rather than a Mendelian condition. (iorga2024noninvasiveretinalvessel pages 5-7)
+
+### 4.2 Modifier genes / epigenetics / chromosomal abnormalities
+Not identified in the retrieved evidence. (iorga2024noninvasiveretinalvessel pages 5-7)
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Lifestyle and environmental factors
+* **Heavy alcohol intake** was associated with *marked* enhanced arteriolar light reflex in the Blue Mountains Eye Study (OR 2.66 for ≥40 g/day). (kaushik2007prevalenceandassociations pages 1-3)
+* Traditional cardiovascular risk factors (smoking, BMI/obesity, lipid and glucose measures) were associated with enhanced light reflex and/or Scheie-defined retinopathy in population studies. (kaushik2007prevalenceandassociations pages 1-3, sugiura2022examinationoflarge pages 12-13)
+
+### 5.2 Infectious agents
+No infectious etiology is supported in retrieved texts. (nokiba2015associationbetweenophthalmological pages 1-3)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Causal chain (conceptual)
+**Chronic systemic vascular risk exposure** (hypertension, diabetes, dyslipidemia, CKD-related mineral/inflammatory milieu) → **endothelial dysfunction and vascular remodeling** → **retinal arteriolar wall thickening/sclerosis** (medial hypertrophy, intimal hyalinization, endothelial hyperplasia) → **ophthalmoscopic signs** (increased light reflex “copper/silver wiring”, AV crossing changes, arteriolar narrowing) → associations with **systemic arterial stiffness and atherosclerotic burden**. (nokiba2015associationbetweenophthalmological pages 1-3, nokiba2015associationbetweenophthalmological pages 3-4, sugiura2022examinationoflarge media a2b302a2)
+
+### 6.2 Histopathology-linked description
+A clinical pathologic description in CKD/hemodialysis literature emphasizes that arteriosclerotic retinopathy reflects vascular wall remodeling with **“medial layer hypertrophy, hyalinization of the intima, and hyperplasia of the endothelial layer.”** (nokiba2015associationbetweenophthalmological pages 1-3)
+
+### 6.3 Microvascular–macrovascular coupling (human data)
+Evidence supports that retinal arteriosclerotic findings track systemic vascular disease:
+* In hemodialysis patients (n=44), **Scheie S grade** correlated with arterial stiffness (PWV) and past CVD (reported p=0.001 and p=0.045). (nokiba2015associationbetweenophthalmological pages 1-3)
+* In untreated middle-aged adults (n=7,730), measures of large-artery atherosclerosis/stiffness—**carotid IMT and CAVI**—were independently associated with Scheie-defined retinopathy; carotid IMT per 0.1 mm showed ORs around ~1.18 for retinopathy in multivariable models. (sugiura2022examinationoflarge pages 7-9, sugiura2022examinationoflarge pages 6-7)
+* In a large cross-sectional health-exam sample (n=20,836), fundus arteriosclerosis was associated with carotid atherosclerosis (adjusted OR 1.17). (liu2023sexspecificassociationbetween pages 3-4)
+
+### 6.4 Molecular pathways / immune involvement (evidence level)
+The retrieved texts emphasize general vascular mechanisms (endothelial dysfunction, oxidative stress, inflammation) in the context of systemic vascular disease and retinal microvasculature but do not provide disease-specific retinal transcriptomic/proteomic signatures for arteriosclerotic retinopathy. (nokiba2015associationbetweenophthalmological pages 1-3, bisen2025retinalimagingas pages 5-8)
+
+### 6.5 Suggested ontology terms
+**GO (biological process) suggestions (verify IDs):**
+* Blood vessel remodeling; extracellular matrix organization; regulation of vascular smooth muscle cell proliferation; response to oxidative stress; inflammatory response (conceptually consistent with sclerosis/remodeling and inflammation noted as risk factors). (nokiba2015associationbetweenophthalmological pages 1-3)
+
+**CL (cell type) suggestions (verify IDs):**
+* Vascular endothelial cell; vascular smooth muscle cell/pericyte (arteriolar wall remodeling). (nokiba2015associationbetweenophthalmological pages 1-3)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/tissue/cell targets
+* **Primary organ/tissue:** Retina (retinal arterioles; AV crossings). (sugiura2022examinationoflarge media a2b302a2)
+* **Vascular structures:** Retinal arterioles and arteriovenous crossings. (sugiura2022examinationoflarge media a2b302a2)
+
+**UBERON suggestions (verify IDs):** retina; retinal blood vessel; retinal arteriole.
+
+### 7.2 Laterality
+Generally bilateral in systemic disease, but laterality was not specified in retrieved texts.
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset and course
+Arteriosclerotic retinal changes are typically **chronic/insidious** and accumulate with age and vascular risk exposure. In middle-aged workers (mean ~45 years), Scheie S1+S2 prevalence was already ~13.6%, supporting early/midlife detectability. (sugiura2022examinationoflarge pages 12-13, sugiura2022examinationoflarge pages 1-2)
+
+### 8.2 Staging
+Scheie S0–S4 provides a practical staging framework from normal through copper/silver wiring and severe AV crossing changes. (sugiura2022examinationoflarge media a2b302a2)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology (available statistics)
+Population-based frequencies depend heavily on definitions:
+* Enhanced arteriolar light reflex prevalence: **31.7%** in a ≥49-year cohort. (kaushik2007prevalenceandassociations pages 1-3)
+* Scheie-defined atherosclerotic retinopathy (S1+S2): **13.6%** in untreated workers aged 35–61. (sugiura2022examinationoflarge pages 12-13)
+
+Incidence data from a longitudinal study:
+* Retinal arteriosclerosis events over ~9.5 years: **295 men and 97 women** among 4,324 adults initially free of retinal arteriosclerosis. (geng2023sexspecificassociationof pages 1-2)
+
+### 9.2 Demographics and sex effects
+Sex-specific associations have been reported for biochemical predictors (e.g., SUA trajectories and TBIL associations stronger in men). (geng2023sexspecificassociationof pages 1-2, nokiba2015associationbetweenophthalmological pages 1-3)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical and imaging tests (current practice)
+**Fundus examination / fundus photography** is the core diagnostic modality for Scheie and KWB grading.
+* Sugiura et al. used **non-mydriatic fundus photographs** graded by ophthalmologists according to Scheie H and S grades. (sugiura2022examinationoflarge pages 2-4, sugiura2022examinationoflarge media a2b302a2)
+* Liu et al. used standardized **nonmydriatic fundus photography** with two trained ophthalmologists grading KWB-based fundus arteriosclerosis. (liu2023sexspecificassociationbetween pages 3-4)
+
+**OCT and OCTA (modern developments; 2024 evidence):**
+* A 2024 systematic review/meta-analysis of CAD studies supports that OCT/OCTA capture retinal structural and microvascular signatures in systemic CAD, including reduced RNFL thickness and reduced vessel density with expanded FAZ in CAD. (rusu2024retinalstructuraland pages 1-2)
+* A 2024 review describes limitations and strengths of OCTA vs fundus-photo vessel measurement and summarizes normative CRAE/CRVE/AVR metrics. (iorga2024noninvasiveretinalvessel pages 5-7)
+
+### 10.2 Biomarkers
+Biochemical predictors investigated in recent cohorts include **serum uric acid trajectories** (incident retinal arteriosclerosis in men) and **total bilirubin quartiles** (risk in males). (geng2023sexspecificassociationof pages 1-2, nokiba2015associationbetweenophthalmological pages 1-3)
+
+### 10.3 Differential diagnosis
+Not systematically addressed in retrieved texts, but clinically overlaps with:
+* Hypertensive retinopathy (acute and chronic stages)
+* Diabetic retinopathy (microaneurysms/hemorrhages/exudates)
+* Retinal vein/artery occlusions (acute ischemic presentations)
+
+The current evidence set emphasizes that arteriosclerotic signs (light reflex and crossing changes) are often embedded within hypertensive retinopathy staging systems. (sugiura2022examinationoflarge media a2b302a2)
+
+---
+
+## 11. Outcome / Prognosis
+
+### 11.1 Systemic vascular prognosis (associative)
+Arteriosclerotic retinal signs and retinal microvascular biomarkers are repeatedly associated with systemic vascular disease burden:
+* Fundus arteriosclerosis associated with carotid atherosclerosis (adjusted OR 1.17). (liu2023sexspecificassociationbetween pages 3-4)
+* Scheie grades correlated with arterial stiffness and CVD history in hemodialysis patients. (nokiba2015associationbetweenophthalmological pages 1-3)
+
+### 11.2 Ocular prognosis
+The retrieved texts did not provide direct longitudinal estimates of vision loss attributable specifically to arteriosclerotic retinopathy without occlusive events. However, retinal microvascular compromise is positioned as part of a continuum toward ischemic retinal complications and systemic vascular events. (bisen2025retinalimagingas pages 5-8, rusu2024retinalstructuraland pages 1-2)
+
+---
+
+## 12. Treatment
+
+### 12.1 Disease-specific therapy
+No disease-specific ocular therapy for isolated arteriosclerotic retinopathy is established in the retrieved literature; management typically targets **systemic risk factor modification** and surveillance.
+
+### 12.2 Risk factor management (real-world implementation)
+Given strong associations with hypertension, diabetes, dyslipidemia, and CKD, real-world management aligns with cardiovascular risk reduction. Supporting evidence includes the strong unadjusted associations of these conditions with Scheie-defined retinopathy in population screening. (sugiura2022examinationoflarge pages 12-13)
+
+### 12.3 MAXO term suggestions (verify IDs)
+* Antihypertensive therapy; lipid-lowering therapy; diabetes management; smoking cessation counseling; screening fundus photography; optical coherence tomography angiography.
+
+---
+
+## 13. Prevention
+
+### 13.1 Primary prevention
+* Control of hypertension, diabetes, dyslipidemia, and CKD-related risk likely reduces development/progression of retinal arteriosclerotic changes; population data show these factors are strongly associated with prevalent Scheie-defined lesions. (sugiura2022examinationoflarge pages 12-13)
+
+### 13.2 Secondary prevention / screening
+**Screening and risk stratification** using fundus photography and retinal analytics is an active area:
+* A 2023 deep-learning meta-analysis supports that retinal-image-based models can predict multiple CVD risk-related outcomes and future CVD events with AUROC ~0.68–0.81 in some studies, but emphasizes need for validation for real-world adoption. (nokiba2015associationbetweenophthalmological pages 1-3)
+* A 2024 review argues retinal microvascular biomarkers (e.g., CRAE/CRVE/AVR; dynamic retinal vessel analysis; AI systems) could aid screening and treatment monitoring for CVD. (iorga2024noninvasiveretinalvessel pages 5-7)
+
+---
+
+## 14. Other Species / Natural Disease
+No naturally occurring veterinary analogs were identified in the retrieved evidence set for “arteriosclerotic retinopathy” as a named entity.
+
+---
+
+## 15. Model Organisms
+No specific model organism papers for retinal arteriosclerosis were retrieved in the available evidence. Mechanistic modeling is likely to rely on hypertension/atherosclerosis animal models with retinal vascular endpoints, but this could not be substantiated with the current evidence set.
+
+---
+
+## Recent developments (2023–2024 highlight)
+1) **Large observational datasets** are increasingly treating fundus arteriosclerosis as a quantitative marker linked to systemic atherosclerosis (e.g., carotid ultrasound associations; sex-specific effects). (liu2023sexspecificassociationbetween pages 3-4, geng2023sexspecificassociationof pages 1-2)
+2) **OCT/OCTA biomarkers** are being consolidated in systematic reviews as potential non-invasive correlates of coronary artery disease (reduced vessel density; larger FAZ; thinner RNFL/choroid). (rusu2024retinalstructuraland pages 1-2)
+3) **AI/deep learning and “retinal analytics”** for cardiovascular risk prediction has matured into systematic evidence syntheses, with performance competitive with but not clearly superior to standard risk scores in current studies. (nokiba2015associationbetweenophthalmological pages 1-3)
+
+---
+
+## Key quantitative evidence table (2023–2024 prioritized)
+The following table consolidates the most relevant quantitative studies and syntheses captured in this run.
+
+| Study (first author, year) | Design/Population (N, setting) | Retinal phenotype definition (Scheie/KWB, vessel measures) | Main findings with effect sizes (OR/HR/WMD etc.) | Publication date | PMID | URL |
+|---|---|---|---|---|---|---|
+| Geng 2023 | Population-based longitudinal study; N=4,324 adults aged 18–60 without retinal arteriosclerosis at baseline; exposure window 2006–2010, follow-up 2011–2019; Chinese health-examination cohort | Incident retinal arteriosclerosis; study evaluated sex-specific serum uric acid (SUA) trajectory groups (low, moderate, moderate-high, high) as predictors of later retinal arteriosclerosis | During median 9.54-year follow-up, 97 women and 295 men developed retinal arteriosclerosis. In men, moderate-high SUA trajectory vs low: HR 1.76 (95% CI 1.17–2.65); high trajectory vs low: HR 1.81 (95% CI 1.04–3.17). No significant increase in women for moderate-high trajectory: HR 0.77 (95% CI 0.39–1.52) (geng2023sexspecificassociationof pages 1-2) | 2023-02-28 |  | https://doi.org/10.3389/fcvm.2023.1116486 |
+| Liu 2023 | Retrospective cross-sectional study; N=20,836 Chinese health-examination participants (13,050 male; 7,786 female) | Fundus arteriosclerosis graded from standardized nonmydriatic fundus photographs using Keith–Wagener–Barker (KWB) grades 1–4; any grade 1–4 counted as fundus arteriosclerosis; carotid atherosclerosis assessed by Doppler ultrasound | Carotid atherosclerosis incidence was higher in those with fundus arteriosclerosis (52.94% vs 47.06%). Adjusted association between fundus arteriosclerosis and carotid atherosclerosis: OR 1.17 (95% CI 1.02–1.34; p=0.0262); association significant in males but not females (liu2023sexspecificassociationbetween pages 3-4) | 2023-11 |  | https://doi.org/10.1186/s40001-023-01508-6 |
+| Dong 2023 | Retrospective cohort study; N=27,477 Chinese participants, follow-up 2006–2019 | Incident fundus arteriosclerosis; exposure was quartiles of serum total bilirubin (TBIL); fundus arteriosclerosis assessed in routine examinations | In males, higher TBIL quartiles associated with higher fundus arteriosclerosis risk vs Q1: Q2 HR 1.217 (95% CI 1.095–1.354), Q3 HR 1.255 (95% CI 1.128–1.396), Q4 HR 1.396 (95% CI 1.254–1.555); linear dose-response reported. No significant association in females (nokiba2015associationbetweenophthalmological pages 1-3) | 2023-07 |  | https://doi.org/10.1038/s41598-023-38378-1 |
+| Rusu 2024 | Systematic review and meta-analysis; 11 studies of CAD vs controls | OCT/OCTA retinal structural and vascular biomarkers rather than classic Scheie/KWB lesions; included retinal thickness, RNFL, choroid, vessel density, FAZ | CAD associated with thinner RNFL (WMD −3.11), thinner subfoveal choroid (WMD −58.79), lower overall retinal thickness (WMD −4.61), lower superficial foveal vessel density (WMD −2.19; p<0.0001), and larger FAZ (WMD 52.73; p=0.02), supporting retinal vascularization as a noninvasive CAD biomarker (rusu2024retinalstructuraland pages 1-2) | 2024-03 |  | https://doi.org/10.3390/life14040448 |
+| Iorga 2024 | Narrative/systematic-style review of non-invasive retinal vessel analysis in cardiovascular disease | Retinal vessel analysis metrics: CRAE, CRVE, AVR; fundus photography, dynamic retinal vessel analysis, OCTA | Summarized normative Gutenberg Health Study metrics: mean CRAE 178.37 µm, CRVE 212.30 µm, AVR 0.84. Review notes uncontrolled hypertension example values CRAE 172.28 µm and AVR 0.81; hypertension strongly associated with lower AVR/CRAE, with tabulated ORs 2.703 for AVR and 2.881 for CRAE (p=0.001). Emphasizes AI systems (e.g., QUARTZ, SIVA-DLS) for scalable extraction of retinal vascular biomarkers (iorga2024noninvasiveretinalvessel pages 5-7) | 2024-05 |  | https://doi.org/10.3390/jpm14050501 |
+| Girach 2024 | Systematic review of prospective studies assessing retinal imaging biomarkers for stroke risk; 24 studies included | Retinal imaging biomarkers including vessel caliber, fractal dimension, tortuosity, retinopathy, emboli, AV nicking; fundus photography and limited OCT studies | Review found wider retinal venules, lower fractal dimension, increased arteriolar tortuosity, retinopathy, and retinal emboli associated with higher stroke risk; evidence weaker for narrower arterioles and isolated AV nicking. AI models performed similarly to conventional risk scores but did not clearly outperform them (nokiba2015associationbetweenophthalmological pages 1-3) | 2024-03 |  | https://doi.org/10.1007/s00415-023-12171-6 |
+| Hu 2023 | Systematic review and meta-analysis of deep learning for CVD risk prediction from retinal images; 26 studies | Retinal-image-based DL using fundus photographs and retinal vascular morphology/geometry features rather than disease-specific Scheie grading | Future CVD-event prediction studies reported AUROC 0.68–0.81. Pooled performance for related tasks: age MAE 3.19 years; gender AUROC 0.96; diabetes AUROC 0.80; CKD AUROC 0.86. Authors conclude real-world applicability requires further validation despite promise of noninvasive retinal-image-based risk prediction (nokiba2015associationbetweenophthalmological pages 1-3) | 2023-07 |  | https://doi.org/10.1167/tvst.12.7.14 |
+| Colcombe 2023 | Targeted narrative review of retinal findings and cardiovascular risk | Reviewed retinal disease states and imaging biomarkers including AV nicking, vessel caliber changes, OCT/OCTA biomarkers | Concludes retinal findings and retinal bioimaging biomarkers may aid cardiovascular prognostication and personalized counseling; notes classic retinopathy findings such as arteriovenous nicking have been incorporated into cardiovascular/stroke risk literature, but emphasizes heterogeneity and need for validation before routine implementation (nokiba2015associationbetweenophthalmological pages 1-3) | 2023-10 |  | https://doi.org/10.3390/jpm13111564 |
+
+
+*Table: This table summarizes recent quantitative studies and reviews relevant to arteriosclerotic retinopathy, fundus arteriosclerosis, and related retinal vascular biomarkers. It highlights study design, retinal phenotype definitions, effect sizes, and links to cardiovascular outcomes or risk stratification.*
+
+---
+
+## Notes on evidence gaps and limitations
+* **Ontology identifiers (MONDO/MeSH/ICD)** for “arteriosclerotic retinopathy” were not retrievable from the accessed full texts; many studies define the condition via **fundus grading** rather than standardized diagnostic codes. (liu2023sexspecificassociationbetween pages 3-4, sugiura2022examinationoflarge media a2b302a2)
+* **Genetic causality** is not supported in the current evidence set; the phenotype appears primarily as a complex, risk-factor-driven manifestation. (iorga2024noninvasiveretinalvessel pages 5-7)
+* Several high-impact clinical guideline sources and some 2023–2024 articles were **unobtainable** via the toolchain in this run; thus, the report emphasizes available primary cohort studies and systematic reviews.
+
+---
+
+## URLs and publication dates (as available in sources)
+* Geng et al., Front Cardiovasc Med, published 2023-02-28, https://doi.org/10.3389/fcvm.2023.1116486 (geng2023sexspecificassociationof pages 1-2)
+* Liu et al., Eur J Med Res, published 2023-11, https://doi.org/10.1186/s40001-023-01508-6 (liu2023sexspecificassociationbetween pages 3-4)
+* Dong et al., Sci Rep, published 2023-07, https://doi.org/10.1038/s41598-023-38378-1 (nokiba2015associationbetweenophthalmological pages 1-3)
+* Rusu et al., Life, published 2024-03, https://doi.org/10.3390/life14040448 (rusu2024retinalstructuraland pages 1-2)
+* Iorga et al., J Pers Med, published 2024-05, https://doi.org/10.3390/jpm14050501 (iorga2024noninvasiveretinalvessel pages 5-7)
+
+
+
+References
+
+1. (nokiba2015associationbetweenophthalmological pages 1-3): Hirohiko Nokiba, Takashi Takei, Chikako Suto, and Kosaku Nitta. Association between ophthalmological changes and cardiovascular diseases in patients with chronic kidney disease undergoing hemodialysis. Journal of atherosclerosis and thrombosis, 22 12:1248-54, Dec 2015. URL: https://doi.org/10.5551/jat.30601, doi:10.5551/jat.30601. This article has 9 citations and is from a peer-reviewed journal.
+
+2. (sugiura2022examinationoflarge media a2b302a2): Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, and Nobuyuki Ohte. Examination of large artery atherosclerosis could reveal small artery retinopathy in untreated middle-aged individuals. Journal of Atherosclerosis and Thrombosis, 29:11-23, Jan 2022. URL: https://doi.org/10.5551/jat.59857, doi:10.5551/jat.59857. This article has 8 citations and is from a peer-reviewed journal.
+
+3. (liu2023sexspecificassociationbetween pages 3-4): Chunxing Liu, Xiaolong Yang, Mengmeng Ji, Xiaowei Zhang, Xiyun Bian, Tingli Chen, Yihan Li, Xing Qi, Jianfeng Wu, Jing Wang, and Zaixiang Tang. Sex-specific association between carotid atherosclerosis and fundus arteriosclerosis in a chinese population: a retrospective cross-sectional study. European Journal of Medical Research, Nov 2023. URL: https://doi.org/10.1186/s40001-023-01508-6, doi:10.1186/s40001-023-01508-6. This article has 5 citations and is from a peer-reviewed journal.
+
+4. (rusu2024retinalstructuraland pages 1-2): Alexandra Cristina Rusu, Karin Ursula Horvath, Grigore Tinica, Raluca Ozana Chistol, Andra-Irina Bulgaru-Iliescu, Ecaterina Tomaziu Todosia, and Klara Brînzaniuc. Retinal structural and vascular changes in patients with coronary artery disease: a systematic review and meta-analysis. Life, 14:448, Mar 2024. URL: https://doi.org/10.3390/life14040448, doi:10.3390/life14040448. This article has 23 citations.
+
+5. (sugiura2022examinationoflarge pages 2-4): Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, and Nobuyuki Ohte. Examination of large artery atherosclerosis could reveal small artery retinopathy in untreated middle-aged individuals. Journal of Atherosclerosis and Thrombosis, 29:11-23, Jan 2022. URL: https://doi.org/10.5551/jat.59857, doi:10.5551/jat.59857. This article has 8 citations and is from a peer-reviewed journal.
+
+6. (kaushik2007prevalenceandassociations pages 1-3): Shweta Kaushik, Ava Grace Tan, Paul Mitchell, and Jie Jin Wang. Prevalence and associations of enhanced retinal arteriolar light reflex: a new look at an old sign. Ophthalmology, 114 1:113-20, Jan 2007. URL: https://doi.org/10.1016/j.ophtha.2006.06.046, doi:10.1016/j.ophtha.2006.06.046. This article has 37 citations and is from a highest quality peer-reviewed journal.
+
+7. (geng2023sexspecificassociationof pages 1-2): Ruirui Geng, Qinbei Feng, Mengmeng Ji, Yongfei Dong, Shuanshuan Xu, Chunxing Liu, Yufeng He, and Zaixiang Tang. Sex-specific association of serum uric acid trajectories with risk of incident retinal arteriosclerosis in chinese population: a population-based longitudinal study. Frontiers in Cardiovascular Medicine, Feb 2023. URL: https://doi.org/10.3389/fcvm.2023.1116486, doi:10.3389/fcvm.2023.1116486. This article has 2 citations and is from a peer-reviewed journal.
+
+8. (sugiura2022examinationoflarge pages 12-13): Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, and Nobuyuki Ohte. Examination of large artery atherosclerosis could reveal small artery retinopathy in untreated middle-aged individuals. Journal of Atherosclerosis and Thrombosis, 29:11-23, Jan 2022. URL: https://doi.org/10.5551/jat.59857, doi:10.5551/jat.59857. This article has 8 citations and is from a peer-reviewed journal.
+
+9. (iorga2024noninvasiveretinalvessel pages 5-7): Raluca Eugenia Iorga, Damiana Costin, Răzvana Sorina Munteanu-Dănulescu, Elena Rezuș, and Andreea Dana Moraru. Non-invasive retinal vessel analysis as a predictor for cardiovascular disease. Journal of Personalized Medicine, 14:501, May 2024. URL: https://doi.org/10.3390/jpm14050501, doi:10.3390/jpm14050501. This article has 21 citations.
+
+10. (nokiba2015associationbetweenophthalmological pages 3-4): Hirohiko Nokiba, Takashi Takei, Chikako Suto, and Kosaku Nitta. Association between ophthalmological changes and cardiovascular diseases in patients with chronic kidney disease undergoing hemodialysis. Journal of atherosclerosis and thrombosis, 22 12:1248-54, Dec 2015. URL: https://doi.org/10.5551/jat.30601, doi:10.5551/jat.30601. This article has 9 citations and is from a peer-reviewed journal.
+
+11. (sugiura2022examinationoflarge pages 7-9): Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, and Nobuyuki Ohte. Examination of large artery atherosclerosis could reveal small artery retinopathy in untreated middle-aged individuals. Journal of Atherosclerosis and Thrombosis, 29:11-23, Jan 2022. URL: https://doi.org/10.5551/jat.59857, doi:10.5551/jat.59857. This article has 8 citations and is from a peer-reviewed journal.
+
+12. (sugiura2022examinationoflarge pages 6-7): Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, and Nobuyuki Ohte. Examination of large artery atherosclerosis could reveal small artery retinopathy in untreated middle-aged individuals. Journal of Atherosclerosis and Thrombosis, 29:11-23, Jan 2022. URL: https://doi.org/10.5551/jat.59857, doi:10.5551/jat.59857. This article has 8 citations and is from a peer-reviewed journal.
+
+13. (bisen2025retinalimagingas pages 5-8): Jay Bharatsingh Bisen, Hayden Sikora, Anushree Aneja, Sanjiv J. Shah, and Rukhsana G. Mirza. Retinal imaging as a window into cardiovascular health: towards harnessing retinal analytics for precision cardiovascular medicine. Journal of Cardiovascular Development and Disease, 12:230, Jun 2025. URL: https://doi.org/10.3390/jcdd12060230, doi:10.3390/jcdd12060230. This article has 6 citations.
+
+14. (sugiura2022examinationoflarge pages 1-2): Tomonori Sugiura, Yasuaki Dohi, Yasuyuki Takagi, Takashi Yokochi, Naofumi Yoshikane, Kenji Suzuki, Takamasa Tomiishi, Takashi Nagami, Mitsunori Iwase, Hiroyuki Takase, Yoshihiro Seo, and Nobuyuki Ohte. Examination of large artery atherosclerosis could reveal small artery retinopathy in untreated middle-aged individuals. Journal of Atherosclerosis and Thrombosis, 29:11-23, Jan 2022. URL: https://doi.org/10.5551/jat.59857, doi:10.5551/jat.59857. This article has 8 citations and is from a peer-reviewed journal.

--- a/research/Arteriosclerotic_Retinopathy-deep-research-falcon.md.citations.md
+++ b/research/Arteriosclerotic_Retinopathy-deep-research-falcon.md.citations.md
@@ -1,0 +1,480 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Arteriosclerotic Retinopathy
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Arteriosclerotic Retinopathy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T13:43:16.992744
+
+1. nokiba2015associationbetweenophthalmological pages 1-3
+2. liu2023sexspecificassociationbetween pages 3-4
+3. sugiura2022examinationoflarge pages 12-13
+4. geng2023sexspecificassociationof pages 1-2
+5. iorga2024noninvasiveretinalvessel pages 5-7
+6. kaushik2007prevalenceandassociations pages 1-3
+7. rusu2024retinalstructuraland pages 1-2
+8. sugiura2022examinationoflarge pages 2-4
+9. nokiba2015associationbetweenophthalmological pages 3-4
+10. sugiura2022examinationoflarge pages 7-9
+11. sugiura2022examinationoflarge pages 6-7
+12. bisen2025retinalimagingas pages 5-8
+13. sugiura2022examinationoflarge pages 1-2
+14. https://doi.org/10.3389/fcvm.2023.1116486
+15. https://doi.org/10.1186/s40001-023-01508-6
+16. https://doi.org/10.1038/s41598-023-38378-1
+17. https://doi.org/10.3390/life14040448
+18. https://doi.org/10.3390/jpm14050501
+19. https://doi.org/10.1007/s00415-023-12171-6
+20. https://doi.org/10.1167/tvst.12.7.14
+21. https://doi.org/10.3390/jpm13111564
+22. https://doi.org/10.5551/jat.30601,
+23. https://doi.org/10.5551/jat.59857,
+24. https://doi.org/10.1186/s40001-023-01508-6,
+25. https://doi.org/10.3390/life14040448,
+26. https://doi.org/10.1016/j.ophtha.2006.06.046,
+27. https://doi.org/10.3389/fcvm.2023.1116486,
+28. https://doi.org/10.3390/jpm14050501,
+29. https://doi.org/10.3390/jcdd12060230,


### PR DESCRIPTION
## Summary

- Adds `kb/disorders/Arteriosclerotic_Retinopathy.yaml` for arteriosclerotic retinopathy (`MONDO:0042495`).
- Uses Falcon deep research to populate phenotypes, mechanisms, vascular risk contexts, diagnostics, and prevention-oriented management.
- Adds generated PMID/DOI reference caches and Falcon research artifacts for the curated evidence and citation mapping.

## Validation

| Command | Result |
| --- | --- |
| `just validate kb/disorders/Arteriosclerotic_Retinopathy.yaml` | Passed |
| `just validate-references kb/disorders/Arteriosclerotic_Retinopathy.yaml` | Passed; total checks: 0 |
| `just check-reference-cache-frontmatter` | Passed |
| `uv run python scripts/qc_deep_research.py --only Arteriosclerotic_Retinopathy --fail-on-missing-reference --fail-on-unresolved-cache --fail-on-holder-bucket --fail-on-missing-found-in` | Passed; 12 cited refs, 0 missing refs, 0 unresolved cache refs, 0 missing `found_in` links, 0 holder buckets |
| `just compliance kb/disorders/Arteriosclerotic_Retinopathy.yaml` | Passed; weighted compliance 76.7% |

## Notes

- The deep-research QC still reports `disorders_meeting_second_provider: 0/1` because this batch requested Falcon only.
- Conservative preferred-term-only entries are used where local ontology lookup did not support a confident binding, including serum uric acid trajectory and cardiovascular risk-factor management.
