### PR TITLE
Improve peroxisome biogenesis disorder pathograph

### DIFF
--- a/kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
+++ b/kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
@@ -1,6 +1,6 @@
 name: Peroxisome Biogenesis Disorder
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-02-17T21:53:14Z'
+updated_date: '2026-05-06T22:59:14Z'
 category: Genetic
 parents:
 - Inborn Error of Metabolism
@@ -39,7 +39,8 @@ inheritance:
     reference_title: "[Peroxisomal hereditary diseases]."
     supports: SUPPORT
     snippet: With the exception of X-bound adrenoleukodystrophy, all diseases
-      are based on autosomally recessive type of inheritance...
+      are based on autosomally recessive type of inheritance and a majority of
+      them are characteristic by specific neurologic symptoms.
     explanation: This reference also confirms the autosomal recessive
       inheritance of peroxisomal diseases, including PBDs.
 pathophysiology:
@@ -77,7 +78,9 @@ pathophysiology:
     supports: SUPPORT
     snippet: Peroxisome biogenesis factor 10 (PEX10) is involved in the import
       of peroxisomal matrix proteins, and the mutation of this gene causes 3
-      subtypes of peroxisome biogenesis disorders...
+      subtypes of peroxisome biogenesis disorders, namely Zellweger syndrome
+      (severe), neonatal adrenoleukodystrophy (moderate) and an ataxic form
+      (mild).
     explanation: The reference details how mutations in PEX10 affect peroxisomal
       import, aligning with the statement's assertion about disrupted peroxisome
       function.
@@ -109,6 +112,19 @@ pathophysiology:
     explanation: This reference illustrates the role of PEX genes in peroxisomal
       disorders, supporting the claim of their involvement in cellular and
       metabolic disruption.
+  downstream:
+  - target: Impaired Peroxisome Biogenesis and Import
+    causal_link_type: DIRECT
+    description: PEX-gene defects disrupt assembly and import machinery needed for functional peroxisomes.
+  - target: Peroxisome-Organelle Crosstalk Disruption
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Loss of functional peroxisomes disrupts lipid handling and contacts with ER and mitochondria.
+  - target: Microglial Dysfunction and Neuroinflammation
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Peroxisomal defects in CNS-resident microglia promote lipid-stress and inflammatory phenotypes.
+  - target: Multisystem Involvement
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Global peroxisome dysfunction affects development and metabolic homeostasis across organ systems.
 - name: Accumulation of Toxic Metabolites
   description: The inability to break down very long-chain fatty acids (VLCFAs)
     and other compounds leads to their accumulation in tissues.
@@ -160,6 +176,17 @@ pathophysiology:
     explanation: This reference supports the accumulation of bile acid
       intermediates in peroxisomal disorders but does not mention VLCFAs or
       phytanic acid.
+  downstream:
+  - target: Very Long Chain Fatty Acids (VLCFA)
+    causal_link_type: DIRECT
+  - target: Bile Acid Intermediates
+    causal_link_type: DIRECT
+  - target: Hepatic Dysfunction
+    causal_link_type: DIRECT
+    description: Accumulated bile-acid intermediates and VLCFAs contribute to liver pathology in peroxisomal disorders.
+  - target: Neurological Dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Accumulated peroxisomal lipid metabolites contribute to CNS lipid imbalance and neurodegeneration.
 - name: Deficiency of Essential Compounds
   description: Impaired synthesis of plasmalogens and other essential compounds
     disrupts normal cellular functions.
@@ -212,6 +239,18 @@ pathophysiology:
     explanation: The abstract confirms that peroxisomes are crucial for the
       synthesis of plasmalogens and that their dysfunction could disrupt normal
       cellular functions.
+  downstream:
+  - target: Plasmalogens
+    causal_link_type: DIRECT
+  - target: Neurological Dysfunction
+    causal_link_type: DIRECT
+    description: Plasmalogen and ether-lipid deficiency impairs CNS myelin and neuronal lipid homeostasis.
+  - target: Skeletal Abnormalities
+    causal_link_type: DIRECT
+    description: Plasmalogen deficiency is linked to chondrodysplasia punctata and abnormal skeletal development.
+  - target: Retinal Pigment Epithelium Dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Retinal lipid remodeling reflects deficient ether-lipid and plasmalogen metabolism.
 - name: Neurological Dysfunction
   locations:
   - preferred_term: central nervous system
@@ -277,6 +316,15 @@ pathophysiology:
       peroxisomal dysfunction but does not specifically describe demyelination
       and neuronal migration defects. Partial support is given as it indicates a
       broad CNS impact.
+  downstream:
+  - target: Hypotonia
+    causal_link_type: DIRECT
+  - target: Developmental Delay
+    causal_link_type: DIRECT
+  - target: Seizures
+    causal_link_type: DIRECT
+  - target: Leukodystrophy
+    causal_link_type: DIRECT
 - name: Hepatic Dysfunction
   locations:
   - preferred_term: liver
@@ -322,8 +370,9 @@ pathophysiology:
   - reference: PMID:8729109
     reference_title: "Very long-chain fatty acids in diagnosis, pathogenesis, and therapy of peroxisomal disorders."
     supports: SUPPORT
-    snippet: Abnormally high levels of very long-chain fatty acids (VLCFA) are a
-      feature in...peroxisomal disorders.
+    snippet: Abnormally high levels of very long-chain fatty acids (VLCFA) are
+      a feature in nine of the fifteen peroxisomal disorders that have been
+      identified so far.
     explanation: Supports the accumulation of VLCFAs as part of the
       pathophysiology.
   - reference: PMID:17682975
@@ -334,6 +383,14 @@ pathophysiology:
       synthesis in infants, children, and adults.
     explanation: This reference supports the accumulation of bile acid
       intermediates, contributing to hepatic dysfunction.
+  downstream:
+  - target: Hepatomegaly
+    causal_link_type: DIRECT
+  - target: Cholestasis
+    causal_link_type: DIRECT
+  - target: Thrombocytopenia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hematologic abnormalities are modeled as secondary to severe multisystem or hepatic involvement when present.
 - name: Skeletal Abnormalities
   locations:
   - preferred_term: bones
@@ -390,6 +447,12 @@ pathophysiology:
       biosynthesis leads to skeletal abnormalities characteristic of rhizomelic
       chondrodysplasia punctata, including rhizomelic shortening of limbs and
       chondrodysplasia punctata.
+  downstream:
+  - target: Chondrodysplasia Punctata
+    causal_link_type: DIRECT
+  - target: Craniofacial Dysmorphism
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Craniofacial dysmorphism is grouped with abnormal skeletal and developmental patterning in severe presentations.
 - name: Multisystem Involvement
   description: The pervasive nature of peroxisomal dysfunction affects multiple
     organ systems, resulting in a wide range of clinical manifestations.
@@ -444,6 +507,22 @@ pathophysiology:
       and affect many organs with varying degrees of involvement.
     explanation: This source supports the statement by highlighting the
       multi-organ involvement in peroxisomal disorders.
+  downstream:
+  - target: Renal Dysfunction
+    causal_link_type: UNKNOWN
+    description: Renal involvement is connected through broad cerebro-hepato-renal multisystem disease rather than a single curated renal mechanism.
+  - target: Hearing Loss
+    causal_link_type: UNKNOWN
+    description: Hearing loss is a recurrent sensory manifestation of the multisystem PBD-ZSD spectrum.
+  - target: Adrenal Insufficiency
+    causal_link_type: UNKNOWN
+    description: Adrenal insufficiency is included as an endocrine manifestation of peroxisomal disease, with the proximal mechanism not yet separated in this graph.
+  - target: Cardiomyopathy
+    causal_link_type: UNKNOWN
+    description: Cardiac involvement remains mechanistically unresolved in this entry.
+  - target: Heart Failure
+    causal_link_type: UNKNOWN
+    description: Heart failure is retained as a downstream severe cardiac outcome where cardiomyopathy is present.
 - name: Microglial Dysfunction and Neuroinflammation
   description: Peroxisomal defects in microglial cells induce a
     disease-associated microglial (DAM) signature with altered lipid metabolism,
@@ -462,6 +541,10 @@ pathophysiology:
   notes: Recent research highlights that microglial peroxisomal defects force
     cells into a pathological phenotype that may be a key contributor to CNS
     pathogenesis in peroxisomal disorders.
+  downstream:
+  - target: Neurological Dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Microglial lipid stress and neuroinflammation contribute to CNS degeneration and neurologic manifestations.
 - name: Peroxisome-Organelle Crosstalk Disruption
   description: Disruption of peroxisome-ER-mitochondria interactions impairs
     lipid trafficking and metabolic coordination, particularly affecting VLCFA
@@ -481,6 +564,13 @@ pathophysiology:
       label: mitochondrion
   notes: ACBD5 tethers peroxisomes to ER via VAPs, facilitating lipid flux;
     disruption perturbs VLCFA and ether-lipid trafficking.
+  downstream:
+  - target: Accumulation of Toxic Metabolites
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Defective peroxisome-organelle lipid trafficking contributes to VLCFA and related lipid accumulation.
+  - target: Deficiency of Essential Compounds
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: ER-peroxisome lipid trafficking is required for normal ether-lipid and plasmalogen homeostasis.
 - name: Retinal Pigment Epithelium Dysfunction
   description: In peroxisome biogenesis disorders, retinal pigment epithelium
     shows progressive lipid remodeling with decreased plasmalogens and increased
@@ -503,6 +593,9 @@ pathophysiology:
   notes: RPE lipid changes precede structural changes and show dorsal-to-ventral
     progression in animal models. Both RPE and photoreceptors are affected by
     peroxisomal dysfunction.
+  downstream:
+  - target: Retinopathy
+    causal_link_type: DIRECT
 - name: Impaired Peroxisome Biogenesis and Import
   description: Mutations in PEX genes disrupt the peroxisomal protein import
     machinery, including PEX5/PEX7 receptors, the PEX13/PEX14 docking complex,
@@ -525,6 +618,13 @@ pathophysiology:
   notes: The import cycle involves PTS1/PTS2 cargo binding, docking,
     translocation, ubiquitination of PEX5, and AAA+ ATPase-mediated extraction
     for recycling.
+  downstream:
+  - target: Accumulation of Toxic Metabolites
+    causal_link_type: DIRECT
+    description: Failed matrix-enzyme import disables peroxisomal beta-oxidation and related catabolic pathways.
+  - target: Deficiency of Essential Compounds
+    causal_link_type: DIRECT
+    description: Failed peroxisomal assembly and import impair ether-lipid, plasmalogen, and bile-acid synthetic steps.
 phenotypes:
 - category: Neurologic
   name: Hypotonia
@@ -534,14 +634,19 @@ phenotypes:
     reference_title: "Peroxisomal disorders. Neurodevelopmental and biochemical aspects."
     supports: SUPPORT
     snippet: These disorders should be considered in the differential diagnosis
-      of the infant with hypotonia and psychomotor delay...
+      of the infant with hypotonia and psychomotor delay (especially if
+      accompanied by facial dysmorphisms, hepatomegaly, cataracts and/or
+      retinitis, calcific stippling, short limbs, or combinations of these
+      features), in the school-aged child with progressive neurologic
+      dysfunction, and in adults with slowly progressive motor dysfunction.
     explanation: The reference mentions hypotonia as a significant clinical
       feature in peroxisomal disorders.
   - reference: PMID:28320181
     reference_title: "Ataxic form of autosomal recessive PEX10-related peroxisome biogenesis disorders with a novel compound heterozygous gene mutation and characteristic clinical phenotype."
     supports: PARTIAL
-    snippet: '...suggest that these PEX10 mutations involve not only cerebellar but
-      also more multiple nervous systems...'
+    snippet: The present cases suggest that these PEX10 mutations involve not
+      only cerebellar but also more multiple nervous systems including pupillary
+      autonomic, pyramidal and extrapyramidal systems.
     explanation: While the reference primarily discusses cerebellar involvement,
       it indirectly supports the statement by implicating neurological systems
       in PEX10-related peroxisome biogenesis disorders.
@@ -550,7 +655,7 @@ phenotypes:
     supports: SUPPORT
     snippet: The floppy infant syndrome is a well-recognized entity for
       pediatricians and neonatologists. The condition refers to an infant with
-      generalized hypotonia...
+      generalized hypotonia presenting at birth or in early life.
     explanation: The reference directly supports the very frequent occurrence of
       hypotonia in infants with peroxisomal disorders.
   - reference: PMID:38409970
@@ -584,9 +689,7 @@ phenotypes:
     reference_title: "Diagnostic Odyssey in an Adult Patient with Ophthalmologic Abnormalities and Hearing Loss: Contribution of RNA-Seq to the Diagnosis of a PEX1 Deficiency."
     supports: SUPPORT
     snippet: The clinical presentation of PBDs may range from severe, lethal
-      multisystemic disorders to milder, late-onset disease. The vast majority
-      of PBDs belong to Zellweger Spectrum Disordes (ZSDs) and represents a
-      continuum of overlapping clinical symptoms.
+      multisystemic disorders to milder, late-onset disease.
     explanation: Although this does not explicitly mention developmental delay,
       the overall description implies a frequent occurrence of neurologic
       dysfunction, which is often tied to developmental delays.
@@ -664,9 +767,10 @@ phenotypes:
   - reference: PMID:26615381
     reference_title: "Early Onset Hepatocellular Disease in an Infant with Zellweger Syndrome."
     supports: NO_EVIDENCE
-    snippet: ZS is a peroxisomal disorder with a multiple congenital anomalies,
-      characterized by stereotypical facies, profound hypotonia, organ
-      involvement including cerebral, retinal, hepatic, and renal.
+    snippet: Zellweger syndrome (ZS) is a peroxisomal disorder with a multiple
+      congenital anomalies, characterized by stereotypical facies, profound
+      hypotonia, organ involvement including cerebral, retinal, hepatic, and
+      renal.
     explanation: The reference discusses organ involvement including hepatic
       involvement but does not specify hepatomegaly as frequent.
   phenotype_term:
@@ -728,7 +832,8 @@ phenotypes:
     reference_title: "A longitudinal study of retinopathy in the PEX1-Gly844Asp mouse model for mild Zellweger Spectrum Disorder."
     supports: SUPPORT
     snippet: Retinopathy leading to blindness is one of the major untreatable
-      handicaps faced by patients with ZSD but is not well characterized.
+      handicaps faced by patients with ZSD but is not well characterized, and
+      the requirement for peroxisomes in retinal health is unknown.
     explanation: The study highlights that retinopathy leading to blindness is a
       significant issue in patients with Zellweger Spectrum Disorder, a type of
       peroxisome biogenesis disorder, supporting the frequency of retinopathy as
@@ -746,7 +851,8 @@ phenotypes:
     reference_title: "A Retrospective Study of Hearing Loss in Patients Diagnosed with Peroxisome Biogenesis Disorders in the Zellweger Spectrum."
     supports: SUPPORT
     snippet: The majority of PBD-ZSD patients in this study presented with
-      moderately-severe to severe hearing loss.
+      moderately-severe to severe hearing loss and relatively slow rates of
+      longitudinal changes in hearing sensitivity.
     explanation: This study characterizes hearing loss as a common phenotype in
       patients with Peroxisome Biogenesis Disorder within the Zellweger
       Spectrum.
@@ -782,7 +888,9 @@ phenotypes:
     reference_title: "Child neurology: Zellweger syndrome."
     supports: SUPPORT
     snippet: Patients with ZS present in the neonatal period with a
-      characteristic phenotype of distinctive facial stigmata.
+      characteristic phenotype of distinctive facial stigmata, pronounced
+      hypotonia, poor feeding, hepatic dysfunction, and often seizures and boney
+      abnormalities.
     explanation: Distinctive facial stigmata can be considered a form of
       craniofacial dysmorphism, supporting the statement.
   - reference: PMID:1710072
@@ -992,7 +1100,8 @@ biochemical:
     reference_title: "Biochemical markers predicting survival in peroxisome biogenesis disorders."
     supports: SUPPORT
     snippet: A poor correlation with age at death was found for de novo
-      plasmalogen synthesis.
+      plasmalogen synthesis, C26:0/C22:0 ratio, and phytanic acid
+      alpha-oxidation.
     explanation: The study mentions that impaired plasmalogen synthesis is one
       of the biochemical markers analyzed in PBD patients.
   - reference: PMID:3460088
@@ -1161,8 +1270,9 @@ genetic:
     reference_title: "Genomic sequencing highlights the diverse molecular causes of Perrault syndrome: a peroxisomal disorder (PEX6), metabolic disorders (CLPP, GGPS1), and mtDNA maintenance/translation disorders (LARS2, TFAM)."
     supports: SUPPORT
     snippet: For the first time, we show that pathogenic variants in PEX6 can
-      present clinically as Perrault syndrome... PEX6 encodes a peroxisomal
-      biogenesis factor.
+      present clinically as Perrault syndrome. PEX6 encodes a peroxisomal
+      biogenesis factor, and we demonstrate evidence of peroxisomal dysfunction
+      in patient serum.
     explanation: Although this reference primarily discusses Perrault syndrome,
       it confirms that variants in PEX genes such as PEX6 are associated with
       peroxisomal biogenesis disorders.
@@ -1222,7 +1332,7 @@ treatments:
     supports: PARTIAL
     snippet: Despite an absence of treatment options, prompt diagnosis of
       Zellweger syndrome is important for providing appropriate symptomatic
-      care.
+      care, definitive genetic testing and prenatal counselling.
     explanation: The statement supports symptomatic care but does not detail
       specific treatments such as physical therapy for hypotonia or seizure
       management.
@@ -1231,6 +1341,10 @@ treatments:
     term:
       id: MAXO:0000011
       label: physical therapy
+  target_mechanisms:
+  - target: Neurological Dysfunction
+    treatment_effect: MODULATES
+    description: Symptomatic therapy targets neurologic manifestations such as hypotonia and seizures without correcting the upstream peroxisome defect.
 - name: Nutritional Support
   description: Specialized diet and supplements to manage biochemical
     abnormalities.
@@ -1271,6 +1385,13 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Accumulation of Toxic Metabolites
+    treatment_effect: MODULATES
+    description: Dietary modification and supplementation are intended to reduce or manage toxic metabolite burden.
+  - target: Deficiency of Essential Compounds
+    treatment_effect: MODULATES
+    description: Supplementation can address deficient products downstream of impaired peroxisomal metabolism.
 - name: Liver Transplant
   description: Considered in severe cases with significant liver dysfunction.
   evidence:
@@ -1307,6 +1428,10 @@ treatments:
     term:
       id: MAXO:0010039
       label: organ transplantation
+  target_mechanisms:
+  - target: Hepatic Dysfunction
+    treatment_effect: BYPASSES
+    description: Liver transplantation replaces failing hepatic function but does not correct systemic PEX-gene biogenesis defects.
 - name: Genetic Counseling
   description: Providing information and support to families regarding
     inheritance and implications.


### PR DESCRIPTION
## Summary
- add downstream causal edges connecting PEX biogenesis/import defects to toxic metabolite accumulation, essential-compound deficiency, organ mechanisms, phenotypes, and biochemical markers
- add target-mechanism links for symptomatic management, nutritional support, and liver transplant
- repair pre-existing cached-reference snippets in this disorder so manual snippet audit passes exactly

## Validation
- just validate kb/disorders/Peroxisome_Biogenesis_Disorder.yaml
- manual normalized snippet audit: 102 checks, 0 failures, 0 missing caches
- graph audit: 11 pathophysiology nodes, 15 phenotypes, 3 biochemical markers, 32 downstream edges, 0 dangling targets, 0 untargeted phenotype/biochemical nodes, 0 isolated pathophysiology nodes

## Notes
- Restored validation-generated cache churn; PR is scoped to kb/disorders/Peroxisome_Biogenesis_Disorder.yaml.
- Left Genetic Counseling without target_mechanisms because it does not modify a disease mechanism.