### PR TITLE
Improve Alpha-mannosidosis pathograph connectivity

### DIFF
--- a/kb/disorders/Alpha_Mannosidosis.yaml
+++ b/kb/disorders/Alpha_Mannosidosis.yaml
@@ -1,7 +1,7 @@
 name: Alpha-mannosidosis
 category: Mendelian
 creation_date: "2026-05-04T17:13:27Z"
-updated_date: "2026-05-04T17:13:27Z"
+updated_date: "2026-05-06T21:44:37Z"
 synonyms:
 - Lysosomal alpha-D-mannosidase deficiency
 description: >
@@ -270,6 +270,10 @@ pathophysiology:
   downstream:
   - target: Mannose-rich oligosaccharide lysosomal storage
     description: Reduced lysosomal alpha-mannosidase blocks glycoprotein oligosaccharide degradation.
+  - target: Reduced acid alpha-mannosidase activity
+    description: MAN2B1 pathogenic variation is reflected diagnostically by reduced leukocyte or cellular acid alpha-mannosidase activity.
+  - target: Infantile form abnormal circulating enzyme concentration or activity
+    description: The infantile subtype records abnormal enzyme/coenzyme activity as the enzyme-level phenotype.
 - name: Mannose-rich oligosaccharide lysosomal storage
   description: >
     Deficient lysosomal alpha-mannosidase activity causes accumulation of
@@ -306,6 +310,34 @@ pathophysiology:
     description: Systemic storage disease is associated with immunodeficiency and recurrent infections.
   - target: Skeletal and craniofacial storage manifestations
     description: Connective-tissue and skeletal involvement produces coarse facial features and skeletal dysplasia.
+  - target: Increased urinary mannose-rich oligosaccharides
+    description: Lysosomal storage is reflected by increased urinary excretion of mannose-rich oligosaccharides.
+  - target: Oligosacchariduria in alpha-mannosidosis subtypes
+    description: Orphanet subtype records capture oligosacchariduria as a frequent storage biomarker.
+  - target: Hearing impairment
+    description: Multisystem storage disease includes moderate-to-severe hearing impairment.
+  - target: Cataract
+    description: Ocular involvement in alpha-mannosidosis includes cataract.
+  - target: Corneal opacity
+    description: Ocular storage manifestations can include corneal opacity.
+  - target: Infantile form cataract
+    description: The infantile alpha-mannosidosis subtype includes cataract.
+  - target: Infantile form strabismus
+    description: The infantile alpha-mannosidosis subtype includes strabismus.
+  - target: Infantile form hypermetropia
+    description: The infantile alpha-mannosidosis subtype includes hypermetropia.
+  - target: Infantile form myopia
+    description: The infantile alpha-mannosidosis subtype includes myopia.
+  - target: Splenomegaly
+    description: Visceral storage manifestations include splenic enlargement.
+  - target: Hepatomegaly
+    description: Visceral storage manifestations include hepatic enlargement.
+  - target: Infantile form hepatosplenomegaly
+    description: The infantile subtype includes combined hepatic and splenic enlargement.
+  - target: Generalized abnormality of skin
+    description: Multisystem storage manifestations include generalized skin abnormalities.
+  - target: Inguinal hernia
+    description: Connective-tissue and visceral manifestations include inguinal hernia.
 - name: Neurodevelopmental and motor impairment
   description: >
     Central nervous system involvement produces intellectual disability,
@@ -336,6 +368,34 @@ pathophysiology:
     description: Early neurodevelopmental involvement delays acquisition of developmental milestones.
   - target: Hypotonia
     description: Motor system involvement contributes to low tone and delayed motor function.
+  - target: Atypical behavior
+    description: CNS involvement includes behavioral manifestations.
+  - target: Hallucinations
+    description: Psychiatric involvement can include hallucinations.
+  - target: Increased intracranial pressure
+    description: Neurologic involvement can include increased intracranial pressure.
+  - target: Infantile form intellectual disability
+    description: Neurodevelopmental involvement in the infantile subtype includes intellectual disability.
+  - target: Infantile form hypotonia
+    description: Motor involvement in the infantile subtype includes hypotonia.
+  - target: Infantile form short attention span
+    description: Neurodevelopmental involvement in the infantile subtype includes impaired attention.
+  - target: Infantile form delayed speech and language development
+    description: CNS involvement impairs speech and language development in the infantile subtype.
+  - target: Ataxia in alpha-mannosidosis subtypes
+    description: Motor-system involvement includes ataxia across recorded subtypes.
+  - target: Infantile form mild intellectual disability
+    description: The infantile subtype includes mild intellectual disability in Orphanet records.
+  - target: Adult form mild intellectual disability
+    description: The adult subtype includes mild intellectual disability in Orphanet records.
+  - target: Infantile form motor delay
+    description: Motor-system involvement in the infantile subtype delays motor milestones.
+  - target: Infantile form specific learning disability
+    description: Neurodevelopmental involvement in the infantile subtype includes specific learning disability.
+  - target: Infantile form myopathy
+    description: Motor-system involvement in the infantile subtype includes myopathy.
+  - target: Asthenia in alpha-mannosidosis subtypes
+    description: Motor and systemic involvement includes asthenia across recorded subtypes.
 - name: Immune deficiency and recurrent infections
   description: >
     Immune dysfunction is a core alpha-mannosidosis manifestation and is
@@ -352,6 +412,20 @@ pathophysiology:
     description: Immunodeficiency contributes to recurrent respiratory infections.
   - target: Chronic otitis media
     description: Recurrent infections include frequent middle-ear disease.
+  - target: Infantile form otitis media
+    description: Recurrent middle-ear infections are prominent in the infantile subtype.
+  - target: Infantile form mixed hearing impairment
+    description: Recurrent middle-ear disease can contribute to the conductive component of mixed hearing impairment in the infantile subtype.
+  - target: Infantile form pneumonia
+    description: Immunodeficiency predisposes to pneumonia in the infantile subtype.
+  - target: Infantile form recurrent infections
+    description: The infantile subtype includes recurrent infections as a core immune manifestation.
+  - target: Adult form recurrent infections
+    description: The adult subtype can also retain recurrent infections.
+  - target: Infantile form immunodeficiency
+    description: The infantile subtype includes immunodeficiency.
+  - target: Infantile form recurrent gastroenteritis
+    description: Immune dysfunction can include recurrent gastrointestinal infections.
 - name: Skeletal and craniofacial storage manifestations
   description: >
     Storage disease produces progressive craniofacial coarsening and skeletal
@@ -382,6 +456,62 @@ pathophysiology:
     description: Skeletal involvement causes dysplasia and delayed skeletal maturation.
   - target: Scoliosis
     description: Vertebral and skeletal involvement contributes to spinal curvature.
+  - target: Macroglossia
+    description: Craniofacial and oral storage manifestations include macroglossia.
+  - target: Narrow palate
+    description: Craniofacial development and storage manifestations include a narrow palate.
+  - target: Gingival overgrowth
+    description: Oral soft-tissue storage manifestations include gingival overgrowth.
+  - target: Macrocephaly
+    description: Craniofacial storage manifestations include macrocephaly.
+  - target: Mandibular prognathia
+    description: Craniofacial skeletal involvement can produce mandibular prognathia.
+  - target: Hypertelorism
+    description: Craniofacial involvement includes hypertelorism.
+  - target: Prominent supraorbital ridges
+    description: Craniofacial coarsening includes prominent supraorbital ridges.
+  - target: Macrotia
+    description: Craniofacial dysmorphism includes macrotia.
+  - target: Short neck
+    description: Craniofacial and skeletal involvement includes a short neck.
+  - target: Widely spaced teeth
+    description: Oral and craniofacial involvement includes widely spaced teeth.
+  - target: Dental malocclusion
+    description: Craniofacial skeletal and dental involvement includes malocclusion.
+  - target: Arthritis
+    description: Skeletal involvement can include arthritis.
+  - target: Hip dysplasia
+    description: Skeletal dysplasia includes hip involvement.
+  - target: Delayed skeletal maturation
+    description: Skeletal storage manifestations include delayed skeletal maturation.
+  - target: Kyphosis
+    description: Vertebral skeletal involvement contributes to kyphosis.
+  - target: Craniofacial hyperostosis
+    description: Craniofacial skeletal involvement includes hyperostosis.
+  - target: Depressed nasal bridge
+    description: Craniofacial coarsening includes a depressed nasal bridge.
+  - target: Bowing of the long bones
+    description: Skeletal dysplasia includes bowing of long bones.
+  - target: Hypoplastic inferior ilia
+    description: Pelvic skeletal dysplasia includes hypoplastic inferior ilia.
+  - target: Open bite
+    description: Craniofacial and dental involvement includes open bite.
+  - target: Avascular necrosis
+    description: Skeletal involvement can include avascular necrosis.
+  - target: Abnormality of the helix
+    description: Craniofacial dysmorphism includes abnormal helix morphology.
+  - target: Synostosis of joints
+    description: Skeletal involvement includes joint synostosis.
+  - target: Infantile form coarse facial features
+    description: The infantile subtype includes coarse facial features.
+  - target: Infantile form hypertelorism
+    description: The infantile subtype includes hypertelorism.
+  - target: Infantile form dysostosis multiplex
+    description: The infantile subtype includes dysostosis multiplex.
+  - target: Infantile form facial shape deformation
+    description: The infantile subtype includes facial shape deformation.
+  - target: Infantile form abnormal skeletal morphology
+    description: The infantile subtype includes abnormal skeletal morphology.
 histopathology:
 - name: Lysosomal cellular storage pathology
   description: >
@@ -959,25 +1089,6 @@ phenotypes:
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "HP:0005280 | Depressed nasal bridge | Very frequent (99-80%)"
-    explanation: Orphanet provides the disease-phenotype association and frequency band.
-- name: Type II diabetes mellitus
-  frequency: VERY_FREQUENT
-  review_notes: >
-    ORPHA:61 lists HP:0005978 at Very frequent (99-80%), but this association
-    is not corroborated by the cited primary clinical literature and is likely
-    an Orphanet data-quality issue. Do not rely on this frequency band as a
-    recognized alpha-mannosidosis clinical feature without additional evidence.
-  phenotype_term:
-    preferred_term: Type II diabetes mellitus
-    term:
-      id: HP:0005978
-      label: Type II diabetes mellitus
-  evidence:
-  - reference: ORPHA:61
-    reference_title: "Alpha-mannosidosis (Orphanet structured-database record)"
-    supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "HP:0005978 | Type II diabetes mellitus | Very frequent (99-80%)"
     explanation: Orphanet provides the disease-phenotype association and frequency band.
 - name: Bowing of the long bones
   frequency: FREQUENT


### PR DESCRIPTION
## Summary
- Connect alpha-mannosidosis phenotype and biochemical nodes to existing pathophysiology mechanisms, reducing graph-disconnected phenotypes to zero.
- Remove the Type II diabetes mellitus phenotype because the YAML already marked the Orphanet-only association as likely data-quality noise without primary clinical corroboration.
- Narrow the mixed-hearing downstream description to the conductive/recurrent-otitis component after focused review.

## Validation
- `just validate kb/disorders/Alpha_Mannosidosis.yaml` passed
- Manual normalized snippet audit: 125 checks, 0 failures, 0 missing caches
- Graph audit: 5 pathophysiology nodes, 71 phenotypes, 2 biochemical targets, 4 treatments, 77 downstream edges, 0 untargeted phenotypes, 0 dangling targets, 0 treatment target issues
- Focused subagent review found one blocker around the Type II diabetes edge; fixed by removing that unsupported phenotype and edge

Validator-created cache churn was restored before commit; final diff is scoped to the disorder YAML only.