### PR TITLE
Improve Pyruvate Dehydrogenase Deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Pyruvate Dehydrogenase Deficiency
 creation_date: "2026-05-05T20:20:53Z"
-updated_date: "2026-05-05T21:19:26Z"
+updated_date: "2026-05-06T22:31:47Z"
 category: Mendelian
 parents:
 - mitochondrial disease
@@ -352,6 +352,57 @@ pathophysiology:
   downstream:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: DIRECT
+  - target: Decreased PDH complex activity
+    causal_link_type: DIRECT
+    description: Loss of PDH complex subunit or regulatory function is measured clinically as reduced PDH complex activity.
+  - target: PDH complex enzyme activity
+    causal_link_type: DIRECT
+    description: The initiating molecular lesion lowers residual PDH complex enzyme activity.
+  - target: DLAT-associated E2 neurodegenerative movement-retinal syndrome
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: DLAT/E2 deficiency is a specific PDH complex subtype with retinal, neurodegenerative, movement, and basal-ganglia imaging findings.
+  - target: DLD-associated E3 hepatic and branched-chain ketoacid dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: DLD/E3 deficiency is a specific PDH complex subtype that can include hepatic disease and branched-chain amino-acid abnormalities.
+  - target: Abnormal facial shape
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Orphanet records craniofacial morphology as part of the PDH deficiency phenotype spectrum; the intermediate developmental mechanism is not resolved here.
+  - target: Frontal bossing
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: High palate
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Trigonocephaly
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Narrow face
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Epicanthus
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Hypertelorism
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Long philtrum
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Wide nasal bridge
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Upslanted palpebral fissure
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+  - target: Pectus excavatum
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: This skeletal phenotype is recorded in the PDH deficiency spectrum, but the intermediate morphogenetic mechanism is not specified.
+  - target: Multiple lipomas
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: This cutaneous phenotype is recorded in the PDH deficiency spectrum, but the intermediate mechanism is not specified.
+  - target: Osteolytic defects of the middle phalanx of the 4th toe
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: This skeletal phenotype is recorded in the PDH deficiency spectrum, but the intermediate mechanism is not specified.
 - name: PDHA1 variant folding and assembly defects
   description: >-
     Many PDHA1 E1-alpha pathogenic variants impair folding, E1 incorporation,
@@ -502,6 +553,18 @@ pathophysiology:
   downstream:
   - target: Congenital lactic acidosis
     causal_link_type: DIRECT
+  - target: Lactate
+    causal_link_type: DIRECT
+    description: Impaired pyruvate oxidation increases lactate in blood and CSF.
+  - target: Pyruvate
+    causal_link_type: DIRECT
+    description: Blocked PDH flux leaves pyruvate insufficiently cleared.
+  - target: Increased circulating lactate
+    causal_link_type: DIRECT
+    description: Lactate accumulation appears clinically as increased circulating lactate concentration.
+  - target: Increased serum pyruvate
+    causal_link_type: DIRECT
+    description: Pyruvate accumulation appears clinically as increased circulating pyruvate concentration.
 - name: Cerebral energy failure and neurodevelopmental injury
   description: >-
     Reduced acetyl-CoA delivery to the TCA cycle and mitochondrial energy
@@ -541,6 +604,18 @@ pathophysiology:
     causal_link_type: DIRECT
   - target: Seizures and movement disorders
     causal_link_type: DIRECT
+  - target: Aplasia/Hypoplasia of the corpus callosum
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Energy failure in brain development is associated with structural brain malformations, including corpus-callosum dysgenesis.
+  - target: Ventriculomegaly
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Structural brain abnormalities in PDH complex deficiency include ventriculomegaly.
+  - target: Neurodegeneration
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Chronic cerebral energy failure contributes to progressive neurological degeneration.
+  - target: Microcephaly
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Microcephaly is linked to the neurodevelopmental injury spectrum, with intermediate growth mechanisms not resolved here.
 - name: Congenital lactic acidosis
   description: >-
     Lactate accumulation causes congenital or early-onset lactic acidosis, often
@@ -553,6 +628,28 @@ pathophysiology:
     evidence_source: OTHER
     snippet: "Manifestations range from often fatal, severe, neonatal lactic acidosis to later-onset neurological disorders."
     explanation: Orphanet identifies severe neonatal lactic acidosis as a key manifestation.
+  downstream:
+  - target: Lactic acidosis
+    causal_link_type: DIRECT
+    description: Congenital lactic acidosis is the clinical manifestation of lactate accumulation.
+  - target: Tachypnea
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Tachypnea can reflect respiratory compensation during metabolic acidosis.
+  - target: Dyspnea
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Dyspnea is recorded in the PDH deficiency phenotype spectrum and can accompany severe metabolic decompensation.
+  - target: Lethargy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Metabolic decompensation from lactic acidosis contributes to lethargy.
+  - target: Feeding difficulties in infancy
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Feeding difficulty is part of the early severe presentation; the immediate intermediate is not resolved in this graph.
+  - target: Vomiting
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Vomiting is recorded in the E3 deficiency metabolic-decompensation phenotype spectrum.
+  - target: Hypoglycemia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hypoglycemia is recorded in E3 deficiency and grouped here with metabolic decompensation features.
 - name: Neurodevelopmental delay and hypotonia
   description: >-
     Neurodevelopmental delay and hypotonia are among the most common clinical
@@ -564,6 +661,22 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Neurodevelopmental delay and hypotonia were the commonest clinical signs of PDC deficiency."
     explanation: The large review directly identifies neurodevelopmental delay and hypotonia as the commonest signs.
+  downstream:
+  - target: Hypotonia
+    causal_link_type: DIRECT
+    description: Hypotonia is one of the commonest signs in the PDC deficiency spectrum.
+  - target: Global developmental delay
+    causal_link_type: DIRECT
+    description: Global developmental delay is the clinical phenotype captured by this neurodevelopmental injury node.
+  - target: Cerebral palsy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: PDH deficiency can resemble nonprogressive cerebral palsy, especially in female PDHA1 deficiency.
+  - target: Growth delay
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Growth delay is part of the broader developmental phenotype spectrum.
+  - target: Intrauterine growth retardation
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Intrauterine growth restriction is part of the broader developmental phenotype spectrum.
 - name: Seizures and movement disorders
   description: >-
     Severe and milder PDH deficiency states can produce seizures, ataxia,
@@ -582,6 +695,148 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Dystonia precipitated by exercise may be the only symptom of a PDH deficiency"
     explanation: This case report and mini-review support dystonia as part of the PDH deficiency spectrum.
+  downstream:
+  - target: Seizure
+    causal_link_type: DIRECT
+    description: Seizures are a core manifestation of PDH-related cerebral energy failure.
+  - target: Ataxia
+    causal_link_type: DIRECT
+    description: Milder PDH deficiency states can include ataxia.
+  - target: Spasticity
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Spasticity is a pyramidal motor manifestation within the PDH neurologic phenotype spectrum.
+  - target: Dysarthria
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Dysarthria is grouped with PDH-related movement and motor-control dysfunction.
+  - target: Choreoathetosis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Choreoathetosis is grouped with PDH-related movement disorder manifestations.
+  - target: Gait disturbance
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Gait disturbance follows from ataxic, dystonic, or pyramidal motor involvement.
+  - target: Dystonia
+    causal_link_type: DIRECT
+    description: Dystonia is directly supported as a PDH deficiency manifestation.
+  - target: Tremor
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Tremor is grouped with the movement-disorder manifestations of PDH deficiency.
+  - target: Abnormal pyramidal sign
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Pyramidal signs reflect motor pathway involvement in the PDH neurologic phenotype.
+  - target: Abnormality of eye movement
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Abnormal eye movements are grouped with the neurologic movement-control phenotype.
+  - target: Paroxysmal dystonia
+    causal_link_type: DIRECT
+    description: Paroxysmal dystonia is a subtype-specific dystonic manifestation.
+  - target: Broad-based gait
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Broad-based gait is a subtype-specific gait manifestation linked to movement-system involvement.
+  - target: Lower limb hyperreflexia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Lower-limb hyperreflexia is grouped with pyramidal motor involvement.
+  - target: Atypical behavior
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Atypical behavior is grouped with neurologic involvement, with intermediate neurobehavioral mechanisms not resolved here.
+- name: DLAT-associated E2 neurodegenerative movement-retinal syndrome
+  description: >-
+    The DLAT/E2 subtype is characterized by childhood lactic acidosis and
+    neurological dysfunction, with Orphanet phenotype rows documenting retinal
+    degeneration, neurodegeneration, paroxysmal dystonia, broad-based gait,
+    lower-limb hyperreflexia, globus-pallidus imaging abnormalities, atypical
+    behavior, and low circulating vitamin B1.
+  genes:
+  - preferred_term: DLAT
+    term:
+      id: hgnc:2896
+      label: DLAT
+  evidence:
+  - reference: ORPHA:79244
+    reference_title: "Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "A very rare form of pyruvate dehydrogenase deficiency (PDHD) characterized by variable lactic acidosis and neurological dysfunction, mainly appearing during childhood."
+    explanation: Orphanet defines E2 deficiency as a childhood PDH deficiency subtype with lactic acidosis and neurologic dysfunction.
+  - reference: ORPHA:79244
+    reference_title: "Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "DLAT | dihydrolipoamide S-acetyltransferase | hgnc:2896 | Disease-causing germline mutation(s) (loss of function) in"
+    explanation: Orphanet identifies DLAT loss-of-function variants as causal for the E2 subtype.
+  downstream:
+  - target: Retinal degeneration
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Retinal degeneration is an E2-deficiency neurologic sensory phenotype.
+  - target: Neurodegeneration
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Neurodegeneration is recorded as a frequent E2-deficiency manifestation.
+  - target: Paroxysmal dystonia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Paroxysmal dystonia is recorded as a frequent E2-deficiency movement phenotype.
+  - target: Broad-based gait
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Broad-based gait is recorded as a frequent E2-deficiency gait phenotype.
+  - target: Lower limb hyperreflexia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Lower-limb hyperreflexia is recorded as a frequent E2-deficiency pyramidal sign.
+  - target: Eye of the tiger anomaly of globus pallidus
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: This globus-pallidus imaging sign is recorded in E2 deficiency.
+  - target: Atypical behavior
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Atypical behavior is recorded in E2 deficiency, with intermediate neurobehavioral mechanisms not resolved here.
+  - target: Low levels of vitamin B1
+    causal_link_type: UNKNOWN
+    description: Low vitamin B1 is recorded in the E2 deficiency phenotype table; its mechanistic role is not resolved here.
+- name: DLD-associated E3 hepatic and branched-chain ketoacid dysfunction
+  description: >-
+    The DLD/E3 subtype can present with early lactic acidosis, delayed
+    development, later neurologic dysfunction, or liver disease, and Orphanet
+    synonymizes it with E3-deficient maple syrup urine disease. This captures
+    the E3-subtype hepatic and branched-chain amino-acid phenotype branch.
+  genes:
+  - preferred_term: DLD
+    term:
+      id: hgnc:2898
+      label: DLD
+  evidence:
+  - reference: ORPHA:2394
+    reference_title: "Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Pyruvate dehydrogenase E3 deficiency is a very rare subtype of pyruvate dehydrogenase deficiency (PDHD) characterized by either early-onset lactic acidosis and delayed development, later-onset neurological dysfunction or liver disease."
+    explanation: Orphanet defines E3 deficiency as a PDH deficiency subtype with lactic acidosis, developmental delay, neurologic dysfunction, or liver disease.
+  - reference: ORPHA:2394
+    reference_title: "Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "E3-deficient maple syrup urine disease"
+    explanation: The synonym supports the E3 subtype's overlap with branched-chain ketoacid dehydrogenase dysfunction.
+  downstream:
+  - target: Hepatic failure
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hepatic failure is an E3-deficiency systemic manifestation of DLD-related disease.
+  - target: Hypoglycemia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hypoglycemia is recorded in E3 deficiency and grouped with metabolic decompensation features.
+  - target: Vomiting
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Vomiting is recorded in the E3 deficiency metabolic-decompensation phenotype spectrum.
+  - target: Hepatomegaly
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hepatomegaly is an E3-deficiency systemic manifestation of DLD-related disease.
+  - target: Hepatic encephalopathy
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hepatic encephalopathy is an E3-deficiency systemic manifestation of DLD-related disease.
+  - target: Elevated circulating hepatic transaminase concentration
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Elevated transaminases are an E3-deficiency hepatic biochemical manifestation.
+  - target: Elevated plasma branched chain amino acids
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: DLD/E3 deficiency overlaps with E3-deficient maple syrup urine disease, producing branched-chain amino acid abnormalities.
+  - target: Hypercoagulability
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hypercoagulability is recorded in E3 deficiency, with intermediate mechanisms not resolved here.
 phenotypes:
 - category: Biochemical
   name: Lactic acidosis


### PR DESCRIPTION
## Summary
- Connect the existing PDH mechanism graph to all curated biochemical and phenotype nodes.
- Add E2/DLAT and E3/DLD subtype-specific pathophysiology branches using existing cached Orphanet evidence.
- Keep morphology-only phenotype links marked as indirect/unknown where the intermediate mechanism is not resolved.

## Validation
- `just validate kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml`
- Manual normalized snippet audit: 124 checks, 0 failures, 0 missing caches
- Graph audit: 12 pathophysiology nodes, 55 phenotypes, 3 biochemical nodes, 76 downstream edges, 0 dangling targets, 0 untargeted phenotypes/biochemical nodes, 0 isolated pathophysiology nodes

## Scope
- Only `kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml` changed.
- No reference cache files were hand-edited or committed.