### PR TITLE
Add retinal arterial tortuosity disorder

### DIFF
--- a/kb/disorders/Retinal_Arterial_Tortuosity.yaml
+++ b/kb/disorders/Retinal_Arterial_Tortuosity.yaml
@@ -1,0 +1,585 @@
+name: Retinal Arterial Tortuosity
+creation_date: "2026-05-06T19:00:30Z"
+updated_date: "2026-05-06T19:30:27Z"
+description: >-
+  Retinal arterial tortuosity, often described as familial retinal arteriolar
+  tortuosity, is a rare autosomal dominant retinal vasculopathy with
+  characteristic tortuosity of second and higher order retinal arterioles,
+  episodic retinal hemorrhage, and transient visual symptoms. Familial cases
+  have been linked to heterozygous COL4A1 variants, placing the disorder within
+  the COL4A1-related small-vessel basement-membrane disease spectrum.
+references:
+- reference: DOI:10.1007/s00417-014-2800-6
+  title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: COL4A1 p.Gly510Arg segregates with familial retinal arteriolar tortuosity.
+    supporting_text: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+- reference: DOI:10.1002/ajmg.c.32099
+  title: Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a clinical management protocol
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: COL4A1/2 disease has variable multiorgan manifestations and includes retinal arterial tortuosity.
+    supporting_text: Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a clinical management protocol.
+- reference: DOI:10.1186/s12886-020-01413-0
+  title: Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Valsalva-like exertion can trigger sub-ILM hemorrhage in FRAT.
+    supporting_text: Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism.
+- reference: DOI:10.1016/j.ajoc.2019.03.001
+  title: Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Swept-source OCT angiography can quantify retinal arteriolar tortuosity in FRAT.
+    supporting_text: Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography.
+- reference: DOI:10.1016/j.ajoc.2021.101230
+  title: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Familial retinal arteriolar tortuosity can present with sudden visual loss and resolving retinal hemorrhage.
+    supporting_text: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+- reference: DOI:10.1038/srep18602
+  title: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Col4a1 mutant mice support a primary vascular defect model for retinal pathology.
+    supporting_text: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+- reference: DOI:10.1038/s41433-022-02278-x
+  title: Retinal arterial tortuosity in Ehlers-Danlos syndromes
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Ehlers-Danlos syndromes are part of the retinal arterial tortuosity differential context.
+    supporting_text: Retinal arterial tortuosity in Ehlers-Danlos syndromes.
+- reference: DOI:10.1159/000456069
+  title: Familial Retinal Arteriolar Tortuosity with Acute Hippocampal Infarction
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Familial retinal arteriolar tortuosity has been reported with brain ischemic lesions in a case report.
+    supporting_text: Familial Retinal Arteriolar Tortuosity with Acute Hippocampal Infarction.
+- reference: DOI:10.1212/wnl.0000000000209796
+  title: "Clinical Reasoning: A 50-Year-Old Man With Intracerebral Hemorrhage and Tortuous Retinal Arterioles"
+  found_in:
+  - Retinal_Arterial_Tortuosity-deep-research-falcon.md
+  findings:
+  - statement: Tortuous retinal arterioles can be a clue in COL4A1/2-related cerebral small-vessel disease workup.
+    supporting_text: "Clinical Reasoning: A 50-Year-Old Man With Intracerebral Hemorrhage and Tortuous Retinal Arterioles."
+category: Mendelian
+disease_term:
+  preferred_term: retinal arterial tortuosity
+  term:
+    id: MONDO:0008373
+    label: retinal arterial tortuosity
+synonyms:
+- Familial retinal arteriolar tortuosity
+- Familial retinal arterial tortuosity
+- Retinal arteriolar tortuosity
+- Retinal hemorrhage with vascular tortuosity
+- FRAT
+- RATOR
+parents:
+- Retinal Vascular Disorder
+- Arterial Disorder
+inheritance:
+- name: Autosomal dominant inheritance
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  description: >-
+    Familial retinal arteriolar tortuosity has been described as an autosomal
+    dominant disorder, including pedigrees with affected parents and children.
+  evidence:
+  - reference: PMID:25228067
+    reference_title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      OBJECTIVES: Our aim was to determine the molecular cause of autosomal
+      dominant familial retinal arteriolar tortuosity (FRAT) in a family with
+      three affected subjects.
+    explanation: >-
+      The study objective explicitly characterizes the familial disorder as
+      autosomal dominant.
+  - reference: PMID:30931409
+    reference_title: Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PURPOSE: Familial retinal arteriolar tortuosity (FRAT) is a rare autosomal
+      dominant disorder that is characterized by tortuosity of the second and
+      higher order retinal arterioles.
+    explanation: >-
+      This FRAT imaging report also states the autosomal dominant inheritance
+      pattern.
+pathophysiology:
+- name: COL4A1 collagen IV basement membrane defect
+  description: >-
+    Heterozygous COL4A1 pathogenic variants disrupt type IV collagen-dependent
+    basement membrane structure, providing an upstream molecular mechanism for
+    retinal small-vessel fragility.
+  cell_types:
+  - preferred_term: retinal blood vessel endothelial cell
+    term:
+      id: CL:0002585
+      label: retinal blood vessel endothelial cell
+  biological_processes:
+  - preferred_term: extracellular matrix organization
+    modifier: ABNORMAL
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  evidence:
+  - reference: PMID:25228067
+    reference_title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Sanger sequencing confirmed that all three patients harbored the same
+      pathogenetic mutation in COL4A1.
+    explanation: >-
+      The familial FRAT pedigree segregated a pathogenic COL4A1 variant in all
+      affected individuals.
+  - reference: PMID:26813606
+    reference_title: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Mutations in collagen, type IV, alpha 1 (COL4A1), a major component of
+      basement membranes, cause multisystem disorders in humans and mice.
+    explanation: >-
+      This mouse mechanistic study supports COL4A1 as a basement-membrane
+      collagen relevant to small-vessel disease.
+  downstream:
+  - target: Primary retinal vascular structural defect
+    description: >-
+      Altered type IV collagen in vascular basement membrane compromises retinal
+      vessel structure and stability.
+- name: Primary retinal vascular structural defect
+  description: >-
+    COL4A1-associated retinal disease is driven by primary vascular defects,
+    producing abnormal retinal vessel morphology, vascular tortuosity,
+    hemorrhage susceptibility, and neovascular/fibrotic lesions in experimental
+    models.
+  cell_types:
+  - preferred_term: retinal blood vessel endothelial cell
+    term:
+      id: CL:0002585
+      label: retinal blood vessel endothelial cell
+  biological_processes:
+  - preferred_term: blood vessel morphogenesis
+    modifier: ABNORMAL
+    term:
+      id: GO:0048514
+      label: blood vessel morphogenesis
+  - preferred_term: angiogenesis
+    modifier: INCREASED
+    term:
+      id: GO:0001525
+      label: angiogenesis
+  evidence:
+  - reference: PMID:26813606
+    reference_title: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      To identify the cell-type responsible for pathogenesis we generated a
+      conditional Col4a1 mutation and determined that primary vascular defects
+      underlie Col4a1-associated retinopathy.
+    explanation: >-
+      Conditional mouse data identify the retinal vascular compartment as the
+      primary disease-driving tissue.
+  - reference: PMID:26813606
+    reference_title: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Retinal examinations revealed serous chorioretinopathy, retinal
+      hemorrhages, fibrosis or signs of pathogenic angiogenesis with
+      chorioretinal anastomosis in up to approximately 90% of Col4a1 mutant
+      eyes depending on age and the specific mutation.
+    explanation: >-
+      Mutant Col4a1 mice develop retinal hemorrhage and pathogenic angiogenic
+      lesions, supporting the downstream vascular injury model.
+  downstream:
+  - target: Retinal arteriolar tortuosity
+    description: >-
+      Primary vascular structural defects manifest clinically as tortuous
+      retinal arterioles.
+  - target: Retinal hemorrhage episodes
+    description: >-
+      Fragile retinal vessels are susceptible to hemorrhage, especially during
+      pressure-raising events.
+- name: Retinal hemorrhage episodes
+  description: >-
+    Fragility of tortuous retinal arterioles predisposes affected individuals to
+    recurrent intraretinal, preretinal, or sub-internal limiting membrane
+    hemorrhage, often with acute visual symptoms.
+  cell_types:
+  - preferred_term: retinal blood vessel endothelial cell
+    term:
+      id: CL:0002585
+      label: retinal blood vessel endothelial cell
+  biological_processes:
+  - preferred_term: blood vessel morphogenesis
+    modifier: ABNORMAL
+    term:
+      id: GO:0048514
+      label: blood vessel morphogenesis
+  evidence:
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This is the first reported case of a FRAT patient suffering from bilateral
+      and multiple Valsalva-related sub-ILM hemorrhages which were treated by
+      both observation and Nd: YAG laser treatment.
+    explanation: >-
+      The case report directly links FRAT with bilateral Valsalva-related
+      sub-ILM retinal hemorrhage episodes.
+  - reference: PMID:34825110
+    reference_title: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Bilateral retinal arteriolar tortuosity as well as retinal hemorrhage was
+      seen.
+    explanation: >-
+      The family case series documents concurrent retinal arteriolar tortuosity
+      and retinal hemorrhage.
+phenotypes:
+- category: Ophthalmologic
+  name: Retinal arteriolar tortuosity
+  diagnostic: true
+  frequency: VERY_FREQUENT
+  description: >-
+    Tortuosity of the second and higher order retinal arterioles is the defining
+    funduscopic feature of familial retinal arterial tortuosity.
+  phenotype_term:
+    preferred_term: Retinal arteriolar tortuosity
+    term:
+      id: HP:0001136
+      label: Retinal arteriolar tortuosity
+  evidence:
+  - reference: PMID:30931409
+    reference_title: Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PURPOSE: Familial retinal arteriolar tortuosity (FRAT) is a rare autosomal
+      dominant disorder that is characterized by tortuosity of the second and
+      higher order retinal arterioles.
+    explanation: >-
+      This directly defines the core retinal arteriolar tortuosity phenotype.
+- category: Ophthalmologic
+  name: Retinal hemorrhage
+  description: >-
+    Affected individuals can develop retinal hemorrhage, including sub-internal
+    limiting membrane or bilateral hemorrhage.
+  phenotype_term:
+    preferred_term: Retinal hemorrhage
+    term:
+      id: HP:0000573
+      label: Retinal hemorrhage
+  evidence:
+  - reference: PMID:34825110
+    reference_title: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The ophthalmologic examination showed retinal hemorrhage bilaterally.
+    explanation: >-
+      This family case series directly supports retinal hemorrhage as a clinical
+      manifestation.
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      BACKGROUND: Bilateral and multiple Valsalva-related sub-internal limiting
+      membrane (ILM) hemorrhages in a familial retinal arteriolar tortuosity
+      (FRAT) patient is rare, and we treated this patient by both observation
+      and Neodymium yttrium aluminum garnet (Nd: YAG) laser membranotomy
+      methods.
+    explanation: >-
+      This report supports sub-ILM hemorrhage as a documented hemorrhagic
+      presentation in FRAT.
+- category: Ophthalmologic
+  name: Sudden transient visual loss
+  description: >-
+    Hemorrhagic episodes can produce sudden visual loss that improves as blood
+    clears.
+  phenotype_term:
+    preferred_term: Sudden transient visual loss
+    term:
+      id: HP:0000572
+      label: Visual loss
+    temporality: TRANSIENT
+  evidence:
+  - reference: PMID:34825110
+    reference_title: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      PURPOSE: To report family members with familial retinal arteriolar
+      tortuosity (FRAT) identified after sudden visual loss.
+    explanation: >-
+      The case series was ascertained through sudden visual loss in affected
+      family members.
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CASE PRESENTATION: A 13-year-old female student presented with sudden
+      visual loss and central scotoma in both eyes after running 800 m at the
+      school gym.
+    explanation: >-
+      This FRAT case directly connects exertion-triggered hemorrhage with sudden
+      visual loss.
+- category: Ophthalmologic
+  name: Central scotoma
+  description: >-
+    Premacular or sub-ILM hemorrhage can cause central scotoma during acute
+    episodes.
+  phenotype_term:
+    preferred_term: Central scotoma
+    term:
+      id: HP:0000603
+      label: Central scotoma
+  evidence:
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CASE PRESENTATION: A 13-year-old female student presented with sudden
+      visual loss and central scotoma in both eyes after running 800 m at the
+      school gym.
+    explanation: >-
+      The reported FRAT patient had central scotoma during the acute
+      hemorrhagic episode.
+genetic:
+- name: COL4A1
+  association: Causative
+  presence: Positive
+  gene_term:
+    preferred_term: COL4A1
+    term:
+      id: hgnc:2202
+      label: COL4A1
+  inheritance:
+  - name: Autosomal dominant inheritance
+    inheritance_term:
+      preferred_term: Autosomal dominant inheritance
+      term:
+        id: HP:0000006
+        label: Autosomal dominant inheritance
+  variants:
+  - name: COL4A1 p.Gly510Arg
+    type: missense
+    description: >-
+      The heterozygous COL4A1 p.Gly510Arg missense variant segregated with
+      familial retinal arteriolar tortuosity in the reported pedigree and has
+      also been described in broader COL4A1-related disease.
+    evidence:
+    - reference: PMID:25228067
+      reference_title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The p. Gly510Arg variant in COL4A1 was absent in DNA from an available
+        unaffected daughter, from a set of control alleles, and from publicly
+        available databases.
+      explanation: >-
+        The familial sequencing study reports absence of the variant in
+        unaffected and control datasets, supporting pathogenicity.
+  notes: >-
+    COL4A1 is the best-supported causal gene for familial retinal arteriolar
+    tortuosity. COL4A2 is relevant to the broader COL4A1/2 small-vessel disease
+    spectrum, but disease-specific COL4A2 evidence for isolated FRAT remains
+    limited.
+  evidence:
+  - reference: PMID:25228067
+    reference_title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The molecular basis of familial retinal arteriolar tortuosity was
+      identified for the first time, thus expanding the human phenotypes linked
+      to COL4A1 mutations.
+    explanation: >-
+      The paper identifies COL4A1 as the molecular cause in a familial FRAT
+      pedigree.
+  - reference: PMID:25228067
+    reference_title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These data indicate that identical mutations in COL4A1 can originate both
+      eye-restricted and systemic phenotypes.
+    explanation: >-
+      The same COL4A1 variant can produce isolated ocular FRAT or broader
+      systemic COL4A1-related disease.
+environmental:
+- name: Valsalva-like exertional trigger
+  presence: Positive
+  description: >-
+    Exertion or Valsalva-like pressure increases can trigger hemorrhage
+    episodes in genetically susceptible retinal vessels.
+  evidence:
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient was diagnosed as having Valsalva retinopathy associated with
+      FRAT.
+    explanation: >-
+      This case directly identifies a Valsalva-related hemorrhagic episode in
+      FRAT.
+diagnosis:
+- name: Fundus examination and retinal vascular imaging
+  description: >-
+    Diagnosis is based on the characteristic retinal arteriolar tortuosity
+    pattern, supported by fundus photography, fluorescein angiography, OCT, and
+    OCT angiography to localize hemorrhage and quantify vessel tortuosity.
+  diagnosis_term:
+    preferred_term: retinal vascular imaging
+  results: >-
+    Second and higher order retinal arteriolar tortuosity, retinal hemorrhage,
+    and increased objective tortuosity measurements support diagnosis.
+  evidence:
+  - reference: PMID:30931409
+    reference_title: Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSIONS AND IMPORTANCE: Our results are consistent with the hypothesis
+      that patients with FRAT have higher objective measurements of tortuosity
+      compared to controls.
+    explanation: >-
+      Swept-source OCTA can objectively quantify the retinal vascular
+      tortuosity phenotype.
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient was diagnosed as having Valsalva retinopathy associated with
+      FRAT.
+    explanation: >-
+      The case report supports clinical ophthalmic diagnosis during an acute
+      hemorrhagic presentation.
+- name: COL4A1 molecular testing
+  description: >-
+    COL4A1 sequencing can confirm the molecular diagnosis in familial cases and
+    should be interpreted in the context of possible broader COL4A1/2
+    vasculopathy.
+  diagnosis_term:
+    preferred_term: genetic testing
+    term:
+      id: MAXO:0000127
+      label: genetic testing
+  results: Heterozygous pathogenic COL4A1 variants support familial FRAT.
+  evidence:
+  - reference: PMID:25228067
+    reference_title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Molecular methods included whole exome sequencing analysis and Sanger
+      sequencing validation of putative causal mutation in DNA from affected
+      individuals.
+    explanation: >-
+      This supports exome sequencing with Sanger validation as a molecular
+      diagnostic approach for familial FRAT.
+- name: COL4A1/2 multiorgan risk assessment
+  description: >-
+    Patients with COL4A1 or COL4A2 variants may need individualized neurologic,
+    ophthalmologic, renal, and cardiovascular assessment because retinal
+    arterial tortuosity can occur within a variable multiorgan vasculopathy.
+  evidence:
+  - reference: PMID:39016117
+    reference_title: Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a clinical management protocol.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      COL4A1/2 variants are associated with highly variable multiorgan
+      manifestations.
+    explanation: >-
+      This systematic review and cohort-based protocol supports evaluating RAT
+      in the broader COL4A1/2 disease context.
+  - reference: PMID:39016117
+    reference_title: Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a clinical management protocol.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We propose a protocol for prevention and management based on individualized
+      risk estimation and periodic multiorgan evaluations.
+    explanation: >-
+      This supports periodic multiorgan surveillance when a COL4A1/2 variant is
+      identified.
+treatments:
+- name: Observation for resolving retinal hemorrhage
+  description: >-
+    Observation is appropriate for many retinal hemorrhage episodes, with
+    follow-up until hemorrhage resolves and visual acuity recovers.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: PMID:34825110
+    reference_title: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He was followed without intervention. Retinal hemorrhage gradually
+      decreased and resolved after 3 months.
+    explanation: >-
+      The family case series supports observation without intervention for a
+      retinal hemorrhage episode.
+- name: Nd:YAG laser membranotomy for selected premacular hemorrhage
+  description: >-
+    Nd:YAG laser membranotomy can be considered in selected large premacular or
+    sub-ILM hemorrhages when rapid visual recovery is needed, but safety and
+    follow-up should be individualized.
+  treatment_term:
+    preferred_term: Nd:YAG laser membranotomy
+    term:
+      id: NCIT:C15466
+      label: Laser Therapy
+  target_phenotypes:
+  - preferred_term: Retinal hemorrhage
+    term:
+      id: HP:0000573
+      label: Retinal hemorrhage
+  evidence:
+  - reference: PMID:32293357
+    reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Nd: YAG laser could be considered for treating premacular hemorrhage in
+      FRAT patient especially when a quick vision recovery was needed.
+    explanation: >-
+      A single case report supports laser membranotomy as an option for selected
+      premacular hemorrhage, so support is partial rather than definitive.
+notes: >-
+  Retinal arterial tortuosity is curated here as the ocular FRAT/RATOR disorder
+  rather than the broader multisystem COL4A1/2 syndrome. The broader syndrome is
+  represented in diagnosis and management context because COL4A1 variants can
+  produce either eye-restricted or systemic phenotypes.
+datasets:

--- a/kb/disorders/Retinal_Arterial_Tortuosity.yaml
+++ b/kb/disorders/Retinal_Arterial_Tortuosity.yaml
@@ -1,6 +1,6 @@
 name: Retinal Arterial Tortuosity
 creation_date: "2026-05-06T19:00:30Z"
-updated_date: "2026-05-06T19:30:27Z"
+updated_date: "2026-05-06T19:44:31Z"
 description: >-
   Retinal arterial tortuosity, often described as familial retinal arteriolar
   tortuosity, is a rare autosomal dominant retinal vasculopathy with
@@ -219,6 +219,10 @@ pathophysiology:
     description: >-
       Fragile retinal vessels are susceptible to hemorrhage, especially during
       pressure-raising events.
+  - target: Reactive Muller glial response
+    description: >-
+      Retinal vascular injury in Col4a1 mutant mice is accompanied by glial
+      activation and pro-angiogenic signaling.
 - name: Retinal hemorrhage episodes
   description: >-
     Fragility of tortuous retinal arterioles predisposes affected individuals to
@@ -229,12 +233,6 @@ pathophysiology:
     term:
       id: CL:0002585
       label: retinal blood vessel endothelial cell
-  biological_processes:
-  - preferred_term: blood vessel morphogenesis
-    modifier: ABNORMAL
-    term:
-      id: GO:0048514
-      label: blood vessel morphogenesis
   evidence:
   - reference: PMID:32293357
     reference_title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
@@ -257,6 +255,39 @@ pathophysiology:
     explanation: >-
       The family case series documents concurrent retinal arteriolar tortuosity
       and retinal hemorrhage.
+- name: Reactive Muller glial response
+  description: >-
+    In Col4a1 mutant mouse retina, vascular pathology is accompanied by focal
+    activation of retinal Muller glia and increased pro-angiogenic factor
+    expression, suggesting a secondary retinal injury response downstream of the
+    primary vascular defect.
+  cell_types:
+  - preferred_term: Muller glial cell
+    term:
+      id: CL:0000125
+      label: glial cell
+  biological_processes:
+  - preferred_term: glial cell activation
+    modifier: INCREASED
+    term:
+      id: GO:0061900
+      label: glial cell activation
+  - preferred_term: angiogenesis
+    modifier: INCREASED
+    term:
+      id: GO:0001525
+      label: angiogenesis
+  evidence:
+  - reference: PMID:26813606
+    reference_title: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      We also found focal activation of Müller cells and increased expression of
+      pro-angiogenic factors in retinas from Col4a1(+/Δex41)mice.
+    explanation: >-
+      This mouse study supports a secondary Muller glial activation and
+      pro-angiogenic response after Col4a1-associated retinal vascular injury.
 phenotypes:
 - category: Ophthalmologic
   name: Retinal arteriolar tortuosity
@@ -456,6 +487,9 @@ diagnosis:
     OCT angiography to localize hemorrhage and quantify vessel tortuosity.
   diagnosis_term:
     preferred_term: retinal vascular imaging
+    term:
+      id: MAXO:0001155
+      label: eye examination
   results: >-
     Second and higher order retinal arteriolar tortuosity, retinal hemorrhage,
     and increased objective tortuosity measurements support diagnosis.

--- a/references_cache/PMID_25228067.md
+++ b/references_cache/PMID_25228067.md
@@ -1,0 +1,91 @@
+---
+reference_id: "PMID:25228067"
+title: Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+authors:
+- Zenteno JC
+- Crespí J
+- Buentello-Volante B
+- Buil JA
+- Bassaganyas F
+- Vela-Segarra JI
+- Diaz-Cascajosa J
+- Marieges MT
+journal: Graefes Arch Clin Exp Ophthalmol
+year: '2014'
+doi: 10.1007/s00417-014-2800-6
+keywords:
+- Adolescent
+- "Arterioles/abnormalities, pathology"
+- Collagen Type IV/genetics
+- Exome/genetics
+- Female
+- Fluorescein Angiography
+- High-Throughput Nucleotide Sequencing
+- Humans
+- Magnetic Resonance Angiography
+- Male
+- Middle Aged
+- "Mutation, Missense/genetics"
+- Pedigree
+- Polymerase Chain Reaction
+- "Retinal Artery/abnormalities, pathology"
+- Retinal Hemorrhage/genetics
+- Retinal Telangiectasis/genetics
+- Visual Acuity
+- Young Adult
+content_type: abstract_only
+---
+
+# Next generation sequencing uncovers a missense mutation in COL4A1 as the cause of familial retinal arteriolar tortuosity.
+**Authors:** Zenteno JC, Crespí J, Buentello-Volante B, Buil JA, Bassaganyas F, Vela-Segarra JI, Diaz-Cascajosa J, Marieges MT
+**Journal:** Graefes Arch Clin Exp Ophthalmol (2014)
+**DOI:** [10.1007/s00417-014-2800-6](https://doi.org/10.1007/s00417-014-2800-6)
+
+## Content
+
+1. Graefes Arch Clin Exp Ophthalmol. 2014 Nov;252(11):1789-94. doi: 
+10.1007/s00417-014-2800-6. Epub 2014 Sep 17.
+
+Next generation sequencing uncovers a missense mutation in COL4A1 as the cause 
+of familial retinal arteriolar tortuosity.
+
+Zenteno JC(1), Crespí J, Buentello-Volante B, Buil JA, Bassaganyas F, 
+Vela-Segarra JI, Diaz-Cascajosa J, Marieges MT.
+
+Author information:
+(1)Genetics Department and Research Unit, Institute of Ophthalmology "Conde de 
+Valenciana" and Biochemistry Department, Faculty of Medicine, National 
+Autonomous University of Mexico (UNAM), Chimalpopoca 14, Col. Obrera, Mexico 
+City, CP, 06800, Mexico, jczenteno@institutodeoftalmologia.org.
+
+Erratum in
+    Graefes Arch Clin Exp Ophthalmol. 2015 Aug;253(8):1417. doi: 
+10.1007/s00417-015-3089-9.
+
+OBJECTIVES: Our aim was to determine the molecular cause of autosomal dominant 
+familial retinal arteriolar tortuosity (FRAT) in a family with three affected 
+subjects.
+MATERIAL AND METHODS: Ophthalmologic evaluation included determination of 
+best-corrected visual acuity (BCVA), slit-lamp and dilated fundus inspection, 
+applanation tonometry, fundus photography, and fluorescein retinal angiography 
+(FA). Molecular methods included whole exome sequencing analysis and Sanger 
+sequencing validation of putative causal mutation in DNA from affected 
+individuals.
+RESULTS: Typical signs of familial retinal arteriolar tortuosity were observed 
+in all three patients. Exome sequencing identified a heterozygous c.1528G > A 
+(p. Gly510Arg) mutation in COL4A1. Sanger sequencing confirmed that all three 
+patients harbored the same pathogenetic mutation in COL4A1. The p. Gly510Arg 
+variant in COL4A1 was absent in DNA from an available unaffected daughter, from 
+a set of control alleles, and from publicly available databases.
+CONCLUSIONS: The molecular basis of familial retinal arteriolar tortuosity was 
+identified for the first time, thus expanding the human phenotypes linked to 
+COL4A1 mutations. Interestingly, the COL4A1 p.Gly510Arg mutation has been 
+previously identified in a family with HANAC (Hereditary Angiopathy with 
+Nephropathy, Aneurysm and Cramps), a multisystemic disease featuring retinal 
+arteriolar tortuosity. No cerebral, neurologic, renal, cardiac or vascular 
+anomalies were recognized in the pedigree described here. These data indicate 
+that identical mutations in COL4A1 can originate both eye-restricted and 
+systemic phenotypes.
+
+DOI: 10.1007/s00417-014-2800-6
+PMID: 25228067 [Indexed for MEDLINE]

--- a/references_cache/PMID_26813606.md
+++ b/references_cache/PMID_26813606.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:26813606"
+title: Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+authors:
+- Alavi MV
+- Mao M
+- Pawlikowski BT
+- Kvezereli M
+- Duncan JL
+- Libby RT
+- John SW
+- Gould DB
+journal: Sci Rep
+year: '2016'
+doi: 10.1038/srep18602
+keywords:
+- Animals
+- Collagen Type IV/genetics
+- "Disease Models, Animal"
+- Disease Progression
+- Mice
+- "Mice, Knockout"
+- Mutation
+- Ophthalmoscopes
+- Phenotype
+- "Retina/metabolism, pathology, ultrastructure"
+- "Retinal Diseases/diagnosis, genetics, pathology"
+- "Tomography, Optical Coherence"
+content_type: abstract_only
+---
+
+# Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+**Authors:** Alavi MV, Mao M, Pawlikowski BT, Kvezereli M, Duncan JL, Libby RT, John SW, Gould DB
+**Journal:** Sci Rep (2016)
+**DOI:** [10.1038/srep18602](https://doi.org/10.1038/srep18602)
+
+## Content
+
+1. Sci Rep. 2016 Jan 27;6:18602. doi: 10.1038/srep18602.
+
+Col4a1 mutations cause progressive retinal neovascular defects and retinopathy.
+
+Alavi MV(1), Mao M(1), Pawlikowski BT(1), Kvezereli M(1), Duncan JL(1), Libby 
+RT(2), John SW(3), Gould DB(1)(4).
+
+Author information:
+(1)Department of Ophthalmology, School of Medicine, University of California, 
+San Francisco, San Francisco, CA, 94143.
+(2)Department of Ophthalmology, University of Rochester, Rochester, NY, 14642.
+(3)Howard Hughes Medical Institute and The Jackson Laboratory, Bar Harbor, ME 
+04609.
+(4)Department of Anatomy and Institute for Human Genetics, School of Medicine, 
+University of California, San Francisco, San Francisco, CA, 94143.
+
+Mutations in collagen, type IV, alpha 1 (COL4A1), a major component of basement 
+membranes, cause multisystem disorders in humans and mice. In the eye, these 
+include anterior segment dysgenesis, optic nerve hypoplasia and retinal vascular 
+tortuosity. Here we investigate the retinal pathology in mice carrying 
+dominant-negative Col4a1 mutations. To this end, we examined retinas 
+longitudinally in vivo using fluorescein angiography, funduscopy and optical 
+coherence tomography. We assessed retinal function by electroretinography and 
+studied the retinal ultrastructural pathology. Retinal examinations revealed 
+serous chorioretinopathy, retinal hemorrhages, fibrosis or signs of pathogenic 
+angiogenesis with chorioretinal anastomosis in up to approximately 90% of Col4a1 
+mutant eyes depending on age and the specific mutation. To identify the 
+cell-type responsible for pathogenesis we generated a conditional Col4a1 
+mutation and determined that primary vascular defects underlie Col4a1-associated 
+retinopathy. We also found focal activation of Müller cells and increased 
+expression of pro-angiogenic factors in retinas from Col4a1(+/Δex41)mice. 
+Together, our findings suggest that patients with COL4A1 and COL4A2 mutations 
+may be at elevated risk of retinal hemorrhages and that retinal examinations may 
+be useful for identifying patients with COL4A1 and COL4A2 mutations who are also 
+at elevated risk of hemorrhagic strokes.
+
+DOI: 10.1038/srep18602
+PMCID: PMC4728690
+PMID: 26813606 [Indexed for MEDLINE]

--- a/references_cache/PMID_28611653.md
+++ b/references_cache/PMID_28611653.md
@@ -1,0 +1,50 @@
+---
+reference_id: "PMID:28611653"
+title: Familial Retinal Arteriolar Tortuosity with Acute Hippocampal Infarction.
+authors:
+- Kim TH
+- Lee S
+- Lim SJ
+journal: Case Rep Ophthalmol
+year: '2017'
+doi: 10.1159/000456069
+content_type: abstract_only
+---
+
+# Familial Retinal Arteriolar Tortuosity with Acute Hippocampal Infarction.
+**Authors:** Kim TH, Lee S, Lim SJ
+**Journal:** Case Rep Ophthalmol (2017)
+**DOI:** [10.1159/000456069](https://doi.org/10.1159/000456069)
+
+## Content
+
+1. Case Rep Ophthalmol. 2017 Mar 10;8(1):185-189. doi: 10.1159/000456069. 
+eCollection 2017 Jan-Apr.
+
+Familial Retinal Arteriolar Tortuosity with Acute Hippocampal Infarction.
+
+Kim TH(1), Lee S(2), Lim SJ(1).
+
+Author information:
+(1)aDepartment of Ophthalmology, Saevit Eye Hospital, Goyang, Republic of Korea, 
+California, USA.
+(2)bDepartment of Radiology and Biomedical Imaging, University of California, 
+San Francisco, California, USA.
+
+PURPOSE: To report a case of familial retinal arteriolar tortuosity with acute 
+hippocampal infarction.
+METHOD: Single-patient case report.
+RESULTS: A 50-year-old woman presented with blurred vision and was found to have 
+cataract, retinal hemorrhages, and tortuous retinal arterioles in both eyes. 
+Similar findings of tortuous retinal arterioles were observed in her daughter 
+and son. In her past history of 6 years prior to the visit, she had been 
+diagnosed with transient global amnesia after brain magnetic resonance imaging, 
+which showed hippocampal infarction and multiple chronic ischemic lesions in the 
+periventricular and subcortical white matter.
+CONCLUSION: Familial retinal arteriolar tortuosity is known to affect the 
+retinal vessels only. To our knowledge, this is the first report of ischemic 
+injury to the brain in a patient with familial retinal arteriolar tortuosity.
+
+DOI: 10.1159/000456069
+PMCID: PMC5465648
+PMID: 28611653

--- a/references_cache/PMID_30931409.md
+++ b/references_cache/PMID_30931409.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:30931409"
+title: Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography.
+authors:
+- Saraf SS
+- Tyring AJ
+- Chen CL
+- Le TP
+- Kalina RE
+- Wang RK
+- Chao JR
+journal: Am J Ophthalmol Case Rep
+year: '2019'
+doi: 10.1016/j.ajoc.2019.03.001
+content_type: abstract_only
+---
+
+# Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography.
+**Authors:** Saraf SS, Tyring AJ, Chen CL, Le TP, Kalina RE, Wang RK, Chao JR
+**Journal:** Am J Ophthalmol Case Rep (2019)
+**DOI:** [10.1016/j.ajoc.2019.03.001](https://doi.org/10.1016/j.ajoc.2019.03.001)
+
+## Content
+
+1. Am J Ophthalmol Case Rep. 2019 Mar 7;14:74-78. doi:
+10.1016/j.ajoc.2019.03.001.  eCollection 2019 Jun.
+
+Familial retinal arteriolar tortuosity and quantification of vascular tortuosity 
+using swept-source optical coherence tomography angiography.
+
+Saraf SS(1), Tyring AJ(1), Chen CL(2), Le TP(1), Kalina RE(2), Wang RK(1)(2), 
+Chao JR(1).
+
+Author information:
+(1)University of Washington Department of Ophthalmology 325 Ninth Avenue, Box 
+359608, Seattle, WA, 98104, USA.
+(2)Department of Bioengineering, University of Washington, Foege N410E, 3720 
+15th Ave NE, Seattle, WA, 98195, USA.
+
+PURPOSE: Familial retinal arteriolar tortuosity (FRAT) is a rare autosomal 
+dominant disorder that is characterized by tortuosity of the second and higher 
+order retinal arterioles. We implement swept-source optical coherence tomography 
+angiography (SS-OCTA) to quantify vessel tortuosity in patients with FRAT. We 
+hypothesize that patients with FRAT will have higher retinal arteriole 
+tortuosity when compared to controls.
+METHODS: Patients were scanned with a SS-OCTA device (Plex Elite 9000, Carl 
+Zeiss Meditec, Dublin, CA). Images of a 12 × 12 mm2 area centered on the fovea 
+were processed, and retinal vessels >23.5 μm in diameter were identified. An 
+automatic tortuosity measurement program written in MATLAB was used to assess 
+vessel tortuosity. Branch points in the vessels were detected and used to 
+separate the vasculature into individual segments. The tortuosity was measured 
+by calculating the arc-chord ratio of each vessel segment, where a minimum value 
+of 1 indicated a straight vessel and higher values corresponded to increasing 
+tortuosity.
+RESULTS: Two patients (4 eyes) with a known history of FRAT and six controls (12 
+eyes) were enrolled in the study. The mean tortuosity of all vessel segments 
+(MTVS) in scans of FRAT eyes was on average 1.1244 [range: 1.1044-1.1438] while 
+for control eyes it was 1.0818 [range: 1.0746-1.0872]. Average MTVS of FRAT eyes 
+was significantly higher compared to control eyes (p = 0.03).
+CONCLUSIONS AND IMPORTANCE: Our results are consistent with the hypothesis that 
+patients with FRAT have higher objective measurements of tortuosity compared to 
+controls. Broader applications of this method may be of benefit in other retinal 
+diseases with changes in retinal vessel configuration.
+
+DOI: 10.1016/j.ajoc.2019.03.001
+PMCID: PMC6425085
+PMID: 30931409

--- a/references_cache/PMID_32293357.md
+++ b/references_cache/PMID_32293357.md
@@ -1,0 +1,110 @@
+---
+reference_id: "PMID:32293357"
+title: "Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report."
+authors:
+- Chen T
+- Zheng H
+- Wang Y
+- Hu J
+- Chen C
+journal: BMC Ophthalmol
+year: '2020'
+doi: 10.1186/s12886-020-01413-0
+keywords:
+- Adolescent
+- Arterioles/abnormalities
+- "Basement Membrane/pathology, physiopathology, surgery"
+- "Blindness/diagnosis, etiology"
+- Eye Abnormalities/pathology
+- Female
+- Fluorescein Angiography
+- Humans
+- Laser Coagulation
+- "Lasers, Solid-State/therapeutic use"
+- Retinal Artery/abnormalities
+- "Retinal Hemorrhage/etiology, physiopathology, surgery"
+- "Scotoma/diagnosis, etiology"
+- "Tomography, Optical Coherence"
+- Valsalva Maneuver
+- Visual Acuity/physiology
+content_type: full_text_xml
+---
+
+# Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by Valsalva-like mechanism: an observational case report.
+**Authors:** Chen T, Zheng H, Wang Y, Hu J, Chen C
+**Journal:** BMC Ophthalmol (2020)
+**DOI:** [10.1186/s12886-020-01413-0](https://doi.org/10.1186/s12886-020-01413-0)
+
+## Content
+
+1. BMC Ophthalmol. 2020 Apr 15;20(1):151. doi: 10.1186/s12886-020-01413-0.
+
+Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial 
+retinal arteriolar tortuosity patient by Valsalva-like mechanism: an 
+observational case report.
+
+Chen T, Zheng H, Wang Y(1), Hu J(1), Chen C(2).
+
+Author information:
+(1)Department of Ophthalmology, Renmin Hospital of Wuhan University, No. 9 
+ZhangZhiDong Street, Wuchang District, Wuhan, 430060, Hubei, China.
+(2)Department of Ophthalmology, Renmin Hospital of Wuhan University, No. 9 
+ZhangZhiDong Street, Wuchang District, Wuhan, 430060, Hubei, China. 
+whuchenchzh@163.com.
+
+BACKGROUND: Bilateral and multiple Valsalva-related sub-internal limiting 
+membrane (ILM) hemorrhages in a familial retinal arteriolar tortuosity (FRAT) 
+patient is rare, and we treated this patient by both observation and Neodymium 
+yttrium aluminum garnet (Nd: YAG) laser membranotomy methods.
+CASE PRESENTATION: A 13-year-old female student presented with sudden visual 
+loss and central scotoma in both eyes after running 800 m at the school gym. The 
+examination revealed six sub-ILM hemorrhages with the biggest hemorrhage 
+measuring approximately 1.5-disc diameters (DD) in the right eye and two sub-ILM 
+hemorrhages with the biggest one measuring 5.5 DD in the left eye. The patient 
+was diagnosed as having Valsalva retinopathy associated with FRAT. Nd: YAG laser 
+membranotomy was performed at the biggest hemorrhages and the rest hemorrhages 
+were treated with observation in both eyes. The visual acuity recovered to 20/16 
+in the right eye and 20/20 in the left eye. Epiretinal membrane (ERM) formation 
+was observed in the left eye.
+CONCLUSIONS: Nd: YAG laser could be considered for treating premacular 
+hemorrhage in FRAT patient especially when a quick vision recovery was needed. 
+This is the first reported case of a FRAT patient suffering from bilateral and 
+multiple Valsalva-related sub-ILM hemorrhages which were treated by both 
+observation and Nd: YAG laser treatment.
+
+DOI: 10.1186/s12886-020-01413-0
+PMCID: PMC7161018
+PMID: 32293357 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.
+
+Familial retinal arteriolar tortuosity (FRAT) is a disorder characterized by pronounced tortuosity of the second-order and third-order retinal arterioles in the macular and peripapillary areas while sparing of the first-order arteriole and the whole venous system. The observation of male to male inheritance as well as occurrence in parents and their children in the absence of consanguinity suggest an autosomal dominant inheritance in FRAT [1]. FRAT patients are often asymptomatic but some may experience transient vision loss due to intra- or preretinal hemorrhages following physical exertion or minor trauma [1, 2]. The long-time visual prognosis is usually excellent.
+
+The Valsalva maneuver is performed by forceful exhalation against a closed glottis causing an increase in intraabdominal and intrathoracic pressure during activities such as coughing, vomiting, straining, or weightlifting. When the increased pressure transmitted to the eye, the spontaneous rupture of superficial perifoveal retinal capillaries may happen. It can be bilateral but the unilateral characteristic is more common [3]. The hemorrhages in most cases resolve spontaneously over several weeks.
+
+Here, we presented a case of a FRAT patient suffering from Valsalva-related retinal hemorrhages was treated with Neodymium yttrium aluminum garnet (Nd: YAG) laser membranotomy and observation methods. This case was unusual as it underwent multiple sub-internal limiting membrane (ILM) hemorrhages in both eyes in FRAT patient by a Valsalva-like mechanism, as well as both observation and Nd: YAG laser treatment were chosen in this FRAT patient.
+
+A 13-year-old female student was admitted to our department because of sudden visual loss and central scotoma in both eyes after running 800 m at the school gym for 1 week. She had no history of ocular, systemic disease or trauma. The presenting best corrected visual acuity (BCVA) was 20/100 in the right eye and 20/160 in the left eye. Her intraocular pressures were 20 mmHg in the right eye and 18 mmHg in the left eye. Her pupillary response, ocular motility, external and anterior segment examinations were unremarkable. Dilated fundus examination revealed six retinal hemorrhages with the biggest hemorrhage measuring approximately 1.5-disc diameters (DD) in the right eye and two retinal hemorrhages with the biggest one measuring 5.5 DD in the left eye. The hemorrhages showed a double-ring sign, with the outer ring representing the subhyaloid bleed and the inner ring representing the sub-ILM hemorrhage. Several areas of intraretinal hemorrhages located in and around the posterior pole were also observed. Moreover, fundus examination of both eyes showed the tortuosity of second and higher order arterioles which were consistent with FRAT (Fig. 1). Her mother has similar arteriolar tortuosity in the fundus (Fig. 2). Spectral-domain optical coherence tomography (SD-OCT; Spectralis HRA + OCT; Heidelberg Engineering, Heidelberg, Germany) showed a dome-shaped lesion with a hyper-reflective band and a hypo-reflective area beneath consistent with blood at the macula in both eyes. From the OCT, the hemorrhages were confined below the ILM (Fig. 1). Findings from fundus fluorescein angiography (FFA) in both eyes showed the blocked fluorescence from the retinal hemorrhages, and the second- and third-order retinal arteriolar tortuosity with corkscrew shape in the posterior pole, without vascular filling defects or hyperfluorescent lesions. No lesions were detected in the venous vasculature and first-order arteries (Fig. 1). The blood pressure, biochemical test, blood cell count and coagulation were normal. Based on the clinical presentation and her history, the ultimately diagnosis of this patient was Valsalva retinopathy associated with FRAT.
+Fig. 1Fundus photographs, FFA and SD-OCT results of a student in both eyes. Fundus photograph showed multiple retinal hemorrhages, as well as second- and third-order retinal arteriolar tortuosity in the macula and peripapillary area in the right eye (a) and the left eye (d). FFA of the right (b) and the left (e) eye revealed retinal arteriolar tortuosity with the blocked fluorescence from the retinal hemorrhages. SD-OCT demonstrated a dome-shaped lesion with a hyper-reflective band and a hypo-reflective area beneath consistent with blood in the right (c) and the left eye (f)Fig. 2Fundus photographs of this familial retinal arteriolar tortuosity (FRAT) patient’s mother
+
+Fundus photographs, FFA and SD-OCT results of a student in both eyes. Fundus photograph showed multiple retinal hemorrhages, as well as second- and third-order retinal arteriolar tortuosity in the macula and peripapillary area in the right eye (a) and the left eye (d). FFA of the right (b) and the left (e) eye revealed retinal arteriolar tortuosity with the blocked fluorescence from the retinal hemorrhages. SD-OCT demonstrated a dome-shaped lesion with a hyper-reflective band and a hypo-reflective area beneath consistent with blood in the right (c) and the left eye (f)
+
+Fundus photographs of this familial retinal arteriolar tortuosity (FRAT) patient’s mother
+
+As a student, she and her family request a quick vision recovery. Comparing the potential risks, benefits and costs between surgery and laser, Nd:YAG laser was chosen. Nd:YAG laser (Ultra Q Reflex, Ellex, Australia) with a Goldmann three-mirror contact lens was performed at the lower part of the maximum premacular hemorrhages in both eyes at the same time. The energy was 5–6 mJ with single pulse. Consequently, the hemorrhages were rapidly trapped into the vitreous cavity. Five days after the membranotomy, the premacular hemorrhages had drained mostly with mild vitreous hemorrhages inferiorly, and her visual acuity was improved to 20/16 in the right eye and 20/20 in the left eye. At 7 weeks, the visual acuity of both eyes were stable. All retinal hemorrhages were resolved completely with little grayish vitreous hemorrhages in both eyes and the ILM was wrinkled in the left eye (Fig. 3). OCT showed subtle loss of foveal contour in both eyes and in the left eye, a laser perforation in the ILM and hypo-reflective premacular cavity was observed (Fig. 3).
+Fig. 3Fundus photographs and SD-OCT images 7 weeks after Nd: YAG laser membranotomy. Fundus photos showed that all retinal hemorrhages were resolved in the right (a) and left (c) eye, with the internal limiting membrane (ILM) wrinkling in the left eye (c, arrow). SD-OCT revealed subtle loss of foveal contour in the right (b) and left (d) eye, as well as a laser perforation in the ILM and a sub-ILM hypo-reflective area in the left eye (d, arrow)
+
+Fundus photographs and SD-OCT images 7 weeks after Nd: YAG laser membranotomy. Fundus photos showed that all retinal hemorrhages were resolved in the right (a) and left (c) eye, with the internal limiting membrane (ILM) wrinkling in the left eye (c, arrow). SD-OCT revealed subtle loss of foveal contour in the right (b) and left (d) eye, as well as a laser perforation in the ILM and a sub-ILM hypo-reflective area in the left eye (d, arrow)
+
+FRAT is a rare disease (OMIM %180,000), with the exact etiology is unknown yet. Diagnosis of FRAT is based on the clinical feature of the second and third order tortuosity of arterioles in the peripapillary and macular areas. Moreover, when there is a family history or a positive fundus result of one family member, the diagnosis is more definite. FRAT is usually asymptomatic and the visual symptoms occur with the retinal hemorrhage. However, the hemorrhage is not associated with the severity of the arterioles tortuosity in FRAT [1]. The hemorrhages are often correlated with mild trauma, physical exertion, or other activities that could result in elevated central venous pressure (Valsalva effect) [4].
+
+This case is unique as our FRAT patients suffering from bilateral and multiple sub-ILM hemorrhages likely because of a Valsalva effect related to the running activity. It was unclear how FART predisposes to Valsalva retinopathy. Some researchers indicated that the tortuosity of the retinal arterioles may be the result of disruption of the extracellular matrix of the arterial wall [5, 6]. Meanwhile, FRAT is thought to be an autosomal dominant disorder associated with a missense mutation in the Collagen types IV alpha-1 (COL4A1) gene in some cases [7]. COL4A1 is the most abundant and ubiquitous basement membrane protein and is present in the basal lamina of various ocular structures and vascular basement membranes [8, 9]. COL4A1 mutation can affect the collagen secretion and accumulate misfolded proteins [7]. So we hypothesized that when a Valsalva-like mechanism induced an increased venous pressure, the hemorrhage originating from the fragility of the tortuous arterioles in FRAT patients happened.
+
+The visual prognosis is often excellent either in FRAT or in Valsalva retinopathy. Following the absorption of the hemorrhages, the visual acuity usually returns to normal [10]. The primary treatment of FRAT and Valsalva retinopathy are both conservation. However, in some observed cases, irreversible visual impairment may occur because of macular pigmentary changes, epiretinal membrane (ERM) formation, or the toxicity of hemoglobin and iron on retina [11–13]. Other treatment options such as Nd: YAG laser membranotomy [14], vitrectomy [15], intravitreal injection of ranibizumab [16], preumatic displacement of the hemorrhage by gas and tissue plasminogen activator [17] and argon green laser [18] were recommended in Valsalva retinopathy, while not reported in FRAT patient until now. The other particularity of our case was that this FRAT patient was under observation for the little sub-ILM hemorrhages as well as Nd: YAG for the maximum premacular sub-ILM hemorrhages. Both therapies were effective for our patient. To our best knowledge, this was the first case report of sub-ILM hemorrhages in FRAT patient treated by Nd: YAG laser membranotomy. Although it has been advocated that if the premacular hemorrhage is < 3 DD, Nd-YAG laser should not be performed [19]. However, other study also suggested that if quicker resolution of symptoms was demanded, Nd: YAG laser is an option for premacular hemorrhage [14]. Chang et al. [20] also advised that if Nd: YAG laser is considered, it should be performed as early as possible. As it is hard to achieve the complete drainage of the clotted blood, despite successful laser perforation. As a student, our patient and her family demanded a quick resolution, so we also gave a Nd:YAG laser treatment for the right eye with the premacular hemorrhage was only 1.5 DD.
+
+Some research showed that the ERM formation and ILM wrinkling may occur as a late complication of Nd: YAG laser therapy [21, 22]. In this case, we also observed the ERM formation in left eye. Although we reported that ERM formation occurred in one eye, it did not indicate that the complication rate of Nd: YAG laser membranotomy for treating premacular hemorrhage in FRAT patient was 50% when the studied sample was only one patient. The presence of persistent hemorrhage beneath the ILM may be the stimulus for ERM formation rather than the Nd: YAG laser treatment itself [22]. ILM’s molecular constituents include members of the laminin, nidogen, collagen IV, and proteoglycan families [23]. The mutation in the COL4A1 gene, which encodes type IV collagen in basement membranes, has been reported in FRAT [7]. Thus, it was possible that the FRAT patient may have a defect ILM due to the genetic abnormality, and it may be related to the unsealed and un-reattached ILM membrane observed in this patient. In addition, the ERM formation may originate from the persistent unsealed and un-reattached ILM membrane [22]. This opinion was verified by our patient by the evidence that the ERM formation only occurred in the left eye with unsealed ILM membrane while did not observe in the right eye. And there was investigation showed that any elevations of the ILM may seal and reattach among 2–6 months [24]. According to this view, our patient may have a structure alteration in macular in the left eye observed by OCT. Meanwhile, at the follow-up of 7 weeks, our FRAT patient did not complain of metamorphopsia. We will observe this patient for a long time.
+
+We conducted the Nd:YAG laser membranectomy at the lower part of the maximum premacular hemorrhages. But in our patient, the location of ILM defect observed in the fundus after 7 weeks after the membranotomy was far from the inferior border of the initial sub-ILM hemorrhage, which may indicate that the laser performed at an inappropriate location. The explanation for the location of ILM defect far from the inferior border was due to the tangential traction of the ILM [25].
+
+In conclusion, we reported a rare case of a FRAT patient suffering from bilateral and multiple Valsalva-related sub-ILM hemorrhages which were treated by both observation and Nd: YAG laser treatment. Nd: YAG laser could be considered for treating premacular hemorrhage in FRAT patient especially when a quick vision recovery was needed. We recommend that this student avoid physically intensive performances or Valsalva. The long-time efficacy and safety of Nd: YAG laser in FRAT patient needs further study.

--- a/references_cache/PMID_34825110.md
+++ b/references_cache/PMID_34825110.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:34825110"
+title: A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+authors:
+- Obayashi T
+- Kato A
+- Suzuki H
+- Ohashi K
+- Yoshida M
+- Shibata Y
+- Ogura Y
+- Yasukawa T
+journal: Am J Ophthalmol Case Rep
+year: '2021'
+doi: 10.1016/j.ajoc.2021.101230
+content_type: abstract_only
+---
+
+# A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss.
+**Authors:** Obayashi T, Kato A, Suzuki H, Ohashi K, Yoshida M, Shibata Y, Ogura Y, Yasukawa T
+**Journal:** Am J Ophthalmol Case Rep (2021)
+**DOI:** [10.1016/j.ajoc.2021.101230](https://doi.org/10.1016/j.ajoc.2021.101230)
+
+## Content
+
+1. Am J Ophthalmol Case Rep. 2021 Nov 9;24:101230. doi:
+10.1016/j.ajoc.2021.101230.  eCollection 2021 Dec.
+
+A case series from a single family of familial retinal arteriolar tortuosity 
+with common history of sudden visual loss.
+
+Obayashi T(1), Kato A(1), Suzuki H(2), Ohashi K(3), Yoshida M(1), Shibata Y(1), 
+Ogura Y(1), Yasukawa T(1).
+
+Author information:
+(1)Department of Ophthalmology and Visual Science, Nagoya City University 
+Graduate School of Medical Sciences, Nagoya, Aichi, Japan.
+(2)Suzuki Eye Clinic Midori, Nagoya, Aichi, Japan.
+(3)Department of Pediatrics and Neonatology, Nagoya City University Graduate 
+School of Medical Sciences, Nagoya, Aichi, Japan.
+
+PURPOSE: To report family members with familial retinal arteriolar tortuosity 
+(FRAT) identified after sudden visual loss.
+OBSERVATIONS: A 15-year-old boy had sudden visual loss in his left eye while 
+playing on a horizontal bar. He was referred to Nagoya City University Hospital 
+from an eye clinic. The ophthalmologic examination showed retinal hemorrhage 
+bilaterally. His best-corrected visual acuity (BCVA) was 20/17 in the right eye 
+and 20/67 in the left eye. Bilateral retinal arteriolar tortuosity as well as 
+retinal hemorrhage was seen. Since his mother with 54 years of age also had a 
+history of retinal hemorrhage that improved spontaneously, fundus examination 
+was performed, revealing tortuosity of the retinal arterioles. Consequently, the 
+patient and his mother were diagnosed as FRAT. He was followed without 
+intervention. Retinal hemorrhage gradually decreased and resolved after 3 
+months. The BCVA of his left eye gradually improved and reached 20/20 after 1 
+year.
+CONCLUSIONS AND IMPORTANCE: In this case, the family history was very useful for 
+early diagnosis. Immediate and accurate diagnosis allowed the patient to be 
+followed without intervention and achieve subsequent resolution of retinal 
+hemorrhage and improved vision. FRAT should be considered in cases of 
+sub-internal limiting membrane hemorrhages in young patients even in the 
+presence of discrete retinal arteriolar tortuosity.
+
+© 2021 The Authors. Published by Elsevier Inc.
+
+DOI: 10.1016/j.ajoc.2021.101230
+PMCID: PMC8603015
+PMID: 34825110
+
+Conflict of interest statement: The authors declare that they have no conflicts 
+of interest associated with this report.

--- a/references_cache/PMID_39016117.md
+++ b/references_cache/PMID_39016117.md
@@ -1,0 +1,131 @@
+---
+reference_id: "PMID:39016117"
+title: Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a clinical management protocol.
+authors:
+- Gasparini S
+- Balestrini S
+- Saccaro LF
+- Bacci G
+- Panichella G
+- Montomoli M
+- Cantalupo G
+- Bigoni S
+- Mancano G
+- Pellacani S
+- Leuzzi V
+- Volpi N
+- Mari F
+- Melani F
+- Cavallin M
+- Pisano T
+- Porcedda G
+- Vaglio A
+- Mei D
+- Barba C
+- Parrini E
+- Guerrini R
+journal: Am J Med Genet C Semin Med Genet
+year: '2024'
+doi: 10.1002/ajmg.c.32099
+keywords:
+- Humans
+- Female
+- Male
+- Adult
+- Collagen Type IV/genetics
+- Child
+- Adolescent
+- "Child, Preschool"
+- "Epilepsy/genetics, etiology, therapy, pathology"
+- "Intellectual Disability/genetics, pathology"
+- Seizures/genetics
+- "Stroke/genetics, pathology"
+- "Cataract/genetics, pathology"
+- Middle Aged
+- Hematuria/genetics
+- Porencephaly/genetics
+- Phenotype
+- "Developmental Disabilities/genetics, etiology, pathology"
+- Mutation
+content_type: abstract_only
+---
+
+# Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a clinical management protocol.
+**Authors:** Gasparini S, Balestrini S, Saccaro LF, Bacci G, Panichella G, Montomoli M, Cantalupo G, Bigoni S, Mancano G, Pellacani S, Leuzzi V, Volpi N, Mari F, Melani F, Cavallin M, Pisano T, Porcedda G, Vaglio A, Mei D, Barba C, Parrini E, Guerrini R
+**Journal:** Am J Med Genet C Semin Med Genet (2024)
+**DOI:** [10.1002/ajmg.c.32099](https://doi.org/10.1002/ajmg.c.32099)
+
+## Content
+
+1. Am J Med Genet C Semin Med Genet. 2024 Dec;196(4):e32099. doi: 
+10.1002/ajmg.c.32099. Epub 2024 Jul 17.
+
+Multiorgan manifestations of COL4A1 and COL4A2 variants and proposal for a 
+clinical management protocol.
+
+Gasparini S(1)(2), Balestrini S(1)(2), Saccaro LF(3), Bacci G(4), Panichella 
+G(2)(5), Montomoli M(1), Cantalupo G(6)(7)(8), Bigoni S(9), Mancano G(1), 
+Pellacani S(1)(2), Leuzzi V(10), Volpi N(11), Mari F(12), Melani F(1), Cavallin 
+M(1), Pisano T(1), Porcedda G(13), Vaglio A(14)(15), Mei D(1), Barba C(1)(2), 
+Parrini E(1), Guerrini R(1)(2).
+
+Author information:
+(1)Neuroscience and Human Genetics Department, Meyer Children's Hospital IRCCS 
+(full member of the European Reference Network EpiCARE), Florence, Italy.
+(2)University of Florence, Florence, Italy.
+(3)Department of Psychiatry, Geneva University and Geneva University Hospitals, 
+Geneva, Switzerland.
+(4)Pediatric Ophthalmology Unit, Meyer Children's Hospital IRCCS, Florence, 
+Italy.
+(5)Department of Clinical and Experimental Medicine, University Hospital 
+Careggi, Florence, Italy.
+(6)Child Neuropsychiatry Unit, University Hospital of Verona (full member of the 
+European Reference Network EpiCARE), Verona, Italy.
+(7)Department of Engineering for Innovation Medicine, Innovation Biomedicine 
+Section, University of Verona, Verona, Italy.
+(8)Center for Research on Epilepsy in Pediatric Age (CREP), University Hospital 
+of Verona, Verona, Italy.
+(9)Medical Genetics Unit, Ferrara University Hospital, Ferrara, Italy.
+(10)Unit of Child Neurology and Psychiatry, Department of Human Neuroscience, 
+Sapienza University of Rome, Rome, Italy.
+(11)Neurology and Clinical Neurophysiology Unit, Department of Medical, Surgical 
+and Neurological Sciences, University of Siena, Siena, Italy.
+(12)Child and Adolescent Epilepsy and Clinical Neurophysiology Departmental 
+Unit, USL Centro Toscana, Prato, Italy.
+(13)Department of Paediatric Cardiology, Meyer Children's Hospital IRCCS, 
+Florence, Italy.
+(14)Nephrology and Dialysis Unit, Meyer Children's Hospital IRCCS, Florence, 
+Italy.
+(15)Department of Biomedical, Experimental and Clinical Sciences "Mario Serio", 
+University of Florence, Florence, Italy.
+
+COL4A1/2 variants are associated with highly variable multiorgan manifestations. 
+Depicting the whole clinical spectrum of COL4A1/2-related manifestations is 
+challenging, and there is no consensus on management and preventative 
+strategies. Based on a systematic review of current evidence on COL4A1/2-related 
+disease, we developed a clinical questionnaire that we administered to 43 
+individuals from 23 distinct families carrying pathogenic variants. In this 
+cohort, we extended ophthalmological and cardiological examinations to 
+asymptomatic individuals and those with only limited or mild, often nonspecific, 
+clinical signs commonly occurring in the general population (i.e., 
+oligosymptomatic). The most frequent clinical findings emerging from both the 
+literature review and the questionnaire included stroke (203/685, 29.6%), 
+seizures or epilepsy (199/685, 29.0%), intellectual disability or developmental 
+delay (168/685, 24.5%), porencephaly/schizencephaly (168/685, 24.5%), motor 
+impairment (162/685, 23.6%), cataract (124/685, 18.1%), hematuria (63/685, 
+9.2%), and retinal arterial tortuosity (58/685, 8.5%). In oligosymptomatic and 
+asymptomatic carriers, ophthalmological investigations detected retinal vascular 
+tortuosity (5/13, 38.5%), dysgenesis of the anterior segment (4/13, 30.8%), and 
+cataract (2/13, 15.4%), while cardiological investigations were unremarkable 
+except for mild ascending aortic ectasia in 1/8 (12.5%). Our multimodal approach 
+confirms highly variable penetrance and expressivity in COL4A1/2-related 
+conditions, even at the intrafamilial level with neurological involvement being 
+the most frequent and severe finding in both children and adults. We propose a 
+protocol for prevention and management based on individualized risk estimation 
+and periodic multiorgan evaluations.
+
+© 2024 The Author(s). American Journal of Medical Genetics Part C: Seminars in 
+Medical Genetics published by Wiley Periodicals LLC.
+
+DOI: 10.1002/ajmg.c.32099
+PMID: 39016117 [Indexed for MEDLINE]

--- a/references_cache/PMID_39167747.md
+++ b/references_cache/PMID_39167747.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:39167747"
+title: "Clinical Reasoning: A 50-Year-Old Man With Intracerebral Hemorrhage and Tortuous Retinal Arterioles."
+authors:
+- Bouchart J
+- Weber S
+- Coste T
+- Laville MA
+- Loisel M
+- Nehme A
+journal: Neurology
+year: '2024'
+doi: 10.1212/WNL.0000000000209796
+keywords:
+- Humans
+- Male
+- Middle Aged
+- "Cerebral Hemorrhage/diagnostic imaging, etiology"
+- "Arterioles/diagnostic imaging, pathology"
+- Clinical Reasoning
+- "Retinal Artery/diagnostic imaging, pathology"
+- "Cerebral Small Vessel Diseases/diagnostic imaging, complications"
+content_type: abstract_only
+---
+
+# Clinical Reasoning: A 50-Year-Old Man With Intracerebral Hemorrhage and Tortuous Retinal Arterioles.
+**Authors:** Bouchart J, Weber S, Coste T, Laville MA, Loisel M, Nehme A
+**Journal:** Neurology (2024)
+**DOI:** [10.1212/WNL.0000000000209796](https://doi.org/10.1212/WNL.0000000000209796)
+
+## Content
+
+1. Neurology. 2024 Sep 24;103(6):e209796. doi: 10.1212/WNL.0000000000209796. Epub
+ 2024 Aug 21.
+
+Clinical Reasoning: A 50-Year-Old Man With Intracerebral Hemorrhage and Tortuous 
+Retinal Arterioles.
+
+Bouchart J(1), Weber S(1), Coste T(1), Laville MA(1), Loisel M(1), Nehme A(1).
+
+Author information:
+(1)From the Departments of Neurology (J.B., S.W., M.L., A.N.), Genetics (S.W.), 
+and Ophthalmology (M-A. L.), Université Caen-Normandie, CHU de Caen-Normandie, 
+Caen; NeuroDiderot (T.C.), Université Paris Cité, Inserm UMR 1141; and Service 
+de Génétique Moléculaire Neurovasculaire (T.C.), AP-HP, Hôpital Saint-Louis, 
+Paris, France.
+
+A 50-year-old man presented with headache. Examination showed left sided ataxic 
+hemiparesis and elevated blood pressure. Brain imaging revealed an acute 
+intracerebral hemorrhage in the right lentiform nucleus, deep and 
+periventricular white matter hyperintensities, and predominantly deep cerebral 
+microbleeds. Fundus examination showed important arteriolar tortuosity involving 
+several blood vessels. In this young patient, we explain the diagnostic approach 
+to intracerebral hemorrhage, the causes of cerebral small vessel disease, and 
+the interpretation of biomolecular tests.
+
+DOI: 10.1212/WNL.0000000000209796
+PMID: 39167747 [Indexed for MEDLINE]

--- a/research/Retinal_Arterial_Tortuosity-deep-research-falcon.md
+++ b/research/Retinal_Arterial_Tortuosity-deep-research-falcon.md
@@ -1,0 +1,1258 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T15:02:14.058632'
+end_time: '2026-05-06T15:25:09.491201'
+duration_seconds: 1375.43
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Retinal Arterial Tortuosity
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 35
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Retinal Arterial Tortuosity
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Retinal Arterial Tortuosity** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Retinal Arterial Tortuosity
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Retinal Arterial Tortuosity** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Retinal Arterial Tortuosity (Familial Retinal Arteriolar Tortuosity; FRAT/RATOR): Disease Characteristics Research Report
+
+## 1. Disease Information
+
+### 1.1 Overview (current understanding)
+Retinal arterial tortuosity (often discussed clinically as **familial retinal arteriolar tortuosity**, FRAT; also termed **retinal arterial tortuosity**, RATOR) is a rare, typically autosomal-dominant retinal vasculopathy characterized by **marked tortuosity/contortion of second- and third-order retinal arterioles**, with **relative sparing of first-order arterioles and the venous system**; this funduscopic pattern is repeatedly described as **pathognomonic** in familial forms. (zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolved pages 65-72, gasparini2024multiorganmanifestationsof pages 2-2)
+
+A typical clinical issue is **episodic retinal hemorrhage** (intraretinal, preretinal/subhyaloid, sub-internal limiting membrane [sub-ILM], and occasionally subretinal/vitreous), causing **transient visual impairment** often triggered by minor stress, exertion, or Valsalva-like maneuvers; many episodes resolve spontaneously with good visual recovery. (gasparini2024multiorganmanifestationsof pages 2-2, chen2020bilateralandmultiple pages 1-3, saraf2019familialretinalarteriolar pages 3-5)
+
+### 1.2 Key identifiers and nomenclature
+- **MONDO (disease ontology)**: **MONDO_0008373** (“retinal arterial tortuosity”). (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+- **OMIM**: **OMIM %180000** for familial retinal arteriolar/arterial tortuosity (historically “%” denoted unknown molecular basis). (vilimelis2015newgenesinvolveda pages 65-72, zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolveda pages 84-91)
+- **Related MONDO entry**: **MONDO_0012726** (“autosomal dominant familial hematuria–retinal arteriolar tortuosity–contractures syndrome”)—a COL4A1/2-associated phenotype class in Open Targets. (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+
+**Synonyms / alternative names** (as used in the literature retrieved here):
+- Familial retinal arteriolar tortuosity (FRAT)
+- Familial retinal arterial tortuosity
+- Retinal arterial tortuosity (RATOR)
+- fRAT (abbreviation used in some sources) (zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolveda pages 84-91, gasparini2024multiorganmanifestationsof pages 2-2)
+
+**ICD-10/ICD-11 / MeSH / Orphanet IDs**: Not explicitly provided in the retrieved full-text excerpts; Open Targets indicates Orphanet as a source but did not return an Orphanet disease identifier in the retrieved evidence. (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+
+### 1.3 Evidence source type
+The disease knowledge in this report derives primarily from:
+- **Human case reports/series** (FRAT clinical phenotype and hemorrhage triggers/outcomes). (chen2020bilateralandmultiple pages 1-3, obayashi2021acaseseries pages 2-4)
+- **Human genetics studies** (segregating COL4A1 variant for FRAT). (zenteno2014nextgenerationsequencing pages 4-5)
+- **Model organism mechanistic work** (Col4a1 mutant mice with retinal vascular pathology). (alavi2016col4a1mutationscause pages 2-3)
+- **Aggregated disease-level evidence / protocols** from a 2024 systematic review + cohort-based management protocol for COL4A1/2-related disease (in which retinal arterial tortuosity is a component feature). (gasparini2024multiorganmanifestationsof pages 19-19)
+
+
+## 2. Etiology
+
+### 2.1 Primary causal factors
+**Genetic (major)**: Familial retinal arteriolar/arterial tortuosity is strongly linked to **monoallelic pathogenic variants in COL4A1** (and more broadly retinal arterial tortuosity is associated with **COL4A1/COL4A2**). (zenteno2014nextgenerationsequencing pages 4-5, gasparini2024multiorganmanifestationsof pages 2-2, OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+
+**Mechanistic concept**: COL4A1 encodes the type IV collagen α1 chain, a core component of vascular basement membranes. Glycine substitutions in the collagenous domain can disrupt collagen IV assembly and secretion (see Mechanism section). (zenteno2014nextgenerationsequencing pages 4-5)
+
+### 2.2 Risk factors (clinical/episode-level)
+While disease susceptibility is genetic, **episodic hemorrhages** are frequently reported to be precipitated by:
+- **Physical exertion / minor trauma** (gasparini2024multiorganmanifestationsof pages 2-2, zenteno2014nextgenerationsequencing pages 1-2)
+- **Valsalva-like maneuvers/straining** (e.g., running) (chen2020bilateralandmultiple pages 1-3)
+
+In a 13-year-old FRAT patient, hemorrhages occurred after running 800 m, consistent with a Valsalva-like trigger. (chen2020bilateralandmultiple pages 1-3)
+
+### 2.3 Protective factors / gene–environment interactions
+No specific protective factors (genetic or environmental) were identified in the retrieved sources.
+
+Gene–environment interactions are implied by variable expressivity and hemorrhage triggers (exertion/trauma), and by explicit suggestions that environmental factors and/or genetic modifiers influence phenotype (ocular-only FRAT vs multisystem COL4A1 disease). (zenteno2014nextgenerationsequencing pages 4-5, vilimelis2015newgenesinvolveda pages 95-96)
+
+
+## 3. Phenotypes (clinical features; HPO suggestions)
+
+A structured phenotype summary is provided in the table artifact below.
+
+| Phenotype feature | Suggested HPO term(s) | Typical onset / course | Triggers / modifiers | Complications / QoL impact | Quantitative data | Key notes / citations |
+|---|---|---|---|---|---|---|
+| Retinal arteriolar tortuosity distribution in familial disease (FRAT/RATOR) | Retinal vascular tortuosity [suggest HP term: retinal arteriolar tortuosity if curated]; Abnormality of retinal vasculature (suggested) | Often recognized in childhood or early adulthood; usually chronic/stable between hemorrhagic episodes | May become clinically relevant during exertion or minor trauma because hemorrhage can occur despite otherwise stable vessel morphology | Can predispose to recurrent retinal hemorrhage and transient visual disturbance; funduscopic pattern is considered highly characteristic/pathognomonic | Classic pattern: marked tortuosity of **second- and third-order retinal arterioles** with **normal first-order arteries and venous sparing** | Core diagnostic description repeated across FRAT/COL4A1 literature (zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolved pages 65-72, vilimelis2015newgenesinvolveda pages 84-91, gasparini2024multiorganmanifestationsof pages 2-2, saraf2019familialretinalarteriolar pages 1-2) |
+| EDS-associated retinal arterial tortuosity phenotype | Abnormal retinal vasculature; Retinal vascular tortuosity (suggested) | Adult cohort described; variable severity from mild to severe | Not clearly linked to hypertension or diabetes in the cohort studied | Usually an imaging finding; establishes that tortuosity also occurs outside FRAT and may broaden differential diagnosis | In 142 EDS patients, **37.3% definite RAT**, **10.6% possible RAT**, **52.1% no RAT**; among definite RAT eyes: **39.2% mild**, **40.2% moderate**, **20.6% severe**; vessel involvement: **84.9% first-order arterioles**, **35.8% macular arterioles**, **1.9% arteriovenous** | Important differential: unlike FRAT, EDS-associated RAT commonly involved **first-order arterioles** (ghoraba2023retinalarterialtortuosity pages 2-5, ghoraba2023retinalarterialtortuosity pages 1-2, ghoraba2023retinalarterialtortuosity pages 5-5) |
+| Retinal hemorrhages: intraretinal / subretinal / premacular-sub-ILM | Retinal hemorrhage; Intraretinal hemorrhage; Subretinal hemorrhage; Preretinal hemorrhage / Premacular hemorrhage (suggested) | Episodic; often sudden onset with spontaneous resolution over weeks to months | Exercise, minor trauma, Valsalva-like maneuvers/straining; running has been reported as a trigger | Acute visual loss, central scotoma; occasional ERM after intervention; anxiety/functional limitation during episodes | FRAT family reports describe recurrent perifoveal/foveal hemorrhages; in one 13-year-old case: **6 sub-ILM hemorrhages OD** (largest **~1.5 DD**) and **2 OS** (largest **5.5 DD**) | Hemorrhage is the main vision-threatening event in FRAT; sub-ILM/premacular hemorrhage well documented by fundus/OCT/FFA (vilimelis2015newgenesinvolveda pages 93-95, vilimelis2015newgenesinvolved pages 93-95, chen2020bilateralandmultiple pages 1-3, chen2020bilateralandmultiple pages 3-5, chen2020bilateralandmultiple media c2e15b79) |
+| Transient vision loss / blurred vision / central scotoma | Transient visual loss; Blurred vision; Central scotoma (suggested) | Usually episodic and linked to hemorrhage rather than progressive neuroretinal degeneration | Often precipitated by hemorrhage after exertion or minor trauma | Temporary loss of reading/central vision; can be bilateral in severe premacular hemorrhage; long-term prognosis often good if hemorrhage clears | Visual acuity in the 2020 case improved from **20/100 OD, 20/160 OS** to **20/16 OD, 20/20 OS** after combined treatment/observation | Most affected individuals are asymptomatic between episodes, but hemorrhage can cause transient marked impairment (saraf2019familialretinalarteriolar pages 1-2, gasparini2024multiorganmanifestationsof pages 2-2, chen2020bilateralandmultiple pages 1-3, chen2020bilateralandmultiple pages 3-5) |
+| Nailbed capillary tortuosity | Capillary tortuosity (suggested) | Chronic accompanying microvascular finding when present | No specific trigger established | May indicate extra-retinal microvascular involvement; little direct QoL impact but useful diagnostically | Historical reports note marked nailbed capillary tortuosity; one thesis notes abnormal capillary tortuosity threshold **>~20%**, with one family showing **>30%** loops affected | Supports systemic small-vessel involvement beyond the retina in some families (vilimelis2015newgenesinvolved pages 65-72, vilimelis2015newgenesinvolveda pages 65-72) |
+| Systemic associations: HANAC-spectrum COL4A1 disease | Hematuria; Cerebral aneurysm; Muscle cramps; Leukoencephalopathy; Raynaud phenomenon; Arrhythmia (suggested HPO mappings) | Variable; penetrance and expressivity are highly heterogeneous, including asymptomatic/oligosymptomatic carriers | Likely modified by genotype plus environmental/genetic modifiers | Renal disease, aneurysm risk, muscle symptoms, neurologic disease; requires multidisciplinary surveillance | In aggregated COL4A1/2 data: **retinal arterial tortuosity 58/685 (8.5%)**; among asymptomatic/oligosymptomatic carriers undergoing ophthalmic workup, retinal vascular tortuosity detected in **5/13 (38.5%)** | Same COL4A1 p.Gly510Arg variant can present as isolated FRAT or multisystem HANAC-like disease, demonstrating variable expressivity (vilimelis2015newgenesinvolved pages 95-96, gasparini2024multiorganmanifestationsof pages 2-2, gasparini2024multiorganmanifestationsof pages 19-19, vilimelis2015newgenesinvolveda pages 95-96, zenteno2014nextgenerationsequencing pages 4-5) |
+| Brain small-vessel disease / intracerebral hemorrhage / ischemic lesions in COL4A1/2-related disease | Intracerebral hemorrhage; Cerebral small vessel disease; Lacunar stroke; Leukoencephalopathy (suggested) | Can occur from childhood to adulthood; chronic vasculopathy with risk of hemorrhagic and ischemic events | Blood-pressure burden and trauma likely relevant modifiers; monogenic background is primary | Major morbidity from stroke, seizures, cognitive/neurologic impairment; retinal arteriolar tortuosity can be a valuable diagnostic clue | Literature aggregation in COL4A1/2 disease: **stroke 203/685 (29.6%)**, **seizures/epilepsy 199/685 (29.0%)**, **porencephaly/schizencephaly 168/685 (24.5%)**; case reports include hippocampal infarction and ICH with tortuous retinal arterioles | Retinal arteriolar tortuosity is emphasized as a clue that should prompt evaluation for monogenic COL4A1/2 vasculopathy (kim2017familialretinalarteriolar pages 2-4, bouchart2024clinicalreasoninga pages 3-5, gasparini2024multiorganmanifestationsof pages 2-2, gasparini2024multiorganmanifestationsof pages 19-19) |
+| Course and intervention-associated sequelae after premacular hemorrhage | Epiretinal membrane; Wrinkling of retinal internal limiting membrane (suggested) | Usually recovery after spontaneous resorption or drainage; sequelae may follow laser membranotomy | Procedure-related risk with Nd:YAG membranotomy | ERM, ILM wrinkling, rarely other iatrogenic macular complications; affects metamorphopsia risk and follow-up needs | In the 2020 bilateral case, ERM developed in the left eye despite excellent acuity recovery | Supports careful individualized management; observation alone is reasonable for smaller hemorrhages, laser may accelerate recovery in selected large premacular bleeds (chen2020bilateralandmultiple pages 5-5, chen2020bilateralandmultiple pages 1-3, chen2020bilateralandmultiple pages 3-5) |
+
+
+*Table: This table summarizes the main clinical phenotype features reported for familial retinal arterial/arteriolar tortuosity and related COL4A1/2-associated presentations, including suggested HPO mappings, course, triggers, complications, and quantitative findings. It is useful for structured knowledge-base curation and differential diagnosis, including comparison with EDS-associated retinal arterial tortuosity.*
+
+### 3.1 Core ocular phenotype (familial FRAT/RATOR)
+**Definition/diagnostic pattern**: “marked contortion of the second- and third-order retinal arteries with no impact on the first-order arteries and the venous system.” (gasparini2024multiorganmanifestationsof pages 2-2)
+
+**Hemorrhages and transient visual symptoms**: Most affected individuals experience “episodes of transient vision impairment caused by retinal hemorrhage prompted by minor stress or trauma.” (gasparini2024multiorganmanifestationsof pages 2-2)
+
+### 3.2 Notable differential diagnosis and phenotypic overlap
+- **Ehlers–Danlos syndromes (EDS)**: A 2023 retrospective cohort study found **retinal arterial tortuosity (RAT)** was common in EDS, with **37.3% definite RAT** and **10.6% possible RAT** among 142 imaged EDS patients; importantly, EDS-associated RAT frequently involved **first-order arterioles (84.9%)**, which contrasts with classic FRAT affecting second/third-order arterioles. (ghoraba2023retinalarterialtortuosity pages 1-2, ghoraba2023retinalarterialtortuosity pages 5-5)
+
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes
+- **COL4A1** (primary gene for familial FRAT in multiple pedigrees; strong evidence). (zenteno2014nextgenerationsequencing pages 4-5)
+- **COL4A2** (associated with retinal arterial tortuosity within the broader COL4A1/2 disease spectrum in aggregated databases). (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+
+### 4.2 Pathogenic variants (examples)
+**COL4A1 c.1528G>A (p.Gly510Arg), heterozygous missense**:
+- Identified by WES and confirmed by Sanger in affected family members with FRAT; absent in unaffected daughter and in multiple control datasets. (zenteno2014nextgenerationsequencing pages 1-2, zenteno2014nextgenerationsequencing pages 4-5)
+- Population data in one study: absent from **200 ethnically matched control alleles** and **~8,600 exomes** in the NHLBI Exome Variant Server. (zenteno2014nextgenerationsequencing pages 4-5)
+- Genotype–phenotype variability: the same p.Gly510Arg variant previously reported in HANAC syndrome, while in the FRAT pedigree no extra-ocular features were found, supporting variable expressivity. (zenteno2014nextgenerationsequencing pages 4-5)
+
+**Variant localization and domain concept**:
+- The p.Gly510Arg substitution lies within a “critical region (residues 498–528) that includes integrin binding sites” in the collagenous domain. (zenteno2014nextgenerationsequencing pages 4-5)
+
+### 4.3 Functional consequences (molecular)
+Glycine substitutions in the collagenous domain are described as disrupting collagen biology: “perturb triple helix assembly, impair secretion of collagen heterotrimers, and cause intracellular accumulation of misfolded proteins.” (zenteno2014nextgenerationsequencing pages 4-5, vilimelis2015newgenesinvolveda pages 95-96)
+
+### 4.4 Modifier genes / variable expressivity
+Multiple sources emphasize that identical COL4A1 mutations can yield ocular-only FRAT vs multisystem disease (HANAC), consistent with modifier effects (genetic background, environment). (vilimelis2015newgenesinvolveda pages 95-96, zenteno2014nextgenerationsequencing pages 4-5)
+
+### 4.5 Epigenetics / chromosomal abnormalities
+No disease-specific epigenetic or chromosomal abnormality evidence was identified in the retrieved texts.
+
+
+## 5. Environmental Information
+No specific environmental toxins, lifestyle factors, or infectious agents were identified as causal. The major “environmental” role described is **episode triggering** (exertion/trauma/Valsalva-like stress) for hemorrhage in genetically susceptible individuals. (chen2020bilateralandmultiple pages 1-3, saraf2019familialretinalarteriolar pages 3-5)
+
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Mechanistic causal chain (COL4A1/2-related small-vessel fragility)
+A unifying model supported by human genetics and mouse data is:
+1) **COL4A1 pathogenic variant** → abnormal type IV collagen network in vascular basement membranes (zenteno2014nextgenerationsequencing pages 4-5)
+2) **Primary retinal vascular defects** (vessel instability/tortuosity, permeability, hemorrhage) (alavi2016col4a1mutationscause pages 7-8, alavi2016col4a1mutationscause pages 2-3)
+3) **Secondary retinal responses** (reactive Müller glia activation; pro-angiogenic factor upregulation; possible neovascular complications in some COL4A1 contexts) (alavi2016col4a1mutationscause pages 7-8)
+4) Clinical manifestation as **arteriolar tortuosity + hemorrhagic episodes** with transient vision loss. (gasparini2024multiorganmanifestationsof pages 2-2, chen2020bilateralandmultiple pages 1-3)
+
+### 6.2 Evidence from model organisms (mechanistic depth)
+In Col4a1 mutant mice, retinal pathology included hemorrhage and angiogenic lesions. Key quantitative findings include:
+- Retinal pathology (serous chorioretinopathy, hemorrhages, fibrosis or pathogenic angiogenesis) occurred in **up to ~90%** of mutant eyes depending on age and allele. (alavi2016col4a1mutationscause pages 1-2)
+- In a large cohort, penetrance increased with age (estimated **36–43% by P21** and **68–88% after 1 month** in one line), and “all mutant eyes exhibited abnormal vascular branching and vascular tortuosity” on fluorescein angiography. (alavi2016col4a1mutationscause pages 2-3)
+- Cell-type dissection: “Conditional expression of mutant Col4a1 in vascular endothelium, but not RPE, phenocopies the retinal defects.” (alavi2016col4a1mutationscause pages 7-8)
+- Lesion-associated glial response: Müller cell activation (GFAP/vimentin) and elevated pro-angiogenic factors (Vegfa, Pdgfb, Pgf). (alavi2016col4a1mutationscause pages 7-8)
+
+### 6.3 Pathways / ontology suggestions
+**GO Biological Process (suggested)**
+- extracellular matrix organization
+- basement membrane organization
+- angiogenesis / regulation of VEGF signaling
+- blood vessel morphogenesis
+- response to oxidative stress / wound healing (secondary)
+
+**Cell types (CL suggestions)**
+- vascular endothelial cell
+- pericyte (retinal microvasculature)
+- Müller glial cell (reactive gliosis noted) (alavi2016col4a1mutationscause pages 7-8)
+
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Primary anatomical site
+- **Retina – arteriolar vasculature** (especially second- and third-order arterioles in classic FRAT/RATOR). (gasparini2024multiorganmanifestationsof pages 2-2)
+
+**UBERON suggestions**
+- retina (UBERON:0000966)
+- retinal blood vessel (UBERON term as applicable)
+
+### 7.2 Secondary / systemic involvement (context-dependent)
+Although FRAT is often described as primarily ocular, retinal arteriolar tortuosity can be a clue to broader COL4A1/2 vasculopathy, including cerebral small vessel disease and hemorrhage risk. (bouchart2024clinicalreasoninga pages 3-5)
+
+
+## 8. Temporal Development
+
+### 8.1 Onset
+Onset is often described in **childhood or early adulthood** in familial FRAT. (zenteno2014nextgenerationsequencing pages 1-2)
+
+### 8.2 Course
+- Baseline vascular tortuosity is chronic.
+- Hemorrhage episodes are intermittent; visual prognosis is usually good with recovery after hemorrhage clearance. (saraf2019familialretinalarteriolar pages 1-2)
+- Tortuosity may increase with age over decades in some individuals. (saraf2019familialretinalarteriolar pages 3-5)
+
+
+## 9. Inheritance and Population
+
+### 9.1 Inheritance
+Familial FRAT is generally **autosomal dominant**; one pedigree includes male-to-male transmission and vertical inheritance consistent with AD. (zenteno2014nextgenerationsequencing pages 1-2)
+
+Open Targets annotations for retinal arterial tortuosity and related entries list **monoallelic autosomal** allelic requirements. (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+
+### 9.2 Epidemiology / prevalence
+Robust population prevalence estimates were not found in the retrieved evidence. A historical estimate notes “approximately 100 cases described” (as of the cited older literature compilation), reflecting rarity and likely underdiagnosis. (vilimelis2015newgenesinvolved pages 65-72)
+
+### 9.3 Penetrance / expressivity
+Penetrance and expressivity in COL4A1/2-related disease are explicitly described as highly variable, with asymptomatic/oligosymptomatic carriers detectable by protocolized screening. (gasparini2024multiorganmanifestationsof pages 19-19)
+
+
+## 10. Diagnostics
+
+### 10.1 Clinical diagnosis (ophthalmic)
+Diagnosis is commonly made via:
+- Dilated fundus examination / color fundus photography identifying the characteristic arteriolar pattern (vilimelis2015newgenesinvolved pages 65-72)
+- Fluorescein angiography (FA) to document vessel anatomy and hemorrhage-related blocked fluorescence and to exclude leakage in some cases (chen2020bilateralandmultiple media c2e15b79, obayashi2021acaseseries pages 2-4)
+- Optical coherence tomography (OCT) to localize premacular hemorrhage (subhyaloid vs sub-ILM) and follow resolution (chen2020bilateralandmultiple pages 1-3)
+- OCT angiography (OCTA), including swept-source OCTA, increasingly used to delineate tortuosity and quantify it objectively (saraf2019familialretinalarteriolar pages 1-2, obayashi2021acaseseries pages 4-5)
+
+**Real-world imaging example (figure evidence)**: In a FRAT patient with bilateral premacular hemorrhages, Figure 1 demonstrates tortuous arterioles on fundus photographs and corresponding SD-OCT evidence of dome-shaped sub-ILM hemorrhage. (chen2020bilateralandmultiple media c2e15b79)
+
+### 10.2 Genetic testing
+- **Single-gene testing / targeted panels** including COL4A1 can be used; WES identified COL4A1 p.Gly510Arg in one FRAT pedigree. (zenteno2014nextgenerationsequencing pages 4-5)
+- Diagnostic caveat: FRAT-like families can be negative on panels. In one family case series, a targeted NGS panel of 328 genes “found no pathogenic variants … including COL4A1,” and the family declined further testing, suggesting locus heterogeneity, undetected variant types, or limitations of panels. (obayashi2021acaseseries pages 4-5)
+
+### 10.3 Differential diagnosis (examples)
+In the neurologic setting, retinal arteriolar tortuosity is highlighted as a clue to COL4A1/2-related disorders and helps distinguish from other hereditary CSVDs (e.g., CADASIL, CARASIL, Fabry). (bouchart2024clinicalreasoninga pages 3-5)
+
+
+## 11. Outcome / Prognosis
+
+### 11.1 Visual prognosis
+Visual prognosis is generally favorable. A case series documented spontaneous resolution of hemorrhage with recovery to **20/20** by 1 year in a teenager, and good outcomes overall with observation. (obayashi2021acaseseries pages 1-2)
+
+A 2019 OCTA-based FRAT report states prognosis is “excellent” with most patients recovering normal acuity after hemorrhage clearance, though some may have mild irreversible impairment due to macular pigment changes. (saraf2019familialretinalarteriolar pages 3-5)
+
+### 11.2 Systemic prognosis considerations (COL4A1/2 context)
+When retinal arteriolar tortuosity occurs in COL4A1/2 vasculopathy, neurologic risks (ICH, cerebral microbleeds, seizures) can dominate morbidity, warranting multidisciplinary evaluation. (bouchart2024clinicalreasoninga pages 3-5)
+
+
+## 12. Treatment / Management
+
+### 12.1 Acute hemorrhage management
+- **Observation** is standard for many hemorrhages, with spontaneous reabsorption and visual recovery. (saraf2019familialretinalarteriolar pages 1-2, obayashi2021acaseseries pages 1-2)
+- **Nd:YAG laser membranotomy** can be considered for large premacular sub-ILM hemorrhage when rapid visual recovery is needed; a bilateral FRAT case achieved improvement from **20/100 and 20/160** to **20/16 and 20/20**, but developed an **epiretinal membrane (ERM)** in one eye, and the authors caution about long-term safety/placement considerations. (chen2020bilateralandmultiple pages 1-3, chen2020bilateralandmultiple pages 5-5)
+
+**MAXO suggestions**
+- Observation / watchful waiting
+- Laser membranotomy (Nd:YAG)
+- Patient education / avoidance counseling
+
+### 12.2 Prevention of hemorrhage episodes
+Avoidance of triggering activities (straining/Valsalva-like maneuvers) is commonly recommended in case management. (saraf2019familialretinalarteriolar pages 1-2)
+
+### 12.3 Multiorgan management (COL4A1/2 carriers)
+A 2024 expert protocol proposes baseline and follow-up screening in COL4A1/2 variant carriers, including brain MRI with angiographic sequences, baseline labs (blood count, CK, coagulation indices), and ophthalmologic evaluation with OCT-based monitoring depending on initial severity; prenatal imaging is suggested for pregnancy risk counseling. (gasparini2024multiorganmanifestationsof pages 19-19)
+
+
+## 13. Prevention
+
+Primary prevention is not established (genetic). Key prevention concepts are:
+- **Secondary prevention / surveillance** for COL4A1/2 carriers via periodic multi-organ evaluation (brain imaging, ophthalmology, lab screening). (gasparini2024multiorganmanifestationsof pages 19-19)
+- **Tertiary prevention**: avoid triggers for hemorrhage; control modifiable vascular risks (e.g., blood pressure) in those with COL4A1/2 vasculopathy. (bouchart2024clinicalreasoninga pages 3-5)
+
+
+## 14. Other Species / Natural Disease
+No naturally occurring veterinary analogs were identified in the retrieved evidence.
+
+
+## 15. Model Organisms
+A well-developed mechanistic model exists in **Col4a1 mutant mice**, which recapitulate retinal vascular tortuosity, hemorrhage, and progressive retinopathy; endothelial expression of mutant Col4a1 is sufficient to induce the phenotype. (alavi2016col4a1mutationscause pages 7-8, alavi2016col4a1mutationscause pages 2-3)
+
+
+## 16. Recent developments and real-world implementations (prioritizing 2023–2024)
+
+### 16.1 2023: EDS association study (real-world EHR + imaging repository)
+A 2023 Eye study used a large institutional repository (STARR) and multimodal imaging to systematically grade RAT in EDS, providing practical prevalence estimates and a grading framework with intergrader agreement (kappa). It reported **37.3% definite RAT** and subclassified severity and vessel distributions. (ghoraba2023retinalarterialtortuosity pages 1-2, ghoraba2023retinalarterialtortuosity pages 2-5)
+
+### 16.2 2024: Clinical reasoning and diagnostic positioning in Neurology
+A 2024 Neurology “Clinical Reasoning” article emphasizes that “retinal arteriolar tortuosity, while not always present, is an important finding that strongly suggests the diagnosis of COL4A1/2-related disorders,” integrating ophthalmic findings into monogenic CSVD workups and highlighting management implications (blood pressure control; avoiding head trauma). (bouchart2024clinicalreasoninga pages 3-5)
+
+### 16.3 2024: Management protocol for COL4A1/2 disease
+A 2024 AJMG Seminars paper proposes an explicit screening/management protocol (brain MRI/MRA, baseline labs, ophthalmology/OCT monitoring, prenatal imaging, genetic counseling). This is a concrete step toward standard-of-care harmonization for COL4A1/2 carriers in which retinal arterial tortuosity is a recognized phenotype component. (gasparini2024multiorganmanifestationsof pages 19-19)
+
+### 16.4 Clinical trials / prospective implementation
+An actively recruiting ClinicalTrials.gov study (NCT07374913; sponsor: Meyer Children’s Hospital IRCCS; posted 2021, currently recruiting) operationalizes multi-organ screening for COL4A1/2 variant carriers in routine care settings with standardized ophthalmological OCT assessments, cardiology testing, and exploratory plasma biomarkers (MMP2/MMP9). (NCT07374913 chunk 1)
+
+
+## Key limitations of the current evidence base
+- FRAT/RATOR remains rare; much evidence comes from case reports/series, limiting precise penetrance and population prevalence estimates. (vilimelis2015newgenesinvolved pages 65-72)
+- Database identifiers (Orphanet/ICD/MeSH) were not recoverable from the retrieved excerpts; additional targeted database queries (OMIM/Orphanet directly) would be needed for full code normalization. (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+- COL4A2-specific variant-to-FRAT evidence was limited in the retrieved full texts; associations appear in aggregated resources. (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1)
+
+
+# Identifier normalization artifact
+| Preferred name | Key synonyms / alternative names | MONDO ID(s) | OMIM identifier | Associated gene(s) | Typical inheritance | Key defining diagnostic description |
+|---|---|---|---|---|---|---|
+| Retinal arterial tortuosity | Retinal arteriolar tortuosity; familial retinal arteriolar tortuosity (FRAT); familial retinal arterial tortuosity; fRAT; retinal arterial tortuosity (RATOR) (zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolveda pages 84-91, gasparini2024multiorganmanifestationsof pages 2-2) | MONDO:0008373 = retinal arterial tortuosity; MONDO:0012726 = autosomal dominant familial hematuria-retinal arteriolar tortuosity-contractures syndrome (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1) | OMIM %180000 for familial retinal arteriolar/arterial tortuosity (vilimelis2015newgenesinvolveda pages 65-72, zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolveda pages 84-91) | COL4A1 strongly supported; COL4A2 also associated in Open Targets evidence for retinal arterial tortuosity / related syndrome (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1, vilimelis2015newgenesinvolveda pages 84-91, gasparini2024multiorganmanifestationsof pages 2-2) | Usually autosomal dominant / monoallelic; vertical transmission and male-to-male transmission reported in families (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1, zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolveda pages 84-91) | Marked tortuosity/contortion of second- and third-order retinal arteries/arterioles, typically with normal first-order arteries and sparing of the venous system; funduscopic appearance described as pathognomonic (vilimelis2015newgenesinvolveda pages 65-72, zenteno2014nextgenerationsequencing pages 1-2, vilimelis2015newgenesinvolved pages 65-72, gasparini2024multiorganmanifestationsof pages 2-2) |
+
+
+*Table: This table summarizes the principal disease names, identifiers, genes, inheritance, and defining diagnostic features for retinal arterial/arteriolar tortuosity. It is useful as a compact normalization reference for disease knowledge-base curation.*
+
+References
+
+1. (zenteno2014nextgenerationsequencing pages 1-2): Juan C. Zenteno, Jaume Crespí, Beatriz Buentello-Volante, Jose A. Buil, Francisca Bassaganyas, Jose I. Vela-Segarra, Jesus Diaz-Cascajosa, and Maria T. Marieges. Next generation sequencing uncovers a missense mutation in col4a1 as the cause of familial retinal arteriolar tortuosity. Graefe's Archive for Clinical and Experimental Ophthalmology, 252:1789-1794, Sep 2014. URL: https://doi.org/10.1007/s00417-014-2800-6, doi:10.1007/s00417-014-2800-6. This article has 55 citations.
+
+2. (vilimelis2015newgenesinvolved pages 65-72): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+3. (gasparini2024multiorganmanifestationsof pages 2-2): Simone Gasparini, Simona Balestrini, Luigi Francesco Saccaro, Giacomo Bacci, Giorgia Panichella, Martino Montomoli, Gaetano Cantalupo, Stefania Bigoni, Giorgia Mancano, Simona Pellacani, Vincenzo Leuzzi, Nila Volpi, Francesco Mari, Federico Melani, Mara Cavallin, Tiziana Pisano, Giulio Porcedda, Augusto Vaglio, Davide Mei, Carmen Barba, Elena Parrini, and Renzo Guerrini. Multiorgan manifestations of col4a1 and col4a2 variants and proposal for a clinical management protocol. American Journal of Medical Genetics Part C: Seminars in Medical Genetics, Jul 2024. URL: https://doi.org/10.1002/ajmg.c.32099, doi:10.1002/ajmg.c.32099. This article has 21 citations.
+
+4. (chen2020bilateralandmultiple pages 1-3): Ting Chen, Hongmei Zheng, Yunyun Wang, Junyi Hu, and Changzheng Chen. Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by valsalva-like mechanism: an observational case report. BMC Ophthalmology, Apr 2020. URL: https://doi.org/10.1186/s12886-020-01413-0, doi:10.1186/s12886-020-01413-0. This article has 8 citations and is from a peer-reviewed journal.
+
+5. (saraf2019familialretinalarteriolar pages 3-5): Steven S. Saraf, Ariel J. Tyring, Chieh-Li Chen, Thao Phuong Le, Robert E. Kalina, Ruikang K. Wang, and Jennifer R. Chao. Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography. American Journal of Ophthalmology Case Reports, 14:74-78, Jun 2019. URL: https://doi.org/10.1016/j.ajoc.2019.03.001, doi:10.1016/j.ajoc.2019.03.001. This article has 24 citations.
+
+6. (OpenTargets Search: retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1): Open Targets Query (retinal arterial tortuosity,familial retinal arterial tortuosity-COL4A1, 4 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+7. (vilimelis2015newgenesinvolveda pages 65-72): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+8. (vilimelis2015newgenesinvolveda pages 84-91): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+9. (obayashi2021acaseseries pages 2-4): Tomohiro Obayashi, Aki Kato, Harumitsu Suzuki, Kei Ohashi, Munenori Yoshida, Yu Shibata, Yuichiro Ogura, and Tsutomu Yasukawa. A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss. American Journal of Ophthalmology Case Reports, 24:101230, Dec 2021. URL: https://doi.org/10.1016/j.ajoc.2021.101230, doi:10.1016/j.ajoc.2021.101230. This article has 2 citations.
+
+10. (zenteno2014nextgenerationsequencing pages 4-5): Juan C. Zenteno, Jaume Crespí, Beatriz Buentello-Volante, Jose A. Buil, Francisca Bassaganyas, Jose I. Vela-Segarra, Jesus Diaz-Cascajosa, and Maria T. Marieges. Next generation sequencing uncovers a missense mutation in col4a1 as the cause of familial retinal arteriolar tortuosity. Graefe's Archive for Clinical and Experimental Ophthalmology, 252:1789-1794, Sep 2014. URL: https://doi.org/10.1007/s00417-014-2800-6, doi:10.1007/s00417-014-2800-6. This article has 55 citations.
+
+11. (alavi2016col4a1mutationscause pages 2-3): Marcel V. Alavi, Mao Mao, Bradley T. Pawlikowski, Manana Kvezereli, Jacque L. Duncan, Richard T. Libby, Simon W. M. John, and Douglas B. Gould. Col4a1 mutations cause progressive retinal neovascular defects and retinopathy. Scientific Reports, Jan 2016. URL: https://doi.org/10.1038/srep18602, doi:10.1038/srep18602. This article has 58 citations and is from a peer-reviewed journal.
+
+12. (gasparini2024multiorganmanifestationsof pages 19-19): Simone Gasparini, Simona Balestrini, Luigi Francesco Saccaro, Giacomo Bacci, Giorgia Panichella, Martino Montomoli, Gaetano Cantalupo, Stefania Bigoni, Giorgia Mancano, Simona Pellacani, Vincenzo Leuzzi, Nila Volpi, Francesco Mari, Federico Melani, Mara Cavallin, Tiziana Pisano, Giulio Porcedda, Augusto Vaglio, Davide Mei, Carmen Barba, Elena Parrini, and Renzo Guerrini. Multiorgan manifestations of col4a1 and col4a2 variants and proposal for a clinical management protocol. American Journal of Medical Genetics Part C: Seminars in Medical Genetics, Jul 2024. URL: https://doi.org/10.1002/ajmg.c.32099, doi:10.1002/ajmg.c.32099. This article has 21 citations.
+
+13. (vilimelis2015newgenesinvolveda pages 95-96): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+14. (saraf2019familialretinalarteriolar pages 1-2): Steven S. Saraf, Ariel J. Tyring, Chieh-Li Chen, Thao Phuong Le, Robert E. Kalina, Ruikang K. Wang, and Jennifer R. Chao. Familial retinal arteriolar tortuosity and quantification of vascular tortuosity using swept-source optical coherence tomography angiography. American Journal of Ophthalmology Case Reports, 14:74-78, Jun 2019. URL: https://doi.org/10.1016/j.ajoc.2019.03.001, doi:10.1016/j.ajoc.2019.03.001. This article has 24 citations.
+
+15. (ghoraba2023retinalarterialtortuosity pages 2-5): Hashem H. Ghoraba and Darius M. Moshfeghi. Retinal arterial tortuosity in ehlers–danlos syndromes. Eye, 37:1936-1941, Oct 2023. URL: https://doi.org/10.1038/s41433-022-02278-x, doi:10.1038/s41433-022-02278-x. This article has 4 citations and is from a peer-reviewed journal.
+
+16. (ghoraba2023retinalarterialtortuosity pages 1-2): Hashem H. Ghoraba and Darius M. Moshfeghi. Retinal arterial tortuosity in ehlers–danlos syndromes. Eye, 37:1936-1941, Oct 2023. URL: https://doi.org/10.1038/s41433-022-02278-x, doi:10.1038/s41433-022-02278-x. This article has 4 citations and is from a peer-reviewed journal.
+
+17. (ghoraba2023retinalarterialtortuosity pages 5-5): Hashem H. Ghoraba and Darius M. Moshfeghi. Retinal arterial tortuosity in ehlers–danlos syndromes. Eye, 37:1936-1941, Oct 2023. URL: https://doi.org/10.1038/s41433-022-02278-x, doi:10.1038/s41433-022-02278-x. This article has 4 citations and is from a peer-reviewed journal.
+
+18. (vilimelis2015newgenesinvolveda pages 93-95): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+19. (vilimelis2015newgenesinvolved pages 93-95): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+20. (chen2020bilateralandmultiple pages 3-5): Ting Chen, Hongmei Zheng, Yunyun Wang, Junyi Hu, and Changzheng Chen. Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by valsalva-like mechanism: an observational case report. BMC Ophthalmology, Apr 2020. URL: https://doi.org/10.1186/s12886-020-01413-0, doi:10.1186/s12886-020-01413-0. This article has 8 citations and is from a peer-reviewed journal.
+
+21. (chen2020bilateralandmultiple media c2e15b79): Ting Chen, Hongmei Zheng, Yunyun Wang, Junyi Hu, and Changzheng Chen. Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by valsalva-like mechanism: an observational case report. BMC Ophthalmology, Apr 2020. URL: https://doi.org/10.1186/s12886-020-01413-0, doi:10.1186/s12886-020-01413-0. This article has 8 citations and is from a peer-reviewed journal.
+
+22. (vilimelis2015newgenesinvolved pages 95-96): J Crespí Vilimelis. New genes involved in rare diseases in ophthalmology. Unknown journal, 2015.
+
+23. (kim2017familialretinalarteriolar pages 2-4): Tae Hee Kim, Sonia Lee, and Su Jin Lim. Familial retinal arteriolar tortuosity with acute hippocampal infarction. Case Reports in Ophthalmology, 8:185-189, Mar 2017. URL: https://doi.org/10.1159/000456069, doi:10.1159/000456069. This article has 5 citations and is from a peer-reviewed journal.
+
+24. (bouchart2024clinicalreasoninga pages 3-5): Jean Bouchart, Sacha Weber, Thibault Coste, Marie-Alice Laville, Margaux Loisel, and Ahmad Nehme. Clinical reasoning: a 50-year-old man with intracerebral hemorrhage and tortuous retinal arterioles. Neurology, Sep 2024. URL: https://doi.org/10.1212/wnl.0000000000209796, doi:10.1212/wnl.0000000000209796. This article has 1 citations and is from a highest quality peer-reviewed journal.
+
+25. (chen2020bilateralandmultiple pages 5-5): Ting Chen, Hongmei Zheng, Yunyun Wang, Junyi Hu, and Changzheng Chen. Bilateral and multiple sub-internal limiting membrane hemorrhages in a familial retinal arteriolar tortuosity patient by valsalva-like mechanism: an observational case report. BMC Ophthalmology, Apr 2020. URL: https://doi.org/10.1186/s12886-020-01413-0, doi:10.1186/s12886-020-01413-0. This article has 8 citations and is from a peer-reviewed journal.
+
+26. (alavi2016col4a1mutationscause pages 7-8): Marcel V. Alavi, Mao Mao, Bradley T. Pawlikowski, Manana Kvezereli, Jacque L. Duncan, Richard T. Libby, Simon W. M. John, and Douglas B. Gould. Col4a1 mutations cause progressive retinal neovascular defects and retinopathy. Scientific Reports, Jan 2016. URL: https://doi.org/10.1038/srep18602, doi:10.1038/srep18602. This article has 58 citations and is from a peer-reviewed journal.
+
+27. (alavi2016col4a1mutationscause pages 1-2): Marcel V. Alavi, Mao Mao, Bradley T. Pawlikowski, Manana Kvezereli, Jacque L. Duncan, Richard T. Libby, Simon W. M. John, and Douglas B. Gould. Col4a1 mutations cause progressive retinal neovascular defects and retinopathy. Scientific Reports, Jan 2016. URL: https://doi.org/10.1038/srep18602, doi:10.1038/srep18602. This article has 58 citations and is from a peer-reviewed journal.
+
+28. (obayashi2021acaseseries pages 4-5): Tomohiro Obayashi, Aki Kato, Harumitsu Suzuki, Kei Ohashi, Munenori Yoshida, Yu Shibata, Yuichiro Ogura, and Tsutomu Yasukawa. A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss. American Journal of Ophthalmology Case Reports, 24:101230, Dec 2021. URL: https://doi.org/10.1016/j.ajoc.2021.101230, doi:10.1016/j.ajoc.2021.101230. This article has 2 citations.
+
+29. (obayashi2021acaseseries pages 1-2): Tomohiro Obayashi, Aki Kato, Harumitsu Suzuki, Kei Ohashi, Munenori Yoshida, Yu Shibata, Yuichiro Ogura, and Tsutomu Yasukawa. A case series from a single family of familial retinal arteriolar tortuosity with common history of sudden visual loss. American Journal of Ophthalmology Case Reports, 24:101230, Dec 2021. URL: https://doi.org/10.1016/j.ajoc.2021.101230, doi:10.1016/j.ajoc.2021.101230. This article has 2 citations.
+
+30. (NCT07374913 chunk 1): Simona Balestrini. COL4A1COL4A2: Study of Pathological Conditions Involving Multiple Organs Caused by Mutations in the COL4A1 and COL4A2 Genes. Meyer Children's Hospital IRCCS. 2021. ClinicalTrials.gov Identifier: NCT07374913

--- a/research/Retinal_Arterial_Tortuosity-deep-research-falcon.md.citations.md
+++ b/research/Retinal_Arterial_Tortuosity-deep-research-falcon.md.citations.md
@@ -1,0 +1,486 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Retinal Arterial Tortuosity
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Retinal Arterial Tortuosity** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T15:25:09.491201
+
+1. zenteno2014nextgenerationsequencing pages 4-5
+2. gasparini2024multiorganmanifestationsof pages 19-19
+3. chen2020bilateralandmultiple pages 1-3
+4. gasparini2024multiorganmanifestationsof pages 2-2
+5. bouchart2024clinicalreasoninga pages 3-5
+6. zenteno2014nextgenerationsequencing pages 1-2
+7. saraf2019familialretinalarteriolar pages 1-2
+8. saraf2019familialretinalarteriolar pages 3-5
+9. vilimelis2015newgenesinvolved pages 65-72
+10. obayashi2021acaseseries pages 4-5
+11. obayashi2021acaseseries pages 1-2
+12. vilimelis2015newgenesinvolveda pages 65-72
+13. vilimelis2015newgenesinvolveda pages 84-91
+14. obayashi2021acaseseries pages 2-4
+15. vilimelis2015newgenesinvolveda pages 95-96
+16. ghoraba2023retinalarterialtortuosity pages 2-5
+17. ghoraba2023retinalarterialtortuosity pages 1-2
+18. ghoraba2023retinalarterialtortuosity pages 5-5
+19. vilimelis2015newgenesinvolveda pages 93-95
+20. vilimelis2015newgenesinvolved pages 93-95
+21. chen2020bilateralandmultiple pages 3-5
+22. vilimelis2015newgenesinvolved pages 95-96
+23. kim2017familialretinalarteriolar pages 2-4
+24. chen2020bilateralandmultiple pages 5-5
+25. sub-ILM
+26. suggest HP term: retinal arteriolar tortuosity if curated
+27. https://doi.org/10.1007/s00417-014-2800-6,
+28. https://doi.org/10.1002/ajmg.c.32099,
+29. https://doi.org/10.1186/s12886-020-01413-0,
+30. https://doi.org/10.1016/j.ajoc.2019.03.001,
+31. https://doi.org/10.1016/j.ajoc.2021.101230,
+32. https://doi.org/10.1038/srep18602,
+33. https://doi.org/10.1038/s41433-022-02278-x,
+34. https://doi.org/10.1159/000456069,
+35. https://doi.org/10.1212/wnl.0000000000209796,


### PR DESCRIPTION
## Summary

Adds `kb/disorders/Retinal_Arterial_Tortuosity.yaml` for MONDO:0008373 with Falcon-backed curation.

## Curation Scope

| Area | Added |
|---|---|
| Disease identity | MONDO:0008373, synonyms, retinal vascular/arterial parents |
| Mechanism | COL4A1 collagen IV basement membrane defect, primary retinal vascular structural defects, hemorrhage episodes |
| Phenotypes | Retinal arteriolar tortuosity, retinal hemorrhage, sudden transient visual loss, central scotoma |
| Genetics | COL4A1 with p.Gly510Arg variant evidence and variable expressivity notes |
| Diagnosis | Retinal vascular imaging, COL4A1 molecular testing, COL4A1/2 multiorgan risk assessment |
| Management | Observation for resolving hemorrhage; selected Nd:YAG laser membranotomy with partial support |

## Research and References

- Ran Falcon deep research: `research/Retinal_Arterial_Tortuosity-deep-research-falcon.md`
- Added citation mapping in the YAML `references` section for all nine Falcon DOI citations.
- Generated PMID caches only via `just fetch-reference`.
- Did not hand-edit `references_cache/*.md`.

## Validation

- `just validate kb/disorders/Retinal_Arterial_Tortuosity.yaml` passed.
- `just validate-references kb/disorders/Retinal_Arterial_Tortuosity.yaml` passed; current wrapper reports `Total checks: 0` for this new file.
- Custom local snippet sanity check found `25` evidence items and `0` snippet mismatches against generated PMID caches.
- `just check-reference-cache-frontmatter` passed.
- `just qc-deep-research --only Retinal_Arterial_Tortuosity --target-providers falcon` passed with `total_missing_refs: 0` and `total_unresolved_cache_refs: 0`.

## Notes

- COL4A2 and systemic COL4A1/2 manifestations are included as diagnostic/surveillance context, not modeled as core isolated FRAT phenotypes.
- `git diff --check` flags trailing whitespace in generated `references_cache/*.md`; those files were left exactly as generated by `just fetch-reference`.
