### PR TITLE
Add splenic artery aneurysm disorder curation

### DIFF
--- a/kb/disorders/Splenic_Artery_Aneurysm.yaml
+++ b/kb/disorders/Splenic_Artery_Aneurysm.yaml
@@ -297,12 +297,6 @@ pathophysiology:
     term:
       id: UBERON:0001194
       label: splenic artery
-  biological_processes:
-  - preferred_term: response to wounding
-    modifier: INCREASED
-    term:
-      id: GO:0009611
-      label: response to wounding
   evidence:
   - reference: PMID:38249169
     reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
@@ -340,11 +334,11 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      They are the third most common type of abdominal aneurysm, after aneurysms
-      of the aorta and of the iliac artery, and account for almost the all
-      aneurysms of visceral arteries.
+      True splenic artery aneurysms (SAA) are a rare, but potentially fatal,
+      pathology.
     explanation: >-
-      The review supports SAA as a visceral abdominal aneurysm manifestation.
+      The review directly defines true SAA as a rare and potentially fatal
+      aneurysm pathology.
 - category: Constitutional
   name: Asymptomatic incidental presentation
   description: >-
@@ -697,6 +691,8 @@ treatments:
     Selected intact asymptomatic true SAAs can be monitored rather than repaired
     immediately when high-risk features such as childbearing potential,
     symptoms, growth, large size, or pseudoaneurysm are absent.
+  treatment_term:
+    preferred_term: clinical surveillance
   target_phenotypes:
   - preferred_term: splenic artery aneurysm
     term:
@@ -772,5 +768,7 @@ notes: >-
   Falcon deep research and PubMed follow-up did not identify a causal gene,
   multi-omics signature, model organism system, or validated quality-of-life
   instrument for isolated splenic artery aneurysm. Portal hypertension,
-  pregnancy/childbearing potential, pseudoaneurysm biology, size, symptoms, and
-  growth are the dominant actionable risk stratifiers.
+  pregnancy/childbearing potential, size, symptoms, and growth are the dominant
+  actionable risk stratifiers for true SAA. Pseudoaneurysm-specific pancreatitis
+  and pseudocyst mechanisms were treated as out of scope for this MONDO true-SAA
+  entry.

--- a/kb/disorders/Splenic_Artery_Aneurysm.yaml
+++ b/kb/disorders/Splenic_Artery_Aneurysm.yaml
@@ -1,0 +1,776 @@
+name: Splenic artery aneurysm
+creation_date: "2026-05-06T18:59:54Z"
+updated_date: "2026-05-06T19:28:47Z"
+category: Complex
+description: >-
+  Splenic artery aneurysm is a visceral arterial aneurysm involving focal
+  dilatation of the splenic artery. Most intact true aneurysms are discovered
+  incidentally, but risk stratification changes substantially with portal
+  hypertension, pregnancy or childbearing potential, aneurysm growth or large
+  size, symptoms, pseudoaneurysm biology, and rupture.
+disease_term:
+  preferred_term: splenic artery aneurysm
+  term:
+    id: MONDO:0001856
+    label: splenic artery aneurysm
+synonyms:
+- SAA
+- Splenic aneurysm
+- True splenic artery aneurysm
+parents:
+- Arterial disorder
+- Vascular disorder
+definitions:
+- name: Visceral splenic arterial aneurysm
+  definition_type: CASE_DEFINITION
+  description: >-
+    A true splenic artery aneurysm is an aneurysmal dilatation of the splenic
+    artery and is distinct from splenic artery pseudoaneurysm, which is usually
+    caused by local wall disruption and carries a higher rupture-risk management
+    threshold.
+  scope: Clinical and imaging definition of splenic artery aneurysm
+  evidence:
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      True splenic artery aneurysms (SAA) are a rare, but potentially fatal,
+      pathology.
+    explanation: >-
+      The review defines true SAA as a rare but clinically important splenic
+      arterial aneurysm entity.
+  - reference: PMID:39407852
+    reference_title: "The Definition, Diagnosis, and Management of Giant Splenic Artery Aneurysms and Pseudoaneurysms: A Systematic Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Giant splenic artery aneurysms (SAAs) and pseudoaneurysms (SAPs)
+      represent rare conditions, characterized by a diameter greater than or
+      equal to 5 cm.
+    explanation: >-
+      The systematic review supports the aneurysm/pseudoaneurysm distinction and
+      the clinically important giant-lesion size category.
+progression:
+- phase: Incidental intact aneurysm
+  age_range: Mostly adult detection in available cohorts
+  notes: >-
+    Many intact SAAs are detected incidentally and can grow slowly, so
+    observation may be appropriate for selected small, stable, asymptomatic true
+    aneurysms outside high-risk contexts.
+  evidence:
+  - reference: PMID:12089631
+    reference_title: "Splenic artery aneurysms: two decades experience at Mayo clinic."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Growth rates of SAA are slow and growth is infrequent.
+    explanation: >-
+      This Mayo Clinic series supports slow growth as a common natural-history
+      pattern for intact SAA.
+- phase: Rupture and hemorrhagic emergency
+  age_range: Any age with SAA, with especially high concern in pregnancy and portal hypertension
+  notes: >-
+    Rupture converts a usually silent vascular lesion into an abdominal or
+    gastrointestinal hemorrhage emergency with shock and high mortality risk.
+  evidence:
+  - reference: PMID:38249169
+    reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Splenic artery aneurysms are rare and usually asymptomatic, with a high
+      risk of mortality once they get ruptured.
+    explanation: >-
+      This case-report abstract summarizes the high-risk transition from
+      asymptomatic SAA to rupture-associated mortality.
+pathophysiology:
+- name: Splenic arterial wall remodeling
+  description: >-
+    Multifactorial splenic arterial wall remodeling weakens the vessel wall and
+    permits focal aneurysmal dilatation. The structured evidence base for
+    isolated true SAA is mostly clinical, so this node represents the shared
+    vessel-wall failure endpoint rather than a single molecular cause.
+  cell_types:
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
+  locations:
+  - preferred_term: splenic artery
+    term:
+      id: UBERON:0001194
+      label: splenic artery
+  - preferred_term: tunica media
+    term:
+      id: UBERON:0002522
+      label: tunica media
+  biological_processes:
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  - preferred_term: extracellular matrix organization
+    modifier: ABNORMAL
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  evidence:
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      There are multiple etiologies and it is believed that hormonal influences
+      and changes in portal flow during gestation play an important role in
+      development of SAA.
+    explanation: >-
+      The review supports a multifactorial vessel-wall and hemodynamic model,
+      while the abstract does not define a single cellular mechanism.
+  downstream:
+  - target: Aneurysm rupture and hemorrhage
+    description: Loss of wall integrity can progress from dilatation to rupture with hematoma, gastrointestinal bleeding, or shock.
+    causal_link_type: DIRECT
+- name: Portal-hypertensive splenic hyperkinetic flow
+  description: >-
+    Portal hypertension can increase splenic arterial diameter and flow,
+    creating a hyperkinetic splenic circulation that increases mechanical stress
+    on the splenic artery and favors aneurysm formation or intervention.
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  locations:
+  - preferred_term: splenic artery
+    term:
+      id: UBERON:0001194
+      label: splenic artery
+  biological_processes:
+  - preferred_term: response to mechanical stimulus
+    modifier: INCREASED
+    term:
+      id: GO:0009612
+      label: response to mechanical stimulus
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  evidence:
+  - reference: PMID:1483666
+    reference_title: Splenic hyperkinetic state and splenic artery aneurysm in portal hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In the portal hypertensive patients with splenic artery aneurysms, the
+      splenic artery was larger (p < 0.05) and the splenic arterial flow greater
+      (p < 0.05), and these patients were in a more hyperkinetic state, than
+      were those with no splenic artery aneurysm.
+    explanation: >-
+      This case-control angiographic study directly links portal hypertension
+      with increased splenic artery size and flow in SAA patients.
+  downstream:
+  - target: Splenic arterial wall remodeling
+    description: Increased flow and wall stress can drive remodeling of the splenic arterial wall.
+    causal_link_type: DIRECT
+- name: Tortuous splenic artery hemodynamic stress
+  description: >-
+    Tortuous splenic artery geometry may concentrate hemodynamic forces and
+    correlate with aneurysm formation and dilatation, especially in female
+    patients.
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  locations:
+  - preferred_term: splenic artery
+    term:
+      id: UBERON:0001194
+      label: splenic artery
+  biological_processes:
+  - preferred_term: response to mechanical stimulus
+    modifier: INCREASED
+    term:
+      id: GO:0009612
+      label: response to mechanical stimulus
+  evidence:
+  - reference: PMID:29363319
+    reference_title: Morphological analysis using geometric parameters for splenic aneurysms.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Background Considering the unique characteristics of splenic artery
+      aneurysms, we hypothesized that hemodynamic forces could play an important
+      role in splenic artery aneurysm formation and that splenic artery geometry
+      should be correlated with aneurysm development.
+    explanation: >-
+      This study frames tortuous splenic artery geometry as a hemodynamic
+      contributor to SAA formation.
+  - reference: PMID:29363319
+    reference_title: Morphological analysis using geometric parameters for splenic aneurysms.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Conclusion Females with a tortuous splenic artery may have an increased
+      risk of aneurysm formation.
+    explanation: >-
+      The abstract conclusion supports tortuosity as a sex-linked geometric
+      risk context for SAA.
+  downstream:
+  - target: Splenic arterial wall remodeling
+    description: Local geometry-driven stress can promote focal dilatation.
+    causal_link_type: DIRECT
+- name: Pregnancy-associated portal-flow and hormonal stress
+  description: >-
+    Pregnancy is a high-risk physiologic context for SAA because gestational
+    hormonal influences and portal-flow changes can interact with pre-existing
+    wall vulnerability, and rupture has very high maternal and fetal mortality.
+  cell_types:
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000359
+      label: vascular associated smooth muscle cell
+  locations:
+  - preferred_term: splenic artery
+    term:
+      id: UBERON:0001194
+      label: splenic artery
+  biological_processes:
+  - preferred_term: blood vessel remodeling
+    modifier: ABNORMAL
+    term:
+      id: GO:0001974
+      label: blood vessel remodeling
+  evidence:
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Among pregnant patients, mortality after rupture is 65-75%, with fetal
+      mortality exceeding 90%.
+    explanation: >-
+      The review quantifies the exceptionally severe pregnancy-associated
+      rupture prognosis.
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      There are multiple etiologies and it is believed that hormonal influences
+      and changes in portal flow during gestation play an important role in
+      development of SAA.
+    explanation: >-
+      This supports pregnancy-related hormonal and portal-flow mechanisms while
+      preserving the review's wording that the mechanism is believed rather than
+      experimentally proven.
+  downstream:
+  - target: Aneurysm rupture and hemorrhage
+    description: Pregnancy-related hemodynamic and hormonal stress increases concern for rupture.
+    causal_link_type: DIRECT
+- name: Aneurysm rupture and hemorrhage
+  description: >-
+    Rupture of a splenic artery aneurysm causes internal bleeding that may
+    present with abdominal pain, hematoma, gastrointestinal bleeding,
+    hypotension, syncope, or hypovolemic shock.
+  locations:
+  - preferred_term: splenic artery
+    term:
+      id: UBERON:0001194
+      label: splenic artery
+  biological_processes:
+  - preferred_term: response to wounding
+    modifier: INCREASED
+    term:
+      id: GO:0009611
+      label: response to wounding
+  evidence:
+  - reference: PMID:38249169
+    reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient presented in the emergency department with abdominal pain,
+      nausea, and vomiting, followed by syncope.
+    explanation: >-
+      The case report supports the symptomatic rupture presentation.
+  - reference: PMID:35915344
+    reference_title: Giant splenic artery aneurysm rupture into the stomach that was successfully managed with emergency distal pancreatectomy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He developed upper gastrointestinal (UGI) bleeding and hypovolemic shock.
+    explanation: >-
+      This case report directly supports bleeding and shock as rupture
+      consequences.
+phenotypes:
+- category: Cardiovascular
+  name: Splenic artery aneurysm
+  diagnostic: true
+  description: >-
+    The defining finding is aneurysmal dilatation of the splenic artery,
+    detected by vascular imaging, angiography, operation, or pathology.
+  phenotype_term:
+    preferred_term: splenic artery aneurysm
+    term:
+      id: HP:0002617
+      label: Vascular dilatation
+  evidence:
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      They are the third most common type of abdominal aneurysm, after aneurysms
+      of the aorta and of the iliac artery, and account for almost the all
+      aneurysms of visceral arteries.
+    explanation: >-
+      The review supports SAA as a visceral abdominal aneurysm manifestation.
+- category: Constitutional
+  name: Asymptomatic incidental presentation
+  description: >-
+    Many intact true SAAs are found incidentally before rupture or other
+    complication.
+  evidence:
+  - reference: PMID:30496903
+    reference_title: Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thirty-nine (92.9%) patients were asymptomatic, and 3 (7.1%) patients were
+      symptomatic.
+    explanation: >-
+      This intact-SAA intervention cohort supports frequent asymptomatic
+      presentation among intact aneurysms.
+- category: Gastrointestinal
+  name: Abdominal pain
+  description: >-
+    Symptomatic SAA, especially giant or ruptured lesions, can present with
+    abdominal, epigastric, or left upper quadrant pain.
+  phenotype_term:
+    preferred_term: Abdominal pain
+    term:
+      id: HP:0002027
+      label: Abdominal pain
+  evidence:
+  - reference: PMID:39407852
+    reference_title: "The Definition, Diagnosis, and Management of Giant Splenic Artery Aneurysms and Pseudoaneurysms: A Systematic Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most frequently described symptom was pain (59.76%).
+    explanation: >-
+      The systematic review identifies pain as the most common symptom among
+      giant SAA/SAP cases.
+  - reference: PMID:38249169
+    reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient presented in the emergency department with abdominal pain,
+      nausea, and vomiting, followed by syncope.
+    explanation: >-
+      This rupture case demonstrates abdominal pain at acute presentation.
+- category: Gastrointestinal
+  name: Gastrointestinal hemorrhage
+  description: >-
+    Rare rupture into the stomach or gastrointestinal tract can cause upper
+    gastrointestinal bleeding.
+  phenotype_term:
+    preferred_term: Gastrointestinal hemorrhage
+    term:
+      id: HP:0002239
+      label: Gastrointestinal hemorrhage
+  evidence:
+  - reference: PMID:35915344
+    reference_title: Giant splenic artery aneurysm rupture into the stomach that was successfully managed with emergency distal pancreatectomy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This report shows that splenic artery aneurysm can cause UGI bleeding.
+    explanation: >-
+      The case-report conclusion directly supports upper gastrointestinal
+      bleeding as a possible complication.
+- category: Cardiovascular
+  name: Hypovolemic shock
+  severity: SEVERE
+  description: >-
+    Rupture-related blood loss can produce hypovolemic shock.
+  phenotype_term:
+    preferred_term: Hypovolemic shock
+    term:
+      id: HP:0031274
+      label: Hypovolemic shock
+  evidence:
+  - reference: PMID:35915344
+    reference_title: Giant splenic artery aneurysm rupture into the stomach that was successfully managed with emergency distal pancreatectomy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He developed upper gastrointestinal (UGI) bleeding and hypovolemic shock.
+    explanation: >-
+      The case report directly documents hypovolemic shock from ruptured SAA.
+- category: Cardiovascular
+  name: Hematoma after rupture
+  description: >-
+    Rupture may be visible on contrast CT as peri-aneurysmal hematoma or active
+    contrast extravasation.
+  phenotype_term:
+    preferred_term: Internal hemorrhage
+    term:
+      id: HP:0011029
+      label: Internal hemorrhage
+  evidence:
+  - reference: PMID:38249169
+    reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A contrast-enhanced CT scan was performed and showed a splenic artery
+      aneurysm measuring 40 × 35 mm surrounded by a hematoma.
+    explanation: >-
+      The CT finding of a hematoma surrounding the ruptured aneurysm supports
+      internal hemorrhage.
+environmental:
+- name: Portal hypertension
+  presence: Associated
+  description: >-
+    Portal hypertension is a high-risk clinical context for SAA, associated
+    with hyperkinetic splenic flow, larger aneurysm diameter at diagnosis, and
+    greater intervention rates.
+  effect: Increased SAA formation risk and higher-risk management context
+  evidence:
+  - reference: PMID:1483666
+    reference_title: Splenic hyperkinetic state and splenic artery aneurysm in portal hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The study suggests that splenic artery aneurysms in cases of portal
+      hypertension may be the consequence of a hyperkinetic state in the spleen.
+    explanation: >-
+      This provides a mechanistic association between portal hypertension and
+      SAA through splenic hyperkinesis.
+  - reference: PMID:39009114
+    reference_title: Comparison of Splenic Artery Aneurysms in Patients with and without Portal Hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Splenic artery aneurysms (SAAs) are rare but seem to have higher incidence
+      in patients with portal hypertension (PH).
+    explanation: >-
+      The 2024 cohort paper identifies portal hypertension as an incidence-risk
+      context.
+- name: Liver transplantation and parenchymal liver disease context
+  presence: Associated
+  description: >-
+    SAA is enriched in liver-transplant populations with portal hypertension and
+    parenchymal liver disease, making pre- or peri-transplant detection and
+    management clinically important.
+  effect: Higher prevalence and rupture concern in transplant populations
+  evidence:
+  - reference: PMID:9382977
+    reference_title: Splenic artery aneurysms in liver transplant patients. Liver Transplant Group.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In patients without portal hypertension no aneurysms were identified,
+      whereas in 16% of the patients with portal hypertension aneurysms were
+      found (p<0.001).
+    explanation: >-
+      The liver-transplant angiography series supports the portal-hypertension
+      association in a transplant-relevant cohort.
+- name: Pregnancy and childbearing potential
+  presence: Associated
+  description: >-
+    Pregnancy and childbearing potential are high-risk contexts because rupture
+    during pregnancy carries very high maternal and fetal mortality.
+  effect: Lower threshold for repair and heightened rupture-risk concern
+  evidence:
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      True aneurysms account for 60% of SAA and affect four times as many women
+      as men, generally related to increased incidental or symptomatic findings
+      that coincide with use of ultrasonography in pregnancy.
+    explanation: >-
+      The review supports female and pregnancy-linked detection/risk context.
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Among pregnant patients, mortality after rupture is 65-75%, with fetal
+      mortality exceeding 90%.
+    explanation: >-
+      This quantifies the high-consequence pregnancy rupture risk.
+- name: Essential hypertension
+  presence: Associated
+  description: >-
+    Essential hypertension has been reported as a significant risk factor in
+    non-portal-hypertension SAA patients.
+  effect: Increased SAA development risk in non-portal-hypertension patients
+  evidence:
+  - reference: PMID:10549737
+    reference_title: "Management of splenic artery aneurysms: the significance of portal and essential hypertension."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In patients without a history of PHTN (n = 12), essential hypertension was
+      a significant risk factor (p < 0.001) for development of SAA.
+    explanation: >-
+      This treated-SAA cohort identifies essential hypertension as a risk factor
+      outside portal hypertension.
+diagnosis:
+- name: Contrast-enhanced CT angiography
+  description: >-
+    Contrast CT/CTA is central for identifying SAA size, location, hematoma,
+    active extravasation, and treatment anatomy.
+  results: Splenic artery aneurysm size, location, hematoma, and active extravasation
+  evidence:
+  - reference: PMID:39407852
+    reference_title: "The Definition, Diagnosis, and Management of Giant Splenic Artery Aneurysms and Pseudoaneurysms: A Systematic Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The CT scan was the most utilized imaging study (80.49%).
+    explanation: >-
+      The 2024 systematic review supports CT as the dominant diagnostic imaging
+      modality in giant SAA/SAP cases.
+  - reference: PMID:38249169
+    reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A contrast-enhanced CT scan was performed and showed a splenic artery
+      aneurysm measuring 40 × 35 mm surrounded by a hematoma.
+    explanation: >-
+      This rupture case shows contrast-enhanced CT detecting the aneurysm and
+      adjacent hemorrhage.
+- name: Angiographic and ultrasound assessment
+  description: >-
+    Angiography can define splenic artery anatomy and enable endovascular
+    therapy, while ultrasound may detect SAA incidentally or in pregnancy but is
+    less comprehensive than CTA/MRA for treatment planning.
+  results: Aneurysm morphology, splenic arterial flow, and treatment-access anatomy
+  evidence:
+  - reference: PMID:1483666
+    reference_title: Splenic hyperkinetic state and splenic artery aneurysm in portal hypertension.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The splenic arterial flow was assessed by measuring the radii of the
+      splenic arteries on celiac arteriograms.
+    explanation: >-
+      This supports angiography-based measurement of splenic arterial flow in
+      portal-hypertension-associated SAA.
+  - reference: PMID:31839799
+    reference_title: "Splenic aneurysms: natural history and treatment techniques."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      True aneurysms account for 60% of SAA and affect four times as many women
+      as men, generally related to increased incidental or symptomatic findings
+      that coincide with use of ultrasonography in pregnancy.
+    explanation: >-
+      This supports ultrasound as a frequent route to detection in pregnancy.
+- name: Post-embolization surveillance imaging
+  description: >-
+    After coil embolization, follow-up imaging is used to detect sac
+    reperfusion, bleeding, or other complications.
+  results: Persistent sac perfusion, reperfusion, or post-procedural bleeding
+  evidence:
+  - reference: PMID:40626033
+    reference_title: Imaging modalities used in follow-up after coil embolization of splenic artery aneurysm - a systematic review.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      MRA should be preferred over DSA for detecting aneurysmal sac reperfusion.
+    explanation: >-
+      This systematic review conclusion supports MRA-based surveillance for sac
+      reperfusion after coil embolization.
+treatments:
+- name: Endovascular coil embolization
+  description: >-
+    Coil embolization excludes the aneurysm or parent artery from flow and is a
+    common first-line approach for intact anatomically suitable SAA.
+  treatment_term:
+    preferred_term: embolization therapy
+    term:
+      id: NCIT:C15230
+      label: Embolization Therapy
+  target_phenotypes:
+  - preferred_term: splenic artery aneurysm
+    term:
+      id: HP:0002617
+      label: Vascular dilatation
+  target_mechanisms:
+  - target: Splenic arterial wall remodeling
+    treatment_effect: INHIBITS
+    description: Endovascular exclusion reduces flow into the aneurysm sac and mitigates rupture risk.
+  evidence:
+  - reference: PMID:30496903
+    reference_title: Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In the endovascular group, the exclusive means was embolization with coils.
+    explanation: >-
+      The intact-SAA cohort directly describes coil embolization as the
+      endovascular approach used.
+  - reference: PMID:30496903
+    reference_title: Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Endovascular repair is less invasive accompanied with an obvious decrease
+      in surgery time and rapid recovery with a short hospital time.
+    explanation: >-
+      The cohort conclusion supports the perioperative recovery advantage of
+      endovascular repair.
+- name: Open surgical repair, ligation, resection, or splenectomy
+  description: >-
+    Open repair includes aneurysm ligation or resection, sometimes with
+    splenectomy, arterial reconstruction, or distal pancreatic resection,
+    especially for rupture, giant lesions, unfavorable anatomy, or instability.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  target_phenotypes:
+  - preferred_term: splenic artery aneurysm
+    term:
+      id: HP:0002617
+      label: Vascular dilatation
+  target_mechanisms:
+  - target: Aneurysm rupture and hemorrhage
+    treatment_effect: INHIBITS
+    description: Open ligation, resection, and splenectomy control bleeding and remove the aneurysm when rupture or anatomy requires surgery.
+  evidence:
+  - reference: PMID:30496903
+    reference_title: Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In the surgical group, the common methods used were splenic artery
+      aneurysm resection (9 patients), followed by splenic artery aneurysms
+      resection and splenectomy (6 patients), splenic artery aneurysm resection
+      and arterial reconstruction with end-to-end anastomosis (3 patients), and
+      laparoscopic splenic artery aneurysm resection coexisting with splenectomy
+      (2 patients).
+    explanation: >-
+      The cohort enumerates open/laparoscopic surgical approaches for intact
+      SAA.
+  - reference: PMID:38249169
+    reference_title: Spontaneous Rupture of Splenic Artery Aneurysm.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient was submitted to emergency laparotomy with ligation of the
+      splenic artery, aneurysm resection, and splenectomy.
+    explanation: >-
+      This rupture case supports emergency open surgical control with ligation,
+      aneurysm resection, and splenectomy.
+- name: Selective surveillance of small stable intact true aneurysms
+  description: >-
+    Selected intact asymptomatic true SAAs can be monitored rather than repaired
+    immediately when high-risk features such as childbearing potential,
+    symptoms, growth, large size, or pseudoaneurysm are absent.
+  target_phenotypes:
+  - preferred_term: splenic artery aneurysm
+    term:
+      id: HP:0002617
+      label: Vascular dilatation
+  evidence:
+  - reference: PMID:12089631
+    reference_title: "Splenic artery aneurysms: two decades experience at Mayo clinic."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      From analysis of the patient data we concluded that although SAAs may
+      rupture, not all intact aneurysms need intervention.
+    explanation: >-
+      This supports selective nonintervention for carefully selected intact
+      aneurysms.
+  - reference: PMID:32201007
+    reference_title: The Society for Vascular Surgery clinical practice guidelines on the management of visceral aneurysms.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      They include evidence-based size thresholds for repair of aneurysms of the
+      renal arteries, splenic artery, celiac artery, and hepatic artery, among
+      others.
+    explanation: >-
+      The SVS guideline abstract supports threshold-based rather than universal
+      repair of visceral aneurysms including SAA.
+clinical_trials:
+- name: NCT07053605
+  status: RECRUITING
+  description: >-
+    Single-group interventional study evaluating laparoscopic resection of SAA
+    with spleen preservation and post-treatment immune and portal/splenic
+    hemodynamic markers.
+  target_phenotypes:
+  - preferred_term: splenic artery aneurysm
+    term:
+      id: HP:0002617
+      label: Vascular dilatation
+  evidence:
+  - reference: clinicaltrials:NCT07053605
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In this study, researchers examined the changes in related indicators such
+      as immune function, splenic vein,proper hepatic artery, and portal venous
+      hemodynamics following laparoscopic resection of a splenic artery
+      aneurysm.
+    explanation: >-
+      The trial summary directly describes laparoscopic SAA resection with
+      spleen preservation and hemodynamic/immune follow-up.
+- name: NCT01387828
+  status: COMPLETED
+  description: >-
+    Randomized comparison of open versus laparoscopic surgical management of
+    splenic artery aneurysms.
+  target_phenotypes:
+  - preferred_term: splenic artery aneurysm
+    term:
+      id: HP:0002617
+      label: Vascular dilatation
+  evidence:
+  - reference: clinicaltrials:NCT01387828
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The purpose of this study is compare two different surgical treatments of
+      splenic artery aneurysms: open and laparoscopic approach.
+    explanation: >-
+      The trial summary supports the existence of a completed open-vs-laparoscopic
+      SAA surgical comparison.
+notes: >-
+  Falcon deep research and PubMed follow-up did not identify a causal gene,
+  multi-omics signature, model organism system, or validated quality-of-life
+  instrument for isolated splenic artery aneurysm. Portal hypertension,
+  pregnancy/childbearing potential, pseudoaneurysm biology, size, symptoms, and
+  growth are the dominant actionable risk stratifiers.

--- a/references_cache/PMID_10549737.md
+++ b/references_cache/PMID_10549737.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:10549737"
+title: "Management of splenic artery aneurysms: the significance of portal and essential hypertension."
+authors:
+- Lee PC
+- Rhee RY
+- Gordon RY
+- Fung JJ
+- Webster MW
+journal: J Am Coll Surg
+year: '1999'
+doi: 10.1016/s1072-7515(99)00168-4
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aneurysm/epidemiology, etiology, surgery"
+- "Aneurysm, Ruptured/surgery"
+- Chi-Square Distribution
+- Female
+- Humans
+- Hypertension/complications
+- "Hypertension, Portal/complications"
+- Incidence
+- Liver Transplantation
+- Middle Aged
+- Retrospective Studies
+- Risk Factors
+- Splenic Artery
+- Survival Analysis
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Management of splenic artery aneurysms: the significance of portal and essential hypertension.
+**Authors:** Lee PC, Rhee RY, Gordon RY, Fung JJ, Webster MW
+**Journal:** J Am Coll Surg (1999)
+**DOI:** [10.1016/s1072-7515(99)00168-4](https://doi.org/10.1016/s1072-7515(99)00168-4)
+
+## Content
+
+1. J Am Coll Surg. 1999 Nov;189(5):483-90. doi: 10.1016/s1072-7515(99)00168-4.
+
+Management of splenic artery aneurysms: the significance of portal and essential 
+hypertension.
+
+Lee PC(1), Rhee RY, Gordon RY, Fung JJ, Webster MW.
+
+Author information:
+(1)Department of Surgery, University of Pittsburgh, PA, USA.
+
+BACKGROUND: Splenic artery aneurysm(s) (SAA) are rare. But the incidence and 
+significance of SAA among patients with portal hypertension (PHTN), especially 
+among those who undergo orthotopic liver transplantation (OLT), have not been 
+clearly delineated.
+STUDY DESIGN: An 11-year (February 1987 to June 1998) retrospective review of 
+our experience with treated SAA was performed. Patient characteristics, risk 
+factors, clinical presentation, surgical management, aneurysm characteristics, 
+and patient outcomes were assessed. Patients were separated according to a 
+history of PHTN for analysis. Patients were also subdivided into ruptured versus 
+elective presentations.
+RESULTS: Thirty-four patients (22 in the PHTN group) were treated for SAA during 
+the study period. Sixty-two percent (21 of 34) were women; the average age was 
+50.6 years. In patients without a history of PHTN (n = 12), essential 
+hypertension was a significant risk factor (p < 0.001) for development of SAA. 
+All patients underwent surgical treatment for SAA: resection with splenectomy (n 
+= 23), ligation with splenectomy (n = 5), ligation of SAA only (n = 4), and 
+vascular reconstruction (n = 2). The average size of all treated SAA was 4.8 +/- 
+2.6 cm, ranging from 1.5 to 12cm. Operative mortality after SAA rupture (n = 15) 
+was 40%, compared with zero mortality for elective SAA repair (n = 19, p < 
+0.005). Rupture of SAA was associated with a higher mortality in patients with 
+PHTN compared with patients without such history (56% versus 17%, respectively). 
+After a mean followup period of 46 months, survival after rupture was 60% in 
+contrast to 84% after elective repair. The majority of our patients with a 
+history of PHTN (20 of 22) has undergone OLT, representing 0.46% of all OLT 
+recipients (n = 4,374) during the study period. In four patients, SAA were 
+repaired concurrently during transplantation. Of the 7 patients presented with 
+rupture of SAA after OLT, 6 patients presented within 3 to 16 days 
+postoperatively, with a median of 6 days and an overall mortality of 57%.
+CONCLUSIONS: Essential hypertension and PHTN appear to be significant risk 
+factors for development of SAA. Rupture of SAA is associated with a significant 
+mortality, highest among patients with PHTN. Elective repair remains a safe and 
+effective method of treatment. The significance of SAA is recognized among 
+patients undergoing liver transplantation. A decision should be made to screen 
+and electively treat SAA found in liver transplant patients, especially if the 
+aneurysm is larger than 1.5 cm. Awareness of the increased rupture risk is 
+crucial in management during the immediate posttransplant period.
+
+DOI: 10.1016/s1072-7515(99)00168-4
+PMID: 10549737 [Indexed for MEDLINE]

--- a/references_cache/PMID_12089631.md
+++ b/references_cache/PMID_12089631.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:12089631"
+title: "Splenic artery aneurysms: two decades experience at Mayo clinic."
+authors:
+- Abbas MA
+- Stone WM
+- Fowl RJ
+- Gloviczki P
+- Oldenburg WA
+- Pairolero PC
+- Hallett JW
+- Bower TC
+- Panneton JM
+- Cherry KJ
+journal: Ann Vasc Surg
+year: '2002'
+doi: 10.1007/s10016-001-0207-4
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Aneurysm/diagnosis, epidemiology, therapy"
+- "Aneurysm, Ruptured/surgery"
+- Child
+- Female
+- Humans
+- Male
+- Middle Aged
+- Retrospective Studies
+- Risk Factors
+- Splenic Artery/surgery
+- Vascular Surgical Procedures/methods
+content_type: abstract_only
+---
+
+# Splenic artery aneurysms: two decades experience at Mayo clinic.
+**Authors:** Abbas MA, Stone WM, Fowl RJ, Gloviczki P, Oldenburg WA, Pairolero PC, Hallett JW, Bower TC, Panneton JM, Cherry KJ
+**Journal:** Ann Vasc Surg (2002)
+**DOI:** [10.1007/s10016-001-0207-4](https://doi.org/10.1007/s10016-001-0207-4)
+
+## Content
+
+1. Ann Vasc Surg. 2002 Jul;16(4):442-9. doi: 10.1007/s10016-001-0207-4. Epub 2002
+ Jul 1.
+
+Splenic artery aneurysms: two decades experience at Mayo clinic.
+
+Abbas MA(1), Stone WM, Fowl RJ, Gloviczki P, Oldenburg WA, Pairolero PC, Hallett 
+JW, Bower TC, Panneton JM, Cherry KJ.
+
+Author information:
+(1)Department of Surgery, Division of Vascular Surgery, Mayo Clinic Scottsdale, 
+Scottsdale, AZ 85259, USA.
+
+Although rare, splenic artery aneurysms (SAAs) have a definite risk of rupture. 
+The optimal management of these aneurysms remains elusive. A retrospective chart 
+review of all patients treated at our institutions with the diagnosis of SAA 
+from January 1980 until December 1998 was undertaken. Follow-up was obtained via 
+chart review and by direct phone contact of the patient or relative. No specific 
+protocol was followed for management. From analysis of the patient data we 
+concluded that although SAAs may rupture, not all intact aneurysms need 
+intervention. Calcification does not appear to protect against rupture, although 
+beta-blockade may be protective. Growth rates of SAA are slow and growth is 
+infrequent. Selective management of SAAs is safe. Open ligation or transcatheter 
+embolization should be considered for symptomatic aneurysms, for aneurysms > or 
+= 2 cm in size, or for any SAA in women of childbearing years.
+
+DOI: 10.1007/s10016-001-0207-4
+PMID: 12089631 [Indexed for MEDLINE]

--- a/references_cache/PMID_1483666.md
+++ b/references_cache/PMID_1483666.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:1483666"
+title: Splenic hyperkinetic state and splenic artery aneurysm in portal hypertension.
+authors:
+- Ohta M
+- Hashizume M
+- Tanoue K
+- Kitano S
+- Sugimachi K
+- Yasumori K
+journal: Hepatogastroenterology
+year: '1992'
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aneurysm/diagnostic imaging, epidemiology, etiology, physiopathology"
+- Case-Control Studies
+- Female
+- Humans
+- "Hypertension, Portal/complications, diagnostic imaging, epidemiology, physiopathology"
+- Male
+- Middle Aged
+- Radiography
+- "Splenic Artery/diagnostic imaging, physiology"
+content_type: abstract_only
+---
+
+# Splenic hyperkinetic state and splenic artery aneurysm in portal hypertension.
+**Authors:** Ohta M, Hashizume M, Tanoue K, Kitano S, Sugimachi K, Yasumori K
+**Journal:** Hepatogastroenterology (1992)
+
+## Content
+
+1. Hepatogastroenterology. 1992 Dec;39(6):529-32.
+
+Splenic hyperkinetic state and splenic artery aneurysm in portal hypertension.
+
+Ohta M(1), Hashizume M, Tanoue K, Kitano S, Sugimachi K, Yasumori K.
+
+Author information:
+(1)Department of Surgery II, Faculty of Medicine, Kyushu University, Fukuoka, 
+Japan.
+
+Forty-eight out of six hundred and thirty patients with portal hypertension 
+undergoing a celiac angiography series were diagnosed as cases of splenic artery 
+aneurysm during the period 1977-1988. The case-control study of patients with 
+portal hypertension with splenic artery aneurysms and those without was designed 
+to characterize the angiological features. The splenic arterial flow was 
+assessed by measuring the radii of the splenic arteries on celiac arteriograms. 
+In the portal hypertensive patients with splenic artery aneurysms, the splenic 
+artery was larger (p < 0.05) and the splenic arterial flow greater (p < 0.05), 
+and these patients were in a more hyperkinetic state, than were those with no 
+splenic artery aneurysm. The study suggests that splenic artery aneurysms in 
+cases of portal hypertension may be the consequence of a hyperkinetic state in 
+the spleen.
+
+PMID: 1483666 [Indexed for MEDLINE]

--- a/references_cache/PMID_29363319.md
+++ b/references_cache/PMID_29363319.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:29363319"
+title: Morphological analysis using geometric parameters for splenic aneurysms.
+authors:
+- Kimura M
+- Hoshina K
+- Kobayashi M
+- Yamamoto S
+- Ohshima M
+- Watanabe T
+journal: Asian Cardiovasc Thorac Ann
+year: '2018'
+doi: 10.1177/0218492318757040
+keywords:
+- Aged
+- "Aneurysm/complications, diagnostic imaging, pathology, physiopathology"
+- "Aneurysm, Ruptured/diagnostic imaging, etiology"
+- Chi-Square Distribution
+- Computed Tomography Angiography/methods
+- "Dilatation, Pathologic"
+- Female
+- Hemodynamics
+- Humans
+- "Imaging, Three-Dimensional/methods"
+- Male
+- Middle Aged
+- Patient-Specific Modeling
+- Predictive Value of Tests
+- Prognosis
+- Propensity Score
+- "Radiographic Image Interpretation, Computer-Assisted/methods"
+- Retrospective Studies
+- Risk Factors
+- Software
+- "Splenic Artery/diagnostic imaging, pathology, physiopathology"
+content_type: abstract_only
+---
+
+# Morphological analysis using geometric parameters for splenic aneurysms.
+**Authors:** Kimura M, Hoshina K, Kobayashi M, Yamamoto S, Ohshima M, Watanabe T
+**Journal:** Asian Cardiovasc Thorac Ann (2018)
+**DOI:** [10.1177/0218492318757040](https://doi.org/10.1177/0218492318757040)
+
+## Content
+
+1. Asian Cardiovasc Thorac Ann. 2018 Feb;26(2):133-138. doi: 
+10.1177/0218492318757040. Epub 2018 Jan 24.
+
+Morphological analysis using geometric parameters for splenic aneurysms.
+
+Kimura M(1), Hoshina K(1), Kobayashi M(2), Yamamoto S(3), Ohshima M(2), Watanabe 
+T(1).
+
+Author information:
+(1)1 Division of Vascular Surgery, Department of Surgery, Graduate School of 
+Medicine, The University of Tokyo, Tokyo, Japan.
+(2)2 Interfaculty Initiative in Information Studies/Institute of Industrial 
+Science, The University of Tokyo, Tokyo, Japan.
+(3)3 Department of Mechanical Engineering, Graduate School, Shibaura Institute 
+of Technology, Tokyo, Japan.
+
+Background Considering the unique characteristics of splenic artery aneurysms, 
+we hypothesized that hemodynamic forces could play an important role in splenic 
+artery aneurysm formation and that splenic artery geometry should be correlated 
+with aneurysm development. Methods Tortuosity of the splenic artery was 
+evaluated three-dimensionally by calculating the curvature using software and 
+the original modeling system. We selected 54 splenic artery aneurysm patients 
+who had undergone thin-slice computed tomography imaging with contrast. We 
+compared the splenic artery aneurysm group to non-vascular patients via 
+propensity-score matching (35 patients in each group). The splenic artery length 
+index, average curvature, and maximum curvature were analyzed. Results Splenic 
+artery aneurysm patients tended to have a longer splenic artery and the 
+curvature was more severe compared to the non-vascular control patients. The 
+average curvature of splenic artery aneurysm patients was associated with the 
+dilatation rate in female patients. Conclusion Females with a tortuous splenic 
+artery may have an increased risk of aneurysm formation.
+
+DOI: 10.1177/0218492318757040
+PMID: 29363319 [Indexed for MEDLINE]

--- a/references_cache/PMID_30496903.md
+++ b/references_cache/PMID_30496903.md
@@ -1,0 +1,99 @@
+---
+reference_id: "PMID:30496903"
+title: Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+authors:
+- Zhu C
+- Zhao J
+- Yuan D
+- Huang B
+- Yang Y
+- Ma Y
+- Xiong F
+journal: Ann Vasc Surg
+year: '2019'
+doi: 10.1016/j.avsg.2018.08.088
+keywords:
+- Adult
+- Aged
+- "Aneurysm/diagnostic imaging, surgery, therapy"
+- "Embolization, Therapeutic/adverse effects"
+- "Endovascular Procedures/adverse effects, methods"
+- Female
+- Humans
+- Laparoscopy/adverse effects
+- Length of Stay
+- Male
+- Middle Aged
+- "Postoperative Complications/etiology, therapy"
+- Retrospective Studies
+- Splenectomy
+- "Splenic Artery/diagnostic imaging, surgery"
+- Time Factors
+- Treatment Outcome
+- "Vascular Surgical Procedures/adverse effects, methods"
+content_type: abstract_only
+---
+
+# Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+**Authors:** Zhu C, Zhao J, Yuan D, Huang B, Yang Y, Ma Y, Xiong F
+**Journal:** Ann Vasc Surg (2019)
+**DOI:** [10.1016/j.avsg.2018.08.088](https://doi.org/10.1016/j.avsg.2018.08.088)
+
+## Content
+
+1. Ann Vasc Surg. 2019 May;57:75-82. doi: 10.1016/j.avsg.2018.08.088. Epub 2018
+Nov  26.
+
+Endovascular and Surgical Management of Intact Splenic Artery Aneurysm.
+
+Zhu C(1), Zhao J(2), Yuan D(3), Huang B(3), Yang Y(3), Ma Y(3), Xiong F(3).
+
+Author information:
+(1)West China Medical School of Sichuan University, Chengdu, Sichuan, China.
+(2)Department of Vascular Surgery, West China Hospital, Sichuan University, 
+Chengdu, Sichuan, China. Electronic address: zhaojc3@163.com.
+(3)Department of Vascular Surgery, West China Hospital, Sichuan University, 
+Chengdu, Sichuan, China.
+
+OBJECTIVE: This study aims to reveal the experience with endovascular and 
+surgical management of intact splenic artery aneurysms in our single center.
+METHOD: Between January 2011 and June 2017, 42 patients with intact splenic 
+artery aneurysm were enrolled in this study. Twenty patients undergoing surgical 
+intervention were classified as the surgical group, and 22 patients who received 
+endovascular repair were categorized as the endovascular group. Demographic 
+data, preoperative comorbidities, and anatomical characteristics of aneurysms 
+were collected and analyzed. Details of interventions, perioperative outcomes, 
+and follow-up results were evaluated and compared between the 2 groups.
+RESULTS: Forty-two patients with a mean age of 53.4 ± 11.6 years were enrolled 
+in this study, and 44 aneurysms were repaired. Thirty-nine (92.9%) patients were 
+asymptomatic, and 3 (7.1%) patients were symptomatic. The diameter of splenic 
+artery aneurysms was 3.3 ± 1.6 cm, and the shape was mostly saccular. In the 
+surgical group, the common methods used were splenic artery aneurysm resection 
+(9 patients), followed by splenic artery aneurysms resection and splenectomy (6 
+patients), splenic artery aneurysm resection and arterial reconstruction with 
+end-to-end anastomosis (3 patients), and laparoscopic splenic artery aneurysm 
+resection coexisting with splenectomy (2 patients). In the endovascular group, 
+the exclusive means was embolization with coils. The technical success rates in 
+both open repair and endovascular repair were 100%. The 30-day mortality was 
+nil, and no severe complication was found in the early time except that 1 
+patient suffered multiple splenic abscess in the endovascular group after 
+embolization. Endovascular repair had significantly shorter surgery time 
+(82.5 ± 27.6 vs 191.9 ± 62.7 min, P < 0.001) and hospital stay (5.6 ± 3.1 vs 
+10.8 ± 5.2 days, P < 0.001) compared with open repair. The median follow-up 
+period in this study was 34.5 (interquartile range 16.8-60.8) months. Two sac 
+reperfusions were detected during the follow-up in the endovascular group, and 
+patients needed new embolization. No late deaths were found in the follow-up 
+period, and the freedom from reintervention in the endovascular group at 1 and 
+3 years postoperatively was 95.5% and 82.4%, respectively. In addition, the 
+freedom from reintervention in the surgical group at both 1 year and 3 years 
+postoperatively were 100%. No significant differences were observed in late 
+survival and reintervention between open repair and endovascular repair.
+CONCLUSIONS: Open repair and endovascular repair were equally feasible, safe, 
+and effective for intact splenic artery aneurysm. Endovascular repair is less 
+invasive accompanied with an obvious decrease in surgery time and rapid recovery 
+with a short hospital time.
+
+Copyright © 2018 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.avsg.2018.08.088
+PMID: 30496903 [Indexed for MEDLINE]

--- a/references_cache/PMID_31839799.md
+++ b/references_cache/PMID_31839799.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:31839799"
+title: "Splenic aneurysms: natural history and treatment techniques."
+authors:
+- Mariúba JVO
+journal: J Vasc Bras
+year: '2019'
+doi: 10.1590/1677-5449.190058
+content_type: abstract_only
+---
+
+# Splenic aneurysms: natural history and treatment techniques.
+**Authors:** Mariúba JVO
+**Journal:** J Vasc Bras (2019)
+**DOI:** [10.1590/1677-5449.190058](https://doi.org/10.1590/1677-5449.190058)
+
+## Content
+
+1. J Vasc Bras. 2019 Dec 4;19:e20190058. doi: 10.1590/1677-5449.190058.
+
+Splenic aneurysms: natural history and treatment techniques.
+
+Mariúba JVO(1).
+
+Author information:
+(1)Centro de Cuidados da Circulação e da Coluna, Sorocaba, SP, Brazil.
+
+True splenic artery aneurysms (SAA) are a rare, but potentially fatal, 
+pathology. They are the third most common type of abdominal aneurysm, after 
+aneurysms of the aorta and of the iliac artery, and account for almost the all 
+aneurysms of visceral arteries. True aneurysms account for 60% of SAA and affect 
+four times as many women as men, generally related to increased incidental or 
+symptomatic findings that coincide with use of ultrasonography in pregnancy. 
+Among pregnant patients, mortality after rupture is 65-75%, with fetal mortality 
+exceeding 90%. There are multiple etiologies and it is believed that hormonal 
+influences and changes in portal flow during gestation play an important role in 
+development of SAA. This review discusses their history, epidemiology, 
+pathophysiology, and diagnosis and current treatment techniques.
+
+Aneurismas da artéria esplênica (AAE) verdadeiros são uma patologia rara, mas 
+potencialmente fatal. São o terceiro aneurisma abdominal mais comum, após 
+aneurismas da aorta e da artéria ilíaca, e representam quase todos os aneurismas 
+de artérias viscerais. Os aneurismas verdadeiros são responsáveis ​​por 60% dos 
+AAEs e afetam as mulheres quatro vezes mais do que os homens, geralmente 
+relacionados a uma descoberta incidental ou sintomática aumentada que coincide 
+com o uso da ultrassonografia na gravidez. Em pacientes grávidas, a mortalidade, 
+após a ruptura, é de 65-75%, com mais de 90% de mortalidade fetal. Têm múltiplas 
+etiologias, e acredita-se que as influências hormonais e as alterações do fluxo 
+portal durante a gestação desempenhem um papel importante no desenvolvimento do 
+AAE. Esta revisão discorrerá sobre sua história, epidemiologia, fisiopatologia, 
+diagnóstico, e as técnicas atuais de tratamento.
+
+DOI: 10.1590/1677-5449.190058
+PMCID: PMC6904962
+PMID: 31839799
+
+Conflict of interest statement: Conflicts of interest: No conflicts of interest 
+declared concerning the publication of this article.

--- a/references_cache/PMID_32201007.md
+++ b/references_cache/PMID_32201007.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:32201007"
+title: The Society for Vascular Surgery clinical practice guidelines on the management of visceral aneurysms.
+authors:
+- Chaer RA
+- Abularrage CJ
+- Coleman DM
+- Eslami MH
+- Kashyap VS
+- Rockman C
+- Murad MH
+journal: J Vasc Surg
+year: '2020'
+doi: 10.1016/j.jvs.2020.01.039
+keywords:
+- "Aneurysm/diagnostic imaging, surgery"
+- "Arteries/diagnostic imaging, surgery"
+- Consensus
+- "Endovascular Procedures/adverse effects, standards"
+- Evidence-Based Medicine/standards
+- Humans
+- Risk Factors
+- Treatment Outcome
+- "Vascular Surgical Procedures/adverse effects, standards"
+- Viscera/blood supply
+content_type: abstract_only
+---
+
+# The Society for Vascular Surgery clinical practice guidelines on the management of visceral aneurysms.
+**Authors:** Chaer RA, Abularrage CJ, Coleman DM, Eslami MH, Kashyap VS, Rockman C, Murad MH
+**Journal:** J Vasc Surg (2020)
+**DOI:** [10.1016/j.jvs.2020.01.039](https://doi.org/10.1016/j.jvs.2020.01.039)
+
+## Content
+
+1. J Vasc Surg. 2020 Jul;72(1S):3S-39S. doi: 10.1016/j.jvs.2020.01.039. Epub 2020
+ Mar 20.
+
+The Society for Vascular Surgery clinical practice guidelines on the management 
+of visceral aneurysms.
+
+Chaer RA(1), Abularrage CJ(2), Coleman DM(3), Eslami MH(4), Kashyap VS(5), 
+Rockman C(6), Murad MH(7).
+
+Author information:
+(1)Division of Vascular Surgery, University of Pittsburgh Medical Center, 
+Pittsburgh, Pa. Electronic address: chaerra@upmc.edu.
+(2)Division of Vascular Surgery, Johns Hopkins Hospital, Baltimore, Md.
+(3)Division of Vascular Surgery, University of Michigan Hospitals, Ann Arbor, 
+Mich.
+(4)Division of Vascular Surgery, University of Pittsburgh Medical Center, 
+Pittsburgh, Pa.
+(5)Division of Vascular Surgery, University Hospitals Case Medical Center, 
+Cleveland, Ohio.
+(6)Division of Vascular Surgery, New York University Langone Medicine Center, 
+New York, NY.
+(7)Mayo Clinic Evidence-Based Practice Center, Rochester, Minn.
+
+Comment in
+    J Vasc Surg. 2020 Jul;72(1S):1S-2S. doi: 10.1016/j.jvs.2020.04.485.
+
+These Society for Vascular Surgery Clinical Practice Guidelines describe the 
+care of patients with aneurysms of the visceral arteries. They include 
+evidence-based size thresholds for repair of aneurysms of the renal arteries, 
+splenic artery, celiac artery, and hepatic artery, among others. Specific open 
+surgical and endovascular repair strategies are also discussed. They also 
+describe specific circumstances in which aneurysms may be repaired at smaller 
+sizes than these size thresholds, including in women of childbearing age and 
+false aneurysms. These Guidelines offer important recommendations for the care 
+of patients with aneurysms of the visceral arteries and long-awaited guidance 
+for clinicians who treat these patients.
+
+Copyright © 2020 Society for Vascular Surgery. Published by Elsevier Inc. All 
+rights reserved.
+
+DOI: 10.1016/j.jvs.2020.01.039
+PMID: 32201007 [Indexed for MEDLINE]

--- a/references_cache/PMID_35915344.md
+++ b/references_cache/PMID_35915344.md
@@ -1,0 +1,71 @@
+---
+reference_id: "PMID:35915344"
+title: Giant splenic artery aneurysm rupture into the stomach that was successfully managed with emergency distal pancreatectomy.
+authors:
+- Yoshikawa C
+- Yamato I
+- Nakata Y
+- Nakagawa T
+- Inoue T
+- Nakatani M
+- Nezu D
+- Doi S
+- Kuroda Y
+- Fujii K
+- Kishida S
+- Kamikubo M
+- Ko S
+journal: Surg Case Rep
+year: '2022'
+doi: 10.1186/s40792-022-01498-3
+content_type: abstract_only
+---
+
+# Giant splenic artery aneurysm rupture into the stomach that was successfully managed with emergency distal pancreatectomy.
+**Authors:** Yoshikawa C, Yamato I, Nakata Y, Nakagawa T, Inoue T, Nakatani M, Nezu D, Doi S, Kuroda Y, Fujii K, Kishida S, Kamikubo M, Ko S
+**Journal:** Surg Case Rep (2022)
+**DOI:** [10.1186/s40792-022-01498-3](https://doi.org/10.1186/s40792-022-01498-3)
+
+## Content
+
+1. Surg Case Rep. 2022 Aug 2;8(1):148. doi: 10.1186/s40792-022-01498-3.
+
+Giant splenic artery aneurysm rupture into the stomach that was successfully 
+managed with emergency distal pancreatectomy.
+
+Yoshikawa C(1), Yamato I(2), Nakata Y(2), Nakagawa T(2), Inoue T(2), Nakatani 
+M(2), Nezu D(2), Doi S(2), Kuroda Y(2), Fujii K(2), Kishida S(2), Kamikubo M(2), 
+Ko S(2).
+
+Author information:
+(1)Department of Surgery, Nara Prefecture General Medical Center, 2-897-5 
+Shichijo-Nishimachi, Nara, 630-8581, Japan. pc.y.chi.476.hiro2180@gmail.com.
+(2)Department of Surgery, Nara Prefecture General Medical Center, 2-897-5 
+Shichijo-Nishimachi, Nara, 630-8581, Japan.
+
+Erratum in
+    Surg Case Rep. 2022 Dec 8;8(1):216. doi: 10.1186/s40792-022-01577-5.
+
+BACKGROUND: Splenic artery aneurysms usually rupture into the free peritoneal 
+space and rarely into the gastrointestinal tract. We report the case of a 
+patient with a giant splenic artery aneurysm that ruptured in to the stomach 
+with hemorrhagic shock and was successfully treated with emergency surgery.
+CASE PRESENTATION: A 59-year-old man presented to the emergency department with 
+chest pain and syncope. Contrast-enhanced computed tomography showed splenic 
+artery aneurysm with active contrast extravasation. He developed upper 
+gastrointestinal (UGI) bleeding and hypovolemic shock. We diagnosed a splenic 
+artery aneurysm ruptured in to the stomach, performed emergency distal 
+splenopancreatectomy including the aneurysm and partial gastric resection, and 
+could prevent patient death.
+CONCLUSIONS: This report shows that splenic artery aneurysm can cause UGI 
+bleeding. Thus, clinicians should be alert about this condition when managing 
+patients with UGI bleeding and/or splenic artery aneurysm.
+
+© 2022. The Author(s).
+
+DOI: 10.1186/s40792-022-01498-3
+PMCID: PMC9343537
+PMID: 35915344
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_38249169.md
+++ b/references_cache/PMID_38249169.md
@@ -1,0 +1,53 @@
+---
+reference_id: "PMID:38249169"
+title: Spontaneous Rupture of Splenic Artery Aneurysm.
+authors:
+- Carvalho M
+- Mendes J
+- Pereira-Macedo J
+- Vinagreiro M
+- Lemos R
+journal: Cureus
+year: '2023'
+doi: 10.7759/cureus.50937
+content_type: abstract_only
+---
+
+# Spontaneous Rupture of Splenic Artery Aneurysm.
+**Authors:** Carvalho M, Mendes J, Pereira-Macedo J, Vinagreiro M, Lemos R
+**Journal:** Cureus (2023)
+**DOI:** [10.7759/cureus.50937](https://doi.org/10.7759/cureus.50937)
+
+## Content
+
+1. Cureus. 2023 Dec 22;15(12):e50937. doi: 10.7759/cureus.50937. eCollection 2023
+ Dec.
+
+Spontaneous Rupture of Splenic Artery Aneurysm.
+
+Carvalho M(1), Mendes J(1), Pereira-Macedo J(1), Vinagreiro M(1), Lemos R(1).
+
+Author information:
+(1)Surgery, Centro Hospitalar do Médio Ave, Santo Tirso, PRT.
+
+Splenic artery aneurysms are rare and usually asymptomatic, with a high risk of 
+mortality once they get ruptured. A case report of a spontaneous rupture of a 
+splenic artery aneurysm in a 65-year-old female is reported. The patient 
+presented in the emergency department with abdominal pain, nausea, and vomiting, 
+followed by syncope. A contrast-enhanced CT scan was performed and showed a 
+splenic artery aneurysm measuring 40 × 35 mm surrounded by a hematoma. The 
+patient was submitted to emergency laparotomy with ligation of the splenic 
+artery, aneurysm resection, and splenectomy. There were no surgical 
+complications, and the patient was discharged home on the fifth postoperative 
+day. A rupture of a splenic aneurysm is a rare condition with a high mortality 
+rate and should be considered a differential diagnosis in a patient with 
+abdominal pain and hemodynamic instability.
+
+Copyright © 2023, Carvalho et al.
+
+DOI: 10.7759/cureus.50937
+PMCID: PMC10800027
+PMID: 38249169
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_39009114.md
+++ b/references_cache/PMID_39009114.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:39009114"
+title: Comparison of Splenic Artery Aneurysms in Patients with and without Portal Hypertension.
+authors:
+- Leal J
+- Batagini NC
+- Stefan de Faria Oliveira I
+- Frederico MG
+- Rodrigues MS
+- Casella IB
+- Simão da Silva E
+journal: Ann Vasc Surg
+year: '2024'
+doi: 10.1016/j.avsg.2024.06.010
+keywords:
+- Humans
+- "Hypertension, Portal/etiology, physiopathology, diagnosis, surgery"
+- Female
+- Middle Aged
+- Splenic Artery/diagnostic imaging
+- Male
+- "Aneurysm/surgery, diagnostic imaging, mortality"
+- Retrospective Studies
+- Aged
+- Risk Factors
+- Adult
+- Time Factors
+- Risk Assessment
+- Portal Pressure
+- "Aneurysm, Ruptured/surgery, diagnostic imaging, mortality"
+- Disease Progression
+content_type: abstract_only
+---
+
+# Comparison of Splenic Artery Aneurysms in Patients with and without Portal Hypertension.
+**Authors:** Leal J, Batagini NC, Stefan de Faria Oliveira I, Frederico MG, Rodrigues MS, Casella IB, Simão da Silva E
+**Journal:** Ann Vasc Surg (2024)
+**DOI:** [10.1016/j.avsg.2024.06.010](https://doi.org/10.1016/j.avsg.2024.06.010)
+
+## Content
+
+1. Ann Vasc Surg. 2024 Dec;109:232-237. doi: 10.1016/j.avsg.2024.06.010. Epub
+2024  Jul 14.
+
+Comparison of Splenic Artery Aneurysms in Patients with and without Portal 
+Hypertension.
+
+Leal J(1), Batagini NC(2), Stefan de Faria Oliveira I(1), Frederico MG(1), 
+Rodrigues MS(1), Casella IB(1), Simão da Silva E(1).
+
+Author information:
+(1)Vascular and Endovascular Surgery Department, Clinicas Hospitals of 
+University of São Paulo Medical School, São Paulo, São Paulo, Brazil.
+(2)Vascular and Endovascular Surgery Department, Clinicas Hospitals of 
+University of São Paulo Medical School, São Paulo, São Paulo, Brazil. Electronic 
+address: nayaracioffi@yahoo.com.
+
+BACKGROUND: Splenic artery aneurysms (SAAs) are rare but seem to have higher 
+incidence in patients with portal hypertension (PH). The present article aims to 
+analyze the interference of PH in the natural history of these aneurysms.
+METHODS: This was a retrospective study of data recorded prospectively. Between 
+January 2000 and December 2019, all SAAs patients in follow-up at a tertiary 
+institution were selected for analysis. Primary end point was to analyze the 
+presentation and evolution of SAAs in patients with PH, and secondary was to 
+identify cumulative rates of freedom from rupture, interventions, and survival 
+in this group, during a 10-year follow-up.
+RESULTS: In total, 96 patients were identified with SAAs, 79 (82.29%) did not 
+have PH and 17 (17.7%) had this comorbidity. Among the demographic 
+characteristics, the patients with SAAs and PH were significantly younger 
+(52 years [standard deviation {SD} 13.3] versus 61.9 years [SD 12.2] [P = 0.05]) 
+and had lower number of pregnancies (1.1 pregnancies [SD 1.2] versus 3.37 
+pregnancies [SD 2.3] [P = 0.03]). Patients with PH had a higher cumulative rate 
+of surgical intervention throughout follow-up (up to 75.6% in 10 years) when 
+compared to patients without PH, with 36.9% intervention rate in 10 years of 
+follow-up. Patients with PH had larger diameter at diagnosis (35 mm, SD 27.3) 
+compared to patients without PH (22.6 mm, SD 16.1), P = 0.008. However, there 
+were no statistical differences in the relative growth rate, in aneurysmal 
+rupture rate throughout follow-up, as well as in survival over the years, 
+between the groups.
+CONCLUSIONS: The patients with SAAs and PH are significantly younger, have 
+larger SAA diameters at diagnosis and have a higher cumulative rate of surgical 
+intervention throughout follow-up in 10 years, despite the relative growth rate 
+being similar to that of patients without PH.
+
+Copyright © 2024 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.avsg.2024.06.010
+PMID: 39009114 [Indexed for MEDLINE]

--- a/references_cache/PMID_39407852.md
+++ b/references_cache/PMID_39407852.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:39407852"
+title: "The Definition, Diagnosis, and Management of Giant Splenic Artery Aneurysms and Pseudoaneurysms: A Systematic Review."
+authors:
+- Rinaldi V
+- Illuminati G
+- Caronna R
+- Prezioso G
+- Palumbo P
+- Saullo P
+- "D'Andrea V"
+- Nardi P
+journal: J Clin Med
+year: '2024'
+doi: 10.3390/jcm13195793
+content_type: abstract_only
+---
+
+# The Definition, Diagnosis, and Management of Giant Splenic Artery Aneurysms and Pseudoaneurysms: A Systematic Review.
+**Authors:** Rinaldi V, Illuminati G, Caronna R, Prezioso G, Palumbo P, Saullo P, D'Andrea V, Nardi P
+**Journal:** J Clin Med (2024)
+**DOI:** [10.3390/jcm13195793](https://doi.org/10.3390/jcm13195793)
+
+## Content
+
+1. J Clin Med. 2024 Sep 28;13(19):5793. doi: 10.3390/jcm13195793.
+
+The Definition, Diagnosis, and Management of Giant Splenic Artery Aneurysms and 
+Pseudoaneurysms: A Systematic Review.
+
+Rinaldi V(1), Illuminati G(1), Caronna R(1), Prezioso G(1), Palumbo P(1), Saullo 
+P(1), D'Andrea V(1), Nardi P(1).
+
+Author information:
+(1)Department of Surgery, Sapienza University of Rome, Viale Regina Elena 324, 
+00161 Rome, Italy.
+
+Background/Objectives: Giant splenic artery aneurysms (SAAs) and pseudoaneurysms 
+(SAPs) represent rare conditions, characterized by a diameter greater than or 
+equal to 5 cm. The risk of rupture is increased compared to common SAAs and 
+SAPs, necessitating urgent treatments to prevent it. Methods: This systematic 
+review was conducted through a comprehensive search involving the PubMed, Google 
+Scholar, and Scopus databases. A total of 82 patients and 65 articles were 
+included in the analysis. For each patient, we investigated age, sex, symptoms, 
+comorbidities, the presence of a true or a false aneurysm, the dimensional 
+criteria used to define dilations as giant aneurysms or pseudoaneurysms, the 
+dimension of the two greatest diameters, imaging studies, surgical treatment, 
+post-operative length of stay (LOS), and post-operative follow-up. Results: The 
+results revealed a similar incidence in both genders (43 males vs. 39 females) 
+with a median age of 55.79 years. The most frequently described symptom was pain 
+(59.76%). Thirteen cases were false aneurysms and 69 were true aneurysms. The 
+mean greatest diameter was 9.90 cm. The CT scan was the most utilized imaging 
+study (80.49%). Open, endovascular, and hybrid surgery were performed in 47, 26, 
+and 9 patients, respectively, with complication rates of 14.89%, 23.08%, and 
+22.22% occurring for each treatment. The post-operative LOS was 12.29 days, 2.36 
+days, and 5 days, respectively. The median follow-up was 17.28 months overall. 
+No recanalization was observed after endovascular procedures during the 
+follow-up period. Conclusions: The dimensional criterion to define SAAs and SAPs 
+as giant was most frequently that at least one diameter was ≥ 5 cm. The CT scan 
+was the most frequently utilized radiological study to diagnose giant SAAs and 
+SAPs. Finally, endovascular procedures, open surgeries, and hybrid treatments 
+presented similar post-operative complication rates. The post-operative LOS was 
+lower for the endovascular group, and the follow-up period did not show aneurysm 
+recanalization in any patients.
+
+DOI: 10.3390/jcm13195793
+PMCID: PMC11477110
+PMID: 39407852
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_40626033.md
+++ b/references_cache/PMID_40626033.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:40626033"
+title: Imaging modalities used in follow-up after coil embolization of splenic artery aneurysm - a systematic review.
+authors:
+- Lamparski KJ
+- Procyk G
+- Sajdek M
+- Gąsecka A
+- Dryjańska-Lamparska A
+- Maj E
+- Januszewicz M
+- Wojtaszek M
+journal: Pol J Radiol
+year: '2025'
+doi: 10.5114/pjr/203730
+content_type: abstract_only
+---
+
+# Imaging modalities used in follow-up after coil embolization of splenic artery aneurysm - a systematic review.
+**Authors:** Lamparski KJ, Procyk G, Sajdek M, Gąsecka A, Dryjańska-Lamparska A, Maj E, Januszewicz M, Wojtaszek M
+**Journal:** Pol J Radiol (2025)
+**DOI:** [10.5114/pjr/203730](https://doi.org/10.5114/pjr/203730)
+
+## Content
+
+1. Pol J Radiol. 2025 May 13;90:e224-e233. doi: 10.5114/pjr/203730. eCollection 
+2025.
+
+Imaging modalities used in follow-up after coil embolization of splenic artery 
+aneurysm - a systematic review.
+
+Lamparski KJ(1), Procyk G(2)(3), Sajdek M(1), Gąsecka A(2), Dryjańska-Lamparska 
+A(1), Maj E(1), Januszewicz M(1), Wojtaszek M(1).
+
+Author information:
+(1)2 Department of Clinical Radiology, Medical University of Warsaw, Poland.
+(2)1 Chair and Department of Cardiology, Medical University of Warsaw, Poland.
+(3)Doctoral School, Medical University of Warsaw, Poland.
+
+PURPOSE: Endovascular procedures have become the method of choice for treating 
+splenic artery aneurysms (SSAs). However, there is no consensus regarding the 
+intervals and imaging methods for follow-up examinations in patients with true 
+SAAs treated with coil embolisation. We aimed to evaluate the utility of digital 
+subtraction angiography (DSA), computed tomography angiography (CTA), magnetic 
+resonance angiography (MRA), contrast-enhanced ultrasound, and duplex ultrasound 
+(DUS) for follow-up screening of patients with SAAs treated with coil 
+embolisation.
+MATERIAL AND METHODS: We conducted a systematic review according to the PRISMA 
+2020 Statement. We searched 5 databases: Embase, Medline Ultimate, PubMed, 
+Scopus, and Web of Science, each up to 10 April 2024. Eventually, 20 relevant 
+original studies were included.
+RESULTS: DSA is an invasive procedure that requires ionising radiation and 
+should not be performed as a routine check-up. CTA is an appropriate examination 
+method in patients immediately after coil embolisation in whom severe 
+complications, primarily bleeding, are suspected. Still, it is unsuitable for 
+assessing persistent aneurysmal sac perfusion. MRA is a promising noninvasive 
+technique that does not require ionising radiation. Several studies have 
+demonstrated the superiority of MRA over DSA in detecting small aneurysmal sac 
+reperfusion. DUS, while not a standalone method, may supplement MRA in patients 
+at low risk of reintervention.
+CONCLUSIONS: The evidence regarding follow-up imaging methods after SAAs coil 
+embolisation is limited and of low quality. MRA should be preferred over DSA for 
+detecting aneurysmal sac reperfusion. Due to artifacts, CTA is suitable for 
+emergency cases but not for routine follow-up.
+
+© Pol J Radiol 2025.
+
+DOI: 10.5114/pjr/203730
+PMCID: PMC12232415
+PMID: 40626033

--- a/references_cache/PMID_9382977.md
+++ b/references_cache/PMID_9382977.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:9382977"
+title: Splenic artery aneurysms in liver transplant patients. Liver Transplant Group.
+authors:
+- Kóbori L
+- van der Kolk MJ
+- de Jong KP
+- Peeters PM
+- Klompmaker IJ
+- Kok T
+- Haagsma EB
+- Slooff MJ
+journal: J Hepatol
+year: '1997'
+doi: 10.1016/s0168-8278(97)80327-3
+keywords:
+- Adolescent
+- Adult
+- Age Factors
+- Aged
+- "Aneurysm/epidemiology, pathology"
+- Angiography
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- Liver Diseases/complications
+- "Liver Transplantation/adverse effects, pathology"
+- Male
+- Middle Aged
+- "Postoperative Complications/epidemiology, pathology"
+- Risk Factors
+- Sex Factors
+- Splenic Artery/physiopathology
+content_type: abstract_only
+---
+
+# Splenic artery aneurysms in liver transplant patients. Liver Transplant Group.
+**Authors:** Kóbori L, van der Kolk MJ, de Jong KP, Peeters PM, Klompmaker IJ, Kok T, Haagsma EB, Slooff MJ
+**Journal:** J Hepatol (1997)
+**DOI:** [10.1016/s0168-8278(97)80327-3](https://doi.org/10.1016/s0168-8278(97)80327-3)
+
+## Content
+
+1. J Hepatol. 1997 Nov;27(5):890-3. doi: 10.1016/s0168-8278(97)80327-3.
+
+Splenic artery aneurysms in liver transplant patients. Liver Transplant Group.
+
+Kóbori L(1), van der Kolk MJ, de Jong KP, Peeters PM, Klompmaker IJ, Kok T, 
+Haagsma EB, Slooff MJ.
+
+Author information:
+(1)Department of Surgery, University Hospital Groningen, The Netherlands.
+
+BACKGROUND/AIMS: The purpose of the study was to investigate the incidence of 
+and risk factors for splenic artery aneurysms in liver transplant patients.
+METHODS: Medical records and the pre- and 1-year postoperative angiograms of 337 
+liver transplant patients were reviewed to assess the presence and 
+characteristics of these aneurysms.
+RESULTS: Forty-five patients with aneurysms were identified (13%): 41 cases in 
+242 adult patients (17%) and four (4%) in 95 children (p<0.01). The 
+female-to-male ratio was 2:1. The majority of the aneurysms (87%) were located 
+in the distal third of the splenic artery and the majority (87%) of the patients 
+presented multiple aneurysms. In patients without portal hypertension no 
+aneurysms were identified, whereas in 16% of the patients with portal 
+hypertension aneurysms were found (p<0.001). In adult patients the incidence of 
+splenic artery aneurysms was significantly higher in patients with parenchymal 
+diseases than in patients with cholestatic diseases (p<0.0001). Two patients 
+(4%) died due to rupture of the aneurysms. Control angiographies, 1 year after 
+liver transplantation, showed no changes in size and number of the aneurysms, 
+and no new aneurysms were identified.
+CONCLUSIONS: The incidence of splenic artery aneurysms in liver transplant 
+patients is 13%. They are generally multiple and located in the distal third of 
+the splenic artery. The incidence is higher in women and in patients with 
+parenchymal liver disease and portal hypertension. The incidence of rupture was 
+4%.
+
+DOI: 10.1016/s0168-8278(97)80327-3
+PMID: 9382977 [Indexed for MEDLINE]

--- a/references_cache/clinicaltrials_NCT01387828.md
+++ b/references_cache/clinicaltrials_NCT01387828.md
@@ -1,0 +1,11 @@
+---
+reference_id: "clinicaltrials:NCT01387828"
+title: Prospective Randomized Comparison of Open Versus Laparoscopic Management of Splenic Artery Aneurysms. A Ten-Year Study
+content_type: summary
+---
+
+# Prospective Randomized Comparison of Open Versus Laparoscopic Management of Splenic Artery Aneurysms. A Ten-Year Study
+
+## Content
+
+The purpose of this study is compare two different surgical treatments of splenic artery aneurysms: open and laparoscopic approach.

--- a/references_cache/clinicaltrials_NCT07053605.md
+++ b/references_cache/clinicaltrials_NCT07053605.md
@@ -1,0 +1,11 @@
+---
+reference_id: "clinicaltrials:NCT07053605"
+title: Clinical Study on Laparoscopic Resection of Splenic Artery Aneurysm With Preservation of Spleen
+content_type: summary
+---
+
+# Clinical Study on Laparoscopic Resection of Splenic Artery Aneurysm With Preservation of Spleen
+
+## Content
+
+In this study, researchers examined the changes in related indicators such as immune function, splenic vein,proper hepatic artery, and portal venous hemodynamics following laparoscopic resection of a splenic artery aneurysm. We determined the changes in these patient-related indicators after surgical treatment and whether these changes could improve patient outcomes.

--- a/research/Splenic_Artery_Aneurysm-deep-research-falcon.md
+++ b/research/Splenic_Artery_Aneurysm-deep-research-falcon.md
@@ -1,0 +1,1296 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T15:01:27.187809'
+end_time: '2026-05-06T15:22:42.876213'
+duration_seconds: 1275.7
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Splenic artery aneurysm
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 50
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Splenic artery aneurysm
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Splenic artery aneurysm** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Splenic artery aneurysm
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Splenic artery aneurysm** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Splenic Artery Aneurysm (SAA): Comprehensive Disease Characteristics Research Report
+
+## Executive summary (current understanding)
+Splenic artery aneurysm (SAA) is the most common visceral artery aneurysm and is often incidentally detected; despite a generally low rupture rate for true SAAs, rupture can be catastrophic, with particularly high maternal and fetal mortality in pregnancy. Contemporary expert guidance (SVS 2020; CIRSE 2024) recommends CTA-based diagnosis, aggressive management for pseudoaneurysms (treat regardless of size), and size-/risk-stratified treatment for true SAAs (treat ≥3 cm, symptomatic, enlarging, or in women of childbearing age). Endovascular therapy is generally preferred when anatomically feasible and is associated with lower perioperative morbidity and shorter length of stay, while open surgery remains crucial for rupture, hemodynamic instability, pregnancy-associated rupture, and distal/hilar anatomy. (chaer2020thesocietyfor pages 12-13, chaer2020thesocietyfor pages 13-15, rossi2024cirsestandardsof pages 1-3, hogendoorn2014openrepairendovascular pages 4-5, rinaldi2023endovascularandopen pages 1-3)
+
+| Topic | Key points | Quantitative data | Key sources |
+|---|---|---|---|
+| Disease definition / identifiers / synonyms | Splenic artery aneurysm (SAA) is a dilation of the splenic artery; one review defines SAA as arterial dilation >50% of the normal splenic artery diameter. Distinguish **true SAA** from **splenic artery pseudoaneurysm (SAP/SAPA)**, which has a much higher rupture risk. Common synonyms: splenic artery aneurysm, SAA, true splenic artery aneurysm; pseudoaneurysm terms: splenic artery pseudoaneurysm, SAP. “Giant” SAA is variably defined, most often ≥5 cm, sometimes >10 cm. | Giant SAA definition used in literature: ≥5 cm in 62.5% of articles that specified a cutoff; >10 cm in 37.5%. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024) (rinaldi2024thedefinitiondiagnosis pages 1-2, rinaldi2024thedefinitiondiagnosis pages 4-6, rinaldi2024thedefinitiondiagnosis pages 7-9) |
+| Epidemiology / frequency | SAA is the most common visceral artery aneurysm. Population estimates vary by detection method; frequency has risen with modern imaging. | SAAs account for ~60% of visceral/splanchnic aneurysms; reported incidence 0.09% at autopsy and 0.78% on angiography; one older clinical paper cites incidence <0.8%. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024); Sticco et al., *Vascular* 2016, DOI: 10.1177/1708538115613703, https://doi.org/10.1177/1708538115613703 (2016) (rinaldi2024thedefinitiondiagnosis pages 7-9, sticco2016acomparisonof pages 1-2) |
+| Sex / age distribution | Classic SAA is more common in women, especially multiparous women; giant SAA series show more balanced sex distribution. Diagnosis is usually in adulthood/midlife. | Female predominance reported as ~4:1 for common SAA; giant SAA pooled review: 43 males / 39 females, median age 55.79 years. | Obara et al., *Surgery Today* 2020, DOI: 10.1007/s00595-019-01898-3, https://doi.org/10.1007/s00595-019-01898-3 (2020); Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024) (obara2020currentmanagementstrategies pages 5-7, rinaldi2024thedefinitiondiagnosis pages 1-2) |
+| Rupture risk and mortality | True SAA rupture risk is generally low but clinically important because rupture can be catastrophic. Pseudoaneurysms rupture much more often and are treated regardless of size. | Common true SAA rupture risk ~2–3%; older review cites ~3% in more recent series (historically ~10%). Pseudoaneurysm rupture risk reported 37–47%; SVS excerpt cites rupture 76.3% for pseudoaneurysm vs 3.1% for true aneurysm. Ruptured SAA mortality up to ~25% overall; older reports cite rupture mortality up to 30% or 36%. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024); Chaer et al., *J Vasc Surg* 2020, DOI: 10.1016/j.jvs.2020.01.039, https://doi.org/10.1016/j.jvs.2020.01.039 (2020); Obara et al., *Surgery Today* 2020, DOI: 10.1007/s00595-019-01898-3, https://doi.org/10.1007/s00595-019-01898-3 (2020); Dave et al., *Ann Vasc Surg* 2000, DOI: 10.1007/s100169910039, https://doi.org/10.1007/s100169910039 (2000) (rinaldi2024thedefinitiondiagnosis pages 7-9, chaer2020thesocietyfor pages 12-13, chaer2020thesocietyfor pages 13-15, obara2020currentmanagementstrategies pages 5-7, dave2000splenicarteryaneurysm pages 4-5, sticco2016acomparisonof pages 1-2) |
+| Pregnancy-associated risk | Pregnancy markedly increases rupture risk and is a major reason for aggressive treatment in women of childbearing age. Rupture often occurs in late pregnancy. | Pregnancy accounts for ~20–50% of ruptures in older literature/SVS excerpt; maternal mortality ~70–80%; fetal mortality ~90–95%. | Chaer et al., *J Vasc Surg* 2020, DOI: 10.1016/j.jvs.2020.01.039, https://doi.org/10.1016/j.jvs.2020.01.039 (2020); Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024); Dave et al., *Ann Vasc Surg* 2000, DOI: 10.1007/s100169910039, https://doi.org/10.1007/s100169910039 (2000) (chaer2020thesocietyfor pages 12-13, rinaldi2024thedefinitiondiagnosis pages 7-9, dave2000splenicarteryaneurysm pages 4-5) |
+| Portal hypertension / liver transplant association | Portal hypertension, cirrhosis, and liver transplantation are recurring associations and influence management because of higher rupture/growth concern. | Older review: portal hypertension present in up to 24% of SAA patients; incidence in cirrhosis/portal hypertension 7–20%; 8–13% of liver-transplant candidates have SAA. Another review cites 20.5% in liver-transplant recipients. | Dave et al., *Ann Vasc Surg* 2000, DOI: 10.1007/s100169910039, https://doi.org/10.1007/s100169910039 (2000); Obara et al., *Surgery Today* 2020, DOI: 10.1007/s00595-019-01898-3, https://doi.org/10.1007/s00595-019-01898-3 (2020) (dave2000splenicarteryaneurysm pages 4-5, obara2020currentmanagementstrategies pages 5-7, pratesi2024guidelinesonthe pages 51-53) |
+| Other risk factors / associations | Reported associations include multiparity, pancreatitis/pseudocysts, prior surgery, trauma, infection, and nonatherosclerotic arteriopathies such as segmental arterial mediolysis. Pseudoaneurysms are particularly linked to pancreatitis and local inflammatory/surgical injury. | Giant SAA/SAP review: pancreatitis/pseudocysts present in 15.85% of pooled giant cases; giant pooled symptoms included pain in 59.76% and asymptomatic presentation in 17.07%. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024); Rinaldi et al., *J Clin Med* 2023, DOI: 10.3390/jcm12186085, https://doi.org/10.3390/jcm12186085 (2023) (rinaldi2024thedefinitiondiagnosis pages 4-6, rinaldi2024thedefinitiondiagnosis pages 9-10, rinaldi2023endovascularandopen pages 1-3) |
+| Clinical presentation | Most SAAs are asymptomatic and incidentally discovered, but symptomatic lesions usually present with abdominal or left upper quadrant/epigastric pain. Rupture can cause shock and hemoperitoneum. | Older review: 80–95% asymptomatic. Giant pooled series: pain 59.76%, palpable mass 28.05%, asymptomatic 17.07%. | Dave et al., *Ann Vasc Surg* 2000, DOI: 10.1007/s100169910039, https://doi.org/10.1007/s100169910039 (2000); Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024) (dave2000splenicarteryaneurysm pages 4-5, rinaldi2024thedefinitiondiagnosis pages 4-6, rinaldi2024thedefinitiondiagnosis pages 9-10) |
+| Diagnostic imaging | CTA is the preferred initial diagnostic test in most guidelines; MRA is preferred when iodinated contrast is contraindicated and is favored in pregnancy. Angiography is used when planning intervention or when noninvasive imaging is insufficient. Ultrasound/EcoColorDoppler can be first-line screening, but sensitivity for small SAA is limited. | CT used in 80.49% of giant pooled cases; selective angiography 54.88%; EcoColorDoppler 45.12%; MRI 3.66%. SVS excerpt notes ultrasound has poor sensitivity for SAA <3 cm. | Chaer et al., *J Vasc Surg* 2020, DOI: 10.1016/j.jvs.2020.01.039, https://doi.org/10.1016/j.jvs.2020.01.039 (2020); Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024) (chaer2020thesocietyfor pages 12-13, rinaldi2024thedefinitiondiagnosis pages 9-10, rinaldi2024thedefinitiondiagnosis pages 4-6) |
+| SVS 2020 treatment thresholds | Treat ruptured SAAs emergently; treat all splenic artery pseudoaneurysms regardless of size; treat all true SAAs in women of childbearing age regardless of size; treat true SAAs that are symptomatic, enlarging, or ≥3 cm. Observation is reasonable for small, stable, asymptomatic true SAAs in non-childbearing patients or those with limited life expectancy. Endovascular therapy is preferred initially when anatomically feasible; open surgery is favored for rupture, pregnancy-related rupture, or distal/hilar lesions. | Thresholds: pseudoaneurysm any size; true SAA in women of childbearing age any size; true SAA ≥3 cm; interval growth >0.5 cm/year is an indication. Nonoperative series cited by SVS: mean observed size 2.1 cm, mean follow-up 75 months. | Chaer et al., *J Vasc Surg* 2020, DOI: 10.1016/j.jvs.2020.01.039, https://doi.org/10.1016/j.jvs.2020.01.039 (2020) (chaer2020thesocietyfor pages 13-15, chaer2020thesocietyfor pages 12-13) |
+| CIRSE 2024 thresholds / surveillance | Intervene for any symptomatic VAA/VAPA; for SAA specifically, treat asymptomatic lesions ≥2 cm, especially if saccular/distal/favorable anatomy; treat any VAA growing ≥0.5 cm/year; treat VAPAs regardless of symptoms; treat any asymptomatic VAA in women of childbearing age. After endovascular therapy, CTA or MRA surveillance is recommended. | Thresholds: SAA ≥2 cm; growth ≥0.5 cm/year. Surveillance after EVT: 3 months, 12 months, then yearly. | Rossi et al., *Cardiovasc Intervent Radiol* 2024, DOI: 10.1007/s00270-023-03620-w, https://doi.org/10.1007/s00270-023-03620-w (2024) (rossi2024cirsestandardsof pages 1-3) |
+| Other 2024 guideline / review excerpts | 2024 guidance excerpts broadly support emergency treatment for rupture and symptomatic lesions; observation for stable asymptomatic SAAs <3 cm; intervention for SAAs >3 cm. Some sources advocate treatment at ≥2 cm in pregnant/fertile patients with portal hypertension or those awaiting liver transplant. | Usual cutoffs in 2024 excerpts: observe <3 cm if stable; treat >3 cm electively; lesions <2 cm often observed unless rapid growth. | Pratesi et al. guideline excerpt (2024) (pratesi2024guidelinesonthe pages 51-53); Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024) (rinaldi2024thedefinitiondiagnosis pages 9-10) |
+| Endovascular treatment | Endovascular therapy is now generally first-line for elective anatomically suitable SAAs. Techniques include coil embolization, sac/parent-artery embolization, plugs, covered stents/stent-grafts, glue/Lipidol, thrombin, stent-assisted coiling. Advantages include shorter length of stay and lower perioperative morbidity; drawbacks include splenic infarction, post-embolization syndrome, and higher reintervention risk in rupture. | Giant SAA pooled review: endovascular complication rate 23.08%, mean LOS 2.36 days, no recanalization during median follow-up 17.28 months. Stent-graft review: immediate technical/clinical success 90.2%, splenic infarction 4.9%, aneurysm exclusion 87.8%, no reinterventions. Wang 2024 cohort (63 pts): postembolization syndrome 10 pts; splenic infarction 7 pts; mean LOS 5.5 days; complete thrombosis in all at mean 17.2 months. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024); Borghese et al., *J Clin Med* 2024, DOI: 10.3390/jcm13102802, https://doi.org/10.3390/jcm13102802 (2024); Wang et al., *CVIR Endovasc* 2024, DOI: 10.1186/s42155-024-00427-9, https://doi.org/10.1186/s42155-024-00427-9 (2024) (rinaldi2024thedefinitiondiagnosis pages 1-2, rinaldi2024thedefinitiondiagnosis pages 6-7) |
+| Open surgery | Open repair remains important for ruptured SAAs, hemodynamic instability, pregnancy-associated rupture, and distal/hilar aneurysms where splenic preservation may not be feasible. Procedures include ligation, aneurysmectomy, splenectomy ± distal pancreatectomy, and selective reconstruction. | Giant pooled review: open complication rate 14.89%, mean LOS 12.29 days. In nationwide inpatient comparison, open repair had higher cardiac (6.9% vs 2.3%), pulmonary (16.1% vs 8.9%), and SSI (5.1% vs 0.6%) complication rates and longer LOS (6 vs 4 days), with similar in-hospital mortality (3% both) compared with endovascular repair. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024); Sticco et al., *Vascular* 2016, DOI: 10.1177/1708538115613703, https://doi.org/10.1177/1708538115613703 (2016) (rinaldi2024thedefinitiondiagnosis pages 1-2, sticco2016acomparisonof pages 1-2) |
+| Hybrid treatment | Hybrid approaches are used selectively for anatomically complex giant lesions. | Giant pooled review: hybrid used in 9/82 patients (10.98%), complication rate 22.22%, mean LOS 5 days. | Rinaldi et al., *J Clin Med* 2024, DOI: 10.3390/jcm13195793, https://doi.org/10.3390/jcm13195793 (2024) (rinaldi2024thedefinitiondiagnosis pages 1-2, rinaldi2024thedefinitiondiagnosis pages 6-7) |
+| Comparative outcomes: intact/elective SAA | Comparative observational data generally favor endovascular repair for lower perioperative morbidity and shorter hospitalization, while open repair may offer fewer reinterventions/stronger primary technical success in some series. | Nationwide inpatient study: LOS 4 vs 6 days (EVT vs open), similar mortality 3% each; lower cardiac/pulmonary/SSI complications with EVT. Mixed VAA/RAA series: LOS 7.2±6.9 vs 11.8±6.7 days in elective cases; primary technical success 79.3% EVT vs 100% open. | Sticco et al., *Vascular* 2016, DOI: 10.1177/1708538115613703, https://doi.org/10.1177/1708538115613703 (2016); Wolk et al., *Langenbecks Arch Surg* 2021, DOI: 10.1007/s00423-021-02149-1, https://doi.org/10.1007/s00423-021-02149-1 (2021) (sticco2016acomparisonof pages 1-2) |
+| Outcomes in ruptured SAA: open vs EVT | For ruptured SAA, available evidence shows similar mortality between open and EVT overall, but EVT has substantially more reinterventions/conversions; open repair remains preferred in hemodynamic instability and pregnancy-related rupture. | Systematic review of 350 ruptured SAA patients: overall mortality 10.6%; OSR 12.9% vs EVT 7.8% (p=0.84). Reinterventions after EVT 22.4% (37 total; many converted to laparotomy/splenectomy) vs 1.6% after OSR. | Rinaldi et al., *J Clin Med* 2023, DOI: 10.3390/jcm12186085, https://doi.org/10.3390/jcm12186085 (2023) (rinaldi2023endovascularandopen pages 1-3) |
+
+
+*Table: This table summarizes high-yield, evidence-supported facts on splenic artery aneurysm, including epidemiology, major risk factors, imaging, guideline thresholds, and treatment outcomes. It is designed as a compact reference for disease knowledge-base curation and clinical/research synthesis.*
+
+---
+
+## 1. Disease information
+
+### 1.1 Overview / definition
+* **Definition:** A 2024 systematic review defines SAA as **“an arterial dilation exceeding 50% of the normal diameter of the splenic artery.”** (rinaldi2024thedefinitiondiagnosis pages 6-7)
+* **True vs pseudoaneurysm:**
+  * **True SAA** involves dilation of the artery with (by definition) the native wall layers; the 2024 review describes progressive degradation of elastic fibers and smooth muscle cells in the wall. (rinaldi2024thedefinitiondiagnosis pages 7-9)
+  * **Splenic artery pseudoaneurysm (SAP/SAPA)** lacks at least one native wall layer and is replaced by fibrotic tissue; it is strongly linked to local arterial injury (pancreatitis/trauma/surgery/infection) and has substantially higher rupture risk. (rinaldi2024thedefinitiondiagnosis pages 7-9, chaer2020thesocietyfor pages 12-13)
+
+### 1.2 Key identifiers (OMIM/Orphanet/ICD/MeSH/MONDO)
+* **Data gap in retrieved corpus:** The provided full-text/guideline excerpts did **not** include explicit OMIM/Orphanet/MeSH/ICD-10/ICD-11/MONDO identifiers. This report therefore **cannot** cite authoritative codes from the current evidence set.
+
+### 1.3 Synonyms / alternative names
+* Splenic artery aneurysm; SAA; true splenic artery aneurysm. (rinaldi2024thedefinitiondiagnosis pages 1-2)
+* Splenic artery pseudoaneurysm; SAP; splenic artery false aneurysm (in some surgical literature). (rinaldi2024thedefinitiondiagnosis pages 7-9, chaer2020thesocietyfor pages 13-15)
+* **“Giant” SAA/SAP:** often defined as ≥5 cm (most common), sometimes >10 cm. (rinaldi2024thedefinitiondiagnosis pages 4-6, rinaldi2024thedefinitiondiagnosis pages 7-9)
+
+### 1.4 Evidence provenance (individual patients vs aggregated resources)
+Most available evidence for SAA derives from **aggregated disease-level sources** such as guidelines, systematic reviews/meta-analyses, and retrospective series; the rarity and heterogeneity of SAA limit randomized evidence. (marone2023currentdebatesin pages 1-4, hogendoorn2014openrepairendovascular pages 4-5)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (mechanistic)
+SAA is a multifactorial vascular disease driven by arterial wall vulnerability and hemodynamic stress.
+
+* **Arterial wall degeneration and stress:** An older but influential review attributes SAA formation to degenerative and dysplastic processes (e.g., atherosclerosis/calcification, fibromuscular dysplasia, cystic medial degeneration, myxoid degeneration) coupled with turbulent flow and mechanical injury. (dave2000splenicarteryaneurysm pages 4-5)
+* **Portal hypertension/hyperdynamic flow:** Portal hypertension creates a “splenic hyperkinetic state” with increased splenic artery flow and diameter; Kóbori et al. link hyperkinetic flow to increased diameter and wall tension “according to the law of Laplace.” (dave2000splenicarteryaneurysm pages 4-5, kobori1997splenicarteryaneurysms pages 3-4)
+* **Pregnancy-related hormonal and structural changes:** Increased estrogen/progesterone/relaxin (and other pregnancy-associated hormonal factors) are linked to structural weakening (e.g., fragmentation of internal elastic lamina, subendothelial thickening) plus increased third-trimester blood pressure. (rinaldi2024thedefinitiondiagnosis pages 7-9, dave2000splenicarteryaneurysm pages 4-5)
+* **Pseudoaneurysm mechanism:** Pseudoaneurysms are mainly due to **focal wall disruption** from pancreatitis/pseudocysts, trauma, surgery, or infection. (rinaldi2024thedefinitiondiagnosis pages 7-9, uy2017vasculardiseasesof pages 4-5)
+* **Segmental arterial mediolysis (SAM):** A noninflammatory arteriopathy in which “segmental lysis of the tunica media” and smooth muscle loss produce dissecting hematomas and aneurysmal dilatation; portal hypertension may amplify inflow into a pre-existing SAM lesion, precipitating rupture. (lohr2013rapidprogressionof pages 2-3, imai2005berrysplenicartery pages 4-5)
+
+### 2.2 Risk factors (clinical associations)
+* **Portal hypertension / cirrhosis / liver transplantation:** consistently associated with higher prevalence and is treated as a high-risk context in guidelines. (chaer2020thesocietyfor pages 12-13, kobori1997splenicarteryaneurysms pages 2-3, kaya2016prevalenceandpredictive pages 1-2)
+* **Pregnancy and multiparity:** pregnancy is a major rupture-risk setting and drives recommendations to treat all true SAAs in women of childbearing age. (chaer2020thesocietyfor pages 12-13, obara2020currentmanagementstrategies pages 5-7)
+* **Pancreatitis / trauma / surgery / infection:** particularly for pseudoaneurysm formation. (rinaldi2024thedefinitiondiagnosis pages 7-9, rinaldi2024thedefinitiondiagnosis pages 9-10)
+* **Nonatherosclerotic etiologies (e.g., SAM):** guideline excerpts list nondegenerative etiologies as reasons for earlier treatment. (chaer2020thesocietyfor pages 13-15)
+
+### 2.3 Protective factors
+* **Data gap:** No protective genetic variants or environmental protective factors were identified in the retrieved evidence. One 2024 guideline excerpt notes debate on whether **arterial wall calcification** is protective, but does not resolve it with quantitative evidence in the excerpt. (pratesi2024guidelinesonthe pages 51-53)
+
+### 2.4 Gene–environment interactions
+* **Data gap:** No gene–environment interaction studies were present in the retrieved corpus.
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotypes (with suggested HPO terms)
+**A. Asymptomatic/incidental detection (common in non-giant SAAs)**
+* Older review: **80–95%** asymptomatic and incidentally found. (dave2000splenicarteryaneurysm pages 4-5)
+* Giant series differs: only **17.07%** asymptomatic. (rinaldi2024thedefinitiondiagnosis pages 4-6)
+* **Suggested HPO:** *Asymptomatic* (HP:0000007).
+
+**B. Abdominal pain (most common symptom in giant lesions)**
+* Giant pooled review: pain in **59.76%** (left upper quadrant/epigastric common). (rinaldi2024thedefinitiondiagnosis pages 4-6)
+* **Suggested HPO:** *Abdominal pain* (HP:0002027); *Left upper quadrant abdominal pain* (HP:0025404, if used);
+
+**C. Palpable abdominal mass (giant lesions)**
+* Giant pooled review: palpable mass **28.05%**. (rinaldi2024thedefinitiondiagnosis pages 4-6)
+* **Suggested HPO:** *Abdominal mass* (HP:0003270).
+
+**D. Rupture phenotype: hemorrhage and shock**
+* Ruptured SAA commonly presents with severe abdominal pain, hypotension/hemorrhagic shock, anemia/coagulopathy; emergent CTA used for diagnosis. (rinaldi2023endovascularandopen pages 1-3)
+* **Suggested HPO:** *Hemorrhagic shock* (HP:0001919); *Hypotension* (HP:0002615); *Anemia* (HP:0001903).
+
+### 3.2 Temporal phenotype notes
+* Rupture in pregnancy is most often in **third trimester/postpartum** in classic series and referenced guideline summaries. (dave2000splenicarteryaneurysm pages 4-5, chaer2020thesocietyfor pages 12-13)
+
+### 3.3 Quality of life impact
+* Direct QoL instrument data (SF-36/EQ-5D/PROMIS) were not identified in the retrieved sources. Impact is inferred from symptom burden (pain) and catastrophic rupture consequences. (rinaldi2023endovascularandopen pages 1-3, rinaldi2024thedefinitiondiagnosis pages 4-6)
+
+---
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes / pathogenic variants
+* **Not established for isolated SAA in this evidence set.** The retrieved literature emphasizes **acquired hemodynamic/hormonal factors** and **arteriopathies** (e.g., SAM) rather than monogenic causation. (rinaldi2024thedefinitiondiagnosis pages 7-9, lohr2013rapidprogressionof pages 2-3)
+
+### 4.2 Syndromic/associative conditions (non-exhaustive, from retrieved evidence)
+Kaya et al. list associated conditions including **collagen vascular disease**, **arteritis**, **medial fibrodysplasia**, and **alpha-1 antitrypsin deficiency**, but do not provide gene/variant-level data in the excerpt. (kaya2016prevalenceandpredictive pages 5-6)
+
+### 4.3 Epigenetics / omics
+* **Data gap:** No epigenomic, transcriptomic, proteomic, or metabolomic signatures were identified in the retrieved corpus.
+
+---
+
+## 5. Environmental information
+
+### 5.1 Environmental, lifestyle, occupational
+* **Not specifically characterized** for SAA in the retrieved evidence.
+
+### 5.2 Infectious agents
+* Infection is cited as a potential cause of pseudoaneurysm via arterial wall injury in the 2024 systematic review (as part of SAP etiology), but no organism-specific data are provided. (rinaldi2024thedefinitiondiagnosis pages 7-9)
+
+---
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Mechanistic causal chains (upstream → downstream)
+
+**A. Portal hypertension-associated true SAA**
+1. Chronic liver disease → portal hypertension → hyperdynamic splanchnic circulation and increased splenic venous flow (“splenic hyperkinetic state”). (dave2000splenicarteryaneurysm pages 4-5)
+2. Hyperkinetic splenic arterial flow increases arterial diameter and wall tension (Laplace law) → progressive wall degeneration → aneurysm formation and increased rupture susceptibility. (kobori1997splenicarteryaneurysms pages 3-4, dave2000splenicarteryaneurysm pages 4-5)
+3. Clinical manifestation: incidental aneurysm or rupture with hemoperitoneum/shock. (dave2000splenicarteryaneurysm pages 4-5, rinaldi2023endovascularandopen pages 1-3)
+
+**B. Pregnancy-associated SAA rupture risk**
+1. Pregnancy → elevated estrogen/progesterone/relaxin and other hormonal mediators → structural weakening (fragmented internal elastic lamina, subendothelial thickening) and altered elastin integrity. (rinaldi2024thedefinitiondiagnosis pages 7-9, dave2000splenicarteryaneurysm pages 4-5)
+2. Concurrent late-pregnancy hemodynamic stress (increased blood volume/cardiac output, increased BP) → increased wall stress → rupture risk. (rinaldi2024thedefinitiondiagnosis pages 7-9)
+
+**C. Pancreatitis-associated splenic artery pseudoaneurysm (SAP)**
+1. Acute/chronic pancreatitis or pseudocyst → enzymatic/inflammatory injury to arterial wall or focal disruption → pseudoaneurysm formation. (rinaldi2024thedefinitiondiagnosis pages 7-9, uy2017vasculardiseasesof pages 4-5)
+2. Clinical manifestation: hemorrhage, GI bleeding (e.g., hemosuccus pancreaticus), hemodynamic instability. (obara2020currentmanagementstrategies pages 5-7)
+
+**D. Segmental arterial mediolysis (SAM) leading to SAA**
+1. SAM: segmental medial lysis with smooth muscle loss → gaps/dissecting hematoma → aneurysmal dilation. (lohr2013rapidprogressionof pages 2-3)
+2. Superimposed hemodynamic stress (BP surges; portal hypertension increasing inflow) → expansion/rupture. (lohr2013rapidprogressionof pages 2-3, imai2005berrysplenicartery pages 4-5)
+
+### 6.2 Suggested ontology terms
+* **GO biological processes (suggested):** *blood vessel remodeling*; *extracellular matrix organization*; *elastic fiber assembly*; *response to mechanical stimulus*; *smooth muscle cell apoptosis*; *inflammatory response* (for pseudoaneurysm etiologies). (rinaldi2024thedefinitiondiagnosis pages 7-9, dave2000splenicarteryaneurysm pages 4-5)
+* **Cell types (suggested CL terms):** vascular smooth muscle cell; endothelial cell; fibroblast; macrophage (for pancreatitis/injury context). (rinaldi2024thedefinitiondiagnosis pages 7-9, lohr2013rapidprogressionof pages 2-3)
+
+---
+
+## 7. Anatomical structures affected
+
+### 7.1 Primary anatomy (with suggested UBERON terms)
+* **Splenic artery** (primary affected structure). Suggested UBERON: *splenic artery* (UBERON:0001621).
+* **Spleen**: downstream ischemia/infarction risk after embolization or distal ligation. Suggested UBERON: *spleen* (UBERON:0002106). (chaer2020thesocietyfor pages 13-15)
+* **Portal venous system** in portal hypertension context; splenic vein enlargement predicts SAA in cirrhosis. Suggested UBERON: *splenic vein* (UBERON:0001615), *portal vein* (UBERON:0001633). (kaya2016prevalenceandpredictive pages 1-2)
+* **Pancreas**: pseudoaneurysm etiologies (pancreatitis), potential erosion/bleeding into pancreatic duct. Suggested UBERON: *pancreas* (UBERON:0001264). (obara2020currentmanagementstrategies pages 5-7, dave2000splenicarteryaneurysm pages 4-5)
+
+### 7.2 Tissue/cell and subcellular
+* Primary pathology involves arterial wall layers (intima/media/adventitia), with elastic lamina disruption and smooth muscle cell injury in some pathologic descriptions. (imai2005berrysplenicartery pages 4-5, rinaldi2024thedefinitiondiagnosis pages 7-9)
+
+---
+
+## 8. Temporal development
+
+### 8.1 Onset
+* Typically **adult-onset** and often detected incidentally due to imaging. (dave2000splenicarteryaneurysm pages 4-5, chaer2020thesocietyfor pages 12-13)
+
+### 8.2 Progression
+* Many small, stable true SAAs show minimal growth in observed cohorts; SVS excerpt summarizes mean observed size ~2.1 cm with mean follow-up 75 months in a nonoperative Mayo Clinic series. (chaer2020thesocietyfor pages 12-13)
+
+### 8.3 Critical periods
+* **Pregnancy (3rd trimester/postpartum)** is a critical risk window for rupture. (dave2000splenicarteryaneurysm pages 4-5, chaer2020thesocietyfor pages 12-13)
+
+---
+
+## 9. Inheritance and population
+
+### 9.1 Epidemiology (general population)
+* Incidence estimates vary by ascertainment method: **0.09%** (autopsy) and **0.78%** (angiographic) in a 2024 review excerpt. (rinaldi2024thedefinitiondiagnosis pages 7-9)
+* Sticco et al. cite overall incidence **<0.8%**. (sticco2016acomparisonof pages 1-2)
+
+### 9.2 Portal hypertension / cirrhosis / transplant populations
+* **Liver transplant candidates/recipients:** Kóbori et al. (1997) found SAA in **45/337 (13%)** liver transplant patients; incidence **16%** among those with portal hypertension and **0%** without portal hypertension (p<0.001), with higher incidence in adults (17%) vs children (4%). (kobori1997splenicarteryaneurysms pages 2-3)
+* **Cirrhosis cohort:** Kaya et al. (2016) found SAA in **27/171 (15.7%)** cirrhosis patients on four-phase CT; most were distal (74%), solitary (88.8%), and small (mean diameter 11.66 mm). (kaya2016prevalenceandpredictive pages 1-2)
+
+### 9.3 Sex ratio / age distribution
+* Classic SAA reported female predominance (about 4:1) and association with multiparity; giant SAA systematic review shows near-equal sex distribution. (obara2020currentmanagementstrategies pages 5-7, rinaldi2024thedefinitiondiagnosis pages 1-2)
+
+### 9.4 Inheritance
+* No Mendelian inheritance pattern is supported by the retrieved evidence for isolated SAA.
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Imaging (core diagnostic modality)
+**SVS 2020 (key points from excerpt):**
+* **CTA** recommended as initial diagnostic tool for SAA (thin sections if available). (chaer2020thesocietyfor pages 12-13)
+* **MRA** recommended when iodinated contrast is contraindicated; **arteriography** reserved for unclear noninvasive results or when planning endovascular therapy. (chaer2020thesocietyfor pages 12-13)
+* Ultrasound has **poor sensitivity for SAA <3 cm** in SVS excerpt. (chaer2020thesocietyfor pages 12-13)
+
+**Giant SAA/SAP imaging patterns (2024 systematic review):** CT used in **80.49%**, angiography in **54.88%**, EcoColorDoppler in **45.12%**, MRI rarely (3.66%). (rinaldi2024thedefinitiondiagnosis pages 4-6)
+
+### 10.2 Laboratory / biomarkers
+* No specific laboratory biomarkers for diagnosis were identified in the retrieved corpus.
+
+### 10.3 Differential diagnosis
+* Not systematically enumerated in the retrieved excerpts; pseudoaneurysm vs true aneurysm distinction is clinically crucial because pseudoaneurysm rupture risk is much higher. (chaer2020thesocietyfor pages 13-15)
+
+### 10.4 Screening
+* SVS and related excerpts highlight special high-risk groups (women of childbearing age; portal hypertension/liver transplant candidates), but no population screening program is described in the retrieved evidence. (chaer2020thesocietyfor pages 12-13, chaer2020thesocietyfor pages 13-15)
+
+---
+
+## 11. Outcome / prognosis
+
+### 11.1 Natural history and rupture outcomes
+* True SAA rupture risk is often cited around **2–3%**; older and review sources note varying estimates and emphasize risk concentration in pregnancy and portal hypertension contexts. (rinaldi2024thedefinitiondiagnosis pages 7-9, dave2000splenicarteryaneurysm pages 4-5)
+* Ruptured SAA mortality in SVS excerpt: overall mortality up to **~25%**. (chaer2020thesocietyfor pages 12-13)
+
+### 11.2 Pregnancy-related prognosis
+* Pregnancy rupture contributes disproportionately (SVS excerpt: **20–50%** of ruptures) and carries extremely high maternal/fetal mortality (e.g., maternal ~80%, fetal ~90% in SVS excerpt; similar ranges across reviews). (chaer2020thesocietyfor pages 12-13, dave2000splenicarteryaneurysm pages 4-5)
+
+### 11.3 Prognostic factors
+* High-risk contexts: pregnancy, portal hypertension/liver transplantation, pseudoaneurysm etiology, aneurysm growth. (chaer2020thesocietyfor pages 12-13, chaer2020thesocietyfor pages 13-15)
+
+---
+
+## 12. Treatment
+
+### 12.1 Guideline-driven treatment thresholds (expert consensus)
+
+**SVS 2020 (Journal of Vascular Surgery; published Jul 2020; DOI: 10.1016/j.jvs.2020.01.039):**
+* Treat **ruptured SAA** emergently. (chaer2020thesocietyfor pages 12-13)
+* Treat **splenic artery pseudoaneurysms of any size** (high rupture risk). (chaer2020thesocietyfor pages 12-13)
+* Treat **all true SAAs in women of childbearing age regardless of size**. (chaer2020thesocietyfor pages 12-13)
+* Treat true SAAs **≥3 cm**, those with **growth**, or those that are **symptomatic**. (chaer2020thesocietyfor pages 12-13)
+* Observation suggested for small (<3 cm), stable, asymptomatic true SAAs or patients with limited life expectancy. (chaer2020thesocietyfor pages 12-13)
+
+**CIRSE Standards of Practice (Cardiovascular and Interventional Radiology; Nov 2024; DOI: 10.1007/s00270-023-03620-w):**
+* Treat any symptomatic VAA/VAPA; treat **SAA ≥2 cm** (particularly saccular/distal/favorable anatomy); treat lesions growing **≥0.5 cm/year**; treat VAPAs regardless of symptoms; treat asymptomatic VAAs in women of child-bearing age. (rossi2024cirsestandardsof pages 1-3)
+* Post-endovascular surveillance suggested with CTA/MRA at **3 months, 12 months, then yearly**. (rossi2024cirsestandardsof pages 1-3)
+
+**Guideline-collision commentary (May 2023; DOI: 10.3390/jcm12093267):**
+* Notes discrepancies across ESVS vs SVS thresholds (e.g., SVS 3 cm threshold for SAA) and differences in surveillance intervals (SVS annual imaging vs ESVS every 2–3 years for small asymptomatic aneurysms). (marone2023currentdebatesin pages 1-4)
+
+### 12.2 Endovascular treatment (current applications / real-world implementation)
+* SVS and CIRSE emphasize endovascular-first where anatomy allows (coil embolization, parent vessel sacrifice vs preservation strategies, stent-grafts). (chaer2020thesocietyfor pages 13-15, rossi2024cirsestandardsof pages 1-3)
+* Meta-analysis evidence (Hogendoorn 2014; J Vasc Surg; Dec 2014; DOI: 10.1016/j.jvs.2014.08.067):
+  * OPEN vs EV: **30-day mortality 5.1% vs 0.6% (P<.001)**; hospital stay **9.8 vs 2.0 days**. (hogendoorn2014openrepairendovascular pages 4-5)
+  * EV has more minor complications (post-embolization syndrome treated as minor; ~25.1% in the meta-analysis) and higher reinterventions per year (**3.2%/yr EV vs 0.5%/yr open**). (hogendoorn2014openrepairendovascular pages 4-5, hogendoorn2014openrepairendovascular pages 8-9)
+* Comparative US inpatient data (Sticco 2016; DOI: 10.1177/1708538115613703) show lower perioperative morbidity and shorter LOS with endovascular repair with similar in-hospital mortality. (sticco2016acomparisonof pages 1-2)
+
+**MAXO suggestions (non-exhaustive):**
+* Endovascular embolization procedure; stent-graft placement; aneurysm repair (endovascular). (chaer2020thesocietyfor pages 13-15, rossi2024cirsestandardsof pages 1-3)
+
+### 12.3 Open surgery
+* Remains essential for rupture, hemodynamic instability, pregnancy-associated rupture, and distal/hilar anatomy. (chaer2020thesocietyfor pages 13-15, rinaldi2023endovascularandopen pages 1-3)
+
+**MAXO suggestions:**
+* Aneurysmectomy; arterial ligation; splenectomy; distal pancreatectomy (for select hilar lesions). (rinaldi2024thedefinitiondiagnosis pages 6-7, chaer2020thesocietyfor pages 13-15)
+
+### 12.4 Treatment outcomes in ruptured SAA
+* Systematic review (J Clin Med; Sep 2023; DOI: 10.3390/jcm12186085): 129 studies/350 patients; overall mortality **10.6%**; **12.9% open vs 7.8% EVT (p=0.84)**; reinterventions **22.4%** after EVT vs **1.6%** after open repair. (rinaldi2023endovascularandopen pages 1-3)
+
+---
+
+## 13. Prevention
+
+### 13.1 Primary prevention
+* No established primary prevention interventions were identified in the retrieved evidence; prevention focuses on risk recognition (pregnancy/portal hypertension) and addressing modifiable contributors to pancreatitis/trauma when applicable.
+
+### 13.2 Secondary prevention (surveillance)
+* Surveillance practices vary by guideline; CIRSE suggests CTA/MRA at 3 months, 12 months, then yearly post-EVT. (rossi2024cirsestandardsof pages 1-3)
+* SVS vs ESVS surveillance intervals for small asymptomatic lesions differ (annual vs q2–3 years). (marone2023currentdebatesin pages 1-4)
+
+---
+
+## 14. Other species / natural disease
+* **Data gap:** No veterinary or non-human natural disease evidence was identified in the retrieved corpus.
+
+---
+
+## 15. Model organisms
+* **Data gap:** No model organism systems specific to SAA were identified in the retrieved corpus.
+
+---
+
+## Recent developments and expert analysis (2023–2024 emphasis)
+
+1. **Guideline harmonization and persistent evidence gaps (2023):** A 2023 expert commentary highlights how rarity and heterogeneity impede high-level evidence and lead to threshold/surveillance disagreements across SVS vs ESVS, emphasizing the need for careful individualized decision-making. (marone2023currentdebatesin pages 1-4)
+2. **Endovascular standardization (2024):** CIRSE’s 2024 standards codify endovascular indications, device options, and structured post-procedure surveillance schedules, reflecting the central role of interventional radiology in contemporary care. (rossi2024cirsestandardsof pages 1-3)
+3. **Refined characterization of giant SAA/SAP (2024):** The 2024 systematic review quantifies presentation patterns, imaging choices (CT predominance), and comparative LOS/complication rates across open/endovascular/hybrid approaches for giant lesions, while underscoring inconsistent “giant” definitions. (rinaldi2024thedefinitiondiagnosis pages 1-2, rinaldi2024thedefinitiondiagnosis pages 4-6)
+
+---
+
+## Clinical trials / research in progress
+
+* **NCT07053605 (ClinicalTrials.gov; first posted 2025-07-08; recruiting):** single-group interventional study of **laparoscopic resection of SAA with spleen preservation**; estimated enrollment 10; start 2025-06-23; primary completion 2027-06-30; primary outcomes emphasize immune function markers (C3/C4, immunoglobulins, lymphocyte subsets) across follow-up timepoints. URL: https://clinicaltrials.gov/study/NCT07053605 (NCT07053605 chunk 1)
+* **NCT01387828 (ClinicalTrials.gov; posted 2011; completed):** randomized parallel trial comparing open vs laparoscopic splenic aneurysm repair; enrollment 29; start Jan 2001; completion Apr 2011; primary outcome postoperative morbidity (Dindo–Clavien). URL: https://clinicaltrials.gov/study/NCT01387828 (NCT01387828 chunk 1)
+
+---
+
+## Key limitations of this report (evidence availability)
+* Formal **MeSH/ICD/ICD-11/MONDO/OMIM/Orphanet identifiers** were not present in the retrieved full-text excerpts; therefore, codes are not provided with citations.
+* **Genetic variant-level evidence**, multi-omics profiling, model organism data, and validated QoL metrics were not found in the retrieved evidence set; the literature here is predominantly clinical and procedural.
+* The report necessarily integrates older landmark sources (e.g., 1997–2000) for portal-hypertension/pregnancy epidemiology because those specific quantitative observations are widely cited and remain foundational; they are contextualized by 2020–2024 guideline syntheses.
+
+
+References
+
+1. (chaer2020thesocietyfor pages 12-13): Rabih A. Chaer, Christopher J. Abularrage, Dawn M. Coleman, Mohammad H. Eslami, Vikram S. Kashyap, Caron Rockman, and M. Hassan Murad. The society for vascular surgery clinical practice guidelines on the management of visceral aneurysms. Journal of Vascular Surgery, 72:3S-39S, Jul 2020. URL: https://doi.org/10.1016/j.jvs.2020.01.039, doi:10.1016/j.jvs.2020.01.039. This article has 660 citations and is from a domain leading peer-reviewed journal.
+
+2. (chaer2020thesocietyfor pages 13-15): Rabih A. Chaer, Christopher J. Abularrage, Dawn M. Coleman, Mohammad H. Eslami, Vikram S. Kashyap, Caron Rockman, and M. Hassan Murad. The society for vascular surgery clinical practice guidelines on the management of visceral aneurysms. Journal of Vascular Surgery, 72:3S-39S, Jul 2020. URL: https://doi.org/10.1016/j.jvs.2020.01.039, doi:10.1016/j.jvs.2020.01.039. This article has 660 citations and is from a domain leading peer-reviewed journal.
+
+3. (rossi2024cirsestandardsof pages 1-3): Michele Rossi, Miltiadis Krokidis, Elika Kashef, Bora Peynircioglu, and Marcello Andrea Tipaldi. Cirse standards of practice for the endovascular treatment of visceral and renal artery aneurysms and pseudoaneurysms. Cardiovascular and Interventional Radiology, 47:26-35, Nov 2024. URL: https://doi.org/10.1007/s00270-023-03620-w, doi:10.1007/s00270-023-03620-w. This article has 50 citations and is from a peer-reviewed journal.
+
+4. (hogendoorn2014openrepairendovascular pages 4-5): Wouter Hogendoorn, Anthi Lavida, M.G. Myriam Hunink, Frans L. Moll, George Geroulakos, Bart E. Muhs, and Bauer E. Sumpio. Open repair, endovascular repair, and conservative management of true splenic artery aneurysms. Journal of vascular surgery, 60 6:1667-76.e1, Dec 2014. URL: https://doi.org/10.1016/j.jvs.2014.08.067, doi:10.1016/j.jvs.2014.08.067. This article has 164 citations and is from a domain leading peer-reviewed journal.
+
+5. (rinaldi2023endovascularandopen pages 1-3): Luigi Federico Rinaldi, Chiara Brioschi, and Enrico Maria Marone. Endovascular and open surgical treatment of ruptured splenic artery aneurysms: a case report and a systematic literature review. Journal of Clinical Medicine, 12:6085, Sep 2023. URL: https://doi.org/10.3390/jcm12186085, doi:10.3390/jcm12186085. This article has 13 citations.
+
+6. (rinaldi2024thedefinitiondiagnosis pages 1-2): Valerio Rinaldi, Giulio Illuminati, Roberto Caronna, Giampaolo Prezioso, Piergaspare Palumbo, Paolina Saullo, Vito D’Andrea, and Priscilla Nardi. The definition, diagnosis, and management of giant splenic artery aneurysms and pseudoaneurysms: a systematic review. Journal of Clinical Medicine, 13:5793, Sep 2024. URL: https://doi.org/10.3390/jcm13195793, doi:10.3390/jcm13195793. This article has 9 citations.
+
+7. (rinaldi2024thedefinitiondiagnosis pages 4-6): Valerio Rinaldi, Giulio Illuminati, Roberto Caronna, Giampaolo Prezioso, Piergaspare Palumbo, Paolina Saullo, Vito D’Andrea, and Priscilla Nardi. The definition, diagnosis, and management of giant splenic artery aneurysms and pseudoaneurysms: a systematic review. Journal of Clinical Medicine, 13:5793, Sep 2024. URL: https://doi.org/10.3390/jcm13195793, doi:10.3390/jcm13195793. This article has 9 citations.
+
+8. (rinaldi2024thedefinitiondiagnosis pages 7-9): Valerio Rinaldi, Giulio Illuminati, Roberto Caronna, Giampaolo Prezioso, Piergaspare Palumbo, Paolina Saullo, Vito D’Andrea, and Priscilla Nardi. The definition, diagnosis, and management of giant splenic artery aneurysms and pseudoaneurysms: a systematic review. Journal of Clinical Medicine, 13:5793, Sep 2024. URL: https://doi.org/10.3390/jcm13195793, doi:10.3390/jcm13195793. This article has 9 citations.
+
+9. (sticco2016acomparisonof pages 1-2): Andrew Sticco, Alok Aggarwal, Michael D Shapiro, Abimbola Pratt, Donald Rissuci, and Marcus D'ayala. A comparison of open and endovascular treatment strategies for the management of splenic artery aneurysms. Vascular, 24:487-491, Jul 2016. URL: https://doi.org/10.1177/1708538115613703, doi:10.1177/1708538115613703. This article has 17 citations and is from a peer-reviewed journal.
+
+10. (obara2020currentmanagementstrategies pages 5-7): Hideaki Obara, Matsubara Kentaro, Masanori Inoue, and Yuko Kitagawa. Current management strategies for visceral artery aneurysms: an overview. Surgery Today, 50:38-49, Oct 2020. URL: https://doi.org/10.1007/s00595-019-01898-3, doi:10.1007/s00595-019-01898-3. This article has 123 citations and is from a peer-reviewed journal.
+
+11. (dave2000splenicarteryaneurysm pages 4-5): Sandeep P. Dave, Ernane D. Reis, Azhar Hossain, Peter J. Taub, Morris D. Kerstein, and Larry H. Hollier. Splenic artery aneurysm in the 1990s. Annals of Vascular Surgery, 14:223-229, May 2000. URL: https://doi.org/10.1007/s100169910039, doi:10.1007/s100169910039. This article has 229 citations and is from a peer-reviewed journal.
+
+12. (pratesi2024guidelinesonthe pages 51-53): C Pratesi, D Esposito, R Martini, and C Novali. Guidelines on the diagnosis, treatment and management of visceral and renal arteries aneurysms: a joint assessment by the italian societies of vascular and …. Unknown journal, 2024.
+
+13. (rinaldi2024thedefinitiondiagnosis pages 9-10): Valerio Rinaldi, Giulio Illuminati, Roberto Caronna, Giampaolo Prezioso, Piergaspare Palumbo, Paolina Saullo, Vito D’Andrea, and Priscilla Nardi. The definition, diagnosis, and management of giant splenic artery aneurysms and pseudoaneurysms: a systematic review. Journal of Clinical Medicine, 13:5793, Sep 2024. URL: https://doi.org/10.3390/jcm13195793, doi:10.3390/jcm13195793. This article has 9 citations.
+
+14. (rinaldi2024thedefinitiondiagnosis pages 6-7): Valerio Rinaldi, Giulio Illuminati, Roberto Caronna, Giampaolo Prezioso, Piergaspare Palumbo, Paolina Saullo, Vito D’Andrea, and Priscilla Nardi. The definition, diagnosis, and management of giant splenic artery aneurysms and pseudoaneurysms: a systematic review. Journal of Clinical Medicine, 13:5793, Sep 2024. URL: https://doi.org/10.3390/jcm13195793, doi:10.3390/jcm13195793. This article has 9 citations.
+
+15. (marone2023currentdebatesin pages 1-4): Enrico Maria Marone and Luigi Federico Rinaldi. Current debates in the management of visceral artery aneurysms: where the guidelines collide. Journal of Clinical Medicine, 12:3267, May 2023. URL: https://doi.org/10.3390/jcm12093267, doi:10.3390/jcm12093267. This article has 7 citations.
+
+16. (kobori1997splenicarteryaneurysms pages 3-4): László Kóbori, Marjan J. van der Kolk, Koert P. de Jong, Paul M.J.G. Peeters, Ids J. Klompmaker, Theo Kok, Elizabeth B. Haagsma, and Maarten J.H. Slooff. Splenic artery aneurysms in liver transplant patients. Journal of Hepatology, 27:890-893, Nov 1997. URL: https://doi.org/10.1016/s0168-8278(97)80327-3, doi:10.1016/s0168-8278(97)80327-3. This article has 68 citations and is from a highest quality peer-reviewed journal.
+
+17. (uy2017vasculardiseasesof pages 4-5): Pearl Princess D. Uy, Denise Marie Francisco, Anshu Trivedi, Michael O’Loughlin, and George Y. Wu. Vascular diseases of the spleen: a review. Journal of Clinical and Translational Hepatology, 5:152-164, Mar 2017. URL: https://doi.org/10.14218/jcth.2016.00062, doi:10.14218/jcth.2016.00062. This article has 67 citations.
+
+18. (lohr2013rapidprogressionof pages 2-3): J.-Matthias Löhr, Dietmar Dinter, Steffen J. Diehl, Stephan L. Haas, Mira Veeser, Roland Pfützer, Jürgen Retter, Stefan O. Schönberg, Christoph Düber, Volker Keim, Dirk Schadendorf, and Heiko Witt. Rapid progression of a splenic aneurysm due to segmental arterial mediolysis: a rare cause of acute pancreatitis. Pancreatology : official journal of the International Association of Pancreatology (IAP) ... [et al.], 13 5:553-6, Sep 2013. URL: https://doi.org/10.1016/j.pan.2013.06.001, doi:10.1016/j.pan.2013.06.001. This article has 5 citations.
+
+19. (imai2005berrysplenicartery pages 4-5): Miwa Akasofu Imai, Ei Kawahara, Shogo Katsuda, and Tatsuya Yamashita. Berry splenic artery aneurysm rupture in association with segmental arterial mediolysis and portal hypertension. Pathology International, 55:290-295, May 2005. URL: https://doi.org/10.1111/j.1440-1827.2005.01827.x, doi:10.1111/j.1440-1827.2005.01827.x. This article has 16 citations and is from a peer-reviewed journal.
+
+20. (kobori1997splenicarteryaneurysms pages 2-3): László Kóbori, Marjan J. van der Kolk, Koert P. de Jong, Paul M.J.G. Peeters, Ids J. Klompmaker, Theo Kok, Elizabeth B. Haagsma, and Maarten J.H. Slooff. Splenic artery aneurysms in liver transplant patients. Journal of Hepatology, 27:890-893, Nov 1997. URL: https://doi.org/10.1016/s0168-8278(97)80327-3, doi:10.1016/s0168-8278(97)80327-3. This article has 68 citations and is from a highest quality peer-reviewed journal.
+
+21. (kaya2016prevalenceandpredictive pages 1-2): Muhsin Kaya, Şengül Baran, Cemil Güya, and Mehmet Ali Kaplan. Prevalence and predictive factors for development of splenic artery aneurysms in cirrhosis. Indian Journal of Gastroenterology, 35:201-206, Jun 2016. URL: https://doi.org/10.1007/s12664-016-0670-z, doi:10.1007/s12664-016-0670-z. This article has 21 citations and is from a peer-reviewed journal.
+
+22. (kaya2016prevalenceandpredictive pages 5-6): Muhsin Kaya, Şengül Baran, Cemil Güya, and Mehmet Ali Kaplan. Prevalence and predictive factors for development of splenic artery aneurysms in cirrhosis. Indian Journal of Gastroenterology, 35:201-206, Jun 2016. URL: https://doi.org/10.1007/s12664-016-0670-z, doi:10.1007/s12664-016-0670-z. This article has 21 citations and is from a peer-reviewed journal.
+
+23. (hogendoorn2014openrepairendovascular pages 8-9): Wouter Hogendoorn, Anthi Lavida, M.G. Myriam Hunink, Frans L. Moll, George Geroulakos, Bart E. Muhs, and Bauer E. Sumpio. Open repair, endovascular repair, and conservative management of true splenic artery aneurysms. Journal of vascular surgery, 60 6:1667-76.e1, Dec 2014. URL: https://doi.org/10.1016/j.jvs.2014.08.067, doi:10.1016/j.jvs.2014.08.067. This article has 164 citations and is from a domain leading peer-reviewed journal.
+
+24. (NCT07053605 chunk 1): Guo-Qing Jiang. Clinical Study on Laparoscopic Resection of Splenic Artery Aneurysm With Preservation of Spleen. Northern Jiangsu People's Hospital. 2025. ClinicalTrials.gov Identifier: NCT07053605
+
+25. (NCT01387828 chunk 1):  Comparison Between Open and Laparoscopic Splenic Aneurysms Repair. Azienda Socio Sanitaria Territoriale degli Spedali Civili di Brescia. 2001. ClinicalTrials.gov Identifier: NCT01387828

--- a/research/Splenic_Artery_Aneurysm-deep-research-falcon.md.citations.md
+++ b/research/Splenic_Artery_Aneurysm-deep-research-falcon.md.citations.md
@@ -1,0 +1,501 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Splenic artery aneurysm
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Splenic artery aneurysm** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T15:22:42.876213
+
+1. rossi2024cirsestandardsof pages 1-3
+2. pratesi2024guidelinesonthe pages 51-53
+3. rinaldi2024thedefinitiondiagnosis pages 9-10
+4. sticco2016acomparisonof pages 1-2
+5. rinaldi2023endovascularandopen pages 1-3
+6. rinaldi2024thedefinitiondiagnosis pages 6-7
+7. rinaldi2024thedefinitiondiagnosis pages 7-9
+8. rinaldi2024thedefinitiondiagnosis pages 1-2
+9. dave2000splenicarteryaneurysm pages 4-5
+10. chaer2020thesocietyfor pages 13-15
+11. rinaldi2024thedefinitiondiagnosis pages 4-6
+12. kaya2016prevalenceandpredictive pages 5-6
+13. obara2020currentmanagementstrategies pages 5-7
+14. lohr2013rapidprogressionof pages 2-3
+15. kaya2016prevalenceandpredictive pages 1-2
+16. chaer2020thesocietyfor pages 12-13
+17. kobori1997splenicarteryaneurysms pages 2-3
+18. marone2023currentdebatesin pages 1-4
+19. hogendoorn2014openrepairendovascular pages 4-5
+20. kobori1997splenicarteryaneurysms pages 3-4
+21. uy2017vasculardiseasesof pages 4-5
+22. imai2005berrysplenicartery pages 4-5
+23. hogendoorn2014openrepairendovascular pages 8-9
+24. et al.
+25. https://doi.org/10.3390/jcm13195793
+26. https://doi.org/10.1177/1708538115613703
+27. https://doi.org/10.1007/s00595-019-01898-3
+28. https://doi.org/10.1016/j.jvs.2020.01.039
+29. https://doi.org/10.1007/s100169910039
+30. https://doi.org/10.3390/jcm12186085
+31. https://doi.org/10.1007/s00270-023-03620-w
+32. https://doi.org/10.3390/jcm13102802
+33. https://doi.org/10.1186/s42155-024-00427-9
+34. https://doi.org/10.1007/s00423-021-02149-1
+35. https://clinicaltrials.gov/study/NCT07053605
+36. https://clinicaltrials.gov/study/NCT01387828
+37. https://doi.org/10.1016/j.jvs.2020.01.039,
+38. https://doi.org/10.1007/s00270-023-03620-w,
+39. https://doi.org/10.1016/j.jvs.2014.08.067,
+40. https://doi.org/10.3390/jcm12186085,
+41. https://doi.org/10.3390/jcm13195793,
+42. https://doi.org/10.1177/1708538115613703,
+43. https://doi.org/10.1007/s00595-019-01898-3,
+44. https://doi.org/10.1007/s100169910039,
+45. https://doi.org/10.3390/jcm12093267,
+46. https://doi.org/10.1016/s0168-8278(97
+47. https://doi.org/10.14218/jcth.2016.00062,
+48. https://doi.org/10.1016/j.pan.2013.06.001,
+49. https://doi.org/10.1111/j.1440-1827.2005.01827.x,
+50. https://doi.org/10.1007/s12664-016-0670-z,


### PR DESCRIPTION
## Summary

- Add DISMECH curation for splenic artery aneurysm (`MONDO:0001856`).
- Incorporate Falcon deep research evidence for aneurysm-wall remodeling, portal hypertension/liver transplant and pregnancy risk contexts, rupture/hemorrhage, imaging diagnosis, surveillance, and endovascular/open repair.
- Add generated PubMed and ClinicalTrials reference caches using `just fetch-reference` only.

## Validation

- `just validate kb/disorders/Splenic_Artery_Aneurysm.yaml` passed.
- `just validate-references kb/disorders/Splenic_Artery_Aneurysm.yaml` passed.
- `just check-reference-cache-frontmatter` passed.
- `just qc-deep-research --only Splenic_Artery_Aneurysm --target-providers falcon` exited 0. It reported unresolved Falcon citation keys in the provider report (`missing=16`), but the curated YAML uses fetched reference cache IDs.
- `git diff --check -- . ':!references_cache/*'` passed. Generated reference cache files contain upstream trailing whitespace from `just fetch-reference` and were not hand-edited.