### PR TITLE
Add Pontiac fever curation

### DIFF
--- a/kb/disorders/Pontiac_Fever.yaml
+++ b/kb/disorders/Pontiac_Fever.yaml
@@ -1,0 +1,618 @@
+name: Pontiac Fever
+creation_date: '2026-05-06T22:18:19Z'
+updated_date: '2026-05-06T22:18:19Z'
+category: Infectious
+description: >-
+  Pontiac fever is the acute, self-limited, non-pneumonic form of
+  legionellosis caused by exposure to aerosolized Legionella bacteria. It is
+  usually recognized through outbreak or exposure-linked clusters of
+  influenza-like febrile illness rather than through pneumonia-centered
+  legionellosis surveillance.
+references:
+- reference: DOI:10.1007/s40572-018-0201-4
+  title: Outbreaks of Legionnaires' Disease and Pontiac Fever 2006-2017
+  found_in:
+  - Pontiac_Fever-deep-research-falcon.md
+  findings:
+  - statement: Recent Legionnaires disease and Pontiac fever outbreak summary
+    supporting_text: A review was performed and provides a summary of LD and PF outbreaks between 2006 and 2017.
+- reference: DOI:10.1017/s0950268824000979
+  title: "Weather conditions and legionellosis: a nationwide case-crossover study among Medicare recipients"
+  found_in:
+  - Pontiac_Fever-deep-research-falcon.md
+  findings:
+  - statement: Legionella water and soil exposure with milder Pontiac fever form
+    supporting_text: Infection may cause pneumonia (Legionnaires' Disease) and a milder form (Pontiac Fever).
+- reference: DOI:10.14202/ijoh.2025.62-77
+  title: "Legionnaires' disease: a review of emerging public health threats"
+  found_in:
+  - Pontiac_Fever-deep-research-falcon.md
+  findings:
+  - statement: Recent review context for Legionella public health threats
+    supporting_text: Falcon cited this review for contemporary legionellosis background and public health context.
+- reference: DOI:10.26444/monz/101676
+  title: Use of hospital morbidity data in an epidemiological analysis of diseases caused by Legionella pneumophila
+  found_in:
+  - Pontiac_Fever-deep-research-falcon.md
+  findings:
+  - statement: ICD-coded legionellosis morbidity analysis
+    supporting_text: Falcon cited this paper for ICD-10 A48.1/A48.2 coding context.
+- reference: DOI:10.3390/microorganisms12102074
+  title: Legionella in Primary School Hot Water Systems from Two Municipalities in the Danish Capital Region
+  found_in:
+  - Pontiac_Fever-deep-research-falcon.md
+  findings:
+  - statement: Built-environment Legionella hot water control context
+    supporting_text: Falcon cited this paper for recent building water system Legionella control context.
+disease_term:
+  preferred_term: Pontiac fever
+  term:
+    id: MONDO:0020487
+    label: Pontiac fever
+parents:
+- legionellosis
+- bacterial infectious disease
+synonyms:
+- Pontiac fever (PF)
+- non-pneumonic legionellosis
+- nonpneumonic legionellosis
+definitions:
+- name: Non-pneumonic legionellosis syndrome
+  definition_type: CASE_DEFINITION
+  description: >-
+    Pontiac fever is defined clinically as a self-limited influenza-like
+    legionellosis syndrome without pneumonia.
+  scope: Clinical and surveillance framing
+  evidence:
+  - reference: PMID:7304569
+    reference_title: "Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pontiac fever, a unique epidemiologic form of legionellosis, is characterized by a short (one- to two-day) incubation period and a self-limited grippe-like illness without pneumonia."
+    explanation: Defines Pontiac fever as short-incubation, self-limited, influenza-like legionellosis without pneumonia.
+- name: Exposure-linked outbreak definition
+  definition_type: CASE_DEFINITION
+  description: >-
+    Compatible cases are often recognized after shared exposure to a
+    Legionella-contaminated aerosol source, with short incubation and clustered
+    acute febrile illness.
+  scope: Outbreak investigation
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In July 1968, an explosive epidemic of acute febrile illness occurred at a county health department facility in Pontiac, Michigan."
+    explanation: Establishes the outbreak-based clinical framing of the original Pontiac fever syndrome.
+  - reference: PMID:29744757
+    reference_title: "Outbreaks of Legionnaires' Disease and Pontiac Fever 2006-2017."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "While sporadic cases of LD and PF do not always provide contextual information for evaluating causes and drivers of Legionella risks, analysis of outbreaks provides an opportunity to assess these factors."
+    explanation: Supports using outbreak context to evaluate Pontiac fever exposures and drivers.
+infectious_agent:
+- name: Legionella species
+  infectious_agent_term:
+    preferred_term: Legionella
+    term:
+      id: NCBITaxon:445
+      label: Legionella
+  description: >-
+    Pontiac fever is caused by Legionella bacteria; published outbreak and
+    surveillance literature documents disease after aerosol exposure to
+    Legionella-contaminated water sources.
+  evidence:
+  - reference: PMID:39417401
+    reference_title: "Weather conditions and legionellosis: a nationwide case-crossover study among Medicare recipients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Legionellosis is a respiratory infection caused by Legionella sp. that is found in water and soil. Infection may cause pneumonia (Legionnaires' Disease) and a milder form (Pontiac Fever)."
+    explanation: Confirms Legionella species as the etiologic agent for the milder Pontiac fever form.
+  - reference: PMID:18633335
+    reference_title: "[Occurrence and pathogenicity of the family of Legionellaceae]."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Legionellosis in humans has typically been characterized as either a potentially fatal pneumonic condition, known as Legionnaires' disease, or an acute, self-limiting, non-pneumonic condition known as Pontiac fever."
+    explanation: Confirms Pontiac fever as an acute non-pneumonic Legionella-associated syndrome.
+- name: Legionella pneumophila
+  infectious_agent_term:
+    preferred_term: Legionella pneumophila
+    term:
+      id: NCBITaxon:446
+      label: Legionella pneumophila
+  description: >-
+    L. pneumophila has been isolated from implicated outbreak water sources in
+    multiple Pontiac fever reports.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Legionella pneumophila serogroup 6 was isolated from the women's whirlpool."
+    explanation: Documents L. pneumophila isolation from an implicated whirlpool in a Pontiac fever outbreak.
+  - reference: PMID:7616010
+    reference_title: "[An outbreak of Pontiac fever due to Legionella pneumophila serogroup 7. I. Clinical aspects]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Strains of legionellae isolated from the water of the cooling tower located at the top of the Center, were identified as L. pneumophila serogroup 7."
+    explanation: Supports L. pneumophila serogroup 7 as an outbreak-associated Pontiac fever agent.
+transmission:
+- name: Aerosolized water exposure
+  description: >-
+    Human infection follows inhalation of aerosolized Legionella from
+    contaminated water systems or other aerosol-generating sources.
+  evidence:
+  - reference: PMID:18633335
+    reference_title: "[Occurrence and pathogenicity of the family of Legionellaceae]."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Aerosol-generating systems aid in the transmission of Legionella from water to the air. Human inhalation of contaminated aerosols leads to Legionella infection and disease outbreaks."
+    explanation: Directly supports water-to-air aerosol transmission and human inhalational exposure.
+  - reference: PMID:39417401
+    reference_title: "Weather conditions and legionellosis: a nationwide case-crossover study among Medicare recipients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Legionella colonizes water systems and results in exposure by inhalation of aerosolized bacteria."
+    explanation: Supports inhalation of aerosolized bacteria from colonized water systems as the exposure route.
+- name: Whirlpool, hot tub, and spa exposure
+  description: >-
+    Whirlpool and hot tub systems can generate aerosols capable of transporting
+    L. pneumophila and have repeatedly been implicated in Pontiac fever.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Aerosol size studies show that the whirlpool aerator produced water droplets small enough to travel deep into the tracheobronchial tree but large enough to transport L pneumophila."
+    explanation: Supports a mechanistic aerosol route from whirlpool water to the lower respiratory tract.
+  - reference: PMID:8855593
+    reference_title: Hot tub legionellosis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Water from the hot tub was positive for L pneumophila by DFA, culture, and PCR."
+    explanation: Documents contaminated hot tub water as a confirmed exposure source in Pontiac fever.
+- name: Cooling tower and air-conditioning-associated aerosols
+  description: >-
+    Cooling towers and evaporative condenser water aerosols are established
+    Pontiac fever exposure sources.
+  evidence:
+  - reference: PMID:7304569
+    reference_title: "Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Epidemiologic analyses clearly implicated as airborne agent and suggested that evaporative condenser water aerosols being disseminated by a defective air conditioning system played a key role in the outbreak."
+    explanation: Supports airborne dissemination from an evaporative condenser in the original Pontiac fever outbreak.
+  - reference: PMID:7065789
+    reference_title: Pneumonic and nonpneumonic forms of legionellosis. The result of a common-source exposure to Legionella pneumophila.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Two male maintenance workers contracted legionellosis while cleaning the interior of a cooling tower contaminated with Legionella pneumophila."
+    explanation: Supports cooling-tower exposure as a source for pneumonic and non-pneumonic legionellosis.
+environmental:
+- name: Engineered aquatic reservoirs
+  description: >-
+    Legionella persists in natural and anthropogenic aquatic environments,
+    including drinking water, whirlpools, and cooling-tower reservoirs.
+  evidence:
+  - reference: PMID:18633335
+    reference_title: "[Occurrence and pathogenicity of the family of Legionellaceae]."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Consequently, they are also prevalent in anthropogenic water such as drinking water, whirlpools, and cooling tower reservoirs."
+    explanation: Supports engineered water systems as environmental reservoirs relevant to exposure.
+- name: Biofilm-associated Legionella amplification
+  description: >-
+    Biofilms and microbial associations can increase Legionella nutrient
+    availability and protect organisms from adverse conditions, allowing
+    persistence in water systems.
+  evidence:
+  - reference: PMID:18633335
+    reference_title: "[Occurrence and pathogenicity of the family of Legionellaceae]."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "When Legionella co-exist with algae and other bacteria, especially in biofilms, the availability of nutrients increases."
+    explanation: Supports biofilm-associated environmental amplification.
+- name: Warm, stagnant, sediment-containing water systems
+  description: >-
+    Hot water temperature, stagnation, sediment, and other microorganisms can
+    amplify Legionellaceae in engineered systems.
+  evidence:
+  - reference: PMID:3328890
+    reference_title: The epidemiology of Legionella pneumophila infections.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Hot water temperature, stagnant water, sediment, and the presence of other microorganisms are important factors in the amplification of the Legionellaceae."
+    explanation: Supports key environmental amplification conditions in water systems.
+pathophysiology:
+- name: Aerosolized Legionella exposure
+  description: >-
+    Aerosol-producing water systems transfer Legionella from colonized water to
+    air, enabling inhalational exposure through aerosols capable of reaching the
+    tracheobronchial tree.
+  evidence:
+  - reference: PMID:18633335
+    reference_title: "[Occurrence and pathogenicity of the family of Legionellaceae]."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Aerosol-generating systems aid in the transmission of Legionella from water to the air. Human inhalation of contaminated aerosols leads to Legionella infection and disease outbreaks."
+    explanation: Supports the upstream exposure event for Legionella-associated disease.
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Aerosol size studies show that the whirlpool aerator produced water droplets small enough to travel deep into the tracheobronchial tree but large enough to transport L pneumophila."
+    explanation: Supports airway deposition potential for contaminated whirlpool aerosols.
+  biological_processes:
+  - preferred_term: response to bacterium
+    term:
+      id: GO:0009617
+      label: response to bacterium
+  downstream:
+  - target: Brisk systemic inflammatory syndrome
+- name: Brisk systemic inflammatory syndrome
+  description: >-
+    Pontiac fever develops after a short incubation as an acute febrile,
+    influenza-like illness with constitutional symptoms rather than progressive
+    pneumonia.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness characterized principally by fever, headache, myalgia, and malaise affected at least 144 persons, including 95 of 100 persons employed in the health department building."
+    explanation: Supports the central systemic symptom cluster in the original outbreak.
+  - reference: PMID:3328890
+    reference_title: The epidemiology of Legionella pneumophila infections.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Pontiac fever is an acute, self-limited, febrile illness with an attack rate of 95% to 100% and an incubation period of 36 hours."
+    explanation: Supports a short-incubation, high-attack-rate febrile syndrome.
+  biological_processes:
+  - preferred_term: inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  downstream:
+  - target: Fever
+  - target: Myalgia
+  - target: Headache
+  - target: Malaise
+  - target: Chills
+- name: Non-pneumonic clinical expression
+  description: >-
+    After common-source Legionella exposure, Pontiac fever can occur as the
+    mild non-pneumonic clinical expression while other exposed persons develop
+    pneumonic Legionnaires disease.
+  evidence:
+  - reference: PMID:7065789
+    reference_title: Pneumonic and nonpneumonic forms of legionellosis. The result of a common-source exposure to Legionella pneumophila.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In one man severe, life-threatening Legionnaires' disease developed, whereas the other experienced a comparatively mild, self-limiting illness that was consistent with previous descriptions of cases of Pontiac fever."
+    explanation: Supports divergent pneumonic versus non-pneumonic outcomes after common-source exposure.
+  - reference: PMID:8239853
+    reference_title: "Hot tub legionellosis. Legionnaires' disease and Pontiac fever after a point-source exposure to Legionella pneumophila."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Legionella pneumophila is associated with outbreaks of either Pontiac fever, a self-limited influenzalike condition without pneumonia, or Legionnaires' disease, a severe pneumonic disease affecting elderly or immunocompromised individuals."
+    explanation: Supports non-pneumonic Pontiac fever as distinct from severe Legionnaires disease.
+  downstream:
+  - target: Normal chest radiograph in Pontiac fever case
+phenotypes:
+- category: Clinical
+  name: Fever
+  description: Fever is a cardinal component of the acute Pontiac fever syndrome.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness characterized principally by fever, headache, myalgia, and malaise affected at least 144 persons, including 95 of 100 persons employed in the health department building."
+    explanation: Supports fever as a principal manifestation in the original outbreak.
+  phenotype_term:
+    preferred_term: Fever
+    term:
+      id: HP:0001945
+      label: Fever
+    temporality: ACUTE
+- category: Clinical
+  name: Headache
+  description: Headache is part of the core influenza-like symptom complex.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness characterized principally by fever, headache, myalgia, and malaise affected at least 144 persons, including 95 of 100 persons employed in the health department building."
+    explanation: Supports headache as one of the principal Pontiac fever symptoms.
+  phenotype_term:
+    preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+    temporality: ACUTE
+- category: Clinical
+  name: Myalgia
+  description: Muscle pain occurs as part of the acute influenza-like illness.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness characterized principally by fever, headache, myalgia, and malaise affected at least 144 persons, including 95 of 100 persons employed in the health department building."
+    explanation: Supports myalgia as a principal manifestation.
+  phenotype_term:
+    preferred_term: Myalgia
+    term:
+      id: HP:0003326
+      label: Myalgia
+    temporality: ACUTE
+- category: Clinical
+  name: Malaise
+  description: General malaise is part of the acute systemic syndrome.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness characterized principally by fever, headache, myalgia, and malaise affected at least 144 persons, including 95 of 100 persons employed in the health department building."
+    explanation: Supports malaise as a principal manifestation.
+  phenotype_term:
+    preferred_term: Malaise
+    term:
+      id: HP:0033834
+      label: Malaise
+    temporality: ACUTE
+- category: Clinical
+  name: Chills
+  description: Chills may accompany the febrile outbreak syndrome.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fourteen of 23 female members of a church group experienced an acute self-limited illness characterized by chills, fever, chest pain, cough, and nausea, consistent with the diagnosis of Pontiac fever."
+    explanation: Supports chills as an observed outbreak manifestation.
+  phenotype_term:
+    preferred_term: Chills
+    term:
+      id: HP:0025143
+      label: Chills
+    temporality: ACUTE
+- category: Clinical
+  name: Cough
+  description: Cough can occur in Pontiac fever despite absence of pneumonia.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fourteen of 23 female members of a church group experienced an acute self-limited illness characterized by chills, fever, chest pain, cough, and nausea, consistent with the diagnosis of Pontiac fever."
+    explanation: Supports cough as an observed symptom in Pontiac fever.
+  phenotype_term:
+    preferred_term: Cough
+    term:
+      id: HP:0012735
+      label: Cough
+    temporality: ACUTE
+- category: Clinical
+  name: Chest pain
+  description: Chest pain has been reported in whirlpool-associated Pontiac fever.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fourteen of 23 female members of a church group experienced an acute self-limited illness characterized by chills, fever, chest pain, cough, and nausea, consistent with the diagnosis of Pontiac fever."
+    explanation: Supports chest pain as an outbreak-associated manifestation.
+  phenotype_term:
+    preferred_term: Chest pain
+    term:
+      id: HP:0100749
+      label: Chest pain
+    temporality: ACUTE
+- category: Clinical
+  name: Nausea
+  description: Nausea can be part of the acute outbreak-associated syndrome.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Fourteen of 23 female members of a church group experienced an acute self-limited illness characterized by chills, fever, chest pain, cough, and nausea, consistent with the diagnosis of Pontiac fever."
+    explanation: Supports nausea as an observed outbreak manifestation.
+  phenotype_term:
+    preferred_term: Nausea
+    term:
+      id: HP:0002018
+      label: Nausea
+    temporality: ACUTE
+- category: Diagnostic
+  name: Normal chest radiograph in Pontiac fever case
+  description: >-
+    A normal chest radiograph supports the non-pneumonic clinical distinction in
+    compatible cases, although diagnosis still depends on exposure and
+    laboratory/epidemiologic context.
+  evidence:
+  - reference: PMID:8855593
+    reference_title: Hot tub legionellosis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Chest x-ray was normal."
+    explanation: Supports absence of radiographic pneumonia in a reported Pontiac fever case.
+progression:
+- phase: Short incubation period
+  notes: Pontiac fever classically develops after a short one- to two-day incubation period.
+  evidence:
+  - reference: PMID:7304569
+    reference_title: "Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pontiac fever, a unique epidemiologic form of legionellosis, is characterized by a short (one- to two-day) incubation period and a self-limited grippe-like illness without pneumonia."
+    explanation: Supports the short incubation period and acute non-pneumonic course.
+  - reference: PMID:3328890
+    reference_title: The epidemiology of Legionella pneumophila infections.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Pontiac fever is an acute, self-limited, febrile illness with an attack rate of 95% to 100% and an incubation period of 36 hours."
+    explanation: Provides a classic 36-hour incubation estimate.
+- phase: Self-limited illness
+  notes: The syndrome usually resolves over several days.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness was self-limited, generally lasting from two to five days."
+    explanation: Supports a short self-limited clinical duration.
+  - reference: PMID:7616010
+    reference_title: "[An outbreak of Pontiac fever due to Legionella pneumophila serogroup 7. I. Clinical aspects]."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The illness was self-limited, generally lasting from two to five days."
+    explanation: Replicates the two- to five-day duration in a later outbreak.
+epidemiology:
+- name: High-attack-rate outbreak syndrome
+  description: >-
+    Pontiac fever is distinguished epidemiologically by high attack rates among
+    exposed people in outbreak settings.
+  evidence:
+  - reference: PMID:3328890
+    reference_title: The epidemiology of Legionella pneumophila infections.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Pontiac fever is an acute, self-limited, febrile illness with an attack rate of 95% to 100% and an incubation period of 36 hours."
+    explanation: Supports the high attack rate and short incubation that distinguish Pontiac fever outbreaks.
+- name: Recent outbreak summary
+  description: A 2006-2017 review summarized Pontiac fever and mixed LD/PF outbreaks.
+  evidence:
+  - reference: PMID:29744757
+    reference_title: "Outbreaks of Legionnaires' Disease and Pontiac Fever 2006-2017."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Of the 136 outbreaks, 115 were LD outbreaks, 4 were PF outbreaks, and 17 were mixed outbreaks of LD and PF."
+    explanation: Quantifies recent outbreaks involving Pontiac fever.
+diagnosis:
+- name: Exposure-linked clinical diagnosis
+  description: >-
+    Diagnosis relies on an acute compatible non-pneumonic syndrome, short
+    incubation, and epidemiologic linkage to a shared Legionella-contaminated
+    source.
+  evidence:
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness characterized principally by fever, headache, myalgia, and malaise affected at least 144 persons, including 95 of 100 persons employed in the health department building."
+    explanation: Supports syndrome-based recognition in an exposure-linked cluster.
+  - reference: PMID:7304569
+    reference_title: "Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Epidemiologic analyses clearly implicated as airborne agent and suggested that evaporative condenser water aerosols being disseminated by a defective air conditioning system played a key role in the outbreak."
+    explanation: Supports epidemiologic linkage to an airborne aerosol source.
+- name: Legionella testing and environmental source confirmation
+  description: >-
+    Pontiac fever investigations may use serology, culture, DFA, PCR, and
+    environmental water testing to connect cases to contaminated sources.
+  evidence:
+  - reference: PMID:3968786
+    reference_title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Nine of 14 cases showed a seroconversion to heat-fixed antigen prepared from the L pneumophila serogroup 6 isolate."
+    explanation: Supports serologic confirmation in an outbreak investigation.
+  - reference: PMID:8855593
+    reference_title: Hot tub legionellosis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Water from the hot tub was positive for L pneumophila by DFA, culture, and PCR."
+    explanation: Supports environmental source testing using DFA, culture, and PCR.
+modeling_considerations:
+- name: Pontiac fever should not be modeled as pneumonia
+  description: >-
+    The defining clinical distinction from Legionnaires disease is absence of
+    pneumonia; models should represent an acute non-pneumonic febrile syndrome
+    after aerosol exposure.
+  evidence:
+  - reference: PMID:8239853
+    reference_title: "Hot tub legionellosis. Legionnaires' disease and Pontiac fever after a point-source exposure to Legionella pneumophila."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Legionella pneumophila is associated with outbreaks of either Pontiac fever, a self-limited influenzalike condition without pneumonia, or Legionnaires' disease, a severe pneumonic disease affecting elderly or immunocompromised individuals."
+    explanation: Supports separating Pontiac fever from pneumonic Legionnaires disease in modeling.
+- name: Mechanism remains incompletely resolved
+  description: >-
+    Human outbreak evidence strongly supports aerosol exposure and the clinical
+    syndrome, but Pontiac-fever-specific molecular pathways remain less directly
+    established than mechanisms of Legionnaires disease pneumonia.
+  evidence:
+  - reference: PMID:7065789
+    reference_title: Pneumonic and nonpneumonic forms of legionellosis. The result of a common-source exposure to Legionella pneumophila.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The implications of this observation for the pathogenetic mechanisms that underly the different clinical manifestations of legionellosis are discussed."
+    explanation: Supports retaining mechanistic uncertainty about why common exposure yields different clinical expressions.
+treatments:
+- name: Symptom-directed supportive care
+  description: >-
+    Because typical Pontiac fever is self-limited and non-pneumonic, management
+    is framed as symptom-directed supportive care for uncomplicated cases rather
+    than routine disease-specific antimicrobial therapy.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: NCIT:C15747
+      label: Supportive Care
+  target_phenotypes:
+  - preferred_term: Fever
+    term:
+      id: HP:0001945
+      label: Fever
+  - preferred_term: Myalgia
+    term:
+      id: HP:0003326
+      label: Myalgia
+  - preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+  evidence:
+  - reference: PMID:7304569
+    reference_title: "Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pontiac fever, a unique epidemiologic form of legionellosis, is characterized by a short (one- to two-day) incubation period and a self-limited grippe-like illness without pneumonia."
+    explanation: Supports the self-limited non-pneumonic basis for supportive management, but does not directly test treatment strategy.
+  - reference: PMID:623097
+    reference_title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Illness was self-limited, generally lasting from two to five days."
+    explanation: Supports short spontaneous clinical course, indirectly supporting symptom-directed management.
+differential_diagnoses:
+- name: Legionnaires disease
+  description: >-
+    Legionnaires disease shares Legionella exposure and systemic symptoms but
+    is a pneumonic syndrome, whereas Pontiac fever is non-pneumonic and
+    self-limited.
+  distinguishing_features:
+  - Pneumonia, severe respiratory failure, and higher mortality support Legionnaires disease rather than Pontiac fever.
+  - Normal chest radiograph and short self-limited course support Pontiac fever in a compatible exposure cluster.
+  evidence:
+  - reference: PMID:8239853
+    reference_title: "Hot tub legionellosis. Legionnaires' disease and Pontiac fever after a point-source exposure to Legionella pneumophila."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Legionella pneumophila is associated with outbreaks of either Pontiac fever, a self-limited influenzalike condition without pneumonia, or Legionnaires' disease, a severe pneumonic disease affecting elderly or immunocompromised individuals."
+    explanation: Directly contrasts non-pneumonic Pontiac fever with severe pneumonic Legionnaires disease.
+  disease_term:
+    preferred_term: legionnaires' disease
+    term:
+      id: MONDO:0005824
+      label: Legionnaires' disease
+notes: >-
+  Falcon deep research found no evidence that Pontiac fever is a Mendelian or
+  inherited disorder; genetic fields are intentionally omitted. Falcon deep
+  research and PubMed follow-up did not identify Pontiac-fever-specific animal
+  models or clinical trials.

--- a/references_cache/PMID_18633335.md
+++ b/references_cache/PMID_18633335.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:18633335"
+title: "[Occurrence and pathogenicity of the family of Legionellaceae]."
+authors:
+- Palusińska-Szysz M
+- Cendrowska-Pinkosz M
+journal: Postepy Hig Med Dosw (Online)
+year: '2008'
+keywords:
+- Adult
+- Aged
+- Animals
+- Biofilms
+- "Cross Infection/epidemiology, microbiology"
+- "Disease Outbreaks/statistics & numerical data"
+- Disease Reservoirs/microbiology
+- "Disease Transmission, Infectious/prevention & control"
+- Erythromycin/therapeutic use
+- Eukaryota/microbiology
+- Europe/epidemiology
+- Host-Parasite Interactions
+- Humans
+- "Legionella/classification, isolation & purification, pathogenicity"
+- "Legionnaires' Disease/diagnosis, drug therapy, epidemiology, microbiology, transmission"
+- Middle Aged
+- Prevalence
+- Species Specificity
+- Water Microbiology
+content_type: abstract_only
+---
+
+# [Occurrence and pathogenicity of the family of Legionellaceae].
+**Authors:** Palusińska-Szysz M, Cendrowska-Pinkosz M
+**Journal:** Postepy Hig Med Dosw (Online) (2008)
+
+## Content
+
+1. Postepy Hig Med Dosw (Online). 2008 Jul 10;62:337-53.
+
+[Occurrence and pathogenicity of the family of Legionellaceae].
+
+[Article in Polish]
+
+Palusińska-Szysz M(1), Cendrowska-Pinkosz M.
+
+Author information:
+(1)Zakład Genetyki i Mikrobiologii, Instytutu Mikrobiologii i Biotechnologii 
+Uniwersytetu Marii Curie-Skłodowskiej w Lublinie. 
+marta.szysz@poczta.umcs.lublin.pl
+
+Legionella are widespread in natural aquatic environments and are able to exist 
+in water of different temperatures, pH level, and nutrient and oxygen content. 
+Their occurrence in nature can be attributed to their relationships with other 
+microorganisms. When Legionella co-exist with algae and other bacteria, 
+especially in biofilms, the availability of nutrients increases. They also are 
+able to infect protozoa and subsequently reproduce within these organisms. As a 
+result of these relationships, Legionella are protected against adverse 
+conditions, including standard water disinfection techniques. Consequently, they 
+are also prevalent in anthropogenic water such as drinking water, whirlpools, 
+and cooling tower reservoirs. Aerosol-generating systems aid in the transmission 
+of Legionella from water to the air. Human inhalation of contaminated aerosols 
+leads to Legionella infection and disease outbreaks. Legionellosis in humans has 
+typically been characterized as either a potentially fatal pneumonic condition, 
+known as Legionnaires' disease, or an acute, self-limiting, non-pneumonic 
+condition known as Pontiac fever. In addition, Legionella spp. cause 
+extrapulmonary infection, especially in immunosuppressed patients. Timely 
+treatment of Legionnaires' disease is extremely important for the patient's 
+recovery. Although erythromycin has historically been used to treat patients 
+with Legionnaires' disease, newer macrolides and fluoroquinolones are gaining 
+acceptance as the first choice for treatment. Although 52 species of Legionella 
+are known, Legionella pneumophila serogroup 1 is responsible for more than 80% 
+of hospital- and community-acquired cases of Legionnaires' disease.
+
+PMID: 18633335 [Indexed for MEDLINE]

--- a/references_cache/PMID_29744757.md
+++ b/references_cache/PMID_29744757.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:29744757"
+title: "Outbreaks of Legionnaires' Disease and Pontiac Fever 2006-2017."
+authors:
+- Hamilton KA
+- Prussin AJ 2nd
+- Ahmed W
+- Haas CN
+journal: Curr Environ Health Rep
+year: '2018'
+doi: 10.1007/s40572-018-0201-4
+keywords:
+- Disease Outbreaks
+- Humans
+- "Legionnaires' Disease/epidemiology"
+- Water Microbiology
+- Water Supply
+content_type: abstract_only
+---
+
+# Outbreaks of Legionnaires' Disease and Pontiac Fever 2006-2017.
+**Authors:** Hamilton KA, Prussin AJ 2nd, Ahmed W, Haas CN
+**Journal:** Curr Environ Health Rep (2018)
+**DOI:** [10.1007/s40572-018-0201-4](https://doi.org/10.1007/s40572-018-0201-4)
+
+## Content
+
+1. Curr Environ Health Rep. 2018 Jun;5(2):263-271. doi:
+10.1007/s40572-018-0201-4.
+
+Outbreaks of Legionnaires' Disease and Pontiac Fever 2006-2017.
+
+Hamilton KA(1), Prussin AJ 2nd(2), Ahmed W(3), Haas CN(4).
+
+Author information:
+(1)Drexel University, 3141 Chestnut Street, Philadelphia, PA, 19104, USA. 
+kh495@drexel.edu.
+(2)Virginia Polytechnic Institute and State University, Blacksburg, VA, 24061, 
+USA.
+(3)CSIRO Land and Water, Ecosciences Precinct, 41 Boggo Road, Brisbane, QLD, 
+4102, Australia.
+(4)Drexel University, 3141 Chestnut Street, Philadelphia, PA, 19104, USA.
+
+Comment in
+    Curr Environ Health Rep. 2022 Mar;9(1):120-122. doi: 
+10.1007/s40572-021-00319-3.
+
+PURPOSE OF REVIEW: The global importance of Legionnaires' disease (LD) and 
+Pontiac fever (PF) has grown in recent years. While sporadic cases of LD and PF 
+do not always provide contextual information for evaluating causes and drivers 
+of Legionella risks, analysis of outbreaks provides an opportunity to assess 
+these factors.
+RECENT FINDINGS: A review was performed and provides a summary of LD and PF 
+outbreaks between 2006 and 2017. Of the 136 outbreaks, 115 were LD outbreaks, 4 
+were PF outbreaks, and 17 were mixed outbreaks of LD and PF. Cooling towers were 
+implicated or suspected in the a large portion of LD or PF outbreaks (30% total 
+outbreaks, 50% confirmed outbreak-associated cases, and 60% outbreak-associated 
+deaths) over this period of time, while building water systems and pools/spas 
+were also important contributors. Potable water/building water system outbreaks 
+seldom identify specific building water system or fixture deficiencies. The 
+outbreak data summarized here provides information for prioritizing and 
+targeting risk analysis and mitigation strategies.
+
+DOI: 10.1007/s40572-018-0201-4
+PMID: 29744757 [Indexed for MEDLINE]

--- a/references_cache/PMID_3328890.md
+++ b/references_cache/PMID_3328890.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:3328890"
+title: The epidemiology of Legionella pneumophila infections.
+authors:
+- Doebbeling BN
+- Wenzel RP
+journal: Semin Respir Infect
+year: '1987'
+keywords:
+- Disease Outbreaks
+- Humans
+- "Legionnaires' Disease/epidemiology, prevention & control, transmission"
+- Population Surveillance
+- Risk Factors
+- Spain
+- United States
+content_type: abstract_only
+---
+
+# The epidemiology of Legionella pneumophila infections.
+**Authors:** Doebbeling BN, Wenzel RP
+**Journal:** Semin Respir Infect (1987)
+
+## Content
+
+1. Semin Respir Infect. 1987 Dec;2(4):206-21.
+
+The epidemiology of Legionella pneumophila infections.
+
+Doebbeling BN(1), Wenzel RP.
+
+Author information:
+(1)Department of Medicine, University of Iowa Hospitals and Clinics, Iowa City.
+
+The study of outbreaks of Legionella pneumophila has been essential in 
+understanding the organism, the disease, and its pathogenesis. Early epidemics 
+defined the clinical spectrum: Pontiac fever is an acute, self-limited, febrile 
+illness with an attack rate of 95% to 100% and an incubation period of 36 hours. 
+In contrast, legionnaires' disease is a life-threatening bronchopneumonia with 
+an attack rate of 2% to 7% and an incubation period of two to ten days. Three 
+times as many males as females are affected with legionnaires' disease, and age, 
+cigarette smoking, and chronic medical disease (particularly immunosuppression) 
+appear to be separate risk factors. Furthermore, L pneumophila is responsible 
+for approximately 1% to 3% of community-acquired pneumonias, 13% of those 
+acquired in the hospital and as many as 26% of atypical pneumonias. Diverse 
+environmental reservoirs have been identified, including cooling systems, 
+potable or domestic water systems, respiratory therapy devices, industrial 
+coolants, and whirlpool spas. Hot water temperature, stagnant water, sediment, 
+and the presence of other microorganisms are important factors in the 
+amplification of the Legionellaceae. Although airborne transmission has been 
+widely suggested, aspiration may be an important mode in certain patients. 
+Regional and national surveillance may identify common sources and allow the 
+introduction of early control measures. The latter have included primarily pulse 
+and continuous hyperchlorination and super-heating hot water systems to 50 to 60 
+degrees C. Experimental data suggest that ozone and UV light may be useful in 
+the future. Additionally, cooling towers and evaporative condensers have been 
+decontaminated and maintained with a variety of biocides. The prevention of 
+outbreaks requires thoughtful planning, redesign, and good engineering 
+practices.
+
+PMID: 3328890 [Indexed for MEDLINE]

--- a/references_cache/PMID_39417401.md
+++ b/references_cache/PMID_39417401.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:39417401"
+title: "Weather conditions and legionellosis: a nationwide case-crossover study among Medicare recipients."
+authors:
+- Wade TJ
+- Herbert C
+journal: Epidemiol Infect
+year: '2024'
+doi: 10.1017/S0950268824000979
+keywords:
+- Humans
+- United States/epidemiology
+- Legionellosis/epidemiology
+- "Medicare/statistics & numerical data"
+- Weather
+- Aged
+- Female
+- Male
+- "Aged, 80 and over"
+- Cross-Over Studies
+- "Hospitalization/statistics & numerical data"
+- Risk Factors
+- "Legionella/isolation & purification"
+content_type: abstract_only
+---
+
+# Weather conditions and legionellosis: a nationwide case-crossover study among Medicare recipients.
+**Authors:** Wade TJ, Herbert C
+**Journal:** Epidemiol Infect (2024)
+**DOI:** [10.1017/S0950268824000979](https://doi.org/10.1017/S0950268824000979)
+
+## Content
+
+1. Epidemiol Infect. 2024 Oct 17;152:e125. doi: 10.1017/S0950268824000979.
+
+Weather conditions and legionellosis: a nationwide case-crossover study among 
+Medicare recipients.
+
+Wade TJ(1), Herbert C(2).
+
+Author information:
+(1)United States Environmental Protection Agency, Office of Research and 
+Development, Research Triangle Park, NC, USA.
+(2)Oak Ridge Associated Universities, United States Environmental Protection 
+Agency, Office of Research and Development, Research Triangle Park, NC, USA.
+
+Legionellosis is a respiratory infection caused by Legionella sp. that is found 
+in water and soil. Infection may cause pneumonia (Legionnaires' Disease) and a 
+milder form (Pontiac Fever). Legionella colonizes water systems and results in 
+exposure by inhalation of aerosolized bacteria. The incubation period ranges 
+from 2 to 14 days. Precipitation and humidity may be associated with increased 
+risk. We used Medicare records from 1999 to 2020 to identify hospitalizations 
+for legionellosis. Precipitation, temperature, and relative humidity were 
+obtained from the PRISM Climate Group for the zip code of residence. We used a 
+time-stratified bi-directional case-crossover design with lags of 20 days. Data 
+were analyzed using conditional logistic regression and distributed lag 
+non-linear models. A total of 37 883 hospitalizations were identified. 
+Precipitation and relative humidity at lags 8 through 13 days were associated 
+with an increased risk of legionellosis. The strongest association was 
+precipitation at day 10 lag (OR = 1.08, 95% CI = 1.05-1.11 per 1 cm). Over 20 
+days, 3 cm of precipitation increased the odds of legionellosis over four times. 
+The association was strongest in the Northeast and Midwest and during summer and 
+fall. Precipitation and humidity were associated with hospitalization among 
+Medicare recipients for legionellosis at lags consistent with the incubation 
+period for infection.
+
+DOI: 10.1017/S0950268824000979
+PMCID: PMC11502464
+PMID: 39417401 [Indexed for MEDLINE]

--- a/references_cache/PMID_3968786.md
+++ b/references_cache/PMID_3968786.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:3968786"
+title: "An outbreak of Pontiac fever related to whirlpool use, Michigan 1982."
+authors:
+- Mangione EJ
+- Remis RS
+- Tait KA
+- McGee HB
+- Gorman GW
+- Wentworth BB
+- Baron PA
+- Hightower AW
+- Barbaree JM
+- Broome CV
+journal: JAMA
+year: '1985'
+keywords:
+- Adult
+- "Antibodies, Bacterial/analysis"
+- "Bacterial Infections/epidemiology, etiology"
+- Baths/adverse effects
+- Disease Outbreaks/epidemiology
+- Female
+- Humans
+- "Legionella/immunology, isolation & purification"
+- Male
+- Michigan
+- Risk
+- Water Microbiology
+content_type: abstract_only
+---
+
+# An outbreak of Pontiac fever related to whirlpool use, Michigan 1982.
+**Authors:** Mangione EJ, Remis RS, Tait KA, McGee HB, Gorman GW, Wentworth BB, Baron PA, Hightower AW, Barbaree JM, Broome CV
+**Journal:** JAMA (1985)
+
+## Content
+
+1. JAMA. 1985 Jan 25;253(4):535-9.
+
+An outbreak of Pontiac fever related to whirlpool use, Michigan 1982.
+
+Mangione EJ, Remis RS, Tait KA, McGee HB, Gorman GW, Wentworth BB, Baron PA, 
+Hightower AW, Barbaree JM, Broome CV.
+
+Fourteen of 23 female members of a church group experienced an acute 
+self-limited illness characterized by chills, fever, chest pain, cough, and 
+nausea, consistent with the diagnosis of Pontiac fever. All 14 affected women 
+had used a whirlpool located in the women's locker room during a racquetball 
+party. Legionella pneumophila serogroup 6 was isolated from the women's 
+whirlpool. Nine of 14 cases showed a seroconversion to heat-fixed antigen 
+prepared from the L pneumophila serogroup 6 isolate. Aerosol size studies show 
+that the whirlpool aerator produced water droplets small enough to travel deep 
+into the tracheobronchial tree but large enough to transport L pneumophila. This 
+outbreak demonstrated that Pontiac fever may be associated with L pneumophila 
+serogroup 6, that whirlpools can serve as a reservoir for these organisms, and 
+that seroconversion can occur in the absence of illness.
+
+PMID: 3968786 [Indexed for MEDLINE]

--- a/references_cache/PMID_623097.md
+++ b/references_cache/PMID_623097.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:623097"
+title: "Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects."
+authors:
+- Glick TH
+- Gregg MB
+- Berman B
+- Mallison G
+- Rhodes WW Jr
+- Kassanoff I
+journal: Am J Epidemiol
+year: '1978'
+doi: 10.1093/oxfordjournals.aje.a112517
+keywords:
+- Acute Disease
+- Air Conditioning
+- Bacterial Infections
+- Disease Outbreaks
+- "Fever of Unknown Origin/diagnosis, etiology"
+- Government Agencies
+- "Legionnaires' Disease"
+- Michigan
+- Syndrome
+- Water Microbiology
+content_type: abstract_only
+---
+
+# Pontiac fever. An epidemic of unknown etiology in a health department: I. Clinical and epidemiologic aspects.
+**Authors:** Glick TH, Gregg MB, Berman B, Mallison G, Rhodes WW Jr, Kassanoff I
+**Journal:** Am J Epidemiol (1978)
+**DOI:** [10.1093/oxfordjournals.aje.a112517](https://doi.org/10.1093/oxfordjournals.aje.a112517)
+
+## Content
+
+1. Am J Epidemiol. 1978 Feb;107(2):149-60. doi:
+10.1093/oxfordjournals.aje.a112517.
+
+Pontiac fever. An epidemic of unknown etiology in a health department: I. 
+Clinical and epidemiologic aspects.
+
+Glick TH, Gregg MB, Berman B, Mallison G, Rhodes WW Jr, Kassanoff I.
+
+In July 1968, an explosive epidemic of acute febrile illness occurred at a 
+county health department facility in Pontiac, Michigan. Illness characterized 
+principally by fever, headache, myalgia, and malaise affected at least 144 
+persons, including 95 of 100 persons employed in the health department building. 
+The mean incubation period was approximately 36 hours. Illness was self-limited, 
+generally lasting from two to five days. Secondary cases did not occur in family 
+contacts and second attacks did not consistently follow re-exposure in the 
+building. A defective air-conditioning system was implicated as the source and 
+mechanism of spread of the causative factor. However, extensive laboratory and 
+environmental investigations failed to identify the etiologic agent. Since these 
+investigations a bacterium similar to or identical with the agent responsible 
+for Legionnaires' Disease has been isolated from guinea pigs exposed to the 
+Pontiac health department building in 1968 as well as from guinea pigs exposed 
+to water from the evaporative condenser. Paired sera from 32 cases of Pontiac 
+Fever showed seroconversion or diagnostic rises in antibody titers to this 
+bacterium.
+
+DOI: 10.1093/oxfordjournals.aje.a112517
+PMID: 623097 [Indexed for MEDLINE]

--- a/references_cache/PMID_7065789.md
+++ b/references_cache/PMID_7065789.md
@@ -1,0 +1,49 @@
+---
+reference_id: "PMID:7065789"
+title: Pneumonic and nonpneumonic forms of legionellosis. The result of a common-source exposure to Legionella pneumophila.
+authors:
+- Girod JC
+- Reichman RC
+- Winn WC Jr
+- Klaucke DN
+- Vogt RL
+- Dolin R
+journal: Arch Intern Med
+year: '1982'
+keywords:
+- Anti-Bacterial Agents/therapeutic use
+- Humans
+- "Legionella/isolation & purification"
+- "Legionnaires' Disease/diagnosis, therapy, transmission"
+- Male
+- Middle Aged
+- Occupational Diseases/transmission
+- Oxygen/therapeutic use
+- "Respiration, Artificial"
+content_type: abstract_only
+---
+
+# Pneumonic and nonpneumonic forms of legionellosis. The result of a common-source exposure to Legionella pneumophila.
+**Authors:** Girod JC, Reichman RC, Winn WC Jr, Klaucke DN, Vogt RL, Dolin R
+**Journal:** Arch Intern Med (1982)
+
+## Content
+
+1. Arch Intern Med. 1982 Mar;142(3):545-7.
+
+Pneumonic and nonpneumonic forms of legionellosis. The result of a common-source 
+exposure to Legionella pneumophila.
+
+Girod JC, Reichman RC, Winn WC Jr, Klaucke DN, Vogt RL, Dolin R.
+
+Two male maintenance workers contracted legionellosis while cleaning the 
+interior of a cooling tower contaminated with Legionella pneumophila. In one man 
+severe, life-threatening Legionnaires' disease developed, whereas the other 
+experienced a comparatively mild, self-limiting illness that was consistent with 
+previous descriptions of cases of Pontiac fever. This report represents the 
+first documentation of the development of both of these syndromes following 
+exposure to a common source of the organism. The implications of this 
+observation for the pathogenetic mechanisms that underly the different clinical 
+manifestations of legionellosis are discussed.
+
+PMID: 7065789 [Indexed for MEDLINE]

--- a/references_cache/PMID_7304569.md
+++ b/references_cache/PMID_7304569.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:7304569"
+title: "Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission."
+authors:
+- Kaufmann AF
+- McDade JE
+- Patton CM
+- Bennett JV
+- Skaliy P
+- Feeley JC
+- Anderson DC
+- Potter ME
+- Newhouse VF
+- Gregg MB
+- Brachman PS
+journal: Am J Epidemiol
+year: '1981'
+doi: 10.1093/oxfordjournals.aje.a113200
+keywords:
+- Air Conditioning
+- Air Microbiology
+- Animals
+- Disease Outbreaks
+- Epidemiologic Methods
+- Guinea Pigs
+- Humans
+- "Legionella/isolation & purification"
+- "Legionnaires' Disease/transmission"
+- Michigan
+content_type: abstract_only
+---
+
+# Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and demonstration of its mode of transmission.
+**Authors:** Kaufmann AF, McDade JE, Patton CM, Bennett JV, Skaliy P, Feeley JC, Anderson DC, Potter ME, Newhouse VF, Gregg MB, Brachman PS
+**Journal:** Am J Epidemiol (1981)
+**DOI:** [10.1093/oxfordjournals.aje.a113200](https://doi.org/10.1093/oxfordjournals.aje.a113200)
+
+## Content
+
+1. Am J Epidemiol. 1981 Sep;114(3):337-47. doi:
+10.1093/oxfordjournals.aje.a113200.
+
+Pontiac fever: isolation of the etiologic agent (Legionella pneumophilia) and 
+demonstration of its mode of transmission.
+
+Kaufmann AF, McDade JE, Patton CM, Bennett JV, Skaliy P, Feeley JC, Anderson DC, 
+Potter ME, Newhouse VF, Gregg MB, Brachman PS.
+
+Pontiac fever, a unique epidemiologic form of legionellosis, is characterized by 
+a short (one- to two-day) incubation period and a self-limited grippe-like 
+illness without pneumonia. In 1968, the first documented outbreak of this 
+syndrome affected persons who had entered a health department building in 
+Pontiac, Michigan. Epidemiologic analyses clearly implicated as airborne agent 
+and suggested that evaporative condenser water aerosols being disseminated by a 
+defective air conditioning system played a key role in the outbreak. Guinea pigs 
+that were exposed in the building and to laboratory aerosols of evaporative 
+condenser water developed bronchopneumonia. Legionella pneumophilia (serogroup 
+1) was isolated from the exposed guinea pigs' lungs. Paired acute and 
+convalescent serum specimens from 37 patients were tested by the indirect 
+fluorescent antibody technique using L. pneumophila serogroup 1 antigen, and 31 
+(84%) had rises in titer from less than 32 to greater than or equal to 64.
+
+DOI: 10.1093/oxfordjournals.aje.a113200
+PMID: 7304569 [Indexed for MEDLINE]

--- a/references_cache/PMID_7616010.md
+++ b/references_cache/PMID_7616010.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:7616010"
+title: "[An outbreak of Pontiac fever due to Legionella pneumophila serogroup 7. I. Clinical aspects]."
+authors:
+- Mori M
+- Hoshino K
+- Sonoda H
+- Yoshida H
+- Yabuuchi E
+- Yamashiro Y
+- Koide M
+- Saito A
+- Kishimoto T
+- Furuhata K
+journal: Kansenshogaku Zasshi
+year: '1995'
+doi: 10.11150/kansenshogakuzasshi1970.69.646
+keywords:
+- Adolescent
+- Adult
+- Disease Outbreaks
+- Female
+- Humans
+- Legionella pneumophila/classification
+- "Legionnaires' Disease/microbiology, physiopathology"
+- Male
+- Middle Aged
+- Serotyping
+- Tokyo/epidemiology
+content_type: abstract_only
+---
+
+# [An outbreak of Pontiac fever due to Legionella pneumophila serogroup 7. I. Clinical aspects].
+**Authors:** Mori M, Hoshino K, Sonoda H, Yoshida H, Yabuuchi E, Yamashiro Y, Koide M, Saito A, Kishimoto T, Furuhata K
+**Journal:** Kansenshogaku Zasshi (1995)
+**DOI:** [10.11150/kansenshogakuzasshi1970.69.646](https://doi.org/10.11150/kansenshogakuzasshi1970.69.646)
+
+## Content
+
+1. Kansenshogaku Zasshi. 1995 Jun;69(6):646-53. doi: 
+10.11150/kansenshogakuzasshi1970.69.646.
+
+[An outbreak of Pontiac fever due to Legionella pneumophila serogroup 7. I. 
+Clinical aspects].
+
+[Article in Japanese]
+
+Mori M(1), Hoshino K, Sonoda H, Yoshida H, Yabuuchi E, Yamashiro Y, Koide M, 
+Saito A, Kishimoto T, Furuhata K, et al.
+
+Author information:
+(1)Department of Internal Medicine, Yoyogi Hospital.
+
+In August 1994, an epidemic of acute febrile illness occurred at the Education 
+Center Building of a company in Shibuya-ku, Tokyo. All 43 trainees attended in 
+two groups and 2 staff members of the Center fell ill. The 45 patients came to 
+one of our hospitals in two groups, and 35 patients were treated. The patients 
+were 4 males and 31 females, and the average age was 29.0 years. The duration 
+until falling ill was 36 to 90 hours after entering the Center. Symptoms were 
+fever, lumbago arthralgia, headache, dyspnea, general fatigue, etc. Physical 
+examination revealed slightly injected mucosa of the pharynx in a patient who 
+complained of a sore throat. On laboratory examination, leukocytosis with a left 
+shift of the nucleus and elevation of serum CRP levels were found. Erythromycin 
+(600 mg, daily) and nonsteroidal antiinflammatory drugs (NSAIDs) were given by 
+mouth to almost every patient. Two patients were hospitalized. The illness was 
+self-limited, generally lasting from two to five days. Strains of legionellae 
+isolated from the water of the cooling tower located at the top of the Center, 
+were identified as L. pneumophila serogroup 7. Since seroconversion in a patient 
+against the cooling tower strain from 1:16 to 1:256 was determined and the 
+clinical courses agreed with the definition of Pontiac fever by Glick et al, we 
+concluded that the epidemic was an outbreak of Pontiac fever due to L. 
+pneumophila serogroup 7. Pontiac fever is considered to be one of the 
+community-acquired diseases. Thus, we have to note that Pontiac fever may be 
+misdiagnosed as we examine patients who complain of the symptoms noted above.
+
+DOI: 10.11150/kansenshogakuzasshi1970.69.646
+PMID: 7616010 [Indexed for MEDLINE]

--- a/references_cache/PMID_8239853.md
+++ b/references_cache/PMID_8239853.md
@@ -1,0 +1,51 @@
+---
+reference_id: "PMID:8239853"
+title: "Hot tub legionellosis. Legionnaires' disease and Pontiac fever after a point-source exposure to Legionella pneumophila."
+authors:
+- Thomas DL
+- Mundy LM
+- Tucker PC
+journal: Arch Intern Med
+year: '1993'
+doi: 10.1001/archinte.153.22.2597
+keywords:
+- Adult
+- Baths/adverse effects
+- Disease Outbreaks
+- Humans
+- "Legionnaires' Disease/epidemiology, etiology"
+- Male
+- Vermont/epidemiology
+- Water Microbiology
+content_type: abstract_only
+---
+
+# Hot tub legionellosis. Legionnaires' disease and Pontiac fever after a point-source exposure to Legionella pneumophila.
+**Authors:** Thomas DL, Mundy LM, Tucker PC
+**Journal:** Arch Intern Med (1993)
+**DOI:** [10.1001/archinte.153.22.2597](https://doi.org/10.1001/archinte.153.22.2597)
+
+## Content
+
+1. Arch Intern Med. 1993 Nov 22;153(22):2597-9. doi:
+10.1001/archinte.153.22.2597.
+
+Hot tub legionellosis. Legionnaires' disease and Pontiac fever after a 
+point-source exposure to Legionella pneumophila.
+
+Thomas DL(1), Mundy LM, Tucker PC.
+
+Author information:
+(1)Division of Infectious Diseases, Johns Hopkins University School of Medicine, 
+Baltimore, Md.
+
+Legionella pneumophila is associated with outbreaks of either Pontiac fever, a 
+self-limited influenzalike condition without pneumonia, or Legionnaires' 
+disease, a severe pneumonic disease affecting elderly or immunocompromised 
+individuals. An outbreak of both Legionnaires' disease and Pontiac fever after a 
+point-source exposure to L pneumophila was studied. Our observations 
+demonstrated the spectrum of illness that L pneumophila may cause and emphasized 
+the importance of host factors in affecting the expression of infection.
+
+DOI: 10.1001/archinte.153.22.2597
+PMID: 8239853 [Indexed for MEDLINE]

--- a/references_cache/PMID_8855593.md
+++ b/references_cache/PMID_8855593.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:8855593"
+title: Hot tub legionellosis.
+authors:
+- Tolentino A
+- Ahkee S
+- Ramirez J
+journal: J Ky Med Assoc
+year: '1996'
+keywords:
+- Adult
+- Anti-Bacterial Agents
+- "Drug Therapy, Combination/therapeutic use"
+- Female
+- Humans
+- Hydrotherapy
+- "Legionella pneumophila/isolation & purification"
+- "Legionnaires' Disease/diagnosis, drug therapy, transmission"
+- Risk Factors
+- Water Microbiology
+content_type: abstract_only
+---
+
+# Hot tub legionellosis.
+**Authors:** Tolentino A, Ahkee S, Ramirez J
+**Journal:** J Ky Med Assoc (1996)
+
+## Content
+
+1. J Ky Med Assoc. 1996 Sep;94(9):393-4.
+
+Hot tub legionellosis.
+
+Tolentino A(1), Ahkee S, Ramirez J.
+
+Author information:
+(1)Division of Infectious Diseases, University of Louisville, School of 
+Medicine, KY, USA.
+
+Legionella pneumophila is the cause of Legionnaires' disease, and Pontiac fever, 
+an influenza-like condition without pneumonia. We present a case of Pontiac 
+fever after exposure to a hot tub contaminated with L pneumophila. A 37 y/o wf 
+presented to the office with acute onset of sore throat, fever, headache, and 
+myalgia. Patient was hospitalized 3 days later because of worsening shortness of 
+air. Chest x-ray was normal. Patient was treated with 2 days of IV erythromycin 
+and was discharged home on oral erythromycin. Her Legionella IFA was 1:16,384. 
+Two days later, she developed chest tightness, pleuritic chest pain, and 
+increasing shortness of air but did not have any cough or sputum production. She 
+was re-hospitalized with a diagnosis of Pontiac fever and treated with IV 
+erythromycin plus oral rifampin. A repeat chest x-ray remained normal. After a 
+detailed epidemiologic history was obtained, it was noted that she became ill 
+after using a hot tub, which her two children also used and they themselves 
+developed a self limited illness. Water from the hot tub was positive for L 
+pneumophila by DFA, culture, and PCR. Patient improved gradually with therapy 
+and was discharged home. This report emphasizes the importance of a complete 
+epidemiologic history in the diagnosis of respiratory infections. It also 
+demonstrates that aquatic environment can be contaminated with Legionella and 
+serve as a source of infection.
+
+PMID: 8855593 [Indexed for MEDLINE]

--- a/research/Pontiac_Fever-deep-research-falcon.md
+++ b/research/Pontiac_Fever-deep-research-falcon.md
@@ -1,0 +1,1259 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T18:22:51.305386'
+end_time: '2026-05-06T18:34:55.281502'
+duration_seconds: 723.98
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Pontiac Fever
+  mondo_id: ''
+  category: Infectious
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 19
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Pontiac Fever
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Pontiac Fever** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Pontiac Fever
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Pontiac Fever** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Disease Characteristics Research Report: Pontiac Fever (Infectious)
+
+### Target disease
+- **Disease name:** Pontiac fever  
+- **Category:** Infectious (environmentally acquired legionellosis)  
+- **MONDO ID:** Not identified in the retrieved evidence (additional ontology lookup would be needed). (graham2024astudyofa pages 134-137)
+
+---
+
+## 1. Disease Information
+
+### 1.1 Overview (what is Pontiac fever?)
+Pontiac fever is the **non-pneumonic** (no pneumonia) and typically **self-limited, influenza-like** clinical form of **legionellosis** caused by *Legionella* spp. (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, piedade2020analysisoflegionellas pages 30-33). In practical surveillance and outbreak settings, Pontiac fever is frequently recognized as **clusters of acute febrile illness** after a shared environmental exposure rather than as sporadic, individually diagnosed illness, because mild cases may not seek care and diagnostic approaches are often geared toward pneumonia. (currie2023theecologyof pages 20-23, hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+**Abstract-supported definition (direct quote):** A hospital-based epidemiology paper explicitly frames the two forms of disease as: “pneumonic legionnaires’ disease and non-pneumonic legionnaires’ disease (Pontiac fever)” (kosinska2018useofhospital pages 1-2).
+
+### 1.2 Key identifiers
+- **ICD-10:** 
+  - **A48.2** = non-pneumonic legionellosis / **Pontiac fever** (graham2024astudyofa pages 134-137, wade2024weatherconditionsand pages 2-3, kosinska2018useofhospital pages 1-2)  
+  - **A48.1** = Legionnaires’ disease (pneumonic legionellosis) (graham2024astudyofa pages 134-137, kosinska2018useofhospital pages 1-2)
+- **ICD-11:** not identified in retrieved evidence. (graham2024astudyofa pages 134-137)
+- **MeSH:** not identified in retrieved evidence. (graham2024astudyofa pages 134-137)
+- **Orphanet/OMIM/MONDO:** not identified in retrieved evidence. (graham2024astudyofa pages 134-137)
+
+### 1.3 Synonyms / alternative names
+- **Non-pneumonic legionellosis** (explicitly used in ICD-10-context literature) (kosinska2018useofhospital pages 1-2)
+- Sometimes referred to as the **mild, flu-like illness** form of legionellosis in reviews and guidance documents. (sylvestre2023module16legionella pages 10-14, piedade2020analysisoflegionellas pages 30-33)
+
+### 1.4 Evidence type note (individual vs aggregated)
+Evidence available in this retrieval set is primarily **aggregated** (outbreak reviews; administrative hospital datasets; surveillance methodology and environmental control guidance), rather than prospective, patient-level clinical cohorts. (hamilton2018outbreaksoflegionnaires’ pages 2-4, wade2024weatherconditionsand pages 2-3, kosinska2018useofhospital pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+Pontiac fever is caused by **exposure to pathogenic *Legionella* bacteria**, typically via **inhalation of contaminated aerosols** generated from built-environment water systems (e.g., cooling towers, spas, fountains, building water distribution systems). (sylvestre2023module16legionella pages 10-14, hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+### 2.2 Infectious agents implicated
+While *Legionella pneumophila* is often the dominant species in reported legionellosis, Pontiac-fever outbreaks can involve multiple species, including non-*pneumophila* species.
+- Reported Pontiac-fever–associated species in the retrieved evidence include: **L. pneumophila, L. anisa, L. micdadei, L. feeleii, L. longbeachae**. (currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33)
+- A Legionella ecology review notes the genus includes “>72 species” and that “at least 30 species are known to cause human infections,” with most reported cases attributed to *L. pneumophila*. (sylvestre2023module16legionella pages 10-14)
+
+### 2.3 Risk factors
+Pontiac fever risk is dominated by **environmental exposure intensity** and conditions favoring *Legionella* growth and aerosolization.
+
+**Environmental/built environment risk factors:**
+- Colonization of man-made water systems, where growth is favored by **warm temperatures, stagnation, biofilms, nutrients, and low disinfectant levels**. (sylvestre2023module16legionella pages 10-14)
+- Temperature dependence: growth favored around **25–43°C**, with an “optimal 30–40°C,” and die-off above **~60°C**. (sylvestre2023module16legionella pages 10-14)
+
+**Exposure setting risk factors (outbreak-relevant):**
+A large outbreak review (2006–2017) showed most reported Pontiac-fever outbreak cases were associated with engineered water/aerosol sources (Table 1 image). (hamilton2018outbreaksoflegionnaires’ media e7cee3af)
+
+**Host factors:**
+In the retrieved evidence, Pontiac fever is described as not strongly discriminating by age or immune status compared with Legionnaires’ disease (suggesting broader susceptibility once exposed), although rigorous comparative risk estimates were not available. (currie2023theecologyof pages 17-20)
+
+### 2.4 Protective factors
+Protective factors were not directly quantified for Pontiac fever in the retrieved literature. Preventive measures are largely environmental (see Prevention section). (sylvestre2023module16legionella pages 10-14)
+
+### 2.5 Gene–environment interactions
+No host genetic susceptibility loci, causal variants, or modifier genes were identified in the retrieved evidence; Pontiac fever is best supported here as an **environmentally acquired infectious syndrome**. (currie2023theecologyof pages 17-20, graham2024astudyofa pages 134-137)
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotype (symptoms/signs)
+Pontiac fever typically presents as an **influenza-like illness** with:
+- **Fever** (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6)
+- **Headache** (sylvestre2023module16legionella pages 10-14, currie2023theecologyof pages 17-20, khairullah2025legionnaires’diseasea pages 4-6)
+- **Myalgia/muscle aches** (sylvestre2023module16legionella pages 10-14, currie2023theecologyof pages 17-20, khairullah2025legionnaires’diseasea pages 4-6)
+- **Malaise/lethargy** (currie2023theecologyof pages 17-20, khairullah2025legionnaires’diseasea pages 4-6)
+- **Dry cough** (reported in building-water guidance) (sylvestre2023module16legionella pages 10-14)
+
+### 3.2 Phenotype characteristics
+- **Age at onset:** typically adult in outbreak reports, but the syndrome itself is not presented as age-restricted in the retrieved evidence. (currie2023theecologyof pages 17-20)
+- **Severity:** usually mild/moderate. (sylvestre2023module16legionella pages 10-14, piedade2020analysisoflegionellas pages 30-33)
+- **Progression:** acute, self-limited; not progressive. (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6)
+- **Frequency among exposed:** high attack rate is a distinguishing feature in outbreaks (see statistics below). (currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33)
+
+### 3.3 Timing
+- **Incubation period:** often **~24–48 hours**, or broadly “hours to several days.” (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, piedade2020analysisoflegionellas pages 30-33)
+- **Duration:** typically **2–5 days**, with most recovering “within a week.” (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, piedade2020analysisoflegionellas pages 30-33)
+
+### 3.4 Quality of life impact
+No validated quality-of-life metrics (e.g., EQ-5D, SF-36) specific to Pontiac fever were identified in the retrieved evidence. (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+### 3.5 Suggested HPO terms (phenotype ontology)
+Suggested mapping (terms provided as suggestions; IDs not validated within this tool run):
+- Fever (HP:0001945)
+- Headache (HP:0002315)
+- Myalgia (HP:0003326)
+- Malaise/Fatigue (HP:0012378 / HP:0012378-like)
+- Cough (HP:0012735)
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes and pathogenic variants
+Not applicable based on retrieved evidence. Pontiac fever is not supported here as a Mendelian/genetic disorder, and no host causal gene/variant associations were identified. (currie2023theecologyof pages 17-20, graham2024astudyofa pages 134-137)
+
+### 4.2 Pathogen-side molecular context (relevant to diagnostics and surveillance)
+A major molecular diagnostic limitation is that the commonly used **urinary antigen test (UAT)** detects only ***L. pneumophila* serogroup 1**, creating a “blind spot” for other species/serogroups that can cause legionellosis and potentially Pontiac-fever outbreaks. (hamilton2018outbreaksoflegionnaires’ pages 2-4, graham2024astudyofa pages 134-137)
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Environmental factors
+Key environmental factors include colonization of **engineered water systems** and conditions enabling aerosol generation.
+- Reservoirs and sources include cooling towers, hot tubs/spas, fountains, and building water distribution systems. (sylvestre2023module16legionella pages 10-14, hamilton2018outbreaksoflegionnaires’ pages 2-4)
+- *Legionella* ecology includes natural aquatic habitats and association with **biofilms** and likely protozoan hosts (not fully elaborated for PF in this evidence set). (sylvestre2023module16legionella pages 10-14, currie2023theecologyof pages 20-23)
+
+### 5.2 Lifestyle factors
+No direct lifestyle risk factors for Pontiac fever were quantified in the retrieved evidence; lifestyle risks are more often discussed for Legionnaires’ disease (e.g., smoking), not specifically for PF. (khairullah2025legionnaires’diseasea pages 2-3)
+
+### 5.3 Infectious agents
+- *Legionella* spp., including *L. pneumophila* and non-*pneumophila* species (see Etiology). (currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Current mechanistic understanding
+A mechanistic hypothesis described in a 2023 ecology-focused review distinguishes Pontiac fever from Legionnaires’ disease: Pontiac fever may represent a **hypersensitivity/inflammatory response** to an “unknown bacterial/amoebal-host component,” rather than an invasive infection with intracellular replication typical of Legionnaires’ disease. (currie2023theecologyof pages 17-20)
+
+### 6.2 Causal chain (trigger → symptoms)
+1. **Upstream trigger:** aerosol exposure to *Legionella*-containing droplets from colonized water systems (cooling towers, spas, etc.). (sylvestre2023module16legionella pages 10-14, hamilton2018outbreaksoflegionnaires’ pages 2-4)
+2. **Intermediate steps:** short incubation (often 24–48 h) consistent with a brisk inflammatory response. (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6)
+3. **Downstream manifestation:** systemic flu-like symptoms (fever, headache, myalgia, malaise), typically without pneumonia and self-resolving. (sylvestre2023module16legionella pages 10-14, piedade2020analysisoflegionellas pages 30-33)
+
+### 6.3 Suggested GO and CL terms (mechanism annotation)
+Suggested (not validated in this run):
+- GO:0006954 inflammatory response
+- GO:0006955 immune response
+- GO:0032496 response to lipopolysaccharide (relevant for Gram-negative exposures, hypothesis-level)
+- CL:0000540 macrophage (relevant in legionellosis generally; PF-specific cell evidence not identified) (currie2023theecologyof pages 17-20)
+
+---
+
+## 7. Anatomical Structures Affected
+
+Pontiac fever is primarily a **systemic febrile illness** after respiratory exposure; unlike Legionnaires’ disease it is **non-pneumonic**.
+- Primary system involved: **respiratory exposure route** (inhalation of aerosols), with systemic symptoms. (sylvestre2023module16legionella pages 10-14, piedade2020analysisoflegionellas pages 30-33)
+- Suggested UBERON terms (not validated in this run): lung (UBERON:0002048) as exposure/portal; respiratory tract (UBERON:0000065).
+
+---
+
+## 8. Temporal Development
+
+- **Onset pattern:** acute (sylvestre2023module16legionella pages 10-14)
+- **Typical incubation:** ~24–48 h (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6)
+- **Course:** self-limited, typically resolves in 2–5 days or within ~1 week (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, piedade2020analysisoflegionellas pages 30-33)
+- **Remission:** spontaneous (sylvestre2023module16legionella pages 10-14, piedade2020analysisoflegionellas pages 30-33)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology and outbreak statistics
+Pontiac fever is mainly characterized in the literature through outbreaks; surveillance and case definitions are inconsistent.
+
+**No universal case definition:** A major outbreak review states that “there is currently no agreed-upon case definition for Pontiac fever.” (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+**Outbreak burden (2006–2017):** A review of outbreaks reported **725 Pontiac fever cases** in the period 2006–2017. (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+**Outbreak sources:** The same review provides source-specific totals, showing Pontiac-fever cases were mostly associated with pools/spas and aerosol-generating systems; these data are summarized in Table 1 (image). (hamilton2018outbreaksoflegionnaires’ media e7cee3af)
+
+**Attack rate:** Pontiac fever is described as having a **very high attack rate** in outbreak settings, reported “up to 100% of those exposed,” and another review excerpt cites PF sources where “>90% become ill” contrasted with LD sources “<5%.” (currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33)
+
+### 9.2 Demographics (from administrative datasets)
+PF-specific demographic statistics are sparse; however, legionellosis hospitalization datasets provide context:
+- **US Medicare hospitalization case-crossover study (1999–2020):** 37,883 legionellosis hospitalizations (after exclusions), 58% male, median age 73 (range 13–106); authors caution that few PF-only cases existed in this dataset, limiting PF-specific inference. (wade2024weatherconditionsand pages 2-3)
+- **Poland hospital morbidity analysis (2008–2015):** 84 first-time hospitalizations coded as A48.1/A48.2, more frequent in men and urban residents; mean hospital stay 14.68 days (this largely reflects hospitalized legionellosis, not necessarily typical PF). (kosinska2018useofhospital pages 1-2)
+
+### 9.3 Inheritance
+Not applicable (infectious disease; no genetic inheritance pattern identified). (currie2023theecologyof pages 17-20)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical approach
+Pontiac fever is often diagnosed by:
+- compatible clinical syndrome (acute flu-like illness, no pneumonia),
+- short incubation after a shared exposure,
+- and outbreak linkage to *Legionella*-contaminated sources. (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+### 10.2 Laboratory testing
+Tests used in legionellosis outbreak investigations include:
+- **Urinary antigen test (UAT)** (limited to *L. pneumophila* serogroup 1) (hamilton2018outbreaksoflegionnaires’ pages 2-4, graham2024astudyofa pages 134-137)
+- **Serology** (e.g., IFA/ELISA) (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+- **Culture** (may have poor sensitivity) (graham2024astudyofa pages 134-137)
+- **PCR/NAAT** (broader detection; increasing adoption) (currie2023theecologyof pages 20-23, graham2024astudyofa pages 134-137)
+
+Diagnostic blind spot: reliance on UAT biases detection toward *L. pneumophila* serogroup 1 and may under-detect non-*pneumophila* species that can be associated with Pontiac fever. (currie2023theecologyof pages 20-23, graham2024astudyofa pages 134-137)
+
+### 10.3 Environmental testing
+Environmental sampling and linkage of clinical and environmental isolates is a common outbreak method; one outbreak review reported matching of clinical and environmental isolates in ~35% of outbreaks. (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+---
+
+## 11. Outcome / Prognosis
+
+Pontiac fever is typically **self-resolving** and **not associated with mortality** in the retrieved evidence. (piedade2020analysisoflegionellas pages 30-33)
+
+---
+
+## 12. Treatment
+
+### 12.1 Standard care
+Pontiac fever generally requires **supportive/symptomatic care only**, and “most affected people recover within a week and usually do not require medical treatment.” (sylvestre2023module16legionella pages 10-14, piedade2020analysisoflegionellas pages 30-33)
+
+### 12.2 Antibiotics
+Antibiotics (e.g., macrolides, fluoroquinolones) are commonly discussed for Legionnaires’ disease and severe legionellosis; their routine use for typical Pontiac fever is not supported in the retrieved evidence, given self-limited course. (hongUnknownyearthebodysystem pages 12-21, piedade2020analysisoflegionellas pages 30-33)
+
+### 12.3 Suggested MAXO terms (treatment/prevention action ontology)
+Suggested (not validated in this run):
+- Supportive care (MAXO:0000747-like)
+- Symptomatic treatment (MAXO:0000746-like)
+- Environmental disinfection / water system remediation (MAXO terms likely exist but not retrieved here)
+
+---
+
+## 13. Prevention
+
+Prevention of Pontiac fever aligns with prevention of legionellosis generally and is centered on **water management and aerosol source control**.
+
+### 13.1 Primary prevention (built environment)
+A 2023 guide for building managers/operators emphasizes that *Legionella* colonizes engineered water systems and that growth is promoted by warm temperatures, biofilms, stagnation, and low disinfectant levels; controlling these conditions is fundamental to prevention. (sylvestre2023module16legionella pages 10-14)
+
+Practical control levers include:
+- **Temperature control** (keeping hot water sufficiently hot; thresholds discussed in environmental contexts) (sylvestre2023module16legionella pages 10-14)
+- **Reducing stagnation** and maintaining flow (sylvestre2023module16legionella pages 10-14)
+- **Biofilm control** and maintaining disinfectant residuals (sylvestre2023module16legionella pages 10-14)
+
+### 13.2 Secondary/tertiary prevention (outbreak response)
+Outbreak investigations commonly use clinical case finding plus environmental investigation and targeted remediation of implicated sources (e.g., cooling towers/spas) as documented in outbreak-review contexts. (hamilton2018outbreaksoflegionnaires’ pages 2-4)
+
+---
+
+## 14. Other Species / Natural Disease
+
+No naturally occurring Pontiac-fever syndrome in non-human species was identified in the retrieved evidence. (currie2023theecologyof pages 17-20)
+
+---
+
+## 15. Model Organisms
+
+Pontiac-fever–specific experimental models were not identified in the retrieved evidence. However, *Legionella* research broadly uses host–pathogen systems (e.g., protozoa and mammalian phagocytes) to study mechanisms of infection and host interaction; PF-specific translation of these models was not established in the retrieved set. (currie2023theecologyof pages 17-20)
+
+---
+
+## Recent developments and latest research (prioritizing 2023–2024)
+
+1. **Surveillance and coding improvements:** A 2024 New Zealand analysis explicitly uses ICD-10 coding (A48.1/A48.2) and discusses diagnostic evolution and limitations of culture and urinary antigen testing, with increasing use of NAAT/PCR; this is directly relevant to recognizing under-detected, non-pneumonic presentations such as Pontiac fever. (graham2024astudyofa pages 134-137, graham2024astudyof pages 134-137)
+2. **Weather/climate associations (context for legionellosis trends):** A large 2024 US Medicare analysis (37,883 hospitalizations) links precipitation/humidity to legionellosis hospitalization risk at lags consistent with incubation; while not PF-specific, it supports the broader environmental sensitivity of *Legionella* disease risk. (wade2024weatherconditionsand pages 2-3)
+3. **Built-environment implementation guidance (2023):** Practical building water system control guidance provides operationally relevant parameters (growth temperature ranges; system types implicated) and provides accessible definitions of Pontiac fever for non-clinical stakeholders managing risk. (sylvestre2023module16legionella pages 10-14)
+
+---
+
+## Key quantitative data highlights
+- **Incubation:** typically **24–48 h** (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6)
+- **Duration:** typically **2–5 days**, recovery often within **~1 week** (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, piedade2020analysisoflegionellas pages 30-33)
+- **Attack rate:** reported **>90%** to **up to 100%** among exposed in some outbreak contexts (currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33)
+- **Outbreak cases (2006–2017 review):** **725 PF cases**, with many linked to pools/spas and cooling towers (hamilton2018outbreaksoflegionnaires’ pages 2-4, hamilton2018outbreaksoflegionnaires’ media e7cee3af)
+- **ICD-10 code:** **A48.2** (Pontiac fever) (graham2024astudyofa pages 134-137, kosinska2018useofhospital pages 1-2)
+
+---
+
+## Evidence summary table
+| Domain | Key points | Quantitative/statistical data | Key sources (with citation ids) | URLs/publication dates if in evidence |
+|---|---|---|---|---|
+| Definition / current understanding | Pontiac fever is the non-pneumonic, acute, self-limited influenza-like form of legionellosis caused by Legionella spp.; unlike Legionnaires’ disease, pneumonia is absent. Recognition is often outbreak-based because mild cases may be missed. | Illness duration usually 2–5 days or recovery within about 1 week; no mortality typically expected in uncomplicated cases. | (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, currie2023theecologyof pages 20-23, piedade2020analysisoflegionellas pages 30-33) | Sylvestre & Julian, 2023; Khairullah et al., Mar 2025, https://doi.org/10.14202/ijoh.2025.62-77; Piedade, 2020 |
+| Identifiers / codes | Standardized coding is available at the disease-group level as non-pneumonic legionellosis. ICD-10 code A48.2 is used for Pontiac fever; ICD-10 A48.1 is Legionnaires’ disease. Earlier ICD-9 datasets often lacked a distinct PF code, complicating surveillance. No explicit ICD-11 or MeSH identifier was found in the retrieved evidence. | ICD-10: A48.2 (Pontiac fever); A48.1 (Legionnaires’ disease). | (graham2024astudyofa pages 134-137, wade2024weatherconditionsand pages 2-3, kosinska2018useofhospital pages 1-2) | Wade & Herbert, Oct 2024, https://doi.org/10.1017/S0950268824000979; Kosińska et al., Dec 2018, https://doi.org/10.26444/monz/101676 |
+| Clinical characteristics | Typical symptoms include fever, headache, myalgia, malaise/lethargy, and often dry cough; disease is mild to moderate and self-resolving. | Average incubation 24–48 h; can be described more broadly as hours to several days; symptoms usually last 2–5 days, with most recovering within 1 week. | (sylvestre2023module16legionella pages 10-14, currie2023theecologyof pages 17-20, khairullah2025legionnaires’diseasea pages 4-6, piedade2020analysisoflegionellas pages 30-33) | Sylvestre & Julian, 2023; Khairullah et al., Mar 2025, https://doi.org/10.14202/ijoh.2025.62-77; Piedade, 2020 |
+| Attack rate / severity | PF is epidemiologically distinct from Legionnaires’ disease by its very high attack rate and low severity; many exposed persons may become ill, but illness is usually not life-threatening. | Attack rate reported as up to 100% among exposed persons; CDC-sourced comparison cited in one review: PF sources >90% ill vs LD sources <5%. | (currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33) | Currie, 2023; Piedade, 2020 |
+| Etiology / infectious agents | Caused by Legionella species; L. pneumophila is the dominant species overall, but PF outbreaks have also involved non-pneumophila species. Reported PF-associated species include L. anisa, L. micdadei, L. feeleii, and L. longbeachae. | Legionella genus noted as >72 species overall; at least 30 species known to cause human infection; most reported human cases attributed to L. pneumophila. | (sylvestre2023module16legionella pages 10-14, currie2023theecologyof pages 17-20, piedade2020analysisoflegionellas pages 30-33, hamilton2018outbreaksoflegionnaires’ pages 2-4) | Sylvestre & Julian, 2023; Hamilton et al., May 2018, https://doi.org/10.1007/s40572-018-0201-4 |
+| Exposure sources / real-world settings | Exposure is primarily environmental through inhalation of contaminated aerosols from engineered water systems; non-pneumophila disease can also follow exposure to soil/compost or dust. Common sources include cooling towers, pools/spas/hot tubs, fountains, potable building water systems, wastewater systems, and gardening/potting soils for L. longbeachae. No person-to-person transmission evidence was identified in the retrieved PF-focused evidence. | Outbreak review 2006–2017 recorded PF cases by source: pools/spas 433; cooling towers/AC/evaporative condensers 146; non-potable water systems 139; potable/building water systems 7. | (sylvestre2023module16legionella pages 10-14, khairullah2025legionnaires’diseasea pages 4-6, currie2023theecologyof pages 20-23, hamilton2018outbreaksoflegionnaires’ pages 2-4, hamilton2018outbreaksoflegionnaires’ media e7cee3af) | Hamilton et al., May 2018, https://doi.org/10.1007/s40572-018-0201-4; Sylvestre & Julian, 2023 |
+| Environmental growth factors | Legionella is naturally aquatic and colonizes man-made water systems; growth is promoted by warm water, stagnation, biofilms, nutrients, and inadequate disinfectant residuals. | Growth favored at 25–43°C; optimal 30–40°C; die-off above 60°C. Warm-water reservoir often described as 25–40°C. | (sylvestre2023module16legionella pages 10-14, hongUnknownyearthebodysystem pages 12-21) | Sylvestre & Julian, 2023 |
+| Pathophysiology / expert analysis | Evidence supports PF as a host inflammatory/hypersensitivity-like response to Legionella or amoebal-host components rather than the invasive intracellular replication pattern typical of Legionnaires’ disease. This explains short incubation, high attack rate, and absence of pneumonia. | Qualitative rather than numeric; proposed mechanism distinguishes PF from LD. | (currie2023theecologyof pages 17-20) | Currie, 2023 |
+| Epidemiology / burden | PF is underrecognized because surveillance emphasizes pneumonia and urinary antigen testing; sporadic PF is likely substantially underdetected. Outbreak summaries provide the clearest counts. | International outbreak review (2006–2017): 725 PF cases identified; no universally agreed PF case definition noted in that review. | (hamilton2018outbreaksoflegionnaires’ pages 2-4, hamilton2018outbreaksoflegionnaires’ media e7cee3af) | Hamilton et al., May 2018, https://doi.org/10.1007/s40572-018-0201-4 |
+| Demographics / distribution | Legionellosis overall shows male predominance, older age skew for hospitalization datasets, summer seasonality, and urban concentration in some datasets; PF-specific demographic data are much sparser. | Medicare legionellosis hospital dataset: 37,883 cases after exclusions, 58% male, median age 73 years; Poland hospital dataset: 84 first-time hospitalizations with male and urban predominance and summer peak. | (wade2024weatherconditionsand pages 2-3, kosinska2018useofhospital pages 1-2) | Wade & Herbert, Oct 2024, https://doi.org/10.1017/S0950268824000979; Kosińska et al., Dec 2018, https://doi.org/10.26444/monz/101676 |
+| Diagnostics | PF diagnosis is mainly clinical plus exposure/outbreak context; tests used across legionellosis investigations include urinary antigen testing, serology, culture, PCR/NAAT, and epidemiologic linkage. UAT is a major surveillance blind spot because it detects only L. pneumophila serogroup 1. PCR/culture improve breadth of detection; PF may be missed if only UAT is used. | UAT used in 88.6% of European legionellosis cases in one cited discussion; PCR implementation associated with a fourfold increase in detection in one review excerpt. Matching clinical/environmental isolates occurred in ~35% of outbreaks. | (currie2023theecologyof pages 17-20, currie2023theecologyof pages 20-23, hamilton2018outbreaksoflegionnaires’ pages 2-4, graham2024astudyofa pages 134-137) | Hamilton et al., May 2018, https://doi.org/10.1007/s40572-018-0201-4; Wade & Herbert, Oct 2024, https://doi.org/10.1017/S0950268824000979 |
+| Case definitions | There is no universally agreed PF case definition in the outbreak review literature; surveillance case definitions have evolved over time and differ by jurisdiction. | Review explicitly states no agreed-upon PF case definition; NZ surveillance criteria historically relied on serology, DFA, or isolation. | (hamilton2018outbreaksoflegionnaires’ pages 2-4, graham2024astudyofa pages 81-84) | Hamilton et al., May 2018, https://doi.org/10.1007/s40572-018-0201-4 |
+| Treatment / management | Standard management is supportive/symptomatic care; most patients do not require specific antimicrobial therapy. Antibiotics listed in legionellosis guidance (macrolides, fluoroquinolones) are mainly for Legionnaires’ disease or severe invasive infection rather than typical PF. | Recovery without treatment is typical; supportive care only in uncomplicated PF. | (sylvestre2023module16legionella pages 10-14, currie2023theecologyof pages 20-23, piedade2020analysisoflegionellas pages 30-33) | Sylvestre & Julian, 2023; Piedade, 2020 |
+| Prevention / public health implementation | Prevention focuses on source control in building and environmental water systems: water management programs, temperature control, minimizing stagnation, biofilm control, maintaining disinfectant residuals, regular monitoring, corrective actions during outbreaks, and special attention to high-risk sources such as pools/spas, cooling towers, hot-water systems, and wastewater processes. For L. longbeachae risk, avoiding inhalation of dust/aerosols from potting soil/compost and use of masks/gloves are advised, though effectiveness evidence is limited. | Facilities without water management programs accounted for 72% of LD cases and 81% of fatalities in one CDC-led outbreak root-cause analysis (legionellosis control relevance). Tap temperatures >54°C and central tank temperatures >59°C were associated with lower Legionella levels in one recent school-water study. | (sylvestre2023module16legionella pages 10-14, hongUnknownyearthebodysystem pages 12-21, currie2023theecologyof pages 20-23) | Sylvestre & Julian, 2023; Nielsen et al., Oct 2024, https://doi.org/10.3390/microorganisms12102074 |
+| Recent developments (2023–2024) | Recent work emphasizes environmental surveillance, broader molecular diagnostics beyond UAT, climate/weather associations, and built-environment risk modeling. These developments are directly relevant to PF recognition because PF is often missed in pneumonia-centered surveillance systems. | 2024 Medicare weather study: 37,883 legionellosis hospitalizations; precipitation at lag day 10 OR 1.08 (95% CI 1.05–1.11) per 1 cm; over 20 days, 3 cm precipitation increased odds >4-fold for legionellosis hospitalizations. | (wade2024weatherconditionsand pages 2-3, graham2024astudyof pages 134-137) | Wade & Herbert, Oct 2024, https://doi.org/10.1017/S0950268824000979; Graham, 2024 |
+| Data limitations | Many PF data derive from aggregated outbreak investigations rather than individual patient-level natural history cohorts; PF-specific prevalence/incidence, QoL, genetic susceptibility, biomarkers, and formal ontology mappings were not available in the retrieved evidence. | Surveillance underascertainment likely substantial because mild cases may not seek care and UAT misses many non-LpSG1 infections. | (currie2023theecologyof pages 17-20, hamilton2018outbreaksoflegionnaires’ pages 2-4, graham2024astudyofa pages 134-137) | Hamilton et al., May 2018, https://doi.org/10.1007/s40572-018-0201-4; Graham, 2024 |
+
+
+*Table: This table consolidates the most actionable evidence on Pontiac fever across clinical presentation, coding, causative species, exposure settings, diagnostics, management, prevention, and recent epidemiologic findings. It is useful as a compact knowledge-base-ready summary grounded in the cited evidence contexts.*
+
+---
+
+## Supporting visual evidence
+A key summary table of outbreak sources and case counts (Pontiac fever and Legionnaires’ disease, 2006–2017) is provided as a cropped figure. (hamilton2018outbreaksoflegionnaires’ media e7cee3af)
+
+References
+
+1. (graham2024astudyofa pages 134-137): FF Graham. A study of legionellosis epidemiology and alternative environmental risk factors for the disease in new zealand. Unknown journal, 2024.
+
+2. (sylvestre2023module16legionella pages 10-14): É Sylvestre and TR Julian. Module 16 legionella control in building water systems: a guide for building managers and operators. Unknown journal, 2023.
+
+3. (khairullah2025legionnaires’diseasea pages 4-6): Aswin Rafif Khairullah, Harimurti Nuradji, Diana Nurjanah, Ni Luh Putu Indi Dharmayanti, Bantari Wisynu Kusuma Wardhani, Syahputra Wibowo, Ikechukwu Benjamin Moses, Dea Anita Ariani Kurniasih, Ima Fauziah, Muhammad Khaliim Jati Kusala, and Kartika Afrida Fauzia. Legionnaires’ disease: a review of emerging public health threats. International Journal of One Health, pages 62-77, Mar 2025. URL: https://doi.org/10.14202/ijoh.2025.62-77, doi:10.14202/ijoh.2025.62-77. This article has 2 citations.
+
+4. (piedade2020analysisoflegionellas pages 30-33): SBL Piedade. Analysis of legionella's presence and concentration in water systems control. Unknown journal, 2020.
+
+5. (currie2023theecologyof pages 20-23): S Currie. The ecology of legionella spp in compost. Unknown journal, 2023.
+
+6. (hamilton2018outbreaksoflegionnaires’ pages 2-4): K. A. Hamilton, A. J. Prussin, W. Ahmed, and C. N. Haas. Outbreaks of legionnaires’ disease and pontiac fever 2006–2017. Current Environmental Health Reports, 5:263-271, May 2018. URL: https://doi.org/10.1007/s40572-018-0201-4, doi:10.1007/s40572-018-0201-4. This article has 118 citations and is from a peer-reviewed journal.
+
+7. (kosinska2018useofhospital pages 1-2): Irena Kosińska, Aneta Nitsch-Osuch, Krzysztof Kanecki, Paweł Goryński, and Piotr Tyszko. Use of hospital morbidity data in an epidemiological analysis of diseases caused by legionella pneumophila. Medycyna Ogólna i Nauki o Zdrowiu, 24:251-256, Dec 2018. URL: https://doi.org/10.26444/monz/101676, doi:10.26444/monz/101676. This article has 2 citations.
+
+8. (wade2024weatherconditionsand pages 2-3): Timothy J. Wade and Carly Herbert. Weather conditions and legionellosis: a nationwide case-crossover study among medicare recipients. Epidemiology and Infection, Oct 2024. URL: https://doi.org/10.1017/s0950268824000979, doi:10.1017/s0950268824000979. This article has 7 citations and is from a peer-reviewed journal.
+
+9. (currie2023theecologyof pages 17-20): S Currie. The ecology of legionella spp in compost. Unknown journal, 2023.
+
+10. (hamilton2018outbreaksoflegionnaires’ media e7cee3af): K. A. Hamilton, A. J. Prussin, W. Ahmed, and C. N. Haas. Outbreaks of legionnaires’ disease and pontiac fever 2006–2017. Current Environmental Health Reports, 5:263-271, May 2018. URL: https://doi.org/10.1007/s40572-018-0201-4, doi:10.1007/s40572-018-0201-4. This article has 118 citations and is from a peer-reviewed journal.
+
+11. (khairullah2025legionnaires’diseasea pages 2-3): Aswin Rafif Khairullah, Harimurti Nuradji, Diana Nurjanah, Ni Luh Putu Indi Dharmayanti, Bantari Wisynu Kusuma Wardhani, Syahputra Wibowo, Ikechukwu Benjamin Moses, Dea Anita Ariani Kurniasih, Ima Fauziah, Muhammad Khaliim Jati Kusala, and Kartika Afrida Fauzia. Legionnaires’ disease: a review of emerging public health threats. International Journal of One Health, pages 62-77, Mar 2025. URL: https://doi.org/10.14202/ijoh.2025.62-77, doi:10.14202/ijoh.2025.62-77. This article has 2 citations.
+
+12. (hongUnknownyearthebodysystem pages 12-21): A Hong. The body system in legionellosis. Unknown journal, Unknown year.
+
+13. (graham2024astudyof pages 134-137): FF Graham. A study of legionellosis epidemiology and alternative environmental risk factors for the disease in new zealand. Unknown journal, 2024.
+
+14. (graham2024astudyofa pages 81-84): FF Graham. A study of legionellosis epidemiology and alternative environmental risk factors for the disease in new zealand. Unknown journal, 2024.

--- a/research/Pontiac_Fever-deep-research-falcon.md.citations.md
+++ b/research/Pontiac_Fever-deep-research-falcon.md.citations.md
@@ -1,0 +1,470 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Pontiac Fever
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Pontiac Fever** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T18:34:55.281502
+
+1. graham2024astudyofa pages 134-137
+2. kosinska2018useofhospital pages 1-2
+3. currie2023theecologyof pages 17-20
+4. wade2024weatherconditionsand pages 2-3
+5. piedade2020analysisoflegionellas pages 30-33
+6. currie2023theecologyof pages 20-23
+7. graham2024astudyof pages 134-137
+8. graham2024astudyofa pages 81-84
+9. https://doi.org/10.14202/ijoh.2025.62-77;
+10. https://doi.org/10.1017/S0950268824000979;
+11. https://doi.org/10.26444/monz/101676
+12. https://doi.org/10.1007/s40572-018-0201-4
+13. https://doi.org/10.1007/s40572-018-0201-4;
+14. https://doi.org/10.1017/S0950268824000979
+15. https://doi.org/10.3390/microorganisms12102074
+16. https://doi.org/10.14202/ijoh.2025.62-77,
+17. https://doi.org/10.1007/s40572-018-0201-4,
+18. https://doi.org/10.26444/monz/101676,
+19. https://doi.org/10.1017/s0950268824000979,


### PR DESCRIPTION
## Summary

Adds a new DISMECH disorder page for Pontiac fever (MONDO:0020487), including:

- Falcon deep-research artifacts and citation mapping.
- MONDO, HPO, GO, NCBITaxon, NCIT term bindings where validated.
- Evidence-backed definitions, infectious agent, transmission, environmental factors, pathophysiology, phenotypes, progression, epidemiology, diagnostics, treatment, and differential diagnosis.
- PubMed reference cache files generated with `just fetch-reference`.

## Validation

| Command | Result |
| --- | --- |
| `just validate kb/disorders/Pontiac_Fever.yaml` | Passed |
| `just validate-references kb/disorders/Pontiac_Fever.yaml` | Passed |
| `just check-reference-cache-frontmatter` | Passed |
| `just qc-deep-research --target-providers falcon --only Pontiac_Fever` | Passed with zero missing refs/found_in links |
| Local normalized snippet audit | 46/46 snippets found in fetched reference caches |

## Notes

- Unrelated validation-generated `cache/` and clinical-trial cache churn was restored before push.
- Pontiac fever-specific animal models, clinical trials, and inherited/genetic mechanisms were not identified in the Falcon report or PubMed follow-up.