### PR TITLE
Add hantavirus pulmonary syndrome curation

### DIFF
--- a/kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
+++ b/kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
@@ -17,6 +17,38 @@ parents:
 - Hantavirus infectious disease
 - Viral respiratory tract infection
 - Viral hemorrhagic fever
+progression:
+- phase: Febrile prodrome
+  age_range: Any age after exposure
+  notes: >-
+    Hantavirus cardiopulmonary syndrome often begins with a nonspecific febrile
+    prodrome that includes myalgias, chills, nausea, cough, and gastrointestinal
+    symptoms.
+  evidence:
+  - reference: PMID:23680331
+    reference_title: "Hantavirus infection in North America: a clinical review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hantavirus cardiopulmonary syndrome presents as a vague prodrome of fever,
+      cough, myalgias, chills, and nausea followed by a rapidly worsening respiratory
+      phase.
+    explanation: This clinical review supports the prodromal phase and its transition to respiratory disease.
+- phase: Rapid cardiopulmonary decompensation
+  age_range: Acute illness phase
+  notes: >-
+    After respiratory symptoms develop, patients can deteriorate within hours and
+    require ICU-level monitoring, ventilatory support, vasoactive agents, or
+    extracorporeal support.
+  evidence:
+  - reference: PMID:23680331
+    reference_title: "Hantavirus infection in North America: a clinical review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The cardiopulmonary phase of the disease can progress rapidly with catastrophic
+      decompensation in as little as a few hours.
+    explanation: This supports the clinically important rapid progression timeline after cardiopulmonary involvement begins.
 infectious_agent:
 - name: New World orthohantaviruses
   description: >-
@@ -65,8 +97,8 @@ pathophysiology:
     leakage. Endothelial infection and inflammatory signaling increase vascular
     permeability, allowing fluid to enter alveolar spaces.
   downstream:
-  - target: Noncardiogenic pulmonary edema
-    description: Capillary leakage produces alveolar flooding and severe hypoxemia.
+  - target: Cytokine-mediated endothelial activation
+    description: Infected endothelial cells amplify IL-6 and chemokine signaling that disrupts barrier integrity.
   cell_types:
   - preferred_term: pulmonary capillary endothelial cell
     term:
@@ -101,6 +133,48 @@ pathophysiology:
       SNV readily infected pulmonary endothelial cells, while HTNV robustly
       amplified in endothelial cells, cardiomyocytes, and astrocytes.
     explanation: This supports pulmonary endothelial tropism for Sin Nombre virus in human cell systems.
+- name: Cytokine-mediated endothelial activation
+  description: >-
+    Hantavirus-infected endothelial cells can amplify IL-6 trans-signaling,
+    cytokine and chemokine secretion, and adhesion-molecule expression. This
+    inflammatory endothelial activation affects VE-cadherin and disrupts cell
+    barrier integrity, bridging infection to vascular leak.
+  downstream:
+  - target: Noncardiogenic pulmonary edema
+    description: Cytokine-amplified endothelial barrier disruption promotes pulmonary vascular leakage.
+  cell_types:
+  - preferred_term: pulmonary capillary endothelial cell
+    term:
+      id: CL:4028001
+      label: pulmonary capillary endothelial cell
+  biological_processes:
+  - preferred_term: interleukin-6-mediated signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0070102
+      label: interleukin-6-mediated signaling pathway
+  - preferred_term: cytokine-mediated signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0019221
+      label: cytokine-mediated signaling pathway
+  evidence:
+  - reference: PMID:40203030
+    reference_title: IL-6 trans-signaling mediates cytokine secretion and barrier dysfunction in hantavirus-infected cells and correlates to severity in HFRS.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      In vitro, sIL-6R treatment of infected cells enhanced IL-6 and CCL2 secretion,
+      upregulated ICAM-1, and affected VE-cadherin leading to a disrupted cell
+      barrier integrity.
+    explanation: This directly supports IL-6 trans-signaling, cytokine secretion, ICAM-1 induction, VE-cadherin effects, and barrier dysfunction in infected endothelial cells.
+  - reference: PMID:40203030
+    reference_title: IL-6 trans-signaling mediates cytokine secretion and barrier dysfunction in hantavirus-infected cells and correlates to severity in HFRS.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      IL-6 trans-signaling is linked to hantavirus pathogenesis.
+    explanation: The patient-plasma component links IL-6 trans-signaling potential to clinical hantavirus pathogenesis.
 - name: Noncardiogenic pulmonary edema
   description: >-
     Pulmonary capillary leak causes alveolar flooding with impaired gas exchange,
@@ -168,6 +242,64 @@ phenotypes:
     term:
       id: HP:0002315
       label: Headache
+- category: Gastrointestinal
+  name: Nausea
+  description: Nausea is part of the nonspecific prodrome before cardiopulmonary decompensation.
+  phenotype_term:
+    preferred_term: Nausea
+    term:
+      id: HP:0002018
+      label: Nausea
+  evidence:
+  - reference: PMID:23680331
+    reference_title: "Hantavirus infection in North America: a clinical review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hantavirus cardiopulmonary syndrome presents as a vague prodrome of fever,
+      cough, myalgias, chills, and nausea followed by a rapidly worsening respiratory
+      phase.
+    explanation: This supports nausea as a prodromal symptom.
+- category: Gastrointestinal
+  name: Vomiting
+  description: Vomiting can occur as part of prodromal gastrointestinal involvement.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
+  evidence:
+  - reference: PMID:36913929
+    reference_title: Emerging Maripa Hantavirus as a Potential Cause of a Severe Health Threat in French Guiana.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The prodromal phase was characterized by fever (77.8%), myalgia (66.7%),
+      and gastrointestinal symptoms (vomiting and diarrhea; 55.6%) starting, on
+      average, 5 days before the illness phase, which was characterized by respiratory
+      failure in all patients.
+    explanation: This case series supports vomiting as a frequent prodromal gastrointestinal symptom.
+- category: Gastrointestinal
+  name: Diarrhea
+  description: Diarrhea can occur as part of prodromal gastrointestinal involvement.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: Diarrhea
+    term:
+      id: HP:0002014
+      label: Diarrhea
+  evidence:
+  - reference: PMID:36913929
+    reference_title: Emerging Maripa Hantavirus as a Potential Cause of a Severe Health Threat in French Guiana.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The prodromal phase was characterized by fever (77.8%), myalgia (66.7%),
+      and gastrointestinal symptoms (vomiting and diarrhea; 55.6%) starting, on
+      average, 5 days before the illness phase, which was characterized by respiratory
+      failure in all patients.
+    explanation: This case series supports diarrhea as a frequent prodromal gastrointestinal symptom.
 - category: Respiratory
   name: Dyspnea
   description: Dyspnea develops as pulmonary edema and hypoxemia emerge.
@@ -256,11 +388,59 @@ phenotypes:
 - category: Hematologic
   name: Thrombocytopenia
   description: Thrombocytopenia is a common laboratory abnormality in acute hantavirus pulmonary syndrome.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: Thrombocytopenia
     term:
       id: HP:0001873
       label: Thrombocytopenia
+  evidence:
+  - reference: PMID:19077779
+    reference_title: "Hantavirus pulmonary syndrome in Texas: 1993-2006."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Common laboratory features included thrombocytopenia (92% of patients),
+      elevated creatinine (61% of patients), increased polymorphonuclear leukocyte
+      band forms (52% of patients), and hematocrit more than 55% (32% of patients).
+    explanation: This Texas case series supports thrombocytopenia as very frequent at presentation.
+- category: Hematologic
+  name: Hemoconcentration
+  description: Hemoconcentration with increased hematocrit is a diagnostic laboratory clue in HPS.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: Increased hematocrit
+    term:
+      id: HP:0001899
+      label: Increased hematocrit
+  evidence:
+  - reference: PMID:19077779
+    reference_title: "Hantavirus pulmonary syndrome in Texas: 1993-2006."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Common laboratory features included thrombocytopenia (92% of patients),
+      elevated creatinine (61% of patients), increased polymorphonuclear leukocyte
+      band forms (52% of patients), and hematocrit more than 55% (32% of patients).
+    explanation: This supports increased hematocrit as a laboratory feature in HPS.
+- category: Hematologic
+  name: Leukocytosis
+  description: Leukocytosis is a common laboratory abnormality used in presumptive diagnosis.
+  phenotype_term:
+    preferred_term: Leukocytosis
+    term:
+      id: HP:0001974
+      label: Increased total leukocyte count
+  evidence:
+  - reference: PMID:23680331
+    reference_title: "Hantavirus infection in North America: a clinical review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Presumptive diagnosis can be made based on pulmonary interstitial edema on
+      chest radiographs in association with leukocytosis, thrombocytopenia, and
+      hemoconcentration.
+    explanation: This supports leukocytosis as part of the presumptive diagnostic laboratory pattern.
 environmental:
 - name: Aerosolized rodent excreta exposure
   description: >-
@@ -384,6 +564,11 @@ treatments:
     term:
       id: MAXO:0000168
       label: antiviral agent therapy
+    therapeutic_agent:
+    - preferred_term: ribavirin
+      term:
+        id: CHEBI:63580
+        label: ribavirin
   evidence:
   - reference: PMID:15494907
     reference_title: "Placebo-controlled, double-blind trial of intravenous ribavirin for the treatment of hantavirus cardiopulmonary syndrome in North America."
@@ -404,6 +589,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: methylprednisolone
+      term:
+        id: CHEBI:6888
+        label: 6alpha-methylprednisolone
   evidence:
   - reference: PMID:23784924
     reference_title: "High-dose intravenous methylprednisolone for hantavirus cardiopulmonary syndrome in Chile: a double-blind, randomized controlled clinical trial."
@@ -413,6 +603,42 @@ treatments:
       Although methylprednisolone appears to be safe, it did not provide significant
       clinical benefit to patients.
     explanation: This randomized controlled trial supports the statement that methylprednisolone did not provide significant benefit.
+- name: Human Andes virus immune plasma
+  description: >-
+    Convalescent immune plasma containing neutralizing antibodies has been
+    evaluated for Andes virus HCPS. Non-randomized evidence suggests apparent
+    safety and a possible reduction in case-fatality rate, but confirmation in
+    further studies is needed.
+  treatment_term:
+    preferred_term: passive immunization
+    term:
+      id: MAXO:0000121
+      label: passive immunization
+  target_phenotypes:
+  - preferred_term: Respiratory failure
+    term:
+      id: HP:0002878
+      label: Respiratory failure
+  - preferred_term: Shock
+    term:
+      id: HP:0031273
+      label: Shock
+  evidence:
+  - reference: PMID:25316807
+    reference_title: A non-randomized multicentre trial of human immune plasma for treatment of hantavirus cardiopulmonary syndrome caused by Andes virus.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Human ANDV immune plasma infusion appears safe for HCPS.
+    explanation: This supports safety of immune plasma but not definitive efficacy.
+  - reference: PMID:25316807
+    reference_title: A non-randomized multicentre trial of human immune plasma for treatment of hantavirus cardiopulmonary syndrome caused by Andes virus.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We observed a decrease in CFR in treated cases with borderline significance
+      that will require further studies for confirmation.
+    explanation: This supports possible mortality benefit while preserving the study's uncertainty.
 datasets:
 - accession: GEO:GSE232641
   title: Transcriptomic profiling from human hantavirus infection model systems

--- a/kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
+++ b/kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
@@ -1,0 +1,429 @@
+name: Hantavirus Pulmonary Syndrome
+creation_date: '2026-05-06T22:23:33Z'
+updated_date: '2026-05-06T22:40:21Z'
+description: >-
+  Hantavirus pulmonary syndrome, also called hantavirus cardiopulmonary
+  syndrome, is an acute zoonotic orthohantavirus infection in the Americas.
+  Infection usually follows respiratory exposure to rodent-borne virus and can
+  progress rapidly from a febrile prodrome to pulmonary capillary leak,
+  alveolar flooding, shock, and life-threatening hypoxic respiratory failure.
+category: Infectious
+disease_term:
+  preferred_term: hantavirus pulmonary syndrome
+  term:
+    id: MONDO:0017879
+    label: hantavirus pulmonary syndrome
+parents:
+- Hantavirus infectious disease
+- Viral respiratory tract infection
+- Viral hemorrhagic fever
+infectious_agent:
+- name: New World orthohantaviruses
+  description: >-
+    Rodent-borne New World orthohantaviruses, including Sin Nombre virus and
+    Andes virus, cause hantavirus pulmonary/cardiopulmonary syndrome after
+    zoonotic respiratory exposure.
+  evidence:
+  - reference: PMID:40857262
+    reference_title: Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Hantaviruses are zoonotically transmitted from rodents to humans through the
+      respiratory route, with no currently approved antivirals or widely available
+      vaccines.
+    explanation: This recent human-cell and organoid study states the zoonotic respiratory transmission route.
+pathophysiology:
+- name: Rodent-borne hantavirus infection
+  description: >-
+    Respiratory exposure to rodent-borne hantaviruses initiates infection; New
+    World viruses such as Andes virus and Sin Nombre virus show tropism for lung
+    and vascular cell systems relevant to cardiopulmonary disease.
+  downstream:
+  - target: Pulmonary endothelial barrier dysfunction
+    description: Viral infection of pulmonary endothelial cells sets up inflammatory vascular leak.
+  biological_processes:
+  - preferred_term: viral process
+    modifier: ABNORMAL
+    term:
+      id: GO:0016032
+      label: viral process
+  evidence:
+  - reference: PMID:40857262
+    reference_title: Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      We utilized human primary lung endothelial cells, various pluripotent stem
+      cell-derived heart and brain cell types, and established human lung organoid
+      models to evaluate the tropisms of Old World Hantaan (HTNV) and New World
+      ANDV and Sin Nombre (SNV) viruses.
+    explanation: This supports relevant human lung endothelial and organoid infection systems for New World hantaviruses.
+- name: Pulmonary endothelial barrier dysfunction
+  description: >-
+    Hantavirus cardiopulmonary syndrome is centered on pulmonary capillary
+    leakage. Endothelial infection and inflammatory signaling increase vascular
+    permeability, allowing fluid to enter alveolar spaces.
+  downstream:
+  - target: Noncardiogenic pulmonary edema
+    description: Capillary leakage produces alveolar flooding and severe hypoxemia.
+  cell_types:
+  - preferred_term: pulmonary capillary endothelial cell
+    term:
+      id: CL:4028001
+      label: pulmonary capillary endothelial cell
+  biological_processes:
+  - preferred_term: response to virus
+    modifier: ABNORMAL
+    term:
+      id: GO:0009615
+      label: response to virus
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hantavirus cardiopulmonary syndrome is characterized by pulmonary capillary
+      leakage and alveolar flooding, resulting in 50% mortality due to fulminant
+      hypoxic respiratory failure.
+    explanation: This directly links HCPS to pulmonary capillary leak, alveolar flooding, and fatal hypoxic respiratory failure.
+  - reference: PMID:40857262
+    reference_title: Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      SNV readily infected pulmonary endothelial cells, while HTNV robustly
+      amplified in endothelial cells, cardiomyocytes, and astrocytes.
+    explanation: This supports pulmonary endothelial tropism for Sin Nombre virus in human cell systems.
+- name: Noncardiogenic pulmonary edema
+  description: >-
+    Pulmonary capillary leak causes alveolar flooding with impaired gas exchange,
+    dyspnea, and acute hypoxic respiratory failure.
+  downstream:
+  - target: Cardiopulmonary shock
+    description: Respiratory failure and cardiac depression combine to produce life-threatening shock.
+  cell_types:
+  - preferred_term: alveolar macrophage
+    term:
+      id: CL:0000583
+      label: alveolar macrophage
+  biological_processes:
+  - preferred_term: regulation of inflammatory response
+    modifier: ABNORMAL
+    term:
+      id: GO:0050727
+      label: regulation of inflammatory response
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hantavirus cardiopulmonary syndrome is characterized by pulmonary capillary
+      leakage and alveolar flooding, resulting in 50% mortality due to fulminant
+      hypoxic respiratory failure.
+    explanation: Alveolar flooding and fulminant hypoxic respiratory failure support this pulmonary edema node.
+- name: Cardiopulmonary shock
+  description: >-
+    Advanced disease combines hypoxic respiratory failure with cardiac
+    depression, producing cardiogenic shock physiology that may require advanced
+    extracorporeal and hemodynamic support.
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In addition, depression of cardiac function ensues, which complicates the
+      picture with cardiogenic shock.
+    explanation: This directly supports myocardial depression and cardiogenic shock in severe HCPS.
+phenotypes:
+- category: Constitutional
+  name: Fever
+  description: Fever is part of the early flu-like prodrome.
+  phenotype_term:
+    preferred_term: Fever
+    term:
+      id: HP:0001945
+      label: Fever
+- category: Constitutional
+  name: Myalgia
+  description: Myalgia commonly accompanies the early febrile prodrome.
+  phenotype_term:
+    preferred_term: Myalgia
+    term:
+      id: HP:0003326
+      label: Myalgia
+- category: Neurological
+  name: Headache
+  description: Headache can occur during the prodromal phase.
+  phenotype_term:
+    preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+- category: Respiratory
+  name: Dyspnea
+  description: Dyspnea develops as pulmonary edema and hypoxemia emerge.
+  phenotype_term:
+    preferred_term: Dyspnea
+    term:
+      id: HP:0002094
+      label: Dyspnea
+- category: Respiratory
+  name: Pulmonary edema
+  description: Noncardiogenic pulmonary edema is a central cardiopulmonary manifestation.
+  phenotype_term:
+    preferred_term: Pulmonary edema
+    term:
+      id: HP:0100598
+      label: Pulmonary edema
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hantavirus cardiopulmonary syndrome is characterized by pulmonary capillary
+      leakage and alveolar flooding, resulting in 50% mortality due to fulminant
+      hypoxic respiratory failure.
+    explanation: Pulmonary capillary leakage with alveolar flooding supports pulmonary edema as a defining manifestation.
+- category: Respiratory
+  name: Pleural effusion
+  description: Pleural effusions may accompany pulmonary vascular leak.
+  phenotype_term:
+    preferred_term: Pleural effusion
+    term:
+      id: HP:0002202
+      label: Pleural effusion
+- category: Respiratory
+  name: Acute respiratory distress syndrome
+  description: Severe pulmonary involvement can progress to ARDS-like respiratory failure.
+  phenotype_term:
+    preferred_term: Acute respiratory distress syndrome
+    term:
+      id: HP:0033677
+      label: Acute respiratory distress syndrome
+- category: Respiratory
+  name: Respiratory failure
+  description: Life-threatening hypoxic respiratory failure is the defining severe outcome.
+  phenotype_term:
+    preferred_term: Respiratory failure
+    term:
+      id: HP:0002878
+      label: Respiratory failure
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hantavirus cardiopulmonary syndrome is characterized by pulmonary capillary
+      leakage and alveolar flooding, resulting in 50% mortality due to fulminant
+      hypoxic respiratory failure.
+    explanation: This directly supports respiratory failure as a severe manifestation.
+- category: Cardiovascular
+  name: Hypotension
+  description: Hypotension reflects severe capillary leak and shock physiology.
+  phenotype_term:
+    preferred_term: Hypotension
+    term:
+      id: HP:0002615
+      label: Hypotension
+- category: Cardiovascular
+  name: Shock
+  description: Cardiogenic shock can complicate advanced cardiopulmonary disease.
+  phenotype_term:
+    preferred_term: Shock
+    term:
+      id: HP:0031273
+      label: Shock
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In addition, depression of cardiac function ensues, which complicates the
+      picture with cardiogenic shock.
+    explanation: This supports shock as a cardiopulmonary complication.
+- category: Hematologic
+  name: Thrombocytopenia
+  description: Thrombocytopenia is a common laboratory abnormality in acute hantavirus pulmonary syndrome.
+  phenotype_term:
+    preferred_term: Thrombocytopenia
+    term:
+      id: HP:0001873
+      label: Thrombocytopenia
+environmental:
+- name: Aerosolized rodent excreta exposure
+  description: >-
+    Exposure to infectious rodent excreta is the typical environmental context
+    for hantavirus acquisition; rural settings with rodent contact warrant a
+    high index of suspicion.
+  evidence:
+  - reference: PMID:20171551
+    reference_title: Hantavirus pulmonary syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Although infection is sporadic and uncommon compared with other atypical
+      pneumonia syndromes, its high mortality rate warrants the maintenance of a
+      high index of suspicion in rural settings.
+    explanation: This supports rural exposure context and the need for suspicion in relevant settings.
+diagnosis:
+- name: Early clinical recognition with hantavirus testing
+  description: >-
+    Diagnosis relies on recognizing compatible cardiopulmonary illness and
+    exposure context, then confirming infection with hantavirus serology or
+    molecular testing.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  results: Compatible acute cardiopulmonary syndrome plus laboratory evidence of hantavirus infection.
+  evidence:
+  - reference: PMID:20171551
+    reference_title: Hantavirus pulmonary syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This article reviews the nature of the viruses that cause hantavirus pulmonary
+      syndrome, the epidemiology and ecology of disease transmission, and disease
+      recognition, treatment, and prevention.
+    explanation: This review explicitly covers disease recognition and transmission ecology for diagnosis.
+- name: Hantavirus serology or viral RNA testing
+  description: >-
+    Serologic confirmation and viral RNA testing are used to confirm suspected
+    hantavirus cardiopulmonary syndrome.
+  diagnosis_term:
+    preferred_term: serology testing
+    term:
+      id: MAXO:0000609
+      label: serology testing
+  results: Immunoglobulin M antibody positivity or Andes virus RNA in blood confirms infection in appropriate clinical context.
+  evidence:
+  - reference: PMID:23784924
+    reference_title: "High-dose intravenous methylprednisolone for hantavirus cardiopulmonary syndrome in Chile: a double-blind, randomized controlled clinical trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Infection was confirmed by immunoglobulin M antibodies or ANDV RNA in blood.
+    explanation: This trial states the serologic and molecular confirmation methods used for HCPS.
+treatments:
+- name: Intensive supportive cardiopulmonary care
+  description: >-
+    Management is primarily supportive, emphasizing early recognition, intensive
+    oxygenation and ventilation, hemodynamic support, and rapid escalation for
+    shock or respiratory failure.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: NCIT:C15747
+      label: Supportive Care
+  target_phenotypes:
+  - preferred_term: Respiratory failure
+    term:
+      id: HP:0002878
+      label: Respiratory failure
+  - preferred_term: Shock
+    term:
+      id: HP:0031273
+      label: Shock
+  evidence:
+  - reference: PMID:20171551
+    reference_title: Hantavirus pulmonary syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Because no specific therapies are available for the disease, prevention and
+      early recognition play an important role in reducing mortality from the
+      disease.
+    explanation: This supports supportive management and early recognition because no specific therapy is available.
+- name: Extracorporeal membrane oxygenation
+  description: >-
+    ECMO is an advanced rescue support option for severe cardiopulmonary failure
+    in selected patients with refractory hypoxemia or shock.
+  treatment_term:
+    preferred_term: extracorporeal membrane oxygenation
+    term:
+      id: MAXO:0000515
+      label: extracorporeal membrane oxygenation
+  target_phenotypes:
+  - preferred_term: Respiratory failure
+    term:
+      id: HP:0002878
+      label: Respiratory failure
+  - preferred_term: Shock
+    term:
+      id: HP:0031273
+      label: Shock
+  evidence:
+  - reference: PMID:29446472
+    reference_title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Early diagnosis and appropriate use of extracorporeal membrane oxygenation
+      (ECMO) are amongst the lifesaving interventions in this fatal illness.
+    explanation: This review supports ECMO as an advanced life-saving support intervention.
+- name: Intravenous ribavirin
+  description: >-
+    Ribavirin is active against hantaviruses in vitro, but a North American
+    randomized trial did not show a trend supporting benefit in cardiopulmonary
+    stage HCPS.
+  treatment_term:
+    preferred_term: antiviral agent therapy
+    term:
+      id: MAXO:0000168
+      label: antiviral agent therapy
+  evidence:
+  - reference: PMID:15494907
+    reference_title: "Placebo-controlled, double-blind trial of intravenous ribavirin for the treatment of hantavirus cardiopulmonary syndrome in North America."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      However, ribavirin was well tolerated, and the lack of trends supporting the
+      use of intravenous ribavirin suggests that it is probably ineffective in the
+      treatment of HCPS in the cardiopulmonary stage.
+    explanation: This randomized trial supports ribavirin as probably ineffective once cardiopulmonary-stage HCPS is established.
+- name: High-dose methylprednisolone
+  description: >-
+    High-dose methylprednisolone has been tested as immunomodulatory therapy in
+    Andes virus HCPS, but randomized trial evidence does not support clinical
+    benefit.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  evidence:
+  - reference: PMID:23784924
+    reference_title: "High-dose intravenous methylprednisolone for hantavirus cardiopulmonary syndrome in Chile: a double-blind, randomized controlled clinical trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Although methylprednisolone appears to be safe, it did not provide significant
+      clinical benefit to patients.
+    explanation: This randomized controlled trial supports the statement that methylprednisolone did not provide significant benefit.
+datasets:
+- accession: GEO:GSE232641
+  title: Transcriptomic profiling from human hantavirus infection model systems
+  data_type: BULK_RNA_SEQ
+  organism:
+    preferred_term: human
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  publication: PMID:40857262
+  description: >-
+    Human primary lung endothelial cells, iPSC-derived cell types, and lung
+    organoid models were used to define hantavirus tropism and infection-linked
+    transcriptional responses.

--- a/kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
+++ b/kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
@@ -174,7 +174,7 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: >-
       IL-6 trans-signaling is linked to hantavirus pathogenesis.
-    explanation: The patient-plasma component links IL-6 trans-signaling potential to clinical hantavirus pathogenesis.
+    explanation: The patient-plasma component links IL-6 trans-signaling potential to clinical hantavirus pathogenesis; because the cohort was HFRS, the relevance to HPS is mechanistically plausible but indirect.
 - name: Noncardiogenic pulmonary edema
   description: >-
     Pulmonary capillary leak causes alveolar flooding with impaired gas exchange,
@@ -407,7 +407,7 @@ phenotypes:
 - category: Hematologic
   name: Hemoconcentration
   description: Hemoconcentration with increased hematocrit is a diagnostic laboratory clue in HPS.
-  frequency: OCCASIONAL
+  frequency: FREQUENT
   phenotype_term:
     preferred_term: Increased hematocrit
     term:

--- a/references_cache/PMID_15494907.md
+++ b/references_cache/PMID_15494907.md
@@ -1,0 +1,92 @@
+---
+reference_id: "PMID:15494907"
+title: "Placebo-controlled, double-blind trial of intravenous ribavirin for the treatment of hantavirus cardiopulmonary syndrome in North America."
+authors:
+- Mertz GJ
+- Miedzinski L
+- Goade D
+- Pavia AT
+- Hjelle B
+- Hansbarger CO
+- Levy H
+- Koster FT
+- Baum K
+- Lindemulder A
+- Wang W
+- Riser L
+- Fernandez H
+- Whitley RJ
+- Collaborative Antiviral Study Group
+journal: Clin Infect Dis
+year: '2004'
+doi: 10.1086/425007
+keywords:
+- Adult
+- "Antiviral Agents/administration & dosage, adverse effects, therapeutic use"
+- Double-Blind Method
+- Female
+- "Hantavirus Pulmonary Syndrome/drug therapy, mortality"
+- Humans
+- "Injections, Intravenous"
+- Male
+- Middle Aged
+- North America/epidemiology
+- Placebos
+- "Ribavirin/administration & dosage, adverse effects, therapeutic use"
+content_type: abstract_only
+---
+
+# Placebo-controlled, double-blind trial of intravenous ribavirin for the treatment of hantavirus cardiopulmonary syndrome in North America.
+**Authors:** Mertz GJ, Miedzinski L, Goade D, Pavia AT, Hjelle B, Hansbarger CO, Levy H, Koster FT, Baum K, Lindemulder A, Wang W, Riser L, Fernandez H, Whitley RJ, Collaborative Antiviral Study Group
+**Journal:** Clin Infect Dis (2004)
+**DOI:** [10.1086/425007](https://doi.org/10.1086/425007)
+
+## Content
+
+1. Clin Infect Dis. 2004 Nov 1;39(9):1307-13. doi: 10.1086/425007. Epub 2004 Oct 
+11.
+
+Placebo-controlled, double-blind trial of intravenous ribavirin for the 
+treatment of hantavirus cardiopulmonary syndrome in North America.
+
+Mertz GJ(1), Miedzinski L, Goade D, Pavia AT, Hjelle B, Hansbarger CO, Levy H, 
+Koster FT, Baum K, Lindemulder A, Wang W, Riser L, Fernandez H, Whitley RJ; 
+Collaborative Antiviral Study Group.
+
+Author information:
+(1)Internal Medicine, University of New Mexico, Albuquerque, New Mexico 
+87131-0001, USA. gmertz@salud.unm.edu
+
+Comment in
+    Clin Infect Dis. 2005 May 15;40(10):1550-1. doi: 10.1086/429728.
+
+BACKGROUND. Ribavirin is active in vitro against hantaviruses, but the findings 
+of an open trial of the use of intravenous ribavirin for the treatment of 
+hantavirus cardiopulmonary syndrome (HCPS) were inconclusive.
+METHODS: Subjects with suspected HCPS in the prodrome or cardiopulmonary phase 
+but without shock were eligible for randomization to receive either intravenous 
+ribavirin (33 mg/kg [<or=2 g], followed by 16 mg/kg [<or=1 g] given every 6 h 
+for 4 days and by 8 mg/kg [<or=.5 g] given every 8 h for 3 days) or placebo 
+(administered for 7 days or until the initial Sin Nombre virus antibody test 
+result was confirmed to be negative). The primary outcome was survival at day 28 
+of the study without the need for extracorporeal membrane oxygenation (ECMO).
+RESULTS: Thirty-six subjects were enrolled in the trial from March 1996 through 
+July 2001, at which point the study was terminated prematurely because of both 
+the slow rate of accrual of subjects and the findings of a futility analysis. Of 
+the 36 subjects enrolled, 23 (all of whom were enrolled during the 
+cardiopulmonary stage of HCPS) had HCPS confirmed by serologic testing. The 
+severity of illness at entry into the study was similar among the 10 subjects 
+with HCPS who received ribavirin and the 13 subjects with HCPS who received 
+placebo. The proportion of subjects who survived and who did not require ECMO 
+was similar among ribavirin recipients and placebo recipients (70% vs. 62%, 
+respectively); 2 ribavirin recipients and 2 placebo recipients died, including 3 
+of 7 subjects treated with ECMO. The frequency of adverse events, including 
+anemia, was similar between treatment groups.
+CONCLUSIONS: The rate of accrual of subjects in the present study was inadequate 
+to clearly assess the safety or efficacy of ribavirin in the treatment of HCPS. 
+However, ribavirin was well tolerated, and the lack of trends supporting the use 
+of intravenous ribavirin suggests that it is probably ineffective in the 
+treatment of HCPS in the cardiopulmonary stage.
+
+DOI: 10.1086/425007
+PMID: 15494907 [Indexed for MEDLINE]

--- a/references_cache/PMID_17161316.md
+++ b/references_cache/PMID_17161316.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:17161316"
+title: Andes Hantavirus as possible cause of disease in travellers to South America.
+authors:
+- Castillo C
+- Nicklas C
+- Mardones J
+- Ossa G
+journal: Travel Med Infect Dis
+year: '2007'
+doi: 10.1016/j.tmaid.2006.02.002
+keywords:
+- Animals
+- Chile/epidemiology
+- Disease Reservoirs/veterinary
+- Orthohantavirus/pathogenicity
+- "Hantavirus Infections/epidemiology, transmission"
+- "Hantavirus Pulmonary Syndrome/epidemiology, transmission"
+- "Hemorrhagic Fever with Renal Syndrome/epidemiology, transmission"
+- Humans
+- Retrospective Studies
+- Risk Factors
+- "Rodent Diseases/epidemiology, transmission"
+- Rodentia
+- Travel
+- Zoonoses
+content_type: abstract_only
+---
+
+# Andes Hantavirus as possible cause of disease in travellers to South America.
+**Authors:** Castillo C, Nicklas C, Mardones J, Ossa G
+**Journal:** Travel Med Infect Dis (2007)
+**DOI:** [10.1016/j.tmaid.2006.02.002](https://doi.org/10.1016/j.tmaid.2006.02.002)
+
+## Content
+
+1. Travel Med Infect Dis. 2007 Jan;5(1):30-4. doi: 10.1016/j.tmaid.2006.02.002. 
+Epub 2006 May 15.
+
+Andes Hantavirus as possible cause of disease in travellers to South America.
+
+Castillo C(1), Nicklas C, Mardones J, Ossa G.
+
+Author information:
+(1)Department of Internal Medicine, Faculty of Medicine, Universidad de la 
+Frontera, Manuel Montt 112, Temuco, Chile. eureka@telsur.cl
+
+BACKGROUND: Hantaviruses in Europe and Asia cause haemorrhagic fever with renal 
+syndrome and epidemic nephritis (mortality rate <1-15%). New strains of 
+Hantaviruses cause Hantavirus pulmonary syndrome (HPS) from Canada to South 
+America. Andes virus mortality rate is about 30% in Chile.
+METHOD: Clinical charts of 54 patients were reviewed.
+RESULTS: Inhalation of aerosolized urine, faeces or saliva of rodents is the 
+principal cause of infection. The incubation period is between 8 and 43 days. 
+The main prodromal symptoms are: myalgias, fever, fatigue, gastrointestinal 
+disorders, dyspnoea, petechiae and coughing. After the 4th day pulmonary oedema, 
+hypotension and renal failure appear. Haemorrhagic disorders may occur. The 
+first laboratory tests presenting alterations are: haemoconcentration, 
+leukocytosis, low platelet count <150 micro/L, and presence of immunoblasts. The 
+treatment is supportive: mechanical ventilation, vasopressor drugs, 
+haemofiltration or haemodialysis, and extracorporeal membrane oxygenation. There 
+is no specific treatment for HPS. Preventive measures must be empathised.
+CONCLUSION: The principal risk factors for tourists are: accommodation in 
+abandoned or closed up facilities; failure to use indicated pathways when 
+walking in forests; camping outside recommended areas; drinking water from 
+natural sources and fishing in risk areas. The risk of infection for foreign 
+tourists in Chile is low.
+
+DOI: 10.1016/j.tmaid.2006.02.002
+PMID: 17161316 [Indexed for MEDLINE]

--- a/references_cache/PMID_19077779.md
+++ b/references_cache/PMID_19077779.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:19077779"
+title: "Hantavirus pulmonary syndrome in Texas: 1993-2006."
+authors:
+- Rivers MN
+- Alexander JL
+- Rohde RE
+- Pierce JR Jr
+journal: South Med J
+year: '2009'
+doi: 10.1097/SMJ.0b013e318187d06f
+keywords:
+- Animals
+- Biomarkers/blood
+- Disease Reservoirs
+- Female
+- Gastrointestinal Diseases/virology
+- "Hantavirus Pulmonary Syndrome/diagnosis, epidemiology, mortality, transmission"
+- Humans
+- Male
+- Middle Aged
+- Residence Characteristics
+- Retrospective Studies
+- Risk Factors
+- Rodentia
+- Texas/epidemiology
+content_type: abstract_only
+---
+
+# Hantavirus pulmonary syndrome in Texas: 1993-2006.
+**Authors:** Rivers MN, Alexander JL, Rohde RE, Pierce JR Jr
+**Journal:** South Med J (2009)
+**DOI:** [10.1097/SMJ.0b013e318187d06f](https://doi.org/10.1097/SMJ.0b013e318187d06f)
+
+## Content
+
+1. South Med J. 2009 Jan;102(1):36-41. doi: 10.1097/SMJ.0b013e318187d06f.
+
+Hantavirus pulmonary syndrome in Texas: 1993-2006.
+
+Rivers MN(1), Alexander JL, Rohde RE, Pierce JR Jr.
+
+Author information:
+(1)Division of Preventive Medicine, Department of Internal Medicine, Texas Tech 
+University Health Sciences Center, Amarillo, TX 79106, USA.
+
+Comment in
+    South Med J. 2011 Jul;104(7):540-1; author reply 541. doi: 
+10.1097/SMJ.0b013e3182142d35.
+
+BACKGROUND: Hantavirus pulmonary syndrome (HPS) is a rare cardiopulmonary 
+disease that was first described after a 1993 epidemic in the southwestern 
+United States. This study reviewed all cases reported in Texas to date.
+METHODS: We reviewed case report forms submitted to the Texas Department of 
+State Health Services and medical records (when available) to determine 
+demographic and clinical features of Texas HPS cases.
+CONCLUSIONS: Middle-aged adults were more commonly affected. Respiratory 
+symptoms were often accompanied by fever, gastrointestinal symptoms, and 
+headache. Hypoxemia was observed in all cases. Common laboratory features 
+included thrombocytopenia (92% of patients), elevated creatinine (61% of 
+patients), increased polymorphonuclear leukocyte band forms (52% of patients), 
+and hematocrit more than 55% (32% of patients). Most cases were associated with 
+seeing rodents or rodent excreta at home. HPS was frequently misdiagnosed on 
+initial presentation. Mortality was over 46%, higher for infection with the Sin 
+Nombre virus (50%) than with the Bayou virus (0%). In Texas, the distribution of 
+HPS is mainly along the coast and in west Texas.
+
+DOI: 10.1097/SMJ.0b013e318187d06f
+PMID: 19077779 [Indexed for MEDLINE]

--- a/references_cache/PMID_20171551.md
+++ b/references_cache/PMID_20171551.md
@@ -1,0 +1,52 @@
+---
+reference_id: "PMID:20171551"
+title: Hantavirus pulmonary syndrome.
+authors:
+- Simpson SQ
+- Spikes L
+- Patel S
+- Faruqi I
+journal: Infect Dis Clin North Am
+year: '2010'
+doi: 10.1016/j.idc.2009.10.011
+keywords:
+- "Hantavirus Pulmonary Syndrome/diagnosis, epidemiology, pathology, therapy"
+- Humans
+- "Sin Nombre virus/isolation & purification, physiology"
+content_type: abstract_only
+---
+
+# Hantavirus pulmonary syndrome.
+**Authors:** Simpson SQ, Spikes L, Patel S, Faruqi I
+**Journal:** Infect Dis Clin North Am (2010)
+**DOI:** [10.1016/j.idc.2009.10.011](https://doi.org/10.1016/j.idc.2009.10.011)
+
+## Content
+
+1. Infect Dis Clin North Am. 2010 Mar;24(1):159-73. doi:
+10.1016/j.idc.2009.10.011.
+
+Hantavirus pulmonary syndrome.
+
+Simpson SQ(1), Spikes L, Patel S, Faruqi I.
+
+Author information:
+(1)Division of Pulmonary and Critical Care Medicine, University of Kansas, 3901 
+Rainbow Boulevard, Mail Stop 3007, Kansas City, KS 66160-7381, USA. 
+ssimpson3@kumc.edu
+
+Hantavirus pulmonary syndrome, also known as hantavirus cardiopulmonary 
+syndrome, is a recently described infectious syndrome found throughout the 
+Americas. Although infection is sporadic and uncommon compared with other 
+atypical pneumonia syndromes, its high mortality rate warrants the maintenance 
+of a high index of suspicion in rural settings. Because no specific therapies 
+are available for the disease, prevention and early recognition play an 
+important role in reducing mortality from the disease. This article reviews the 
+nature of the viruses that cause hantavirus pulmonary syndrome, the epidemiology 
+and ecology of disease transmission, and disease recognition, treatment, and 
+prevention.
+
+Copyright 2010 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.idc.2009.10.011
+PMID: 20171551 [Indexed for MEDLINE]

--- a/references_cache/PMID_23680331.md
+++ b/references_cache/PMID_23680331.md
@@ -1,0 +1,66 @@
+---
+reference_id: "PMID:23680331"
+title: "Hantavirus infection in North America: a clinical review."
+authors:
+- Hartline J
+- Mierek C
+- Knutson T
+- Kang C
+journal: Am J Emerg Med
+year: '2013'
+doi: 10.1016/j.ajem.2013.02.001
+keywords:
+- Orthohantavirus
+- "Hantavirus Infections/diagnosis, epidemiology, etiology, therapy"
+- Humans
+- North America/epidemiology
+- Prognosis
+- Travel
+- United States/epidemiology
+content_type: abstract_only
+---
+
+# Hantavirus infection in North America: a clinical review.
+**Authors:** Hartline J, Mierek C, Knutson T, Kang C
+**Journal:** Am J Emerg Med (2013)
+**DOI:** [10.1016/j.ajem.2013.02.001](https://doi.org/10.1016/j.ajem.2013.02.001)
+
+## Content
+
+1. Am J Emerg Med. 2013 Jun;31(6):978-82. doi: 10.1016/j.ajem.2013.02.001. Epub 
+2013 May 13.
+
+Hantavirus infection in North America: a clinical review.
+
+Hartline J(1), Mierek C, Knutson T, Kang C.
+
+Author information:
+(1)Madigan Army Medical Center, Department of Emergency Medicine, Fort Lewis 
+(Tacoma), WA, USA. james.hartline@amedd.army.mil
+
+The recent outbreak of hantavirus in Yosemite National Park has attracted 
+national attention, with 10 confirmed cases of hantavirus cardiopulmonary 
+syndrome and thousands of more people exposed. This article will review the 
+epidemiology, presentation, workup, and treatment for this rare but potentially 
+lethal illness. The possibility of infection with hantavirus deserves 
+consideration in patients with severe respiratory symptoms with rodent exposure 
+or rural/wilderness travel. Accurate diagnosis requires a high index of 
+suspicion. Hantavirus cardiopulmonary syndrome presents as a vague prodrome of 
+fever, cough, myalgias, chills, and nausea followed by a rapidly worsening 
+respiratory phase. Presumptive diagnosis can be made based on pulmonary 
+interstitial edema on chest radiographs in association with leukocytosis, 
+thrombocytopenia, and hemoconcentration. Suspected cases should be confirmed 
+with a reference laboratory and reported to the appropriate public health 
+authorities. Although treatment is primarily supportive, aggressive fluid 
+administration should be avoided due to the risk of pulmonary edema. The 
+cardiopulmonary phase of the disease can progress rapidly with catastrophic 
+decompensation in as little as a few hours. Patients require rapid intensive 
+care unit admission for monitoring, mechanical ventilation, vasoactive agents, 
+and possibly extracorporeal mechanical ventilation. Emergency physicians should 
+be aware of outbreaks and vigilant for hantavirus exposures, especially during 
+the summer and early fall months.
+
+Published by Elsevier Inc.
+
+DOI: 10.1016/j.ajem.2013.02.001
+PMID: 23680331 [Indexed for MEDLINE]

--- a/references_cache/PMID_23784924.md
+++ b/references_cache/PMID_23784924.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:23784924"
+title: "High-dose intravenous methylprednisolone for hantavirus cardiopulmonary syndrome in Chile: a double-blind, randomized controlled clinical trial."
+authors:
+- Vial PA
+- Valdivieso F
+- Ferres M
+- Riquelme R
+- Rioseco ML
+- Calvo M
+- Castillo C
+- Díaz R
+- Scholz L
+- Cuiza A
+- Belmar E
+- Hernandez C
+- Martinez J
+- Lee SJ
+- Mertz GJ
+- Hantavirus Study Group in Chile
+journal: Clin Infect Dis
+year: '2013'
+doi: 10.1093/cid/cit394
+keywords:
+- "Administration, Intravenous"
+- Adolescent
+- Adult
+- "Anti-Inflammatory Agents/administration & dosage"
+- Chile
+- Double-Blind Method
+- Female
+- "Orthohantavirus/genetics, isolation & purification"
+- "Hantavirus Pulmonary Syndrome/drug therapy, mortality"
+- Humans
+- Kaplan-Meier Estimate
+- Male
+- "Methylprednisolone/administration & dosage"
+- Middle Aged
+- "RNA, Viral/blood"
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# High-dose intravenous methylprednisolone for hantavirus cardiopulmonary syndrome in Chile: a double-blind, randomized controlled clinical trial.
+**Authors:** Vial PA, Valdivieso F, Ferres M, Riquelme R, Rioseco ML, Calvo M, Castillo C, Díaz R, Scholz L, Cuiza A, Belmar E, Hernandez C, Martinez J, Lee SJ, Mertz GJ, Hantavirus Study Group in Chile
+**Journal:** Clin Infect Dis (2013)
+**DOI:** [10.1093/cid/cit394](https://doi.org/10.1093/cid/cit394)
+
+## Content
+
+1. Clin Infect Dis. 2013 Oct;57(7):943-51. doi: 10.1093/cid/cit394. Epub 2013 Jun
+ 19.
+
+High-dose intravenous methylprednisolone for hantavirus cardiopulmonary syndrome 
+in Chile: a double-blind, randomized controlled clinical trial.
+
+Vial PA(1), Valdivieso F, Ferres M, Riquelme R, Rioseco ML, Calvo M, Castillo C, 
+Díaz R, Scholz L, Cuiza A, Belmar E, Hernandez C, Martinez J, Lee SJ, Mertz GJ; 
+Hantavirus Study Group in Chile.
+
+Collaborators: Abarca J, Tomicic V, Aracena ME, Rehbein AM, Velásquez S, Lavin 
+V, Garrido F, Godoy P, Martinez C, Chamorro JC, Contreras J, Hernandez J, Pino 
+M, Villegas P, Zapata V, León M, Vega I, Otarola I, Ortega C, Daube E, Huecha D, 
+Neira A, Ruiz I, Nuñez MA, Monsalve L, Chabouty H, Riquelme L, Palma S, Bustos 
+R, Miranda R, Mardones J, Hernandez N, Betancur Y, Sanhueza L, Inostroza J, 
+Donoso S, Navarrete M, Acuña L, Manriquez P, Castillo F, Unzueta P, Aguilera T, 
+Osorio C, Yobanolo V, Mardones J, Aranda S, Carvajal S, Sandoval M, Daza S, 
+Vargas F, Diaz V, Riquelme M, Muñoz M, Carriel A, Lanino P, Hernandez S, 
+Schumacher P, Yañez L, Marco C, Ehrenfeld M, Delgado I, Rios S, Vial C, Bedrick 
+E.
+
+Author information:
+(1)Facultad de Medicina Clínica Alemana Universidad del Desarrollo, Santiago.
+
+BACKGROUND: Andes virus (ANDV)-related hantavirus cardiopulmonary syndrome 
+(HCPS) has a 35% case fatality rate in Chile and no specific treatment. In an 
+immunomodulatory approach, we evaluated the efficacy of intravenous 
+methylprednisolone for HCPS treatment, through a parallel-group, 
+placebo-controlled clinical trial.
+METHODS: Patients aged >2 years, with confirmed or suspected HCPS in 
+cardiopulmonary stage, admitted to any of 13 study sites in Chile, were 
+randomized by study center in blocks of 4 with a 1:1 allocation and assigned 
+through sequentially numbered envelopes to receive placebo or methylprednisolone 
+16 mg/kg/day (≤1000 mg) for 3 days. All personnel remained blinded except the 
+local pharmacist. Infection was confirmed by immunoglobulin M antibodies or ANDV 
+RNA in blood. The composite primary endpoint was death, partial pressure of 
+arterial oxygen/fraction of inspired oxygen ratio ≤55, cardiac index ≤2.2, or 
+ventricular tachycardia or fibrillation within 28 days. Safety endpoints 
+included the number of serious adverse events (SAEs) and quantification of viral 
+RNA in blood. Analysis was by intention to treat.
+RESULTS: Infection was confirmed in 60 of 66 (91%) enrollees. Fifteen of 30 
+placebo-treated patients and 11 of 30 methylprednisolone-treated patients 
+progressed to the primary endpoint (P = .43). We observed no significant 
+difference in mortality between treatment groups (P = .41). There was a trend 
+toward more severe disease in placebo recipients at entry. More subjects in the 
+placebo group experienced SAEs (P = .02). There were no SAEs clearly related to 
+methylprednisolone administration, and methylprednisolone did not increase viral 
+load.
+CONCLUSIONS: Although methylprednisolone appears to be safe, it did not provide 
+significant clinical benefit to patients. Our results do not support the use of 
+methylprednisolone for HCPS.
+CLINICAL TRIALS REGISTRATION: NCT00128180.
+
+DOI: 10.1093/cid/cit394
+PMCID: PMC3765009
+PMID: 23784924 [Indexed for MEDLINE]

--- a/references_cache/PMID_25316807.md
+++ b/references_cache/PMID_25316807.md
@@ -1,0 +1,105 @@
+---
+reference_id: "PMID:25316807"
+title: A non-randomized multicentre trial of human immune plasma for treatment of hantavirus cardiopulmonary syndrome caused by Andes virus.
+authors:
+- Vial PA
+- Valdivieso F
+- Calvo M
+- Rioseco ML
+- Riquelme R
+- Araneda A
+- Tomicic V
+- Graf J
+- Paredes L
+- Florenzano M
+- Bidart T
+- Cuiza A
+- Marco C
+- Hjelle B
+- Ye C
+- Hanfelt-Goade D
+- Vial C
+- Rivera JC
+- Delgado I
+- Mertz GJ
+- Hantavirus Study Group in Chile
+journal: Antivir Ther
+year: '2015'
+doi: 10.3851/IMP2875
+keywords:
+- Adult
+- "Antibodies, Neutralizing/therapeutic use"
+- "Antibodies, Viral/therapeutic use"
+- Female
+- Glucocorticoids/therapeutic use
+- "Orthohantavirus/drug effects, growth & development, immunology"
+- "Hantavirus Infections/immunology, mortality, therapy, virology"
+- "Heart/drug effects, physiopathology, virology"
+- Humans
+- Immune Sera/pharmacology
+- "Lung/drug effects, immunology, pathology, virology"
+- Male
+- Methylprednisolone/therapeutic use
+- Middle Aged
+- Neutralization Tests
+- Plasmapheresis
+- "RNA, Viral/antagonists & inhibitors, blood, immunology"
+- Severity of Illness Index
+- Survival Analysis
+- Syndrome
+- Viral Load/drug effects
+content_type: abstract_only
+---
+
+# A non-randomized multicentre trial of human immune plasma for treatment of hantavirus cardiopulmonary syndrome caused by Andes virus.
+**Authors:** Vial PA, Valdivieso F, Calvo M, Rioseco ML, Riquelme R, Araneda A, Tomicic V, Graf J, Paredes L, Florenzano M, Bidart T, Cuiza A, Marco C, Hjelle B, Ye C, Hanfelt-Goade D, Vial C, Rivera JC, Delgado I, Mertz GJ, Hantavirus Study Group in Chile
+**Journal:** Antivir Ther (2015)
+**DOI:** [10.3851/IMP2875](https://doi.org/10.3851/IMP2875)
+
+## Content
+
+1. Antivir Ther. 2015;20(4):377-86. doi: 10.3851/IMP2875. Epub 2014 Oct 15.
+
+A non-randomized multicentre trial of human immune plasma for treatment of 
+hantavirus cardiopulmonary syndrome caused by Andes virus.
+
+Vial PA(1), Valdivieso F, Calvo M, Rioseco ML, Riquelme R, Araneda A, Tomicic V, 
+Graf J, Paredes L, Florenzano M, Bidart T, Cuiza A, Marco C, Hjelle B, Ye C, 
+Hanfelt-Goade D, Vial C, Rivera JC, Delgado I, Mertz GJ; Hantavirus Study Group 
+in Chile.
+
+Collaborators: Täger M, Osorio C, Yobanolo V, Carriel A, Lanino P, Demian A, 
+Bosnich C, Valdes S, Nuñez G, Cornejo C, Wilhelm J, Umaña A, Nagano F, Gonzalez 
+MT, Rios S, Belmar E, Ferres M.
+
+Author information:
+(1)Facultad de Medicina Clínica Alemana Universidad del Desarrollo, Santiago, 
+Chile. pvial@udd.cl.
+
+BACKGROUND: In Chile, Andes virus (ANDV) is the sole aetiological agent of 
+hantavirus cardiopulmonary syndrome (HCPS) with mean annual incidence of 55 
+cases, 32% case fatality rate (CFR) and no specific treatment. Neutralizing 
+antibody (NAb) titres at hospital admission correlate inversely with HCPS 
+severity. We designed an open trial to explore safety and efficacy and evaluate 
+pharmacokinetics of immune plasma as a treatment strategy for this disease.
+METHODS: We performed plasmapheresis on donors at least 6 months after HCPS and 
+measured NAb titres through a focus-reduction neutralization test. Subjects 
+admitted to 10 study sites with suspected/confirmed HCPS were eligible for 
+treatment with immune plasma by intravenous infusion at an ANDV NAb dose of 
+5,000 U/kg. HCPS was confirmed through immunoglobulin M serology or reverse 
+transcriptase-PCR. The main outcome was mortality within 30 days.
+RESULTS: From 2008-2012, we enrolled and treated 32 cases and confirmed HCPS in 
+29. CFR of hantavirus plasma-treated cases was 4/29 (14%); CFR of non-treated 
+cases in the same period in Chile was 63/199 (32%; P=0.049, OR=0.35, CI=0.12, 
+0.99); CFR of non-treated cases at the same study sites between 2005-2012 was 
+18/66 (27%; (P=0.15, OR=0.43, CI=0.14, 1.34) and CFR in a previous 
+methylprednisolone treatment study was 20/60 (33%; P=0.052, OR=0.32, CI=0.10, 
+1.00). We detected no serious adverse events associated to plasma infusion. 
+Plasma NAb titres reached in recipients were variable and viral load remained 
+stable.
+CONCLUSIONS: Human ANDV immune plasma infusion appears safe for HCPS. We 
+observed a decrease in CFR in treated cases with borderline significance that 
+will require further studies for confirmation.
+
+DOI: 10.3851/IMP2875
+PMID: 25316807 [Indexed for MEDLINE]

--- a/references_cache/PMID_29446472.md
+++ b/references_cache/PMID_29446472.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:29446472"
+title: "Hantavirus induced cardiopulmonary syndrome: A public health concern."
+authors:
+- Llah ST
+- Mir S
+- Sharif S
+- Khan S
+- Mir MA
+journal: J Med Virol
+year: '2018'
+doi: 10.1002/jmv.25054
+keywords:
+- Disease Management
+- Early Diagnosis
+- Extracorporeal Membrane Oxygenation
+- Hantavirus Infections/complications
+- "Hantavirus Pulmonary Syndrome/diagnosis, mortality, pathology, therapy"
+- Hemofiltration
+- Humans
+- "Respiration, Artificial"
+- "Shock, Cardiogenic/diagnosis, mortality, pathology, therapy"
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Hantavirus induced cardiopulmonary syndrome: A public health concern.
+**Authors:** Llah ST, Mir S, Sharif S, Khan S, Mir MA
+**Journal:** J Med Virol (2018)
+**DOI:** [10.1002/jmv.25054](https://doi.org/10.1002/jmv.25054)
+
+## Content
+
+1. J Med Virol. 2018 Jun;90(6):1003-1009. doi: 10.1002/jmv.25054. Epub 2018 Mar
+15.
+
+Hantavirus induced cardiopulmonary syndrome: A public health concern.
+
+Llah ST(1), Mir S(2), Sharif S(3), Khan S(4), Mir MA(1).
+
+Author information:
+(1)Saint Joseph's Hospital Medical Center, Phoenix, Arizona.
+(2)Applied BioCode, Santa Fe Springs, Calofornia.
+(3)Mymensingh Medical College, Mymensingh, Bangladesh.
+(4)University of Arkansas For Medical Sciences, Little Rock, Arizona.
+
+Hantavirus cardiopulmonary syndrome is characterized by pulmonary capillary 
+leakage and alveolar flooding, resulting in 50% mortality due to fulminant 
+hypoxic respiratory failure. In addition, depression of cardiac function ensues, 
+which complicates the picture with cardiogenic shock. Early diagnosis and 
+appropriate use of extracorporeal membrane oxygenation (ECMO) are amongst the 
+lifesaving interventions in this fatal illness. However, a recent case report 
+demonstrates that implementation of high volume continuous hemofilteration along 
+with protective ventilation reverses the cardiogenic shock within few hours in 
+hantavirus infected patients. This review article is focused on the recent 
+advances in clinical features, diagnosis, management, epidemiology, and 
+pathogenesis of hantavirus induced cardiopulmonary syndrome. It provides 
+information for clinicians to help in correct diagnosis during the early stages 
+of viral infection that could improve the prognosis of this viral illness.
+
+© 2018 Wiley Periodicals, Inc.
+
+DOI: 10.1002/jmv.25054
+PMID: 29446472 [Indexed for MEDLINE]

--- a/references_cache/PMID_36913929.md
+++ b/references_cache/PMID_36913929.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:36913929"
+title: Emerging Maripa Hantavirus as a Potential Cause of a Severe Health Threat in French Guiana.
+authors:
+- Matheus S
+- Houcke S
+- Lontsi Ngoula GR
+- Lecaros P
+- Pujo JM
+- Higel N
+- Ba A
+- Cook F
+- Djahi P
+- Resiere D
+- Hommel D
+- Lavergne A
+- Kallel H
+journal: Am J Trop Med Hyg
+year: '2023'
+doi: 10.4269/ajtmh.22-0390
+keywords:
+- Male
+- Humans
+- Middle Aged
+- Female
+- French Guiana/epidemiology
+- "Hantavirus Pulmonary Syndrome/diagnosis, epidemiology"
+- RNA Viruses
+- Hospitals
+- Orthohantavirus
+content_type: abstract_only
+---
+
+# Emerging Maripa Hantavirus as a Potential Cause of a Severe Health Threat in French Guiana.
+**Authors:** Matheus S, Houcke S, Lontsi Ngoula GR, Lecaros P, Pujo JM, Higel N, Ba A, Cook F, Djahi P, Resiere D, Hommel D, Lavergne A, Kallel H
+**Journal:** Am J Trop Med Hyg (2023)
+**DOI:** [10.4269/ajtmh.22-0390](https://doi.org/10.4269/ajtmh.22-0390)
+
+## Content
+
+1. Am J Trop Med Hyg. 2023 Mar 13;108(5):1014-1016. doi: 10.4269/ajtmh.22-0390. 
+Print 2023 May 3.
+
+Emerging Maripa Hantavirus as a Potential Cause of a Severe Health Threat in 
+French Guiana.
+
+Matheus S(1), Houcke S(1), Lontsi Ngoula GR(1), Lecaros P(1), Pujo JM(2), Higel 
+N(1), Ba A(1), Cook F(1), Djahi P(1), Resiere D(3), Hommel D(1), Lavergne A(4), 
+Kallel H(1)(5).
+
+Author information:
+(1)Intensive Care Unit, Cayenne General Hospital, Cayenne, French Guiana.
+(2)Emergency Department, Cayenne General Hospital, Cayenne, French Guiana.
+(3)Intensive Care Unit, Martinique University Hospital, Martinique.
+(4)National Hantavirus Reference Center, Institut Pasteur de la Guyane, 
+Laboratoire Associé, French Guiana.
+(5)Tropical Biome and Immunopathology, Université de Guyane, Cayenne, French 
+Guiana.
+
+We describe the clinical parameters and management of nine confirmed cases of 
+hantavirus pulmonary syndrome reported in French Guiana since 2008. All patients 
+were admitted to Cayenne Hospital. Seven patients were men and the mean age was 
+48 years (range, 19-71 years). Two phases characterized the disease. The 
+prodromal phase was characterized by fever (77.8%), myalgia (66.7%), and 
+gastrointestinal symptoms (vomiting and diarrhea; 55.6%) starting, on average, 5 
+days before the illness phase, which was characterized by respiratory failure in 
+all patients. Five patients died (55.6%) and the length of stay in the intensive 
+care unit was 19 days (range, 11-28 days) for survivors. Detection of two 
+back-to-back recent cases highlights the reason to screen for hantavirus 
+infection during the nonspecific phase of the disease, in particular when 
+concomitant pulmonary infection and digestive disorders are observed. Specific 
+longitudinal serological surveys must also be used to identify other potential 
+clinical forms of the disease in French Guiana.
+
+DOI: 10.4269/ajtmh.22-0390
+PMCID: PMC10160908
+PMID: 36913929 [Indexed for MEDLINE]

--- a/references_cache/PMID_40203030.md
+++ b/references_cache/PMID_40203030.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:40203030"
+title: IL-6 trans-signaling mediates cytokine secretion and barrier dysfunction in hantavirus-infected cells and correlates to severity in HFRS.
+authors:
+- Maleki KT
+- Niemetz L
+- Christ W
+- Wigren Byström J
+- Thunberg T
+- Ahlm C
+- Klingström J
+journal: PLoS Pathog
+year: '2025'
+doi: 10.1371/journal.ppat.1013042
+keywords:
+- Humans
+- Interleukin-6/metabolism
+- Signal Transduction
+- "Hemorrhagic Fever with Renal Syndrome/metabolism, immunology, virology, pathology"
+- "Receptors, Interleukin-6/metabolism"
+- Female
+- Male
+- Middle Aged
+- Orthohantavirus
+- Adult
+- "Endothelial Cells/virology, metabolism"
+- Intercellular Adhesion Molecule-1/metabolism
+- Severity of Illness Index
+- Chemokine CCL2/metabolism
+- Cadherins/metabolism
+- Cytokines/metabolism
+- "Cells, Cultured"
+- "Antigens, CD/metabolism"
+- Cadherin 5
+content_type: abstract_only
+---
+
+# IL-6 trans-signaling mediates cytokine secretion and barrier dysfunction in hantavirus-infected cells and correlates to severity in HFRS.
+**Authors:** Maleki KT, Niemetz L, Christ W, Wigren Byström J, Thunberg T, Ahlm C, Klingström J
+**Journal:** PLoS Pathog (2025)
+**DOI:** [10.1371/journal.ppat.1013042](https://doi.org/10.1371/journal.ppat.1013042)
+
+## Content
+
+1. PLoS Pathog. 2025 Apr 9;21(4):e1013042. doi: 10.1371/journal.ppat.1013042. 
+eCollection 2025 Apr.
+
+IL-6 trans-signaling mediates cytokine secretion and barrier dysfunction in 
+hantavirus-infected cells and correlates to severity in HFRS.
+
+Maleki KT(1), Niemetz L(1)(2), Christ W(1), Wigren Byström J(3), Thunberg T(3), 
+Ahlm C(3), Klingström J(1)(4).
+
+Author information:
+(1)Center for Infectious Medicine, Department of Medicine Huddinge, Karolinska 
+Institutet, Stockholm, Sweden.
+(2)Bernhard Nocht Institute for Tropical Medicine, Hamburg, Germany.
+(3)Department of Clinical Microbiology, Umeå University, Umeå, Sweden.
+(4)Division of Molecular Medicine and Virology, Department of Biomedical and 
+Clinical Sciences, Linköping University, Linköping, Sweden.
+
+BACKGROUND: Hantavirus causes hemorrhagic fever with renal syndrome (HFRS) and 
+hantavirus pulmonary syndrome (HPS). Strong inflammatory responses and vascular 
+leakage are important hallmarks of these often fatal diseases. The mechanism 
+behind pathogenesis is unknown and no specific treatment is available. IL-6 was 
+recently highlighted as a biomarker for HPS/HFRS severity. IL-6 signaling is 
+complex and context dependent: while classical signaling generally provide 
+protective responses, trans-signaling can cause severe pathogenic responses. 
+Here, we investigated a potential role for IL-6 trans-signaling in hantavirus 
+pathogenesis.
+METHODS: Effects of IL-6 trans-signaling during in vitro hantavirus infection 
+were assessed using primary human endothelial cells treated with recombinant 
+soluble IL-6 receptor (sIL-6R). Plasma from Puumala orthohantavirus-infected 
+HFRS patients (n=28) were analyzed for IL-6 trans-signaling potential and its 
+associations to severity.
+FINDINGS: In vitro, sIL-6R treatment of infected cells enhanced IL-6 and CCL2 
+secretion, upregulated ICAM-1, and affected VE-cadherin leading to a disrupted 
+cell barrier integrity. HFRS patients showed altered plasma levels of sIL-6R and 
+soluble gp130 (sgp130) resulting in an increased sIL-6R/sgp130 ratio suggesting 
+enhanced IL-6 trans-signaling potential. Plasma sgp130 levels negatively 
+correlated with number of interventions and positively with albumin levels. 
+Patients receiving oxygen treatment displayed a higher sIL-6R/sgp130 ratio 
+compared to patients that did not.
+INTERPRETATION: IL-6 trans-signaling is linked to hantavirus pathogenesis. 
+Targeting IL-6 trans-signaling might provide a therapeutic strategy for 
+treatment of severe HFRS and perhaps also HPS.
+
+Copyright: © 2025 Maleki et al. This is an open access article distributed under 
+the terms of the Creative Commons Attribution License, which permits 
+unrestricted use, distribution, and reproduction in any medium, provided the 
+original author and source are credited.
+
+DOI: 10.1371/journal.ppat.1013042
+PMCID: PMC12054857
+PMID: 40203030 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_40857262.md
+++ b/references_cache/PMID_40857262.md
@@ -1,0 +1,128 @@
+---
+reference_id: "PMID:40857262"
+title: Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates.
+authors:
+- Jeyachandran AV
+- Irudayam JI
+- Dubey S
+- Chakravarty N
+- Daskou M
+- Zaiss A
+- Garcia G
+- Konda B
+- Shah A
+- Venkatraman A
+- Su B
+- Wang C
+- Cui Q
+- Williams KJ
+- Srikanth S
+- Kumar A
+- Shi Y
+- Deb A
+- Damoiseaux R
+- Stripp BR
+- Ramaiah A
+- Arumugaswami V
+journal: PLoS Pathog
+year: '2025'
+doi: 10.1371/journal.ppat.1013401
+keywords:
+- Humans
+- Antiviral Agents/pharmacology
+- "Viral Tropism/physiology, drug effects"
+- "Orthohantavirus/pathogenicity, physiology, drug effects"
+- Animals
+- Endothelial Cells/virology
+- Virulence
+- "Hantavirus Infections/virology, drug therapy"
+- Organoids/virology
+- Lung/virology
+- "Cells, Cultured"
+content_type: abstract_only
+---
+
+# Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates.
+**Authors:** Jeyachandran AV, Irudayam JI, Dubey S, Chakravarty N, Daskou M, Zaiss A, Garcia G, Konda B, Shah A, Venkatraman A, Su B, Wang C, Cui Q, Williams KJ, Srikanth S, Kumar A, Shi Y, Deb A, Damoiseaux R, Stripp BR, Ramaiah A, Arumugaswami V
+**Journal:** PLoS Pathog (2025)
+**DOI:** [10.1371/journal.ppat.1013401](https://doi.org/10.1371/journal.ppat.1013401)
+
+## Content
+
+1. PLoS Pathog. 2025 Aug 26;21(8):e1013401. doi: 10.1371/journal.ppat.1013401. 
+eCollection 2025 Aug.
+
+Differential tropisms of old and new world hantaviruses influence virulence and 
+developing host-directed antiviral candidates.
+
+Jeyachandran AV(1), Irudayam JI(1), Dubey S(1), Chakravarty N(1)(2)(3), Daskou 
+M(1), Zaiss A(1), Garcia G(1), Konda B(4), Shah A(1), Venkatraman A(1), Su 
+B(5)(6), Wang C(7), Cui Q(7), Williams KJ(5)(6), Srikanth S(8), Kumar A(9), Shi 
+Y(7), Deb A(10)(11), Damoiseaux R(1)(11)(12)(13), Stripp BR(4), Ramaiah A(14), 
+Arumugaswami V(1)(11)(12).
+
+Author information:
+(1)Department of Molecular and Medical Pharmacology, University of California, 
+Los Angeles, California, United States of America.
+(2)Department of Epidemiology, University of California, Los Angeles, 
+California, United States of America.
+(3)School of Medicine, California University of Science and Medicine, Colton, 
+California, United States of America.
+(4)Department of Medicine, Lung and Board of Governors Regenerative Medicine 
+Institute, Cedars-Sinai Medical Center, Los Angeles, California, United States 
+of America.
+(5)Department of Biological Chemistry, David Geffen School of Medicine, 
+University of California, Los Angeles, California, United States of America.
+(6)UCLA Lipidomics Lab, University of California, Los Angeles, California, 
+United States of America.
+(7)Department of Neurodegenerative Diseases, Beckman Research Institute of City 
+of Hope, Duarte, California, United States of America.
+(8)Department of Physiology, David Geffen School of Medicine, University of 
+California, Los Angeles, California, United States of America.
+(9)Department of Ophthalmology, Visual and Anatomical Sciences, Wayne State 
+University, Detroit, Michigan, United States of America.
+(10)Division of Cardiology, Department of Medicine, David Geffen School of 
+Medicine, UCLA, Los Angeles, California, United States of America.
+(11)Eli & Edythe Broad Center of Regenerative Medicine and Stem Cell Research, 
+UCLA, Los Angeles, California, United States of America.
+(12)California NanoSystems Institute, UCLA, Los Angeles, California, United 
+States of America.
+(13)Department of Bioengineering, Samueli School of Engineering, UCLA, Los 
+Angeles, California, United States of America.
+(14)City of Milwaukee Health Department, Milwaukee, Wisconsin, United States of 
+America.
+
+Hantaviruses are zoonotically transmitted from rodents to humans through the 
+respiratory route, with no currently approved antivirals or widely available 
+vaccines. The recent discovery of interhuman-transmitted Andes virus (ANDV) 
+necessitates the systematic identification of cell tropism, infective potential, 
+and potent therapeutic agents. We utilized human primary lung endothelial cells, 
+various pluripotent stem cell-derived heart and brain cell types, and 
+established human lung organoid models to evaluate the tropisms of Old World 
+Hantaan (HTNV) and New World ANDV and Sin Nombre (SNV) viruses. ANDV exhibited 
+broad tropism for all cell types assessed. SNV readily infected pulmonary 
+endothelial cells, while HTNV robustly amplified in endothelial cells, 
+cardiomyocytes, and astrocytes. We also provide the first evidence of hantaviral 
+infection in human 3D distal lung organoids, which effectively modeled these 
+differential tropisms. ANDV infection transcriptionally promoted cell injury and 
+inflammatory responses, and downregulated lipid metabolic pathways in lung 
+epithelial cells. Evaluation of selected drug candidates and 
+pharmacotranscriptomics revealed that the host-directed small molecule compound 
+urolithin B inhibited ANDV infection and restored cellular metabolism with 
+minimal changes in host transcription. Given the scarcity of academic BSL-4 
+facilities that enable in vivo hantaviral studies, this investigation presents 
+advanced human cell-based model systems that closely recapitulate host cell 
+tropism and responses to infection, thereby providing critical platforms to 
+evaluate potential antiviral drug candidates.
+
+Copyright: This is an open access article, free of all copyright, and may be 
+freely reproduced, distributed, transmitted, modified, built upon, or otherwise 
+used by anyone for any lawful purpose. The work is made available under the 
+Creative Commons CC0 public domain dedication.
+
+DOI: 10.1371/journal.ppat.1013401
+PMCID: PMC12380290
+PMID: 40857262 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/research/Hantavirus_Pulmonary_Syndrome-deep-research-falcon.md
+++ b/research/Hantavirus_Pulmonary_Syndrome-deep-research-falcon.md
@@ -1,0 +1,1230 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T18:25:24.078039'
+end_time: '2026-05-06T18:39:57.063645'
+duration_seconds: 872.99
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Hantavirus Pulmonary Syndrome
+  mondo_id: ''
+  category: Infectious
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 34
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Hantavirus Pulmonary Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Hantavirus Pulmonary Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Hantavirus Pulmonary Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Hantavirus Pulmonary Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive research report: Hantavirus Pulmonary Syndrome (HPS) / Hantavirus Cardiopulmonary Syndrome (HCPS)
+
+### Target disease
+- **Disease name:** Hantavirus Pulmonary Syndrome (HPS), also called **Hantavirus Cardiopulmonary Syndrome (HCPS)** (chen2023zoonotichantaviridaewith pages 1-2)
+- **Category:** Infectious (zoonotic viral disease)
+- **MONDO ID:** Not retrievable from the provided full texts in this run (evidence gap).
+
+---
+
+## 1. Disease information (overview, identifiers, synonyms)
+
+### Concise overview
+HPS/HCPS is a severe acute zoonotic disease caused by New World orthohantaviruses. A 2023 review of Sin Nombre virus (SNV) describes HPS as **“a life-threatening illness named for the predominance of infection of pulmonary endothelial cells.”** (publication date: Nov 2023; URL: https://doi.org/10.3390/biology12111413) (jacob2023sinnombrevirus pages 1-2).
+
+### Key identifiers (available from retrieved sources)
+- **MeSH IDs (from ClinicalTrials.gov record):**
+  - MeSH **D018804**: “Hantavirus Pulmonary Syndrome”
+  - MeSH **D018778**: “Hantavirus Infections” (NCT00128180 chunk 2)
+
+**ICD-10 / ICD-11 / Orphanet / MONDO identifiers:** Not present in the retrieved full texts and therefore cannot be cited here (evidence gap).
+
+### Common synonyms and alternative names
+- Hantavirus pulmonary syndrome (HPS)
+- Hantavirus cardiopulmonary syndrome (HCPS) (chen2023zoonotichantaviridaewith pages 1-2)
+
+### Evidence source type
+Information here is derived from **aggregated disease-level resources** (reviews, surveillance/tooling papers, and a clinical trial registry entry), not individual EHR-only datasets (jacob2023sinnombrevirus pages 1-2, cintron2023hantanetanew pages 1-2, NCT00128180 chunk 2).
+
+---
+
+## 2. Etiology
+
+### Disease causal factors
+- **Infectious cause:** New World orthohantaviruses; commonly cited etiologic agents include **Sin Nombre virus (SNV)** in North America and **Andes virus (ANDV)** in South America (jacob2023sinnombrevirus pages 1-2, chen2023zoonotichantaviridaewith pages 1-2).
+
+### Risk factors (exposure-related)
+- **Primary transmission route:** exposure to **aerosolized rodent excreta/secreta** (urine/feces/saliva), described in the SNV review (2023; https://doi.org/10.3390/biology12111413) (jacob2023sinnombrevirus pages 1-2).
+- **Reservoir:** the SNV review identifies the primary reservoir as the **deer mouse (*Peromyscus maniculatus*)** (jacob2023sinnombrevirus pages 1-2).
+- **Human-to-human transmission:** limited evidence is noted mainly for **ANDV** (cintron2023hantanetanew pages 1-2, tortosa2024seroprevalenceofhantavirus pages 1-2).
+
+### Protective factors
+Not identified in the retrieved evidence (gap).
+
+### Gene–environment interaction
+Host genetic susceptibility/protective loci were not identified in the retrieved evidence (gap).
+
+---
+
+## 3. Phenotypes, temporal course, and anatomy affected
+
+### Core clinical course (current understanding)
+HPS/HCPS typically progresses from a prodrome to rapid cardiopulmonary decompensation:
+- **Prodrome:** fever and myalgias, often with gastrointestinal symptoms (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+- **Dyspnea is often late**; once dyspnea occurs, rapid deterioration is common: **“Patients presenting with dyspnea typically require intubation and mechanical ventilation within 1 to 6 hours.”** (Simpson et al., 2010; URL: https://doi.org/10.1016/j.idc.2009.10.011; publication date: Mar 2010) (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+- **Hemodynamic pattern:** shock physiology includes **myocardial depression** and relative intravascular volume depletion; volume repletion may not improve cardiac output (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+
+### Key phenotypes (suggested HPO terms)
+Below are phenotype elements repeatedly described in clinical summaries of HPS/HCPS:
+- **Fever** (HPO: HP:0001945) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Myalgia** (HP:0003326) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Headache** (HP:0002315) (llah2018hantavirusinducedcardiopulmonary pages 1-2)
+- **Nausea / vomiting / diarrhea** (HP:0002018 / HP:0002013 / HP:0002014) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Dyspnea** (HP:0002094) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Acute respiratory distress / noncardiogenic pulmonary edema** (HP:0002106, HP:0002091) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Shock / hypotension** (HP:0001251 / HP:0002615) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Thrombocytopenia** (HP:0001873) — reported in **79% at presentation** in one review (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Hemoconcentration / elevated hematocrit** (HP:0001899) — hematocrits up to **77%** reported (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Leukocytosis** (HP:0001974) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+
+### Laboratory abnormalities and suggested mappings
+- **Thrombocytopenia** (HP:0001873) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Leukocytosis with left shift** (HP:0001974) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Hemoconcentration** (HP:0001899) (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+
+### Anatomical structures and cell types affected
+- **Primary organ/system:** lung (respiratory system), with pulmonary edema/alveolar flooding and pleural effusions described in clinical-pathology summaries (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+  - Suggested UBERON terms: **lung** (UBERON:0002048), **pulmonary alveolus** (UBERON:0002299).
+- **Key cellular target:** **endothelial cells** (CL:0000115), emphasized across reviews and mechanistic papers as a principal tropism (jacob2023sinnombrevirus pages 1-2, llah2018hantavirusinducedcardiopulmonary pages 1-2).
+- **Cardiovascular involvement:** myocardial depression/cardiogenic shock is commonly described as a major contributor to death (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+
+### Quality-of-life impact
+Not quantified in the retrieved evidence for 2023–2024 HPS/HCPS survivor cohorts; a long-term QOL cohort exists in the retrieved library (2025) but was not captured with extractable evidence snippets in this run (gap).
+
+---
+
+## 4. Genetic/molecular information
+
+### Causal genes and pathogenic variants
+HPS/HCPS is not a monogenic disorder; no causal human germline variants were identified in the retrieved evidence (gap).
+
+### Pathogen genome/proteins (molecular identifiers)
+Hantaviruses are **negative-sense, tri-segmented RNA viruses** with S/M/L genome segments encoding nucleoprotein, glycoproteins, and RNA polymerase (cintron2023hantanetanew pages 1-2, llah2018hantavirusinducedcardiopulmonary pages 1-2).
+
+---
+
+## 5. Environmental information
+
+### Environmental/lifestyle contributors
+The dominant environmental determinant is **rodent exposure**, particularly aerosolized exposures in contaminated settings (jacob2023sinnombrevirus pages 1-2).
+
+---
+
+## 6. Mechanism / pathophysiology (causal chain, pathways, immune processes)
+
+### Causal chain (current synthesis)
+1. **Exposure and entry:** inhalation of aerosolized rodent excreta containing infectious virus (jacob2023sinnombrevirus pages 1-2).
+2. **Primary infection of endothelial cells:** endothelial tropism is a recurring core concept in HPS/HCPS, including the SNV review emphasis on pulmonary endothelial infection (jacob2023sinnombrevirus pages 1-2, llah2018hantavirusinducedcardiopulmonary pages 1-2).
+3. **Barrier dysfunction and vascular leak:** clinical disease is characterized by pulmonary capillary leak and edema (llah2018hantavirusinducedcardiopulmonary pages 1-2, llah2018hantavirusinducedcardiopulmonary pages 2-3).
+4. **Cardiopulmonary failure:** patients develop severe hypoxemia, shock, and myocardial depression (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+
+### Viral entry factors and upstream host determinants
+- Pathogenic orthohantaviruses preferentially use **β3 integrin** for entry; mechanistic review content also implicates linkage to **VEGFR2** signaling complexes (taylor2025pathogenicityandvirulence pages 10-12, llah2018hantavirusinducedcardiopulmonary pages 1-2).
+- **Protocadherin-1** is also implicated in entry (jeyachandran2025differentialtropismsof pages 27-28).
+
+### Key downstream permeability pathways
+- **VEGF/VEGFR2 – VE-cadherin axis:** a mechanistic framework links pathogenic hantaviruses to sensitization of endothelium to permeability signaling and **VE-cadherin** disruption (taylor2025pathogenicityandvirulence pages 10-12, llah2018hantavirusinducedcardiopulmonary pages 2-3).
+- **Kallikrein–kinin / bradykinin signaling:** implicated in increased vascular permeability and highlighted as a candidate therapeutic axis (taylor2025pathogenicityandvirulence pages 10-12).
+
+### Immune mechanisms and inflammation
+- **Hypercytokinemia:** multiple cytokines/chemokines are reported elevated in pathogenic orthantohantavirus disease, including IL-6 and CXCL10 among others (taylor2025pathogenicityandvirulence pages 10-12).
+- **Type I interferon–linked innate lymphoid activation (2024):** In a 2024 PLOS Pathogens study (publication date: Jul 2024; https://doi.org/10.1371/journal.ppat.1012390), hantavirus infection was associated with strong inflammation and altered innate lymphoid cells; **ILC2 frequency increased**, and in vitro activation was **type I interferon–dependent** (garcia2024innatelymphoidcells pages 1-2). While this cohort was PUUV-HFRS, the authors frame these responses in the broader context of hantaviruses causing HFRS and HPS (garcia2024innatelymphoidcells pages 1-2).
+- **IL-6 trans-signaling and endothelial barrier dysfunction (2025 mechanistic extension):** IL-6 trans-signaling in infected endothelial cells increased cytokine secretion and disrupted barrier integrity via VE-cadherin changes, supporting a plausible mechanism for vascular leak (maleki2025il6transsignalingmediates pages 1-2).
+
+### Suggested ontology terms for mechanisms
+- **GO biological process:**
+  - regulation of endothelial cell barrier (e.g., “regulation of endothelial cell permeability”)
+  - inflammatory response
+  - cytokine-mediated signaling pathway
+  - regulation of vasculature development / VEGF signaling
+- **Cell types (CL):**
+  - endothelial cell (CL:0000115)
+  - innate lymphoid cell (general class) / ILC2 (as used in the 2024 study) (garcia2024innatelymphoidcells pages 1-2)
+
+### Recent developments: omics and advanced models
+A 2025 PLOS Pathogens study used **human primary lung endothelial cells**, multiple iPSC-derived cell types, and **human 3D distal lung organoids**, reporting differential tropism (ANDV broad, SNV more restricted to pulmonary endothelium) and **transcriptomic programs of injury/inflammation and suppressed lipid metabolism** in infected lung epithelial cells; the study reports deposition at **NCBI GEO GSE232641** (publication date: Aug 2025; URL: https://doi.org/10.1371/journal.ppat.1013401) (jeyachandran2025differentialtropismsof pages 1-2).
+
+---
+
+## 7. Anatomical structures affected (structured)
+
+- **Primary:** lung (UBERON:0002048), pulmonary microvascular endothelium (CL:0000115) (jacob2023sinnombrevirus pages 1-2, llah2018hantavirusinducedcardiopulmonary pages 1-2)
+- **Secondary/complication-prone:** cardiovascular system—myocardial depression and shock physiology (simpson2010hantaviruspulmonarysyndrome. pages 7-10)
+- **Subcellular (suggested, not directly evidenced here):** intercellular junction complexes (VE-cadherin), consistent with barrier disruption mechanisms (maleki2025il6transsignalingmediates pages 1-2)
+
+---
+
+## 8. Temporal development (onset/progression)
+
+- **Onset:** acute (prodrome then rapid progression) (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+- **Progression:** rapid, with respiratory failure sometimes requiring intubation within hours after dyspnea begins (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+- **Critical period:** early cardiopulmonary phase is a narrow window for escalation to intensive support (mechanical ventilation, vasopressors, ECMO) (simpson2010hantaviruspulmonarysyndrome. pages 7-10, llah2018hantavirusinducedcardiopulmonary pages 3-4).
+
+---
+
+## 9. Inheritance and population
+
+### Epidemiology and geographic distribution
+- HPS/HCPS is primarily a disease of the **Americas**, associated with New World hantaviruses (chen2023zoonotichantaviridaewith pages 1-2).
+- Global burden context: a 2023 review summarizes that ~150,000–200,000 hantavirus cases (HFRS or HCPS/HPS combined) are reported annually and provides HCPS/HPS CFR ranges (publication date: Aug 2023; URL: https://doi.org/10.3390/v15081705) (chen2023zoonotichantaviridaewith pages 1-2).
+
+### Relevant statistics (recent)
+- **Background seroprevalence (non-epidemic settings):** 2024 systematic review/meta-analysis (publication date: Sep 2024; URL: https://doi.org/10.1186/s12889-024-20014-w) estimates global hantavirus IgG seroprevalence **2.93% (95% CI 2.34–3.67%)**, with regional estimates Americas **2.43%**, Europe **2.98%**, Asia **6.84%**, Africa **2.21%** (tortosa2024seroprevalenceofhantavirus pages 1-2).
+
+### Mortality / prognosis statistics
+- **Case fatality ranges:** reviews commonly cite **~30–50%** for HCPS/HPS, with virus-specific CFRs such as ANDV ~40% and SNV 30–50% (chen2023zoonotichantaviridaewith pages 1-2).
+
+---
+
+## 10. Diagnostics
+
+### Clinical and laboratory confirmation
+A 2023 surveillance/genomic epidemiology paper (HantaNet; publication date: Nov 2023; URL: https://doi.org/10.3390/v15112208) summarizes laboratory confirmation for U.S. surveillance as compatible illness plus one of:
+- **hantavirus-reactive IgM**, or
+- rising hantavirus-specific **IgG titers**, or
+- detection of **hantavirus RNA**, or
+- hantavirus-reactive **immunohistochemistry** (cintron2023hantanetanew pages 1-2).
+
+### Differential diagnosis
+Not systematically extractable from the retrieved evidence snippets in this run (gap).
+
+---
+
+## 11. Outcome / prognosis
+
+- The acute course is frequently fulminant, with high mortality driven by rapid respiratory failure and shock (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+- Elevated lactate has been described as a poor prognostic marker in early series, with some exceptions in ECMO-treated patients (simpson2010hantaviruspulmonarysyndrome. pages 7-10).
+
+---
+
+## 12. Treatment (current applications and evidence)
+
+### Standard of care: supportive critical care
+- Management is primarily **supportive**; advanced respiratory and hemodynamic support are central, and ECMO is used for refractory cardiopulmonary failure (llah2018hantavirusinducedcardiopulmonary pages 3-4).
+
+**Suggested MAXO terms:** mechanical ventilation, extracorporeal membrane oxygenation, vasopressor therapy, intensive care (supportive care).
+
+### Antiviral therapy: ribavirin (clinical trial evidence)
+A placebo-controlled, double-blind North American trial (publication date: Nov 2004; URL: https://doi.org/10.1086/425007) found **no evidence of benefit** for IV ribavirin in confirmed HCPS cases:
+- survival without ECMO: **70% ribavirin vs 62% placebo**
+- **2 deaths** in each arm
+- among ECMO-treated subjects, **3 of 7** died
+- trial stopped early for slow accrual/futility (mertz2004placebocontrolleddoubleblindtrial pages 1-2).
+
+**Suggested MAXO terms:** antiviral therapy; ribavirin administration.
+
+### Corticosteroids: methylprednisolone
+- A methylprednisolone RCT is registered (ClinicalTrials.gov **NCT00128180**), with inclusion/exclusion criteria for presumptive HCPS and a linked publication (PMID 23784924) (NCT00128180 chunk 2).
+- A review summarizes that the methylprednisolone trial showed **no benefit** on mortality or key physiologic outcomes (llah2018hantavirusinducedcardiopulmonary pages 4-5).
+
+**Suggested MAXO terms:** corticosteroid therapy.
+
+### Passive immunotherapy (immune plasma)
+A review describes immune plasma as promising and references a non-randomized multicenter trial reporting a “marked difference in mortality,” but the effect size and statistical details were not extractable in the provided evidence snippets (llah2018hantavirusinducedcardiopulmonary pages 4-5). This remains an evidence gap for precise quantitative synthesis in this report.
+
+**Suggested MAXO terms:** passive immunization; convalescent plasma therapy.
+
+### Vaccination (pipeline)
+- A Phase 1 trial of an **Andes virus DNA vaccine** is listed as completed (ClinicalTrials.gov **NCT03682107**) (trial listing in tool output; not accompanied by extractable results in the evidence snippets provided in this run).
+
+**Suggested MAXO terms:** vaccination.
+
+---
+
+## 13. Prevention
+
+### Primary prevention (current implementation)
+Prevention focuses on interrupting rodent-to-human transmission:
+- rodent control and reducing contact with contaminated rodent excreta, with emphasis on avoiding aerosolization (jacob2023sinnombrevirus pages 1-2, iheukwumere2025hantavirusestransmissiondynamics pages 1-2).
+
+### Public health surveillance and outbreak response (real-world implementation)
+A 2023 paper describes **HantaNet**, a MicrobeTrace-powered visualization and analytics tool for **hantavirus classification and genomic surveillance**, intended to reduce reporting delays and improve outbreak detection (publication date: Nov 2023; URL: https://doi.org/10.3390/v15112208) (cintron2023hantanetanew pages 1-2).
+
+The retrieved figure below depicts the HantaNet workflow and S/M/L segment visualization dashboard (cintron2023hantanetanew media 48129cbd).
+
+---
+
+## 14. Other species / natural disease
+
+- **Reservoirs:** rodents are the main reservoirs for medically important New World hantaviruses; deer mouse is the primary SNV reservoir (jacob2023sinnombrevirus pages 1-2).
+- **Zoonotic potential:** primary transmission is rodent-to-human; limited person-to-person transmission is described mainly for ANDV (cintron2023hantanetanew pages 1-2, tortosa2024seroprevalenceofhantavirus pages 1-2).
+
+---
+
+## 15. Model organisms and experimental models
+
+- **Animal models:** hamster models are widely referenced in the therapeutic development literature for Andes virus disease (contextualized in reviews; not fully extractable here with quantitative model outcomes) (llah2018hantavirusinducedcardiopulmonary pages 4-5).
+- **Human experimental systems (recent):** human endothelial cell infection systems and **3D distal lung organoids** support mechanistic and antiviral candidate studies, enabling transcriptomic/lipidomic profiling (jeyachandran2025differentialtropismsof pages 1-2).
+
+---
+
+## Expert opinion / analysis (authoritative synthesis)
+Across reviews and mechanistic papers, expert consensus is that HPS/HCPS severity is driven less by overt cytolysis and more by **endothelial dysfunction with dysregulated permeability and immune activation**, implicating VEGF/VE-cadherin signaling and inflammatory cytokine networks (taylor2025pathogenicityandvirulence pages 10-12, llah2018hantavirusinducedcardiopulmonary pages 2-3). The failure of ribavirin to show benefit in established cardiopulmonary-phase disease in the 2004 RCT reinforces the clinical emphasis on **early recognition and rapid escalation of supportive critical care**, including ECMO in refractory cases (mertz2004placebocontrolleddoubleblindtrial pages 1-2, llah2018hantavirusinducedcardiopulmonary pages 3-4).
+
+---
+
+## Evidence gaps relative to the template
+- **Formal disease identifiers:** ICD-10/ICD-11, MONDO, Orphanet not extractable from retrieved texts.
+- **Host genetic susceptibility/protective factors:** not identified in retrieved evidence.
+- **Quantitative prevention effectiveness (interventional studies) and immune plasma effect sizes:** not extractable from snippets; would require targeted retrieval of the cited primary trial reports.
+
+
+
+References
+
+1. (chen2023zoonotichantaviridaewith pages 1-2): Ji-Ming Chen, Rui-Xu Chen, Huan-Yu Gong, Xiu Wang, Ming-Hui Sun, Yu-Fei Ji, Su-Mei Tan, and Jian-Wei Shao. Zoonotic hantaviridae with global public health significance. Viruses, Aug 2023. URL: https://doi.org/10.3390/v15081705, doi:10.3390/v15081705. This article has 35 citations.
+
+2. (jacob2023sinnombrevirus pages 1-2): Andrew T. Jacob, Benjamin M. Ziegler, Stefania M. Farha, Lyla R. Vivian, Cora A. Zilinski, Alexis R. Armstrong, Andrew J. Burdette, Dia C. Beachboard, and Christopher C. Stobart. Sin nombre virus and the emergence of other hantaviruses: a review of the biology, ecology, and disease of a zoonotic pathogen. Biology, 12:1413, Nov 2023. URL: https://doi.org/10.3390/biology12111413, doi:10.3390/biology12111413. This article has 18 citations.
+
+3. (NCT00128180 chunk 2):  Efficacy of Methylprednisolone for Hantavirus Cardiopulmonary Syndrome. University of New Mexico. 2003. ClinicalTrials.gov Identifier: NCT00128180
+
+4. (cintron2023hantanetanew pages 1-2): Roxana Cintron, Shannon L. M. Whitmer, Evan Moscoso, Ellsworth M. Campbell, Reagan Kelly, Emir Talundzic, Melissa Mobley, Kuo Wei Chiu, Elizabeth Shedroff, Anupama Shankar, Joel M. Montgomery, John D. Klena, and William M. Switzer. Hantanet: a new microbetrace application for hantavirus classification, genomic surveillance, epidemiology and outbreak investigations. Viruses, 15:2208, Nov 2023. URL: https://doi.org/10.3390/v15112208, doi:10.3390/v15112208. This article has 4 citations.
+
+5. (tortosa2024seroprevalenceofhantavirus pages 1-2): Fernando Tortosa, Fernando Perre, Celia Tognetti, Lucia Lossetti, Gabriela Carrasco, German Guaresti, Ayelén Iglesias, Yesica Espasandin, and Ariel Izcovich. Seroprevalence of hantavirus infection in non-epidemic settings over four decades: a systematic review and meta-analysis. BMC Public Health, Sep 2024. URL: https://doi.org/10.1186/s12889-024-20014-w, doi:10.1186/s12889-024-20014-w. This article has 15 citations and is from a peer-reviewed journal.
+
+6. (simpson2010hantaviruspulmonarysyndrome. pages 7-10): S. Simpson, L. Spikes, Saurin Patel, and I. Faruqi. Hantavirus pulmonary syndrome. Infectious disease clinics of North America, 24 1:159-73, Mar 2010. URL: https://doi.org/10.1016/j.idc.2009.10.011, doi:10.1016/j.idc.2009.10.011. This article has 55 citations and is from a peer-reviewed journal.
+
+7. (llah2018hantavirusinducedcardiopulmonary pages 1-2): Sibghat T. Llah, Sheema Mir, Sumaiya Sharif, Salman Khan, and Mohammed A. Mir. Hantavirus induced cardiopulmonary syndrome: a public health concern. Journal of Medical Virology, 90:1003-1009, Jun 2018. URL: https://doi.org/10.1002/jmv.25054, doi:10.1002/jmv.25054. This article has 50 citations and is from a peer-reviewed journal.
+
+8. (llah2018hantavirusinducedcardiopulmonary pages 2-3): Sibghat T. Llah, Sheema Mir, Sumaiya Sharif, Salman Khan, and Mohammed A. Mir. Hantavirus induced cardiopulmonary syndrome: a public health concern. Journal of Medical Virology, 90:1003-1009, Jun 2018. URL: https://doi.org/10.1002/jmv.25054, doi:10.1002/jmv.25054. This article has 50 citations and is from a peer-reviewed journal.
+
+9. (taylor2025pathogenicityandvirulence pages 10-12): Shannon L. Taylor, Connie S. Schmaljohn, Evan P. Williams, and Colleen B. Jonsson. Pathogenicity and virulence of rodent-borne orthohantaviruses. Virulence, Sep 2025. URL: https://doi.org/10.1080/21505594.2025.2553784, doi:10.1080/21505594.2025.2553784. This article has 4 citations and is from a peer-reviewed journal.
+
+10. (jeyachandran2025differentialtropismsof pages 27-28): Arjit Vijey Jeyachandran, Joseph Ignatius Irudayam, Swati Dubey, Nikhil Chakravarty, Maria Daskou, Anne Zaiss, Gustavo Garcia, Bindu Konda, Aayushi Shah, Aditi Venkatraman, Baolong Su, Cheng Wang, Qi Cui, Kevin J. Williams, Sonal Srikanth, Ashok Kumar, Yanhong Shi, Arjun Deb, Robert Damoiseaux, Barry R. Stripp, Arunachalam Ramaiah, and Vaithilingaraja Arumugaswami. Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates. PLOS Pathogens, 21:e1013401, Aug 2025. URL: https://doi.org/10.1371/journal.ppat.1013401, doi:10.1371/journal.ppat.1013401. This article has 1 citations and is from a highest quality peer-reviewed journal.
+
+11. (garcia2024innatelymphoidcells pages 1-2): Marina García, Anna Carrasco García, Whitney Weigel, Wanda Christ, Ronaldo Lira-Junior, Lorenz Wirth, Johanna Tauriainen, Kimia Maleki, Giulia Vanoni, Antti Vaheri, Satu Mäkelä, Jukka Mustonen, Johan Nordgren, Anna Smed-Sörensen, Tomas Strandin, Jenny Mjösberg, and Jonas Klingström. Innate lymphoid cells are activated in hfrs, and their function can be modulated by hantavirus-induced type i interferons. PLOS Pathogens, 20:e1012390, Jul 2024. URL: https://doi.org/10.1371/journal.ppat.1012390, doi:10.1371/journal.ppat.1012390. This article has 7 citations and is from a highest quality peer-reviewed journal.
+
+12. (maleki2025il6transsignalingmediates pages 1-2): Kimia T. Maleki, Linda Niemetz, Wanda Christ, Julia Wigren Byström, Therese Thunberg, Clas Ahlm, and Jonas Klingström. Il-6 trans-signaling mediates cytokine secretion and barrier dysfunction in hantavirus-infected cells and correlates to severity in hfrs. PLOS Pathogens, 21:e1013042, Apr 2025. URL: https://doi.org/10.1371/journal.ppat.1013042, doi:10.1371/journal.ppat.1013042. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+13. (jeyachandran2025differentialtropismsof pages 1-2): Arjit Vijey Jeyachandran, Joseph Ignatius Irudayam, Swati Dubey, Nikhil Chakravarty, Maria Daskou, Anne Zaiss, Gustavo Garcia, Bindu Konda, Aayushi Shah, Aditi Venkatraman, Baolong Su, Cheng Wang, Qi Cui, Kevin J. Williams, Sonal Srikanth, Ashok Kumar, Yanhong Shi, Arjun Deb, Robert Damoiseaux, Barry R. Stripp, Arunachalam Ramaiah, and Vaithilingaraja Arumugaswami. Differential tropisms of old and new world hantaviruses influence virulence and developing host-directed antiviral candidates. PLOS Pathogens, 21:e1013401, Aug 2025. URL: https://doi.org/10.1371/journal.ppat.1013401, doi:10.1371/journal.ppat.1013401. This article has 1 citations and is from a highest quality peer-reviewed journal.
+
+14. (llah2018hantavirusinducedcardiopulmonary pages 3-4): Sibghat T. Llah, Sheema Mir, Sumaiya Sharif, Salman Khan, and Mohammed A. Mir. Hantavirus induced cardiopulmonary syndrome: a public health concern. Journal of Medical Virology, 90:1003-1009, Jun 2018. URL: https://doi.org/10.1002/jmv.25054, doi:10.1002/jmv.25054. This article has 50 citations and is from a peer-reviewed journal.
+
+15. (mertz2004placebocontrolleddoubleblindtrial pages 1-2): G. J. Mertz, L. Miedzinski, D. Goade, A. T. Pavia, B. Hjelle, C. O. Hansbarger, H. Levy, F. T. Koster, K. Baum, A. Lindemulder, W. Wang, L. Riser, H. Fernandez, and R. J. Whitley. Placebo-controlled, double-blind trial of intravenous ribavirin for the treatment of hantavirus cardiopulmonary syndrome in north america. Clinical infectious diseases : an official publication of the Infectious Diseases Society of America, 39 9:1307-13, Nov 2004. URL: https://doi.org/10.1086/425007, doi:10.1086/425007. This article has 234 citations.
+
+16. (llah2018hantavirusinducedcardiopulmonary pages 4-5): Sibghat T. Llah, Sheema Mir, Sumaiya Sharif, Salman Khan, and Mohammed A. Mir. Hantavirus induced cardiopulmonary syndrome: a public health concern. Journal of Medical Virology, 90:1003-1009, Jun 2018. URL: https://doi.org/10.1002/jmv.25054, doi:10.1002/jmv.25054. This article has 50 citations and is from a peer-reviewed journal.
+
+17. (iheukwumere2025hantavirusestransmissiondynamics pages 1-2): I. H. Iheukwumere, C. M. Iheukwumere, B. C. Unaeze, V. E Ike, H. C. Nnadozie, and S. O. Onyema. Hantaviruses, transmission dynamics, clinical outcomes, and preventive approaches: a review. IPS Journal of Basic and Clinical Medicine, 2:115-121, Oct 2025. URL: https://doi.org/10.54117/ijbcm.v2i4.21, doi:10.54117/ijbcm.v2i4.21. This article has 0 citations.
+
+18. (cintron2023hantanetanew media 48129cbd): Roxana Cintron, Shannon L. M. Whitmer, Evan Moscoso, Ellsworth M. Campbell, Reagan Kelly, Emir Talundzic, Melissa Mobley, Kuo Wei Chiu, Elizabeth Shedroff, Anupama Shankar, Joel M. Montgomery, John D. Klena, and William M. Switzer. Hantanet: a new microbetrace application for hantavirus classification, genomic surveillance, epidemiology and outbreak investigations. Viruses, 15:2208, Nov 2023. URL: https://doi.org/10.3390/v15112208, doi:10.3390/v15112208. This article has 4 citations.

--- a/research/Hantavirus_Pulmonary_Syndrome-deep-research-falcon.md.citations.md
+++ b/research/Hantavirus_Pulmonary_Syndrome-deep-research-falcon.md.citations.md
@@ -1,0 +1,485 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Hantavirus Pulmonary Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Hantavirus Pulmonary Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T18:39:57.063645
+
+1. chen2023zoonotichantaviridaewith pages 1-2
+2. jacob2023sinnombrevirus pages 1-2
+3. llah2018hantavirusinducedcardiopulmonary pages 1-2
+4. jeyachandran2025differentialtropismsof pages 27-28
+5. taylor2025pathogenicityandvirulence pages 10-12
+6. garcia2024innatelymphoidcells pages 1-2
+7. jeyachandran2025differentialtropismsof pages 1-2
+8. tortosa2024seroprevalenceofhantavirus pages 1-2
+9. cintron2023hantanetanew pages 1-2
+10. llah2018hantavirusinducedcardiopulmonary pages 3-4
+11. mertz2004placebocontrolleddoubleblindtrial pages 1-2
+12. llah2018hantavirusinducedcardiopulmonary pages 4-5
+13. llah2018hantavirusinducedcardiopulmonary pages 2-3
+14. iheukwumere2025hantavirusestransmissiondynamics pages 1-2
+15. https://doi.org/10.3390/biology12111413
+16. https://doi.org/10.1016/j.idc.2009.10.011;
+17. https://doi.org/10.1371/journal.ppat.1012390
+18. https://doi.org/10.1371/journal.ppat.1013401
+19. https://doi.org/10.3390/v15081705
+20. https://doi.org/10.1186/s12889-024-20014-w
+21. https://doi.org/10.3390/v15112208
+22. https://doi.org/10.1086/425007
+23. https://doi.org/10.3390/v15081705,
+24. https://doi.org/10.3390/biology12111413,
+25. https://doi.org/10.3390/v15112208,
+26. https://doi.org/10.1186/s12889-024-20014-w,
+27. https://doi.org/10.1016/j.idc.2009.10.011,
+28. https://doi.org/10.1002/jmv.25054,
+29. https://doi.org/10.1080/21505594.2025.2553784,
+30. https://doi.org/10.1371/journal.ppat.1013401,
+31. https://doi.org/10.1371/journal.ppat.1012390,
+32. https://doi.org/10.1371/journal.ppat.1013042,
+33. https://doi.org/10.1086/425007,
+34. https://doi.org/10.54117/ijbcm.v2i4.21,


### PR DESCRIPTION
## Summary
- add Hantavirus Pulmonary Syndrome disorder entry with Falcon-backed curation
- include PMID-backed evidence for pulmonary endothelial tropism, capillary leak, respiratory failure, shock, diagnosis, ECMO support, and trial evidence for ribavirin/methylprednisolone
- add generated Falcon research artifacts and required PMID reference caches

## Validation
- just validate kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
- just validate-references kb/disorders/Hantavirus_Pulmonary_Syndrome.yaml
- just check-reference-cache-frontmatter