### PR TITLE
Add Cutaneous larva migrans curation

### DIFF
--- a/kb/disorders/Cutaneous_Larva_Migrans.yaml
+++ b/kb/disorders/Cutaneous_Larva_Migrans.yaml
@@ -1,0 +1,572 @@
+name: Cutaneous larva migrans
+creation_date: "2026-05-06T23:27:19Z"
+updated_date: "2026-05-06T23:46:46Z"
+category: Infectious
+description: >-
+  Cutaneous larva migrans is a zoonotic hookworm-related dermatosis caused by
+  superficial migration of animal hookworm larvae in human epidermis after
+  exposure to contaminated sand or soil. The disease typically presents with
+  intensely pruritic, erythematous, serpiginous tracks and is usually diagnosed
+  clinically from lesion morphology and exposure history.
+disease_term:
+  preferred_term: cutaneous larva migrans
+  term:
+    id: MONDO:0018500
+    label: cutaneous larva migrans
+parents:
+- parasitic infectious disease
+- helminthiasis
+synonyms:
+- creeping eruption
+- ground itch
+- dew itch
+- hookworm-related cutaneous larva migrans
+- serpiginous linear dermatitis
+references:
+- reference: DOI:10.1007/s40475-021-00239-0
+  title: Cutaneous Larva Migrans
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.7759/cureus.104834
+  title: 'Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile'
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.1097/ms9.0000000000001512
+  title: 'Cutaneous larva migrans in a child: a case report and review of literature'
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.3390/tropicalmed10060163
+  title: 'Cutaneous Larva Migrans Refractory to Therapy with Ivermectin: Case Report and Review of Implicated Zoonotic Pathogens, Epidemiology, Anthelmintic Drug Resistance and Therapy'
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.5001/omj.2028.07
+  title: 'Cutaneous Larva Migrans Outbreak in Seeb Wilaya: A Case Series'
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.5070/d329461906
+  title: Cutaneous larva migrans in the northeastern US
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.1111/j.1708-8305.2007.00148.x
+  title: Hookworm-Related Cutaneous Larva Migrans
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.1371/journal.pntd.0001355
+  title: Life Quality Impairment Caused by Hookworm-Related Cutaneous Larva Migrans in Resource-Poor Communities in Manaus, Brazil
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.1086/313942
+  title: 'Cutaneous Larva Migrans in Travelers: A Prospective Study, with Assessment of Therapy with Ivermectin'
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+- reference: DOI:10.7759/cureus.64665
+  title: 'Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan'
+  found_in:
+  - Cutaneous_Larva_Migrans-deep-research-falcon.md
+classifications:
+  harrisons_chapter:
+  - classification_value: infectious disease
+    evidence:
+    - reference: PMID:41948263
+      reference_title: 'Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cutaneous larva migrans (CLM) is a parasitic dermatosis caused by the superficial migration of animal hookworm larvae in human skin, typically acquired through contact with contaminated soil or sand in tropical environments."
+      explanation: Supports classification as an infectious parasitic dermatosis caused by hookworm larvae.
+  - classification_value: parasitic infectious disease
+    evidence:
+    - reference: PMID:38222776
+      reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cutaneous larva migrans (CLM) is a dermatitis caused by the invasion and migration of parasitic larvae of hookworms, primarily affecting tropical and subtropical regions."
+      explanation: Supports classification as a hookworm larval parasitic disease.
+definitions:
+- name: Clinical case definition for cutaneous larva migrans
+  definition_type: CASE_DEFINITION
+  description: >-
+    Cutaneous larva migrans is defined clinically by pruritic, migrating,
+    serpiginous or linear cutaneous tracks after exposure to contaminated sand or
+    soil harboring animal hookworm larvae.
+  scope: Symptomatic human infection caused by animal hookworm larvae in skin
+  evidence:
+  - reference: PMID:39021742
+    reference_title: 'Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous larva migrans (CLM), caused by third-stage filariform larvae of cat and dog hookworms, presents as pruritic, serpiginous tracks upon skin penetration by larvae from contaminated soil."
+    explanation: Supports the causal agent, exposure route, and characteristic clinical morphology.
+- name: Clinical diagnostic framework
+  definition_type: DIAGNOSTIC_CRITERIA
+  description: >-
+    Diagnosis is usually clinical and based on compatible serpiginous lesions,
+    pruritus, and exposure history; routine investigations are often normal.
+  scope: Routine clinical diagnosis in suspected cases
+  evidence:
+  - reference: PMID:41948263
+    reference_title: 'Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Diagnosis was established clinically based on characteristic morphology and exposure history."
+    explanation: Supports clinical diagnosis from morphology and exposure history.
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Diagnosis is mainly clinical and routine investigations usually reveal no abnormality."
+    explanation: Supports clinical diagnosis and limited routine laboratory utility.
+infectious_agent:
+- name: Ancylostoma braziliense
+  infectious_agent_term:
+    preferred_term: Ancylostoma braziliense
+    term:
+      id: NCBITaxon:369059
+      label: Ancylostoma braziliense
+  description: Dog and cat hookworm species molecularly confirmed in human hookworm-related cutaneous larva migrans.
+  evidence:
+  - reference: PMID:22556085
+    reference_title: Molecular characterization of Ancylostoma braziliense larvae in a patient with hookworm-related cutaneous larva migrans.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Amplification and sequencing of the internal transcribed spacer 2 allowed the specific identification of the larvae as Ancylostoma braziliense."
+    explanation: Molecular identification directly supports A. braziliense as a causative organism in human CLM.
+  - reference: PMID:25146212
+    reference_title: '[Cutaneous larva migrans after a trip to the Caribean].'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous larva migrans is a parasitic disease caused by Ancylostoma braziliense and Ancylostoma caninum larvae, which is transmitted by contact with sand infested with these parasites."
+    explanation: Supports A. braziliense as one of the principal hookworm causes.
+- name: Ancylostoma caninum
+  infectious_agent_term:
+    preferred_term: Ancylostoma caninum
+    term:
+      id: NCBITaxon:29170
+      label: Ancylostoma caninum
+  description: Dog hookworm species implicated in hookworm-related cutaneous larva migrans.
+  evidence:
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hookworm-related cutaneous larva migrans (HRCLM) is caused by the penetration and migration in the epidermis of larvae of Ancylostoma braziliense and Ancylostoma caninum."
+    explanation: Supports A. caninum as a causative hookworm species for HRCLM.
+transmission:
+- name: Contact with contaminated sand or soil
+  description: >-
+    Human infection follows bare-skin exposure to sand or soil contaminated with
+    infective animal hookworm larvae, especially in tropical travel or endemic
+    settings.
+  evidence:
+  - reference: PMID:41948263
+    reference_title: 'Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous larva migrans (CLM) is a parasitic dermatosis caused by the superficial migration of animal hookworm larvae in human skin, typically acquired through contact with contaminated soil or sand in tropical environments."
+    explanation: Supports contaminated soil or sand contact as the acquisition route.
+  - reference: PMID:25146212
+    reference_title: '[Cutaneous larva migrans after a trip to the Caribean].'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous larva migrans is a parasitic disease caused by Ancylostoma braziliense and Ancylostoma caninum larvae, which is transmitted by contact with sand infested with these parasites."
+    explanation: Independently supports sand-associated transmission.
+- name: Dog and cat hookworm environmental contamination
+  description: >-
+    Dogs and cats are definitive hosts for implicated hookworms, contaminating
+    environments where bare skin contact allows larval penetration.
+  evidence:
+  - reference: PMID:25146212
+    reference_title: '[Cutaneous larva migrans after a trip to the Caribean].'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Dogs and cats are the definitive hosts."
+    explanation: Supports the animal reservoir for environmental contamination.
+environmental:
+- name: Barefoot exposure around dogs
+  presence: PRESENT
+  description: Barefoot walking in dog-contaminated environments increases exposure risk.
+  evidence:
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patient's family had poor socioeconomic conditions, and the child frequently walked barefoot in an area with many domestic and stray dogs."
+    explanation: Supports barefoot exposure around domestic and stray dogs as a concrete risk context.
+- name: Tropical and subtropical environmental exposure
+  presence: PRESENT
+  description: CLM is associated with tropical and subtropical exposure, but cases can be imported or occur outside traditional endemic regions.
+  evidence:
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous larva migrans (CLM) is a dermatitis caused by the invasion and migration of parasitic larvae of hookworms, primarily affecting tropical and subtropical regions."
+    explanation: Supports the typical geographic/environmental context.
+  - reference: PMID:37921817
+    reference_title: Cutaneous larva migrans in the northeastern US.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Although cutaneous larva migrans has traditionally been considered a tropical disease, clinicians should be cognizant of its expanding geographic spread."
+    explanation: Supports awareness of cases outside classic tropical settings without quantifying expansion.
+progression:
+- phase: Post-exposure incubation and lesion onset
+  notes: Lesions may appear after return from travel, with a long and variable incubation in some patients.
+  evidence:
+  - reference: PMID:10987711
+    reference_title: 'Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "After the patients had returned from their destinations, 55% had lesions occur within a mean of 16 days (range, 1-120 days; >1 month in 7 patients)."
+    explanation: Supports variable post-exposure timing of lesion onset in travelers.
+- phase: Self-limited cutaneous disease with morbidity
+  notes: Disease is often confined to skin but can cause substantial itch-related morbidity and secondary complications.
+  evidence:
+  - reference: PMID:22087341
+    reference_title: Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in Manaus, Brazil.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The disease causes intense pruritus and is associated with important morbidity."
+    explanation: Supports clinically meaningful morbidity despite cutaneous localization.
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Complications may include secondary bacterial infections, allergies, and rare migration to internal organs."
+    explanation: Supports recognized complications from CLM.
+pathophysiology:
+- name: Hookworm larvae penetrate exposed skin
+  description: Infective larvae enter through exposed skin after contact with contaminated sand or soil.
+  locations:
+  - preferred_term: skin epidermis
+    term:
+      id: UBERON:0001003
+      label: skin epidermis
+  downstream:
+  - target: Intraepidermal larval migration
+    description: Skin penetration enables larval movement within the epidermis.
+    evidence:
+    - reference: PMID:18626615
+      reference_title: '[Cutaneous larva migrans].'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The characteristic manifestation is a gyrated, serpiginous and in some cases vesicular erythema, which appears after penetration of the epidermis by the parasite and the subsequent intraepidermal migration of the larva."
+      explanation: Supports the transition from penetration to intraepidermal larval migration.
+  evidence:
+  - reference: PMID:39021742
+    reference_title: 'Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cutaneous larva migrans (CLM), caused by third-stage filariform larvae of cat and dog hookworms, presents as pruritic, serpiginous tracks upon skin penetration by larvae from contaminated soil."
+    explanation: Supports skin penetration by larvae from contaminated soil as the initiating event.
+- name: Intraepidermal larval migration
+  description: Larvae migrate within the epidermis, producing slowly advancing linear or serpiginous inflammatory tracks.
+  locations:
+  - preferred_term: skin epidermis
+    term:
+      id: UBERON:0001003
+      label: skin epidermis
+  biological_processes:
+  - preferred_term: inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+    modifier: INCREASED
+  downstream:
+  - target: Eosinophil-rich local inflammation
+    description: Migrating larvae trigger local inflammatory responses along the track.
+    evidence:
+    - reference: PMID:38222776
+      reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The larvae of Ancylostoma spp. are common culprits, causing a localized inflammatory reaction as they migrate through the skin."
+      explanation: Supports inflammation caused by larval migration through skin.
+  evidence:
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hookworm-related cutaneous larva migrans (HRCLM) is caused by the penetration and migration in the epidermis of larvae of Ancylostoma braziliense and Ancylostoma caninum."
+    explanation: Supports intraepidermal larval migration as the core mechanism.
+- name: Eosinophil-rich local inflammation
+  description: Local inflammatory reaction with eosinophils contributes to pruritic and bullous/vesicular lesions in some cases.
+  cell_types:
+  - preferred_term: eosinophil
+    term:
+      id: CL:0000771
+      label: eosinophil
+  biological_processes:
+  - preferred_term: eosinophil chemotaxis
+    term:
+      id: GO:0048245
+      label: eosinophil chemotaxis
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cytological examinations of the blisters showed the presence of lymphocytes and neutrophils, with numerous eosinophils."
+    explanation: Supports eosinophil-rich inflammation in bullous HRCLM lesions.
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The larvae of Ancylostoma spp. are common culprits, causing a localized inflammatory reaction as they migrate through the skin."
+    explanation: Supports local inflammation caused by migrating larvae.
+phenotypes:
+- name: Pruritus
+  category: Dermatologic
+  frequency: COMMON
+  description: Itching is a dominant symptom and major driver of morbidity and sleep disturbance.
+  phenotype_term:
+    preferred_term: Pruritus
+    term:
+      id: HP:0000989
+      label: Pruritus
+  evidence:
+  - reference: PMID:22087341
+    reference_title: Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in Manaus, Brazil.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Intense pruritus, sleep disturbance (due to itching) and the feeling of shame were the most frequent skin disease-associated life quality restrictions (reported by 93.4%, 73.6%, and 64.8% of the patients, respectively)."
+    explanation: Supports pruritus as common and clinically impactful in an endemic-community cohort.
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The lesion gradually expanded, forming a serpiginous erythema, and became intensely pruritic."
+    explanation: Supports intense pruritus in a pediatric case.
+- name: Erythematous serpiginous tracks
+  category: Dermatologic
+  frequency: COMMON
+  description: Slowly migrating erythematous linear or serpiginous tracks are the characteristic skin lesion.
+  phenotype_term:
+    preferred_term: Erythematous serpiginous tracks
+    term:
+      id: HP:0010783
+      label: Erythema
+  evidence:
+  - reference: PMID:37921817
+    reference_title: Cutaneous larva migrans in the northeastern US.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It is characterized by erythematous, twisting, and linear plaques that can migrate to adjacent skin."
+    explanation: Supports migrating erythematous linear plaques as characteristic CLM morphology.
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These tracks may be single or multiple, serpiginous or linear, ramified and intertwined, accompanied by pruritus."
+    explanation: Supports serpiginous or linear track morphology.
+- name: Bullous or vesicular lesions
+  category: Dermatologic
+  frequency: OCCASIONAL
+  description: Bullous or vesicular forms are atypical presentations of hookworm-related cutaneous larva migrans.
+  phenotype_term:
+    preferred_term: Bullous or vesicular cutaneous lesions
+    term:
+      id: HP:0000988
+      label: Skin rash
+  evidence:
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Atypical clinical presentations of HRCLM are currently more frequent than in the past."
+    explanation: Supports atypical presentations in HRCLM.
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The infestation was characterized by single or multiple blisters, round or oval in shape, of different size, with a clear serous fluid."
+    explanation: Supports bullous lesions as a documented atypical CLM manifestation.
+- name: Sleep disturbance due to itching
+  category: Neurologic
+  frequency: COMMON
+  description: Itch-related sleep disturbance is a major quality-of-life burden in endemic-community patients.
+  phenotype_term:
+    preferred_term: Sleep disturbance due to itching
+    term:
+      id: HP:0100785
+      label: Insomnia
+  evidence:
+  - reference: PMID:22087341
+    reference_title: Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in Manaus, Brazil.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Intense pruritus, sleep disturbance (due to itching) and the feeling of shame were the most frequent skin disease-associated life quality restrictions (reported by 93.4%, 73.6%, and 64.8% of the patients, respectively)."
+    explanation: Supports sleep disturbance caused by itching as a common quality-of-life restriction.
+histopathology:
+- name: Larvae or eosinophil-rich inflammation in skin samples
+  description: Skin scraping, blister cytology, or biopsy may identify larvae or eosinophil-rich inflammation when confirmation is needed.
+  diagnostic: true
+  evidence:
+  - reference: PMID:22556085
+    reference_title: Molecular characterization of Ancylostoma braziliense larvae in a patient with hookworm-related cutaneous larva migrans.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Viable hookworm larvae were found by microscopic examination of a skin scraping from follicular lesions."
+    explanation: Supports microscopic confirmation from skin scraping in a patient with HRCLM.
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cytological examinations of the blisters showed the presence of lymphocytes and neutrophils, with numerous eosinophils."
+    explanation: Supports eosinophil-rich inflammatory cytology in bullous HRCLM lesions.
+diagnosis:
+- name: Clinical morphology and exposure history
+  description: Diagnosis is usually made from pruritic serpiginous lesions and a compatible exposure history.
+  evidence:
+  - reference: PMID:41948263
+    reference_title: 'Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Diagnosis was established clinically based on characteristic morphology and exposure history."
+    explanation: Supports clinical diagnosis without routine invasive testing.
+- name: Microscopic confirmation when sampled
+  description: Skin scraping or biopsy can confirm hookworm larvae when morphology is atypical or diagnostic uncertainty persists.
+  evidence:
+  - reference: PMID:22556085
+    reference_title: Molecular characterization of Ancylostoma braziliense larvae in a patient with hookworm-related cutaneous larva migrans.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We report a case of hookworm-related cutaneous larva migrans diagnosed microscopically."
+    explanation: Supports microscopy as a confirmatory approach in selected cases.
+treatments:
+- name: Oral ivermectin
+  description: Oral ivermectin is a first-line anthelmintic treatment; some patients require repeat doses.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: ivermectin
+      term:
+        id: CHEBI:6078
+        label: ivermectin
+  target_phenotypes:
+  - preferred_term: Pruritus
+    term:
+      id: HP:0000989
+      label: Pruritus
+  - preferred_term: Erythematous serpiginous tracks
+    term:
+      id: HP:0010783
+      label: Erythema
+  evidence:
+  - reference: PMID:37921817
+    reference_title: Cutaneous larva migrans in the northeastern US.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oral ivermectin, the preferred first-line treatment for cutaneous larva migrans, was administered in combination with triamcinolone."
+    explanation: Supports ivermectin as preferred first-line therapy.
+  - reference: PMID:10987711
+    reference_title: 'Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The cure rate after a single dose of ivermectin was 77%."
+    explanation: Supports efficacy of single-dose ivermectin in a prospective traveler cohort.
+  - reference: PMID:10987711
+    reference_title: 'Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In 14 patients, 1 or 2 supplementary doses were necessary, and the overall cure rate was 97%."
+    explanation: Supports repeat dosing when single-dose therapy is insufficient.
+- name: Oral albendazole
+  description: Albendazole is an anthelmintic alternative used for CLM, including pediatric cases.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: albendazole
+      term:
+        id: CHEBI:16664
+        label: albendazole
+  target_phenotypes:
+  - preferred_term: Pruritus
+    term:
+      id: HP:0000989
+      label: Pruritus
+  - preferred_term: Erythematous serpiginous tracks
+    term:
+      id: HP:0010783
+      label: Erythema
+  evidence:
+  - reference: PMID:38222776
+    reference_title: 'Cutaneous larva migrans in a child: a case report and review of literature.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Treatment options include albendazole or ivermectin, with preventive measures emphasizing hygiene, footwear use, and pet deworming."
+    explanation: Supports albendazole as a treatment option.
+  - reference: PMID:28906088
+    reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All patients were successfully treated with oral albendazole."
+    explanation: Supports oral albendazole efficacy in bullous HRCLM case-series patients.
+- name: Combined albendazole and ivermectin for refractory CLM
+  description: Combination therapy may be considered for refractory or relapsed CLM, but broader use remains investigational.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: albendazole
+      term:
+        id: CHEBI:16664
+        label: albendazole
+    - preferred_term: ivermectin
+      term:
+        id: CHEBI:6078
+        label: ivermectin
+  evidence:
+  - reference: PMID:39021742
+    reference_title: 'Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan.'
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This report highlights the potential of combined albendazole-ivermectin therapy in managing CLM amid emerging antihelminthic resistance, suggesting that its broader application warrants further investigation."
+    explanation: Supports combination therapy as promising but not yet established for broad use.
+  - reference: DOI:10.3390/tropicalmed10060163
+    reference_title: 'Cutaneous Larva Migrans Refractory to Therapy with Ivermectin: Case Report and Review of Implicated Zoonotic Pathogens, Epidemiology, Anthelmintic Drug Resistance and Therapy'
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "For relapsed CLM we now recommend a combination of ivermectin and albendazole therapy."
+    explanation: Supports combination therapy specifically in relapsed or refractory CLM.
+epidemiology:
+- name: Travel-associated and tropical/subtropical exposure
+  description: CLM is associated with tropical/subtropical regions and imported travel cases, but recognition is needed outside classic endemic areas.
+  factors:
+  - tropical travel
+  - beach or sand exposure
+  - tropical and subtropical climates
+  evidence:
+  - reference: PMID:10987711
+    reference_title: 'Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sixty-four patients were enrolled. All were European and had stayed in tropical areas."
+    explanation: Supports travel-associated CLM after stays in tropical areas.
+  - reference: PMID:41948263
+    reference_title: 'Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We report the case of a 17-year-old female patient who presented in Chile with pruritic serpiginous skin lesions following recent travel to Brazil."
+    explanation: Supports imported CLM after travel to a tropical region.
+- name: Quality-of-life burden in endemic communities
+  description: CLM can substantially impair dermatology-related quality of life in resource-poor endemic communities.
+  factors:
+  - intense pruritus
+  - sleep disturbance
+  - shame
+  evidence:
+  - reference: PMID:22087341
+    reference_title: Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in Manaus, Brazil.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Ninety-one point five percent of the study participants showed a considerable reduction of skin disease-associated life quality at the time of diagnosis."
+    explanation: Supports substantial quality-of-life burden in a 91-patient endemic-community cohort.
+notes: "MONDO:0018500 canonical label was confirmed locally with OAK as 'cutaneous larva migrans'."

--- a/kb/disorders/Cutaneous_Larva_Migrans.yaml
+++ b/kb/disorders/Cutaneous_Larva_Migrans.yaml
@@ -150,6 +150,34 @@ infectious_agent:
     evidence_source: HUMAN_CLINICAL
     snippet: "Hookworm-related cutaneous larva migrans (HRCLM) is caused by the penetration and migration in the epidermis of larvae of Ancylostoma braziliense and Ancylostoma caninum."
     explanation: Supports A. caninum as a causative hookworm species for HRCLM.
+- name: Ancylostoma ceylanicum
+  infectious_agent_term:
+    preferred_term: Ancylostoma ceylanicum
+    term:
+      id: NCBITaxon:53326
+      label: Ancylostoma ceylanicum
+  description: Zoonotic hookworm species included among Ancylostoma spp. that can cause cutaneous larva migrans.
+  evidence:
+  - reference: PMID:38500436
+    reference_title: Ecoepidemiology of Ancylostoma spp. in Urban-Marginal and Rural Sectors of the Ecuadorian Coast and Prevalence of Cutaneous Larvae Migrans.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "BACKGROUND Ancylostoma spp., including A. duodenale, A. braziliense, A. caninum, and A. ceylanicum, are hookworms that are transmitted from infected soil and by contact with domestic animals and rodent hosts, and can cause systemic disease and cutaneous larva migrans."
+    explanation: Supports A. ceylanicum as an Ancylostoma species capable of causing cutaneous larva migrans.
+- name: Uncinaria stenocephala
+  infectious_agent_term:
+    preferred_term: Uncinaria stenocephala
+    term:
+      id: NCBITaxon:125367
+      label: Uncinaria stenocephala
+  description: Zoonotic hookworm species reported among causes of cutaneous larva migrans.
+  evidence:
+  - reference: PMID:38680772
+    reference_title: 'Cutaneous Larva Migrans (CLM) may not be easy to diagnose: a case report and narrative review.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It is caused by different types of hookworm, such as Ancylostoma braziliense, Ancylostoma caninum, and Uncinaria stenocephala."
+    explanation: Supports U. stenocephala as a reported hookworm cause of CLM.
 transmission:
 - name: Contact with contaminated sand or soil
   description: >-
@@ -247,7 +275,7 @@ pathophysiology:
     - reference: PMID:18626615
       reference_title: '[Cutaneous larva migrans].'
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "The characteristic manifestation is a gyrated, serpiginous and in some cases vesicular erythema, which appears after penetration of the epidermis by the parasite and the subsequent intraepidermal migration of the larva."
       explanation: Supports the transition from penetration to intraepidermal larval migration.
   evidence:
@@ -316,7 +344,7 @@ pathophysiology:
 phenotypes:
 - name: Pruritus
   category: Dermatologic
-  frequency: COMMON
+  frequency: VERY_FREQUENT
   description: Itching is a dominant symptom and major driver of morbidity and sleep disturbance.
   phenotype_term:
     preferred_term: Pruritus
@@ -365,8 +393,8 @@ phenotypes:
   phenotype_term:
     preferred_term: Bullous or vesicular cutaneous lesions
     term:
-      id: HP:0000988
-      label: Skin rash
+      id: HP:0008066
+      label: Abnormal blistering of the skin
   evidence:
   - reference: PMID:28906088
     reference_title: 'Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.'
@@ -396,6 +424,27 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Intense pruritus, sleep disturbance (due to itching) and the feeling of shame were the most frequent skin disease-associated life quality restrictions (reported by 93.4%, 73.6%, and 64.8% of the patients, respectively)."
     explanation: Supports sleep disturbance caused by itching as a common quality-of-life restriction.
+- name: Increased eosinophil count
+  category: Hematologic
+  description: Blood eosinophil abnormalities may occur in CLM cases and in rare Loffler syndrome presentations.
+  phenotype_term:
+    preferred_term: Increased eosinophil count
+    term:
+      id: HP:0001880
+      label: Increased total eosinophil count
+  evidence:
+  - reference: PMID:39633595
+    reference_title: Consideration of Diagnostic Methods for Cutaneous Larva Migrans in the Sole of an 8-Year-Old Boy.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Ultrasound and MRI did not reveal any parasites, but fluctuations in eosinophils, IgE and IgA levels were observed during treatment."
+    explanation: Supports eosinophil changes as a laboratory feature observed in a treated CLM case.
+  - reference: PMID:36865421
+    reference_title: "Loeffler's Syndrome and Multifocal Cutaneous Larva Migrans: Case report of an uncommon occurrence and review of the literature."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Loeffler's syndrome (LS) is a transient respiratory ailment characterised by pulmonary infiltration along with peripheral eosinophilia and commonly follows parasitic infestation."
+    explanation: Supports peripheral eosinophilia in a rare systemic complication reported with multifocal CLM.
 histopathology:
 - name: Larvae or eosinophil-rich inflammation in skin samples
   description: Skin scraping, blister cytology, or biopsy may identify larvae or eosinophil-rich inflammation when confirmation is needed.

--- a/references_cache/DOI_10.1007_s40475-021-00239-0.md
+++ b/references_cache/DOI_10.1007_s40475-021-00239-0.md
@@ -1,0 +1,28 @@
+---
+reference_id: "DOI:10.1007/s40475-021-00239-0"
+title: Cutaneous Larva Migrans
+authors:
+- Alfonso J. Rodriguez-Morales
+- Natalia González-Leal
+- Maria Camila Montes-Montoya
+- Lorena Fernández-Espíndola
+- D. Katterine Bonilla-Aldana
+- José María Azeñas- Burgoa
+- Juan Carlos Diez de Medina
+- Verónica Rotela-Fisch
+- Melany Bermudez-Calderon
+- Kovy Arteaga-Livias
+- Fredrikke Dam Larsen
+- José A. Suárez
+journal: Current Tropical Medicine Reports
+year: '2021'
+doi: 10.1007/s40475-021-00239-0
+content_type: unavailable
+---
+
+# Cutaneous Larva Migrans
+**Authors:** Alfonso J. Rodriguez-Morales, Natalia González-Leal, Maria Camila Montes-Montoya, Lorena Fernández-Espíndola, D. Katterine Bonilla-Aldana, José María Azeñas- Burgoa, Juan Carlos Diez de Medina, Verónica Rotela-Fisch, Melany Bermudez-Calderon, Kovy Arteaga-Livias, Fredrikke Dam Larsen, José A. Suárez
+**Journal:** Current Tropical Medicine Reports (2021)
+**DOI:** [10.1007/s40475-021-00239-0](https://doi.org/10.1007/s40475-021-00239-0)
+
+## Content

--- a/references_cache/DOI_10.1086_313942.md
+++ b/references_cache/DOI_10.1086_313942.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.1086/313942"
+title: "Cutaneous Larva Migrans in Travelers: A Prospective Study, with Assessment of Therapy with Ivermectin"
+authors:
+- O. Bouchaud
+- S. Houze
+- R. Schiemann
+- R. Durand
+- P. Ralaimazava
+- C. Ruggeri
+- J.-P. Coulaud
+journal: Clinical Infectious Diseases
+year: '2000'
+doi: 10.1086/313942
+content_type: unavailable
+---
+
+# Cutaneous Larva Migrans in Travelers: A Prospective Study, with Assessment of Therapy with Ivermectin
+**Authors:** O. Bouchaud, S. Houze, R. Schiemann, R. Durand, P. Ralaimazava, C. Ruggeri, J.-P. Coulaud
+**Journal:** Clinical Infectious Diseases (2000)
+**DOI:** [10.1086/313942](https://doi.org/10.1086/313942)
+
+## Content

--- a/references_cache/DOI_10.1097_ms9.0000000000001512.md
+++ b/references_cache/DOI_10.1097_ms9.0000000000001512.md
@@ -1,0 +1,36 @@
+---
+reference_id: "DOI:10.1097/ms9.0000000000001512"
+title: "Cutaneous larva migrans in a child: a case report and review of literature"
+authors:
+- Amrita Shrestha
+- Kusha K.C.
+- Abal Baral
+- Rojina Shrestha
+- Rabina Shrestha
+journal: "Annals of Medicine &amp; Surgery"
+year: '2024'
+doi: 10.1097/ms9.0000000000001512
+content_type: abstract_only
+---
+
+# Cutaneous larva migrans in a child: a case report and review of literature
+**Authors:** Amrita Shrestha, Kusha K.C., Abal Baral, Rojina Shrestha, Rabina Shrestha
+**Journal:** Annals of Medicine &amp; Surgery (2024)
+**DOI:** [10.1097/ms9.0000000000001512](https://doi.org/10.1097/ms9.0000000000001512)
+
+## Content
+
+Introduction:
+Cutaneous larva migrans (CLM) is a dermatitis caused by the invasion and migration of parasitic larvae of hookworms, primarily affecting tropical and subtropical regions. This report presents a case of CLM in a Nepali child and provides an overview of the literature on this condition.
+
+
+Case report:
+A 4-year-old boy from a rural area in Nepal presented with a pruritic skin lesion on his left foot, initially misdiagnosed as fungal infection. The lesion gradually expanded, forming a serpiginous erythema, and became intensely pruritic. The patient’s family had poor socioeconomic conditions, and the child frequently walked barefoot in an area with many domestic and stray dogs. Diagnosis was confirmed clinically, and treatment with oral albendazole and antihistamines resulted in complete resolution of symptoms.
+
+
+Discussion:
+CLM is a neglected zoonotic disease, with an underestimated burden in developing countries due to underreporting and misdiagnosis. The larvae of Ancylostoma spp. are common culprits, causing a localized inflammatory reaction as they migrate through the skin. Diagnosis is mainly clinical and routine investigations usually reveal no abnormality. Complications may include secondary bacterial infections, allergies, and rare migration to internal organs. Treatment options include albendazole or ivermectin, with preventive measures emphasizing hygiene, footwear use, and pet deworming.
+
+
+Conclusion:
+CLM is a neglected disease that primarily affects marginalized communities in tropical regions. Raising awareness among healthcare providers, conducting observational studies, and developing treatment guidelines, especially for children, are essential steps to address this public health concern. Preventive efforts, such as promoting hygiene and footwear use, should be encouraged to reduce CLM incidence.

--- a/references_cache/DOI_10.1111_j.1708-8305.2007.00148.x.md
+++ b/references_cache/DOI_10.1111_j.1708-8305.2007.00148.x.md
@@ -1,0 +1,18 @@
+---
+reference_id: "DOI:10.1111/j.1708-8305.2007.00148.x"
+title: Hookworm‐Related Cutaneous Larva Migrans
+authors:
+- Patrick Hochedez
+- Eric Caumes
+journal: Journal of Travel Medicine
+year: '2007'
+doi: 10.1111/j.1708-8305.2007.00148.x
+content_type: unavailable
+---
+
+# Hookworm‐Related Cutaneous Larva Migrans
+**Authors:** Patrick Hochedez, Eric Caumes
+**Journal:** Journal of Travel Medicine (2007)
+**DOI:** [10.1111/j.1708-8305.2007.00148.x](https://doi.org/10.1111/j.1708-8305.2007.00148.x)
+
+## Content

--- a/references_cache/DOI_10.1371_journal.pntd.0001355.md
+++ b/references_cache/DOI_10.1371_journal.pntd.0001355.md
@@ -1,0 +1,22 @@
+---
+reference_id: "DOI:10.1371/journal.pntd.0001355"
+title: "Life Quality Impairment Caused by Hookworm-Related Cutaneous Larva Migrans in Resource-Poor Communities in Manaus, Brazil"
+authors:
+- Angela Schuster
+- Hannah Lesshafft
+- Sinésio Talhari
+- Silás Guedes de Oliveira
+- Ralf Ignatius
+- Hermann Feldmeier
+journal: PLoS Neglected Tropical Diseases
+year: '2011'
+doi: 10.1371/journal.pntd.0001355
+content_type: unavailable
+---
+
+# Life Quality Impairment Caused by Hookworm-Related Cutaneous Larva Migrans in Resource-Poor Communities in Manaus, Brazil
+**Authors:** Angela Schuster, Hannah Lesshafft, Sinésio Talhari, Silás Guedes de Oliveira, Ralf Ignatius, Hermann Feldmeier
+**Journal:** PLoS Neglected Tropical Diseases (2011)
+**DOI:** [10.1371/journal.pntd.0001355](https://doi.org/10.1371/journal.pntd.0001355)
+
+## Content

--- a/references_cache/DOI_10.3390_tropicalmed10060163.md
+++ b/references_cache/DOI_10.3390_tropicalmed10060163.md
@@ -1,0 +1,21 @@
+---
+reference_id: "DOI:10.3390/tropicalmed10060163"
+title: "Cutaneous Larva Migrans Refractory to Therapy with Ivermectin: Case Report and Review of Implicated Zoonotic Pathogens, Epidemiology, Anthelmintic Drug Resistance and Therapy"
+authors:
+- Bart J. Currie
+- Jessica Hoopes
+- Bonny Cumming
+journal: Tropical Medicine and Infectious Disease
+year: '2025'
+doi: 10.3390/tropicalmed10060163
+content_type: abstract_only
+---
+
+# Cutaneous Larva Migrans Refractory to Therapy with Ivermectin: Case Report and Review of Implicated Zoonotic Pathogens, Epidemiology, Anthelmintic Drug Resistance and Therapy
+**Authors:** Bart J. Currie, Jessica Hoopes, Bonny Cumming
+**Journal:** Tropical Medicine and Infectious Disease (2025)
+**DOI:** [10.3390/tropicalmed10060163](https://doi.org/10.3390/tropicalmed10060163)
+
+## Content
+
+Cutaneous larva migrans (CLM) is attributed to zoonotic infection with animal hookworm larvae penetrating the human skin, usually the feet and legs. There is, however, a broad range of differential diagnoses, with the implicated hookworm species usually remaining speculative. Single-dose ivermectin is the most recommended current therapy, with repeat ivermectin doses sometimes required. With the massive global expansion of macrocytic lactone use in both livestock and companion animals, ivermectin resistance is being increasingly described in both helminths and ectoparasites. A case of CLM involving the foot of a healthy 37-year-old is described, with the failure of two doses of ivermectin 15 mg (240 μg/kg) a week apart. This occurred in the context of a remote work environment in tropical Australia with both companion animals (dogs and cats) and wildlife exposed to antiparasitic agents including ivermectin. A combination regimen of multiple doses of albendazole and ivermectin was curative. Parasites with multidrug resistance being described from animals now include hookworms in dogs which are resistant to pyrantel, benzimidazoles such as mebendazole and ivermectin. For relapsed CLM we now recommend a combination of ivermectin and albendazole therapy. This report supports the critical role for a One Health/Planetary Health approach to surveillance and response for emerging zoonoses and antimicrobial resistance in human and animal pathogens. This requires support for systematic approaches to foster and normalize communications and collaborations between human and animal health professionals, environmental scientists and ecologists and First Nations scientists who are the holders of Indigenous knowledge.

--- a/references_cache/DOI_10.5001_omj.2028.07.md
+++ b/references_cache/DOI_10.5001_omj.2028.07.md
@@ -1,0 +1,22 @@
+---
+reference_id: "DOI:10.5001/omj.2028.07"
+title: "Cutaneous Larva Migrans Outbreak in Seeb Wilaya: A Case Series"
+authors:
+- Alya AL Hasni
+- Asma AL Musalhi
+- Fatma AL Ghashri
+- Zainab AL Hinai
+- Isra AL Mahruqi
+- Amal AL Sedairi
+journal: Oman Medical Journal
+year: '2024'
+doi: 10.5001/omj.2028.07
+content_type: unavailable
+---
+
+# Cutaneous Larva Migrans Outbreak in Seeb Wilaya: A Case Series
+**Authors:** Alya AL Hasni, Asma AL Musalhi, Fatma AL Ghashri, Zainab AL Hinai, Isra AL Mahruqi, Amal AL Sedairi
+**Journal:** Oman Medical Journal (2024)
+**DOI:** [10.5001/omj.2028.07](https://doi.org/10.5001/omj.2028.07)
+
+## Content

--- a/references_cache/DOI_10.5070_d329461906.md
+++ b/references_cache/DOI_10.5070_d329461906.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.5070/d329461906"
+title: Cutaneous larva migrans in the northeastern US
+authors:
+- Michael Johanis
+- Karan S Cheema
+- Peter A Young
+- Saisindhu Narala
+- Atif Saleem
+- Roberto A Novoa
+- Gordon H Bae
+journal: Dermatology Online Journal
+year: '2023'
+doi: 10.5070/d329461906
+content_type: unavailable
+---
+
+# Cutaneous larva migrans in the northeastern US
+**Authors:** Michael Johanis, Karan S Cheema, Peter A Young, Saisindhu Narala, Atif Saleem, Roberto A Novoa, Gordon H Bae
+**Journal:** Dermatology Online Journal (2023)
+**DOI:** [10.5070/d329461906](https://doi.org/10.5070/d329461906)
+
+## Content

--- a/references_cache/DOI_10.7759_cureus.104834.md
+++ b/references_cache/DOI_10.7759_cureus.104834.md
@@ -1,0 +1,21 @@
+---
+reference_id: "DOI:10.7759/cureus.104834"
+title: "Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile"
+authors:
+- Diego Guarda
+- Cristóbal Norambuena
+- Priscilla Marquez
+- Gerardo Bascuñan
+- Diego I Mendez-Villanueva
+journal: Cureus
+year: '2026'
+doi: 10.7759/cureus.104834
+content_type: unavailable
+---
+
+# Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile
+**Authors:** Diego Guarda, Cristóbal Norambuena, Priscilla Marquez, Gerardo Bascuñan, Diego I Mendez-Villanueva
+**Journal:** Cureus (2026)
+**DOI:** [10.7759/cureus.104834](https://doi.org/10.7759/cureus.104834)
+
+## Content

--- a/references_cache/DOI_10.7759_cureus.64665.md
+++ b/references_cache/DOI_10.7759_cureus.64665.md
@@ -1,0 +1,18 @@
+---
+reference_id: "DOI:10.7759/cureus.64665"
+title: "Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan"
+authors:
+- Mahdi Shamad
+- Nawaf Al-Mutairi
+journal: Cureus
+year: '2024'
+doi: 10.7759/cureus.64665
+content_type: unavailable
+---
+
+# Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan
+**Authors:** Mahdi Shamad, Nawaf Al-Mutairi
+**Journal:** Cureus (2024)
+**DOI:** [10.7759/cureus.64665](https://doi.org/10.7759/cureus.64665)
+
+## Content

--- a/references_cache/PMID_10987711.md
+++ b/references_cache/PMID_10987711.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:10987711"
+title: "Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin."
+authors:
+- Bouchaud O
+- Houzé S
+- Schiemann R
+- Durand R
+- Ralaimazava P
+- Ruggeri C
+- Coulaud JP
+journal: Clin Infect Dis
+year: '2000'
+doi: 10.1086/313942
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Ancylostomiasis/drug therapy, epidemiology, parasitology"
+- Animals
+- Antinematodal Agents/therapeutic use
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- Ivermectin/therapeutic use
+- "Larva Migrans/drug therapy, epidemiology, parasitology"
+- Male
+- Middle Aged
+- Prospective Studies
+- Surveys and Questionnaires
+- Travel
+content_type: abstract_only
+---
+
+# Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin.
+**Authors:** Bouchaud O, Houzé S, Schiemann R, Durand R, Ralaimazava P, Ruggeri C, Coulaud JP
+**Journal:** Clin Infect Dis (2000)
+**DOI:** [10.1086/313942](https://doi.org/10.1086/313942)
+
+## Content
+
+1. Clin Infect Dis. 2000 Aug;31(2):493-8. doi: 10.1086/313942. Epub 2000 Sep 7.
+
+Cutaneous larva migrans in travelers: a prospective study, with assessment of 
+therapy with ivermectin.
+
+Bouchaud O(1), Houzé S, Schiemann R, Durand R, Ralaimazava P, Ruggeri C, Coulaud 
+JP.
+
+Author information:
+(1)Department of Infectious and Tropical Diseases, Hôpital Bichat Claude 
+Bernard, Paris, France. olivier.bouchaud@bch.ap-hop-paris.fr
+
+Erratum in
+    Clin Infect Dis 2001 Feb 1;32(3):523.
+
+The purpose of this prospective study was to update epidemiological data on 
+cutaneous larva migrans (CLM) and to assess the therapeutic efficacy of 
+ivermectin. We performed the study between June 1994 and December 1998 at our 
+travel clinic. Ivermectin (a single dose of 200 microg/kg) was offered to all 
+the patients with CLM, and its efficacy and tolerability were assessed by a 
+questionnaire. Sixty-four patients were enrolled. All were European and had 
+stayed in tropical areas. After the patients had returned from their 
+destinations, 55% had lesions occur within a mean of 16 days (range, 1-120 days; 
+>1 month in 7 patients). The initial diagnosis was wrong in 55% of patients. The 
+mean number of lesions was 3 (range, 1-15), and the main sites were the feet 
+(48%) and buttocks (23%). The cure rate after a single dose of ivermectin was 
+77%. In 14 patients, 1 or 2 supplementary doses were necessary, and the overall 
+cure rate was 97%. The median time required for pruritus and lesions to 
+disappear was 3 and 7 days, respectively. No systemic adverse effects were 
+reported. Physicians' knowledge of CLM, which can have a long incubation period, 
+is poor. Single-dose ivermectin therapy appears to be effective and well 
+tolerated, even if several treatments are sometimes necessary.
+
+DOI: 10.1086/313942
+PMID: 10987711 [Indexed for MEDLINE]

--- a/references_cache/PMID_18626615.md
+++ b/references_cache/PMID_18626615.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:18626615"
+title: "[Cutaneous larva migrans]."
+authors:
+- Hoff NP
+- Mota R
+- Groffik A
+- Hengge UR
+journal: Hautarzt
+year: '2008'
+doi: 10.1007/s00105-008-1514-2
+keywords:
+- Ancylostoma
+- "Ancylostomiasis/diagnosis, drug therapy"
+- Animals
+- "Anthelmintics/adverse effects, therapeutic use"
+- "Diagnosis, Differential"
+- Humans
+- "Ivermectin/adverse effects, therapeutic use"
+- "Larva Migrans/diagnosis, drug therapy"
+- Pruritus/etiology
+- Travel
+- Tropical Climate
+content_type: abstract_only
+---
+
+# [Cutaneous larva migrans].
+**Authors:** Hoff NP, Mota R, Groffik A, Hengge UR
+**Journal:** Hautarzt (2008)
+**DOI:** [10.1007/s00105-008-1514-2](https://doi.org/10.1007/s00105-008-1514-2)
+
+## Content
+
+1. Hautarzt. 2008 Aug;59(8):622-6. doi: 10.1007/s00105-008-1514-2.
+
+[Cutaneous larva migrans].
+
+[Article in German]
+
+Hoff NP(1), Mota R, Groffik A, Hengge UR.
+
+Author information:
+(1)Hautklinik der Heinrich-Heine-Universität, Moorenstrasse 5, 40225 Düsseldorf.
+
+As a result of the rise of mass tourism with increasingly cheap and exotic 
+destinations, tropical diseases are becoming an increasingly important part of 
+dermatology. Infection with cutaneous larva migrans is one of the most common 
+"souvenirs" from the tropics. The disease is caused by the nematode infection 
+with dog or cat hookworm parasites (Ancylostoma braziliense or A. caninum). The 
+characteristic manifestation is a gyrated, serpiginous and in some cases 
+vesicular erythema, which appears after penetration of the epidermis by the 
+parasite and the subsequent intraepidermal migration of the larva. This is often 
+accompanied by intense pruritus in the affected skin. The infection is usually 
+found in those areas of the foot, calf or buttocks exposed by walking or sitting 
+on sand. Although subjectively very unpleasant, the disease is self-limiting and 
+resolves after several weeks; it is treated locally in most cases (e.g. using 
+cryotherapy). The prognosis of the disease is excellent, but a prolonged course 
+or complications have been observed, e.g. due to superinfection.
+
+DOI: 10.1007/s00105-008-1514-2
+PMID: 18626615 [Indexed for MEDLINE]

--- a/references_cache/PMID_22087341.md
+++ b/references_cache/PMID_22087341.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:22087341"
+title: "Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in Manaus, Brazil."
+authors:
+- Schuster A
+- Lesshafft H
+- Talhari S
+- Guedes de Oliveira S
+- Ignatius R
+- Feldmeier H
+journal: PLoS Negl Trop Dis
+year: '2011'
+doi: 10.1371/journal.pntd.0001355
+keywords:
+- Adolescent
+- Adult
+- Animals
+- "Anthelmintics/administration & dosage"
+- Brazil
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- "Ivermectin/administration & dosage"
+- "Larva Migrans/drug therapy, pathology, psychology"
+- Male
+- Poverty Areas
+- Prospective Studies
+- Quality of Life/psychology
+- Treatment Outcome
+- Urban Population
+- Young Adult
+content_type: abstract_only
+---
+
+# Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in Manaus, Brazil.
+**Authors:** Schuster A, Lesshafft H, Talhari S, Guedes de Oliveira S, Ignatius R, Feldmeier H
+**Journal:** PLoS Negl Trop Dis (2011)
+**DOI:** [10.1371/journal.pntd.0001355](https://doi.org/10.1371/journal.pntd.0001355)
+
+## Content
+
+1. PLoS Negl Trop Dis. 2011 Nov;5(11):e1355. doi: 10.1371/journal.pntd.0001355. 
+Epub 2011 Nov 8.
+
+Life quality impairment caused by hookworm-related cutaneous larva migrans in 
+resource-poor communities in Manaus, Brazil.
+
+Schuster A(1), Lesshafft H, Talhari S, Guedes de Oliveira S, Ignatius R, 
+Feldmeier H.
+
+Author information:
+(1)Institute of Microbiology and Hygiene, Charité Universitätsmedizin Berlin, 
+Germany. schuster_angela@gmx.de
+
+BACKGROUND: Hookworm-related cutaneous larva migrans (CLM) is a common but 
+neglected tropical skin disease caused by the migration of animal hookworm 
+larvae in the epidermis. The disease causes intense pruritus and is associated 
+with important morbidity. The extent to which CLM impairs skin 
+disease-associated life quality has never been studied.
+METHODS: A modified version of the Dermatology Life Quality Index (mDLQI) was 
+used to determine skin disease-associated life quality in 91 adult and child 
+patients with CLM, living in resource-poor communities in Manaus, Brazil. 
+Symptoms and signs were documented and skin disease-associated life quality was 
+semi-quantitatively assessed using mDLQI scores. The assessment was repeated two 
+and four weeks after treatment with ivermectin.
+RESULTS: Ninety-one point five percent of the study participants showed a 
+considerable reduction of skin disease-associated life quality at the time of 
+diagnosis. The degree of impairment correlated with the intensity of infection 
+(rho = 0.76, p<0.001), the number of body areas affected (rho = 0.30; 
+p = 0.004), and the presence of lesions on visible areas of the skin 
+(p = 0.002). Intense pruritus, sleep disturbance (due to itching) and the 
+feeling of shame were the most frequent skin disease-associated life quality 
+restrictions (reported by 93.4%, 73.6%, and 64.8% of the patients, 
+respectively). No differences were observed in skin disease-associated life 
+quality restriction between boys and girls or men and women. Two weeks after 
+treatment with ivermectin, skin disease-associated life quality improved 
+significantly. After four weeks, 73.3% of the patients considered their 
+disease-associated life quality to have returned to normal.
+CONCLUSIONS: CLM significantly impaired the skin disease-associated life quality 
+in child and adult patients living in urban slums in North Brazil. After 
+treatment with ivermectin, life quality normalised rapidly.
+
+DOI: 10.1371/journal.pntd.0001355
+PMCID: PMC3210737
+PMID: 22087341 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_22556085.md
+++ b/references_cache/PMID_22556085.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:22556085"
+title: Molecular characterization of Ancylostoma braziliense larvae in a patient with hookworm-related cutaneous larva migrans.
+authors:
+- Le Joncour A
+- Lacour SA
+- Lecso G
+- Regnier S
+- Guillot J
+- Caumes E
+journal: Am J Trop Med Hyg
+year: '2012'
+doi: 10.4269/ajtmh.2012.11-0734
+keywords:
+- "Administration, Oral"
+- "Administration, Topical"
+- Adult
+- "Albendazole/administration & dosage"
+- "Ancylostoma/drug effects, growth & development, isolation & purification, pathogenicity"
+- Animals
+- "Antiparasitic Agents/administration & dosage"
+- "DNA, Helminth/genetics"
+- Female
+- Humans
+- "Ivermectin/administration & dosage"
+- "Larva Migrans/diagnosis, drug therapy, pathology"
+- "Skin/parasitology, pathology"
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Molecular characterization of Ancylostoma braziliense larvae in a patient with hookworm-related cutaneous larva migrans.
+**Authors:** Le Joncour A, Lacour SA, Lecso G, Regnier S, Guillot J, Caumes E
+**Journal:** Am J Trop Med Hyg (2012)
+**DOI:** [10.4269/ajtmh.2012.11-0734](https://doi.org/10.4269/ajtmh.2012.11-0734)
+
+## Content
+
+1. Am J Trop Med Hyg. 2012 May;86(5):843-5. doi: 10.4269/ajtmh.2012.11-0734.
+
+Molecular characterization of Ancylostoma braziliense larvae in a patient with 
+hookworm-related cutaneous larva migrans.
+
+Le Joncour A(1), Lacour SA, Lecso G, Regnier S, Guillot J, Caumes E.
+
+Author information:
+(1)Département des Maladies Infectieuses et Tropicales, Hôpital Universitaire de 
+la Pitié-Salpêtrière, Paris, France. lejoncour.alexandre@gmail.com
+
+We report a case of hookworm-related cutaneous larva migrans diagnosed 
+microscopically. Viable hookworm larvae were found by microscopic examination of 
+a skin scraping from follicular lesions. Amplification and sequencing of the 
+internal transcribed spacer 2 allowed the specific identification of the larvae 
+as Ancylostoma braziliense.
+
+DOI: 10.4269/ajtmh.2012.11-0734
+PMCID: PMC3335691
+PMID: 22556085 [Indexed for MEDLINE]

--- a/references_cache/PMID_25146212.md
+++ b/references_cache/PMID_25146212.md
@@ -1,0 +1,49 @@
+---
+reference_id: "PMID:25146212"
+title: "[Cutaneous larva migrans after a trip to the Caribean]."
+authors:
+- García-Fernández L
+- Calderón M
+journal: Rev Chilena Infectol
+year: '2014'
+doi: 10.4067/S0716-10182014000300016
+keywords:
+- Adult
+- Animals
+- Antiparasitic Agents/therapeutic use
+- Female
+- Humans
+- Ivermectin/therapeutic use
+- "Larva Migrans/diagnosis, drug therapy"
+- "Skin Diseases, Parasitic/diagnosis, drug therapy"
+- Travel
+content_type: abstract_only
+---
+
+# [Cutaneous larva migrans after a trip to the Caribean].
+**Authors:** García-Fernández L, Calderón M
+**Journal:** Rev Chilena Infectol (2014)
+**DOI:** [10.4067/S0716-10182014000300016](https://doi.org/10.4067/S0716-10182014000300016)
+
+## Content
+
+1. Rev Chilena Infectol. 2014 Jun;31(3):346-8. doi: 
+10.4067/S0716-10182014000300016.
+
+[Cutaneous larva migrans after a trip to the Caribean].
+
+[Article in Spanish]
+
+García-Fernández L, Calderón M.
+
+Cutaneous larva migrans is a parasitic disease caused by Ancylostoma braziliense 
+and Ancylostoma caninum larvae, which is transmitted by contact with sand 
+infested with these parasites. Dogs and cats are the definitive hosts. This 
+parasitic disease is endemic in the Caribbean, Africa, Australia, and Asia. We 
+present the case of a 27-year-old woman, who developed skin lesions compatible 
+with cutaneous larva migrans on her right foot after returning from beach 
+vacations in the Mexican Caribbean. After clinical diagnosis, oral ivermectin 
+was administered, with good clinical response.
+
+DOI: 10.4067/S0716-10182014000300016
+PMID: 25146212 [Indexed for MEDLINE]

--- a/references_cache/PMID_28906088.md
+++ b/references_cache/PMID_28906088.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:28906088"
+title: "Bullous cutaneous larva migrans: case series and review of atypical clinical presentations."
+authors:
+- Veraldi S
+- Çuka E
+- Pontini P
+- Vaira F
+journal: G Ital Dermatol Venereol
+year: '2017'
+doi: 10.23736/S0392-0488.16.04832-X
+keywords:
+- Adult
+- Albendazole/therapeutic use
+- Anthelmintics/therapeutic use
+- Female
+- "Hookworm Infections/diagnosis, drug therapy, parasitology"
+- Humans
+- "Larva Migrans/diagnosis, drug therapy, parasitology"
+- Male
+- Middle Aged
+- Pruritus/parasitology
+content_type: abstract_only
+---
+
+# Bullous cutaneous larva migrans: case series and review of atypical clinical presentations.
+**Authors:** Veraldi S, Çuka E, Pontini P, Vaira F
+**Journal:** G Ital Dermatol Venereol (2017)
+**DOI:** [10.23736/S0392-0488.16.04832-X](https://doi.org/10.23736/S0392-0488.16.04832-X)
+
+## Content
+
+1. G Ital Dermatol Venereol. 2017 Oct;152(5):516-519. doi: 
+10.23736/S0392-0488.16.04832-X.
+
+Bullous cutaneous larva migrans: case series and review of atypical clinical 
+presentations.
+
+Veraldi S(1), Çuka E(2), Pontini P(2), Vaira F(2).
+
+Author information:
+(1)Department of Pathophysiology and Transplantation, Università degli Studi di 
+Milano, I.R.C.C.S. Foundation Ca' Granda, Ospedale Maggiore Policlinico, Milan, 
+Italy - stefano.veraldi@unimi.it.
+(2)Department of Pathophysiology and Transplantation, Università degli Studi di 
+Milano, I.R.C.C.S. Foundation Ca' Granda, Ospedale Maggiore Policlinico, Milan, 
+Italy.
+
+Hookworm-related cutaneous larva migrans (HRCLM) is caused by the penetration 
+and migration in the epidermis of larvae of Ancylostoma braziliense and 
+Ancylostoma caninum. It is characterized by slightly raised and erythematous 
+tracks, located especially on the feet. These tracks may be single or multiple, 
+serpiginous or linear, ramified and intertwined, accompanied by pruritus. 
+Atypical clinical presentations of HRCLM are currently more frequent than in the 
+past. We present six patients with bullous HRCLM and discuss the possible 
+pathogenetic factors. Furthermore, we present a review of atypical clinical 
+presentations of HRCLM. From 1998 to 2013 we observed approximately 180 patients 
+with HRCLM. In all patients race, nationality, sex, age, country of infestation, 
+location of the disease, clinical picture, laboratory and instrumental 
+examinations and therapy were collected. In six patients (4 males and 2 
+females), we made a diagnosis, based on the history and clinical picture, of 
+bullous HRCLM. The infestation was characterized by single or multiple blisters, 
+round or oval in shape, of different size, with a clear serous fluid. Some 
+tracks were also visible. All patients complained of pruritus. General physical 
+examination and laboratory and instrumental examinations were normal or 
+negative. Cytological examinations of the blisters showed the presence of 
+lymphocytes and neutrophils, with numerous eosinophils. All patients were 
+successfully treated with oral albendazole. Blisters appear because of the 
+release by the larvae of lytic enzymes (metalloproteases and hyaluronidases). 
+Furthermore, blisters might be the final clinical result of a delayed 
+hypersensitivity reaction due to the release by larvae of unknown antigens. 
+Finally, only in some patients, bullous HRCLM might represent an acute 
+irritant/allergic contact dermatitis caused by topical drugs applied on the 
+lesions. This hypothesis has been excluded in our patients because no topical 
+treatment was made before our observation.
+
+DOI: 10.23736/S0392-0488.16.04832-X
+PMID: 28906088 [Indexed for MEDLINE]

--- a/references_cache/PMID_36865421.md
+++ b/references_cache/PMID_36865421.md
@@ -1,0 +1,62 @@
+---
+reference_id: "PMID:36865421"
+title: "Loeffler's Syndrome and Multifocal Cutaneous Larva Migrans: Case report of an uncommon occurrence and review of the literature."
+authors:
+- Sil A
+- Bhanja DB
+- Chandra A
+- Biswas SK
+journal: Sultan Qaboos Univ Med J
+year: '2023'
+doi: 10.18295/squmj.5.2022.036
+keywords:
+- Male
+- Humans
+- Adult
+- "Larva Migrans/diagnosis, drug therapy"
+- Skin
+- Albendazole/therapeutic use
+- India
+- Levalbuterol
+content_type: abstract_only
+---
+
+# Loeffler's Syndrome and Multifocal Cutaneous Larva Migrans: Case report of an uncommon occurrence and review of the literature.
+**Authors:** Sil A, Bhanja DB, Chandra A, Biswas SK
+**Journal:** Sultan Qaboos Univ Med J (2023)
+**DOI:** [10.18295/squmj.5.2022.036](https://doi.org/10.18295/squmj.5.2022.036)
+
+## Content
+
+1. Sultan Qaboos Univ Med J. 2023 Feb;23(1):104-108. doi: 
+10.18295/squmj.5.2022.036. Epub 2023 Feb 23.
+
+Loeffler's Syndrome and Multifocal Cutaneous Larva Migrans: Case report of an 
+uncommon occurrence and review of the literature.
+
+Sil A(1), Bhanja DB(2), Chandra A(3), Biswas SK(1).
+
+Author information:
+(1)Department of Dermatology, Venereology and Leprosy, RG Kar Medical College 
+and Hospital, Kolkata, India.
+(2)Department of Dermatology, Venereology and Leprosy, Midnapore Medical College 
+and Hospital, West Bengal, India.
+(3)Department of Internal Medicine, RG Kar Medical College and Hospital, 
+Kolkata, India.
+
+Cutaneous larva migrans (CLM) is a zoonotic skin disease that is frequently 
+diagnosed in tropical and subtropical countries. Loeffler's syndrome (LS) is a 
+transient respiratory ailment characterised by pulmonary infiltration along with 
+peripheral eosinophilia and commonly follows parasitic infestation. We report a 
+33-year-old male patient who presented to a tertiary care hospital in eastern 
+India in 2019 with LS that was attributed secondary to multifocal CLM. Treatment 
+with seven-day course of oral albendazole (400 mg daily) coupled with 
+nebulisation (levosalbutamol and budesonide) led to complete resolution of 
+cutaneous lesions and respiratory complaints within two weeks. There was 
+complete resolution of pulmonary pathology at four-weeks follow-up.
+
+© Copyright 2023, Sultan Qaboos University Medical Journal, All Rights Reserved.
+
+DOI: 10.18295/squmj.5.2022.036
+PMCID: PMC9974021
+PMID: 36865421 [Indexed for MEDLINE]

--- a/references_cache/PMID_37921817.md
+++ b/references_cache/PMID_37921817.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:37921817"
+title: Cutaneous larva migrans in the northeastern US.
+authors:
+- Johanis M
+- Cheema KS
+- Young PA
+- Narala S
+- Saleem A
+- Novoa RA
+- Bae GH
+journal: Dermatol Online J
+year: '2023'
+doi: 10.5070/D329461906
+keywords:
+- Humans
+- Female
+- Middle Aged
+- "Larva Migrans/diagnosis, drug therapy, epidemiology"
+- Ivermectin/therapeutic use
+- Skin/pathology
+- Epidermis
+- Exanthema/pathology
+content_type: abstract_only
+---
+
+# Cutaneous larva migrans in the northeastern US.
+**Authors:** Johanis M, Cheema KS, Young PA, Narala S, Saleem A, Novoa RA, Bae GH
+**Journal:** Dermatol Online J (2023)
+**DOI:** [10.5070/D329461906](https://doi.org/10.5070/D329461906)
+
+## Content
+
+1. Dermatol Online J. 2023 Aug 15;29(4). doi: 10.5070/D329461906.
+
+Cutaneous larva migrans in the northeastern US.
+
+Johanis M, Cheema KS, Young PA, Narala S, Saleem A, Novoa RA, Bae GH(1).
+
+Author information:
+(1)Department of Dermatology, Stanford University School of Medicine, Redwood 
+City, California, USA. GBae@Stanford.edu.
+
+Cutaneous larva migrans (CLM) is a dermo-epidermal parasitic infection with a 
+disproportionate incidence in developing countries, particularly in, and near 
+tropical areas. It is characterized by erythematous, twisting, and linear 
+plaques that can migrate to adjacent skin. Herein, we present an otherwise 
+healthy 45-year-old woman who acquired a pruritic, erythematous, and serpiginous 
+rash localized to her right medial ankle during a trip to New England. Oral 
+ivermectin, the preferred first-line treatment for cutaneous larva migrans, was 
+administered in combination with triamcinolone. This was followed by removal of 
+the papular area via punch biopsy; treatment was successful with a one-week 
+recovery. Although cutaneous larva migrans has traditionally been considered a 
+tropical disease, clinicians should be cognizant of its expanding geographic 
+spread.
+
+DOI: 10.5070/D329461906
+PMID: 37921817 [Indexed for MEDLINE]

--- a/references_cache/PMID_38222776.md
+++ b/references_cache/PMID_38222776.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:38222776"
+title: "Cutaneous larva migrans in a child: a case report and review of literature."
+authors:
+- Shrestha A
+- K C K
+- Baral A
+- Shrestha R
+- Shrestha R
+journal: Ann Med Surg (Lond)
+year: '2024'
+doi: 10.1097/MS9.0000000000001512
+content_type: abstract_only
+---
+
+# Cutaneous larva migrans in a child: a case report and review of literature.
+**Authors:** Shrestha A, K C K, Baral A, Shrestha R, Shrestha R
+**Journal:** Ann Med Surg (Lond) (2024)
+**DOI:** [10.1097/MS9.0000000000001512](https://doi.org/10.1097/MS9.0000000000001512)
+
+## Content
+
+1. Ann Med Surg (Lond). 2023 Nov 16;86(1):530-534. doi: 
+10.1097/MS9.0000000000001512. eCollection 2024 Jan.
+
+Cutaneous larva migrans in a child: a case report and review of literature.
+
+Shrestha A(1), K C K(2), Baral A(3), Shrestha R(4), Shrestha R(5).
+
+Author information:
+(1)Koshi Hospital, Biratnagar, Koshi Province.
+(2)Department of Health Services, Epidemiology and Disease Control Division.
+(3)Ministry of Health and Population.
+(4)Bir Hospital, Kathmandu.
+(5)Dhulikhel Hospital, Kathmandu University, Kavrepalanchowk, Bagmati Province, 
+Nepal.
+
+INTRODUCTION: Cutaneous larva migrans (CLM) is a dermatitis caused by the 
+invasion and migration of parasitic larvae of hookworms, primarily affecting 
+tropical and subtropical regions. This report presents a case of CLM in a Nepali 
+child and provides an overview of the literature on this condition.
+CASE REPORT: A 4-year-old boy from a rural area in Nepal presented with a 
+pruritic skin lesion on his left foot, initially misdiagnosed as fungal 
+infection. The lesion gradually expanded, forming a serpiginous erythema, and 
+became intensely pruritic. The patient's family had poor socioeconomic 
+conditions, and the child frequently walked barefoot in an area with many 
+domestic and stray dogs. Diagnosis was confirmed clinically, and treatment with 
+oral albendazole and antihistamines resulted in complete resolution of symptoms.
+DISCUSSION: CLM is a neglected zoonotic disease, with an underestimated burden 
+in developing countries due to underreporting and misdiagnosis. The larvae of 
+Ancylostoma spp. are common culprits, causing a localized inflammatory reaction 
+as they migrate through the skin. Diagnosis is mainly clinical and routine 
+investigations usually reveal no abnormality. Complications may include 
+secondary bacterial infections, allergies, and rare migration to internal 
+organs. Treatment options include albendazole or ivermectin, with preventive 
+measures emphasizing hygiene, footwear use, and pet deworming.
+CONCLUSION: CLM is a neglected disease that primarily affects marginalized 
+communities in tropical regions. Raising awareness among healthcare providers, 
+conducting observational studies, and developing treatment guidelines, 
+especially for children, are essential steps to address this public health 
+concern. Preventive efforts, such as promoting hygiene and footwear use, should 
+be encouraged to reduce CLM incidence.
+
+Copyright © 2023 The Author(s). Published by Wolters Kluwer Health, Inc.
+
+DOI: 10.1097/MS9.0000000000001512
+PMCID: PMC10783223
+PMID: 38222776
+
+Conflict of interest statement: There are no conflicts of interest.Sponsorships 
+or competing interests that may be relevant to content are disclosed at the end 
+of this article.

--- a/references_cache/PMID_38500436.md
+++ b/references_cache/PMID_38500436.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:38500436"
+title: Ecoepidemiology of Ancylostoma spp. in Urban-Marginal and Rural Sectors of the Ecuadorian Coast and Prevalence of Cutaneous Larvae Migrans.
+authors:
+- Coello Peralta RD
+- Pazmiño Gómez BJ
+- Salazar Mazamba ML
+- Parra-Guayasamin SG
+- Vinueza Sierra RL
+- Rodas Pazmiño JP
+- Rodas Neira EI
+- Gómez Landires EA
+- Ramallo G
+journal: Med Sci Monit
+year: '2024'
+doi: 10.12659/MSM.943931
+keywords:
+- Humans
+- Animals
+- Dogs
+- Ancylostoma
+- "Larva Migrans/epidemiology, parasitology"
+- Ecuador/epidemiology
+- Prevalence
+- Larva
+- Feces
+content_type: abstract_only
+---
+
+# Ecoepidemiology of Ancylostoma spp. in Urban-Marginal and Rural Sectors of the Ecuadorian Coast and Prevalence of Cutaneous Larvae Migrans.
+**Authors:** Coello Peralta RD, Pazmiño Gómez BJ, Salazar Mazamba ML, Parra-Guayasamin SG, Vinueza Sierra RL, Rodas Pazmiño JP, Rodas Neira EI, Gómez Landires EA, Ramallo G
+**Journal:** Med Sci Monit (2024)
+**DOI:** [10.12659/MSM.943931](https://doi.org/10.12659/MSM.943931)
+
+## Content
+
+1. Med Sci Monit. 2024 Mar 8;30:e943931. doi: 10.12659/MSM.943931.
+
+Ecoepidemiology of Ancylostoma spp. in Urban-Marginal and Rural Sectors of the 
+Ecuadorian Coast and Prevalence of Cutaneous Larvae Migrans.
+
+Coello Peralta RD(1), Pazmiño Gómez BJ(2), Salazar Mazamba ML(1), 
+Parra-Guayasamin SG(1), Vinueza Sierra RL(3), Rodas Pazmiño JP(4), Rodas Neira 
+EI(4), Gómez Landires EA(5), Ramallo G(6).
+
+Author information:
+(1)Department of Microbiology, Faculty of Veterinary Medicine and Zootechnics, 
+Universidad de Guayaquil, Chile y Av. Olmedo, Guayaquil, Ecuador.
+(2)Faculty of Health and Social Services, Universidad Estatal de Milagro 
+(UNEMI), Milagro, Ecuador.
+(3)Escuela de Medicina Veterinaria, Universidad San Francisco de Quito (USFQ), 
+Quito, Ecuador.
+(4)Department of Microbiology, Clinical and Microbiological Laboratory Pazmiño, 
+Milagro, Ecuador.
+(5)Faculty of Medical Sciences, Universidad Católica de Santiago de Guayaquil, 
+Guayaquil, Ecuador.
+(6)Instituto de Invertebrados, Fundación Miguel Lillo, San Miguel de Tucumán, 
+Argentina.
+
+BACKGROUND Ancylostoma spp., including A. duodenale, A. braziliense, A. caninum, 
+and A. ceylanicum, are hookworms that are transmitted from infected soil and by 
+contact with domestic animals and rodent hosts, and can cause systemic disease 
+and cutaneous larva migrans. The objective of this study was to describe the 
+ecoepidemiology of Ancylostoma caninum and Ancylostoma spp. in urban-marginal 
+sectors and in rural sectors located in Ecuador. MATERIAL AND METHODS Through 
+addressed sampling, a total of 498 domestic dogs and 40 synanthropic rodents 
+were analyzed via the following coproparasitic methods: direct, flotation, 
+sedimentation with centrifugation using saline (egg identification), modified 
+Baermann (larval identification), and morphometric methods (confirmation). A 
+total of 236 people were surveyed, and a clinical analysis was performed via 
+physical examination. The environmental variables were obtained through reports 
+from the INAMHI of Ecuador and the use of online environmental programs. Through 
+surveys, data related to social determinants were obtained. Epidemiological 
+indicators (prevalence, morbidity, and mortality) were obtained through 
+microbial analysis and surveys. RESULTS A total of 250 domestic dogs were 
+diagnosed with Ancylostoma caninum (50, 20%), and 41 were diagnosed with 
+Ancylostoma spp. (8.23%). One synanthropic rodent (2.5%) was positive for A. 
+caninum. In the clinical analysis, 3 patients were identified as positive 
+(1.27%) for cutaneous larva migrans (CLM). Likewise, environmental variables and 
+social determinants influence the transmission, prevalence, and nature of 
+parasitism by hookworm. CONCLUSIONS People, domestic dogs, and rodents were 
+infected with these parasites. Consequently, there is a risk of ancylostomiasis 
+and cutaneous larvae migrans spreading.
+
+DOI: 10.12659/MSM.943931
+PMCID: PMC10929298
+PMID: 38500436 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of interest: None declared

--- a/references_cache/PMID_38680772.md
+++ b/references_cache/PMID_38680772.md
@@ -1,0 +1,54 @@
+---
+reference_id: "PMID:38680772"
+title: "Cutaneous Larva Migrans (CLM) may not be easy to diagnose: a case report and narrative review."
+authors:
+- Osman S
+- Tarnari N
+- Ahsan A
+- Ahmed KAHM
+journal: Oxf Med Case Reports
+year: '2024'
+doi: 10.1093/omcr/omae025
+content_type: abstract_only
+---
+
+# Cutaneous Larva Migrans (CLM) may not be easy to diagnose: a case report and narrative review.
+**Authors:** Osman S, Tarnari N, Ahsan A, Ahmed KAHM
+**Journal:** Oxf Med Case Reports (2024)
+**DOI:** [10.1093/omcr/omae025](https://doi.org/10.1093/omcr/omae025)
+
+## Content
+
+1. Oxf Med Case Reports. 2024 Apr 25;2024(4):omae025. doi: 10.1093/omcr/omae025. 
+eCollection 2024 Apr.
+
+Cutaneous Larva Migrans (CLM) may not be easy to diagnose: a case report and 
+narrative review.
+
+Osman S(1), Tarnari N(1), Ahsan A(2), Ahmed KAHM(3).
+
+Author information:
+(1)Assistant Professor of Dermatology, Internal Security Force, Doha, Qatar.
+(2)School of Health Sciences, Foundation University, Islamabad, Pakistan.
+(3)Faculty of Medicine, University of Khartoum, Khartoum, Sudan.
+
+BACKGROUND: Cutaneous Larva Migrans (CLM) is one of the most common zoonotic 
+dermatoses in subtropical and tropical regions and some European countries. It 
+is caused by different types of hookworm, such as Ancylostoma braziliense, 
+Ancylostoma caninum, and Uncinaria stenocephala. It is usually easy to diagnose, 
+but the atypical presentation may occasionally mimic other dermatoses.
+CASE REPORT: A 32-year-old man presented with an extensive eczematous rash that 
+developed during a recent vacation in Thailand. He didn't respond to 
+antihistamines and systemic steroids. Finally, he was diagnosed with an atypical 
+presentation of CLM and treated successfully with anthelminthic therapy.
+CONCLUSION: The report of an atypical presentation of CLM is crucial to increase 
+awareness among healthcare workers, helping in early diagnosis and reducing 
+potential psychological distress that patients may face.
+
+© The Author(s) 2024. Published by Oxford University Press.
+
+DOI: 10.1093/omcr/omae025
+PMCID: PMC11049579
+PMID: 38680772
+
+Conflict of interest statement: There is no conflict of interest of any author.

--- a/references_cache/PMID_39021742.md
+++ b/references_cache/PMID_39021742.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:39021742"
+title: "Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan."
+authors:
+- Shamad M
+- Al-Mutairi N
+journal: Cureus
+year: '2024'
+doi: 10.7759/cureus.64665
+content_type: abstract_only
+---
+
+# Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and Ivermectin Therapy: A Report of Two Cases From Sudan.
+**Authors:** Shamad M, Al-Mutairi N
+**Journal:** Cureus (2024)
+**DOI:** [10.7759/cureus.64665](https://doi.org/10.7759/cureus.64665)
+
+## Content
+
+1. Cureus. 2024 Jul 16;16(7):e64665. doi: 10.7759/cureus.64665. eCollection 2024 
+Jul.
+
+Successful Treatment of Cutaneous Larva Migrans With Combined Albendazole and 
+Ivermectin Therapy: A Report of Two Cases From Sudan.
+
+Shamad M(1)(2), Al-Mutairi N(2).
+
+Author information:
+(1)College of Medicine, University of Bahri, Khartoum, SDN.
+(2)Faculty of Medicine, Kuwait University, Kuwait City, KWT.
+
+Cutaneous larva migrans (CLM), caused by third-stage filariform larvae of cat 
+and dog hookworms, presents as pruritic, serpiginous tracks upon skin 
+penetration by larvae from contaminated soil. Herein, we report the successful 
+treatment of two CLM patients using albendazole and ivermectin combination 
+therapy. A 42-year-old man from Kordofan and a 38-year-old man from White Nile 
+State presented with characteristic lesions on their lower extremities, 
+resolving completely within one week post-treatment without recurrence. This 
+report highlights the potential of combined albendazole-ivermectin therapy in 
+managing CLM amid emerging antihelminthic resistance, suggesting that its 
+broader application warrants further investigation.
+
+Copyright © 2024, Shamad et al.
+
+DOI: 10.7759/cureus.64665
+PMCID: PMC11253558
+PMID: 39021742
+
+Conflict of interest statement: Human subjects: Consent was obtained or waived 
+by all participants in this study. Conflicts of interest: In compliance with the 
+ICMJE uniform disclosure form, all authors declare the following: 
+Payment/services info: All authors have declared that no financial support was 
+received from any organization for the submitted work. Financial relationships: 
+All authors have declared that they have no financial relationships at present 
+or within the previous three years with any organizations that might have an 
+interest in the submitted work. Other relationships: All authors have declared 
+that there are no other relationships or activities that could appear to have 
+influenced the submitted work.

--- a/references_cache/PMID_39633595.md
+++ b/references_cache/PMID_39633595.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:39633595"
+title: Consideration of Diagnostic Methods for Cutaneous Larva Migrans in the Sole of an 8-Year-Old Boy.
+authors:
+- Kondo M
+- Habe K
+- Tanaka M
+- Yamanaka K
+journal: Parasite Immunol
+year: '2024'
+doi: 10.1111/pim.13078
+keywords:
+- Child
+- Humans
+- Male
+- Eosinophils
+- "Foot/parasitology, pathology"
+- Immunoglobulin A/blood
+- Immunoglobulin E/blood
+- Ivermectin/therapeutic use
+- "Larva Migrans/diagnosis, drug therapy"
+- Magnetic Resonance Imaging
+- Treatment Outcome
+- Ultrasonography
+content_type: abstract_only
+---
+
+# Consideration of Diagnostic Methods for Cutaneous Larva Migrans in the Sole of an 8-Year-Old Boy.
+**Authors:** Kondo M, Habe K, Tanaka M, Yamanaka K
+**Journal:** Parasite Immunol (2024)
+**DOI:** [10.1111/pim.13078](https://doi.org/10.1111/pim.13078)
+
+## Content
+
+1. Parasite Immunol. 2024 Dec;46(12):e13078. doi: 10.1111/pim.13078.
+
+Consideration of Diagnostic Methods for Cutaneous Larva Migrans in the Sole of 
+an 8-Year-Old Boy.
+
+Kondo M(1), Habe K(1), Tanaka M(2), Yamanaka K(1).
+
+Author information:
+(1)Department of Dermatology, Mie University Graduate School of Medicine, Tsu, 
+Mie, Japan.
+(2)Division of Parasitology, Department of Infectious Diseases, Faculty of 
+Medicine, University of Miyazaki, Miyazaki-shi, Miyazaki, Japan.
+
+An 8-year-old boy developed serpiginous erythema on the soles of his feet and 
+was diagnosed with cutaneous larva migrans (CLM). Following treatment with 
+ivermectin, the erythema improved within 7 days, but it recurred 14 days later, 
+requiring a second dose for complete resolution. Ultrasound and MRI did not 
+reveal any parasites, but fluctuations in eosinophils, IgE and IgA levels were 
+observed during treatment. This case highlights the importance of combining 
+multiple diagnostic methods to evaluate treatment effectiveness.
+
+© 2024 John Wiley & Sons Ltd.
+
+DOI: 10.1111/pim.13078
+PMID: 39633595 [Indexed for MEDLINE]

--- a/references_cache/PMID_41948263.md
+++ b/references_cache/PMID_41948263.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:41948263"
+title: "Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile."
+authors:
+- Guarda D
+- Norambuena C
+- Marquez P
+- Bascuñan G
+- Mendez-Villanueva DI
+journal: Cureus
+year: '2026'
+doi: 10.7759/cureus.104834
+content_type: abstract_only
+---
+
+# Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From Chile.
+**Authors:** Guarda D, Norambuena C, Marquez P, Bascuñan G, Mendez-Villanueva DI
+**Journal:** Cureus (2026)
+**DOI:** [10.7759/cureus.104834](https://doi.org/10.7759/cureus.104834)
+
+## Content
+
+1. Cureus. 2026 Mar 7;18(3):e104834. doi: 10.7759/cureus.104834. eCollection 2026
+ Mar.
+
+Imported Cutaneous Larva Migrans in an Adolescent Traveler: A Case Report From 
+Chile.
+
+Guarda D(1), Norambuena C(1), Marquez P(2), Bascuñan G(3), Mendez-Villanueva 
+DI(4).
+
+Author information:
+(1)General Practice, Clínica Andes Salud, Puerto Montt, CHL.
+(2)General Practice, Universidad Andres Bello, Santiago, CHL.
+(3)General Practice, Hospital Familiar y Comunitario de Carahue, Carahue, CHL.
+(4)Dermatology, Universidad de Santiago de Chile, Santiago, CHL.
+
+Cutaneous larva migrans (CLM) is a parasitic dermatosis caused by the 
+superficial migration of animal hookworm larvae in human skin, typically 
+acquired through contact with contaminated soil or sand in tropical 
+environments. We report the case of a 17-year-old female patient who presented 
+in Chile with pruritic serpiginous skin lesions following recent travel to 
+Brazil. Diagnosis was established clinically based on characteristic morphology 
+and exposure history. The patient was treated with oral ivermectin, resulting in 
+complete resolution of active lesions and symptoms. Given the rarity of locally 
+reported cases in Chile, this report underscores the importance of clinical 
+recognition in nonendemic settings to ensure prompt treatment and avoid 
+unnecessary diagnostic procedures.
+
+Copyright © 2026, Guarda et al.
+
+DOI: 10.7759/cureus.104834
+PMCID: PMC13051245
+PMID: 41948263
+
+Conflict of interest statement: Human subjects: Informed consent for treatment 
+and open access publication was obtained or waived by all participants in this 
+study. Not applicable issued approval N/A. This study is a single-patient case 
+report. According to institutional policy, ethics committee or IRB approval is 
+not required for case reports when written informed consent for publication has 
+been obtained. Conflicts of interest: In compliance with the ICMJE uniform 
+disclosure form, all authors declare the following: Payment/services info: All 
+authors have declared that no financial support was received from any 
+organization for the submitted work. Financial relationships: All authors have 
+declared that they have no financial relationships at present or within the 
+previous three years with any organizations that might have an interest in the 
+submitted work. Other relationships: All authors have declared that there are no 
+other relationships or activities that could appear to have influenced the 
+submitted work.

--- a/research/Cutaneous_Larva_Migrans-deep-research-falcon.md
+++ b/research/Cutaneous_Larva_Migrans-deep-research-falcon.md
@@ -1,0 +1,1195 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T19:28:48.183932'
+end_time: '2026-05-06T19:39:31.437236'
+duration_seconds: 643.25
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Cutaneous larva migrans
+  mondo_id: ''
+  category: Infectious
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 36
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Cutaneous larva migrans
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Cutaneous larva migrans** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Cutaneous larva migrans
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Cutaneous larva migrans** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Cutaneous Larva Migrans (CLM) — Disease Characteristics Research Report
+
+## 1. Disease information
+
+### Overview / current definition
+Cutaneous larva migrans (CLM) is a zoonotic, hookworm-related dermatosis caused by penetration of animal hookworm larvae and their subsequent superficial migration within human skin, producing intensely pruritic, slowly advancing, linear/serpiginous tracks (“creeping eruption”). (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7)
+
+A representative clinical image (serpiginous plaque) and histopathologic confirmation (organism in stratum corneum with eosinophil-rich infiltrate) are shown in the 2023 Dermatology Online Journal report. (johanis2023cutaneouslarvamigrans media 1be38c9c, johanis2023cutaneouslarvamigrans media a6ff90a3)
+
+### Synonyms / alternative names
+Synonyms used in the clinical/review literature include: hookworm-related cutaneous larva migrans (HrCLM), creeping eruption, zoonotic hookworm infection, serpiginous linear dermatitis, ground itch, sandworm, and plumber’s itch. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3)
+
+### Key identifiers (ontology/coding)
+* **MeSH:** “Cutaneous Larva Migrans” / “Larva Migrans, Cutaneous” is used as an indexed subject term in the biomedical literature; however, the **MeSH ID** was not present in the retrieved full-text snippets. (guarda2026importedcutaneouslarva pages 4-7)
+* **ICD-10/ICD-11:** A CLM-specific ICD code was not explicitly stated in the CLM-focused papers retrieved here; several sources refer generally to use of ICD groupings/codes in datasets, but without giving a CLM code. (shrestha2024cutaneouslarvamigrans pages 1-2)
+* **MONDO:** A MONDO ID was **not found in the retrieved evidence**.
+
+### Evidence source type
+The evidence retrieved here is primarily **aggregated disease-level reviews**, **case reports**, and **case series/outbreak investigations** in humans (travel medicine, dermatology), with supporting epidemiologic and quality-of-life cohort studies. (hochedez2007hookwormrelatedcutaneouslarva pages 4-6, hasni2024cutaneouslarvamigrans pages 2-6, schuster2011lifequalityimpairment pages 1-2)
+
+| Category | Details (concise) | Key sources (with DOI/URL + year) |
+|---|---|---|
+| Definition / synonyms | Zoonotic, hookworm-related dermatosis caused by intraepidermal migration of non-human hookworm larvae, producing intensely pruritic, linear/serpiginous “creeping” tracks. Synonyms reported in the evidence: hookworm-related cutaneous larva migrans (HrCLM), creeping eruption, zoonotic hookworm infection, serpiginous linear dermatitis, ground itch, sandworm, plumber’s itch. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3) | Rodriguez-Morales et al., 2021, https://doi.org/10.1007/s40475-021-00239-0 |
+| Key identifiers | MeSH term name appears in indexed literature as “Cutaneous Larva Migrans” / “Larva Migrans, Cutaneous” (term name evidenced, numeric ID not found in provided evidence). ICD-10/11 specific code not directly given for CLM in the provided disease-focused sources; broader helminthiasis coding context only. MONDO ID: not found in evidence. (guarda2026importedcutaneouslarva pages 4-7, shrestha2024cutaneouslarvamigrans pages 1-2) | Guarda et al., 2026, https://doi.org/10.7759/cureus.104834; Shrestha et al., 2024, https://doi.org/10.1097/ms9.0000000000001512 |
+| Main causal organisms | Most commonly Ancylostoma braziliense; also Ancylostoma caninum, Ancylostoma ceylanicum, and Uncinaria stenocephala are implicated. Humans are accidental/dead-end hosts; larvae generally do not mature in the intestine. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, currie2025cutaneouslarvamigrans pages 6-7, elmi2025cutaneouslarvamigrans pages 1-3) | Rodriguez-Morales et al., 2021, https://doi.org/10.1007/s40475-021-00239-0; Currie et al., 2025, https://doi.org/10.3390/tropicalmed10060163 |
+| Typical exposure / risk factors | Barefoot walking or lying on contaminated sand/soil, especially beaches and sandboxes; contact with dog/cat feces or untreated pets; muddy/wet soil exposure; travel to tropical/subtropical regions; some occupational exposures (farming, gardening, animal handling). Pediatric risk is prominent in some recent series. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, hasni2024cutaneouslarvamigrans pages 2-6, shrestha2024cutaneouslarvamigrans pages 1-2, johanis2023cutaneouslarvamigrans pages 1-3) | Rodriguez-Morales et al., 2021, https://doi.org/10.1007/s40475-021-00239-0; Hasni et al., 2024, https://doi.org/10.5001/omj.2028.07; Shrestha et al., 2024, https://doi.org/10.1097/ms9.0000000000001512; Johanis et al., 2023, https://doi.org/10.5070/d329461906 |
+| First-line treatments / example dosing | Oral ivermectin is generally preferred first-line: single dose 150–200 µg/kg (adult example 12 mg), repeat if needed. Albendazole is an effective alternative: 400 mg/day for 3–7 days; some reports/series recommend 400 mg once daily for 5 days or 400 mg/day for 1 week. Topical 10% albendazole is an option when oral therapy is contraindicated (e.g., very small children). Cryotherapy is not recommended. (hochedez2007hookwormrelatedcutaneouslarva pages 4-6, johanis2023cutaneouslarvamigrans pages 3-5, hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7) | Hochedez & Caumes, 2007, https://doi.org/10.1111/j.1708-8305.2007.00148.x; Johanis et al., 2023, https://doi.org/10.5070/d329461906; Hasni et al., 2024, https://doi.org/10.5001/omj.2028.07 |
+| Key 2023–2024 developments | 2024 Oman urban outbreak/case series linked cases to heavy rainfall, puddles/mud, and recommended surveillance plus municipal/agricultural collaboration; 7/9 cases (78%) were pediatric. 2023 northeastern US case highlighted possible geographic expansion beyond classic tropical zones and climate-linked spread. 2024 Nepal pediatric review emphasized neglected burden, footwear/pet deworming prevention, and pediatric treatment guidance. 2024 Sudan report described successful combination albendazole + ivermectin in 2 cases amid concern about emerging anthelmintic resistance. (hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7, johanis2023cutaneouslarvamigrans pages 1-3, shrestha2024cutaneouslarvamigrans pages 3-4, currie2025cutaneouslarvamigrans pages 13-13) | Hasni et al., 2024, https://doi.org/10.5001/omj.2028.07; Johanis et al., 2023, https://doi.org/10.5070/d329461906; Shrestha et al., 2024, https://doi.org/10.1097/ms9.0000000000001512; Shamad et al., 2024, https://doi.org/10.7759/cureus.64665 |
+
+
+*Table: This compact table summarizes the most actionable disease-characteristics evidence for cutaneous larva migrans, including definition, likely identifiers, causes, exposures, treatment, and recent 2023–2024 developments. It is designed for quick knowledge-base population and citation tracing.*
+
+## 2. Etiology
+
+### Primary causal factors (infectious)
+CLM is most often attributed to zoonotic hookworms of dogs/cats. Reviews emphasize **Ancylostoma braziliense** as a principal cause, with other implicated species including **Ancylostoma caninum** and **Uncinaria stenocephala**. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, elmi2025cutaneouslarvamigrans pages 1-3, currie2025cutaneouslarvamigrans pages 6-7)
+
+Humans are accidental/dead-end hosts; larvae generally do not mature to adult intestinal worms in humans. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3)
+
+### Risk factors
+Commonly supported risks include:
+* **Bare-skin contact with contaminated sand/soil**, especially **beaches** and sandboxes (walking barefoot, sitting/lying on sand). (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7)
+* **Exposure to dog/cat feces or untreated pets** (domestic or stray), especially in resource-poor settings. (shrestha2024cutaneouslarvamigrans pages 1-2, johanis2023cutaneouslarvamigrans pages 1-3)
+* **Occupational soil exposure** (e.g., farming, gardening, animal handling). (elmi2025cutaneouslarvamigrans pages 1-3, hasni2024cutaneouslarvamigrans pages 2-6)
+* **Climate/environmental events**: a 2024 Oman case series reported a cluster occurring “mainly after periods of rainfall” and noted recent contact with “water puddles or mud” across cases, supporting a role for unusual wet conditions facilitating larval survival/exposure. (hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7)
+
+### Protective factors
+Direct, empirically quantified protective factors were not provided in the retrieved primary studies. Prevention recommendations (Section 13) imply protective effects of **consistent footwear** and avoidance of direct contact with contaminated sand/soil. (hochedez2007hookwormrelatedcutaneouslarva pages 4-6, shrestha2024cutaneouslarvamigrans pages 1-2)
+
+### Genetic risk / protective factors; gene–environment interactions
+CLM is not a genetic disease; **no causal human genes/variants** or gene–environment interaction studies were present in the retrieved evidence.
+
+## 3. Phenotypes (clinical presentation)
+
+### Core clinical phenotypes
+The typical presentation is a **pruritic, erythematous, linear/serpiginous track** that migrates to adjacent skin over time. (johanis2023cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7)
+
+A 2023 abstract states CLM is “characterized by erythematous, twisting, and linear plaques that can migrate to adjacent skin.” (johanis2023cutaneouslarvamigrans pages 1-3)
+
+Common sites reflect exposure (feet/ankles; sometimes thighs/buttocks). (guarda2026importedcutaneouslarva pages 4-7, johanis2023cutaneouslarvamigrans pages 1-3)
+
+### Complications / atypical features
+Complications described across recent and foundational sources include:
+* **Secondary bacterial infection** due to excoriation/scratching. (guarda2026importedcutaneouslarva pages 4-7, shrestha2024cutaneouslarvamigrans pages 3-4)
+* **Vesiculobullous lesions** and **folliculitis** (including “hookworm folliculitis”/follicular CLM). (johanis2023cutaneouslarvamigrans pages 1-3, hochedez2007hookwormrelatedcutaneouslarva pages 4-6)
+* Rare systemic manifestations such as **Löffler syndrome** are mentioned as exceptional. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, hasni2024cutaneouslarvamigrans pages 6-7)
+
+Shrestha et al. (2024) summarizes that routine investigations are often normal and that complications can include secondary bacterial infection, allergy, and rare internal migration; the abstract explicitly notes the lesion was initially misdiagnosed as fungal infection and later became “intensely pruritic.” (shrestha2024cutaneouslarvamigrans pages 1-2)
+
+### Onset, severity, progression
+CLM is often **subacute** after exposure, with lesions migrating over days to weeks; the condition is generally **self-limited**, with larvae dying after several weeks if untreated (reported as ~5–6 weeks in a 2024 review/case report). (shrestha2024cutaneouslarvamigrans pages 3-4)
+
+### Quality-of-life impact (statistics)
+In a cohort of **91 adults and children** in Manaus, Brazil, **91.5%** had “a considerable reduction of skin disease-associated life quality” at diagnosis; the most frequent restrictions were **intense pruritus (93.4%)**, **sleep disturbance (73.6%)**, and **shame (64.8%)**. (schuster2011lifequalityimpairment pages 1-2)
+
+QoL improved rapidly with ivermectin; by four weeks, **73.3%** considered disease-associated life quality to have returned to normal in the abstract, and detailed results show a median mDLQI drop from 5 to 0 with most participants reporting normalization. (schuster2011lifequalityimpairment pages 1-2, schuster2011lifequalityimpairment pages 3-4)
+
+### Suggested HPO terms
+(Approximate mappings based on described phenotypes; HPO IDs not retrieved in evidence snippets.)
+* Serpiginous/migratory skin lesion: **Skin lesion**, **Erythema**, **Linear skin lesion**
+* Pruritus: **Pruritus**
+* Excoriations: **Excoriation**
+* Vesicles/bullae: **Vesicle**, **Bulla**
+* Sleep disturbance from itch: **Insomnia**
+* Eosinophilia (sometimes): **Eosinophilia**
+
+## 4. Genetic / molecular information
+
+No human causal genes, pathogenic variants, modifier genes, or epigenetic mechanisms were identified in the retrieved evidence; CLM is fundamentally an **infectious/parasitic exposure-driven** condition.
+
+## 5. Environmental information
+
+### Environmental factors
+Key environmental determinants are **soil/sand contamination with animal feces** and conditions that permit larval development/survival in the environment (warmth and moisture). (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7, johanis2023cutaneouslarvamigrans pages 3-5)
+
+A 2024 Oman cluster associated CLM occurrence with unusual rainfall events and muddy/puddled environments, implying environmental moisture as a practical outbreak driver. (hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7)
+
+### Lifestyle factors
+Walking barefoot and lying directly on sand/soil are recurring behavioral risks. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, hochedez2007hookwormrelatedcutaneouslarva pages 4-6)
+
+### Infectious agents (pathogens)
+Most commonly dog/cat hookworms (Ancylostoma spp.). (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, elmi2025cutaneouslarvamigrans pages 1-3)
+
+## 6. Mechanism / pathophysiology
+
+### Causal chain (trigger → mechanism → phenotype)
+1. **Environmental contamination** with infective larvae from dog/cat hookworms (feces contaminating sand/soil). (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7)
+2. **Skin penetration** of infective larvae after bare-skin contact with contaminated substrate. (guarda2026importedcutaneouslarva pages 4-7)
+3. **Intraepidermal migration** of larvae in humans (who are accidental hosts), producing a moving inflammatory focus along the larval path. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7)
+4. **Local inflammation with eosinophils** contributes to intense pruritus and visible serpiginous tracks; histology in a U.S. case showed organism in the stratum corneum with a dermal mixed infiltrate including eosinophils. (johanis2023cutaneouslarvamigrans media a6ff90a3)
+5. **Downstream consequences**: scratching/excoriation → secondary bacterial infection; atypical manifestations include bullae or folliculitis. (guarda2026importedcutaneouslarva pages 4-7, hochedez2007hookwormrelatedcutaneouslarva pages 4-6)
+
+### Immune involvement / tissue injury
+Evidence supports eosinophil-rich inflammation as a recurring histologic pattern, consistent with helminth-driven type 2 inflammation. (johanis2023cutaneouslarvamigrans media a6ff90a3)
+
+### Suggested ontology terms
+* **GO (biological process):** inflammatory response; eosinophil chemotaxis; leukocyte migration; pruritus (as neuro-immune symptom)
+* **CL (cell types):** eosinophil; keratinocyte; dermal macrophage; T cell
+* **UBERON (anatomy):** skin of foot; epidermis; stratum corneum; dermis
+
+### Molecular profiling / omics
+No transcriptomic/proteomic/metabolomic profiling studies were identified in the retrieved evidence.
+
+## 7. Anatomical structures affected
+
+### Organ/system level
+Primary organ: **skin** (typically exposed areas such as foot/ankle, thigh, buttocks). (guarda2026importedcutaneouslarva pages 4-7, johanis2023cutaneouslarvamigrans pages 1-3)
+
+### Tissue/cell level
+Primary tissue layer: **epidermis/stratum corneum** with associated dermal inflammation; organism within stratum corneum is documented histologically. (johanis2023cutaneouslarvamigrans media a6ff90a3)
+
+## 8. Temporal development
+
+### Onset and course
+CLM is typically **acute-to-subacute** following exposure and is often self-limited if untreated, although symptoms can persist for weeks; treatment shortens duration substantially. (hochedez2007hookwormrelatedcutaneouslarva pages 4-6, shrestha2024cutaneouslarvamigrans pages 3-4)
+
+### Remission
+After ivermectin treatment in a Brazilian cohort, lesion resolution and QoL normalization occurred within weeks for most patients. (schuster2011lifequalityimpairment pages 1-2, schuster2011lifequalityimpairment pages 3-4)
+
+## 9. Inheritance and population
+
+### Epidemiology and geography
+CLM is classically associated with tropical/subtropical climates and beach exposure, but recent case literature highlights **possible geographic expansion**.
+
+A 2023 report emphasized that although CLM is traditionally tropical, clinicians should recognize expanding spread, including a case acquired in New England. (johanis2023cutaneouslarvamigrans pages 1-3)
+
+### Recent outbreak/case-series data (2023–2024)
+* **Oman (Seeb, Muscat), 2022–2024:** “nine cases of CLM” were reported, **78% pediatric** (7/9), with cases occurring mainly after rainfall events and with exposure to puddles/mud. (hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7)
+
+### Endemic-community prevalence (older but quantitative)
+In Manaus, Brazil, CLM prevalence was reported in the QoL study background as **up to ~4% overall and 15% in young children** in slum communities (contextualizing the burden). (schuster2011lifequalityimpairment pages 1-2)
+
+## 10. Diagnostics
+
+### Clinical diagnosis
+Diagnosis is predominantly **clinical**, based on characteristic serpiginous/migratory track morphology and exposure history; Oman outbreak cases did not require biopsy. (hasni2024cutaneouslarvamigrans pages 2-6)
+
+### Laboratory testing
+Routine laboratory investigations are often normal; eosinophilia may occur but is not required for diagnosis. (elmi2025cutaneouslarvamigrans pages 1-3, hochedez2007hookwormrelatedcutaneouslarva pages 4-6)
+
+### Histopathology / biopsy
+Biopsy is not routinely required, but may confirm diagnosis; one 2023 U.S. case described punch biopsy at the leading edge with histology consistent with hookworm. (johanis2023cutaneouslarvamigrans pages 1-3, johanis2023cutaneouslarvamigrans media a6ff90a3)
+
+### Differential diagnosis
+A recent review of refractory CLM emphasized important mimics and broader differential diagnoses for migratory lesions, including **Strongyloides** (larva currens—migrates much faster), **Gnathostoma**, and other parasitic and non-parasitic causes; the differential list included dracunculiasis, fascioliasis, loiasis, paragonimiasis, tungiasis, and myiasis. (currie2025cutaneouslarvamigrans pages 6-7)
+
+A Cureus case report additionally lists common outpatient differentials such as tinea corporis, contact dermatitis, scabies, cellulitis, and arthropod bites. (guarda2026importedcutaneouslarva pages 4-7)
+
+## 11. Outcome / prognosis
+
+### Natural history
+CLM is usually self-limited and confined to the skin; however, morbidity can be substantial due to pruritus and sleep disturbance. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, schuster2011lifequalityimpairment pages 1-2)
+
+### Treatment outcomes (statistics)
+* **Travelers (prospective study):** ivermectin achieved an overall **97% cure rate** in a prospective series; **77%** cured after a single dose and **23% (14/64)** required additional treatment because of relapse/non-response; median time to pruritus disappearance **3 days** and lesion disappearance **7 days**; superinfection occurred in **8%** (5 cases). (bouchaud2000cutaneouslarvamigrans pages 4-5)
+* **Endemic-community QoL cohort:** substantial QoL restoration within weeks after ivermectin (median mDLQI improved to near-normal by 2–4 weeks). (schuster2011lifequalityimpairment pages 1-2, schuster2011lifequalityimpairment pages 3-4)
+
+## 12. Treatment
+
+### First-line pharmacotherapy (real-world implementation)
+* **Ivermectin (oral):** widely recommended first-line; cohort-series cure rates reported as **94–100%** in most series (lowest 81% in one series), with repeat dosing sometimes required. (johanis2023cutaneouslarvamigrans pages 3-5, bouchaud2000cutaneouslarvamigrans pages 4-5)
+* **Albendazole (oral):** effective alternative; dosing commonly **400 mg/day for 3–7 days**, with some practice recommending 400 mg once daily for 5 days (e.g., Oman outbreak recommendation) or 400 mg/day for 1 week in a retrospective series. (johanis2023cutaneouslarvamigrans pages 3-5, hasni2024cutaneouslarvamigrans pages 2-6)
+
+### Pediatric considerations
+A 2024 case report/review notes a WHO consultation indicating albendazole/mebendazole safety in children ≥12 months and advises against treatment under 12 months; topical therapies may be used when oral therapy is contraindicated. (shrestha2024cutaneouslarvamigrans pages 3-4)
+
+### Topical/adjunctive therapy
+Topical 10% albendazole is described as an alternative when oral ivermectin/albendazole are contraindicated (e.g., very small children), though multiple lesions/folliculitis may respond less well. (hochedez2007hookwormrelatedcutaneouslarva pages 4-6, shrestha2024cutaneouslarvamigrans pages 3-4)
+
+### Treatment developments (2023–2024)
+* **Outbreak practice variation (Oman 2024):** variability in albendazole prescribing prompted a recommended standardized regimen of **albendazole 400 mg once daily for five days** and improved surveillance. (hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7)
+* **Combination therapy and resistance concern:** a 2024 two-patient report from Sudan described successful **combined albendazole + ivermectin** and framed it as potentially relevant amid concerns about emerging antihelminthic resistance. (currie2025cutaneouslarvamigrans pages 13-13)
+
+### Suggested MAXO terms (treatments)
+* Anthelmintic therapy; ivermectin administration; albendazole administration; topical anthelmintic therapy; antipruritic therapy (antihistamine); treatment of secondary bacterial infection (antibiotic therapy).
+
+## 13. Prevention
+
+### Primary prevention (behavioral/environmental)
+Evidence-based recommendations emphasize:
+* **Consistent footwear** and avoidance of direct skin contact with potentially contaminated sand/soil (beaches, sandboxes). (hochedez2007hookwormrelatedcutaneouslarva pages 4-6, shrestha2024cutaneouslarvamigrans pages 1-2)
+* **Pet deworming** and management of stray dogs/cats to reduce environmental contamination. (shrestha2024cutaneouslarvamigrans pages 1-2, guarda2026importedcutaneouslarva pages 4-7)
+
+### Public health / One Health implementations
+The 2024 Oman outbreak report explicitly calls for stronger surveillance and multi-sectoral action, including “electronic notification” of cases, “environmental eradication campaigns,” and collaboration between **Ministry of Health, municipality, and agriculture**—a practical One Health approach to prevention. (hasni2024cutaneouslarvamigrans pages 6-7)
+
+## 14. Other species / natural disease
+
+CLM is a zoonosis originating from **dogs and cats** harboring hookworm infections; environmental contamination with animal feces is repeatedly cited as central to transmission. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3, guarda2026importedcutaneouslarva pages 4-7)
+
+## 15. Model organisms
+
+No experimental model organism systems were described in the retrieved evidence set. Mechanistic inference relies largely on veterinary parasitology of canine/feline hookworms and human clinical/histopathologic observation. (currie2025cutaneouslarvamigrans pages 6-7, johanis2023cutaneouslarvamigrans media a6ff90a3)
+
+---
+
+## Recent developments and expert synthesis (emphasis 2023–2024)
+
+1. **Climate/environment linkage in applied settings:** The Oman 2024 case series/outbreak suggests extreme weather and unusual rainfall may precipitate local clusters through increased muddy exposure and larval survival, highlighting a need for climate-aware surveillance. (hasni2024cutaneouslarvamigrans pages 2-6, hasni2024cutaneouslarvamigrans pages 6-7)
+2. **Geographic expansion beyond classic tropics:** A 2023 U.S. case acquired in New England illustrates potential northward spread and the importance of clinician vigilance in temperate regions. (johanis2023cutaneouslarvamigrans pages 1-3)
+3. **Treatment standardization and access:** Recent practice-focused papers emphasize ivermectin as preferred first-line but also document the operational reality of variable dosing practices and the need for standardized regimens and surveillance. (johanis2023cutaneouslarvamigrans pages 3-5, hasni2024cutaneouslarvamigrans pages 6-7)
+4. **Emerging resistance concerns (One Health):** Clinical reports of refractory disease and calls for combination therapy are framed in the broader context of expanding macrocyclic lactone use in animals and emerging multi-drug resistance in animal hookworms, implying a One Health antimicrobial-resistance problem. (currie2025cutaneouslarvamigrans pages 13-13, currie2025cutaneouslarvamigrans pages 6-7)
+
+## Key limitations of this evidence package
+* Many retrieved clinical sources are case reports/series; robust incidence/prevalence estimates for CLM at national/global scale were not present in the retrieved texts.
+* The retrieved full texts did not provide MONDO/MeSH numeric identifiers or CLM-specific ICD codes.
+* Several 2023–2024 items were unobtainable in the current retrieval set; additional targeted PubMed/ontology queries would likely improve identifier completeness.
+
+
+References
+
+1. (rodriguezmorales2021cutaneouslarvamigrans pages 1-3): Alfonso J. Rodriguez-Morales, Natalia González-Leal, Maria Camila Montes-Montoya, Lorena Fernández-Espíndola, D. Katterine Bonilla-Aldana, José María Azeñas- Burgoa, Juan Carlos Diez de Medina, Verónica Rotela-Fisch, Melany Bermudez-Calderon, Kovy Arteaga-Livias, Fredrikke Dam Larsen, and José A. Suárez. Cutaneous larva migrans. Current Tropical Medicine Reports, 8:190-203, Apr 2021. URL: https://doi.org/10.1007/s40475-021-00239-0, doi:10.1007/s40475-021-00239-0. This article has 25 citations and is from a peer-reviewed journal.
+
+2. (guarda2026importedcutaneouslarva pages 4-7): Diego Guarda, Cristóbal Norambuena, Priscilla Marquez, Gerardo Bascuñan, and Diego I Mendez-Villanueva. Imported cutaneous larva migrans in an adolescent traveler: a case report from chile. Cureus, Mar 2026. URL: https://doi.org/10.7759/cureus.104834, doi:10.7759/cureus.104834. This article has 0 citations.
+
+3. (johanis2023cutaneouslarvamigrans media 1be38c9c): Michael Johanis, Karan S Cheema, Peter A Young, Saisindhu Narala, Atif Saleem, Roberto A Novoa, and Gordon H Bae. Cutaneous larva migrans in the northeastern us. Dermatology Online Journal, Sep 2023. URL: https://doi.org/10.5070/d329461906, doi:10.5070/d329461906. This article has 7 citations and is from a peer-reviewed journal.
+
+4. (johanis2023cutaneouslarvamigrans media a6ff90a3): Michael Johanis, Karan S Cheema, Peter A Young, Saisindhu Narala, Atif Saleem, Roberto A Novoa, and Gordon H Bae. Cutaneous larva migrans in the northeastern us. Dermatology Online Journal, Sep 2023. URL: https://doi.org/10.5070/d329461906, doi:10.5070/d329461906. This article has 7 citations and is from a peer-reviewed journal.
+
+5. (shrestha2024cutaneouslarvamigrans pages 1-2): Amrita Shrestha, Kusha K.C., Abal Baral, Rojina Shrestha, and Rabina Shrestha. Cutaneous larva migrans in a child: a case report and review of literature. Annals of Medicine and Surgery, 86:530-534, Nov 2024. URL: https://doi.org/10.1097/ms9.0000000000001512, doi:10.1097/ms9.0000000000001512. This article has 10 citations.
+
+6. (hochedez2007hookwormrelatedcutaneouslarva pages 4-6): Patrick Hochedez and Eric Caumes. Hookworm-related cutaneous larva migrans. Journal of travel medicine, 14 5:326-33, Sep 2007. URL: https://doi.org/10.1111/j.1708-8305.2007.00148.x, doi:10.1111/j.1708-8305.2007.00148.x. This article has 213 citations and is from a domain leading peer-reviewed journal.
+
+7. (hasni2024cutaneouslarvamigrans pages 2-6): Alya AL Hasni, Asma Al Musalhi, Fatma AL Ghashri, Zainab AL Hinai, Isra Al Mahruqi, and Amal AL Sedairi. Cutaneous larva migrans outbreak in seeb wilaya: a case series. Oman Medical Journal, Jan 2024. URL: https://doi.org/10.5001/omj.2028.07, doi:10.5001/omj.2028.07. This article has 0 citations.
+
+8. (schuster2011lifequalityimpairment pages 1-2): Angela Schuster, Hannah Lesshafft, Sinésio Talhari, Silás Guedes de Oliveira, Ralf Ignatius, and Hermann Feldmeier. Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in manaus, brazil. PLoS Neglected Tropical Diseases, 5:e1355, Nov 2011. URL: https://doi.org/10.1371/journal.pntd.0001355, doi:10.1371/journal.pntd.0001355. This article has 51 citations and is from a domain leading peer-reviewed journal.
+
+9. (currie2025cutaneouslarvamigrans pages 6-7): Bart J. Currie, Jessica Hoopes, and Bonny Cumming. Cutaneous larva migrans refractory to therapy with ivermectin: case report and review of implicated zoonotic pathogens, epidemiology, anthelmintic drug resistance and therapy. Tropical Medicine and Infectious Disease, 10:163, Jun 2025. URL: https://doi.org/10.3390/tropicalmed10060163, doi:10.3390/tropicalmed10060163. This article has 2 citations.
+
+10. (elmi2025cutaneouslarvamigrans pages 1-3): T Elmi, A Ghorbannia Delavar, and M Taheri. Cutaneous larva migrans: clinical challenges and insights from a case report with a literature review. Unknown journal, 2025.
+
+11. (johanis2023cutaneouslarvamigrans pages 1-3): Michael Johanis, Karan S Cheema, Peter A Young, Saisindhu Narala, Atif Saleem, Roberto A Novoa, and Gordon H Bae. Cutaneous larva migrans in the northeastern us. Dermatology Online Journal, Sep 2023. URL: https://doi.org/10.5070/d329461906, doi:10.5070/d329461906. This article has 7 citations and is from a peer-reviewed journal.
+
+12. (johanis2023cutaneouslarvamigrans pages 3-5): Michael Johanis, Karan S Cheema, Peter A Young, Saisindhu Narala, Atif Saleem, Roberto A Novoa, and Gordon H Bae. Cutaneous larva migrans in the northeastern us. Dermatology Online Journal, Sep 2023. URL: https://doi.org/10.5070/d329461906, doi:10.5070/d329461906. This article has 7 citations and is from a peer-reviewed journal.
+
+13. (hasni2024cutaneouslarvamigrans pages 6-7): Alya AL Hasni, Asma Al Musalhi, Fatma AL Ghashri, Zainab AL Hinai, Isra Al Mahruqi, and Amal AL Sedairi. Cutaneous larva migrans outbreak in seeb wilaya: a case series. Oman Medical Journal, Jan 2024. URL: https://doi.org/10.5001/omj.2028.07, doi:10.5001/omj.2028.07. This article has 0 citations.
+
+14. (shrestha2024cutaneouslarvamigrans pages 3-4): Amrita Shrestha, Kusha K.C., Abal Baral, Rojina Shrestha, and Rabina Shrestha. Cutaneous larva migrans in a child: a case report and review of literature. Annals of Medicine and Surgery, 86:530-534, Nov 2024. URL: https://doi.org/10.1097/ms9.0000000000001512, doi:10.1097/ms9.0000000000001512. This article has 10 citations.
+
+15. (currie2025cutaneouslarvamigrans pages 13-13): Bart J. Currie, Jessica Hoopes, and Bonny Cumming. Cutaneous larva migrans refractory to therapy with ivermectin: case report and review of implicated zoonotic pathogens, epidemiology, anthelmintic drug resistance and therapy. Tropical Medicine and Infectious Disease, 10:163, Jun 2025. URL: https://doi.org/10.3390/tropicalmed10060163, doi:10.3390/tropicalmed10060163. This article has 2 citations.
+
+16. (schuster2011lifequalityimpairment pages 3-4): Angela Schuster, Hannah Lesshafft, Sinésio Talhari, Silás Guedes de Oliveira, Ralf Ignatius, and Hermann Feldmeier. Life quality impairment caused by hookworm-related cutaneous larva migrans in resource-poor communities in manaus, brazil. PLoS Neglected Tropical Diseases, 5:e1355, Nov 2011. URL: https://doi.org/10.1371/journal.pntd.0001355, doi:10.1371/journal.pntd.0001355. This article has 51 citations and is from a domain leading peer-reviewed journal.
+
+17. (bouchaud2000cutaneouslarvamigrans pages 4-5): Olivier Bouchaud, S. Houzé, R. Schiemann, Rémy Durand, P. Ralaimazava, Catherine Ruggeri, and Jean-Pierre Coulaud. Cutaneous larva migrans in travelers: a prospective study, with assessment of therapy with ivermectin. Clinical infectious diseases : an official publication of the Infectious Diseases Society of America, 31 2:493-8, Aug 2000. URL: https://doi.org/10.1086/313942, doi:10.1086/313942. This article has 179 citations.

--- a/research/Cutaneous_Larva_Migrans-deep-research-falcon.md.citations.md
+++ b/research/Cutaneous_Larva_Migrans-deep-research-falcon.md.citations.md
@@ -1,0 +1,487 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Cutaneous larva migrans
+- **MONDO ID:**  (if available)
+- **Category:** Infectious
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Cutaneous larva migrans** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T19:39:31.437236
+
+1. rodriguezmorales2021cutaneouslarvamigrans pages 1-3
+2. guarda2026importedcutaneouslarva pages 4-7
+3. shrestha2024cutaneouslarvamigrans pages 1-2
+4. johanis2023cutaneouslarvamigrans pages 1-3
+5. shrestha2024cutaneouslarvamigrans pages 3-4
+6. schuster2011lifequalityimpairment pages 1-2
+7. hasni2024cutaneouslarvamigrans pages 2-6
+8. currie2025cutaneouslarvamigrans pages 6-7
+9. bouchaud2000cutaneouslarvamigrans pages 4-5
+10. currie2025cutaneouslarvamigrans pages 13-13
+11. hasni2024cutaneouslarvamigrans pages 6-7
+12. hochedez2007hookwormrelatedcutaneouslarva pages 4-6
+13. elmi2025cutaneouslarvamigrans pages 1-3
+14. johanis2023cutaneouslarvamigrans pages 3-5
+15. schuster2011lifequalityimpairment pages 3-4
+16. https://doi.org/10.1007/s40475-021-00239-0
+17. https://doi.org/10.7759/cureus.104834;
+18. https://doi.org/10.1097/ms9.0000000000001512
+19. https://doi.org/10.1007/s40475-021-00239-0;
+20. https://doi.org/10.3390/tropicalmed10060163
+21. https://doi.org/10.5001/omj.2028.07;
+22. https://doi.org/10.1097/ms9.0000000000001512;
+23. https://doi.org/10.5070/d329461906
+24. https://doi.org/10.1111/j.1708-8305.2007.00148.x;
+25. https://doi.org/10.5070/d329461906;
+26. https://doi.org/10.5001/omj.2028.07
+27. https://doi.org/10.7759/cureus.64665
+28. https://doi.org/10.1007/s40475-021-00239-0,
+29. https://doi.org/10.7759/cureus.104834,
+30. https://doi.org/10.5070/d329461906,
+31. https://doi.org/10.1097/ms9.0000000000001512,
+32. https://doi.org/10.1111/j.1708-8305.2007.00148.x,
+33. https://doi.org/10.5001/omj.2028.07,
+34. https://doi.org/10.1371/journal.pntd.0001355,
+35. https://doi.org/10.3390/tropicalmed10060163,
+36. https://doi.org/10.1086/313942,


### PR DESCRIPTION
## Summary
- Add `kb/disorders/Cutaneous_Larva_Migrans.yaml` for MONDO:0018500.
- Curate infectious agent, transmission, environmental exposure, pathophysiology, phenotypes, diagnosis, treatment, and epidemiology from Falcon deep research and cache-backed PubMed/DOI snippets.
- Add Falcon research artifacts and generated reference caches for cited DOI/PMID references.

## Validation
- `just validate kb/disorders/Cutaneous_Larva_Migrans.yaml`
- `just validate-references kb/disorders/Cutaneous_Larva_Migrans.yaml`
- `just check-reference-cache-frontmatter`
- `just qc-deep-research --target-providers falcon --only Cutaneous_Larva_Migrans`
- Custom cache substring check: 44 snippets found in generated cache files

## Notes
- Confirmed MONDO:0018500 label with OAK as `cutaneous larva migrans`.
- Restored unrelated generated cache and clinical-trial cache churn before committing.
