### PR TITLE
Add Vertebral Artery Insufficiency curation

### DIFF
--- a/kb/disorders/Vertebral_Artery_Insufficiency.yaml
+++ b/kb/disorders/Vertebral_Artery_Insufficiency.yaml
@@ -1,0 +1,603 @@
+name: Vertebral Artery Insufficiency
+creation_date: "2026-05-06T19:00:20Z"
+updated_date: "2026-05-06T19:24:30Z"
+description: >-
+  Vertebral artery insufficiency is a posterior-circulation vascular disorder in
+  which vertebral or vertebrobasilar stenosis, occlusion, dissection, injury,
+  hypoplasia, or dynamic compression compromises perfusion or generates embolic
+  ischemia in the brainstem, cerebellar, thalamic, or occipital circulation.
+  Clinical presentations overlap with vertebrobasilar insufficiency,
+  symptomatic vertebrobasilar disease, posterior-circulation transient ischemic
+  attack, and posterior-circulation ischemic stroke.
+category: Complex
+disease_term:
+  preferred_term: vertebral artery insufficiency
+  term:
+    id: MONDO:0001631
+    label: vertebral artery insufficiency
+parents:
+- Vascular insufficiency disorder
+- Arterial disorder
+- Transient ischemic attack
+synonyms:
+- Vertebrobasilar insufficiency
+- Vertebrobasilar disease
+- Symptomatic vertebral artery stenosis
+- Vertebral artery stenosis and occlusion
+- Vertebral artery occlusive disease
+- Posterior circulation ischemia due to vertebral artery disease
+references:
+- reference: DOI:10.2174/1573403x18666220317093131
+  title: "Vertebral Artery Interventions: A Comprehensive Updated Review"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1111/j.1747-4949.2010.00528.x
+  title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke Study (Veritas): Rationale and Design"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.3389/fneur.2023.1202565
+  title: "Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1177/17474930221107500
+  title: "Treatment of posterior circulation stroke: Acute management and secondary prevention"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1161/str.0000000000000475
+  title: "2024 Guideline for the Primary Prevention of Stroke: A Guideline From the American Heart Association/American Stroke Association"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1186/s12883-023-03110-z
+  title: In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1007/s10143-024-03153-x
+  title: "Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1177/21925682231209631
+  title: A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1186/s41983-024-00893-x
+  title: "Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging's case illustration"
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: DOI:10.1161/strokeaha.115.009215
+  title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease
+  found_in:
+  - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+pathophysiology:
+- name: Atherosclerotic vertebrobasilar stenosis or occlusion
+  description: >-
+    Atherosclerotic narrowing or occlusion of extracranial or intracranial
+    vertebral and basilar arteries is a major substrate for symptomatic
+    vertebrobasilar disease. Severe stenosis or tandem vertebral-basilar disease
+    can reduce immediate downstream flow and set up later hypoperfusion or
+    thromboembolic ischemia.
+  locations:
+  - preferred_term: vertebral artery
+    term:
+      id: UBERON:0001535
+      label: vertebral artery
+  - preferred_term: basilar artery
+    term:
+      id: UBERON:0001633
+      label: basilar artery
+  evidence:
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Over one-third of ischaemic strokes occur in the posterior circulation, and a leading cause is atherosclerotic vertebrobasilar disease.
+    explanation: This identifies atherosclerotic vertebrobasilar disease as a leading posterior-circulation ischemic stroke cause.
+  - reference: PMID:25977279
+    reference_title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with recent vertebrobasilar transient ischemic attack or stroke and ≥50% atherosclerotic stenosis or occlusion in vertebral or basilar arteries (BA) were enrolled.
+    explanation: The VERiTAS cohort directly operationalized symptomatic vertebrobasilar disease as recent TIA or stroke with at least 50% vertebral or basilar atherosclerotic stenosis or occlusion.
+  - reference: PMID:25977279
+    reference_title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A relative threshold effect was evident, with flows dropping most significantly with ≥80% stenosis/occlusion (P<0.05).
+    explanation: This supports severe stenosis or occlusion as a flow-limiting event in vertebrobasilar disease.
+  downstream:
+  - target: Posterior circulation hypoperfusion
+    description: Severe vertebrobasilar stenosis or occlusion can reduce distal posterior-circulation flow.
+  - target: Vertebrobasilar thromboembolism
+    description: Atherosclerotic plaque and low-flow states can contribute to local thrombus formation and distal embolic events.
+- name: Posterior circulation hypoperfusion
+  description: >-
+    Low vertebrobasilar flow can impair perfusion reserve in posterior
+    circulation territories. Quantitative magnetic resonance angiography (QMRA)
+    is used in VERiTAS-style assessments to distinguish low from normal distal
+    flow and to evaluate risk beyond anatomic stenosis alone.
+  locations:
+  - preferred_term: brainstem
+    term:
+      id: UBERON:0002298
+      label: brainstem
+  - preferred_term: cerebellum
+    term:
+      id: UBERON:0002037
+      label: cerebellum
+  - preferred_term: occipital lobe
+    term:
+      id: UBERON:0002021
+      label: occipital lobe
+  evidence:
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Preliminary studies indicate that stroke risk in vertebrobasilar disease is strongly related to haemodynamic compromise, which can be measured noninvasively using quantitative magnetic resonance angiography.
+    explanation: This supports hemodynamic compromise as an upstream risk mechanism measurable with QMRA.
+  - reference: PMID:25977279
+    reference_title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Flow in stenotic posterior circulation vessels correlates with residual diameter and drops significantly with tandem disease.
+    explanation: This directly supports reduced flow downstream of posterior-circulation stenotic disease.
+  downstream:
+  - target: Posterior circulation ischemia
+    description: Sustained or recurrent low flow can culminate in posterior-circulation TIA or infarction.
+- name: Vertebrobasilar thromboembolism
+  description: >-
+    Vertebrobasilar atherostenosis can produce ischemia by thromboembolism as
+    well as by flow failure. Hypoperfusion may also reduce embolus washout and
+    promote local thrombus formation at diseased arterial segments.
+  biological_processes:
+  - preferred_term: blood coagulation
+    modifier: INCREASED
+    term:
+      id: GO:0007596
+      label: blood coagulation
+  evidence:
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Furthermore, both embolic and flow processes can synergize to increase stroke risk; a proposed mechanism is the reduced wash-out of emboli from the distal circulation in hypoperfused regions (6, 7). Low flow may also promote local thrombus formation at the site of disease, with resultant stroke (3).
+    explanation: This supports mixed embolic and flow-mediated mechanisms linking vertebrobasilar disease to stroke.
+  downstream:
+  - target: Posterior circulation ischemia
+    description: Emboli or local thrombosis can occlude posterior-circulation branches and cause transient or completed ischemia.
+- name: Dissection or traumatic vertebral artery injury
+  description: >-
+    Vertebral artery dissection or trauma-related vertebral artery injury can
+    compromise the arterial lumen by mural blood entry, intimal disruption,
+    stenosis, occlusion, or embolic complications. This mechanism is distinct
+    from chronic atherosclerotic vertebrobasilar stenosis but can converge on
+    the same posterior-circulation TIA and stroke phenotypes.
+  locations:
+  - preferred_term: vertebral artery
+    term:
+      id: UBERON:0001535
+      label: vertebral artery
+  evidence:
+  - reference: DOI:10.1186/s41983-024-00893-x
+    reference_title: "Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Vertebral artery dissection occurs due to a tear in the vertebral artery wall, which results in blood flow entering the blood vessel wall.
+    explanation: This supports mural dissection as a vertebral artery mechanism that can lead to insufficiency or ischemia.
+  - reference: PMID:37924280
+    reference_title: A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Identify the incidence, mechanism of injury, investigations, management, and outcomes of Vertebral Artery Injury (VAI) after cervical spine trauma.
+    explanation: This systematic review frames traumatic vertebral artery injury as a clinically characterized vertebral artery disease mechanism.
+  downstream:
+  - target: Posterior circulation ischemia
+    description: Dissection or traumatic injury can cause posterior-circulation TIA or stroke through stenosis, occlusion, or embolization.
+- name: Posterior circulation ischemia
+  description: >-
+    Final common ischemic injury occurs when hemodynamic compromise or
+    thromboembolism reduces oxygen delivery to brainstem, cerebellar, thalamic,
+    or occipital territories, causing transient ischemic attacks, ischemic
+    stroke, or recurrent posterior-circulation symptoms.
+  locations:
+  - preferred_term: brainstem
+    term:
+      id: UBERON:0002298
+      label: brainstem
+  - preferred_term: cerebellum
+    term:
+      id: UBERON:0002037
+      label: cerebellum
+  - preferred_term: occipital lobe
+    term:
+      id: UBERON:0002021
+      label: occipital lobe
+  evidence:
+  - reference: DOI:10.2174/1573403x18666220317093131
+    reference_title: "Vertebral Artery Interventions: A Comprehensive Updated Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with posterior circulation ischemia due to vertebral artery stenosis account for 20 to 25% of ischemic strokes and have an increased risk of recurrent stroke.
+    explanation: This directly links vertebral artery stenosis to posterior-circulation ischemia and ischemic stroke burden.
+phenotypes:
+- category: Cardiovascular
+  name: Abnormal vertebral artery morphology
+  diagnostic: true
+  description: >-
+    Structural or luminal vertebral artery abnormalities, including stenosis,
+    occlusion, dissection, traumatic injury, hypoplasia, or limited collateral
+    flow, are the defining vascular abnormalities.
+  phenotype_term:
+    preferred_term: abnormal vertebral artery morphology
+    term:
+      id: HP:0030321
+      label: Abnormal vertebral artery morphology
+  evidence:
+  - reference: PMID:25977279
+    reference_title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Details of the VERiTAS study design have been previously published10. Briefly, the study is a multi-center prospective cohort study of patients with ≥ 50% extracranial or intracranial atherosclerotic VB stenosis or occlusion based upon conventional digital subtraction angiography (DSA) or computed tomographic angiography (CTA) presenting with referable VB distribution TIA or stroke within 60 days.
+    explanation: This supports vertebral or basilar stenosis/occlusion as the defining vascular lesion in symptomatic vertebrobasilar disease cohorts.
+- category: Neurological
+  name: Vertigo
+  description: >-
+    Vertigo is a common symptom of atherosclerotic vertebrobasilar
+    insufficiency and can present as recurrent episodic vertigo when vertebral
+    artery stenosis and limited collateral flow threaten the posterior
+    circulation.
+  phenotype_term:
+    preferred_term: vertigo
+    term:
+      id: HP:0002321
+      label: Vertigo
+    temporality: RECURRENT
+  evidence:
+  - reference: PMID:40148099
+    reference_title: "Signs and symptoms of vertebrobasilar insufficiency secondary to atherosclerosis: a systematic review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Vertigo was the most common reported symptom, within a total of 37 different symptoms reported either in isolation or combination.
+    explanation: This systematic review supports vertigo as the most common reported symptom in atherosclerotic VBI cases.
+  - reference: PMID:40951011
+    reference_title: "Critical Vertebrobasilar Insufficiency From Left Intracranial Vertebral Artery Stenosis With Contralateral Hypoplasia Presenting as Recurring Vertigo: Urgent Stenting to Prevent the Progression of a Posterior Circulation Stroke."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This case emphasizes that recurrent atypical vertigo and brief syncope may be warning signs of vertebrobasilar insufficiency, especially in the context of vertebral artery stenosis with limited collateral flow.
+    explanation: This case report supports recurrent vertigo as a warning symptom in a vertebral stenosis and hypoplastic collateral-flow presentation, but case-level evidence is indirect for population frequency.
+- category: Neurological
+  name: Transient ischemic attack
+  description: >-
+    Reversible posterior-circulation neurologic deficits can occur when
+    vertebrobasilar flow or embolic protection is transiently inadequate.
+  phenotype_term:
+    preferred_term: transient ischemic attack
+    term:
+      id: HP:0002326
+      label: Transient ischemic attack
+    temporality: TRANSIENT
+  evidence:
+  - reference: PMID:25977279
+    reference_title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      METHODS: Patients with recent vertebrobasilar transient ischemic attack or stroke and ≥50% atherosclerotic stenosis or occlusion in vertebral or basilar arteries (BA) were enrolled.
+    explanation: This directly identifies recent vertebrobasilar TIA as a qualifying clinical presentation in symptomatic vertebrobasilar stenosis or occlusion.
+  - reference: DOI:10.1186/s41983-024-00893-x
+    reference_title: "Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most frequent clinical manifestations include stroke, transient ischemic attack, neck pain, headaches, and vertigo.
+    explanation: This supports TIA among common manifestations in dissection-associated vertebral artery disease.
+- category: Neurological
+  name: Ischemic stroke
+  description: >-
+    Persistent posterior-circulation ischemia can cause infarction in
+    vertebrobasilar territories and carries substantial early recurrence risk.
+  phenotype_term:
+    preferred_term: ischemic stroke
+    term:
+      id: HP:0002140
+      label: Ischemic stroke
+  evidence:
+  - reference: DOI:10.2174/1573403x18666220317093131
+    reference_title: "Vertebral Artery Interventions: A Comprehensive Updated Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with posterior circulation ischemia due to vertebral artery stenosis account for 20 to 25% of ischemic strokes and have an increased risk of recurrent stroke.
+    explanation: This directly links vertebral artery stenosis-related posterior circulation ischemia to ischemic stroke burden.
+  - reference: PMID:37924280
+    reference_title: A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      From the 16 studies which reported data on outcomes, 8.87% (95% CI 5.34- 12.99) of patients with VAI had a posterior stroke.
+    explanation: This meta-analysis supports posterior stroke as an outcome in trauma-associated vertebral artery injury.
+- category: Neurological
+  name: Headache
+  description: >-
+    Headache can occur in dissection-associated vertebral artery presentations,
+    particularly alongside neck pain, vertigo, TIA, or stroke.
+  phenotype_term:
+    preferred_term: headache
+    term:
+      id: HP:0002315
+      label: Headache
+  evidence:
+  - reference: DOI:10.1186/s41983-024-00893-x
+    reference_title: "Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most frequent clinical manifestations include stroke, transient ischemic attack, neck pain, headaches, and vertigo.
+    explanation: This review supports headache as a frequent manifestation in vertebral artery dissection.
+- category: Musculoskeletal
+  name: Neck pain
+  description: >-
+    Neck pain is a common symptom in dissection-associated vertebral artery
+    disease and can accompany posterior-circulation ischemic events.
+  phenotype_term:
+    preferred_term: neck pain
+    term:
+      id: HP:0030833
+      label: Neck pain
+  evidence:
+  - reference: DOI:10.1186/s41983-024-00893-x
+    reference_title: "Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most frequent clinical manifestations include stroke, transient ischemic attack, neck pain, headaches, and vertigo.
+    explanation: This review supports neck pain as a frequent manifestation in vertebral artery dissection.
+environmental:
+- name: Atherosclerotic vascular risk factor burden
+  description: >-
+    Symptomatic vertebrobasilar disease cohorts are enriched for conventional
+    vascular risk factors, especially hypertension and hyperlipidemia; smoking,
+    diabetes, coronary disease, obesity, and other vascular risk factors are
+    tracked and treated as part of risk-factor management.
+  evidence:
+  - reference: PMID:25977279
+    reference_title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The cohort (n=72; 44% women) had a mean age of 65.6 years; 72% presented with ischemic stroke. Hypertension (93%) and hyperlipidemia (81%) were the most prevalent vascular risk factors.
+    explanation: This prospective cohort documents high prevalence of hypertension and hyperlipidemia in symptomatic vertebrobasilar disease.
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The nature and frequency of cerebral ischemic events is recorded Medications at the time of enrollment and specific data regarding vascular risk factors are gathered including age, gender, race, hypertension, diabetes mellitus, lipid disorder, coronary disease, smoking, alcohol consumption, and parental death from stroke.
+    explanation: VERiTAS explicitly collected these as vascular risk factors in symptomatic vertebrobasilar disease.
+- name: Cervical spine trauma
+  description: >-
+    Cervical spine trauma can cause vertebral artery injury, which may lead to
+    posterior-circulation stroke and can require conservative, antithrombotic,
+    endovascular, or surgical management.
+  evidence:
+  - reference: PMID:37924280
+    reference_title: A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      20-studies (n = 503) included data on trauma type; 75.5% (n = 380) suffered blunt trauma and 24.5% (n = 123) penetrating.
+    explanation: This supports trauma as an extrinsic cause category for vertebral artery injury.
+diagnosis:
+- name: Quantitative magnetic resonance angiography
+  diagnosis_term:
+    preferred_term: magnetic resonance angiography procedure
+    term:
+      id: MAXO:0035088
+      label: magnetic resonance angiography procedure
+  description: >-
+    QMRA can noninvasively measure large-vessel vertebrobasilar flow and help
+    classify distal flow compromise in symptomatic vertebrobasilar disease.
+  evidence:
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke (VERiTAS) study, a prospective multicentre NIH-funded observational study of symptomatic vertebrobasilar stenosis (≥50%) or occlusion, is designed to test the hypothesis that patients demonstrating compromised blood flow as assessed by quantitative magnetic resonance angiography are at higher stroke risk.
+    explanation: This supports QMRA as a hemodynamic assessment tool for symptomatic vertebrobasilar stenosis or occlusion.
+- name: CT angiography and catheter angiography confirmation
+  diagnosis_term:
+    preferred_term: contrast angiography procedure
+    term:
+      id: MAXO:0035038
+      label: contrast angiography procedure
+  description: >-
+    CTA or conventional catheter angiography can confirm extracranial or
+    intracranial vertebrobasilar stenosis or occlusion for clinical diagnosis
+    or study eligibility.
+  evidence:
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Diagnostic evaluation is performed at the discretion of the treating physicians, but commonly includes: MRA, CT angiography (CTA), TCD or conventional angiography.
+    explanation: This supports CTA, MRA, TCD, and conventional angiography as diagnostic evaluations for suspected vertebrobasilar ischemia.
+treatments:
+- name: Aggressive medical secondary prevention
+  description: >-
+    Standard medical management focuses on antithrombotic therapy, statins, and
+    intensive cerebrovascular risk-factor control. For high-risk minor posterior
+    circulation stroke or TIA, short-term dual antiplatelet therapy may be used
+    before transition to monotherapy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: transient ischemic attack
+    term:
+      id: HP:0002326
+      label: Transient ischemic attack
+  - preferred_term: ischemic stroke
+    term:
+      id: HP:0002140
+      label: Ischemic stroke
+  evidence:
+  - reference: PMID:21050408
+    reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patients are prospectively followed for a minimum of one year on current standard medical regimen including vascular risk factor modification, statins and antithrombotic therapy, and evaluated for recurrent ischemic events.
+    explanation: This supports vascular risk-factor modification, statins, and antithrombotic therapy as standard medical management in symptomatic vertebrobasilar disease.
+  - reference: PMID:35658624
+    reference_title: "Treatment of posterior circulation stroke: Acute management and secondary prevention."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Secondary prevention of posterior circulation strokes includes aggressive treatment of cerebrovascular risk factors with both drugs and lifestyle interventions and short-term dual anti-platelet therapy.
+    explanation: This supports aggressive medical secondary prevention and short-term dual antiplatelet therapy for posterior-circulation stroke contexts.
+- name: Vertebral artery angioplasty and stenting
+  description: >-
+    Endovascular angioplasty and stenting can restore vertebral artery patency
+    in selected symptomatic extracranial vertebral stenosis, especially with
+    recurrent symptoms despite medical therapy, but trial evidence has not
+    conclusively shown superiority over medical therapy and intracranial
+    stenting carries higher procedural risk.
+  treatment_term:
+    preferred_term: placement of a stent
+    term:
+      id: MAXO:0000917
+      label: placement of a stent
+  target_mechanisms:
+  - target: Atherosclerotic vertebrobasilar stenosis or occlusion
+    treatment_effect: MODULATES
+    description: Stenting attempts to restore arterial lumen and improve flow across stenotic vertebral artery segments.
+  evidence:
+  - reference: DOI:10.2174/1573403x18666220317093131
+    reference_title: "Vertebral Artery Interventions: A Comprehensive Updated Review"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Percutaneous transluminal angioplasty and stenting of symptomatic vertebral artery stenosis are promising options widely used in clinical practice with good technical results; however, the improved clinical outcome has been examined in various clinical trials without a sufficient sample size to conclusively determine whether stenting is better than medical therapy.
+    explanation: This supports clinical use of angioplasty/stenting but preserves uncertainty about outcome superiority over medical therapy.
+  - reference: PMID:40951011
+    reference_title: "Critical Vertebrobasilar Insufficiency From Left Intracranial Vertebral Artery Stenosis With Contralateral Hypoplasia Presenting as Recurring Vertigo: Urgent Stenting to Prevent the Progression of a Posterior Circulation Stroke."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Given refractory symptoms despite dual antiplatelet therapy and permissive hypertension, urgent intracranial balloon angioplasty and balloon-mounted drug-eluting stent placement was performed.
+    explanation: This case report supports stenting as an intervention for refractory vertebrobasilar insufficiency from vertebral artery stenosis, but evidence remains case-level.
+- name: Microsurgical vertebral artery revascularization
+  description: >-
+    Vertebral endarterectomy, artery transposition, hybrid surgery, or related
+    microsurgical reconstruction may be considered for selected proximal
+    vertebral artery stenosis or occlusion when endovascular treatment is
+    unsuitable, fails, or restenosis occurs.
+  treatment_term:
+    preferred_term: surgical procedure on vascular system
+    term:
+      id: MAXO:0001515
+      label: surgical procedure on vascular system
+  target_mechanisms:
+  - target: Atherosclerotic vertebrobasilar stenosis or occlusion
+    treatment_effect: MODULATES
+    description: Microsurgical reconstruction attempts to restore vertebral artery inflow or bypass obstructive anatomy.
+  evidence:
+  - reference: PMID:37483445
+    reference_title: "Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Microsurgical reconstruction is an alternative option that can effectively treat refractory proximal VASO disease and in-stent stenosis, with a high rate of postoperative vascular recirculation.
+    explanation: This supports microsurgical reconstruction for refractory proximal vertebral artery stenosis/occlusion and in-stent stenosis.
+  - reference: PMID:39673653
+    reference_title: "Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Microsurgical surgery for patients with proximal vertebral artery stenosis, when endovascular treatment is unsuitable, demonstrates good clinical efficacy and a low incidence of complications, offering a viable surgical treatment option.
+    explanation: This supports microsurgical surgery in selected proximal vertebral stenosis patients unsuitable for endovascular treatment.
+- name: Acute posterior circulation reperfusion therapy
+  description: >-
+    When vertebral artery insufficiency progresses to posterior-circulation
+    ischemic stroke, acute stroke treatment may include thrombolysis or, for
+    basilar artery occlusion, mechanical thrombectomy according to stroke-care
+    eligibility.
+  treatment_term:
+    preferred_term: therapeutic procedure
+    term:
+      id: NCIT:C49236
+      label: Therapeutic Procedure
+  target_phenotypes:
+  - preferred_term: ischemic stroke
+    term:
+      id: HP:0002140
+      label: Ischemic stroke
+  evidence:
+  - reference: PMID:35658624
+    reference_title: "Treatment of posterior circulation stroke: Acute management and secondary prevention."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thrombolysis seems to have similar benefits and lower hemorrhage risks than in the anterior circulation. The recent ATTENTION and BAOCHE trials have demonstrated that thrombectomy benefits strokes with basilar artery occlusion, but its effect on other posterior occlusion sites remains uncertain.
+    explanation: This supports acute reperfusion treatment for posterior-circulation stroke while noting uncertainty outside basilar artery occlusion.
+clinical_trials:
+- name: NCT05885932
+  phase: NOT_APPLICABLE
+  status: RECRUITING
+  description: >-
+    Randomized multicenter trial of drug-eluting stenting plus best medical
+    treatment versus best medical treatment alone for 70-99% extracranial
+    vertebral artery stenosis causing recent stroke or TIA.
+  target_phenotypes:
+  - preferred_term: transient ischemic attack
+    term:
+      id: HP:0002326
+      label: Transient ischemic attack
+  - preferred_term: ischemic stroke
+    term:
+      id: HP:0002140
+      label: Ischemic stroke
+  evidence:
+  - reference: clinicaltrials:NCT05885932
+    reference_title: "Drug-eluting Stenting Versus Medical Treatment Alone for Patients With Extracranial Vertebral Artery Stenosis: The VISTA Trial"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients will be randomized (1:1) to best medical treatment alone or medical treatment plus stenting.
+    explanation: This trial summary directly supports randomized comparison of medical therapy alone versus stenting plus medical therapy.
+- name: NCT03201432
+  phase: NOT_APPLICABLE
+  status: COMPLETED
+  description: >-
+    Randomized trial comparing drug-eluting stents versus bare metal stents for
+    symptomatic extracranial vertebral artery stenosis, focused on restenosis
+    prevention after vertebral artery reconstruction.
+  target_phenotypes:
+  - preferred_term: ischemic stroke
+    term:
+      id: HP:0002140
+      label: Ischemic stroke
+  evidence:
+  - reference: clinicaltrials:NCT03201432
+    reference_title: "A Randomized Trial for Treatment of Symptomatic Extracranial Vertebral Artery Stenosis: Drug Eluting Stents Versus Bare Metal Stents"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Previous systematic review had suggested that the drug eluting stent might reduce the incidence of restenosis of vertebral artery.
+    explanation: This trial summary supports evaluation of stent type for restenosis prevention in symptomatic extracranial vertebral artery stenosis.
+datasets:

--- a/kb/disorders/Vertebral_Artery_Insufficiency.yaml
+++ b/kb/disorders/Vertebral_Artery_Insufficiency.yaml
@@ -1,6 +1,6 @@
 name: Vertebral Artery Insufficiency
 creation_date: "2026-05-06T19:00:20Z"
-updated_date: "2026-05-06T19:24:30Z"
+updated_date: "2026-05-06T19:56:26Z"
 description: >-
   Vertebral artery insufficiency is a posterior-circulation vascular disorder in
   which vertebral or vertebrobasilar stenosis, occlusion, dissection, injury,
@@ -67,6 +67,14 @@ references:
   title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease
   found_in:
   - Vertebral_Artery_Insufficiency-deep-research-falcon.md
+- reference: PMID:28680502
+  title: "Pathophysiology and Diagnosis of Vertebrobasilar Insufficiency: A Review of the Literature."
+- reference: PMID:11385214
+  title: Accuracy of color-Doppler in the quantification of proximal vertebral artery stenoses.
+- reference: PMID:36127977
+  title: "Vertebral Artery Stenosis: A Narrative Review."
+- reference: PMID:12870261
+  title: "A case of intimal hyperplasia induced by stenting for vertebral artery origin stenosis: assessed on intravascular ultrasound."
 pathophysiology:
 - name: Atherosclerotic vertebrobasilar stenosis or occlusion
   description: >-
@@ -84,6 +92,15 @@ pathophysiology:
     term:
       id: UBERON:0001633
       label: basilar artery
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: vascular smooth muscle cell
+    term:
+      id: CL:0000192
+      label: smooth muscle cell
   evidence:
   - reference: PMID:21050408
     reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
@@ -159,6 +176,15 @@ pathophysiology:
     term:
       id: GO:0007596
       label: blood coagulation
+  cell_types:
+  - preferred_term: endothelial cell
+    term:
+      id: CL:0000115
+      label: endothelial cell
+  - preferred_term: platelet
+    term:
+      id: CL:0000233
+      label: platelet
   evidence:
   - reference: PMID:21050408
     reference_title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
@@ -303,6 +329,78 @@ phenotypes:
       The most frequent clinical manifestations include stroke, transient ischemic attack, neck pain, headaches, and vertigo.
     explanation: This supports TIA among common manifestations in dissection-associated vertebral artery disease.
 - category: Neurological
+  name: Ataxia
+  description: >-
+    Cerebellar or brainstem ischemia in vertebrobasilar insufficiency can
+    manifest as impaired coordination or imbalance.
+  phenotype_term:
+    preferred_term: ataxia
+    term:
+      id: HP:0001251
+      label: Ataxia
+  evidence:
+  - reference: PMID:28680502
+    reference_title: "Pathophysiology and Diagnosis of Vertebrobasilar Insufficiency: A Review of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Dizziness, vertigo, headaches, vomit, diplopia, blindness, ataxia, imbalance, and weakness in both sides of the body are the most common symptoms.
+    explanation: This review identifies ataxia as a common symptom of vertebrobasilar insufficiency.
+- category: Neurological
+  name: Diplopia
+  description: >-
+    Posterior-circulation ischemia can affect ocular motor pathways and present
+    with double vision.
+  phenotype_term:
+    preferred_term: diplopia
+    term:
+      id: HP:0000651
+      label: Diplopia
+  evidence:
+  - reference: PMID:28680502
+    reference_title: "Pathophysiology and Diagnosis of Vertebrobasilar Insufficiency: A Review of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Dizziness, vertigo, headaches, vomit, diplopia, blindness, ataxia, imbalance, and weakness in both sides of the body are the most common symptoms.
+    explanation: This review identifies diplopia as a common symptom of vertebrobasilar insufficiency.
+- category: Neurological
+  name: Dysarthria
+  description: >-
+    Vertebral artery stenosis with inadequate collateral flow can produce
+    posterior-circulation neurologic deficits including impaired articulation.
+  phenotype_term:
+    preferred_term: dysarthria
+    term:
+      id: HP:0001260
+      label: Dysarthria
+  evidence:
+  - reference: PMID:12870261
+    reference_title: "A case of intimal hyperplasia induced by stenting for vertebral artery origin stenosis: assessed on intravascular ultrasound."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A 69-year-old man was admitted because of dysarthria and dysphagia. Angiography revealed hypoplasia of left vertebral artery (VA) and remarkable stenosis of the proximal right VA with inadequate collateral flow from the anterior circulation.
+    explanation: This vertebral artery origin stenosis case supports dysarthria as a posterior-circulation symptom, but the evidence is case-level.
+- category: Neurological
+  name: Dysphagia
+  description: >-
+    Brainstem or lower cranial nerve involvement in vertebrobasilar ischemia can
+    present with impaired swallowing.
+  phenotype_term:
+    preferred_term: dysphagia
+    term:
+      id: HP:0002015
+      label: Dysphagia
+  evidence:
+  - reference: PMID:12870261
+    reference_title: "A case of intimal hyperplasia induced by stenting for vertebral artery origin stenosis: assessed on intravascular ultrasound."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A 69-year-old man was admitted because of dysarthria and dysphagia. Angiography revealed hypoplasia of left vertebral artery (VA) and remarkable stenosis of the proximal right VA with inadequate collateral flow from the anterior circulation.
+    explanation: This vertebral artery origin stenosis case supports dysphagia as a posterior-circulation symptom, but the evidence is case-level.
+- category: Neurological
   name: Ischemic stroke
   description: >-
     Persistent posterior-circulation ischemia can cause infarction in
@@ -399,6 +497,32 @@ environmental:
       20-studies (n = 503) included data on trauma type; 75.5% (n = 380) suffered blunt trauma and 24.5% (n = 123) penetrating.
     explanation: This supports trauma as an extrinsic cause category for vertebral artery injury.
 diagnosis:
+- name: Color Doppler duplex ultrasonography screening
+  diagnosis_term:
+    preferred_term: ultrasound imaging
+    term:
+      id: NCIT:C17230
+      label: Ultrasound Imaging
+  description: >-
+    Color Doppler or duplex ultrasonography is a noninvasive screening method
+    for detecting and quantifying proximal vertebral artery stenosis, with
+    positive or intervention-relevant findings typically requiring confirmatory
+    angiographic imaging.
+  evidence:
+  - reference: PMID:11385214
+    reference_title: Accuracy of color-Doppler in the quantification of proximal vertebral artery stenoses.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSION: Duplex sonography should be proposed first in VB attacks or stroke to detect and quantify vertebral artery stenoses for surgery and angioplasty.
+    explanation: This directly supports duplex sonography as an early diagnostic test for vertebral artery stenosis in vertebrobasilar attacks or stroke.
+  - reference: PMID:36127977
+    reference_title: "Vertebral Artery Stenosis: A Narrative Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Digital subtraction angiography (DSA) is considered the current gold standard in diagnosing vertebral artery stenosis; however, its associated morbidity and mortality have led to increased use of non-invasive techniques such as duplex ultrasonography (DUS), computed tomography angiography (CTA), and magnetic resonance angiography (MRA).
+    explanation: This review supports DUS as a noninvasive diagnostic technique used for vertebral artery stenosis.
 - name: Quantitative magnetic resonance angiography
   diagnosis_term:
     preferred_term: magnetic resonance angiography procedure
@@ -446,6 +570,15 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: aspirin
+      term:
+        id: CHEBI:15365
+        label: acetylsalicylic acid
+    - preferred_term: statin
+      term:
+        id: CHEBI:87631
+        label: statin
   target_phenotypes:
   - preferred_term: transient ischemic attack
     term:
@@ -531,17 +664,16 @@ treatments:
     snippet: >-
       Microsurgical surgery for patients with proximal vertebral artery stenosis, when endovascular treatment is unsuitable, demonstrates good clinical efficacy and a low incidence of complications, offering a viable surgical treatment option.
     explanation: This supports microsurgical surgery in selected proximal vertebral stenosis patients unsuitable for endovascular treatment.
-- name: Acute posterior circulation reperfusion therapy
+- name: Acute posterior circulation thrombolysis
   description: >-
     When vertebral artery insufficiency progresses to posterior-circulation
-    ischemic stroke, acute stroke treatment may include thrombolysis or, for
-    basilar artery occlusion, mechanical thrombectomy according to stroke-care
-    eligibility.
+    ischemic stroke, intravenous thrombolysis may be considered according to
+    acute stroke eligibility.
   treatment_term:
-    preferred_term: therapeutic procedure
+    preferred_term: pharmacotherapy
     term:
-      id: NCIT:C49236
-      label: Therapeutic Procedure
+      id: MAXO:0000058
+      label: pharmacotherapy
   target_phenotypes:
   - preferred_term: ischemic stroke
     term:
@@ -554,7 +686,30 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: >-
       Thrombolysis seems to have similar benefits and lower hemorrhage risks than in the anterior circulation. The recent ATTENTION and BAOCHE trials have demonstrated that thrombectomy benefits strokes with basilar artery occlusion, but its effect on other posterior occlusion sites remains uncertain.
-    explanation: This supports acute reperfusion treatment for posterior-circulation stroke while noting uncertainty outside basilar artery occlusion.
+    explanation: This supports thrombolysis as an acute reperfusion treatment for posterior-circulation stroke.
+- name: Basilar artery mechanical thrombectomy
+  description: >-
+    Mechanical thrombectomy is relevant when posterior-circulation ischemic
+    stroke involves basilar artery occlusion, while evidence for other posterior
+    occlusion sites remains less certain.
+  treatment_term:
+    preferred_term: thrombectomy
+    term:
+      id: NCIT:C52003
+      label: Thrombectomy
+  target_phenotypes:
+  - preferred_term: ischemic stroke
+    term:
+      id: HP:0002140
+      label: Ischemic stroke
+  evidence:
+  - reference: PMID:35658624
+    reference_title: "Treatment of posterior circulation stroke: Acute management and secondary prevention."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thrombolysis seems to have similar benefits and lower hemorrhage risks than in the anterior circulation. The recent ATTENTION and BAOCHE trials have demonstrated that thrombectomy benefits strokes with basilar artery occlusion, but its effect on other posterior occlusion sites remains uncertain.
+    explanation: This supports thrombectomy for basilar artery occlusion while preserving uncertainty for other posterior-circulation occlusion sites.
 clinical_trials:
 - name: NCT05885932
   phase: NOT_APPLICABLE

--- a/references_cache/DOI_10.1007_s10143-024-03153-x.md
+++ b/references_cache/DOI_10.1007_s10143-024-03153-x.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.1007/s10143-024-03153-x"
+title: "Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study"
+authors:
+- Mingyuan Liu
+- Peiguang Yan
+- Mingxin Wang
+- Jia Guo
+- Wei Liu
+- Ganchun Wu
+- Lufei Wang
+- Jingjing Liu
+- Li Li
+journal: Neurosurgical Review
+year: '2024'
+doi: 10.1007/s10143-024-03153-x
+content_type: unavailable
+---
+
+# Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study
+**Authors:** Mingyuan Liu, Peiguang Yan, Mingxin Wang, Jia Guo, Wei Liu, Ganchun Wu, Lufei Wang, Jingjing Liu, Li Li
+**Journal:** Neurosurgical Review (2024)
+**DOI:** [10.1007/s10143-024-03153-x](https://doi.org/10.1007/s10143-024-03153-x)
+
+## Content

--- a/references_cache/DOI_10.1111_j.1747-4949.2010.00528.x.md
+++ b/references_cache/DOI_10.1111_j.1747-4949.2010.00528.x.md
@@ -1,0 +1,43 @@
+---
+reference_id: "DOI:10.1111/j.1747-4949.2010.00528.x"
+title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke Study (Veritas): Rationale and Design"
+authors:
+- Sepideh Amin-Hanjani
+- Linda Rose-Finnell
+- DeJuran Richardson
+- Sean Ruland
+- Dilip Pandey
+- Keith R. Thulborn
+- David S. Liebeskind
+- Gregory J. Zipfel
+- Mitchell S. V. Elkind
+- Jeffrey Kramer
+- Frank L. Silver
+- Scott E. Kasner
+- Louis R. Caplan
+- Colin P. Derdeyn
+- Philip B. Gorelick
+- Fady T. Charbel
+journal: International Journal of Stroke
+year: '2010'
+doi: 10.1111/j.1747-4949.2010.00528.x
+content_type: abstract_only
+---
+
+# Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke Study (Veritas): Rationale and Design
+**Authors:** Sepideh Amin-Hanjani, Linda Rose-Finnell, DeJuran Richardson, Sean Ruland, Dilip Pandey, Keith R. Thulborn, David S. Liebeskind, Gregory J. Zipfel, Mitchell S. V. Elkind, Jeffrey Kramer, Frank L. Silver, Scott E. Kasner, Louis R. Caplan, Colin P. Derdeyn, Philip B. Gorelick, Fady T. Charbel
+**Journal:** International Journal of Stroke (2010)
+**DOI:** [10.1111/j.1747-4949.2010.00528.x](https://doi.org/10.1111/j.1747-4949.2010.00528.x)
+
+## Content
+
+Background
+Over one-third of ischaemic strokes occur in the posterior circulation, and a leading cause is atherosclerotic vertebrobasilar disease. Symptomatic vertebrobasilar disease carries a high annual recurrent stroke risk, averaging 10–15% per year. Endovascular angioplasty and stenting are increasingly used but carry risks, and the benefit remains unproven. Determining stroke predictors in this population is critical to identifying high-risk patients for future trials of intervention. Preliminary studies indicate that stroke risk in vertebrobasilar disease is strongly related to haemodynamic compromise, which can be measured noninvasively using quantitative magnetic resonance angiography.
+
+
+Methods/study design
+The Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke (VERiTAS) study, a prospective multicentre NIH-funded observational study of symptomatic vertebrobasilar stenosis (≥50%) or occlusion, is designed to test the hypothesis that patients demonstrating compromised blood flow as assessed by quantitative magnetic resonance angiography are at higher stroke risk. The study will recruit 80 patients at six sites in North America over 4-years. Upon enrollment, subjects will undergo haemodynamic assessment with blinded quantitative magnetic resonance angiography to assess large vessel flow in the vertebrobasilar territory, and be prospectively designated as compromised or normal flow. Patients will be re-imaged with quantitative magnetic resonance angiography at 6-, 12-, and 24-months, and followed for 12–24-months for the primary end-point of stroke in the vertebrobasilar territory.
+
+
+Conclusion
+The VERiTAS study is the first prospective study of haemodynamics and stroke risk in the posterior circulation. The results may impact the selection criteria for interventional candidates and also define a low-risk population in whom the risks of invasive interventions would be unnecessary.

--- a/references_cache/DOI_10.1161_str.0000000000000475.md
+++ b/references_cache/DOI_10.1161_str.0000000000000475.md
@@ -1,0 +1,53 @@
+---
+reference_id: "DOI:10.1161/str.0000000000000475"
+title: "2024 Guideline for the Primary Prevention of Stroke: A Guideline From the American Heart Association/American Stroke Association"
+authors:
+- Cheryl Bushnell
+- Walter N. Kernan
+- Anjail Z. Sharrief
+- Seemant Chaturvedi
+- John W. Cole
+- William K. Cornwell
+- Christine Cosby-Gaither
+- Sarah Doyle
+- Larry B. Goldstein
+- Olive Lennon
+- Deborah A. Levine
+- Mary Love
+- Eliza Miller
+- Mai Nguyen-Huynh
+- Jennifer Rasmussen-Winkler
+- Kathryn M. Rexrode
+- Nicole Rosendale
+- Satyam Sarma
+- Daichi Shimbo
+- Alexis N. Simpkins
+- Erica S. Spatz
+- Lisa R. Sun
+- Vin Tangpricha
+- Dawn Turnage
+- Gabriela Velazquez
+- Paul K. Whelton
+journal: Stroke
+year: '2024'
+doi: 10.1161/str.0000000000000475
+content_type: abstract_only
+---
+
+# 2024 Guideline for the Primary Prevention of Stroke: A Guideline From the American Heart Association/American Stroke Association
+**Authors:** Cheryl Bushnell, Walter N. Kernan, Anjail Z. Sharrief, Seemant Chaturvedi, John W. Cole, William K. Cornwell, Christine Cosby-Gaither, Sarah Doyle, Larry B. Goldstein, Olive Lennon, Deborah A. Levine, Mary Love, Eliza Miller, Mai Nguyen-Huynh, Jennifer Rasmussen-Winkler, Kathryn M. Rexrode, Nicole Rosendale, Satyam Sarma, Daichi Shimbo, Alexis N. Simpkins, Erica S. Spatz, Lisa R. Sun, Vin Tangpricha, Dawn Turnage, Gabriela Velazquez, Paul K. Whelton
+**Journal:** Stroke (2024)
+**DOI:** [10.1161/str.0000000000000475](https://doi.org/10.1161/str.0000000000000475)
+
+## Content
+
+AIM:
+The “2024 Guideline for the Primary Prevention of Stroke” replaces the 2014 “Guidelines for the Primary Prevention of Stroke.” This updated guideline is intended to be a resource for clinicians to use to guide various prevention strategies for individuals with no history of stroke.
+
+
+METHODS:
+A comprehensive search for literature published since the 2014 guideline; derived from research involving human participants published in English; and indexed in MEDLINE, PubMed, Cochrane Library, and other selected and relevant databases was conducted between May and November 2023. Other documents on related subject matter previously published by the American Heart Association were also reviewed.
+
+
+STRUCTURE:
+Ischemic and hemorrhagic strokes lead to significant disability but, most important, are preventable. The 2024 primary prevention of stroke guideline provides recommendations based on current evidence for strategies to prevent stroke throughout the life span. These recommendations align with the American Heart Association’s Life’s Essential 8 for optimizing cardiovascular and brain health, in addition to preventing incident stroke. We also have added sex-specific recommendations for screening and prevention of stroke, which are new compared with the 2014 guideline. Many recommendations for similar risk factor prevention were updated, new topics were reviewed, and recommendations were created when supported by sufficient-quality published data.

--- a/references_cache/DOI_10.1161_strokeaha.115.009215.md
+++ b/references_cache/DOI_10.1161_strokeaha.115.009215.md
@@ -1,0 +1,128 @@
+---
+reference_id: "DOI:10.1161/strokeaha.115.009215"
+title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease
+authors:
+- Sepideh Amin-Hanjani
+- Xinjian Du
+- Linda Rose-Finnell
+- Dilip K. Pandey
+- DeJuran Richardson
+- Keith R. Thulborn
+- Mitchell S.V. Elkind
+- Gregory J. Zipfel
+- David S. Liebeskind
+- Frank L. Silver
+- Scott E. Kasner
+- Victor A. Aletich
+- Louis R. Caplan
+- Colin P. Derdeyn
+- Philip B. Gorelick
+- Fady T. Charbel
+- Hui Xie
+- Michael P. Flannery
+- Hagai Ganin
+- Sean Ruland
+- Rebecca Grysiewicz
+- Aslam Khaja
+- Laura Pedelty
+- Fernando Testai
+- Archie Ong
+- Noam Epstein
+- Hurmina Muqtadar
+- Karriem Watson
+- Nada Mlinarevich
+- Maureen Hillmann
+- Joy Hirsch
+- Stephen Dashnaw
+- Philip M. Meyers
+- Josh Z. Willey
+- Edwina McNeill-Simaan
+- Veronica Perez
+- Alberto Canaan
+- Wayna Paulino-Hernandez
+- Katie Vo
+- Glenn Foster
+- Andria Ford
+- Abdullah Nassief
+- Abbie Bradley
+- Jannie Serna-Northway
+- Kristi Kraus
+- Lina Shiwani
+- Nancy Hantler
+- Jeffrey Alger
+- Sergio Godinez
+- Jeffrey L. Saver
+- Latisha Ali
+- Doojin Kim
+- Matthew Tenser
+- Michael Froehler
+- Radoslav Raychev
+- Sarah Song
+- Bruce Ovbiagele
+- Hermelinda Abcede
+- Peter Adamczyk
+- Neal Rao
+- Anil Yallapragada
+- Royya Modir
+- Jason Hinman
+- Aaron Tansy
+- Mateo Calderon-Arnulphi
+- Sunil Sheth
+- Alireza Noorian
+- Kwan Ng
+- Conrad Liang
+- Jignesh Gadhia
+- Hannah Smith
+- Gilda Avila
+- Johanna Avelar
+- David Mikulis
+- Jorn Fierstra
+- Eugen Hlasny
+- Leanne K. Casaubon
+- Mervyn Vergouwen
+- J.C. Martin del Campo
+- Cheryl S. Jaigobin
+- Cherissa Astorga
+- Libby Kalman
+- Jeffrey Kramer
+- Susan Vaughan
+- Laura Owens
+- Brett Kissela
+- Tanya N. Turan
+- Tom P. Jacobs
+- Scott Janis
+journal: Stroke
+year: '2015'
+doi: 10.1161/strokeaha.115.009215
+content_type: abstract_only
+---
+
+# Hemodynamic Features of Symptomatic Vertebrobasilar Disease
+**Authors:** Sepideh Amin-Hanjani, Xinjian Du, Linda Rose-Finnell, Dilip K. Pandey, DeJuran Richardson, Keith R. Thulborn, Mitchell S.V. Elkind, Gregory J. Zipfel, David S. Liebeskind, Frank L. Silver, Scott E. Kasner, Victor A. Aletich, Louis R. Caplan, Colin P. Derdeyn, Philip B. Gorelick, Fady T. Charbel, Hui Xie, Michael P. Flannery, Hagai Ganin, Sean Ruland, Rebecca Grysiewicz, Aslam Khaja, Laura Pedelty, Fernando Testai, Archie Ong, Noam Epstein, Hurmina Muqtadar, Karriem Watson, Nada Mlinarevich, Maureen Hillmann, Joy Hirsch, Stephen Dashnaw, Philip M. Meyers, Josh Z. Willey, Edwina McNeill-Simaan, Veronica Perez, Alberto Canaan, Wayna Paulino-Hernandez, Katie Vo, Glenn Foster, Andria Ford, Abdullah Nassief, Abbie Bradley, Jannie Serna-Northway, Kristi Kraus, Lina Shiwani, Nancy Hantler, Jeffrey Alger, Sergio Godinez, Jeffrey L. Saver, Latisha Ali, Doojin Kim, Matthew Tenser, Michael Froehler, Radoslav Raychev, Sarah Song, Bruce Ovbiagele, Hermelinda Abcede, Peter Adamczyk, Neal Rao, Anil Yallapragada, Royya Modir, Jason Hinman, Aaron Tansy, Mateo Calderon-Arnulphi, Sunil Sheth, Alireza Noorian, Kwan Ng, Conrad Liang, Jignesh Gadhia, Hannah Smith, Gilda Avila, Johanna Avelar, David Mikulis, Jorn Fierstra, Eugen Hlasny, Leanne K. Casaubon, Mervyn Vergouwen, J.C. Martin del Campo, Cheryl S. Jaigobin, Cherissa Astorga, Libby Kalman, Jeffrey Kramer, Susan Vaughan, Laura Owens, Brett Kissela, Tanya N. Turan, Tom P. Jacobs, Scott Janis
+**Journal:** Stroke (2015)
+**DOI:** [10.1161/strokeaha.115.009215](https://doi.org/10.1161/strokeaha.115.009215)
+
+## Content
+
+Background and Purpose—
+Atherosclerotic vertebrobasilar disease is an important cause of posterior circulation stroke. To examine the role of hemodynamic compromise, a prospective multicenter study, Vertebrobasilar Flow Evaluation and Risk of Transient Ischemic Attack and Stroke (VERiTAS), was conducted. Here, we report clinical features and vessel flow measurements from the study cohort.
+
+
+Methods—
+Patients with recent vertebrobasilar transient ischemic attack or stroke and ≥50% atherosclerotic stenosis or occlusion in vertebral or basilar arteries (BA) were enrolled. Large-vessel flow in the vertebrobasilar territory was assessed using quantitative MRA.
+
+
+Results—
+
+              The cohort (n=72; 44% women) had a mean age of 65.6 years; 72% presented with ischemic stroke. Hypertension (93%) and hyperlipidemia (81%) were the most prevalent vascular risk factors. BA flows correlated negatively with percentage stenosis in the affected vessel and positively to the minimal diameter at the stenosis site (
+              P
+              <0.01). A relative threshold effect was evident, with flows dropping most significantly with ≥80% stenosis/occlusion (
+              P
+              <0.05). Tandem disease involving the BA and either/both vertebral arteries had the greatest negative impact on immediate downstream flow in the BA (43 mL/min versus 71 mL/min;
+              P
+              =0.01). Distal flow status assessment, based on an algorithm incorporating collateral flow by examining distal vessels (BA and posterior cerebral arteries), correlated neither with multifocality of disease nor with severity of the maximal stenosis.
+            
+
+
+Conclusions—
+Flow in stenotic posterior circulation vessels correlates with residual diameter and drops significantly with tandem disease. However, distal flow status, incorporating collateral capacity, is not well predicted by the severity or location of the disease.

--- a/references_cache/DOI_10.1177_17474930221107500.md
+++ b/references_cache/DOI_10.1177_17474930221107500.md
@@ -1,0 +1,22 @@
+---
+reference_id: "DOI:10.1177/17474930221107500"
+title: "Treatment of posterior circulation stroke: Acute management and secondary prevention"
+authors:
+- Hugh S Markus
+- Patrik Michel
+journal: International Journal of Stroke
+year: '2022'
+doi: 10.1177/17474930221107500
+content_type: abstract_only
+---
+
+# Treatment of posterior circulation stroke: Acute management and secondary prevention
+**Authors:** Hugh S Markus, Patrik Michel
+**Journal:** International Journal of Stroke (2022)
+**DOI:** [10.1177/17474930221107500](https://doi.org/10.1177/17474930221107500)
+
+## Content
+
+One-fifth of strokes occur in the territory of the posterior circulation, but their management, particularly acute reperfusion therapy and neurointervention procedures for secondary prevention, has received much less attention than similar interventions for the anterior circulation. In this review, we overview the treatment of posterior circulation stroke, including both interventions in the acute setting and secondary prevention. We focus on areas in which the management of posterior circulation stroke differs from that of stroke in general and highlight recent advances.
+Effectiveness of acute revascularization of posterior circulation strokes remains in large parts unproven. Thrombolysis seems to have similar benefits and lower hemorrhage risks than in the anterior circulation. The recent ATTENTION and BAOCHE trials have demonstrated that thrombectomy benefits strokes with basilar artery occlusion, but its effect on other posterior occlusion sites remains uncertain. Ischemic and hemorrhagic space-occupying cerebellar strokes can benefit from decompressive craniectomy.
+Secondary prevention of posterior circulation strokes includes aggressive treatment of cerebrovascular risk factors with both drugs and lifestyle interventions and short-term dual anti-platelet therapy. Randomized controlled trial (RCT) data suggest basilar artery stenosis is better treated with medical therapy than stenting, which has a high peri-procedural risk. Limited data from RCTs in stenting for vertebral stenosis suggest that intracranial stenosis is currently best treated with medical therapy alone; the situation for extracranial stenosis is less clear where stenting for symptomatic stenosis is an option, particularly for recurrent symptoms; larger RCTs are required in this area.

--- a/references_cache/DOI_10.1177_21925682231209631.md
+++ b/references_cache/DOI_10.1177_21925682231209631.md
@@ -1,0 +1,43 @@
+---
+reference_id: "DOI:10.1177/21925682231209631"
+title: A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma
+authors:
+- Kartik Goyal
+- Jesvin T. Sunny
+- Conor S. Gillespie
+- Martin Wilby
+- Simon R. Clark
+- Radek Kaiser
+- Michael G. Fehlings
+- Nisaharan Srikandarajah
+journal: Global Spine Journal
+year: '2024'
+doi: 10.1177/21925682231209631
+content_type: abstract_only
+---
+
+# A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma
+**Authors:** Kartik Goyal, Jesvin T. Sunny, Conor S. Gillespie, Martin Wilby, Simon R. Clark, Radek Kaiser, Michael G. Fehlings, Nisaharan Srikandarajah
+**Journal:** Global Spine Journal (2024)
+**DOI:** [10.1177/21925682231209631](https://doi.org/10.1177/21925682231209631)
+
+## Content
+
+Study Design
+Systematic Review and Meta-Analysis.
+
+
+Objective
+Identify the incidence, mechanism of injury, investigations, management, and outcomes of Vertebral Artery Injury (VAI) after cervical spine trauma.
+
+
+Methods
+A systematic review and meta-analysis were conducted in accordance with the PRISMA guidelines (PROSPERO-ID CRD42021295265). Three databases were searched (PubMed, SCOPUS, Google Scholar, CINAHL PLUS). Incidence of VAI, investigations to diagnose (Computed Tomography Angiography, Digital Subtraction Angiography, Magnetic Resonance Angiography), stroke incidence, and management paradigms (conservative, antiplatelets, anticoagulants, surgical, endovascular treatment) were delineated. Incidence was calculated using pooled proportions random effects meta-analysis.
+
+
+Results
+A total of 44 studies were included (1777 patients). 20-studies (n = 503) included data on trauma type; 75.5% (n = 380) suffered blunt trauma and 24.5% (n = 123) penetrating. The overall incidence of VAI was .95% (95% CI 0.65-1.29). From the 16 studies which reported data on outcomes, 8.87% (95% CI 5.34- 12.99) of patients with VAI had a posterior stroke. Of the 33 studies with investigation data, 91.7% (2929/3629) underwent diagnostic CTA; 7.5% (242/3629) underwent MRA and 3.0% (98/3629) underwent DSA. Management data from 20 papers (n = 475) showed 17.9% (n = 85) undergoing conservative therapy, anticoagulation in 14.1% (n = 67), antiplatelets in 16.4% (n = 78), combined therapy in 25.5% (n = 121) and the rest (n = 124) managed using surgical and endovascular treatments.
+
+
+Conclusion
+VAI in cervical spine trauma has an approximate posterior circulation stroke risk of 9%. Optimal management paradigms for the prevention and management of VAI are yet to be standardized and require further research.

--- a/references_cache/DOI_10.1186_s12883-023-03110-z.md
+++ b/references_cache/DOI_10.1186_s12883-023-03110-z.md
@@ -1,0 +1,40 @@
+---
+reference_id: "DOI:10.1186/s12883-023-03110-z"
+title: In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting
+authors:
+- Jae-Chan Ryu
+- Jae-Han Bae
+- Sang Hee Ha
+- Boseong Kwon
+- Yunsun Song
+- Deok Hee Lee
+- Jun Young Chang
+- Dong-Wha Kang
+- Sun U. Kwon
+- Jong S. Kim
+- Bum Joon Kim
+journal: BMC Neurology
+year: '2023'
+doi: 10.1186/s12883-023-03110-z
+content_type: abstract_only
+---
+
+# In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting
+**Authors:** Jae-Chan Ryu, Jae-Han Bae, Sang Hee Ha, Boseong Kwon, Yunsun Song, Deok Hee Lee, Jun Young Chang, Dong-Wha Kang, Sun U. Kwon, Jong S. Kim, Bum Joon Kim
+**Journal:** BMC Neurology (2023)
+**DOI:** [10.1186/s12883-023-03110-z](https://doi.org/10.1186/s12883-023-03110-z)
+
+## Content
+
+Abstract
+Background
+Prognosis after vertebrobasilar stenting (VBS) may differ from that after carotid artery stenting (CAS). Here, we directly compared the incidence and predictors of in-stent restenosis and stented-territory infarction after VBS and compared them with those of CAS.
+
+Methods
+We enrolled patients who underwent VBS or CAS. Clinical variables and procedure-related factors were obtained. During the 3 years of follow-up, in-stent restenosis and infarction were investigated in each group. In-stent restenosis was defined as reduction in the lumen diameter > 50% compared with that after stenting. Factors associated with the occurrence of in-stent restenosis and stented-territory infarction in VBS and CAS were compared.
+
+Results
+Among 417 stent insertions (93 VBS and 324 CAS), there was no statistical difference in in-stent restenosis between VBS and CAS (12.9% vs. 6.8%, P = 0.092). However, stented-territory infarction was more frequently observed in VBS than in CAS (22.6% vs. 10.8%; P = 0.006), especially a month after stent insertion. HbA1c level, clopidogrel resistance, and multiple stents in VBS and young age in CAS increased the risk of in-stent restenosis. Diabetes (3.82 [1.24–11.7]) and multiple stents (22.4 [2.4–206.4]) were associated with stented-territory infarction in VBS. However, in-stent restenosis (odds ratio: 15.1, 95% confidence interval: 3.17–72.2) was associated with stented-territory infarction in CAS.
+
+Conclusions
+Stented-territory infarction occurred more frequently in VBS, especially after the periprocedural period. In-stent restenosis was associated with stented-territory infarction after CAS, but not in VBS. The mechanism of stented-territory infarction after VBS may be different from that after CAS.

--- a/references_cache/DOI_10.1186_s41983-024-00893-x.md
+++ b/references_cache/DOI_10.1186_s41983-024-00893-x.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.1186/s41983-024-00893-x"
+title: "Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration"
+authors:
+- Muhammad Yunus Amran
+- Irbab Hawari
+- Fitri Jafani La’biran
+- Siti Giranti Ardilia Gunadi
+- Lisa Tenriesa Muslich
+journal: "The Egyptian Journal of Neurology, Psychiatry and Neurosurgery"
+year: '2024'
+doi: 10.1186/s41983-024-00893-x
+content_type: abstract_only
+---
+
+# Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration
+**Authors:** Muhammad Yunus Amran, Irbab Hawari, Fitri Jafani La’biran, Siti Giranti Ardilia Gunadi, Lisa Tenriesa Muslich
+**Journal:** The Egyptian Journal of Neurology, Psychiatry and Neurosurgery (2024)
+**DOI:** [10.1186/s41983-024-00893-x](https://doi.org/10.1186/s41983-024-00893-x)
+
+## Content
+
+AbstractVertebral artery dissection is one of the causes of stroke and transient ischemic attack in young adults, with an incidence rate of 1.0–1.1 per 100,000 people. Vertebral artery dissection occurs due to a tear in the vertebral artery wall, which results in blood flow entering the blood vessel wall. The etiology of vertebral artery dissection is very diverse, which can be classified as intrinsic (such as anatomical abnormalities of the blood vessels) or extrinsic (such as trauma), and there are several rarer causes. The most frequent clinical manifestations include stroke, transient ischemic attack, neck pain, headaches, and vertigo. Management in this case comprises treatment according to symptoms in the form of intravenous thrombolysis, administering antithrombotic drugs, and endovascular therapy.

--- a/references_cache/DOI_10.2174_1573403x18666220317093131.md
+++ b/references_cache/DOI_10.2174_1573403x18666220317093131.md
@@ -1,0 +1,45 @@
+---
+reference_id: "DOI:10.2174/1573403x18666220317093131"
+title: "Vertebral Artery Interventions: A Comprehensive Updated Review"
+authors:
+- Tamunoinemi Bob-Manuel
+- Oscar Maitas
+- Justin Price
+- Abdullah Noor
+- Koyenum Obi
+- Nelson Okoh
+- Kiran Garikapati
+- Jeong Kim
+- Sanjida Jahan
+- James S. Jenkins
+journal: Current Cardiology Reviews
+year: '2023'
+doi: 10.2174/1573403x18666220317093131
+content_type: abstract_only
+---
+
+# Vertebral Artery Interventions: A Comprehensive Updated Review
+**Authors:** Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, James S. Jenkins
+**Journal:** Current Cardiology Reviews (2023)
+**DOI:** [10.2174/1573403x18666220317093131](https://doi.org/10.2174/1573403x18666220317093131)
+
+## Content
+
+Abstract:
+Patients with posterior circulation ischemia due to vertebral artery stenosis account for
+20 to 25% of ischemic strokes and have an increased risk of recurrent stroke. In patients treated
+with medical therapy alone, the risk of recurrence is particularly increased in the first few weeks
+after symptoms occur, with an annual stroke rate of 10 to 15%. Additionally, obstructive disease of
+the vertebrobasilar system carries a worse prognosis, with a 30% mortality at 2-years if managed
+medically without additional surgical or endovascular intervention.
+Percutaneous transluminal angioplasty and stenting of symptomatic vertebral artery stenosis are
+promising options widely used in clinical practice with good technical results; however, the improved
+clinical outcome has been examined in various clinical trials without a sufficient sample
+size to conclusively determine whether stenting is better than medical therapy. Surgical revascularization
+is an alternative approach for the treatment of symptomatic vertebral artery stenosis that
+carries a 10-20% mortality rate.
+Despite the advances in medical therapy and endovascular and surgical options, symptomatic vertebral
+artery stenosis continues to impose a high risk of stroke recurrence with associated high
+morbidity and mortality. This review aims to provide a focused update on the percutaneous treatment
+of vertebral artery stenosis, its appropriate diagnostic approach, and advances in medical
+therapies.

--- a/references_cache/DOI_10.3389_fneur.2023.1202565.md
+++ b/references_cache/DOI_10.3389_fneur.2023.1202565.md
@@ -1,0 +1,29 @@
+---
+reference_id: "DOI:10.3389/fneur.2023.1202565"
+title: "Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center"
+authors:
+- Tongfu Zhang
+- Donglin Zhou
+- Yangyang Xu
+- Maogui Li
+- Jianfeng Zhuang
+- Hai Wang
+- Weiying Zhong
+- Chao Chen
+- Hong Kuang
+- Donghai Wang
+- Yunyan Wang
+journal: Frontiers in Neurology
+year: '2023'
+doi: 10.3389/fneur.2023.1202565
+content_type: abstract_only
+---
+
+# Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center
+**Authors:** Tongfu Zhang, Donglin Zhou, Yangyang Xu, Maogui Li, Jianfeng Zhuang, Hai Wang, Weiying Zhong, Chao Chen, Hong Kuang, Donghai Wang, Yunyan Wang
+**Journal:** Frontiers in Neurology (2023)
+**DOI:** [10.3389/fneur.2023.1202565](https://doi.org/10.3389/fneur.2023.1202565)
+
+## Content
+
+BackgroundVertebral artery stenosis and occlusion (VASO) is a high-risk factor for posterior circulation stroke. Post-stent restenosis and drug tolerance have facilitated the exploration of microsurgical vascular reconstruction. This study aims to evaluate the safety and efficacy of microsurgical reconstruction of the proximal VA.MethodsTwenty-nine patients (25 men, aged 63.2 years) who had symptoms of posterior circulation ischemia underwent microsurgical revascularization for proximal VASO were retrospectively included in this study. Procedural complications and clinical and angiographic outcomes were reviewed.ResultsTwelve, three, and five patients underwent VA endarterectomy, artery transposition, or both, respectively; seven patients underwent vertebral endarterectomy plus stent implantation; and two patients failed surgery because of the difficult exposure of the VA and the occurrence of vascular dissection. The perioperative period-related complications included seven cases of Horner’s syndrome, five cases of hoarseness, and one case of chylothorax. No cases of perioperative stroke or death were reported. The mean follow-up period was 28.4 (8–62 months). Most patients improved clinically; however, the vertebrobasilar ischemia symptoms did not decrease significantly in two patients during the follow-up. Moreover, follow-up imaging was performed in all the patients, and no signs of anastomotic stenosis were reported.ConclusionMicrosurgical reconstruction is an alternative option that can effectively treat refractory proximal VASO disease and in-stent stenosis, with a high rate of postoperative vascular recirculation. Prospective cohort studies with larger sample sizes must be conducted to validate the above conclusions.

--- a/references_cache/PMID_11385214.md
+++ b/references_cache/PMID_11385214.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:11385214"
+title: Accuracy of color-Doppler in the quantification of proximal vertebral artery stenoses.
+authors:
+- de Bray JM
+- Pasco A
+- Tranquart F
+- Papon X
+- Alecu C
+- Giraudeau B
+- Dubas F
+- Emile J
+journal: Cerebrovasc Dis
+year: '2001'
+doi: 10.1159/000047663
+keywords:
+- Arterial Occlusive Diseases/diagnostic imaging
+- "Arteriosclerosis/complications, diagnostic imaging"
+- Cerebral Angiography
+- Double-Blind Method
+- False Positive Reactions
+- Humans
+- Prospective Studies
+- Stroke/diagnostic imaging
+- "Ultrasonography, Doppler, Color"
+- Vertebral Artery/diagnostic imaging
+content_type: abstract_only
+---
+
+# Accuracy of color-Doppler in the quantification of proximal vertebral artery stenoses.
+**Authors:** de Bray JM, Pasco A, Tranquart F, Papon X, Alecu C, Giraudeau B, Dubas F, Emile J
+**Journal:** Cerebrovasc Dis (2001)
+**DOI:** [10.1159/000047663](https://doi.org/10.1159/000047663)
+
+## Content
+
+1. Cerebrovasc Dis. 2001;11(4):335-40. doi: 10.1159/000047663.
+
+Accuracy of color-Doppler in the quantification of proximal vertebral artery 
+stenoses.
+
+de Bray JM(1), Pasco A, Tranquart F, Papon X, Alecu C, Giraudeau B, Dubas F, 
+Emile J.
+
+Author information:
+(1)Department of Neurology, CHU, Angers, France.
+
+BACKGROUND: Vertebrobasilar (VB) strokes appear to have the same causes as 
+carotid strokes. Obstructive lesions of proximal vertebral arteries probably 
+occur in about 30% of stroke patients.
+PURPOSE: Our aim was to assess the validity of color Doppler sonography compared 
+to selective intra-arterial angiography in the quantification of proximal 
+vertebral artery stenoses.
+MATERIALS AND METHODS: A prospective blind study of 316 vertebral arteries was 
+undertaken between 1996 and 1998. One hundred and fifty-eight patients with 
+cerebrovascular disorders without cerebral hemorrhage were studied consecutively 
+by frequency or amplitude color Doppler flow imaging and intra-arterial 
+angiography. The lesions were quantified by morphological and hemodynamic 
+criteria and classified into 6 groups: 0% 207 arteries; 1-29% 32 arteries; 
+30-49% 29 arteries; 50-69% 13 arteries; 70-99% 23 arteries; 100% 12 arteries.
+RESULTS: Ten of the 12 occlusions were identified, the 2 false-negatives were 
+due to 2 revascularized vessels. Moderate stenoses (<50%) were differentiated 
+from tight stenoses (>50%) using hemodynamic criteria. The majority of 
+false-negative stenoses (38) in the different groups were related to 
+intrathoracic or very deep origin of the artery, anechogenic stenosis or a 
+tortuous vessel. Stenoses greater than 70% were diagnosed in 71% of cases with a 
+specificity of 99%. The kappa value was 0.80.
+CONCLUSION: Duplex sonography should be proposed first in VB attacks or stroke 
+to detect and quantify vertebral artery stenoses for surgery and angioplasty.
+
+Copyright 2001 S. Karger AG, Basel.
+
+DOI: 10.1159/000047663
+PMID: 11385214 [Indexed for MEDLINE]

--- a/references_cache/PMID_12870261.md
+++ b/references_cache/PMID_12870261.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:12870261"
+title: "A case of intimal hyperplasia induced by stenting for vertebral artery origin stenosis: assessed on intravascular ultrasound."
+authors:
+- Hayashi K
+- Kitagawa N
+- Morikawa M
+- Kaminogo M
+journal: Neurol Res
+year: '2003'
+doi: 10.1179/016164103101201689
+keywords:
+- Aged
+- "Angioplasty, Balloon/adverse effects"
+- Humans
+- Hyperplasia
+- Male
+- "Postoperative Complications/diagnostic imaging, etiology"
+- Recurrence
+- Stents/adverse effects
+- Tunica Intima/pathology
+- "Ultrasonography, Interventional"
+- "Vertebrobasilar Insufficiency/diagnostic imaging, etiology, therapy"
+content_type: abstract_only
+---
+
+# A case of intimal hyperplasia induced by stenting for vertebral artery origin stenosis: assessed on intravascular ultrasound.
+**Authors:** Hayashi K, Kitagawa N, Morikawa M, Kaminogo M
+**Journal:** Neurol Res (2003)
+**DOI:** [10.1179/016164103101201689](https://doi.org/10.1179/016164103101201689)
+
+## Content
+
+1. Neurol Res. 2003 Jun;25(4):357-60. doi: 10.1179/016164103101201689.
+
+A case of intimal hyperplasia induced by stenting for vertebral artery origin 
+stenosis: assessed on intravascular ultrasound.
+
+Hayashi K(1), Kitagawa N, Morikawa M, Kaminogo M.
+
+Author information:
+(1)Department of Neurosurgery, Nagasaki University School of Medicine, 1-7-1 
+Sakamoto, Nagasaki-city, Nagasaki 852-8501, Japan. 
+Kentaro.Hayashi@ma8.seikyou.ne.jp
+
+We report a case of proximal vertebral artery restenosis following stent 
+placement. Intravascular ultrasound study helped delineate its characteristics. 
+A 69-year-old man was admitted because of dysarthria and dysphagia. Angiography 
+revealed hypoplasia of left vertebral artery (VA) and remarkable stenosis of the 
+proximal right VA with inadequate collateral flow from the anterior circulation. 
+Balloon angioplasty and stent placement at the VA was performed to an excellent 
+angiographic result with recovery of neurological symptoms. His condition 
+deteriorated six months later due to intimal hyperplasia, which we evaluated by 
+intravascular ultrasound (IVUS). Balloon angioplasty was then performed. Stent 
+placement may induce intimal hyperplasia and IVUS is useful to assess the 
+lesion.
+
+DOI: 10.1179/016164103101201689
+PMID: 12870261 [Indexed for MEDLINE]

--- a/references_cache/PMID_21050408.md
+++ b/references_cache/PMID_21050408.md
@@ -1,0 +1,144 @@
+---
+reference_id: "PMID:21050408"
+title: "Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design."
+authors:
+- Amin-Hanjani S
+- Rose-Finnell L
+- Richardson D
+- Ruland S
+- Pandey D
+- Thulborn KR
+- Liebeskind DS
+- Zipfel GJ
+- Elkind MS
+- Kramer J
+- Silver FL
+- Kasner SE
+- Caplan LR
+- Derdeyn CP
+- Gorelick PB
+- Charbel FT
+- VERiTAS Study Group
+journal: Int J Stroke
+year: '2010'
+doi: 10.1111/j.1747-4949.2010.00528.x
+keywords:
+- Basilar Artery/physiology
+- "Brain Ischemia/epidemiology, pathology, physiopathology"
+- Cerebrovascular Circulation
+- Humans
+- "Ischemic Attack, Transient/epidemiology, pathology, physiopathology"
+- Magnetic Resonance Angiography
+- Multicenter Studies as Topic/methods
+- Prospective Studies
+- Risk Factors
+- Vertebral Artery/physiology
+content_type: full_text_xml
+---
+
+# Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and Stroke study (VERiTAS): rationale and design.
+**Authors:** Amin-Hanjani S, Rose-Finnell L, Richardson D, Ruland S, Pandey D, Thulborn KR, Liebeskind DS, Zipfel GJ, Elkind MS, Kramer J, Silver FL, Kasner SE, Caplan LR, Derdeyn CP, Gorelick PB, Charbel FT, VERiTAS Study Group
+**Journal:** Int J Stroke (2010)
+**DOI:** [10.1111/j.1747-4949.2010.00528.x](https://doi.org/10.1111/j.1747-4949.2010.00528.x)
+
+## Content
+
+1. Int J Stroke. 2010 Dec;5(6):499-505. doi: 10.1111/j.1747-4949.2010.00528.x.
+
+Vertebrobasilar Flow Evaluation and Risk of Transient Ischaemic Attack and 
+Stroke study (VERiTAS): rationale and design.
+
+Amin-Hanjani S(1), Rose-Finnell L, Richardson D, Ruland S, Pandey D, Thulborn 
+KR, Liebeskind DS, Zipfel GJ, Elkind MS, Kramer J, Silver FL, Kasner SE, Caplan 
+LR, Derdeyn CP, Gorelick PB, Charbel FT; VERiTAS Study Group.
+
+Collaborators: Amin-Hanjani S, Rose-Finnell L, Jacobs TP, Richardson D, Xie H, 
+Simkus V, Thulborn K, Flannery MP, Ganin H, Grysecwicz R, Khaja A, Pedelty L, 
+Testai F, Watson K, Mlinarevich N, Zipfel GJ, Vo K, Foster G, Ford A, Bradley A, 
+Liebeskind DS, Alger J, Godinez S, Saver J, Ali L, Kim D, Raychev R, Song S, 
+Ovbiagele B, Smith H, Elkind MS, Hirsch J, Dashnaw S, Meyers P, McNeill-Simaan 
+E, Silver FL, Mikulis D, Fierstra J, Hlasny E, Casaubon LK, Vergouwen M, Martin 
+del Campo JC, Jaigobin CS, Astorga C, Kramer J, Vaughan S, Owens L, Charbel FT, 
+Gorelick PB, Pandey DK, Ruland SD, Thulborn KR, Derdeyn CP, Caplan LR, Kasner 
+SE, Kissela B, Turan TN, Gobin YP.
+
+Author information:
+(1)Department of Neurosurgery, Neuropsychiatric Institute, University of 
+Illinois at Chicago, Chicago, IL 60612-5970, USA. hanjani@uic.edu
+
+BACKGROUND: Over one-third of ischaemic strokes occur in the posterior 
+circulation, and a leading cause is atherosclerotic vertebrobasilar disease. 
+Symptomatic vertebrobasilar disease carries a high annual recurrent stroke risk, 
+averaging 10-15% per year. Endovascular angioplasty and stenting are 
+increasingly used but carry risks, and the benefit remains unproven. Determining 
+stroke predictors in this population is critical to identifying high-risk 
+patients for future trials of intervention. Preliminary studies indicate that 
+stroke risk in vertebrobasilar disease is strongly related to haemodynamic 
+compromise, which can be measured noninvasively using quantitative magnetic 
+resonance angiography.
+METHODS/STUDY DESIGN: The Vertebrobasilar Flow Evaluation and Risk of Transient 
+Ischaemic Attack and Stroke (VERiTAS) study, a prospective multicentre 
+NIH-funded observational study of symptomatic vertebrobasilar stenosis (≥50%) or 
+occlusion, is designed to test the hypothesis that patients demonstrating 
+compromised blood flow as assessed by quantitative magnetic resonance 
+angiography are at higher stroke risk. The study will recruit 80 patients at six 
+sites in North America over 4-years. Upon enrollment, subjects will undergo 
+haemodynamic assessment with blinded quantitative magnetic resonance angiography 
+to assess large vessel flow in the vertebrobasilar territory, and be 
+prospectively designated as compromised or normal flow. Patients will be 
+re-imaged with quantitative magnetic resonance angiography at 6-, 12-, and 
+24-months, and followed for 12-24-months for the primary end-point of stroke in 
+the vertebrobasilar territory.
+CONCLUSION: The VERiTAS study is the first prospective study of haemodynamics 
+and stroke risk in the posterior circulation. The results may impact the 
+selection criteria for interventional candidates and also define a low-risk 
+population in whom the risks of invasive interventions would be unnecessary.
+
+© 2010 The Authors. International Journal of Stroke © 2010 World Stroke 
+Organization.
+
+DOI: 10.1111/j.1747-4949.2010.00528.x
+PMCID: PMC3057649
+PMID: 21050408 [Indexed for MEDLINE]
+
+Posterior circulation strokes account for up to 30–40% of all ischemic events (1), an important etiology of which is atherosclerotic vertebrobasilar disease (VBD). Symptomatic VBD carries a high annual risk of recurrent stroke, averaging 10–15% per year despite medical therapy. Vertebrobasilar stroke is particularly prone to devastating consequences due to the ‘eloquence’ of the regional brain tissue (2), and is associated with high rates of death and disability.
+
+Large vessel atherosclerotic VBD accounts for approximately one third of ischemic events in the posterior circulation territory (3, 4). An important stroke mechanism in vertebrobasilar atherostenosis is regional hypoperfusion (5). Furthermore, both embolic and flow processes can synergize to increase stroke risk; a proposed mechanism is the reduced wash-out of emboli from the distal circulation in hypoperfused regions (6, 7). Low flow may also promote local thrombus formation at the site of disease, with resultant stroke (3). In the setting of hypoperfusion, however, posterior circulation collateral channels such as the posterior communicating arteries may maintain adequate distal flow (8). The existence and extent of these compensatory blood flow pathways may, therefore, influence the risk of stroke. Hemodynamic impairment has been linked to stroke in the anterior circulation: in carotid occlusion, severe hemodynamic compromise measured by positron emission tomography (PET) and other perfusion modalities predicts subsequent stroke risk (7, 9). The same role for hemodynamic impairment may be relevant to the posterior circulation, but has not been well examined to date.
+
+Several studies have estimated the recurrent stroke risk associated with vertebrobasilar stenosis (50–99%) to be 10–15% per year (10–13). Current medical therapies for cerebrovascular occlusive disease are directed primarily at curtailing the risk of thrombo-embolism (antithrombotic agents) and stabilizing plaque (statins, antihypertensives), but do not address an underlying low flow state. Recently, therapies aimed at augmenting blood flow have emerged, primarily in the endovascular arena. Endovascular angioplasty and stenting offer the potential to restore vessel flow and improve hemodynamic compromise. However, these interventions carry significant procedural risk, with periprocedural and one year stroke rates ranging from 8% up to 26% in recent series (14–18). The benefit from these interventions has not yet been established. Therefore, identification of a high risk subgroup, owing to hemodynamic impairment, would be important for future trials of intervention.
+
+Various imaging techniques exist for assessing cerebrovascular hemodynamic compromise, including single photon emission computed tomography (SPECT,) PET, Xenon computed tomography (CT), perfusion magnetic resonance (MR) and CT imaging, and transcranial Doppler (TCD). These modalities primarily assess cerebral tissue perfusion, and have proven useful in evaluating anterior circulation flow compromise (7, 9). However, factors such as inadequate spatial resolution and bony skull base artifacts have rendered them less useful in the posterior circulation, necessitating an alternative strategy. Measurement of large vessel flow in affected and major collateral vessels is one such strategy, and can be obtained non-invasively using the technique of quantitative magnetic resonance angiography (QMRA). QMRA involves anatomic visualization of cerebral vessels using time of flight (TOF) imaging, and direct measurement of flow velocity and volume flow rate using phase contrast (PC) imaging. Flow measurement with this technique has demonstrated accuracy in both in vitro and in vivo settings (19, 20). Commercially available software, Noninvasive Optimal Vessel Analysis (NOVA, VasSol, Inc.) uses a standardized TOF and PC MRA protocol to perform cerebrovascular QMRA (21–24). In comparison to QMRA, MR perfusion imaging provides tissue level perfusion data from the brain region of interest. Tissue perfusion has not been well studied in the posterior circulation territory, particularly the brainstem and cerebellum, but may provide important correlative and predictive data for the large vessel conductance flow measured by QMRA. The two imaging modalities can be readily combined to provide both large vessel and tissue level hemodynamic assessment in VBD.
+
+Retrospective data suggest that QMRA flow measurements have predictive value for subsequent stroke (22): 48 patients with symptomatic VBD (>50% stenosis or occlusion, extracranial or intracranial vertebral or basilar artery) were evaluated based on an algorithm defining flow compromise as >20% reduction below normative lower limits of posterior circulation vessel-specific flow. One third of patients were characterized as ‘low’ flow based upon the algorithm, and demonstrated a significantly worse stroke free survival of 71% (95% CI 23–92%) at 24 months compared to 100% stroke free survival in the ‘normal’ flow group. Flow status remained an independent predictor of recurrent stroke after adjusting for stenosis severity and disease location. These data strongly suggest that stroke risk in VBD is determined by the extent of intracranial blood flow compromise, as assessed by QMRA.
+
+Although compelling, retrospective studies have limitations, including the potential for selection bias, recall bias, and ascertainment bias. These can be improved upon with a well designed and conducted prospective study. Furthermore it is important to establish that flow measurement QMRA technology is generalizable to a broad range of sites. Therefore, the Vertebrobasilar Flow Evaluation and Risk of Transient Ischemic Attack and Stroke (VERiTAS) study is designed as a prospective blinded multi-center observational study to provide high quality evidence assessing flow status as a stroke predictor in patients with symptomatic VBD.
+
+VERiTAS is a multi-center prospective cohort study. Eligible patients undergo MR imaging to assess their cerebrovascular hemodynamic status, the results of which are interpreted centrally and kept blinded from the treating clinicians. The patients are prospectively followed for a minimum of one year on current standard medical regimen including vascular risk factor modification, statins and antithrombotic therapy, and evaluated for recurrent ischemic events.
+
+The primary hypothesis is that among patients with symptomatic VBD, those with distal blood flow compromise are at higher risk of subsequent posterior circulation stroke than those with normal flow. Secondary aims of the study are to determine the correlation between large vessel flow and tissue level perfusion in the posterior circulation, determine other predictive factors for stroke in the target population, evaluate the hemodynamic effects of varying degrees of vertebrobasilar stenosis, examine changes in hemodynamic status of patients on medical therapy over time, and determine the utility of QMRA as a non-invasive screening and monitoring tool for VBD.
+
+Patients presenting with vertebrobasilar distribution TIA or stroke are the source group. Symptoms and signs indicative of vertebrobasilar ischemia are defined as outlined by the Special Report from the National Institute of Neurological Disorders and Stroke (25). Diagnostic evaluation is performed at the discretion of the treating physicians, but commonly includes: MRA, CT angiography (CTA), TCD or conventional angiography. Patients with evidence of ≥ 50% extracranial or intracranial vertebrobasilar stenosis or occlusion are screened for final eligibility based upon the inclusion/exclusion criteria (Table). Final eligibility requires either CTA or conventional angiographic confirmation; if not performed as standard of care, subjects are asked to consent to craniocervical CTA or two vessel vertebral catheter angiography as part of the research protocol.
+
+The nature and frequency of cerebral ischemic events is recorded Medications at the time of enrollment and specific data regarding vascular risk factors are gathered including age, gender, race, hypertension, diabetes mellitus, lipid disorder, coronary disease, smoking, alcohol consumption, and parental death from stroke. A physical examination and neurological evaluation is performed by a study physician. The National Institute of Health Stroke Scale (NIHSS) is administered, and functional status assessed using the Barthel Index, modified Rankin Scales and modified Glasgow Outcome Score. Available laboratory data including hemoglobin, serum creatinine, lipid profile, homocysteine, high sensitivity C-reactive protein, hemoglobin-A1c, and casual or fasting plasma glucose is collected, in addition to results of cerebral imaging studies and ancillary testing such as echocardiography and electrocardiography.
+
+A standardized MR imaging protocol consisting of QMRA and MR perfusion is performed within 7–14 days of enrollment. The QMRA portion of the study is performed using NOVA (Noninvasive Optimal Vessel Analysis, VasSol, Inc.) software, and MR perfusion is performed using dynamic susceptibility contrast (DSC) technique. Imaging consists of axial 3D TOF imaging of the cranial vasculature, from which a 3-D image of the vessels is created. Standard sites for flow measurement are chosen from this image in 15 vessels (Figure 1); the locations have been pre-specified for consistency between scans and between patients. To minimize potential effects of turbulent flow, the site for flow measurement is placed at the furthest distance from any existing stenosis within the designated segment. Quantitative flow measurements are then obtained in the chosen vessels using PC MR technique (24). Finally, DSC MR perfusion scanning is performed using the magnetic susceptibility contrast bolus tracking method with gradient echo, echo-planar imaging during first passage through the brain of intravenously administered gadolinium contrast (Omniscan, 0.1mmol/kg, via 20 gauge angiocath in antecubital vein using mechanical injector). Equivalent protocols for each MR vendor (GE, Siemens, Phillips) have been specified, with all imaging performed on 3 Tesla machines. The QMRA portion of the study is remotely supervised at the time of imaging by a certified NOVA technician to ensure correct parameters and vessel placement for flow measurement, and the data is automatically transferred via secure internet based transfer to the clinical coordinating center (CCC) at University of Illinois at Chicago (UIC) for central review. The MR perfusion portion of the study is similarly sent for review to the CCC. The imaging results remain blinded to the patient and all participating site personnel. To ensure blinding, the QMRA imaging is permanently removed from the local site workstation after central transfer.
+
+Treating physicians are encouraged to adhere to published guidelines and employ antithrombotic agents, antihypertensive agents, statins and vascular risk factor control strategies as per published guidelines (26–29). Risk factor modification is managed by the study physician in conjunction with the patient’s primary care physician or neurologist.
+
+The patient is contacted monthly by telephone until 12 months for determination of new events using a standardized telephone questionnaire. In-person follow-up is performed at 6 and 12 months at a minimum, and every 6 months thereafter up until completion of the study or 2 years maximum. A detailed neurological evaluation including the standardized assessments (such as NIHSS, Barthel Index etc.) is performed by the blinded study physician, and interval occurrence of any cerebral ischemic symptoms/signs are noted.
+
+The MR imaging protocol is repeated at 6 and 12 months, and at 24 months if prior to the completion of the study. Results are centrally reviewed and remain blinded from the participating center.
+
+The primary endpoint is fatal and nonfatal ischemic stroke in the vertebrobasilar territory within 12 months. Ischemic stroke is defined as new neurological symptoms or signs lasting at least 24 hours or lasting < 24 hours but associated with new infarct on CT or MRI. Symptoms and signs indicative of vertebrobasilar ischemia are defined as outlined previously (25). Secondary endpoints are: TIA and ischemic stroke in the vertebrobasilar territory; ischemic stroke in any vascular territory; all ischemic stroke and vascular death (death from a vascular etiology or sudden death not explained by a known nonvascular process); aggregate of any ischemic stroke, myocardial infarction and vascular death; all stroke (ischemic and hemorrhagic); all death; neurological impairment as determined by the NIHSS; neurological disability as determined by the modified Barthel Index; and handicap as determined by the modified Rankin Scale.
+
+When a potential endpoint is identified, study personnel arrange for the patient to be evaluated by the blinded study physician within 72 hours. Initial endpoint determinations are made by the participating site but the relevant information is submitted to the CCC for final adjudication by an independent panel of two vascular neurologists, blinded to the patient’s study protocol imaging results. If the opinions of the two adjudicators differ, a third adjudicator is consulted for majority opinion.
+
+All clinical data is submitted to the Data Management Center (DMC) at UIC via secure web-based data entry system. All study imaging data is centrally reviewed to confirm adequate imaging quality and completeness. Data from the MR perfusion portion of the imaging is analyzed for calculation of regional perfusion parameters (tissue transit time, time to arrival, and cerebral blood volume). Initial determination of vertebral or basilar stenosis for eligibility is made locally at the participating center using the WASID technique (30). Relevant angiographic images are sent to the CCC, and reviewed by a blinded neuroradiologist for final determination of degree of stenosis.
+
+Event rates were estimated from published preliminary data (22), which indicated a 71% one year stroke free survival in symptomatic VBD patients designated as low flow, translating into an annual event rate of 29%. There was a 0% stroke and 4% TIA rate in the normal flow group; consequently, a conservative estimate of 2% stroke event rate was used for this group. The data also indicated that recruitment into the normal vs. low flow group would occur at a 2:1 ratio. Sample sizes were calculated for a range of possible event rates in the low flow group from 18% to 28%, assuming a 2:1 proportion of normal: low flow. 10% attrition rate was included. Based upon these assumptions, a sample size of 80 patients achieves 80% power in detecting a significant difference between an annual event rate of 22% in the low flow group and 2% in the normal flow group, and at least 50% power for detecting a difference even if the event rate in the low flow group is as low as 13%.
+
+Analysis of the primary endpoint (ischemic stroke in the vertebrobasilar territory) will be a time-to-event comparison using the log-rank test between subjects designated as low vs. normal flow, based upon the subject’s initial enrollment QMRA study (using parameters defined in our preliminary studies) (22). Subjects will be censored at the time of any endovascular or surgical revascularization procedures, or at the end of the follow-up period. Exploration for risk factors and adjustment for covariates will be performed with Cox proportional hazards analysis. Post-hoc sensitivity analysis will examine alternative cut-points for designation of low or normal flow status, to determine if an ‘optimized’ flow algorithm can be generated with greater sensitivity/specificity in stroke prediction. Correlation analyses will be performed to assess the linear relationships between perfusion parameters and large vessel flow measurements. The sensitivity analysis performed to examine varying cut-points for large vessel flows will also be performed with integration of the MR perfusion data.
+
+The organizational elements of VERiTAS Study group are listed in the appendix, and consist of the CCC, DMC, participating sites, and committees (Operations Committees, Advisory committee, Adjudication Committee, and Angiography Review Committee).
+
+VERiTAS is the first prospective study of hemodynamics and stroke risk in the posterior circulation. The results may impact the selection criteria and likelihood for success of future clinical trials aimed at assessing the efficacy of endovascular or surgical interventions for VBD. Moreover, defining a low risk population in whom the risks of invasive interventions would be unnecessary would have an equally important impact on VBD management, both from a clinical, and cost, perspective. The data regarding the hemodynamic effects of VBD, and their temporal progression, may also enhance our understanding of the basic pathophysiology and mechanisms of stroke in this morbid disease entity.

--- a/references_cache/PMID_25977279.md
+++ b/references_cache/PMID_25977279.md
@@ -1,0 +1,187 @@
+---
+reference_id: "PMID:25977279"
+title: Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+authors:
+- Amin-Hanjani S
+- Du X
+- Rose-Finnell L
+- Pandey DK
+- Richardson D
+- Thulborn KR
+- Elkind MS
+- Zipfel GJ
+- Liebeskind DS
+- Silver FL
+- Kasner SE
+- Aletich VA
+- Caplan LR
+- Derdeyn CP
+- Gorelick PB
+- Charbel FT
+- VERiTAS Study Group
+journal: Stroke
+year: '2015'
+doi: 10.1161/STROKEAHA.115.009215
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Blood Flow Velocity/physiology
+- Cerebrovascular Circulation/physiology
+- Cohort Studies
+- Female
+- Hemodynamics/physiology
+- Humans
+- Male
+- Middle Aged
+- Prospective Studies
+- Risk Factors
+- "Stroke/diagnosis, etiology, physiopathology"
+- "Vertebrobasilar Insufficiency/complications, diagnosis, physiopathology"
+content_type: full_text_xml
+---
+
+# Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+**Authors:** Amin-Hanjani S, Du X, Rose-Finnell L, Pandey DK, Richardson D, Thulborn KR, Elkind MS, Zipfel GJ, Liebeskind DS, Silver FL, Kasner SE, Aletich VA, Caplan LR, Derdeyn CP, Gorelick PB, Charbel FT, VERiTAS Study Group
+**Journal:** Stroke (2015)
+**DOI:** [10.1161/STROKEAHA.115.009215](https://doi.org/10.1161/STROKEAHA.115.009215)
+
+## Content
+
+1. Stroke. 2015 Jul;46(7):1850-6. doi: 10.1161/STROKEAHA.115.009215. Epub 2015
+May  14.
+
+Hemodynamic Features of Symptomatic Vertebrobasilar Disease.
+
+Amin-Hanjani S(1), Du X(2), Rose-Finnell L(2), Pandey DK(2), Richardson D(2), 
+Thulborn KR(2), Elkind MS(2), Zipfel GJ(2), Liebeskind DS(2), Silver FL(2), 
+Kasner SE(2), Aletich VA(2), Caplan LR(2), Derdeyn CP(2), Gorelick PB(2), 
+Charbel FT(2); VERiTAS Study Group.
+
+Collaborators: Xie H, Flannery MP, Ganin H, Ruland S, Grysiewicz R, Khaja A, 
+Pedelty L, Testai F, Ong A, Epstein N, Muqtadar H, Watson K, Mlinarevich N, 
+Hillmann M, Hirsch J, Dashnaw S, Meyers PM, Willey JZ, McNeill-Simaan E, Perez 
+V, Canaan A, Paulino-Hernandez W, Vo K, Foster G, Ford A, Nassief A, Bradley A, 
+Serna-Northway J, Kraus K, Shiwani L, Hantler N, Alger J, Godinez S, Saver JL, 
+Ali L, Kim D, Tenser M, Froehler M, Raychev R, Song S, Ovbiagele B, Abcede H, 
+Adamczyk P, Rao N, Yallapragada A, Modir R, Hinman J, Tansy A, Calderon-Arnulphi 
+M, Sheth S, Noorian A, Ng K, Liang C, Gadhia J, Smith H, Avila G, Avelar J, 
+Mikulis D, Fierstra J, Hlasny E, Casaubon LK, Vergouwen M, Del Campo JC, 
+Jaigobin CS, Astorga C, Kalman L, Kramer J, Vaughan S, Owens L, Kissela B, Turan 
+TN, Jacobs TP, Janis S.
+
+Author information:
+(1)From the Department of Neurosurgery (S.A.-H., X.D., L.R.-F., V.A.A., F.T.C.), 
+Department of Neurology and Rehabilitation (D.K.P., D.R.), and Center for 
+Magnetic Resonance Research (K.R.T.), University of Illinois at Chicago; 
+Department of Mathematics and Computer Science, Lake Forest College, IL (D.R.); 
+Departments of Neurology and Epidemiology, Columbia University, New York, NY 
+(M.S.V.E.); Departments of Neurosurgery and Neurology, Washington University in 
+St. Louis, MO (G.J.Z., C.P.D.); Department of Neurology, University of 
+California at Los Angeles (D.S.L.); Division of Neurology, Department of 
+Medicine, University of Toronto, Toronto, Ontario, Canada (F.L.S.); Department 
+of Neurology, University of Pennsylvania, Philadelphia (S.E.K.); Department of 
+Neurology, Beth Israel Deaconess Medical Center, Boston, MA (L.R.C.); 
+Departments of Radiology, Neurology and Neurological Surgery, Mallinkrodt 
+Institute of Radiology, Washington University in St. Louis, MO (C.P.D.); and 
+Department of Translational Science and Molecular Medicine, Michigan State 
+University College of Human Medicine, and Mercy Health Hauenstein Neurosciences, 
+Grand Rapids (P.B.G.). hanjani@uic.edu.
+(2)From the Department of Neurosurgery (S.A.-H., X.D., L.R.-F., V.A.A., F.T.C.), 
+Department of Neurology and Rehabilitation (D.K.P., D.R.), and Center for 
+Magnetic Resonance Research (K.R.T.), University of Illinois at Chicago; 
+Department of Mathematics and Computer Science, Lake Forest College, IL (D.R.); 
+Departments of Neurology and Epidemiology, Columbia University, New York, NY 
+(M.S.V.E.); Departments of Neurosurgery and Neurology, Washington University in 
+St. Louis, MO (G.J.Z., C.P.D.); Department of Neurology, University of 
+California at Los Angeles (D.S.L.); Division of Neurology, Department of 
+Medicine, University of Toronto, Toronto, Ontario, Canada (F.L.S.); Department 
+of Neurology, University of Pennsylvania, Philadelphia (S.E.K.); Department of 
+Neurology, Beth Israel Deaconess Medical Center, Boston, MA (L.R.C.); 
+Departments of Radiology, Neurology and Neurological Surgery, Mallinkrodt 
+Institute of Radiology, Washington University in St. Louis, MO (C.P.D.); and 
+Department of Translational Science and Molecular Medicine, Michigan State 
+University College of Human Medicine, and Mercy Health Hauenstein Neurosciences, 
+Grand Rapids (P.B.G.).
+
+BACKGROUND AND PURPOSE: Atherosclerotic vertebrobasilar disease is an important 
+cause of posterior circulation stroke. To examine the role of hemodynamic 
+compromise, a prospective multicenter study, Vertebrobasilar Flow Evaluation and 
+Risk of Transient Ischemic Attack and Stroke (VERiTAS), was conducted. Here, we 
+report clinical features and vessel flow measurements from the study cohort.
+METHODS: Patients with recent vertebrobasilar transient ischemic attack or 
+stroke and ≥50% atherosclerotic stenosis or occlusion in vertebral or basilar 
+arteries (BA) were enrolled. Large-vessel flow in the vertebrobasilar territory 
+was assessed using quantitative MRA.
+RESULTS: The cohort (n=72; 44% women) had a mean age of 65.6 years; 72% 
+presented with ischemic stroke. Hypertension (93%) and hyperlipidemia (81%) were 
+the most prevalent vascular risk factors. BA flows correlated negatively with 
+percentage stenosis in the affected vessel and positively to the minimal 
+diameter at the stenosis site (P<0.01). A relative threshold effect was evident, 
+with flows dropping most significantly with ≥80% stenosis/occlusion (P<0.05). 
+Tandem disease involving the BA and either/both vertebral arteries had the 
+greatest negative impact on immediate downstream flow in the BA (43 mL/min 
+versus 71 mL/min; P=0.01). Distal flow status assessment, based on an algorithm 
+incorporating collateral flow by examining distal vessels (BA and posterior 
+cerebral arteries), correlated neither with multifocality of disease nor with 
+severity of the maximal stenosis.
+CONCLUSIONS: Flow in stenotic posterior circulation vessels correlates with 
+residual diameter and drops significantly with tandem disease. However, distal 
+flow status, incorporating collateral capacity, is not well predicted by the 
+severity or location of the disease.
+
+© 2015 American Heart Association, Inc.
+
+DOI: 10.1161/STROKEAHA.115.009215
+PMCID: PMC4607265
+PMID: 25977279 [Indexed for MEDLINE]
+
+Large vessel atherosclerotic disease of the vertebrobasilar (VB) system, both intracranial and extracranial, is a significant etiology of posterior circulation stroke, accounting for approximately one third of ischemic events in this territory1, 2. Symptomatic VB disease carries a high annual risk of recurrent events, averaging 10-15% per year despite medical therapy3-6. In addition to thromboembolism as a contributing etiology, regional hypoperfusion is considered an important potential contributor to stroke risk in VB disease7. Evaluation of hemodynamic status has been traditionally limited to assessment of tissue perfusion in anterior circulation disease with imaging techniques which translate poorly into assessment of the more compact posterior circulation territory8. Retrospective data, however, suggest that measurement of large vessel flow using quantitative magnetic resonance angiography (QMRA) provides a useful surrogate for hemodynamic assessment in the posterior circulation, and may be predictive of future stroke risk9.
+
+In order to examine the utility of QMRA in assessment of hemodynamic compromise and prediction of stroke risk in symptomatic VBD, a prospective observational multi-center study, Vertebrobasilar Flow Evaluation and Risk of Transient Ischemic Attack and Stroke (VERiTAS) was undertaken10. In this paper, we evaluate the affected vessel, immediate downstream and distal hemodynamic impact of VB disease.
+
+Details of the VERiTAS study design have been previously published10. Briefly, the study is a multi-center prospective cohort study of patients with ≥ 50% extracranial or intracranial atherosclerotic VB stenosis or occlusion based upon conventional digital subtraction angiography (DSA) or computed tomographic angiography (CTA) presenting with referable VB distribution TIA or stroke within 60 days. The clinical criteria for enrollment are further detailed in the supplemental methods (please see http://stroke.ahajournals.org). In addition to standard clinical assessments, eligible patients underwent, QMRA imaging to assess their cerebrovascular hemodynamic status; the results of this imaging were interpreted centrally as low or normal distal flow status, and kept blinded from the treating clinicians. The patients were prospectively followed on medical regimens consistent with national guidelines for a minimum of one year, up to a planned maximum of two years, and evaluated for recurrent ischemic events. The study was approved by the local institutional review boards, and all subjects provided informed consent.
+
+After the initiation of the study, interim analysis of flow and angiographic data following enrollment of the initial 35 patients resulted in two additional exclusion criteria, as follows. First, interim analysis of distal flow status revealed a 4:1 ratio of normal flow to low flow subjects, as compared to the 2:1 ratio which had been used in initial sample size calculations; thus, decision was made to exclude further enrollment of patients with unilateral vertebral disease (stenosis or occlusion) as distal flow status in such previously enrolled subjects was normal in the vast majority (8:1 ratio). Second, interim review of angiographic data raised concern that subjects already enrolled with unilateral vertebral occlusion as the only finding on imaging could not reliably be distinguished as atherosclerosis or dissection as the underlying etiology; given the differing prognosis and potential stroke mechanisms of these two entities, an exclusion criteria was imposed to exclude from subsequent analyses all patients with unilateral vertebral occlusion in the absence of concomitant basilar disease.
+
+Standard neurological evaluation was performed, and data gathered including demographic information, nature and frequency of cerebral ischemic events, medications at the time of enrollment, vascular risk factors and available laboratory and imaging data. Hypertension (HTN) was defined as self-reported history or use of antihypertensive medication; diabetes mellitus (DM) was defined as self-reported history or use of insulin or oral hypoglycemic treatment; hyperlipidemia (HL) was defined as self-reported history or current treatment with lipid lowering therapy; coronary artery disease was defined as reported history of myocardial infarction, angina pectoris, positive stress test or cardiac surgery/intervention; renal dysfunction was defined as chronic renal failure (CRF, need for dialysis) and chronic renal insufficiency (CRI, as per criteria of the National Kidney Foundation for chronic kidney disease including decreased GFR for ≥ 3 months). Smoking history was obtained and specified as current (smoked within the past 12 months), former (not within past 12 months, but smoked for >1 year previously) or never. Alcohol intake history was recorded as number of drinks per day in the past year. Body mass index (BMI) was calculated from recorded height and weight data and classified as normal (18.5 to 24.9 kg/m2), overweight (25 to 29.9 kg/m m2), class 1 obesity (30 to 34.9 kg/m2), class 2 obesity (35 to 39.9 kg/m2), or Class 3 obesity (≥ 40 kg/m2).
+
+Enrollment angiographic data (DSA or CTA) was centrally reviewed by a blinded interventional neuroradiologist for final determination of degree of stenosis using the Warfarin-Aspirin Symptomatic Intracranial Disease (WASID) method11, further detailed in the supplemental methods (please see http://stroke.ahajournals.org). Measurements of residual lumen and vessel diameters were obtained from site review of the angiographic imaging.
+
+A magnetic resonance (MR) imaging protocol including QMRA was performed within 7-14 days of enrollment using a standardized protocol on a 3 Tesla MR scanner. The QMRA portion of the imaging was performed with a protocol utilizing NOVA (Noninvasive Optimal Vessel Analysis, VasSol, Inc.) software as previously described10, and is further detailed in the supplemental methods (please see http://stroke.ahajournals.org). Flow measurements were performed on pre-specified locations of each major cerebral artery including the vertebral arteries (VA, straight segment proximal to posterior inferior cerebellar artery) , basilar artery (BA, proximal to superior cerebellar arteries, distal to stenosis if present) and posterior cerebral arteries (PCA, P2 segment distal to the posterior communicating arteries). The study was remotely supervised at the time of the imaging by a certified NOVA technician to ensure correct parameters and vessel placement for flow measurement, and the data were transferred automatically via secure internet based transfer to the clinical coordinating center at University of Illinois at Chicago (UIC) for central review. The results of the imaging remained blinded to the patient and participating site personnel including the evaluating study physician.
+
+Anterograde flow in the affected vessel was examined relative to degree of stenosis and minimal vessel diameter at the site of stenosis using correlation analysis, for patients with exclusively VA or BA stenosis. Any vessels with retrograde flow were designated as 0 cc/min anterograde flow for the purposes of this analysis (BA n=3; VA n= 2). VA or BA occlusions were excluded from this correlation analysis which aimed to assess the impact of stenosis on anterograde local flow. Similarly, any patients with tandem VA and BA disease were excluded from this analysis as the flow in the affected vessel would be influenced not just by that vessel’s disease but also by the tandem disease.
+
+Next, anterograde immediate downstream flow in the BA was assessed by examining the BA flow in all subjects, including those with BA or VA occlusion and tandem disease. Retrograde flow was designated as 0 cc/min anterograde flow (BA n= 5). For purposes of analyzing the relationship of immediate downstream flow to severity of disease, subjects were characterized as moderate (50-69%), severe (70-99%), or occlusion based on their most severe disease in either the VA or BA.
+
+Finally, distal flow status was assigned for all subjects as a measure of regional flow, and designated as low or normal based on a previously published algorithm9 (please see http://stroke.ahajournals.org, supplemental figure I) defining flow compromise as >20% reduction below normative lower limits of flow in distal vessels, namely the BA and PCAs. Conceptually, the algorithm incorporates any sources of collateral flow (e.g. via the posterior communicating arteries) by their effect on the blood flow within these distal vessels.
+
+Following completion of study enrollment, aggregate clinical data were collated from the baseline assessments. Clinical presentation relative to disease location, severity and flow status was assessed using χ2 analysis with Fisher’s exact test where appropriate. The relationship between degree of stenosis/diameter and blood flow in the affected vessel was assessed using Pearson correlation analysis; the relationship was also examined using linear regression analysis. The impact of increasing degrees of stenosis was evaluated using t-test. Downstream flow rates in the BA were averaged, and comparisons relative to location and severity of disease performed using t-test or analysis of variance methods with post hoc Tukey test, where appropriate; flow status comparisons were performed using χ2 analysis with Fisher’s exact test. P<0.05 was considered significant. All analysis was performed with SAS (version 9.4, SAS institute, Cary, NC, USA).
+
+The study was open for enrollment from August 2008 to July 2013, with an initial target sample size of 80 patients. During this period 200 patients were screened, 89 of whom meet eligibility criteria, and 82 of whom consented to participate and were enrolled. Following central angiographic review, 8 patients with unilateral vertebral occlusions were excluded, and an additional patient was determined to have a vertebrobasilar junction fenestration, rather than atherosclerotic stenosis; one patient with angiographic basilar occlusion at time of enrollment demonstrated complete resolution of the occlusion without evidence of underlying atherosclerotic disease on baseline QMRA imaging, and was excluded. Consequently, 72 patients with centrally adjudicated atherosclerotic VB disease ≥ 50% comprised the study cohort analyzed.
+
+The cohort consisted of 40 (56%) men, with mean age of 65.6 years (median 65.7, range 40 to 90). Baseline characteristics, including race, ethnicity, and vascular risk factors are outlined in Table 1. Both HTN and HL were present in a majority of patients, as well as elevated BMI.
+
+DSA was performed in 44 (60%) of cases as enrollment imaging, as compared to CTA in the remaining cases (except one patient who had previously undergone DSA, but the only imaging at time of qualifying event was MRA). The profile of vertebrobasilar vessel involvement is outlined in table 1. The majority of patients harbored only intracranial disease (78%), with predominantly exclusive basilar artery disease (40%). In terms of the worst disease severity in a given patient, severe stenosis (70-99%) was predominant, accounting for 44% of the cohort.
+
+As regards their qualifying event, 52 (72%) patients presented with stroke, and the rest with TIA. Stroke was confirmed by imaging in the vast majority of patients (n=49); in the remaining minority and those with diagnosis of TIA, all patients presented with a constellation of symptoms consistent with posterior circulation etiology. Patients with vertebral only disease presented with stroke slightly less frequently (59%) than basilar (76%) or vertebrobasilar involvement (81%), but not statistically significant (p=0.29). Patients with exclusively extracranial disease also presented with stroke less frequently (43%) than those with exclusively intracranial disease (75%) or both (78%), but this difference was not statistically significant (p=0.21). The severity of disease (occlusion vs. severe vs. moderate) did not impact the frequency of stroke as the presenting symptom, nor did the distal flow status (p>0.50). The majority of patients presented with a symptom complex indicative of pontine syndrome (44%). The frequency of clinical syndromes relative to location of disease is shown in supplementary table I (please see http://stroke.ahajournals.org).
+
+Forty two (58%) of patients had a history of a prior posterior circulation ischemic event (TIA or stroke). The majority of these prior stroke or TIAs occurred within 30 days of the qualifying event (Supplementary Figure II).
+
+Flows within the affected vessels were examined in patients with exclusively BA or VA stenosis, to evaluate the impact of the stenosis on proximate flow within the vessel. Flows correlated moderately well with degree of stenosis in the affected vessel for the BA (rho=−0.49, p=0.01) but not for the VA (rho=−0.09, p=0.66) (Figure 1). For the BA, the largest and most statistically significant drop in vessel flow was first encountered at a threshold of 80% stenosis (p=0.02) (Figure 2). The correlation between flow and the residual diameter at the site of stenosis was more robust and evident both in the BA (rho=0.65, p<0.01 for BA) and VA (rho=0.62, p<0.01) (Figure 1).
+
+The immediate downstream effect of stenosis was examined by assessing BA flow. Flow reduction was significantly related to severity of stenosis (p<0.01) (Table 2). Tandem disease also had a significant impact on downstream flow: 43 ml/min in multifocal disease (concomitant BA and VA) compared to 71 ml/min in the patients with only BA or only VA disease (p=0.01).
+
+Of the cohort, 18 (25%) were designated low flow based on the pre-determined regional flow algorithm which incorporates collateral flow. Unlike the immediate downstream flow, distal flow status was independent of tandem disease (Table 3). Similarly, distal flow status was largely independent of disease severity with 89% of low flow patients demonstrating severe stenosis or occlusion (≥70%) compared with 75% of normal flow patients (p=0.08) (Table 3).
+
+We report here, for the first time, vessel flow measurements and clinical characteristics in a cohort of patients with symptomatic VB disease, correlated with severity and location of disease. Clinically, our cohort resembles those reported in other prospective studies of similar patients. Both a hospital based cohort of 58 patients and a population based cohort of 37 patients with ≥50% symptomatic VB stenosis demonstrate a similar mean age, and male predominance, with HTN and HL as the most common vascular risk factors12, 13. Also similar to these prior studies, the majority of patients presented with stroke rather than TIA. We did not find a significant relationship between presentation with stroke and disease location, although exclusively VA or extracranial disease trended towards the less severe presentation of TIA. Interestingly, the severity of stenosis and distal flow status both showed no relationship to presentation. Over half of our patients reported a prior posterior circulation ischemic event, primarily within the previous 30 days, in keeping with data reporting a high risk of recurrent stroke early after TIA or minor stroke in general14, and after VB TIA or stroke in specific13.
+
+In our hemodynamic analysis, we examined the impact of vessel stenosis in the posterior circulation in a number of ways: at the level of the affected vessel, downstream in the BA as the major conduit immediately distal to the VB disease, and finally, as a regional distal flow status incorporating collateral capacity. The importance of hemodynamics in predicting stroke risk has been evident in other settings15. Even in carotid stenosis, where the underlying etiology of recurrent stroke is widely considered to be thromboembolism, hemodynamic factors may be relevant16. The hemodynamic impact of stenosis within a vessel was first postulated by Spencer and Reid as a curve which predicts no substantive decline in flow until ~70% stenosis and a steep threshold in flow drop at ~80%17 (Figure 3). Carotid stenosis risk appears to largely correspond to these thresholds, with moderate (50-69%) stenosis having a more benign prognosis than severe stenosis, and a progressive increase in stroke risk with higher degrees of stenosis beyond 70%18. However, flow restriction within the affected vessel may ultimately be less relevant than distal regional flow. In this regard, the importance of collaterals in influencing stroke risk has been demonstrated in the setting of both carotid disease and intracranial stenosis. Post hoc analysis of the NASCET data demonstrated that even in patients with severe stenosis, the relative rate of recurrent stroke was much lower in patients with robust collaterals than those without angiographic collaterals16. Similarly in subsequent analysis of patients with both anterior and posterior circulation intracranial stenosis from the WASID trial, angiographic collaterals had a marked influence on stroke risk, with good collaterals significantly reducing risk in those with severe stenosis19. Recent data from large vessel flow measurements in carotid disease further support the importance of regional flow by demonstrating that flow compromise in the distal territory measured in the middle cerebral artery territory was more frequently associated with symptomatic presentation, whereas flow decline in the internal carotid alone was not predictive20.
+
+In our cohort, we established that flows in affected vessels correlate with residual diameter and stenosis, as would generally be expected, but has not been previously demonstrated in the posterior circulation. The relationship was strongest with diameter, and only evident with stenosis in the BA but not VAs. This latter finding likely reflects the frequent variability encountered in VA size, where asymmetries in luminal diameter are not uncommon. As such, the same % stenosis leads to a markedly smaller residual diameter in a hypoplastic 2 mm vertebral compared to a dominant 5 mm VA, and likely accounts for the lack of correlation between flow and % stenosis in the VA. In the BA, although flow declines with increasing stenosis, our data further support the tenets of Spencer and Reid’s curve, by demonstrating the most significant drop in flows at the 80% stenosis threshold.
+
+When looking at the immediate downstream flow in the BA in the full cohort, both severity of disease and tandem stenosis have a significant impact. Contrary to this, however, hemodynamic assessment of the distal flow status in the posterior circulation, which incorporates the contribution of any large vessel collateral flow, is not well predicted by either the severity or location of the disease. Thus, we illustrate for the first time in the posterior circulation that the distal flow status provides a hemodynamic assessment which, by incorporating collateral capacity, is distinct from anatomic measures such as stenosis and diameter and, as such, can be independent of the local hemodynamic impact of the disease. The importance of distal flow status in predicting stroke risk, as compared to the traditional reliance on anatomic features such as stenosis severity, has preliminary support from prior data9: in a retrospective single center cohort of 48 patients with >50% VB stenosis or occlusion, patients designated as low distal flow status demonstrated a significantly worse stroke free survival of 71% at 24 months compared to 100% stroke free survival in the normal distal flow status group. On multivariate analysis, distal flow status remained an independent predictor of recurrent stroke after adjusting for stenosis severity and location of disease. Although compelling, such retrospective data have drawbacks which limit definitive conclusions. The ultimate determination of the relevance of this form of hemodynamic assessment to predicting stroke risk will be available from future outcome data from the prospective VERiTAS cohort.
+
+The patients in this study are a selected population, rather than representing a population-based cohort; however, their demographic and clinical characteristics resemble other published prospective series. Only stenosis, and not diameter was centrally adjudicated due to inability to perform reliable absolute vessel measurements from centrally transmitted images; the lack of central verification, and the use of both DSA and CTA images may introduce some inaccuracies or variability in the diameter measurements. Patients with unilateral VA disease in the cohort may skew assessments of immediate downstream flow or distal flow status, as even severe stenosis or occlusion in just one VA is less likely to impact distal flow and could dilute an otherwise predictive value of severe disease on these parameters; however, unilateral VA occlusions were excluded from the cohort, and unilateral VA stenosis was limited by the eligibility criteria such that these cases comprise <10% of the cohort. Vessel flows can potentially be impacted by systemic factors such as blood pressure, for which our flow data has not been adjusted due to lack of standardized blood pressure measurements at the time of QMRA imaging. Although data from healthy volunteers suggest that intracranial blood flow is not impacted by blood pressure21, it is possible that in this cohort with underlying cerebrovascular disease and a high prevalence of pre-existing HTN, autoregulation is altered, with flows affected by blood pressure variation.
+
+Flow in stenotic posterior circulation vessels correlates with residual diameter and stenosis and drops most significantly when stenosis exceeds 80%, or in the setting of tandem disease. However, distal flow status, incorporating collateral capacity, is not well predicted by the severity or location of the disease. Final clinical outcome results from the VERiTAS study will further clarify the relevance of hemodynamic assessment to predicting stroke risk in patients with VB disease.

--- a/references_cache/PMID_28680502.md
+++ b/references_cache/PMID_28680502.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:28680502"
+title: "Pathophysiology and Diagnosis of Vertebrobasilar Insufficiency: A Review of the Literature."
+authors:
+- Lima Neto AC
+- Bittar R
+- Gattas GS
+- Bor-Seng-Shu E
+- Oliveira ML
+- Monsanto RDC
+- Bittar LF
+journal: Int Arch Otorhinolaryngol
+year: '2017'
+doi: 10.1055/s-0036-1593448
+content_type: abstract_only
+---
+
+# Pathophysiology and Diagnosis of Vertebrobasilar Insufficiency: A Review of the Literature.
+**Authors:** Lima Neto AC, Bittar R, Gattas GS, Bor-Seng-Shu E, Oliveira ML, Monsanto RDC, Bittar LF
+**Journal:** Int Arch Otorhinolaryngol (2017)
+**DOI:** [10.1055/s-0036-1593448](https://doi.org/10.1055/s-0036-1593448)
+
+## Content
+
+1. Int Arch Otorhinolaryngol. 2017 Jul;21(3):302-307. doi:
+10.1055/s-0036-1593448.  Epub 2016 Oct 26.
+
+Pathophysiology and Diagnosis of Vertebrobasilar Insufficiency: A Review of the 
+Literature.
+
+Lima Neto AC(1)(2), Bittar R(2), Gattas GS(3), Bor-Seng-Shu E(4), Oliveira 
+ML(4), Monsanto RDC(1), Bittar LF(5).
+
+Author information:
+(1)Department of Otolaryngology, Banco de Olhos de Sorocaba Hospital, Sorocaba, 
+São Paulo, Brazil.
+(2)Department of Otoneurology, School of Medicine, Universidade de São Paulo 
+(USP), São Paulo, Brazil.
+(3)Department of Radiology, School of Medicine, USP, São Paulo, Brazil.
+(4)Department of Neurology, School of Medicine, USP, São Paulo, Brazil.
+(5)Department of Engineering, School of Engineering, USP, São Paulo, Brazil.
+
+Introduction  Vertebrobasilar insufficiency is defined as transitory ischemia of 
+the vertebrobasilar circulation. Dizziness, vertigo, headaches, vomit, diplopia, 
+blindness, ataxia, imbalance, and weakness in both sides of the body are the 
+most common symptoms. Objective  To review the literature regarding the three 
+available diagnostic testing in patients with dizziness complaints secondary to 
+vertebrobasilar insufficiency (VBI): magnetic resonance angiography; 
+transcranial Doppler ultrasound; and vertebrobasilar deprivation testing. Data 
+Synthesis  We selected 28 studies that complied with our selection criteria for 
+appraisal. The most frequent cause of the hemodynamic changes leading to VBI is 
+atherosclerosis. The main clinical symptoms are dizziness, vertigo, headaches, 
+vomit, diplopia, blindness, ataxia, imbalance, and weakness in both sides of the 
+body. Even though arteriography is considered the most important exam to 
+diagnose the disease, the inherent risks of this exam should be taken into 
+consideration. The magnetic resonance angiography has been widely studied and is 
+a good method to identify and localize any occlusions and stenosis in both neck 
+and intracranial great vessels. Conclusion  Each patient with a suspected 
+diagnosis of VBI should be individually evaluated and treated, taking in 
+consideration the pros and cons of each diagnostic testing and treatment option.
+
+DOI: 10.1055/s-0036-1593448
+PMCID: PMC5495592
+PMID: 28680502

--- a/references_cache/PMID_35658624.md
+++ b/references_cache/PMID_35658624.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:35658624"
+title: "Treatment of posterior circulation stroke: Acute management and secondary prevention."
+authors:
+- Markus HS
+- Michel P
+journal: Int J Stroke
+year: '2022'
+doi: 10.1177/17474930221107500
+keywords:
+- "Constriction, Pathologic"
+- Endovascular Procedures/methods
+- Humans
+- Randomized Controlled Trials as Topic
+- Secondary Prevention
+- Stents/adverse effects
+- "Stroke/complications, prevention & control"
+- Treatment Outcome
+- "Vertebrobasilar Insufficiency/complications, prevention & control"
+content_type: abstract_only
+---
+
+# Treatment of posterior circulation stroke: Acute management and secondary prevention.
+**Authors:** Markus HS, Michel P
+**Journal:** Int J Stroke (2022)
+**DOI:** [10.1177/17474930221107500](https://doi.org/10.1177/17474930221107500)
+
+## Content
+
+1. Int J Stroke. 2022 Aug;17(7):723-732. doi: 10.1177/17474930221107500. Epub
+2022  Jun 28.
+
+Treatment of posterior circulation stroke: Acute management and secondary 
+prevention.
+
+Markus HS(1), Michel P(2).
+
+Author information:
+(1)Department of Clinical Neurosciences, University of Cambridge, Cambridge, UK.
+(2)Stroke Center, Neurology Service, Department of Clinical Neurosciences, 
+Lausanne University Hospital and University of Lausanne, Lausanne, Switzerland.
+
+One-fifth of strokes occur in the territory of the posterior circulation, but 
+their management, particularly acute reperfusion therapy and neurointervention 
+procedures for secondary prevention, has received much less attention than 
+similar interventions for the anterior circulation. In this review, we overview 
+the treatment of posterior circulation stroke, including both interventions in 
+the acute setting and secondary prevention. We focus on areas in which the 
+management of posterior circulation stroke differs from that of stroke in 
+general and highlight recent advances.Effectiveness of acute revascularization 
+of posterior circulation strokes remains in large parts unproven. Thrombolysis 
+seems to have similar benefits and lower hemorrhage risks than in the anterior 
+circulation. The recent ATTENTION and BAOCHE trials have demonstrated that 
+thrombectomy benefits strokes with basilar artery occlusion, but its effect on 
+other posterior occlusion sites remains uncertain. Ischemic and hemorrhagic 
+space-occupying cerebellar strokes can benefit from decompressive 
+craniectomy.Secondary prevention of posterior circulation strokes includes 
+aggressive treatment of cerebrovascular risk factors with both drugs and 
+lifestyle interventions and short-term dual anti-platelet therapy. Randomized 
+controlled trial (RCT) data suggest basilar artery stenosis is better treated 
+with medical therapy than stenting, which has a high peri-procedural risk. 
+Limited data from RCTs in stenting for vertebral stenosis suggest that 
+intracranial stenosis is currently best treated with medical therapy alone; the 
+situation for extracranial stenosis is less clear where stenting for symptomatic 
+stenosis is an option, particularly for recurrent symptoms; larger RCTs are 
+required in this area.
+
+DOI: 10.1177/17474930221107500
+PMCID: PMC9358302
+PMID: 35658624 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of conflicting interests: The 
+author(s) declared the following potential conflicts of interest with respect to 
+the research, authorship, and/or publication of this article: EIC IJS

--- a/references_cache/PMID_36127977.md
+++ b/references_cache/PMID_36127977.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:36127977"
+title: "Vertebral Artery Stenosis: A Narrative Review."
+authors:
+- Burle VS
+- Panjwani A
+- Mandalaneni K
+- Kollu S
+- Gorantla VR
+journal: Cureus
+year: '2022'
+doi: 10.7759/cureus.28068
+content_type: abstract_only
+---
+
+# Vertebral Artery Stenosis: A Narrative Review.
+**Authors:** Burle VS, Panjwani A, Mandalaneni K, Kollu S, Gorantla VR
+**Journal:** Cureus (2022)
+**DOI:** [10.7759/cureus.28068](https://doi.org/10.7759/cureus.28068)
+
+## Content
+
+1. Cureus. 2022 Aug 16;14(8):e28068. doi: 10.7759/cureus.28068. eCollection 2022 
+Aug.
+
+Vertebral Artery Stenosis: A Narrative Review.
+
+Burle VS(1), Panjwani A(2), Mandalaneni K(3), Kollu S(4), Gorantla VR(5).
+
+Author information:
+(1)Anatomical Sciences, St. George's University School of Medicine, Clarksville, 
+USA.
+(2)Anatomical Sciences, St. George's University School of Medicine, Whitby, CAN.
+(3)Neuroscience, St. George's University School of Medicine, St. George's, GRD.
+(4)Prosthodontics, Mamata Dental College, Khammam, IND.
+(5)Anatomical Sciences, St. George's University School of Medicine, St. 
+George's, GRD.
+
+Vertebral artery stenosis (VAS) is the cause of approximately 20% of ischemic 
+strokes in the posterior circulation. There are several causes of vertebral 
+artery stenosis, including atherosclerosis, calcification, dissections, 
+fibromuscular dysplasia, giant cell arteritis, neurofibromatosis type 1, and 
+bony compressions. The most common cause of VAS is atherosclerosis which is 
+derived from the macrophage-induced oxidation of low-density lipoproteins 
+(LDLs), alongside the accumulation of cholesterol. Calcification of the 
+vertebral artery occurs when there is excess calcium and phosphate deposition in 
+the vessel. Dissection of the vertebral artery can lead to the formation of a 
+hematoma causing stenosis of the vertebral artery. Fibromuscular dysplasia can 
+result in stenosis due to the deposition of collagen fibers in the tunica media, 
+intima, or adventitia. Giant cell arteritis, an autoimmune disorder, causes 
+inflammation of the internal elastic membrane resulting in eventual stenosis of 
+the artery. Neurofibromatosis type 1, an autosomal dominant disorder, results in 
+the stenosis of the vertebral artery due to the altered function of 
+neurofibromin. Mechanical compression of the vertebral artery by bone can also 
+cause stenosis of the vertebral artery. Digital subtraction angiography (DSA) is 
+considered the current gold standard in diagnosing vertebral artery stenosis; 
+however, its associated morbidity and mortality have led to increased use of 
+non-invasive techniques such as duplex ultrasonography (DUS), computed 
+tomography angiography (CTA), and magnetic resonance angiography (MRA). 
+Currently, asymptomatic and symptomatic vertebral artery stenoses are treated by 
+risk factor modification and medical treatment. However, it is recommended that 
+surgical (endarterectomy, reconstruction, and decompression) and endovascular 
+(balloon coronary, bare-metal, and drug-eluting stents) treatments are also used 
+for symptomatic vertebral artery stenosis.
+
+Copyright © 2022, Burle et al.
+
+DOI: 10.7759/cureus.28068
+PMCID: PMC9477552
+PMID: 36127977
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_36803229.md
+++ b/references_cache/PMID_36803229.md
@@ -1,0 +1,92 @@
+---
+reference_id: "PMID:36803229"
+title: In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting.
+authors:
+- Ryu JC
+- Bae JH
+- Ha SH
+- Kwon B
+- Song Y
+- Lee DH
+- Chang JY
+- Kang DW
+- Kwon SU
+- Kim JS
+- Kim BJ
+journal: BMC Neurol
+year: '2023'
+doi: 10.1186/s12883-023-03110-z
+keywords:
+- Humans
+- "Carotid Stenosis/epidemiology, surgery"
+- Stents/adverse effects
+- Coronary Restenosis
+- Carotid Arteries
+- "Constriction, Pathologic"
+- Infarction
+- Treatment Outcome
+- Recurrence
+- Risk Factors
+- Retrospective Studies
+content_type: abstract_only
+---
+
+# In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting.
+**Authors:** Ryu JC, Bae JH, Ha SH, Kwon B, Song Y, Lee DH, Chang JY, Kang DW, Kwon SU, Kim JS, Kim BJ
+**Journal:** BMC Neurol (2023)
+**DOI:** [10.1186/s12883-023-03110-z](https://doi.org/10.1186/s12883-023-03110-z)
+
+## Content
+
+1. BMC Neurol. 2023 Feb 21;23(1):79. doi: 10.1186/s12883-023-03110-z.
+
+In-stent restenosis and stented-territory infarction after carotid and 
+vertebrobasilar artery stenting.
+
+Ryu JC(1), Bae JH(1), Ha SH(2), Kwon B(3), Song Y(3), Lee DH(3), Chang JY(1), 
+Kang DW(1), Kwon SU(1), Kim JS(4), Kim BJ(5).
+
+Author information:
+(1)Department of Neurology, Asan Medical Center, University of Ulsan College of 
+Medicine, Seoul, Korea.
+(2)Department of Neurology, Gil Medical Center, Gachon University, Incheon, 
+Korea.
+(3)Department of Radiology, Asan Medical Center, University of Ulsan College of 
+Medicine, Seoul, Korea.
+(4)Department of Neurology, Gangneung Asan Hospital, University of Ulsan College 
+of Medicine, Gangneung, Korea.
+(5)Department of Neurology, Asan Medical Center, University of Ulsan College of 
+Medicine, Seoul, Korea. medicj80@hanmail.net.
+
+BACKGROUND: Prognosis after vertebrobasilar stenting (VBS) may differ from that 
+after carotid artery stenting (CAS). Here, we directly compared the incidence 
+and predictors of in-stent restenosis and stented-territory infarction after VBS 
+and compared them with those of CAS.
+METHODS: We enrolled patients who underwent VBS or CAS. Clinical variables and 
+procedure-related factors were obtained. During the 3 years of follow-up, 
+in-stent restenosis and infarction were investigated in each group. In-stent 
+restenosis was defined as reduction in the lumen diameter > 50% compared with 
+that after stenting. Factors associated with the occurrence of in-stent 
+restenosis and stented-territory infarction in VBS and CAS were compared.
+RESULTS: Among 417 stent insertions (93 VBS and 324 CAS), there was no 
+statistical difference in in-stent restenosis between VBS and CAS (12.9% vs. 
+6.8%, P = 0.092). However, stented-territory infarction was more frequently 
+observed in VBS than in CAS (22.6% vs. 10.8%; P = 0.006), especially a month 
+after stent insertion. HbA1c level, clopidogrel resistance, and multiple stents 
+in VBS and young age in CAS increased the risk of in-stent restenosis. Diabetes 
+(3.82 [1.24-11.7]) and multiple stents (22.4 [2.4-206.4]) were associated with 
+stented-territory infarction in VBS. However, in-stent restenosis (odds ratio: 
+15.1, 95% confidence interval: 3.17-72.2) was associated with stented-territory 
+infarction in CAS.
+CONCLUSIONS: Stented-territory infarction occurred more frequently in VBS, 
+especially after the periprocedural period. In-stent restenosis was associated 
+with stented-territory infarction after CAS, but not in VBS. The mechanism of 
+stented-territory infarction after VBS may be different from that after CAS.
+
+© 2023. The Author(s).
+
+DOI: 10.1186/s12883-023-03110-z
+PMCID: PMC9942307
+PMID: 36803229 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_37483445.md
+++ b/references_cache/PMID_37483445.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:37483445"
+title: "Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center."
+authors:
+- Zhang T
+- Zhou D
+- Xu Y
+- Li M
+- Zhuang J
+- Wang H
+- Zhong W
+- Chen C
+- Kuang H
+- Wang D
+- Wang Y
+journal: Front Neurol
+year: '2023'
+doi: 10.3389/fneur.2023.1202565
+content_type: abstract_only
+---
+
+# Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center.
+**Authors:** Zhang T, Zhou D, Xu Y, Li M, Zhuang J, Wang H, Zhong W, Chen C, Kuang H, Wang D, Wang Y
+**Journal:** Front Neurol (2023)
+**DOI:** [10.3389/fneur.2023.1202565](https://doi.org/10.3389/fneur.2023.1202565)
+
+## Content
+
+1. Front Neurol. 2023 Jul 7;14:1202565. doi: 10.3389/fneur.2023.1202565. 
+eCollection 2023.
+
+Microsurgical revascularization of a symptomatic proximal vertebral artery: 
+pilot experiences from a single center.
+
+Zhang T(1)(2), Zhou D(1), Xu Y(1), Li M(1), Zhuang J(1), Wang H(3), Zhong W(1), 
+Chen C(1)(4), Kuang H(5), Wang D(1), Wang Y(1).
+
+Author information:
+(1)Department of Neurosurgery, Qilu Hospital of Shandong University, Cheeloo 
+College of Medicine and Institute of Brain and Brain-Inspired Science, Shandong 
+University, Jinan, Shandong, China.
+(2)Department of Neurosurgery, Yangxin County People's Hospital, Binzhou, China.
+(3)Department of Neurosurgery, Yantai Penglai People's Hospital, Yantai, China.
+(4)Department of Neurosurgery, The First Affiliated Hospital of Shandong First 
+Medical University, Jinan, China.
+(5)Department of Neurosurgery, The Second Affiliated Hospital of Guangxi Medical 
+University, Nanning, Guangxi, China.
+
+BACKGROUND: Vertebral artery stenosis and occlusion (VASO) is a high-risk factor 
+for posterior circulation stroke. Post-stent restenosis and drug tolerance have 
+facilitated the exploration of microsurgical vascular reconstruction. This study 
+aims to evaluate the safety and efficacy of microsurgical reconstruction of the 
+proximal VA.
+METHODS: Twenty-nine patients (25 men, aged 63.2 years) who had symptoms of 
+posterior circulation ischemia underwent microsurgical revascularization for 
+proximal VASO were retrospectively included in this study. Procedural 
+complications and clinical and angiographic outcomes were reviewed.
+RESULTS: Twelve, three, and five patients underwent VA endarterectomy, artery 
+transposition, or both, respectively; seven patients underwent vertebral 
+endarterectomy plus stent implantation; and two patients failed surgery because 
+of the difficult exposure of the VA and the occurrence of vascular dissection. 
+The perioperative period-related complications included seven cases of Horner's 
+syndrome, five cases of hoarseness, and one case of chylothorax. No cases of 
+perioperative stroke or death were reported. The mean follow-up period was 28.4 
+(8-62 months). Most patients improved clinically; however, the vertebrobasilar 
+ischemia symptoms did not decrease significantly in two patients during the 
+follow-up. Moreover, follow-up imaging was performed in all the patients, and no 
+signs of anastomotic stenosis were reported.
+CONCLUSION: Microsurgical reconstruction is an alternative option that can 
+effectively treat refractory proximal VASO disease and in-stent stenosis, with a 
+high rate of postoperative vascular recirculation. Prospective cohort studies 
+with larger sample sizes must be conducted to validate the above conclusions.
+
+Copyright © 2023 Zhang, Zhou, Xu, Li, Zhuang, Wang, Zhong, Chen, Kuang, Wang and 
+Wang.
+
+DOI: 10.3389/fneur.2023.1202565
+PMCID: PMC10361759
+PMID: 37483445
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_37924280.md
+++ b/references_cache/PMID_37924280.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:37924280"
+title: A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma.
+authors:
+- Goyal K
+- Sunny JT
+- Gillespie CS
+- Wilby M
+- Clark SR
+- Kaiser R
+- Fehlings MG
+- Srikandarajah N
+journal: Global Spine J
+year: '2024'
+doi: 10.1177/21925682231209631
+content_type: abstract_only
+---
+
+# A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical Spine Trauma.
+**Authors:** Goyal K, Sunny JT, Gillespie CS, Wilby M, Clark SR, Kaiser R, Fehlings MG, Srikandarajah N
+**Journal:** Global Spine J (2024)
+**DOI:** [10.1177/21925682231209631](https://doi.org/10.1177/21925682231209631)
+
+## Content
+
+1. Global Spine J. 2024 May;14(4):1356-1368. doi: 10.1177/21925682231209631. Epub
+ 2023 Nov 4.
+
+A Systematic Review and Meta-Analysis of Vertebral Artery Injury After Cervical 
+Spine Trauma.
+
+Goyal K(1)(2), Sunny JT(1)(3), Gillespie CS(1)(4), Wilby M(1), Clark SR(1), 
+Kaiser R(5), Fehlings MG(6), Srikandarajah N(1)(7).
+
+Author information:
+(1)Department of Neurosurgery, The Walton Centre NHS Foundation Trust, 
+Liverpool, UK.
+(2)Northern General Hospital, Sheffield Teaching Hospital Trusts, Sheffield, UK.
+(3)Cambridge University Hospital NHS Foundation Trust, Addenbrooke's Hospital, 
+Cambridge, UK.
+(4)Department of Clinical Neurosciences, University of Cambridge, Cambridge, UK.
+(5)Department of Neurosurgery and Neurooncology, First Faculty of Medicine, 
+Charles University and Military University Hospital, Prague, Czech Republic.
+(6)Division of Neurosurgery and Spine Program, Department of Surgery, University 
+of Toronto, Toronto, ON, Canada.
+(7)Institute of Systems, Molecular and Integrative Biology, Liverpool, UK.
+
+STUDY DESIGN: Systematic Review and Meta-Analysis.
+OBJECTIVE: Identify the incidence, mechanism of injury, investigations, 
+management, and outcomes of Vertebral Artery Injury (VAI) after cervical spine 
+trauma.
+METHODS: A systematic review and meta-analysis were conducted in accordance with 
+the PRISMA guidelines (PROSPERO-ID CRD42021295265). Three databases were 
+searched (PubMed, SCOPUS, Google Scholar, CINAHL PLUS). Incidence of VAI, 
+investigations to diagnose (Computed Tomography Angiography, Digital Subtraction 
+Angiography, Magnetic Resonance Angiography), stroke incidence, and management 
+paradigms (conservative, antiplatelets, anticoagulants, surgical, endovascular 
+treatment) were delineated. Incidence was calculated using pooled proportions 
+random effects meta-analysis.
+RESULTS: A total of 44 studies were included (1777 patients). 20-studies (n = 
+503) included data on trauma type; 75.5% (n = 380) suffered blunt trauma and 
+24.5% (n = 123) penetrating. The overall incidence of VAI was .95% (95% CI 
+0.65-1.29). From the 16 studies which reported data on outcomes, 8.87% (95% CI 
+5.34- 12.99) of patients with VAI had a posterior stroke. Of the 33 studies with 
+investigation data, 91.7% (2929/3629) underwent diagnostic CTA; 7.5% (242/3629) 
+underwent MRA and 3.0% (98/3629) underwent DSA. Management data from 20 papers 
+(n = 475) showed 17.9% (n = 85) undergoing conservative therapy, anticoagulation 
+in 14.1% (n = 67), antiplatelets in 16.4% (n = 78), combined therapy in 25.5% (n 
+= 121) and the rest (n = 124) managed using surgical and endovascular 
+treatments.
+CONCLUSION: VAI in cervical spine trauma has an approximate posterior 
+circulation stroke risk of 9%. Optimal management paradigms for the prevention 
+and management of VAI are yet to be standardized and require further research.
+
+DOI: 10.1177/21925682231209631
+PMCID: PMC11289537
+PMID: 37924280
+
+Conflict of interest statement: Declaration of Conflicting InterestsThe 
+author(s) declared no potential conflicts of interest with respect to the 
+research, authorship, and/or publication of this article.

--- a/references_cache/PMID_39673653.md
+++ b/references_cache/PMID_39673653.md
@@ -1,0 +1,93 @@
+---
+reference_id: "PMID:39673653"
+title: "Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study."
+authors:
+- Liu M
+- Yan P
+- Wang M
+- Guo J
+- Liu W
+- Wu G
+- Wang L
+- Liu J
+- Li L
+journal: Neurosurg Rev
+year: '2024'
+doi: 10.1007/s10143-024-03153-x
+keywords:
+- Humans
+- Female
+- Male
+- Aged
+- Middle Aged
+- Retrospective Studies
+- Microsurgery/methods
+- Vertebrobasilar Insufficiency/surgery
+- Endovascular Procedures/methods
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study.
+**Authors:** Liu M, Yan P, Wang M, Guo J, Liu W, Wu G, Wang L, Liu J, Li L
+**Journal:** Neurosurg Rev (2024)
+**DOI:** [10.1007/s10143-024-03153-x](https://doi.org/10.1007/s10143-024-03153-x)
+
+## Content
+
+1. Neurosurg Rev. 2024 Dec 14;47(1):901. doi: 10.1007/s10143-024-03153-x.
+
+Application of microsurgical surgery in patients with proximal vertebral artery 
+stenosis unsuited for endovascular treatment: a single-center retrospective 
+study.
+
+Liu M(1)(2), Yan P(2), Wang M(3)(4), Guo J(2), Liu W(2), Wu G(2), Wang L(2), Liu 
+J(2), Li L(2).
+
+Author information:
+(1)Binzhou Medical University, Yantai, China.
+(2)Shengli Oilfield Central Hospital, Shandong, China.
+(3)Binzhou Medical University, Yantai, China. sjwkwangmx@163.com.
+(4)Shengli Oilfield Central Hospital, Shandong, China. sjwkwangmx@163.com.
+
+To investigate the clinical efficacy and safety of microsurgical surgery in 
+patients with proximal vertebral artery stenosis unsuitable for endovascular 
+treatment. A retrospective analysis was conducted on the clinical data of 34 
+patients with proximal vertebral artery stenosis who underwent microsurgical 
+surgery at the Department of Cerebrovascular Surgery, Shengli Oilfield Central 
+Hospital, Dongying, Shandong, from March 2020 to April 2023. Preoperative 
+imaging confirmation of proximal vertebral artery stenosis or occlusion was 
+obtained using cervical CT angiography (CTA), CT perfusion imaging (CTP), and 
+magnetic resonance angiography (MRA). Postoperative imaging examinations were 
+utilized to evaluate blood flow patency, and clinical symptoms and complications 
+during hospitalization and follow-up were documented. Postoperative imaging 
+examinations in the 34 patients (Males: 79.4%; Mean age: 66.7 ± 9.6 years) 
+revealed patent vertebral and supplying arteries. No new instances of transient 
+ischemic attacks (TIAs) or other cerebrovascular events were observed during 
+hospitalization, and clinical symptoms were improved. The mean follow-up 
+duration was 10 months (range: 6-39 months). One patient died from septic shock 
+due to abdominal infection, and one patient exhibited moderate ipsilateral 
+vertebral artery stenosis on a follow-up CTA at 6 months postoperatively. The 
+Modified Rankin Scale (mRS) scores decreased for 30 patients after surgery 
+compared to preoperative scores, with all postoperative mRS scores being less 
+than 1. The difference between preoperative and postoperative mRS scores was 
+statistically significant (P < 0.01). Six patients experienced temporary 
+postoperative complications, which resolved after active treatment, and one 
+patient developed permanent Horner's syndrome without affecting the quality of 
+life. Microsurgical surgery for patients with proximal vertebral artery 
+stenosis, when endovascular treatment is unsuitable, demonstrates good clinical 
+efficacy and a low incidence of complications, offering a viable surgical 
+treatment option. Further multicenter studies with larger sample sizes will be 
+instrumental in validating its clinical application value.
+
+© 2024. The Author(s).
+
+DOI: 10.1007/s10143-024-03153-x
+PMCID: PMC11646275
+PMID: 39673653 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Ethical approval: This study was 
+approved by the Medical Ethics Committee of Shengli Oilfield Central Hospital 
+[Ethical Number: Q/ZXYY–ZY–YWB—LL202361], and patients or their family members 
+signed an informed consent form for diagnosis and treatment. Competing 
+interests: The authors declare no competing interests.

--- a/references_cache/PMID_40148099.md
+++ b/references_cache/PMID_40148099.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:40148099"
+title: "Signs and symptoms of vertebrobasilar insufficiency secondary to atherosclerosis: a systematic review."
+authors:
+- Moors C
+- Stapleton C
+journal: J Osteopath Med
+year: '2025'
+doi: 10.1515/jom-2024-0203
+keywords:
+- Humans
+- "Vertebrobasilar Insufficiency/etiology, diagnosis"
+- Atherosclerosis/complications
+content_type: abstract_only
+---
+
+# Signs and symptoms of vertebrobasilar insufficiency secondary to atherosclerosis: a systematic review.
+**Authors:** Moors C, Stapleton C
+**Journal:** J Osteopath Med (2025)
+**DOI:** [10.1515/jom-2024-0203](https://doi.org/10.1515/jom-2024-0203)
+
+## Content
+
+1. J Osteopath Med. 2025 Mar 28;125(11):519-532. doi: 10.1515/jom-2024-0203. 
+eCollection 2025 Nov 1.
+
+Signs and symptoms of vertebrobasilar insufficiency secondary to 
+atherosclerosis: a systematic review.
+
+Moors C(1), Stapleton C(1).
+
+Author information:
+(1)4212 Keele University , Keele, Newcastle, Staffordshire, UK.
+
+CONTEXT: Clinicians face a difficult challenge in identifying vertebrobasilar 
+insufficiency (VBI) resulting from atherosclerosis. VBI is a term utilized to 
+describe a reduction in blood flow to the vertebral and basilar arteries that 
+supply the posterior cerebral system. For musculoskeletal clinicians, diagnostic 
+differentiation of VBI is essential, because its presence directly impacts the 
+clinical use of manual treatment interventions. Clinical guidelines provide a 
+set of cardinal symptoms (inclusive of Coman's 5D's) in which VBI may manifest, 
+the accuracy of which is under contestation because literature provides evidence 
+suggesting a wider set of symptoms.
+OBJECTIVES: The objectives of this study were to gather all relevant literature 
+reporting features of VBI pertaining to atherosclerosis, with the aim to help 
+provide evidence that may guide clinical practice in the use of manual therapy 
+interventions and to raise awareness of the manifestations that VBI may present.
+METHODS: Six databases were searched from inception to September 2024 (Allied 
+and Alternative Medicine Database [AMED], AgeLine, SPORTDiscus, Medical 
+Literature Analysis and Retrieval System Online [MEDLINE], Cochrane, and 
+Cumulative Index of Nursing and Allied Health (CINAHL Plus). Articles were 
+screened in accordance with Preferred Reporting Items for Systematic Reviews and 
+Meta-Analyses (PRISMA) standards, The included articles required a diagnosis of 
+VBI through clinical examination with radiological evidence of atherosclerotic 
+lesions, without evidence of existing or previous neurological infarcts, 
+concomitant arterial pathology, or any other form of pathological mechanism. 
+Primary data were extracted utilizing a template, and the methodological quality 
+was assessed utilizing the Joanna Briggs Institute critical appraisal tool. 
+Findings were summarized utilizing a narrative synthesis and a table of 
+descriptive statistics.
+RESULTS: Two hundred and eighty-three papers were identified, and 15 were 
+included (93 cases, 50M/43F, age 64 years old ± 9 standard deviation [SD] yrs). 
+Vertigo was the most common reported symptom, within a total of 37 different 
+symptoms reported either in isolation or combination. Symptoms inclusive to 
+Coman's 5D's accounted for 22 % of reported features.
+CONCLUSIONS: Vertigo is the most common symptom (27.7 %) of VBI induced by 
+atherosclerosis. However, there is not sufficient data to make concrete 
+conclusions, although results do instill doubt over the sole use of Coman's 5D's 
+in clinical practice. Prospective observational studies with standardized data 
+extraction for VBI symptoms and their pattern of behavior are warranted.
+
+© 2025 the author(s), published by De Gruyter, Berlin/Boston.
+
+DOI: 10.1515/jom-2024-0203
+PMID: 40148099 [Indexed for MEDLINE]

--- a/references_cache/PMID_40951011.md
+++ b/references_cache/PMID_40951011.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:40951011"
+title: "Critical Vertebrobasilar Insufficiency From Left Intracranial Vertebral Artery Stenosis With Contralateral Hypoplasia Presenting as Recurring Vertigo: Urgent Stenting to Prevent the Progression of a Posterior Circulation Stroke."
+authors:
+- Luan Z
+- Maud A
+- Yang X
+- Rodriguez GJ
+journal: Cureus
+year: '2025'
+doi: 10.7759/cureus.89981
+content_type: abstract_only
+---
+
+# Critical Vertebrobasilar Insufficiency From Left Intracranial Vertebral Artery Stenosis With Contralateral Hypoplasia Presenting as Recurring Vertigo: Urgent Stenting to Prevent the Progression of a Posterior Circulation Stroke.
+**Authors:** Luan Z, Maud A, Yang X, Rodriguez GJ
+**Journal:** Cureus (2025)
+**DOI:** [10.7759/cureus.89981](https://doi.org/10.7759/cureus.89981)
+
+## Content
+
+1. Cureus. 2025 Aug 13;17(8):e89981. doi: 10.7759/cureus.89981. eCollection 2025 
+Aug.
+
+Critical Vertebrobasilar Insufficiency From Left Intracranial Vertebral Artery 
+Stenosis With Contralateral Hypoplasia Presenting as Recurring Vertigo: Urgent 
+Stenting to Prevent the Progression of a Posterior Circulation Stroke.
+
+Luan Z(1), Maud A(2), Yang X(2), Rodriguez GJ(2).
+
+Author information:
+(1)Neurology, Texas Tech University Health Sciences Center El Paso, El Paso, 
+USA.
+(2)Neurology/Interventional Neurology, Texas Tech University Health Sciences 
+Center El Paso, El Paso, USA.
+
+A 67-year-old man with a history of hypertension and untreated dyslipidemia 
+presented with a four-day history of frequent episodic vertigo associated with 
+nausea and vomiting. The patient experienced up to 20 episodes of spinning 
+vertigo per day, each lasting several minutes, without provocation by head 
+movement. MRI confirmed acute infarcts in the right posterior cerebral and 
+cerebellar territories, and CTA revealed severe stenosis of the left vertebral 
+artery V4 segment, with a hypoplastic right vertebral artery. Given refractory 
+symptoms despite dual antiplatelet therapy and permissive hypertension, urgent 
+intracranial balloon angioplasty and balloon-mounted drug-eluting stent 
+placement was performed. The patient recovered completely without further 
+dizziness or neurological deficit. This case emphasizes that recurrent atypical 
+vertigo and brief syncope may be warning signs of vertebrobasilar insufficiency, 
+especially in the context of vertebral artery stenosis with limited collateral 
+flow. Timely vascular imaging and intervention can prevent subsequent 
+debilitating brainstem stroke.
+
+Copyright © 2025, Luan et al.
+
+DOI: 10.7759/cureus.89981
+PMCID: PMC12427593
+PMID: 40951011
+
+Conflict of interest statement: Human subjects: Informed consent for treatment 
+and open access publication was obtained or waived by all participants in this 
+study. Conflicts of interest: In compliance with the ICMJE uniform disclosure 
+form, all authors declare the following: Payment/services info: All authors have 
+declared that no financial support was received from any organization for the 
+submitted work. Financial relationships: All authors have declared that they 
+have no financial relationships at present or within the previous three years 
+with any organizations that might have an interest in the submitted work. Other 
+relationships: All authors have declared that there are no other relationships 
+or activities that could appear to have influenced the submitted work.

--- a/references_cache/clinicaltrials_NCT03201432.md
+++ b/references_cache/clinicaltrials_NCT03201432.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT03201432
+title: "A Randomized Trial for Treatment of Symptomatic Extracranial Vertebral Artery Stenosis: Drug Eluting Stents Versus Bare Metal Stents"
+content_type: summary
+---
+
+# A Randomized Trial for Treatment of Symptomatic Extracranial Vertebral Artery Stenosis: Drug Eluting Stents Versus Bare Metal Stents
+
+## Content
+
+Stroke is one of the important causes of disability and death in the world, in which more than half were ischemic strokes. About 1/4 of the ischemic stroke occurred in the vertebral basilar artery system, especially when in the presence of extracranial proximal vertebral artery stenosis. Vertebral artery stenting is a minimally invasive method for the reconstruction of vertebral artery stenosis and the early clinical studies showed that it was feasible, safe and effective, but the high rate of restenosis has become a bottleneck restricting its development. Previous systematic review had suggested that the drug eluting stent might reduce the incidence of restenosis of vertebral artery. However, prospective randomized controlled trials comparing the efficacy of bare metal stents and drug eluting stents on the prevention of restenosis remains absent.

--- a/references_cache/clinicaltrials_NCT05885932.md
+++ b/references_cache/clinicaltrials_NCT05885932.md
@@ -1,0 +1,15 @@
+---
+reference_id: clinicaltrials:NCT05885932
+title: "Drug-eluting Stenting Versus Medical Treatment Alone for Patients With Extracranial Vertebral Artery Stenosis: The VISTA Trial"
+content_type: summary
+---
+
+# Drug-eluting Stenting Versus Medical Treatment Alone for Patients With Extracranial Vertebral Artery Stenosis: The VISTA Trial
+
+## Content
+
+Posterior circulation stroke accounts for 20% of all ischemic stroke. Approximately one quarter of posterior circulation strokes are due to stenosis in the vertebral artery and basilar artery.
+
+Two previous randomized controlled trials focusing on vertebral artery stenting, the Vertebral Artery Stenting Trial (VAST) and the Vertebral Artery Ischaemia Stenting Trial (VIST) were underpowered because they failed to reach target recruitment, and both the trials found no difference in risk of the primary outcome between the stenting group and medical group.
+
+The drug-eluting stenting versus medical therapy alone for patients with extracranial vertebral artery stenosis (VISTA) trial, is a government-funded, prospective, multicenter, randomized controlled trial. It will recruit patients with 3 months stroke or TIA caused by 70-99% stenosis of extracranial vertebral artery (V1-2 segments). Only high-volume center with a proven track record will enroll patients. Patients will be randomized (1:1) to best medical treatment alone or medical treatment plus stenting. Primary outcome is a composite of any fatal or non-fatal stroke within 30 days after randomization, or ischemic stroke in the territory of the target artery beyond 30 days to 1 year. The VISTA trial will be conducted in 30 sites in China and aims to have a sample size of 472 subjects (stenting, 236; medical treatment, 236). Recruitment is expected to be finished by Sep, 2025. Patients will be followed for 1 year at first stage. Long-term follow-ups till 3 years or longer is also preplanned. The first stage of the trial is scheduled to complete in 2027.

--- a/research/Vertebral_Artery_Insufficiency-deep-research-falcon.md
+++ b/research/Vertebral_Artery_Insufficiency-deep-research-falcon.md
@@ -1,0 +1,1330 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T15:02:20.045873'
+end_time: '2026-05-06T15:23:52.718460'
+duration_seconds: 1292.67
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Vertebral Artery Insufficiency
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 43
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Vertebral Artery Insufficiency
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Vertebral Artery Insufficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Vertebral Artery Insufficiency
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Vertebral Artery Insufficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Research Report: Vertebral Artery Insufficiency (VAI) / Vertebrobasilar Insufficiency (VBI)
+
+### Executive summary (current understanding)
+Vertebral artery insufficiency (often discussed clinically as vertebrobasilar insufficiency, vertebrobasilar disease, or symptomatic vertebral artery stenosis/occlusion) refers to transient ischemic attacks (TIA) or ischemic strokes attributable to pathology of the vertebral arteries and/or basilar artery, most commonly atherosclerotic stenosis/occlusion, but also dissection/trauma or other less common causes. These conditions contribute substantially to posterior-circulation ischemia and carry high early recurrence risk under medical therapy alone, motivating aggressive secondary prevention and selective revascularization in refractory cases. (bobmanuel2023vertebralarteryinterventions pages 1-2, aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+
+---
+
+## 1. Disease information
+
+### 1.1 What is the disease?
+In contemporary cerebrovascular literature, “vertebral artery insufficiency” is not consistently treated as a single discrete nosologic entity; rather it is typically operationalized as *symptomatic posterior circulation ischemia due to vertebral artery (extracranial or intracranial) stenosis/occlusion* and/or broader *atherosclerotic vertebrobasilar disease*. The VERiTAS study frames the clinical problem as symptomatic atherosclerotic vertebrobasilar disease causing posterior circulation stroke, emphasizing that recurrence risk is high and that hemodynamic compromise is a key determinant of risk. (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+
+A 2023 comprehensive review similarly uses overlapping terminology (VAS, vertebrobasilar ischemia/insufficiency) and describes vertebral artery stenosis as a driver of posterior circulation ischemia that may be asymptomatic or symptomatic. (bobmanuel2023vertebralarteryinterventions pages 4-5, bobmanuel2023vertebralarteryinterventions pages 2-3)
+
+### 1.2 Key identifiers (OMIM/Orphanet/ICD/MeSH/MONDO)
+*Not available from the retrieved evidence set.* The sourced papers and guideline excerpts used here do not provide definitive ICD-10/ICD-11, MeSH, OMIM, Orphanet, or MONDO identifiers specific to “vertebral artery insufficiency/vertebrobasilar insufficiency.” This report therefore focuses on evidence-based clinical characterization and management rather than coding/ontology assertions.
+
+### 1.3 Synonyms and alternative names
+Commonly used overlapping terms in the literature include:
+- Vertebrobasilar insufficiency (VBI) / vertebrobasilar ischemia (bobmanuel2023vertebralarteryinterventions pages 4-5, bobmanuel2023vertebralarteryinterventions pages 3-4)
+- Atherosclerotic vertebrobasilar disease (VBD) (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+- Vertebral artery stenosis (VAS) / vertebral artery stenosis and occlusion (VASO) (zhang2023microsurgicalrevascularizationof pages 1-2)
+- Posterior circulation ischemia / posterior circulation stroke (markus2022treatmentofposterior pages 1-2)
+
+### 1.4 Evidence source type
+The information below is derived from aggregated disease-level evidence, including:
+- Peer-reviewed reviews and guideline documents (bobmanuel2023vertebralarteryinterventions pages 4-5, markus2022treatmentofposterior pages 1-2, bushnell20242024guidelinefor pages 25-26)
+- Prospective observational studies (VERiTAS rationale and analyses) (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+- Retrospective real-world surgical/endovascular cohorts (ryu2023instentrestenosisand pages 2-4, liu2024applicationofmicrosurgical pages 1-2)
+- Systematic reviews/meta-analyses for traumatic vertebral artery injury (goyal2024asystematicreview pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+**Primary causal substrate in typical VAI/VBI presentations:**
+- **Atherosclerotic stenosis/occlusion** of vertebral artery segments (notably ostium/proximal segments) is described as the major mechanism in reviews. (bobmanuel2023vertebralarteryinterventions pages 1-2, bobmanuel2023vertebralarteryinterventions pages 2-3)
+
+**Other causes (less common, but clinically important):**
+- **Dissection** (spontaneous or traumatic) (bobmanuel2023vertebralarteryinterventions pages 3-4, amran2024vertebralarterydissection pages 1-2)
+- **Trauma-related vertebral artery injury** (TVAI) after cervical spine trauma (goyal2024asystematicreview pages 1-2)
+- **Congenital anomalies** including vertebral artery hypoplasia/atresia (bobmanuel2023vertebralarteryinterventions pages 3-4)
+- **Extrinsic compression** and **vasculitis** (mentioned as less common causes) (bobmanuel2023vertebralarteryinterventions pages 2-3)
+
+### 2.2 Risk factors
+**Atherosclerotic disease risk factors (vascular risk factor paradigm):**
+AHA/ASA-aligned medical therapy guidance in vertebral artery disease emphasizes standard vascular risk factor modification (blood pressure management, diabetes control, smoking cessation) and intensive medical therapy for secondary prevention. (bobmanuel2023vertebralarteryinterventions pages 4-5)
+
+**Anatomic/structural risk factors:**
+- Vertebral artery hypoplasia reported frequency **2–6%** (autopsy/angiogram), and is noted as associated with symptomatic vertebrobasilar occlusive disease. (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+**Trauma-related risk factors (for traumatic VAI):**
+- In cervical spine trauma, vertebral artery injury is associated with high-risk fracture patterns; evaluation uses modified Denver screening criteria in trauma literature and CTA-based screening. (goyal2024asystematicreview pages 1-2)
+
+### 2.3 Protective factors
+No specific protective genetic variants or protective environmental exposures were identified in the retrieved sources.
+
+### 2.4 Gene–environment interactions
+Not specifically addressed in the retrieved evidence set.
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Symptom and sign spectrum (with suggested HPO terms)
+VAI/VBI phenotypes reflect the affected posterior circulation territory (brainstem, cerebellum, thalamus, occipital cortex, vestibular pathways). (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+**Common posterior circulation TIA/stroke symptom clusters used in VERiTAS baseline characterization** include:
+- “Loss of balance, vertigo, unsteadiness or disequilibrium, diplopia, dysphagia, or dysarthria.” (aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Motor dysfunction (“weakness, paralysis, or clumsiness”) and sensory symptoms (“numbness, or paresthesia”). (aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Homonymous visual field loss. (aminhanjani2015hemodynamicfeaturesof pages 7-10)
+
+**Syndromic localization examples (review-level descriptions):**
+- Intracranial vertebral occlusion → lateral medullary (Wallenberg) syndrome with “Horner’s syndrome, dysphagia, hoarse voice, limb ataxia, and decreased pain/ temperature sensation of the ipsilateral face and contralateral body.” (bobmanuel2023vertebralarteryinterventions pages 3-4)
+- Basilar artery occlusion → “Locked-In-Syndrome (the patient becomes quadriplegic and mute, but remains conscious)” (bobmanuel2023vertebralarteryinterventions pages 3-4)
+- Distal basilar occlusion prodrome: “vertigo, nausea, headache, neck pain, and transient lateralized motor weakness.” (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+**Vertebral artery dissection (VAD) phenotypes (2024 review):**
+- “The most frequent clinical manifestations include stroke, transient ischemic attack, neck pain, headaches, and vertigo.” (amran2024vertebralarterydissection pages 1-2)
+
+**Suggested HPO mappings (non-exhaustive):**
+- Vertigo: HP:0002321 (bobmanuel2023vertebralarteryinterventions pages 3-4, amran2024vertebralarterydissection pages 1-2, aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Ataxia / limb ataxia: HP:0001251 (bobmanuel2023vertebralarteryinterventions pages 3-4)
+- Dysphagia: HP:0002015 (bobmanuel2023vertebralarteryinterventions pages 3-4, aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Dysarthria: HP:0001260 (aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Diplopia: HP:0000651 (aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Visual field defect (homonymous hemianopia): HP:0000581 (aminhanjani2015hemodynamicfeaturesof pages 7-10)
+- Headache: HP:0002315 (bobmanuel2023vertebralarteryinterventions pages 3-4, amran2024vertebralarterydissection pages 1-2)
+- Neck pain: HP:0003302 (bobmanuel2023vertebralarteryinterventions pages 3-4, amran2024vertebralarterydissection pages 1-2)
+- Horner syndrome: HP:0000009 (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+### 3.2 Phenotype characteristics and frequency data
+**Posterior circulation syndrome distribution in VERiTAS (selected):**
+Among symptomatic vertebrobasilar disease patients, “Pontine syndrome” was common (e.g., 59% in basilar-only disease; 23% vertebral-only; 48% combined basilar+vertebral), while “Pure cerebellar” syndromes occurred at ~14–23% across groups. (aminhanjani2015hemodynamicfeaturesof pages 10-15)
+
+**Quality of life impact**
+Not directly quantified with standardized QoL instruments (e.g., EQ-5D, PROMIS) in the retrieved sources; however, posterior circulation ischemic events are recognized to be disabling and associated with substantial morbidity/mortality, particularly for basilar occlusion and recurrent events. (zhang2023microsurgicalrevascularizationof pages 1-2, markus2022treatmentofposterior pages 3-4)
+
+---
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes and pathogenic variants
+**Typical atherosclerotic VAI/VBI:** No monogenic causal genes/variants were identified in the retrieved sources.
+
+**Dissection-associated VAI:** A 2024 VAD review lists “connective tissue disorders” as intrinsic contributors and states “Predisposing factors include connective tissue disorders… and the presence of infection or inflammation,” and later mentions “connective tissue diseases… and elastin insufficiency.” However, **no named hereditary syndromes (e.g., Ehlers–Danlos, Marfan) or specific genes/variants** were provided in the retrieved excerpts. (amran2024vertebralarterydissection pages 1-2, amran2024vertebralarterydissection pages 6-8)
+
+### 4.2 Modifier genes / epigenetics / chromosomal abnormalities
+Not addressed in the retrieved evidence set.
+
+---
+
+## 5. Environmental information
+
+### 5.1 Environmental/lifestyle contributors
+For typical atherosclerotic vertebrobasilar disease, the key modifiable contributors are the standard vascular risk factors targeted by guideline-based prevention: blood pressure control, diabetes management, smoking cessation, lipid management, and lifestyle interventions. (bobmanuel2023vertebralarteryinterventions pages 4-5, markus2022treatmentofposterior pages 4-5)
+
+### 5.2 Infectious agents
+Not established as direct causes in the retrieved sources; infection/inflammation is mentioned only as a predisposing factor context for dissection. (amran2024vertebralarterydissection pages 1-2)
+
+---
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Causal chain (from trigger to manifestations)
+**Atherosclerotic vertebrobasilar disease:**
+1) Atherosclerotic plaque/stenosis in vertebral/basilar arteries (often proximal/ostial vertebral artery) (bobmanuel2023vertebralarteryinterventions pages 1-2)
+2) Reduced perfusion pressure and/or plaque-related thromboembolism (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+3) Distal territory hypoperfusion and/or embolic infarction in brainstem/cerebellum/occipital territories, yielding symptoms such as vertigo, ataxia, diplopia, dysarthria, dysphagia, and focal weakness/sensory loss. (aminhanjani2015hemodynamicfeaturesof pages 7-10, bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+**Hemodynamic compromise as an upstream driver of risk:**
+The VERiTAS rationale highlights that posterior circulation stroke risk is strongly related to hemodynamic compromise and that this can be measured noninvasively with quantitative MRA. (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+
+**Mechanism heterogeneity (hemodynamic vs embolic):**
+Infarct-pattern analyses within the VERiTAS cohort describe both hemodynamic and embolic/perforator-related patterns, implying mixed downstream mechanisms even in the same etiologic category. (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+
+### 6.2 Suggested GO biological process terms (hypothesis-driven)
+Not directly measured in the retrieved evidence set; plausible GO terms for the biological processes involved include:
+- GO:0001525 angiogenesis (collateral adaptation context)
+- GO:0007596 blood coagulation / GO:0030193 regulation of blood coagulation (thromboembolism)
+- GO:0006928 movement of cell or subcellular component (platelet activation/aggregation context)
+
+These are proposed mappings; no direct molecular profiling evidence was retrieved.
+
+### 6.3 Suggested Cell Ontology (CL) terms
+Primary implicated cell types (conceptual, not directly profiled in retrieved evidence):
+- Endothelial cell (CL:0000115)
+- Vascular smooth muscle cell (CL:0000192)
+- Platelet (CL:0000233)
+
+---
+
+## 7. Anatomical structures affected
+
+### 7.1 Organ/system level
+- **Cardiovascular system / cerebrovascular arterial system**: vertebral arteries and basilar artery (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+- **Central nervous system**: posterior circulation territories including brainstem, cerebellum, thalamus, occipital cortex (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+### 7.2 Suggested UBERON terms (examples)
+- Vertebral artery: UBERON:0001643
+- Basilar artery: UBERON:0001642
+- Brainstem: UBERON:0002298
+- Cerebellum: UBERON:0002037
+- Occipital lobe (visual cortex region): UBERON:0001871
+
+(UBERON IDs provided as standard anatomy mappings; not explicitly enumerated in retrieved texts.)
+
+---
+
+## 8. Temporal development
+
+### 8.1 Onset patterns
+- Atherosclerotic VAI/VBI typically presents in older adults (implied by atherosclerotic risk factor management paradigms and interventional cohorts) and can present as TIA or stroke. (bobmanuel2023vertebralarteryinterventions pages 4-5, liu2024applicationofmicrosurgical pages 1-2)
+- Vertebral artery dissection is highlighted as a cause of stroke/TIA in younger adults; one review states it “usually occurs at an average age of 46.5 years.” (amran2024vertebralarterydissection pages 1-2)
+
+### 8.2 Progression
+Early recurrence risk is emphasized: in medically treated symptomatic vertebrobasilar disease, recurrence is particularly increased in the first weeks and annual stroke rates around 10–15% are repeatedly cited. (bobmanuel2023vertebralarteryinterventions pages 1-2, aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+
+---
+
+## 9. Inheritance and population
+
+### 9.1 Epidemiology (key statistics)
+- Posterior-circulation ischemia due to vertebral artery disease accounts for **~20–25% of ischemic strokes**. (bobmanuel2023vertebralarteryinterventions pages 1-2)
+- Symptomatic vertebrobasilar disease recurrence risk averages **10–15% per year**. (bobmanuel2023vertebralarteryinterventions pages 1-2, aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+- Poor prognosis in obstructive vertebrobasilar disease managed medically: **~30% mortality at 2 years** (review-cited). (bobmanuel2023vertebralarteryinterventions pages 1-2)
+- Vertebral artery stenosis/occlusion (VASO) “occurs in **5% of the normal population**” (as reported in a 2023 surgical series background). (zhang2023microsurgicalrevascularizationof pages 1-2)
+- Vertebral artery hypoplasia frequency **2–6%** (autopsy/angiogram). (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+**VAD incidence (relevant VAI subtype):**
+- VAD contributes “around **1.0–1.1 per 100,000 population**” (review). (amran2024vertebralarterydissection pages 1-2)
+
+### 9.2 Inheritance pattern
+Not established as a Mendelian disorder in typical atherosclerotic VAI/VBI. For VAD, connective tissue disease predisposition is discussed without specifying inheritance patterns or genes in retrieved text. (amran2024vertebralarterydissection pages 1-2)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Imaging-based diagnostic strategy (real-world implementation)
+A 2023 review states that **Color duplex ultrasound (DUS)** is used as a “first-line imaging strategy” in suspected vertebrobasilar ischemia and should be followed by **CE-MRA or CTA** before intervention decisions; **DSA** is the gold standard for defining lesions. (bobmanuel2023vertebralarteryinterventions pages 4-5)
+
+### 10.2 Diagnostic performance metrics (selected)
+From the same review:
+- Duplex criterion PSVr >2.2 for ≥50% proximal stenosis: **96% sensitivity / 89% specificity**. (bobmanuel2023vertebralarteryinterventions pages 3-4)
+- CTA/MRA performance: reported sensitivity/specificity around **94–95%**, and **DSA** carries **1–2% stroke risk**. (bobmanuel2023vertebralarteryinterventions pages 3-4)
+
+**Traumatic vertebral artery injury (TVAI):**
+- Pooled data: **91.7%** underwent diagnostic CTA; **7.5%** MRA; **3.0%** DSA. (goyal2024asystematicreview pages 1-2)
+- One cited trauma study: CTA sensitivity ~**98%**, specificity ~**100%**; MRA sensitivity **47–60%**. (goyal2024asystematicreview pages 5-7)
+
+### 10.3 Hemodynamic assessment
+VERiTAS emphasizes quantitative MRA (QMRA) for large-vessel flow measurement and risk stratification; symptom-based “hypoperfusion symptoms” poorly predict low/borderline flow (PPV 37.5%, NPV 65.5%). (aminhanjani2010vertebrobasilarflowevaluation pages 1-2, markus2022treatmentofposterior pages 4-5)
+
+### 10.4 Differential diagnosis
+Not systematically enumerated in the retrieved texts; practical differentials for posterior circulation symptoms include cardioembolic stroke, other intracranial stenoses, basilar artery occlusion, vestibular disorders, and nonvascular brainstem/cerebellar pathology.
+
+---
+
+## 11. Outcome / prognosis
+
+### 11.1 Stroke recurrence and mortality
+- Annual stroke recurrence risk in symptomatic vertebrobasilar disease: **~10–15% per year** (often cited). (bobmanuel2023vertebralarteryinterventions pages 1-2, aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+- Poor prognosis under medical therapy alone in obstructive vertebrobasilar disease: **~30% mortality at 2 years** (review-cited). (bobmanuel2023vertebralarteryinterventions pages 1-2)
+
+### 11.2 Post-procedural outcomes and complications (selected recent data)
+- Vertebrobasilar stenting cohort (VBS n=93): in-stent restenosis **12.9%**; stented-territory infarction **22.6%** over follow-up; diabetes and multiple stents strongly associated with long-term stented-territory infarction. (ryu2023instentrestenosisand pages 2-4, ryu2023instentrestenosisand pages 6-7)
+- Microsurgical series report clinical improvement with low perioperative stroke/death in selected cohorts, with cranial nerve complications (Horner’s syndrome, hoarseness) notable. (zhang2023microsurgicalrevascularizationof pages 1-2, liu2024applicationofmicrosurgical pages 1-2)
+
+---
+
+## 12. Treatment
+
+### 12.1 Medical therapy (secondary prevention emphasis)
+A 2023 review summarizes guideline-oriented management including risk factor modification and therapies such as antiplatelet and statins, with BP goals in that text of <140/90 mmHg (and diastolic <85 mmHg in diabetes). (bobmanuel2023vertebralarteryinterventions pages 4-5)
+
+For posterior circulation stroke/TIA, a secondary-prevention review notes:
+- Short-term **dual antiplatelet therapy** after high-risk minor stroke/TIA is recommended by guidelines, with benefit mainly in the first ~3 weeks, then transition to monotherapy. (markus2022treatmentofposterior pages 4-5)
+
+### 12.2 Acute reperfusion therapy (posterior circulation stroke)
+- IV thrombolysis appears to have similar benefit to anterior circulation and lower hemorrhage risk (meta-analysis estimates provided in review). (markus2022treatmentofposterior pages 2-3)
+- Mechanical thrombectomy has RCT-supported benefit for **basilar artery occlusion**, e.g., mRS 0–3 at 90 days **46% vs 22.8%** in one RCT and **46.4% vs 24.3%** in another. (markus2022treatmentofposterior pages 3-4)
+
+### 12.3 Endovascular intervention for vertebral stenosis
+Evidence remains mixed, with uncertainty about superiority over optimal medical therapy:
+- VAST: 30-day composite **5%** (stent) vs **2%** (OMT); 1-year territory stroke **9%** vs **7%**. (bobmanuel2023vertebralarteryinterventions pages 7-8)
+- VIST: stroke in **5** stent vs **12** medical; HR 0.40 (95% CI 0.14–1.13; p=0.08). (bobmanuel2023vertebralarteryinterventions pages 7-8)
+
+**Restenosis statistics:** reported wide range **0–43%** across studies; BMS 11–43%; meta-analysis cited DES **8.2%** vs BMS **23.7%** restenosis. (bobmanuel2023vertebralarteryinterventions pages 7-8, bobmanuel2023vertebralarteryinterventions pages 5-6)
+
+### 12.4 Microsurgical / hybrid revascularization
+Recent real-world data suggest microsurgical reconstruction is used when endovascular options are unsuitable or in restenosis:
+- Liu 2024 (n=34): postoperative arteries patent; no new in-hospital TIAs/events; mRS improved for 30 patients with all postoperative mRS <1; mean follow-up 10 months; one permanent Horner syndrome and one death from septic shock. (liu2024applicationofmicrosurgical pages 1-2)
+- Zhang 2023 (n=29): no perioperative stroke or death; mean follow-up 28.4 months; cranial nerve complications common; no target vessel restenosis reported. (zhang2023microsurgicalrevascularizationof pages 1-2, zhang2023microsurgicalrevascularizationof pages 4-5)
+
+### 12.5 Relevant clinical trials (current applications)
+- **NCT05885932**: Drug-eluting stenting vs medical treatment for extracranial vertebral artery stenosis; recruiting; planned n=472. (bobmanuel2023vertebralarteryinterventions pages 7-8)
+- **NCT03201432**: Drug-eluting vs bare metal stents in symptomatic extracranial vertebral artery stenosis; completed; n=160. (bobmanuel2023vertebralarteryinterventions pages 7-8)
+
+### 12.6 MAXO (Medical Action Ontology) term suggestions (examples)
+(Provided as mappings; MAXO IDs not retrievable from the current evidence set.)
+- Antiplatelet therapy; dual antiplatelet therapy (markus2022treatmentofposterior pages 4-5)
+- Statin therapy / lipid-lowering therapy (bobmanuel2023vertebralarteryinterventions pages 4-5)
+- Blood pressure management (bobmanuel2023vertebralarteryinterventions pages 4-5)
+- CT angiography; MR angiography; digital subtraction angiography (bobmanuel2023vertebralarteryinterventions pages 3-4)
+- Endovascular stent placement (vertebral artery) (bobmanuel2023vertebralarteryinterventions pages 7-8)
+- Vertebral endarterectomy; artery transposition; bypass grafting (liu2024applicationofmicrosurgical pages 2-4)
+
+---
+
+## 13. Prevention
+
+### 13.1 Primary prevention
+A 2024 AHA/ASA primary prevention guideline explicitly states that for **asymptomatic vertebral artery stenosis** there are limited large-scale data and thus the guideline “cannot develop comprehensive, evidence-based recommendations,” focusing instead on asymptomatic carotid stenosis. This implies prevention is largely through general cardiovascular risk reduction rather than vertebral-specific screening/revascularization strategies. (bushnell20242024guidelinefor pages 25-26)
+
+### 13.2 Secondary/tertiary prevention
+Secondary prevention is centered on aggressive vascular risk factor treatment and antiplatelet therapy, with consideration of short-term DAPT after minor stroke/TIA. (markus2022treatmentofposterior pages 4-5, bobmanuel2023vertebralarteryinterventions pages 4-5)
+
+---
+
+## 14. Other species / natural disease
+No evidence in the retrieved sources about naturally occurring vertebral artery insufficiency as a comparable veterinary disease entity.
+
+---
+
+## 15. Model organisms
+No model organism or experimental induced model evidence was identified in the retrieved sources.
+
+---
+
+## Recent developments and expert analysis (prioritizing 2023–2024)
+
+1) **Shift toward quantifying risk beyond symptoms:** VERiTAS-related work emphasizes that symptom patterns alone may not reliably identify hemodynamic compromise; quantitative flow imaging is more directly linked to risk stratification. (aminhanjani2010vertebrobasilarflowevaluation pages 1-2, markus2022treatmentofposterior pages 4-5)
+
+2) **Interventional practice remains active but evidence-limited:** Contemporary reviews characterize vertebral artery stenting as widely used with good technical success yet without definitive RCT proof of superiority over optimal medical therapy, especially for intracranial disease where peri-procedural risk is higher. (bobmanuel2023vertebralarteryinterventions pages 7-8, markus2022treatmentofposterior pages 5-8)
+
+3) **Real-world microsurgical revival in select niches (2023–2024):** Single-center series report feasibility of vertebral endarterectomy/transposition/bypass in patients unsuited for endovascular therapy or with restenosis, with improved functional outcomes in selected cohorts but cranial nerve morbidity remains salient. (liu2024applicationofmicrosurgical pages 1-2, zhang2023microsurgicalrevascularizationof pages 4-5)
+
+4) **Device technology and restenosis surveillance:** Observational data quantify clinically important rates of stented-territory infarction after vertebrobasilar stenting and identify predictors (e.g., diabetes, multiple stents, clopidogrel resistance). This supports individualized follow-up and antiplatelet optimization strategies in practice. (ryu2023instentrestenosisand pages 2-4, ryu2023instentrestenosisand pages 6-7)
+
+---
+
+## Key abstract quotes (verbatim excerpts)
+
+- Bob-Manuel 2023 (Current Cardiology Reviews; 2023-01; https://doi.org/10.2174/1573403x18666220317093131): “Patients with posterior circulation ischemia due to vertebral artery stenosis account for 20 to 25% of ischemic strokes…” and “with an annual stroke rate of 10 to 15%.” (bobmanuel2023vertebralarteryinterventions pages 1-2)
+
+- Amin-Hanjani 2010 VERiTAS rationale (International Journal of Stroke; 2010-12; https://doi.org/10.1111/j.1747-4949.2010.00528.x): symptomatic vertebrobasilar disease carries a high recurrent stroke risk “averaging 10–15% per year.” (aminhanjani2010vertebrobasilarflowevaluation pages 1-2)
+
+- Bushnell 2024 AHA/ASA Primary Prevention of Stroke guideline (Stroke; 2024-12; https://doi.org/10.1161/str.0000000000000475): limited large-scale data for asymptomatic vertebral stenosis—authors “cannot develop comprehensive, evidence-based recommendations.” (bushnell20242024guidelinefor pages 25-26)
+
+- Goyal 2024 traumatic vertebral artery injury meta-analysis (Global Spine Journal; 2024-11; https://doi.org/10.1177/21925682231209631): pooled VAI incidence “.95% (95% CI 0.65-1.29)” and posterior stroke risk “8.87% (95% CI 5.34- 12.99).” (goyal2024asystematicreview pages 1-2)
+
+---
+
+## Evidence map table
+The following table consolidates the key quantitative findings, diagnostic metrics, mechanistic framing, and treatment evidence, including active clinical trials.
+
+| Domain | Key findings | Evidence type | Citations |
+|---|---|---|---|
+| Definitions / nomenclature | **Vertebral artery insufficiency (VAI)** is best understood as symptomatic posterior-circulation ischemia caused by reduced flow or embolic complications from vertebral artery pathology; in practice literature often uses **vertebrobasilar insufficiency (VBI)**, **vertebrobasilar disease (VBD)**, **vertebral artery stenosis/occlusion (VAS/VASO)**, and **posterior circulation ischemia** with partial overlap. Reviews commonly discuss VAI/VBI under the broader umbrella of symptomatic vertebral or vertebrobasilar atherosclerotic disease rather than as a distinct monogenic disease entity. | Narrative review, prospective study rationale | (bobmanuel2023vertebralarteryinterventions pages 1-2, aminhanjani2010vertebrobasilarflowevaluation pages 1-2, bobmanuel2023vertebralarteryinterventions pages 2-3) |
+| Epidemiology / prognosis | Posterior-circulation ischemia due to vertebral artery disease accounts for about **20–25% of ischemic strokes**; one review notes posterior-circulation strokes comprise about **one-fifth** of all strokes, while VERiTAS background cites **up to 30–40%** of ischemic strokes in the posterior circulation. Symptomatic vertebrobasilar disease has high early recurrence; medically treated patients have an **annual stroke rate of 10–15%**, with particularly high risk in the first weeks. Obstructive vertebrobasilar disease managed medically has about **30% mortality at 2 years**. In one secondary-prevention review, **90-day recurrent stroke** was **33%** for basilar/intracranial vertebral stenosis versus **16%** for extracranial vertebral stenosis. | Review, prospective cohort/rationale | (bobmanuel2023vertebralarteryinterventions pages 1-2, aminhanjani2010vertebrobasilarflowevaluation pages 1-2, markus2022treatmentofposterior pages 4-5) |
+| Major mechanisms / pathophysiology | Major etiologies include **atherosclerotic stenosis/occlusion** (dominant mechanism), with less common causes including **dissection**, **trauma**, **congenital anomalies/hypoplasia**, **extrinsic compression**, and **vasculitis**. Stroke mechanism is heterogeneous: VERiTAS-related work supports **hemodynamic compromise** as a strong predictor of future stroke, but infarct-pattern analysis shows both **hemodynamic** and **embolic / perforator-plaque** mechanisms occur. Traumatic vertebral artery injury/dissection is a separate but clinically relevant VAI mechanism, especially after cervical trauma. | Review, observational cohort, systematic review/meta-analysis | (aminhanjani2010vertebrobasilarflowevaluation pages 1-2, goyal2024asystematicreview pages 5-7, goyal2024asystematicreview pages 1-2, bobmanuel2023vertebralarteryinterventions pages 2-3) |
+| Hemodynamic risk stratification | In symptomatic vertebrobasilar disease, **quantitative MRA (QMRA)**-measured distal flow is more informative than symptom pattern alone. VERiTAS analyses found flow compromise robustly predicts subsequent stroke risk; by contrast, “hypoperfusion symptoms” alone had poor predictive value (**PPV 37.5%, NPV 65.5%**) for low/borderline flow and were not associated with stroke outcome. | Prospective observational study / post hoc analysis | (aminhanjani2010vertebrobasilarflowevaluation pages 1-2, markus2022treatmentofposterior pages 4-5) |
+| Diagnostics: DUS / ultrasound | **Color duplex ultrasound (DUS)** is commonly recommended as **first-line** screening in suspected vertebrobasilar ischemia, but positive studies usually require confirmatory **CTA or CE-MRA** before intervention decisions. Reported duplex criteria for proximal stenosis include **PSVr >2.2** for ≥50% stenosis with **96% sensitivity / 89% specificity**; other thresholds reported include **PSV >108 cm/s**, **EDV >36 cm/s**, **EDVr >1.7**. DUS has lower overall sensitivity than CTA/MRA but good specificity. | Review / guideline-summary review | (bobmanuel2023vertebralarteryinterventions pages 4-5, bobmanuel2023vertebralarteryinterventions pages 3-4) |
+| Diagnostics: CTA / MRA / DSA | **CTA** and **CE-MRA/MRA** are the main confirmatory noninvasive tests; review data cite sensitivity/specificity around **94–95%**, with CE-MRA sometimes slightly outperforming CTA. **DSA** remains the gold standard for lesion definition but is invasive and carries a **1–2% stroke risk**. In traumatic vertebral artery injury, CTA is the preferred acute screening test; pooled trauma data showed **91.7% CTA**, **7.5% MRA**, **3.0% DSA**, and one cited study reported CTA sensitivity near **98%** and specificity near **100%**, while MRA sensitivity was lower (**47–60%**). | Review, systematic review/meta-analysis | (bobmanuel2023vertebralarteryinterventions pages 4-5, bobmanuel2023vertebralarteryinterventions pages 3-4, goyal2024asystematicreview pages 5-7, goyal2024asystematicreview pages 1-2) |
+| Medical treatment / prevention | Guideline-concordant therapy centers on **aggressive vascular risk-factor control**: antiplatelet therapy, statin therapy, BP control, diabetes management, smoking cessation, and lifestyle modification. AHA/ASA-aligned review text cites BP goal **<140/90 mmHg** (diastolic **<85 mmHg** in diabetes). For posterior-circulation minor stroke/TIA, reviews support **short-term DAPT** (aspirin + clopidogrel, or aspirin + ticagrelor in guideline frameworks) for the early high-risk period, with benefit concentrated in approximately the **first 3 weeks**, then transition to single antiplatelet therapy. For asymptomatic vertebral stenosis, high-quality evidence is limited; the 2024 primary-prevention guideline notes insufficient data to make comprehensive evidence-based recommendations specific to asymptomatic vertebral artery stenosis. | Review, guideline, trial-informed secondary-prevention review | (bobmanuel2023vertebralarteryinterventions pages 4-5, markus2022treatmentofposterior pages 4-5, bushnell20242024guidelinefor pages 25-26) |
+| Acute posterior-circulation stroke care relevant to VAI/VBI | For posterior-circulation stroke broadly, **IV thrombolysis** appears at least as effective as for anterior circulation and may have lower symptomatic ICH risk; **mechanical thrombectomy** now has convincing benefit for **basilar artery occlusion** (e.g., 90-day mRS 0–3 in **46% vs 22.8%** in ATTENTION-like data, and **46.4% vs 24.3%** in BAOCHE-like data). Evidence remains sparse for isolated vertebral artery occlusions. | Review of RCTs/observational studies | (markus2022treatmentofposterior pages 1-2, markus2022treatmentofposterior pages 2-3, markus2022treatmentofposterior pages 3-4) |
+| Stenting vs medical therapy: overall interpretation | Endovascular angioplasty/stenting is technically feasible and widely used, but superiority over best medical therapy remains unproven. Reviews note vertebral revascularization may be considered for **symptomatic extracranial lesions ≥50%** with recurrent ischemia despite optimal medical therapy (ESC Class IIb wording in review summary), while **intracranial vertebral/basilar stenosis** is generally better managed medically because peri-procedural risk is higher. | Review / guideline-summary review / RCT synthesis | (bobmanuel2023vertebralarteryinterventions pages 4-5, markus2022treatmentofposterior pages 1-2, markus2022treatmentofposterior pages 5-8) |
+| Vertebral stenting trial data | **VAST**: 30-day composite outcome **5% (3/57)** in stenting vs **2% (1/58)** in optimal medical therapy; 1-year vertebrobasilar-territory stroke **9%** vs **7%**. **VIST**: strokes in **5** stented vs **12** medical patients; HR **0.40 (95% CI 0.14–1.13; p=0.08)**, suggesting possible but unproven benefit, especially extracranially. For intracranial stenosis generally, **SAMMPRIS** showed 30-day stroke/death **14.7%** with stenting vs **5.8%** with medical therapy; basilar stenosis had particularly high peri-procedural risk (**20.8%** vs **6.7%** in other arteries). | RCTs summarized in reviews | (bobmanuel2023vertebralarteryinterventions pages 7-8, markus2022treatmentofposterior pages 5-8) |
+| Restenosis / post-stent outcomes | Reported vertebral in-stent restenosis varies widely: **0–43%** across studies; early bare-metal stent series reported **11–43%** restenosis, while a meta-analysis cited **8.2%** restenosis with drug-eluting stents vs **23.7%** with bare-metal stents. In a 2023 vertebrobasilar-stenting cohort (n=93 VBS), in-stent restenosis was **12.9%**, with cumulative rates **10.4%, 15.7%, 18.1%** at 12/24/36 months; stented-territory infarction was **22.6%** overall, higher than carotid stenting. Predictors included higher **HbA1c**, **clopidogrel resistance / low platelet inhibition**, **diabetes**, and use of **≥2 stents**. | Review, retrospective observational cohort | (ryu2023instentrestenosisand pages 4-6, ryu2023instentrestenosisand pages 2-4, ryu2023instentrestenosisand pages 1-2, bobmanuel2023vertebralarteryinterventions pages 7-8, bobmanuel2023vertebralarteryinterventions pages 5-6) |
+| Microsurgical / hybrid real-world implementations | **Zhang 2023**: 29 symptomatic proximal vertebral lesions; techniques included endarterectomy, transposition, hybrid endarterectomy+stent; **no perioperative stroke or death**, mean follow-up **28.4 months**, most improved clinically, no anastomotic stenosis on follow-up imaging. **Liu 2024**: 34 patients unsuitable for endovascular treatment; pre-op CTA/CTP/MRA, post-op vessels patent, **30/34** improved mRS with all postoperative mRS **<1**, mean follow-up **10 months**; one death from septic shock unrelated to cerebrovascular event, one residual moderate restenosis, six temporary complications, one permanent Horner syndrome. These series support surgery as a niche option for refractory anatomy, restenosis, or endovascular-unsuitable disease. | Single-center retrospective observational series | (zhang2023microsurgicalrevascularizationof pages 4-5, zhang2023microsurgicalrevascularizationof pages 2-4, zhang2023microsurgicalrevascularizationof pages 5-6, liu2024applicationofmicrosurgical pages 1-2, liu2024applicationofmicrosurgical pages 2-4, zhang2023microsurgicalrevascularizationof pages 1-2, liu2024applicationofmicrosurgical pages 4-6) |
+| Traumatic/dissection-associated vertebral insufficiency | In cervical trauma, pooled incidence of vertebral artery injury was **0.95% (95% CI 0.65–1.29)** and pooled posterior stroke risk among VAI cases was **8.87% (95% CI 5.34–12.99)**. Most were evaluated with CTA, and management varied across conservative care, antiplatelets, anticoagulation, combined therapy, and surgical/endovascular intervention. This is a clinically important VAI subtype but distinct from chronic atherosclerotic VBI. | Systematic review/meta-analysis | (goyal2024asystematicreview pages 5-7, goyal2024asystematicreview pages 1-2) |
+| Real-world trials / implementations | **NCT05885932**: recruiting randomized trial, **Drug-eluting Stenting Versus Medical Treatment for Extracranial Vertebral Artery Stenosis**, planned **n=472**. **NCT03201432**: completed phase 2/3 trial comparing **drug-eluting vs bare-metal stents** for symptomatic extracranial vertebral stenosis, **n=160**. Additional antiplatelet optimization after cerebrovascular stenting: **NCT06301776** (post-BRIDGE dual antiplatelet/ticagrelor strategy, recruiting, **n=560**). These trials show ongoing real-world implementation emphasis on extracranial vertebral stenting technology and post-stent antiplatelet regimens rather than established routine use. | Registered interventional clinical trials | (bobmanuel2023vertebralarteryinterventions pages 7-8) |
+
+
+*Table: This table condenses definitions, mechanisms, diagnostics, prognosis, treatments, and active implementation examples for vertebral artery insufficiency / vertebrobasilar insufficiency. It is designed as a compact evidence map for rapid use in a disease knowledge base.*
+
+References
+
+1. (bobmanuel2023vertebralarteryinterventions pages 1-2): Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, and James S. Jenkins. Vertebral artery interventions: a comprehensive updated review. Current Cardiology Reviews, Jan 2023. URL: https://doi.org/10.2174/1573403x18666220317093131, doi:10.2174/1573403x18666220317093131. This article has 21 citations.
+
+2. (aminhanjani2010vertebrobasilarflowevaluation pages 1-2): Sepideh Amin-Hanjani, Linda Rose-Finnell, DeJuran Richardson, Sean Ruland, Dilip Pandey, Keith R. Thulborn, David S. Liebeskind, Gregory J. Zipfel, Mitchell S. V. Elkind, Jeffrey Kramer, Frank L. Silver, Scott E. Kasner, Louis R. Caplan, Colin P. Derdeyn, Philip B. Gorelick, and Fady T. Charbel. Vertebrobasilar flow evaluation and risk of transient ischaemic attack and stroke study (veritas): rationale and design. International Journal of Stroke, 5:499-505, Dec 2010. URL: https://doi.org/10.1111/j.1747-4949.2010.00528.x, doi:10.1111/j.1747-4949.2010.00528.x. This article has 59 citations and is from a peer-reviewed journal.
+
+3. (bobmanuel2023vertebralarteryinterventions pages 4-5): Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, and James S. Jenkins. Vertebral artery interventions: a comprehensive updated review. Current Cardiology Reviews, Jan 2023. URL: https://doi.org/10.2174/1573403x18666220317093131, doi:10.2174/1573403x18666220317093131. This article has 21 citations.
+
+4. (bobmanuel2023vertebralarteryinterventions pages 2-3): Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, and James S. Jenkins. Vertebral artery interventions: a comprehensive updated review. Current Cardiology Reviews, Jan 2023. URL: https://doi.org/10.2174/1573403x18666220317093131, doi:10.2174/1573403x18666220317093131. This article has 21 citations.
+
+5. (bobmanuel2023vertebralarteryinterventions pages 3-4): Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, and James S. Jenkins. Vertebral artery interventions: a comprehensive updated review. Current Cardiology Reviews, Jan 2023. URL: https://doi.org/10.2174/1573403x18666220317093131, doi:10.2174/1573403x18666220317093131. This article has 21 citations.
+
+6. (zhang2023microsurgicalrevascularizationof pages 1-2): Tongfu Zhang, Donglin Zhou, Yangyang Xu, Maogui Li, Jianfeng Zhuang, Hai Wang, Weiying Zhong, Chao Chen, Hong Kuang, Donghai Wang, and Yunyan Wang. Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1202565, doi:10.3389/fneur.2023.1202565. This article has 3 citations and is from a peer-reviewed journal.
+
+7. (markus2022treatmentofposterior pages 1-2): Hugh S Markus and Patrik Michel. Treatment of posterior circulation stroke: acute management and secondary prevention. International Journal of Stroke, 17:723-732, Jun 2022. URL: https://doi.org/10.1177/17474930221107500, doi:10.1177/17474930221107500. This article has 95 citations and is from a peer-reviewed journal.
+
+8. (bushnell20242024guidelinefor pages 25-26): Cheryl Bushnell, Walter N. Kernan, Anjail Z. Sharrief, Seemant Chaturvedi, John W. Cole, William K. Cornwell, Christine Cosby-Gaither, Sarah Doyle, Larry B. Goldstein, Olive Lennon, Deborah A. Levine, Mary Love, Eliza Miller, Mai Nguyen-Huynh, Jennifer Rasmussen-Winkler, Kathryn M. Rexrode, Nicole Rosendale, Satyam Sarma, Daichi Shimbo, Alexis N. Simpkins, Erica S. Spatz, Lisa R. Sun, Vin Tangpricha, Dawn Turnage, Gabriela Velazquez, and Paul K. Whelton. 2024 guideline for the primary prevention of stroke: a guideline from the american heart association/american stroke association. Stroke, Dec 2024. URL: https://doi.org/10.1161/str.0000000000000475, doi:10.1161/str.0000000000000475. This article has 333 citations and is from a highest quality peer-reviewed journal.
+
+9. (ryu2023instentrestenosisand pages 2-4): Jae-Chan Ryu, Jae-Han Bae, Sang Hee Ha, Boseong Kwon, Yunsun Song, Deok Hee Lee, Jun Young Chang, Dong-Wha Kang, Sun U. Kwon, Jong S. Kim, and Bum Joon Kim. In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting. BMC Neurology, Feb 2023. URL: https://doi.org/10.1186/s12883-023-03110-z, doi:10.1186/s12883-023-03110-z. This article has 11 citations and is from a peer-reviewed journal.
+
+10. (liu2024applicationofmicrosurgical pages 1-2): Mingyuan Liu, Peiguang Yan, Mingxin Wang, Jia Guo, Wei Liu, Ganchun Wu, Lufei Wang, Jingjing Liu, and Li Li. Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study. Neurosurgical Review, Dec 2024. URL: https://doi.org/10.1007/s10143-024-03153-x, doi:10.1007/s10143-024-03153-x. This article has 1 citations and is from a peer-reviewed journal.
+
+11. (goyal2024asystematicreview pages 1-2): Kartik Goyal, Jesvin T. Sunny, Conor S. Gillespie, Martin Wilby, Simon R. Clark, Radek Kaiser, Michael G. Fehlings, and Nisaharan Srikandarajah. A systematic review and meta-analysis of vertebral artery injury after cervical spine trauma. Global Spine Journal, 14:1356-1368, Nov 2024. URL: https://doi.org/10.1177/21925682231209631, doi:10.1177/21925682231209631. This article has 21 citations and is from a peer-reviewed journal.
+
+12. (amran2024vertebralarterydissection pages 1-2): Muhammad Yunus Amran, Irbab Hawari, Fitri Jafani La’biran, Siti Giranti Ardilia Gunadi, and Lisa Tenriesa Muslich. Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration. The Egyptian Journal of Neurology, Psychiatry and Neurosurgery, Sep 2024. URL: https://doi.org/10.1186/s41983-024-00893-x, doi:10.1186/s41983-024-00893-x. This article has 6 citations.
+
+13. (aminhanjani2015hemodynamicfeaturesof pages 7-10): Sepideh Amin-Hanjani, Xinjian Du, Linda Rose-Finnell, Dilip K. Pandey, DeJuran Richardson, Keith R. Thulborn, Mitchell S.V. Elkind, Gregory J. Zipfel, David S. Liebeskind, Frank L. Silver, Scott E. Kasner, Victor A. Aletich, Louis R. Caplan, Colin P. Derdeyn, Philip B. Gorelick, Fady T. Charbel, Hui Xie, Michael P. Flannery, Hagai Ganin, Sean Ruland, Rebecca Grysiewicz, Aslam Khaja, Laura Pedelty, Fernando Testai, Archie Ong, Noam Epstein, Hurmina Muqtadar, Karriem Watson, Nada Mlinarevich, Maureen Hillmann, Joy Hirsch, Stephen Dashnaw, Philip M. Meyers, Josh Z. Willey, Edwina McNeill-Simaan, Veronica Perez, Alberto Canaan, Wayna Paulino-Hernandez, Katie Vo, Glenn Foster, Andria Ford, Abdullah Nassief, Abbie Bradley, Jannie Serna-Northway, Kristi Kraus, Lina Shiwani, Nancy Hantler, Jeffrey Alger, Sergio Godinez, Jeffrey L. Saver, Latisha Ali, Doojin Kim, Matthew Tenser, Michael Froehler, Radoslav Raychev, Sarah Song, Bruce Ovbiagele, Hermelinda Abcede, Peter Adamczyk, Neal Rao, Anil Yallapragada, Royya Modir, Jason Hinman, Aaron Tansy, Mateo Calderon-Arnulphi, Sunil Sheth, Alireza Noorian, Kwan Ng, Conrad Liang, Jignesh Gadhia, Hannah Smith, Gilda Avila, Johanna Avelar, David Mikulis, Jorn Fierstra, Eugen Hlasny, Leanne K. Casaubon, Mervyn Vergouwen, J.C. Martin del Campo, Cheryl S. Jaigobin, Cherissa Astorga, Libby Kalman, Jeffrey Kramer, Susan Vaughan, Laura Owens, Brett Kissela, Tanya N. Turan, Tom P. Jacobs, and Scott Janis. Hemodynamic features of symptomatic vertebrobasilar disease. Stroke, 46:1850–1856, Jul 2015. URL: https://doi.org/10.1161/strokeaha.115.009215, doi:10.1161/strokeaha.115.009215. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+14. (aminhanjani2015hemodynamicfeaturesof pages 10-15): Sepideh Amin-Hanjani, Xinjian Du, Linda Rose-Finnell, Dilip K. Pandey, DeJuran Richardson, Keith R. Thulborn, Mitchell S.V. Elkind, Gregory J. Zipfel, David S. Liebeskind, Frank L. Silver, Scott E. Kasner, Victor A. Aletich, Louis R. Caplan, Colin P. Derdeyn, Philip B. Gorelick, Fady T. Charbel, Hui Xie, Michael P. Flannery, Hagai Ganin, Sean Ruland, Rebecca Grysiewicz, Aslam Khaja, Laura Pedelty, Fernando Testai, Archie Ong, Noam Epstein, Hurmina Muqtadar, Karriem Watson, Nada Mlinarevich, Maureen Hillmann, Joy Hirsch, Stephen Dashnaw, Philip M. Meyers, Josh Z. Willey, Edwina McNeill-Simaan, Veronica Perez, Alberto Canaan, Wayna Paulino-Hernandez, Katie Vo, Glenn Foster, Andria Ford, Abdullah Nassief, Abbie Bradley, Jannie Serna-Northway, Kristi Kraus, Lina Shiwani, Nancy Hantler, Jeffrey Alger, Sergio Godinez, Jeffrey L. Saver, Latisha Ali, Doojin Kim, Matthew Tenser, Michael Froehler, Radoslav Raychev, Sarah Song, Bruce Ovbiagele, Hermelinda Abcede, Peter Adamczyk, Neal Rao, Anil Yallapragada, Royya Modir, Jason Hinman, Aaron Tansy, Mateo Calderon-Arnulphi, Sunil Sheth, Alireza Noorian, Kwan Ng, Conrad Liang, Jignesh Gadhia, Hannah Smith, Gilda Avila, Johanna Avelar, David Mikulis, Jorn Fierstra, Eugen Hlasny, Leanne K. Casaubon, Mervyn Vergouwen, J.C. Martin del Campo, Cheryl S. Jaigobin, Cherissa Astorga, Libby Kalman, Jeffrey Kramer, Susan Vaughan, Laura Owens, Brett Kissela, Tanya N. Turan, Tom P. Jacobs, and Scott Janis. Hemodynamic features of symptomatic vertebrobasilar disease. Stroke, 46:1850–1856, Jul 2015. URL: https://doi.org/10.1161/strokeaha.115.009215, doi:10.1161/strokeaha.115.009215. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+15. (markus2022treatmentofposterior pages 3-4): Hugh S Markus and Patrik Michel. Treatment of posterior circulation stroke: acute management and secondary prevention. International Journal of Stroke, 17:723-732, Jun 2022. URL: https://doi.org/10.1177/17474930221107500, doi:10.1177/17474930221107500. This article has 95 citations and is from a peer-reviewed journal.
+
+16. (amran2024vertebralarterydissection pages 6-8): Muhammad Yunus Amran, Irbab Hawari, Fitri Jafani La’biran, Siti Giranti Ardilia Gunadi, and Lisa Tenriesa Muslich. Vertebral artery dissection from etiopathogenesis to management therapy: a narrative review with neuroimaging’s case illustration. The Egyptian Journal of Neurology, Psychiatry and Neurosurgery, Sep 2024. URL: https://doi.org/10.1186/s41983-024-00893-x, doi:10.1186/s41983-024-00893-x. This article has 6 citations.
+
+17. (markus2022treatmentofposterior pages 4-5): Hugh S Markus and Patrik Michel. Treatment of posterior circulation stroke: acute management and secondary prevention. International Journal of Stroke, 17:723-732, Jun 2022. URL: https://doi.org/10.1177/17474930221107500, doi:10.1177/17474930221107500. This article has 95 citations and is from a peer-reviewed journal.
+
+18. (goyal2024asystematicreview pages 5-7): Kartik Goyal, Jesvin T. Sunny, Conor S. Gillespie, Martin Wilby, Simon R. Clark, Radek Kaiser, Michael G. Fehlings, and Nisaharan Srikandarajah. A systematic review and meta-analysis of vertebral artery injury after cervical spine trauma. Global Spine Journal, 14:1356-1368, Nov 2024. URL: https://doi.org/10.1177/21925682231209631, doi:10.1177/21925682231209631. This article has 21 citations and is from a peer-reviewed journal.
+
+19. (ryu2023instentrestenosisand pages 6-7): Jae-Chan Ryu, Jae-Han Bae, Sang Hee Ha, Boseong Kwon, Yunsun Song, Deok Hee Lee, Jun Young Chang, Dong-Wha Kang, Sun U. Kwon, Jong S. Kim, and Bum Joon Kim. In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting. BMC Neurology, Feb 2023. URL: https://doi.org/10.1186/s12883-023-03110-z, doi:10.1186/s12883-023-03110-z. This article has 11 citations and is from a peer-reviewed journal.
+
+20. (markus2022treatmentofposterior pages 2-3): Hugh S Markus and Patrik Michel. Treatment of posterior circulation stroke: acute management and secondary prevention. International Journal of Stroke, 17:723-732, Jun 2022. URL: https://doi.org/10.1177/17474930221107500, doi:10.1177/17474930221107500. This article has 95 citations and is from a peer-reviewed journal.
+
+21. (bobmanuel2023vertebralarteryinterventions pages 7-8): Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, and James S. Jenkins. Vertebral artery interventions: a comprehensive updated review. Current Cardiology Reviews, Jan 2023. URL: https://doi.org/10.2174/1573403x18666220317093131, doi:10.2174/1573403x18666220317093131. This article has 21 citations.
+
+22. (bobmanuel2023vertebralarteryinterventions pages 5-6): Tamunoinemi Bob-Manuel, Oscar Maitas, Justin Price, Abdullah Noor, Koyenum Obi, Nelson Okoh, Kiran Garikapati, Jeong Kim, Sanjida Jahan, and James S. Jenkins. Vertebral artery interventions: a comprehensive updated review. Current Cardiology Reviews, Jan 2023. URL: https://doi.org/10.2174/1573403x18666220317093131, doi:10.2174/1573403x18666220317093131. This article has 21 citations.
+
+23. (zhang2023microsurgicalrevascularizationof pages 4-5): Tongfu Zhang, Donglin Zhou, Yangyang Xu, Maogui Li, Jianfeng Zhuang, Hai Wang, Weiying Zhong, Chao Chen, Hong Kuang, Donghai Wang, and Yunyan Wang. Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1202565, doi:10.3389/fneur.2023.1202565. This article has 3 citations and is from a peer-reviewed journal.
+
+24. (liu2024applicationofmicrosurgical pages 2-4): Mingyuan Liu, Peiguang Yan, Mingxin Wang, Jia Guo, Wei Liu, Ganchun Wu, Lufei Wang, Jingjing Liu, and Li Li. Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study. Neurosurgical Review, Dec 2024. URL: https://doi.org/10.1007/s10143-024-03153-x, doi:10.1007/s10143-024-03153-x. This article has 1 citations and is from a peer-reviewed journal.
+
+25. (markus2022treatmentofposterior pages 5-8): Hugh S Markus and Patrik Michel. Treatment of posterior circulation stroke: acute management and secondary prevention. International Journal of Stroke, 17:723-732, Jun 2022. URL: https://doi.org/10.1177/17474930221107500, doi:10.1177/17474930221107500. This article has 95 citations and is from a peer-reviewed journal.
+
+26. (ryu2023instentrestenosisand pages 4-6): Jae-Chan Ryu, Jae-Han Bae, Sang Hee Ha, Boseong Kwon, Yunsun Song, Deok Hee Lee, Jun Young Chang, Dong-Wha Kang, Sun U. Kwon, Jong S. Kim, and Bum Joon Kim. In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting. BMC Neurology, Feb 2023. URL: https://doi.org/10.1186/s12883-023-03110-z, doi:10.1186/s12883-023-03110-z. This article has 11 citations and is from a peer-reviewed journal.
+
+27. (ryu2023instentrestenosisand pages 1-2): Jae-Chan Ryu, Jae-Han Bae, Sang Hee Ha, Boseong Kwon, Yunsun Song, Deok Hee Lee, Jun Young Chang, Dong-Wha Kang, Sun U. Kwon, Jong S. Kim, and Bum Joon Kim. In-stent restenosis and stented-territory infarction after carotid and vertebrobasilar artery stenting. BMC Neurology, Feb 2023. URL: https://doi.org/10.1186/s12883-023-03110-z, doi:10.1186/s12883-023-03110-z. This article has 11 citations and is from a peer-reviewed journal.
+
+28. (zhang2023microsurgicalrevascularizationof pages 2-4): Tongfu Zhang, Donglin Zhou, Yangyang Xu, Maogui Li, Jianfeng Zhuang, Hai Wang, Weiying Zhong, Chao Chen, Hong Kuang, Donghai Wang, and Yunyan Wang. Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1202565, doi:10.3389/fneur.2023.1202565. This article has 3 citations and is from a peer-reviewed journal.
+
+29. (zhang2023microsurgicalrevascularizationof pages 5-6): Tongfu Zhang, Donglin Zhou, Yangyang Xu, Maogui Li, Jianfeng Zhuang, Hai Wang, Weiying Zhong, Chao Chen, Hong Kuang, Donghai Wang, and Yunyan Wang. Microsurgical revascularization of a symptomatic proximal vertebral artery: pilot experiences from a single center. Frontiers in Neurology, Jul 2023. URL: https://doi.org/10.3389/fneur.2023.1202565, doi:10.3389/fneur.2023.1202565. This article has 3 citations and is from a peer-reviewed journal.
+
+30. (liu2024applicationofmicrosurgical pages 4-6): Mingyuan Liu, Peiguang Yan, Mingxin Wang, Jia Guo, Wei Liu, Ganchun Wu, Lufei Wang, Jingjing Liu, and Li Li. Application of microsurgical surgery in patients with proximal vertebral artery stenosis unsuited for endovascular treatment: a single-center retrospective study. Neurosurgical Review, Dec 2024. URL: https://doi.org/10.1007/s10143-024-03153-x, doi:10.1007/s10143-024-03153-x. This article has 1 citations and is from a peer-reviewed journal.

--- a/research/Vertebral_Artery_Insufficiency-deep-research-falcon.md.citations.md
+++ b/research/Vertebral_Artery_Insufficiency-deep-research-falcon.md.citations.md
@@ -1,0 +1,494 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Vertebral Artery Insufficiency
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Vertebral Artery Insufficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T15:23:52.718460
+
+1. aminhanjani2010vertebrobasilarflowevaluation pages 1-2
+2. zhang2023microsurgicalrevascularizationof pages 1-2
+3. markus2022treatmentofposterior pages 1-2
+4. goyal2024asystematicreview pages 1-2
+5. bobmanuel2023vertebralarteryinterventions pages 3-4
+6. bobmanuel2023vertebralarteryinterventions pages 2-3
+7. bobmanuel2023vertebralarteryinterventions pages 4-5
+8. aminhanjani2015hemodynamicfeaturesof pages 7-10
+9. amran2024vertebralarterydissection pages 1-2
+10. aminhanjani2015hemodynamicfeaturesof pages 10-15
+11. bobmanuel2023vertebralarteryinterventions pages 1-2
+12. goyal2024asystematicreview pages 5-7
+13. markus2022treatmentofposterior pages 4-5
+14. markus2022treatmentofposterior pages 2-3
+15. markus2022treatmentofposterior pages 3-4
+16. bobmanuel2023vertebralarteryinterventions pages 7-8
+17. liu2024applicationofmicrosurgical pages 1-2
+18. liu2024applicationofmicrosurgical pages 2-4
+19. ryu2023instentrestenosisand pages 2-4
+20. amran2024vertebralarterydissection pages 6-8
+21. ryu2023instentrestenosisand pages 6-7
+22. bobmanuel2023vertebralarteryinterventions pages 5-6
+23. zhang2023microsurgicalrevascularizationof pages 4-5
+24. markus2022treatmentofposterior pages 5-8
+25. ryu2023instentrestenosisand pages 4-6
+26. ryu2023instentrestenosisand pages 1-2
+27. zhang2023microsurgicalrevascularizationof pages 2-4
+28. zhang2023microsurgicalrevascularizationof pages 5-6
+29. liu2024applicationofmicrosurgical pages 4-6
+30. https://doi.org/10.2174/1573403x18666220317093131
+31. https://doi.org/10.1111/j.1747-4949.2010.00528.x
+32. https://doi.org/10.1161/str.0000000000000475
+33. https://doi.org/10.1177/21925682231209631
+34. https://doi.org/10.2174/1573403x18666220317093131,
+35. https://doi.org/10.1111/j.1747-4949.2010.00528.x,
+36. https://doi.org/10.3389/fneur.2023.1202565,
+37. https://doi.org/10.1177/17474930221107500,
+38. https://doi.org/10.1161/str.0000000000000475,
+39. https://doi.org/10.1186/s12883-023-03110-z,
+40. https://doi.org/10.1007/s10143-024-03153-x,
+41. https://doi.org/10.1177/21925682231209631,
+42. https://doi.org/10.1186/s41983-024-00893-x,
+43. https://doi.org/10.1161/strokeaha.115.009215,


### PR DESCRIPTION
## Summary

- Add `kb/disorders/Vertebral_Artery_Insufficiency.yaml` for MONDO:0001631.
- Incorporate Falcon deep-research evidence for posterior circulation hypoperfusion, vertebrobasilar stenosis/occlusion, thromboembolism, dissection or traumatic vertebral artery injury, stroke/TIA phenotypes, diagnostics, treatments, and clinical trials.
- Add generated reference cache files and Falcon research artifacts for cited evidence.

## Validation

| Command | Result |
| --- | --- |
| `just validate kb/disorders/Vertebral_Artery_Insufficiency.yaml` | Passed |
| `just validate-references kb/disorders/Vertebral_Artery_Insufficiency.yaml` | Passed |
| `just check-reference-cache-frontmatter` | Passed |
| `just qc-deep-research --only Vertebral_Artery_Insufficiency` | Passed with Falcon research present and no missing cited references |
| Custom exact-snippet check against `references_cache` | Passed for 32 evidence snippets |

## Notes

- `references_cache/*.md` files were generated with `just fetch-reference`; I did not hand-edit them.
- I restored unrelated generated cache churn before staging.
