### PR TITLE
Add Giant Cell Hepatitis With Autoimmune Hemolytic Anemia curation

### DIFF
--- a/kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml
+++ b/kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml
@@ -1,0 +1,590 @@
+name: Giant Cell Hepatitis With Autoimmune Hemolytic Anemia
+creation_date: '2026-05-07T02:03:20Z'
+updated_date: '2026-05-07T02:18:30Z'
+description: >-
+  Giant cell hepatitis with autoimmune hemolytic anemia is a rare autoimmune
+  disease of infancy and early childhood in which severe liver disease with
+  giant-cell transformation of hepatocytes occurs together with Coombs-positive
+  autoimmune hemolytic anemia. This entry is scoped to the combined hepatic and
+  hematologic syndrome rather than isolated autoimmune hemolytic anemia.
+category: Autoimmune Disease
+disease_term:
+  preferred_term: giant cell hepatitis with autoimmune hemolytic anemia
+  term:
+    id: MONDO:1060166
+    label: giant cell hepatitis with autoimmune hemolytic anemia
+parents:
+- Autoimmune hepatitis
+- Autoimmune hemolytic anemia
+synonyms:
+- GCH-AHA
+- GCH-AIHA
+- Giant cell hepatitis associated with autoimmune hemolytic anemia
+pathophysiology:
+- name: Systemic B-cell autoimmunity
+  description: >-
+    The syndrome is best supported as a systemic humoral autoimmune disorder:
+    Coombs-positive hemolysis distinguishes it from early-onset autoimmune
+    hepatitis, and liver injury responds in many refractory cases to B-cell
+    depletion.
+  downstream:
+  - target: Complement-mediated hepatocyte injury
+    description: B-cell autoimmunity can drive antibody and complement injury in the liver.
+  - target: Coombs-positive erythrocyte destruction
+    description: Humoral autoimmunity also produces Coombs-positive hemolytic anemia.
+  cell_types:
+  - preferred_term: B cell
+    term:
+      id: CL:0000236
+      label: B cell
+  biological_processes:
+  - preferred_term: immunoglobulin mediated immune response
+    modifier: ABNORMAL
+    term:
+      id: GO:0016064
+      label: immunoglobulin mediated immune response
+  evidence:
+  - reference: PMID:23969541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Widespread complement-mediated hepatocyte injury and typical C3a and C5a
+      complement-driven liver inflammation along with Coombs-positive hemolytic
+      anemia in GCH-AHA provide convincing evidence that systemic B-cell
+      autoimmunity plays a central pathologic mechanism in the disease.
+    explanation: This mechanistic case series directly identifies systemic B-cell autoimmunity as central to GCH-AHA.
+- name: Complement-mediated hepatocyte injury
+  description: >-
+    Complement activation injures hepatocytes across the lobule, with C5b-9
+    membrane attack complex deposition and an inflammatory pattern enriched for
+    macrophages and neutrophils rather than classic portal autoimmune hepatitis.
+  downstream:
+  - target: Giant cell hepatitis
+    description: Complement-associated hepatocyte injury contributes to giant-cell transformation on biopsy.
+  - target: Elevated hepatic transaminases
+    description: Hepatocyte injury is reflected by elevated circulating aminotransferase activity.
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  - preferred_term: macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
+  - preferred_term: neutrophil
+    term:
+      id: CL:0000775
+      label: neutrophil
+  biological_processes:
+  - preferred_term: complement activation
+    modifier: INCREASED
+    term:
+      id: GO:0006956
+      label: complement activation
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  evidence:
+  - reference: PMID:23969541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      C5b-9 staining showed high-grade complement-mediated pan-lobular hepatocyte
+      injury in all of the cases with GCH-AHA, whereas little C5b-9 was seen in
+      hepatocytes in cases with AIH.
+    explanation: The abstract directly supports pan-lobular complement-mediated hepatocyte injury in GCH-AHA.
+  - reference: PMID:23969541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Inflammation in GCH-AHA comprised mainly lobular macrophages and neutrophils,
+      whereas portal and periportal T-cell and B-cell inflammation characterized
+      cases with AIH.
+    explanation: This supports the lobular macrophage/neutrophil inflammatory pattern and distinction from classic autoimmune hepatitis.
+- name: Giant cell transformation of hepatocytes
+  description: >-
+    Liver biopsy shows diffuse giant-cell transformation of hepatocytes, often
+    with architectural damage and fibrosis in severe or recurrent disease.
+  downstream:
+  - target: Hepatic failure
+    description: Progressive hepatocellular damage can lead to liver failure in severe cases.
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  evidence:
+  - reference: PMID:8159622
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histologically, the livers showed loss of lobular architecture with diffuse
+      giant cell transformation of hepatocytes and portal and pericellular fibrosis.
+    explanation: This classic pathology report directly supports the defining hepatic histopathology.
+- name: Coombs-positive erythrocyte destruction
+  description: >-
+    Autoimmune hemolysis targets red blood cells, producing anemia that may
+    precede the hepatitis by weeks to months and can relapse independently of
+    liver inflammation.
+  downstream:
+  - target: Autoimmune hemolytic anemia
+    description: Immune-mediated red-cell destruction manifests as autoimmune hemolytic anemia.
+  cell_types:
+  - preferred_term: erythrocyte
+    term:
+      id: CL:0000232
+      label: erythrocyte
+  biological_processes:
+  - preferred_term: humoral immune response
+    modifier: ABNORMAL
+    term:
+      id: GO:0006959
+      label: humoral immune response
+  evidence:
+  - reference: PMID:32206631
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Giant cell hepatitis with autoimmune hemolytic anemia (AHA) is a rare disease
+      of infancy characterized by the presence of both Coombs-positive hemolytic
+      anemia and progressive liver disease with giant cell transformation of
+      hepatocytes.
+    explanation: This case report abstract directly supports the combined Coombs-positive hemolysis and progressive liver disease phenotype.
+phenotypes:
+- category: Gastrointestinal
+  name: Giant cell hepatitis
+  description: >-
+    Giant cell hepatitis on liver biopsy is the defining hepatic manifestation
+    of this syndrome.
+  phenotype_term:
+    preferred_term: Giant cell hepatitis
+    term:
+      id: HP:0200084
+      label: Giant cell hepatitis
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Children (nine boys; median age, 6 months) presented with jaundice,
+      hepatomegaly, elevated aminotransferases, a positive Coombs test, and diffuse
+      giant-cell transformation of hepatocytes on histology.
+    explanation: This cohort abstract directly documents diffuse giant-cell transformation of hepatocytes.
+- category: Hematologic
+  name: Autoimmune hemolytic anemia
+  description: >-
+    Coombs-positive autoimmune hemolytic anemia occurs with the liver disease
+    and may be the first clinical manifestation.
+  phenotype_term:
+    preferred_term: Autoimmune hemolytic anemia
+    term:
+      id: HP:0001890
+      label: Autoimmune hemolytic anemia
+  evidence:
+  - reference: PMID:25201797
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Giant cell hepatitis with autoimmune hemolytic anemia (GCH-AHA) is a rare
+      autoimmune disease of infancy characterized by severe liver disease associated
+      with Coombs-positive hemolytic anemia.
+    explanation: The abstract directly supports Coombs-positive hemolytic anemia as part of the defining syndrome.
+- category: Gastrointestinal
+  name: Jaundice
+  description: >-
+    Jaundice is a common presenting feature and can reflect both cholestatic
+    hepatitis and hemolysis.
+  phenotype_term:
+    preferred_term: Jaundice
+    term:
+      id: HP:0000952
+      label: Jaundice
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Children (nine boys; median age, 6 months) presented with jaundice,
+      hepatomegaly, elevated aminotransferases, a positive Coombs test, and diffuse
+      giant-cell transformation of hepatocytes on histology.
+    explanation: This cohort abstract lists jaundice among presenting features.
+- category: Gastrointestinal
+  name: Hepatomegaly
+  description: Liver enlargement is a recurring clinical sign in affected infants.
+  phenotype_term:
+    preferred_term: Hepatomegaly
+    term:
+      id: HP:0002240
+      label: Hepatomegaly
+  evidence:
+  - reference: PMID:24792633
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median age of the children was 7 months (2-12 months), follow-up lasted
+      44 months (12-78 months), median (min-max), and the main observed symptoms
+      were jaundice and hepatosplenomegaly.
+    explanation: This severe-case series identifies hepatosplenomegaly, including hepatomegaly, as a main observed symptom.
+- category: Hematologic
+  name: Splenomegaly
+  description: Spleen enlargement can accompany hemolysis and systemic disease.
+  phenotype_term:
+    preferred_term: Splenomegaly
+    term:
+      id: HP:0001744
+      label: Splenomegaly
+  evidence:
+  - reference: PMID:24792633
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median age of the children was 7 months (2-12 months), follow-up lasted
+      44 months (12-78 months), median (min-max), and the main observed symptoms
+      were jaundice and hepatosplenomegaly.
+    explanation: This supports splenomegaly as part of hepatosplenomegaly in pediatric GCH-AIHA.
+- category: Laboratory
+  name: Elevated hepatic transaminases
+  description: Hepatocellular injury is reflected by elevated serum aminotransferases.
+  phenotype_term:
+    preferred_term: Elevated circulating hepatic transaminase concentration
+    term:
+      id: HP:0002910
+      label: Elevated circulating hepatic transaminase concentration
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Children (nine boys; median age, 6 months) presented with jaundice,
+      hepatomegaly, elevated aminotransferases, a positive Coombs test, and diffuse
+      giant-cell transformation of hepatocytes on histology.
+    explanation: This cohort abstract directly documents elevated aminotransferases.
+- category: Gastrointestinal
+  name: Hepatic failure
+  description: Severe disease can progress to liver failure or multiorgan failure.
+  phenotype_term:
+    preferred_term: Hepatic failure
+    term:
+      id: HP:0001399
+      label: Hepatic failure
+  evidence:
+  - reference: PMID:24792633
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The disease is aggressive and may lead to liver or multiorgan failure with
+      fatal prognosis.
+    explanation: This abstract directly supports liver failure as a severe manifestation.
+histopathology:
+- name: Diffuse giant cell transformation of hepatocytes
+  description: >-
+    Biopsy shows diffuse multinucleated giant-cell transformation of hepatocytes,
+    with fibrosis reported in classic cases.
+  diagnostic: true
+  evidence:
+  - reference: PMID:8159622
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histologically, the livers showed loss of lobular architecture with diffuse
+      giant cell transformation of hepatocytes and portal and pericellular fibrosis.
+    explanation: This directly supports the defining histopathologic finding.
+- name: Pan-lobular C5b-9 hepatocyte deposition
+  description: >-
+    C5b-9 complement complex staining across hepatocytes supports complement
+    mediated liver injury and helps distinguish GCH-AIHA from classic autoimmune
+    hepatitis in the mechanistic series.
+  diagnostic: false
+  evidence:
+  - reference: PMID:23969541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      C5b-9 staining showed high-grade complement-mediated pan-lobular hepatocyte
+      injury in all of the cases with GCH-AHA, whereas little C5b-9 was seen in
+      hepatocytes in cases with AIH.
+    explanation: This supports complement immunostaining as a mechanistic histopathology feature.
+diagnosis:
+- name: Liver biopsy
+  diagnosis_term:
+    preferred_term: biopsy of liver
+    term:
+      id: MAXO:0000376
+      label: biopsy of liver
+  description: >-
+    Liver biopsy is used to document giant-cell transformation of hepatocytes and
+    associated inflammation or fibrosis.
+  results: Diffuse giant-cell transformation of hepatocytes supports the diagnosis.
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Children (nine boys; median age, 6 months) presented with jaundice,
+      hepatomegaly, elevated aminotransferases, a positive Coombs test, and diffuse
+      giant-cell transformation of hepatocytes on histology.
+    explanation: This cohort abstract supports histologic confirmation as part of the diagnostic pattern.
+- name: Direct Coombs test
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  description: >-
+    Direct antiglobulin testing documents Coombs-positive immune hemolysis in
+    the hematologic component of the syndrome.
+  results: A positive Coombs test supports autoimmune hemolytic anemia in the combined syndrome.
+  evidence:
+  - reference: PMID:24792633
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All of the children had positive direct Coombs test and biopsy-proven giant
+      cell transformation of hepatocytes.
+    explanation: This abstract directly supports the combined diagnostic findings.
+treatments:
+- name: Prednisone and azathioprine immunosuppression
+  description: >-
+    Prednisone with azathioprine has been used as traditional immunosuppression;
+    it can induce remission, but relapses and prolonged treatment are common.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: prednisone
+      term:
+        id: CHEBI:8382
+        label: prednisone
+    - preferred_term: azathioprine
+      term:
+        id: CHEBI:2948
+        label: azathioprine
+  target_phenotypes:
+  - preferred_term: Giant cell hepatitis
+    term:
+      id: HP:0200084
+      label: Giant cell hepatitis
+  - preferred_term: Autoimmune hemolytic anemia
+    term:
+      id: HP:0001890
+      label: Autoimmune hemolytic anemia
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment with prednisone and azathioprine, plus, in three children,
+      cyclosporine, resulted in complete remission in eight, partial remission in
+      six, and failure in two.
+    explanation: This cohort supports prednisone/azathioprine-based immunosuppression as a remission-inducing treatment with incomplete response.
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Relapses of hepatitis and/or anemia occurred in 11 and 10 children,
+      respectively, requiring prolonged high levels of immunosuppression, and
+      splenectomy or Rituximab, respectively.
+    explanation: This supports the relapsing course and frequent need for prolonged or escalated treatment.
+- name: Rituximab
+  description: >-
+    Rituximab is an anti-CD20 monoclonal antibody that targets B lymphocytes and
+    is supported by disease-specific series for refractory or severe disease.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: rituximab
+      term:
+        id: NCIT:C1702
+        label: Rituximab
+  target_mechanisms:
+  - target: Systemic B-cell autoimmunity
+    treatment_effect: INHIBITS
+    description: Rituximab depletes CD20-positive B cells implicated in systemic humoral autoimmunity.
+  - target: Complement-mediated hepatocyte injury
+    treatment_effect: INHIBITS
+    description: B-cell depletion is expected to reduce upstream antibody-driven complement injury.
+  evidence:
+  - reference: PMID:25201797
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We describe here the detailed clinical evolution of 4 children with GCH-AHA
+      who showed a complete response to rituximab.
+    explanation: This case series directly supports rituximab response in GCH-AHA.
+  - reference: PMID:23969541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our findings support B-cell-directed immunotherapy as a first-line treatment
+      of GCH-AHA.
+    explanation: The mechanistic study links complement/B-cell pathology to B-cell-directed treatment.
+- name: Intravenous immunoglobulin
+  description: >-
+    IVIG can reduce liver enzyme activity and help maintain remission as an
+    adjunct, but repeated infusions have temporary efficacy and are not routine
+    long-term therapy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: Elevated circulating hepatic transaminase concentration
+    term:
+      id: HP:0002910
+      label: Elevated circulating hepatic transaminase concentration
+  evidence:
+  - reference: PMID:26138133
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      IVIg infusions as first-line therapy associated with prednisone and other
+      immunosuppressive drugs significantly (P=0.04) reduced the aminotransferase
+      activity in all patients and normalized prothrombin activity in the only
+      patient with severe liver dysfunction.
+    explanation: This multicenter series supports IVIG-associated improvement in liver biochemical activity.
+  - reference: PMID:26138133
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Repeated IVIg infusions may help maintain remission, however, due to their
+      temporary efficacy, they should not be routinely employed.
+    explanation: This supports IVIG as useful but temporary adjunctive therapy rather than routine maintenance.
+- name: Liver transplantation
+  description: >-
+    Liver transplantation has been used for advanced liver disease, but the
+    syndrome is primarily managed by immune control when possible.
+  treatment_term:
+    preferred_term: organ transplantation
+    term:
+      id: MAXO:0010039
+      label: organ transplantation
+  target_phenotypes:
+  - preferred_term: Hepatic failure
+    term:
+      id: HP:0001399
+      label: Hepatic failure
+  evidence:
+  - reference: PMID:21349541
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      One child is alive 9 years after liver transplantation.
+    explanation: This supports liver transplantation as a possible survival-associated intervention in selected severe cases, but not as routine first-line therapy.
+progression:
+- phase: Relapsing hepatitis and anemia
+  notes: >-
+    The clinical course often involves relapse of either liver disease or
+    hemolytic anemia, requiring prolonged or escalated immunosuppression.
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Relapses of hepatitis and/or anemia occurred in 11 and 10 children,
+      respectively, requiring prolonged high levels of immunosuppression, and
+      splenectomy or Rituximab, respectively.
+    explanation: This long-term cohort directly supports a relapsing disease course.
+- phase: Mortality from severe systemic complications
+  notes: >-
+    Severe cases may be fatal, including death from sepsis or multiple organ
+    failure in long-term cohort follow-up.
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Four children died of sepsis or multiple organ failure.
+    explanation: This cohort directly supports mortality from severe complications.
+animal_models: []
+clinical_trials: []
+datasets: []
+references:
+- reference: DOI:10.1016/j.jpeds.2010.12.050
+  title: "Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: long-term outcome in 16 children."
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Long-term cohort of 16 children with GCH-AIHA.
+    supporting_text: "Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: long-term outcome in 16 children."
+- reference: DOI:10.1097/mpg.0b013e3182a98dbe
+  title: Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia.
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Humoral and complement-mediated liver injury mechanism in GCH-AIHA.
+    supporting_text: Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia.
+- reference: DOI:10.1016/j.clinre.2015.03.009
+  title: "Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: A multicenter study."
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Multicenter IVIG treatment series in GCH-AIHA.
+    supporting_text: "Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: A multicenter study."
+- reference: DOI:10.1542/peds.2014-0032
+  title: Anti-CD20 treatment of giant cell hepatitis with autoimmune hemolytic anemia.
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Anti-CD20 treatment series supporting rituximab use in GCH-AIHA.
+    supporting_text: Anti-cd20 treatment of giant cell hepatitis with autoimmune hemolytic anemia.
+- reference: DOI:10.5223/pghn.2020.23.2.180
+  title: Successful Treatment of a Korean Infant with Giant Cell Hepatitis with Autoimmune Hemolytic Anemia Using Rituximab.
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Infant GCH-AIHA case treated with rituximab.
+    supporting_text: Successful treatment of a korean infant with giant cell hepatitis with autoimmune hemolytic anemia using rituximab.
+- reference: DOI:10.3109/15513819409022027
+  title: Coombs-positive autoimmune hemolytic anemia and postinfantile giant cell hepatitis in children.
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Classic pediatric pathology report of Coombs-positive AIHA with postinfantile giant cell hepatitis.
+    supporting_text: Coombs-positive autoimmune hemolytic anemia and postinfantile giant cell hepatitis in children.
+- reference: DOI:10.1097/mpg.0000000000000270
+  title: "Giant cell hepatitis with autoimmune hemolytic anemia in children: proposal for therapeutic approach."
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Severe pediatric GCH-AIHA series proposing rituximab therapeutic approach.
+    supporting_text: "Giant cell hepatitis with autoimmune hemolytic anemia in children: proposal for therapeutic approach."
+- reference: DOI:10.1177/0009922810379501
+  title: "Giant cell hepatitis with autoimmune hemolytic anemia: a case report and review of pediatric literature."
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Pediatric case report and literature review of GCH-AIHA.
+    supporting_text: "Giant cell hepatitis with autoimmune hemolytic anemia: a case report and review of pediatric literature."
+- reference: DOI:10.1111/ped.12874
+  title: Giant cell hepatitis with autoimmune hemolytic anemia in a Korean infant.
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Korean infant case report of GCH-AIHA.
+    supporting_text: Giant cell hepatitis with autoimmune hemolytic anemia in a Korean infant.
+- reference: DOI:10.5152/tjh.2010.55
+  title: "Autoimmune hemolytic anemia and giant cell hepatitis: Report of three infants."
+  found_in:
+  - Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+  findings:
+  - statement: Three-infant report of autoimmune hemolytic anemia and giant cell hepatitis.
+    supporting_text: "Autoimmune hemolytic anemia and giant cell hepatitis: Report of three infants."
+review_notes: >-
+  Falcon deep research found no disease-specific clinical trials or genetic
+  etiology. The entry therefore emphasizes the best-supported pediatric clinical
+  series, pathology series, humoral/complement mechanism, IVIG data, and
+  rituximab treatment reports.

--- a/kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml
+++ b/kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml
@@ -59,7 +59,7 @@ pathophysiology:
     membrane attack complex deposition and an inflammatory pattern enriched for
     macrophages and neutrophils rather than classic portal autoimmune hepatitis.
   downstream:
-  - target: Giant cell hepatitis
+  - target: Giant cell transformation of hepatocytes
     description: Complement-associated hepatocyte injury contributes to giant-cell transformation on biopsy.
   - target: Elevated hepatic transaminases
     description: Hepatocyte injury is reflected by elevated circulating aminotransferase activity.
@@ -197,6 +197,21 @@ phenotypes:
       autoimmune disease of infancy characterized by severe liver disease associated
       with Coombs-positive hemolytic anemia.
     explanation: The abstract directly supports Coombs-positive hemolytic anemia as part of the defining syndrome.
+- category: Hematologic
+  name: Pallor
+  description: Pallor can occur as a visible manifestation of the hemolytic anemia component.
+  phenotype_term:
+    preferred_term: Pallor
+    term:
+      id: HP:0000980
+      label: Pallor
+  evidence:
+  - reference: PMID:32206631
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The clinical features included jaundice, pallor, and red urine.
+    explanation: This case report abstract directly documents pallor among clinical features of GCH-AIHA.
 - category: Gastrointestinal
   name: Jaundice
   description: >-
@@ -334,10 +349,10 @@ diagnosis:
     explanation: This cohort abstract supports histologic confirmation as part of the diagnostic pattern.
 - name: Direct Coombs test
   diagnosis_term:
-    preferred_term: diagnostic procedure
+    preferred_term: Coombs Test
     term:
-      id: MAXO:0000003
-      label: diagnostic procedure
+      id: NCIT:C25163
+      label: Coombs Test
   description: >-
     Direct antiglobulin testing documents Coombs-positive immune hemolysis in
     the hematologic component of the syndrome.
@@ -437,10 +452,15 @@ treatments:
     adjunct, but repeated infusions have temporary efficacy and are not routine
     long-term therapy.
   treatment_term:
-    preferred_term: pharmacotherapy
+    preferred_term: Intravenous Immunoglobulin Therapy
     term:
-      id: MAXO:0000058
-      label: pharmacotherapy
+      id: NCIT:C121331
+      label: Intravenous Immunoglobulin Therapy
+    therapeutic_agent:
+    - preferred_term: Therapeutic Immune Globulin
+      term:
+        id: NCIT:C2701
+        label: Therapeutic Immune Globulin
   target_phenotypes:
   - preferred_term: Elevated circulating hepatic transaminase concentration
     term:
@@ -484,6 +504,29 @@ treatments:
     snippet: >-
       One child is alive 9 years after liver transplantation.
     explanation: This supports liver transplantation as a possible survival-associated intervention in selected severe cases, but not as routine first-line therapy.
+- name: Splenectomy
+  description: >-
+    Splenectomy has been used as an escalation option for relapsing or refractory
+    hemolytic anemia in the long-term cohort.
+  treatment_term:
+    preferred_term: splenectomy
+    term:
+      id: MAXO:0001077
+      label: splenectomy
+  target_phenotypes:
+  - preferred_term: Autoimmune hemolytic anemia
+    term:
+      id: HP:0001890
+      label: Autoimmune hemolytic anemia
+  evidence:
+  - reference: PMID:21349541
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Relapses of hepatitis and/or anemia occurred in 11 and 10 children,
+      respectively, requiring prolonged high levels of immunosuppression, and
+      splenectomy or Rituximab, respectively.
+    explanation: This cohort abstract names splenectomy as an escalation treatment used for relapsing anemia.
 progression:
 - phase: Relapsing hepatitis and anemia
   notes: >-

--- a/references_cache/PMID_21349541.md
+++ b/references_cache/PMID_21349541.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:21349541"
+title: "Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: long-term outcome in 16 children."
+authors:
+- Maggiore G
+- Sciveres M
+- Fabre M
+- Gori L
+- Pacifico L
+- Resti M
+- Choulot JJ
+- Jacquemin E
+- Bernard O
+journal: J Pediatr
+year: '2011'
+doi: 10.1016/j.jpeds.2010.12.050
+keywords:
+- "Anemia, Hemolytic, Autoimmune/complications, mortality, therapy"
+- "Antibodies, Monoclonal, Murine-Derived/therapeutic use"
+- Azathioprine/therapeutic use
+- Bilirubin/blood
+- Coombs Test
+- Cyclosporine/therapeutic use
+- Female
+- Follow-Up Studies
+- Giant Cells/pathology
+- Glucocorticoids/therapeutic use
+- "Hepatitis/complications, mortality, therapy"
+- Hepatocytes/pathology
+- Hepatomegaly/etiology
+- Humans
+- Immunologic Factors/therapeutic use
+- Immunosuppressive Agents/therapeutic use
+- Infant
+- Jaundice/etiology
+- Liver/pathology
+- Liver Transplantation
+- Male
+- Multiple Organ Failure/mortality
+- Prednisone/therapeutic use
+- Recurrence
+- Remission Induction
+- Rituximab
+- Sepsis/mortality
+- Splenectomy
+- Splenomegaly/etiology
+- Transaminases/blood
+- Treatment Outcome
+- gamma-Globulins/analysis
+content_type: abstract_only
+---
+
+# Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: long-term outcome in 16 children.
+**Authors:** Maggiore G, Sciveres M, Fabre M, Gori L, Pacifico L, Resti M, Choulot JJ, Jacquemin E, Bernard O
+**Journal:** J Pediatr (2011)
+**DOI:** [10.1016/j.jpeds.2010.12.050](https://doi.org/10.1016/j.jpeds.2010.12.050)
+
+## Content
+
+1. J Pediatr. 2011 Jul;159(1):127-132.e1. doi: 10.1016/j.jpeds.2010.12.050. Epub 
+2011 Feb 24.
+
+Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: 
+long-term outcome in 16 children.
+
+Maggiore G(1), Sciveres M, Fabre M, Gori L, Pacifico L, Resti M, Choulot JJ, 
+Jacquemin E, Bernard O.
+
+Author information:
+(1)Department of Pediatrics and Division of Pediatric Gastroenterology and 
+Hepatology, University Hospital Santa Chiara, Pisa, Italy.
+
+OBJECTIVE: To assess the outcome of giant cell hepatitis combined with 
+autoimmune hemolytic anemia in early childhood.
+STUDY DESIGN: We report on 16 children with this disease evaluated over a 
+28-year period.
+RESULTS: Children (nine boys; median age, 6 months) presented with jaundice, 
+hepatomegaly, elevated aminotransferases, a positive Coombs test, and diffuse 
+giant-cell transformation of hepatocytes on histology. Treatment with prednisone 
+and azathioprine, plus, in three children, cyclosporine, resulted in complete 
+remission in eight, partial remission in six, and failure in two. Relapses of 
+hepatitis and/or anemia occurred in 11 and 10 children, respectively, requiring 
+prolonged high levels of immunosuppression, and splenectomy or Rituximab, 
+respectively. Treatment was stopped after a mean duration of 6 years, with no 
+relapse, in seven children, with a median follow-up of 14 years. One child is 
+alive 9 years after liver transplantation. Four children died of sepsis or 
+multiple organ failure.
+CONCLUSIONS: Giant cell hepatitis combined with autoimmune hemolytic anemia 
+requires rigorous treatment. Immunosuppressive therapy results in remission in 
+most cases. A complete cure can be expected after several years of intensive 
+treatment. Liver transplantation may be associated with prolonged survival.
+
+Copyright © 2011 Mosby, Inc. All rights reserved.
+
+DOI: 10.1016/j.jpeds.2010.12.050
+PMID: 21349541 [Indexed for MEDLINE]

--- a/references_cache/PMID_23969541.md
+++ b/references_cache/PMID_23969541.md
@@ -1,0 +1,91 @@
+---
+reference_id: "PMID:23969541"
+title: Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia.
+authors:
+- Whitington PF
+- Vos MB
+- Bass LM
+- Melin-Aldana H
+- Romero R
+- Roy CC
+- Alvarez F
+journal: J Pediatr Gastroenterol Nutr
+year: '2014'
+doi: 10.1097/MPG.0b013e3182a98dbe
+keywords:
+- "Anemia, Hemolytic, Autoimmune/immunology, metabolism, pathology, therapy"
+- Anti-Inflammatory Agents/therapeutic use
+- "Antibodies, Monoclonal, Murine-Derived/therapeutic use"
+- Autoantibodies/blood
+- Azathioprine/therapeutic use
+- B-Lymphocytes/metabolism
+- Biopsy
+- "Child, Preschool"
+- Complement C3a/metabolism
+- Complement C5b/metabolism
+- Coombs Test
+- Female
+- Giant Cells
+- "Hepatitis, Autoimmune/immunology, metabolism, pathology, therapy"
+- "Hepatocytes/immunology, pathology"
+- Humans
+- Immunologic Factors/therapeutic use
+- Immunotherapy
+- Infant
+- "Inflammation/immunology, metabolism, therapy"
+- Leukocytes/metabolism
+- "Liver/cytology, immunology, pathology"
+- Male
+- Prednisone/therapeutic use
+- Rituximab
+content_type: abstract_only
+---
+
+# Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia.
+**Authors:** Whitington PF, Vos MB, Bass LM, Melin-Aldana H, Romero R, Roy CC, Alvarez F
+**Journal:** J Pediatr Gastroenterol Nutr (2014)
+**DOI:** [10.1097/MPG.0b013e3182a98dbe](https://doi.org/10.1097/MPG.0b013e3182a98dbe)
+
+## Content
+
+1. J Pediatr Gastroenterol Nutr. 2014 Jan;58(1):74-80. doi: 
+10.1097/MPG.0b013e3182a98dbe.
+
+Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune 
+hemolytic anemia.
+
+Whitington PF(1), Vos MB, Bass LM, Melin-Aldana H, Romero R, Roy CC, Alvarez F.
+
+Author information:
+(1)*Ann and Robert H. Lurie Children's Hospital of Chicago, IL †Department of 
+Pediatrics, Emory University, Atlanta, GA ‡Department of Pediatrics, CHU Sainte 
+Justine, University of Montreal, Montreal, Quebec, Canada.
+
+BACKGROUND AND AIMS: Giant cell hepatitis with autoimmune hemolytic anemia 
+(GCH-AHA) is presumed to be an autoimmune disease, but the mechanism of liver 
+injury is unknown. We proposed that in CGH-AHA, the humoral limb of autoimmunity 
+is the dominant force driving progressive liver injury.
+METHODS: We studied 6 cases of GCH-AHA and 6 cases of autoimmune hepatitis (AIH) 
+with early childhood onset (3 type 1 and 3 type 2). Liver biopsies were graded 
+for portal and periportal inflammation and for giant cells. Immunohistochemistry 
+characterized cellular inflammation and complement involvement in injury by 
+showing C5b-9 complex in hepatocytes.
+RESULTS: Clinical and biochemical features at presentation were generally 
+similar; however, the absence of autoantibodies and the presence of Coombs 
+positivity did distinguish GCH-AHA from early-onset AIH. Liver biopsy pathology 
+in CGH-AHA showed giant cells and little inflammation, whereas AIH showed the 
+opposite. C5b-9 staining showed high-grade complement-mediated pan-lobular 
+hepatocyte injury in all of the cases with GCH-AHA, whereas little C5b-9 was 
+seen in hepatocytes in cases with AIH. Inflammation in GCH-AHA comprised mainly 
+lobular macrophages and neutrophils, whereas portal and periportal T-cell and 
+B-cell inflammation characterized cases with AIH. Most cases with AIH responded 
+to therapy with prednisone and azathioprine, whereas most cases with GCH-AHA 
+responded only to rituximab.
+CONCLUSIONS: Widespread complement-mediated hepatocyte injury and typical C3a 
+and C5a complement-driven liver inflammation along with Coombs-positive 
+hemolytic anemia in GCH-AHA provide convincing evidence that systemic B-cell 
+autoimmunity plays a central pathologic mechanism in the disease. Our findings 
+support B-cell-directed immunotherapy as a first-line treatment of GCH-AHA.
+
+DOI: 10.1097/MPG.0b013e3182a98dbe
+PMID: 23969541 [Indexed for MEDLINE]

--- a/references_cache/PMID_24792633.md
+++ b/references_cache/PMID_24792633.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:24792633"
+title: "Giant cell hepatitis with autoimmune hemolytic anemia in children: proposal for therapeutic approach."
+authors:
+- Bakula A
+- Socha P
+- Klaudel-Dreszler M
+- Karolczyk G
+- Wozniak M
+- Rutynowska-Pronicka O
+- Matysiak M
+journal: J Pediatr Gastroenterol Nutr
+year: '2014'
+doi: 10.1097/MPG.0000000000000270
+keywords:
+- "Anemia, Hemolytic, Autoimmune/complications"
+- "Antibodies, Monoclonal, Murine-Derived/administration & dosage, therapeutic use"
+- Biopsy
+- Coombs Test
+- Female
+- Giant Cells/pathology
+- "Hepatitis/drug therapy, immunology, pathology"
+- Hepatocytes/pathology
+- Humans
+- Immunosuppressive Agents/therapeutic use
+- Infant
+- Male
+- Prognosis
+- Remission Induction
+- Rituximab
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Giant cell hepatitis with autoimmune hemolytic anemia in children: proposal for therapeutic approach.
+**Authors:** Bakula A, Socha P, Klaudel-Dreszler M, Karolczyk G, Wozniak M, Rutynowska-Pronicka O, Matysiak M
+**Journal:** J Pediatr Gastroenterol Nutr (2014)
+**DOI:** [10.1097/MPG.0000000000000270](https://doi.org/10.1097/MPG.0000000000000270)
+
+## Content
+
+1. J Pediatr Gastroenterol Nutr. 2014 May;58(5):669-73. doi: 
+10.1097/MPG.0000000000000270.
+
+Giant cell hepatitis with autoimmune hemolytic anemia in children: proposal for 
+therapeutic approach.
+
+Bakula A(1), Socha P, Klaudel-Dreszler M, Karolczyk G, Wozniak M, 
+Rutynowska-Pronicka O, Matysiak M.
+
+Author information:
+(1)*Department of Gastroenterology, Hepatology, and Eating Disorders, Children's 
+Memorial Health Institute, Warsaw †Department of Hemato-Oncology, Children's 
+Hospital, Kielce ‡Department of Oncology, Children's Memorial Health Institute 
+§Department of Pediatrics, Hematology and Oncology, Medical University of 
+Warsaw, Poland.
+
+BACKGROUND AND OBJECTIVE: Giant cell hepatitis (GCH) with autoimmune hemolytic 
+anemia (AIHA) is a rare, progressive disorder in infants and young children. The 
+disease is aggressive and may lead to liver or multiorgan failure with fatal 
+prognosis. Therapy with anti-CD20 monoclonal antibody, rituximab (Rtx), proved 
+effective. The primary objective of the study was to evaluate therapy for severe 
+GCH with AIHA.
+METHODS: We report on 5 cases of severe GCH with AIHA treated in our department 
+between 2006 and 2011.
+RESULTS: The median age of the children was 7 months (2-12 months), follow-up 
+lasted 44 months (12-78 months), median (min-max), and the main observed 
+symptoms were jaundice and hepatosplenomegaly. All of the children had positive 
+direct Coombs test and biopsy-proven giant cell transformation of hepatocytes. 
+Liver failure was observed in 3 children. First-line therapy (prednisone, 
+azathioprine) proved ineffective in all but 1 of the patients, who initially 
+responded to the treatment but relapsed after 4 months. The child subsequently 
+developed hemophagocytic lymphohistiocytosis and died 2 months after hemopoietic 
+stem cell transplantation. Four remaining patients finally achieved complete 
+remission after 4 to 6 doses of Rtx.
+CONCLUSIONS: We propose Rtx as the treatment of choice for severe GCH with AIHA 
+in the early stages of the disease, provided steroids and azathioprine are 
+ineffective.
+
+DOI: 10.1097/MPG.0000000000000270
+PMID: 24792633 [Indexed for MEDLINE]

--- a/references_cache/PMID_25201797.md
+++ b/references_cache/PMID_25201797.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:25201797"
+title: Anti-CD20 treatment of giant cell hepatitis with autoimmune hemolytic anemia.
+authors:
+- Paganelli M
+- Patey N
+- Bass LM
+- Alvarez F
+journal: Pediatrics
+year: '2014'
+doi: 10.1542/peds.2014-0032
+keywords:
+- Adolescent
+- "Anemia, Hemolytic, Autoimmune/complications, drug therapy, immunology"
+- "Antibodies, Monoclonal, Murine-Derived/pharmacology, therapeutic use"
+- "Antigens, CD20/immunology"
+- Autoantibodies/immunology
+- Child
+- "Giant Cells/immunology, pathology"
+- "Hepatitis/complications, drug therapy, immunology"
+- Humans
+- Rituximab
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Anti-CD20 treatment of giant cell hepatitis with autoimmune hemolytic anemia.
+**Authors:** Paganelli M, Patey N, Bass LM, Alvarez F
+**Journal:** Pediatrics (2014)
+**DOI:** [10.1542/peds.2014-0032](https://doi.org/10.1542/peds.2014-0032)
+
+## Content
+
+1. Pediatrics. 2014 Oct;134(4):e1206-10. doi: 10.1542/peds.2014-0032. Epub 2014
+Sep  8.
+
+Anti-CD20 treatment of giant cell hepatitis with autoimmune hemolytic anemia.
+
+Paganelli M(1), Patey N(2), Bass LM(3), Alvarez F(4).
+
+Author information:
+(1)Departments of Gastroenterology, Hepatology and Nutrition, and 
+m.paganelli@umontreal.ca.
+(2)Pathology, Centre Hospitalier Universitaire Sainte-Justine, Université de 
+Montréal, Montreal (QC), Canada;
+(3)Ann and Robert H. Lurie Children's Hospital of Chicago, Chicago, Illinois; 
+and Department of Pediatrics, Feinberg Medical School of Northwestern 
+University, Chicago, Illinois.
+(4)Departments of Gastroenterology, Hepatology and Nutrition, and.
+
+Giant cell hepatitis with autoimmune hemolytic anemia (GCH-AHA) is a rare 
+autoimmune disease of infancy characterized by severe liver disease associated 
+with Coombs-positive hemolytic anemia. We recently showed that GCH-AHA is 
+probably caused by a humoral immune mechanism. Such data support the use of 
+rituximab, an anti-CD-20 monoclonal antibody specifically targeting B 
+lymphocytes, as a treatment for GCH-AHA. We describe here the detailed clinical 
+evolution of 4 children with GCH-AHA who showed a complete response to 
+rituximab. All patients shared a severe course of the disease with poor control 
+on standard and aggressive immunosuppression. Rituximab was well tolerated, and 
+no side effects or infections were registered. Several doses were needed to 
+induce remission, and 5 to 11 additional maintenance injections were necessary 
+in the 2 more severe cases. Weaning from corticosteroids was achieved in all 
+subjects. A steroid-sparing effect was noted in the 3 children who started 
+rituximab early in the course of the disease. Overall, we show here that there 
+is a strong rationale for treating GCH-AHA with rituximab. Early treatment could 
+reduce the use of corticosteroids. Nevertheless, short-term steroids should be 
+initially associated with rituximab to account for autoantibodies' half-life. 
+Repeated injections are needed to treat and prevent relapses, but the best 
+frequency and duration of treatment remain to be defined.
+
+Copyright © 2014 by the American Academy of Pediatrics.
+
+DOI: 10.1542/peds.2014-0032
+PMID: 25201797 [Indexed for MEDLINE]

--- a/references_cache/PMID_26138133.md
+++ b/references_cache/PMID_26138133.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:26138133"
+title: "Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: A multicenter study."
+authors:
+- Marsalli G
+- Nastasio S
+- Sciveres M
+- Calvo PL
+- Ramenghi U
+- Gatti S
+- Albano V
+- Lega S
+- Ventura A
+- Maggiore G
+journal: Clin Res Hepatol Gastroenterol
+year: '2016'
+doi: 10.1016/j.clinre.2015.03.009
+keywords:
+- "Anemia, Hemolytic, Autoimmune/complications"
+- Female
+- "Hepatitis/complications, drug therapy"
+- Humans
+- "Immunoglobulins, Intravenous/therapeutic use"
+- Infant
+- Male
+- Remission Induction
+- Retrospective Studies
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: A multicenter study.
+**Authors:** Marsalli G, Nastasio S, Sciveres M, Calvo PL, Ramenghi U, Gatti S, Albano V, Lega S, Ventura A, Maggiore G
+**Journal:** Clin Res Hepatol Gastroenterol (2016)
+**DOI:** [10.1016/j.clinre.2015.03.009](https://doi.org/10.1016/j.clinre.2015.03.009)
+
+## Content
+
+1. Clin Res Hepatol Gastroenterol. 2016 Feb;40(1):83-9. doi: 
+10.1016/j.clinre.2015.03.009. Epub 2015 Jun 29.
+
+Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with 
+autoimmune hemolytic anemia: A multicenter study.
+
+Marsalli G(1), Nastasio S(2), Sciveres M(3), Calvo PL(4), Ramenghi U(4), Gatti 
+S(5), Albano V(5), Lega S(6), Ventura A(6), Maggiore G(2).
+
+Author information:
+(1)Department of Clinical and Experimental Medicine, University of Pisa, 
+Pediatric Gastroenterology Unit; University Hospital Santa Chiara, Pisa, Italy. 
+Electronic address: giuliamarsalli.med@gmail.com.
+(2)Department of Clinical and Experimental Medicine, University of Pisa, 
+Pediatric Gastroenterology Unit; University Hospital Santa Chiara, Pisa, Italy.
+(3)Paediatric Hepatology and Liver Transplant Unit, UPMC-IsMett, Palermo, Italy.
+(4)Department of Paediatric and Public Health Sciences, University of Torino, 
+Azienda Ospedaliera Città della Salute e della Scienza, Torino, Italy.
+(5)Department of Paediatrics, Università Politecnica delle Marche, Ancona, 
+Italy.
+(6)Institute for Maternal and Child Health, University of Trieste, Trieste, 
+Italy; IRCCS Burlo Garofolo, Trieste, Italy.
+
+BACKGROUND AND OBJECTIVE: Giant cell hepatitis with autoimmune hemolytic anemia 
+(GCH-AHA) is a rare disease of infancy, of possible autoimmune mechanism with 
+poor prognosis due to its scarce response to immunosuppressive drugs. The aim of 
+this retrospective multicenter study was to evaluate the efficacy and safety of 
+intravenous immunoglobulin (IVIg) treatment in inducing and maintaining 
+remission of the liver disease, in patients with GCH-AHA.
+METHODS: Seven children with GCH-AHA, four newly diagnosed, and three in 
+relapse, being treated with different therapies, received one to three IVIg 
+infusions (0.5 to 2g/kg) in association with other immunosuppressive drugs. 
+Subsequently five of them received monthly sequential IVIg infusions (mean 13.4, 
+range 7-24).
+RESULTS: IVIg infusions as first-line therapy associated with prednisone and 
+other immunosuppressive drugs significantly (P=0.04) reduced the 
+aminotransferase activity in all patients and normalized prothrombin activity in 
+the only patient with severe liver dysfunction. Sequential monthly IVIg 
+infusions determined a steroid-sparing effect and allowed a complete or partial 
+remission in all patients, although with temporary efficacy, since relapse of 
+the hemolytic anemia and/or of liver disease occurred in all patients. IVIg 
+infusions were associated with mild side effects in two patients.
+CONCLUSIONS: IVIg infusion can be safely and effectively administered in 
+patients with severe GCH-AHA at diagnosis, or in case of relapse, in association 
+with other immunosuppressive drugs. Repeated IVIg infusions may help maintain 
+remission, however, due to their temporary efficacy, they should not be 
+routinely employed.
+
+Copyright © 2015 Elsevier Masson SAS. All rights reserved.
+
+DOI: 10.1016/j.clinre.2015.03.009
+PMID: 26138133 [Indexed for MEDLINE]

--- a/references_cache/PMID_32206631.md
+++ b/references_cache/PMID_32206631.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:32206631"
+title: Successful Treatment of a Korean Infant with Giant Cell Hepatitis with Autoimmune Hemolytic Anemia Using Rituximab.
+authors:
+- Kim YH
+- Kim JW
+- Lee EJ
+- Kang GH
+- Kang HJ
+- Moon JS
+- Ko JS
+journal: Pediatr Gastroenterol Hepatol Nutr
+year: '2020'
+doi: 10.5223/pghn.2020.23.2.180
+content_type: abstract_only
+---
+
+# Successful Treatment of a Korean Infant with Giant Cell Hepatitis with Autoimmune Hemolytic Anemia Using Rituximab.
+**Authors:** Kim YH, Kim JW, Lee EJ, Kang GH, Kang HJ, Moon JS, Ko JS
+**Journal:** Pediatr Gastroenterol Hepatol Nutr (2020)
+**DOI:** [10.5223/pghn.2020.23.2.180](https://doi.org/10.5223/pghn.2020.23.2.180)
+
+## Content
+
+1. Pediatr Gastroenterol Hepatol Nutr. 2020 Mar;23(2):180-187. doi: 
+10.5223/pghn.2020.23.2.180. Epub 2020 Mar 4.
+
+Successful Treatment of a Korean Infant with Giant Cell Hepatitis with 
+Autoimmune Hemolytic Anemia Using Rituximab.
+
+Kim YH(1), Kim JW(1), Lee EJ(1), Kang GH(2), Kang HJ(3), Moon JS(1), Ko JS(1).
+
+Author information:
+(1)Department of Pediatrics, Seoul National University Hospital, Seoul, Korea.
+(2)Department of Pathology, Seoul National University Hospital, Seoul, Korea.
+(3)Department of Pediatrics, Seoul National University College of Medicine, 
+Seoul National University Cancer Research Institute, Seoul National University 
+Children's Hospital, Seoul, Korea.
+
+Giant cell hepatitis with autoimmune hemolytic anemia (AHA) is a rare disease of 
+infancy characterized by the presence of both Coombs-positive hemolytic anemia 
+and progressive liver disease with giant cell transformation of hepatocytes. 
+Here, we report a case involving a seven-month-old male infant who presented 
+with AHA followed by cholestatic hepatitis. The clinical features included 
+jaundice, pallor, and red urine. Physical examination showed generalized icterus 
+and splenomegaly. The laboratory findings suggested warm-type AHA with 
+cholestatic hepatitis. Liver biopsy revealed giant cell transformation of 
+hepatocytes and moderate lobular inflammation. The patient was successfully 
+treated with four doses of rituximab. Early relapse of hemolytic anemia and 
+hepatitis was observed, which prompted the use of an additional salvage dose of 
+rituximab. He is currently in clinical remission.
+
+Copyright © 2020 by The Korean Society of Pediatric Gastroenterology, Hepatology 
+and Nutrition.
+
+DOI: 10.5223/pghn.2020.23.2.180
+PMCID: PMC7073370
+PMID: 32206631
+
+Conflict of interest statement: Conflict of Interest: The authors have no 
+financial conflicts of interest.

--- a/references_cache/PMID_8159622.md
+++ b/references_cache/PMID_8159622.md
@@ -1,0 +1,56 @@
+---
+reference_id: "PMID:8159622"
+title: Coombs-positive autoimmune hemolytic anemia and postinfantile giant cell hepatitis in children.
+authors:
+- Perez-Atayde AR
+- Sirlin SM
+- Jonas M
+journal: Pediatr Pathol
+year: '1994'
+doi: 10.3109/15513819409022027
+keywords:
+- "Anemia, Hemolytic, Autoimmune/complications"
+- Coombs Test
+- Fatal Outcome
+- Female
+- Giant Cells
+- "Hepatitis/complications, pathology, therapy"
+- Humans
+- Infant
+- Liver Cirrhosis/complications
+- Male
+content_type: abstract_only
+---
+
+# Coombs-positive autoimmune hemolytic anemia and postinfantile giant cell hepatitis in children.
+**Authors:** Perez-Atayde AR, Sirlin SM, Jonas M
+**Journal:** Pediatr Pathol (1994)
+**DOI:** [10.3109/15513819409022027](https://doi.org/10.3109/15513819409022027)
+
+## Content
+
+1. Pediatr Pathol. 1994 Jan-Feb;14(1):69-77. doi: 10.3109/15513819409022027.
+
+Coombs-positive autoimmune hemolytic anemia and postinfantile giant cell 
+hepatitis in children.
+
+Perez-Atayde AR(1), Sirlin SM, Jonas M.
+
+Author information:
+(1)Department of Pathology, Children's Hospital, Boston, Massachusetts 02115.
+
+We report a 23-month-old girl and a 9-month-old boy who presented with 
+autoimmune hemolytic anemia followed by recurrent episodes of severe hepatitis. 
+The first episode of hepatitis occurred 1 week and 15 months after presentation, 
+respectively. Histologically, the livers showed loss of lobular architecture 
+with diffuse giant cell transformation of hepatocytes and portal and 
+pericellular fibrosis. The first patient died at 4 1/2 months after her initial 
+presentation with a well-established micronodular cirrhosis. The second patient 
+responded to steroid therapy and the hepatitis recurred when steroids were 
+tapered. Postinfantile giant cell hepatitis may occur in association with 
+Coombs-positive hemolytic anemia, it is thought to have an autoimmune mechanism, 
+and early and sustained immunosuppression may control the progressive 
+hepatocellular damage and prevent cirrhosis.
+
+DOI: 10.3109/15513819409022027
+PMID: 8159622 [Indexed for MEDLINE]

--- a/research/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
+++ b/research/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md
@@ -1,0 +1,1271 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T22:04:45.008041'
+end_time: '2026-05-06T22:18:02.304566'
+duration_seconds: 797.3
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Giant Cell Hepatitis With Autoimmune Hemolytic Anemia
+  mondo_id: ''
+  category: Autoimmune Disease
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 43
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Giant Cell Hepatitis With Autoimmune Hemolytic Anemia
+- **MONDO ID:**  (if available)
+- **Category:** Autoimmune Disease
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Giant Cell Hepatitis With Autoimmune Hemolytic Anemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Giant Cell Hepatitis With Autoimmune Hemolytic Anemia
+- **MONDO ID:**  (if available)
+- **Category:** Autoimmune Disease
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Giant Cell Hepatitis With Autoimmune Hemolytic Anemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Research Report: Giant Cell Hepatitis With Autoimmune Hemolytic Anemia (GCH-AIHA)
+
+### Scope and evidence base
+This report synthesizes evidence from pediatric cohorts/case series and case reports available in the retrieved full texts (1994–2020; plus a 2016 IVIG multicenter series). Disease-specific 2023–2024 primary sources were not retrievable in this environment; therefore, “latest research” is reported up to what could be accessed, and gaps are explicitly noted. (maggiore2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3, marsalli2016efficacyofintravenous pages 1-2)
+
+A compact evidence map (clinical features, mechanisms, treatment outcomes) is provided in the table artifact below.
+
+| Aspect | Key points (with quantitative stats when available) | Key sources (author year; PMID if known; DOI/URL) |
+|---|---|---|
+| Age of onset / demographic pattern | Predominantly an infantile/early-childhood disease. Median age at onset/diagnosis was **6 months** in a 16-child cohort; onset ranged from **2.5-17 months** in that series. Review-level summaries report median onset around **8 months**; in a 6-case mechanistic series mean presentation age was **17.3 ± 8.3 months** (range **4-52 months**). AHA often precedes hepatitis by **<1 month to several months**; reported intervals include **1 week-15 months**, commonly **1-2 months**. (maggiore2011giantcellhepatitis pages 1-2, raj2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3, kim2020successfultreatmentof pages 2-4) | Maggiore 2011; PMID not available here; https://doi.org/10.1016/j.jpeds.2010.12.050. Raj 2011; PMID not available here; https://doi.org/10.1177/0009922810379501. Whitington 2014; PMID not available here; https://doi.org/10.1097/MPG.0b013e3182a98dbe. Kim 2020; PMID not available here; https://doi.org/10.5223/pghn.2020.23.2.180 |
+| Disease definition / rarity | Rare pediatric syndrome combining **Coombs-positive autoimmune hemolytic anemia** with **giant cell hepatitis** on biopsy. Literature estimates evolved from **18 previously reported cases** before the 2011 cohort, to about **29 pediatric cases** in older reviews, to approximately **50 cases** by 2015-2016, and **<100 reported cases** by 2020, underscoring extreme rarity. (maggiore2011giantcellhepatitis pages 1-2, raj2011giantcellhepatitis pages 1-2, cho2016giantcellhepatitis pages 1-2, kim2020successfultreatmentof pages 2-4) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050. Raj 2011; https://doi.org/10.1177/0009922810379501. Cho 2016; https://doi.org/10.1111/ped.12874. Kim 2020; https://doi.org/10.5223/pghn.2020.23.2.180 |
+| Diagnostic hallmarks | Core diagnostic combination: **direct antiglobulin (Coombs) positive hemolytic anemia** plus **liver biopsy showing diffuse giant/multinucleated hepatocyte transformation**. In the 16-child cohort all had **IgG+C type** Coombs positivity and biopsy-proven giant cell hepatitis. Giant cell transformation, cholestasis, architectural distortion, fibrosis, ballooning degeneration, spotty necrosis, and portal/lobular inflammation are recurrent biopsy findings. Autoimmune hepatitis serologies are often absent despite immune-mediated disease. (maggiore2011giantcellhepatitis pages 1-2, perezatayde1994coombspositiveautoimmunehemolytic pages 1-4, bakula2014giantcellhepatitis pages 1-3, paganelli2014anticd20treatmentof pages 1-2, cho2016giantcellhepatitis pages 1-2) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050. Perez-Atayde 1994; https://doi.org/10.3109/15513819409022027. Bakula 2014; https://doi.org/10.1097/MPG.0000000000000270. Paganelli 2014; https://doi.org/10.1542/peds.2014-0032. Cho 2016; https://doi.org/10.1111/ped.12874 |
+| Typical clinical features | Common findings include **jaundice, pallor/anemia, hepatomegaly, splenomegaly, fever**, and cholestatic hepatitis. In the 16-child cohort: jaundice **14/16**, hepatomegaly **16/16**, splenomegaly **6/16**, pallor **9/16**, fever **8/16**. In the 6-case mechanistic series: hepatomegaly **6/6**, anemia **6/6**, jaundice **5/6**, splenomegaly **2/6**. (maggiore2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050. Whitington 2014; https://doi.org/10.1097/MPG.0b013e3182a98dbe |
+| Laboratory abnormalities | Severe hemolysis and hepatitis are typical. In the 16-child cohort median hemoglobin was **6.7 g/dL**, reticulocytes **207,000/mL**, total bilirubin **13.5 mg/dL**, direct bilirubin **11 mg/dL**, ALT **45× ULN**. Case reports/series show very high aminotransferases and bilirubin, e.g. AST **4955 U/L** and ALT **6522 U/L** in one report; in a 2020 case AST **1781 IU/L**, ALT **4136 IU/L**, total bilirubin **15.6 mg/dL**. (maggiore2011giantcellhepatitis pages 1-2, raj2011giantcellhepatitis pages 1-2, kim2020successfultreatmentof pages 2-4, bakula2014giantcellhepatitis pages 1-3) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050. Raj 2011; https://doi.org/10.1177/0009922810379501. Kim 2020; https://doi.org/10.5223/pghn.2020.23.2.180. Bakula 2014; https://doi.org/10.1097/MPG.0000000000000270 |
+| Pathophysiology evidence | Evidence supports a **humoral, B-cell/autoantibody- and complement-mediated** mechanism rather than classic T-cell autoimmune hepatitis alone. In Whitington et al., all **6/6** GCH-AHA biopsies showed **high-grade pan-lobular hepatocyte C5b-9 deposition**, with little portal pathology and predominant lobular macrophage/neutrophil inflammation. Autoimmune hepatitis autoantibodies were absent in all 6 cases in that series; another report noted only **3/18** patients with standard AIH autoantibodies. (whitington2014humoralimmunemechanism pages 2-3, whitington2014humoralimmunemechanism pages 1-1, marsalli2016efficacyofintravenous pages 1-2) | Whitington 2014; https://doi.org/10.1097/MPG.0b013e3182a98dbe. Marsalli 2016; https://doi.org/10.1016/j.clinre.2015.03.009 |
+| Prednisone + azathioprine (± cyclosporine) | Traditional first-line immunosuppression can induce remission but relapses are frequent and treatment often must continue for years. In the 16-child cohort, prednisone + azathioprine (3 also received cyclosporine) led to **complete remission in 8/16**, **partial remission in 6/16**, and **failure in 2/16**. Relapses occurred in **11/16** for hepatitis and **10/16** for anemia. Treatment stopped after a mean **6 years** in 7 children, who then remained relapse-free at median follow-up **14 years**. (maggiore2011giantcellhepatitis pages 1-2) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050 |
+| IVIG | IVIG can rapidly improve liver biochemistry and has a steroid-sparing role, but benefit is often temporary. In a multicenter series of **7** children, IVIG plus concomitant immunosuppression significantly reduced aminotransferases (**P = 0.04**) and monthly IVIG achieved complete or partial remission in all initially, yet **relapse of hemolysis and/or liver disease occurred in all patients**. Among 5 patients receiving sequential IVIG, **2/5** remained in complete liver remission after a median **23 months**, but hemolytic anemia relapsed; **3/5** had liver relapse after median **7.3 months**. Mild side effects occurred in **2/7**. (marsalli2016efficacyofintravenous pages 1-2, marsalli2016efficacyofintravenous pages 4-5, marsalli2016efficacyofintravenous pages 6-7) | Marsalli 2016; https://doi.org/10.1016/j.clinre.2015.03.009 |
+| Rituximab (anti-CD20) | Strongest disease-specific targeted evidence. In Whitington et al., **3/3** rituximab-treated refractory patients entered remission; standard therapy alone achieved remission in only **1/6**. Paganelli et al. reported **complete response in 4/4** children; **5-11** maintenance infusions were needed in the 2 most severe cases, and corticosteroid weaning was achieved in all. Individual case reports also describe rapid biochemical improvement after four weekly doses, with additional salvage doses controlling relapses. (whitington2014humoralimmunemechanism pages 2-3, paganelli2014anticd20treatmentof pages 1-2, kim2020successfultreatmentof pages 2-4, bakula2014giantcellhepatitis pages 1-3) | Whitington 2014; https://doi.org/10.1097/MPG.0b013e3182a98dbe. Paganelli 2014; https://doi.org/10.1542/peds.2014-0032. Kim 2020; https://doi.org/10.5223/pghn.2020.23.2.180. Bakula 2014; https://doi.org/10.1097/MPG.0000000000000270 |
+| Other therapies reported | Additional therapies in refractory cases include **cyclophosphamide, cyclosporine, tacrolimus, sirolimus, mycophenolate mofetil, plasmapheresis, splenectomy**, and rarely **stem-cell transplantation** in complex overlap/HLH-like cases. Evidence is limited to small series/case reports and mixed outcomes. (raj2011giantcellhepatitis pages 1-2, kim2020successfultreatmentof pages 5-6, bakula2014giantcellhepatitis pages 1-3) | Raj 2011; https://doi.org/10.1177/0009922810379501. Kim 2020; https://doi.org/10.5223/pghn.2020.23.2.180. Bakula 2014; https://doi.org/10.1097/MPG.0000000000000270 |
+| Outcomes / mortality / transplant | Prognosis is serious. Historical reports cited mortality or need for liver transplantation of about **39%** in earlier literature. In the 16-child cohort, **4/16 died** and **1/16** was alive **9 years after liver transplantation**. In the 6-case mechanistic series, standard therapy remission occurred in **1/6**, **1/6 died of liver failure**, and **1/6** underwent transplant. Reviews/case reports cite mortality around **25-30%**, often from sepsis, liver failure, or relapse. Liver transplantation has been complicated by recurrence and is no longer favored as routine therapy when immune control is possible. (maggiore2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3, cho2016giantcellhepatitis pages 1-2, kim2020successfultreatmentof pages 2-4, kim2020successfultreatmentof pages 5-6) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050. Whitington 2014; https://doi.org/10.1097/MPG.0b013e3182a98dbe. Cho 2016; https://doi.org/10.1111/ped.12874. Kim 2020; https://doi.org/10.5223/pghn.2020.23.2.180 |
+| Prognostic markers / caveats | Disease course is relapsing and infection from prolonged immunosuppression is a major threat. One small 3-infant report suggested **serum ferritin at diagnosis may predict outcome**, but detailed thresholds were not available in the extracted text. More recent disease-specific series do not establish validated prognostic biomarkers. (maggiore2011giantcellhepatitis pages 1-2, marsalli2016efficacyofintravenous pages 2-3) | Maggiore 2011; https://doi.org/10.1016/j.jpeds.2010.12.050. Unal 2010; PMID not available here; https://doi.org/10.5152/tjh.2010.55 |
+
+
+*Table: This table summarizes the main clinical, diagnostic, mechanistic, and treatment findings for giant cell hepatitis with autoimmune hemolytic anemia, emphasizing quantitative results from the largest available pediatric series. It is useful as a compact evidence map for disease characterization and knowledge base curation.*
+
+---
+
+## 1. Disease Information
+
+### 1.1 Definition / overview
+Giant cell hepatitis with autoimmune hemolytic anemia (GCH-AHA/GCH-AIHA) is a rare pediatric syndrome characterized by the association of (i) **Coombs-positive autoimmune hemolytic anemia** and (ii) **biopsy-proven giant cell hepatitis**, typically presenting beyond the neonatal period and often progressing with relapses. (maggiore2011giantcellhepatitis pages 1-2, marsalli2016efficacyofintravenous pages 1-2, paganelli2014anticd20treatmentof pages 1-2)
+
+**Direct abstract quote (definition framing):** In the Pediatrics case series, the abstract begins: “**Giant cell hepatitis with autoimmune hemolytic anemia (GCH-AHA) is a rare autoimmune disease of infancy characterized by severe liver disease associated with Coombs-positive hemolytic anemia.**” (paganelli2014anticd20treatmentof pages 1-2)
+
+### 1.2 Synonyms / alternative names used in the literature
+* Giant cell hepatitis with autoimmune hemolytic anemia (GCH-AHA) (paganelli2014anticd20treatmentof pages 1-2)
+* Giant cell hepatitis with autoimmune hemolytic anemia (GCH-AIHA) (usage varies by author; concept consistent across cohorts) (maggiore2011giantcellhepatitis pages 1-2, marsalli2016efficacyofintravenous pages 1-2)
+* Coombs-positive autoimmune hemolytic anemia with postinfantile/infantile giant cell hepatitis (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4)
+
+### 1.3 Disease identifiers (OMIM/Orphanet/ICD/MeSH/MONDO)
+Within the retrieved full texts, explicit OMIM, Orphanet, ICD-10/ICD-11, MeSH, or MONDO identifiers were **not** present; therefore, these identifiers cannot be asserted from this evidence set.
+
+### 1.4 Evidence source type
+Evidence is largely derived from **case reports and small pediatric series**, plus one **retrospective multicenter observational study** of IVIG and a long-term outcome cohort of 16 children. (maggiore2011giantcellhepatitis pages 1-2, marsalli2016efficacyofintravenous pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Primary causes (current understanding)
+The etiology is not established as genetic; instead, available evidence supports an **immune-mediated (autoimmune) cause**, specifically a **humoral (B-cell/IgG) and complement-mediated** injury mechanism in the liver, alongside antibody/complement-mediated hemolysis. (whitington2014humoralimmunemechanism pages 2-3, marsalli2016efficacyofintravenous pages 1-2)
+
+### 2.2 Risk factors
+**Age** is the dominant epidemiologic risk factor: most cases occur in **infancy/early childhood**. (maggiore2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3)
+
+**Potential triggers/associations** are inconsistently reported. For example, one cohort noted an infectious serology signal (parvovirus) in an individual patient without proving causality (reported in a case series context). (bakula2014giantcellhepatitis pages 1-3)
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved disease-specific literature.
+
+### 2.4 Gene–environment interactions
+No gene–environment interaction evidence was identified in the retrieved literature.
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotypes and suggested HPO terms
+Below are recurring phenotypes with suggested HPO mappings based on cohort/case-series descriptions.
+
+**Hemolysis/AIHA phenotype complex (often first):**
+* Pallor (HP:0000980)
+* Jaundice (HP:0000952)
+* Hemolytic anemia (HP:0001878)
+* Positive direct antiglobulin test / Coombs positive hemolysis (no single HPO term; can map to laboratory abnormality plus “autoimmune hemolytic anemia” concept)
+* Splenomegaly (HP:0001744)
+* Hepatosplenomegaly (HP:0001433)
+* Fever (HP:0001945)
+
+In a 16-child cohort at diagnosis: jaundice 14/16, hepatomegaly 16/16, splenomegaly 6/16, pallor 9/16, fever 8/16. (maggiore2011giantcellhepatitis pages 1-2)
+
+**Liver phenotype complex (often later, relapsing):**
+* Hepatomegaly (HP:0002240)
+* Hepatitis (HP:0012115)
+* Cholestasis (HP:0002904)
+* Hyperbilirubinemia (HP:0002904/HP:0002910 context-dependent)
+* Elevated transaminases (HP:0002910)
+* Liver fibrosis / cirrhosis (HP:0001395)
+* Acute liver failure can occur in some patients (HP:0006557), though not universal (whitington2014humoralimmunemechanism pages 2-3)
+
+**Temporal phenotype relationship:** hemolytic anemia may precede hepatitis by weeks to months; one review-level synthesis described hepatitis appearing **1 week to 15 months** after hemolysis onset (often 1–2 months). (raj2011giantcellhepatitis pages 1-2, kim2020successfultreatmentof pages 2-4)
+
+### 3.2 Laboratory phenotypes and suggested HPO terms
+From cohort/case evidence:
+* Low hemoglobin (HP:0001903): median Hb 6.7 g/dL in the 16-child cohort (maggiore2011giantcellhepatitis pages 1-2)
+* High reticulocyte count (HP:0001898): median reticulocytes 207,000/mL in the 16-child cohort (maggiore2011giantcellhepatitis pages 1-2)
+* Hyperbilirubinemia (HP:0002904): median total bilirubin 13.5 mg/dL, direct 11 mg/dL in the 16-child cohort (maggiore2011giantcellhepatitis pages 1-2)
+* Markedly elevated ALT/AST (HP:0002910): ALT reported as 45× ULN median in the 16-child cohort; extreme values reported in case reports (maggiore2011giantcellhepatitis pages 1-2, raj2011giantcellhepatitis pages 1-2)
+
+### 3.3 Quality of life impact
+Disease is described as severe, requiring prolonged immunosuppression and repeated hospitalization for relapses and infections; formal QoL instruments (e.g., PedsQL) were not reported in the retrieved texts. (maggiore2011giantcellhepatitis pages 1-2, marsalli2016efficacyofintravenous pages 1-2)
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes
+No causal genes or recurrent pathogenic variants were identified in the retrieved disease-specific literature; current evidence supports an immune-mediated syndrome rather than a monogenic disorder.
+
+### 4.2 Pathogenic variants / modifier genes / epigenetics / chromosomal abnormalities
+No disease-specific evidence was found in the retrieved texts.
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Environmental/lifestyle factors
+No environmental or lifestyle risk factors were established in the retrieved texts.
+
+### 5.2 Infectious agents
+Infectious workups are often described as negative in pediatric reports; occasional associations (e.g., parvovirus serology in an individual) do not establish causality. (bakula2014giantcellhepatitis pages 1-3, cho2016giantcellhepatitis pages 1-2)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Key mechanistic concept
+A central, disease-defining mechanistic insight is that liver injury in GCH-AIHA appears to be **antibody/complement (humoral) mediated**, differing from classic T-cell–predominant autoimmune hepatitis (AIH). This is supported by:
+* **Pan-lobular hepatocyte C5b-9 (membrane attack complex) deposition** in GCH-AHA biopsies (high-grade in all cases in one mechanistic series) (whitington2014humoralimmunemechanism pages 2-3, whitington2014humoralimmunemechanism pages 1-1)
+* A lobular inflammatory pattern enriched for macrophages/neutrophils rather than portal/periportal lymphocyte–rich inflammation typical of AIH (whitington2014humoralimmunemechanism pages 3-6)
+* Clinical refractoriness to “standard” AIH regimens in many patients and strong responses to **B-cell depletion** (rituximab) (whitington2014humoralimmunemechanism pages 2-3, paganelli2014anticd20treatmentof pages 1-2)
+
+### 6.2 Causal chain (upstream → downstream)
+**Proposed causal chain (human biopsy and clinical-response supported):**
+1) **B-cell–derived IgG** binds an (unknown) hepatocyte target antigen (upstream trigger not yet defined). (whitington2014humoralimmunemechanism pages 6-6, whitington2014humoralimmunemechanism pages 1-1)
+2) IgG triggers **classical complement pathway** activation on hepatocytes, leading to deposition of **C5b-9**; Whitington et al. note the staining intensity is a marker of complement-mediated injury (“The degree of C5b-9 staining…is indicative of the degree of complement-mediated cell injury”). (whitington2014humoralimmunemechanism pages 2-3)
+3) Complement split products (e.g., C3a/C5a) recruit/activate innate immune cells, producing lobular inflammation dominated by **macrophages** and **neutrophils** and hepatocyte necroinflammation. (whitington2014humoralimmunemechanism pages 3-6, whitington2014humoralimmunemechanism pages 6-6)
+4) Injured hepatocytes undergo **giant cell transformation** (multinucleation/fusion), a histologic hallmark. (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4, whitington2014humoralimmunemechanism pages 3-6)
+5) In parallel, antibody/complement activity produces **Coombs-positive hemolytic anemia**, sometimes preceding the hepatitis, reinforcing a systemic humoral immune disorder phenotype. (marsalli2016efficacyofintravenous pages 1-2, maggiore2011giantcellhepatitis pages 1-2)
+
+### 6.3 Suggested ontology mappings
+**GO biological process terms (suggested):**
+* complement activation, classical pathway
+* regulation of complement activation
+* B cell mediated immunity
+* antibody-mediated immune response
+* inflammatory response
+* macrophage activation
+* neutrophil chemotaxis
+* liver regeneration
+* hepatic fibrosis
+
+**Cell Ontology (CL) terms (suggested):**
+* hepatocyte
+* B cell (CD20+)
+* macrophage (CD68+)
+* neutrophil
+* Kupffer cell (liver macrophage; if specifically described)
+
+**UBERON anatomy (suggested):**
+* liver
+* hepatic lobule
+* spleen
+* bone marrow
+* blood
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ level
+Primary: **liver** (giant cell hepatitis, cholestasis, fibrosis/cirrhosis risk). (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4, maggiore2011giantcellhepatitis pages 1-2)
+
+Secondary/related: **hematologic system** (autoimmune hemolytic anemia; often hepatosplenomegaly). (maggiore2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3)
+
+### 7.2 Tissue and cell level
+* Hepatic parenchyma (lobular architecture disturbance, giant hepatocytes, fibrosis; minimal portal pathology in some mechanistic descriptions) (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4, whitington2014humoralimmunemechanism pages 1-2)
+* Immune infiltrate pattern differing from AIH: relatively fewer portal lymphocytes with more lobular macrophages/neutrophils in GCH-AHA (whitington2014humoralimmunemechanism pages 3-6)
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset
+Typically **infancy/early childhood**. Median age 6 months in a 16-child cohort; mechanistic series range 4–52 months. (maggiore2011giantcellhepatitis pages 1-2, whitington2014humoralimmunemechanism pages 2-3)
+
+### 8.2 Progression and course
+Course is often **relapsing** and may require years of immunosuppression. In the 16-child cohort, relapses occurred in 11/16 (hepatitis) and 10/16 (anemia); treatment could eventually be stopped after a mean 6 years in some patients with sustained remission. (maggiore2011giantcellhepatitis pages 1-2)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology
+Population-level prevalence/incidence estimates were not available in the retrieved texts; the syndrome is repeatedly described as **very rare**, with literature case counts increasing over time (e.g., 18 cases reported before 2011 cohort; approximately 50 cases by 2015; “<100 reported cases” by 2020). (maggiore2011giantcellhepatitis pages 1-2, cho2016giantcellhepatitis pages 1-2, kim2020successfultreatmentof pages 2-4)
+
+### 9.2 Inheritance
+No inherited pattern is established from available evidence.
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Core diagnostic components
+**A. Hematology:** direct antiglobulin (Coombs/DAT) positivity demonstrating autoimmune hemolysis (commonly IgG±complement). (maggiore2011giantcellhepatitis pages 1-2, marsalli2016efficacyofintravenous pages 1-2)
+
+**B. Hepatology:** liver biochemistry consistent with hepatitis/cholestasis plus **liver biopsy** showing diffuse giant cell transformation and associated injury/fibrosis patterns. (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4, maggiore2011giantcellhepatitis pages 1-2)
+
+**C. Exclusion of other causes:** cohorts describe exclusion of viral, metabolic, toxic, and cholestatic etiologies as part of case definition/selection. (maggiore2011giantcellhepatitis pages 1-2)
+
+### 10.2 Key histopathology
+A classic early report describes: “**loss of lobular architecture with diffuse giant cell transformation of hepatocytes and portal and pericellular fibrosis**.” (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4)
+
+Mechanistic work emphasizes complement immunostaining: high-grade hepatocyte **C5b-9** deposition as evidence for complement-mediated injury and potential stratification for B-cell–targeted therapy. (whitington2014humoralimmunemechanism pages 2-3, whitington2014humoralimmunemechanism pages 6-6)
+
+### 10.3 Differential diagnosis (from available evidence)
+The literature emphasizes distinguishing GCH-AHA from classic pediatric autoimmune hepatitis (different autoantibody patterns, different histology/immune infiltrates, different treatment responsiveness). (whitington2014humoralimmunemechanism pages 2-3, whitington2014humoralimmunemechanism pages 1-1)
+
+---
+
+## 11. Outcome / Prognosis
+
+### 11.1 Mortality, transplant, long-term outcomes
+Outcomes can be severe:
+* In the 16-child long-term cohort: **4/16 died** (sepsis or multiple organ failure) and **1/16** survived after liver transplantation (alive 9 years post-transplant). (maggiore2011giantcellhepatitis pages 1-2)
+* Earlier literature summarized within that cohort reported **mortality or need for liver transplantation of 39%** in reported cases at that time. (maggiore2011giantcellhepatitis pages 1-2)
+* In a 6-case mechanistic series: only 1/6 achieved remission with standard therapy; 1 died and 1 underwent transplantation; 3/3 rituximab-treated patients achieved remission. (whitington2014humoralimmunemechanism pages 2-3)
+
+### 11.2 Prognostic factors
+A small 3-infant report concluded: “**We conclude that serum ferritin at diagnosis may be used for prediction of the outcome.**” However, thresholds and validation were not available in the extracted evidence. (marsalli2016efficacyofintravenous pages 2-3)
+
+A dominant practical prognostic concern across cohorts is **infection risk** during prolonged immunosuppression (death from sepsis reported). (maggiore2011giantcellhepatitis pages 1-2)
+
+---
+
+## 12. Treatment
+
+### 12.1 Immunosuppression (historical backbone): corticosteroids + azathioprine
+In the 16-child cohort, prednisone + azathioprine (± cyclosporine) led to **complete remission in 8/16**, **partial remission in 6/16**, and **failure in 2/16**, but relapses were common (11/16 hepatitis; 10/16 anemia). (maggiore2011giantcellhepatitis pages 1-2)
+
+**Suggested MAXO terms (examples):** immunosuppressive therapy; glucocorticoid therapy; azathioprine therapy.
+
+### 12.2 IVIG (immunomodulatory) as adjunct / steroid-sparing
+In a multicenter retrospective series of **7** children, IVIG (0.5–2 g/kg; sequential monthly dosing in 5/7) significantly reduced aminotransferases (P=0.04) and showed steroid-sparing benefit, but **relapse occurred in all patients** over follow-up (hemolysis and/or liver disease). (marsalli2016efficacyofintravenous pages 1-2, marsalli2016efficacyofintravenous pages 6-7)
+
+**Suggested MAXO terms:** intravenous immunoglobulin therapy.
+
+### 12.3 Rituximab (anti-CD20) B-cell depletion: targeted therapy with strong signal
+Multiple series report strong responses:
+* Whitington et al.: rituximab induced remission in **3/3** refractory patients. (whitington2014humoralimmunemechanism pages 2-3)
+* Paganelli et al. (Pediatrics): “**complete response**” in **4 children**, with steroid weaning in all; several doses and **5–11 maintenance injections** in severe cases; no infections/side effects reported in that series. (paganelli2014anticd20treatmentof pages 1-2)
+
+**Suggested MAXO terms:** anti-CD20 monoclonal antibody therapy; B-cell depletion therapy.
+
+### 12.4 Other immunomodulatory/second-line approaches
+Reports include cyclosporine, tacrolimus, mycophenolate, cyclophosphamide, plasmapheresis, splenectomy, and (rarely) stem-cell transplantation in complex immune-dysregulation scenarios; evidence is limited and heterogeneous. (bakula2014giantcellhepatitis pages 1-3, kim2020successfultreatmentof pages 5-6, raj2011giantcellhepatitis pages 1-2)
+
+### 12.5 Liver transplantation
+Transplantation has been used for end-stage liver disease, but recurrence/relapse concerns exist. One child in the 16-patient cohort was alive 9 years post-transplant. (maggiore2011giantcellhepatitis pages 1-2)
+
+A later case review table notes that transplantation has been complicated by relapse/rejection and “is no longer recommended presently” (as a routine strategy), emphasizing immune control instead where possible. (kim2020successfultreatmentof pages 5-6)
+
+### 12.6 Clinical trials
+ClinicalTrials.gov searches in this environment did not yield clear, disease-specific interventional trials for GCH-AIHA.
+
+---
+
+## 13. Prevention
+No primary prevention strategies are established due to unclear triggers and extreme rarity. Secondary/tertiary prevention in practice focuses on relapse monitoring and infection prevention during immunosuppression (not quantified in retrieved sources). (maggiore2011giantcellhepatitis pages 1-2)
+
+---
+
+## 14. Other Species / Natural Disease
+No naturally occurring animal disease analogs were identified in the retrieved texts.
+
+---
+
+## 15. Model Organisms
+No dedicated model organism systems for this syndrome were described in the retrieved texts. Mechanistic reasoning references complement biology and includes supportive statements from experimental complement-depletion contexts, but disease-specific engineered models were not presented in the available extracts. (whitington2014humoralimmunemechanism pages 6-6)
+
+---
+
+## Current applications and real-world implementation (clinical practice implications)
+1) **Diagnosis in real-world settings** relies on recognizing the syndrome pattern (DAT-positive hemolysis plus progressive cholestatic hepatitis) and confirming with **liver biopsy** and exclusion of other causes. (maggiore2011giantcellhepatitis pages 1-2)
+2) **Treatment implementation** is increasingly aligned with the mechanistic model: conventional immunosuppression may induce remission but relapse is common, while **B-cell depletion (rituximab)** has repeatedly induced remission in refractory disease and is supported by complement-pathology findings. (whitington2014humoralimmunemechanism pages 2-3, paganelli2014anticd20treatmentof pages 1-2)
+
+---
+
+## Limitations of this report (evidence availability)
+* Disease-specific 2023–2024 primary studies were not accessible via the current retrieval tools; thus, up-to-date (2023–2024) GCH-AIHA-specific statistics (e.g., contemporary response rates to rituximab regimens) could not be extracted here.
+* Standard ontology identifiers (MONDO/OMIM/Orphanet/MeSH/ICD) were not present in the retrieved full texts; they should be sourced from dedicated ontology databases in a separate curation step.
+* Image extraction from key papers failed in this environment, so no histology figure panels could be provided.
+
+---
+
+## Key referenced sources (publication date, URL)
+* Perez-Atayde AR et al. **1994**. *Coombs-Positive Autoimmune Hemolytic Anemia and Postinfantile Giant Cell Hepatitis in Children.* https://doi.org/10.3109/15513819409022027 (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4)
+* Maggiore G et al. **2011-07**. *Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: long-term outcome in 16 children.* https://doi.org/10.1016/j.jpeds.2010.12.050 (maggiore2011giantcellhepatitis pages 1-2)
+* Raj S et al. **2011-03**. *Giant Cell Hepatitis With Autoimmune Hemolytic Anemia: A Case Report and Review of Pediatric Literature.* https://doi.org/10.1177/0009922810379501 (raj2011giantcellhepatitis pages 1-2)
+* Whitington PF et al. **2014-01**. *Humoral Immune Mechanism of Liver Injury in Giant Cell Hepatitis With Autoimmune Hemolytic Anemia.* https://doi.org/10.1097/MPG.0b013e3182a98dbe (whitington2014humoralimmunemechanism pages 2-3)
+* Paganelli M et al. **2014-10**. *Anti-CD20 Treatment of Giant Cell Hepatitis With Autoimmune Hemolytic Anemia.* https://doi.org/10.1542/peds.2014-0032 (paganelli2014anticd20treatmentof pages 1-2)
+* Marsalli G et al. **2016-02**. *Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: A multicenter study.* https://doi.org/10.1016/j.clinre.2015.03.009 (marsalli2016efficacyofintravenous pages 1-2)
+* Kim YH et al. **2020-03**. *Successful Treatment … Using Rituximab* https://doi.org/10.5223/pghn.2020.23.2.180 (kim2020successfultreatmentof pages 2-4)
+
+
+References
+
+1. (maggiore2011giantcellhepatitis pages 1-2): Giuseppe Maggiore, Marco Sciveres, Monique Fabre, Laura Gori, Lucia Pacifico, Massimo Resti, Jean-Jacques Choulot, Emmanuel Jacquemin, and Olivier Bernard. Giant cell hepatitis with autoimmune hemolytic anemia in early childhood: long-term outcome in 16 children. The Journal of pediatrics, 159 1:127-132.e1, Jul 2011. URL: https://doi.org/10.1016/j.jpeds.2010.12.050, doi:10.1016/j.jpeds.2010.12.050. This article has 72 citations.
+
+2. (whitington2014humoralimmunemechanism pages 2-3): Peter F. Whitington, Miriam B. Vos, Lee M. Bass, Hector Melin‐Aldana, Rene Romero, Claude C. Roy, and Fernando Alvarez. Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia. Journal of Pediatric Gastroenterology and Nutrition, 58:74–80, Jan 2014. URL: https://doi.org/10.1097/mpg.0b013e3182a98dbe, doi:10.1097/mpg.0b013e3182a98dbe. This article has 39 citations and is from a peer-reviewed journal.
+
+3. (marsalli2016efficacyofintravenous pages 1-2): Giulia Marsalli, Silvia Nastasio, Marco Sciveres, Pier Luigi Calvo, Ugo Ramenghi, Simona Gatti, Veronica Albano, Sara Lega, Alessandro Ventura, and Giuseppe Maggiore. Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: a multicenter study. Clinics and research in hepatology and gastroenterology, 40 1:83-9, Feb 2016. URL: https://doi.org/10.1016/j.clinre.2015.03.009, doi:10.1016/j.clinre.2015.03.009. This article has 24 citations and is from a peer-reviewed journal.
+
+4. (raj2011giantcellhepatitis pages 1-2): Shashi Raj, Thomas Stephen, and Robert F. Debski. Giant cell hepatitis with autoimmune hemolytic anemia: a case report and review of pediatric literature. Clinical Pediatrics, 50:357-359, Mar 2011. URL: https://doi.org/10.1177/0009922810379501, doi:10.1177/0009922810379501. This article has 18 citations and is from a peer-reviewed journal.
+
+5. (kim2020successfultreatmentof pages 2-4): Young Ho Kim, Ju Whi Kim, Eun Joo Lee, Gyeong Hoon Kang, Hyoung Jin Kang, Jin Soo Moon, and Jae Sung Ko. Successful treatment of a korean infant with giant cell hepatitis with autoimmune hemolytic anemia using rituximab. Pediatric Gastroenterology, Hepatology & Nutrition, 23:180-187, Mar 2020. URL: https://doi.org/10.5223/pghn.2020.23.2.180, doi:10.5223/pghn.2020.23.2.180. This article has 9 citations and is from a peer-reviewed journal.
+
+6. (cho2016giantcellhepatitis pages 1-2): Myung Hyun Cho, Hee Sun Park, Hye Seung Han, and Sun Hwan Bae. Giant cell hepatitis with autoimmune hemolytic anemia in a korean infant. Pediatrics International, 58:628-631, Feb 2016. URL: https://doi.org/10.1111/ped.12874, doi:10.1111/ped.12874. This article has 10 citations and is from a peer-reviewed journal.
+
+7. (perezatayde1994coombspositiveautoimmunehemolytic pages 1-4): Antonio R. Perez-Atayde, Scott M. Sirlin, and Maureen Jonas. Coombs-positive autoimmune hemolytic anemia and postinfantile giant cell hepatitis in children. Pediatric pathology, 14 1:69-77, Jan 1994. URL: https://doi.org/10.3109/15513819409022027, doi:10.3109/15513819409022027. This article has 33 citations.
+
+8. (bakula2014giantcellhepatitis pages 1-3): Agnieszka Bakula, Piotr Socha, Maja Klaudel‐Dreszler, Grazyna Karolczyk, Malgorzata Wozniak, Olga Rutynowska‐Pronicka, and Michal Matysiak. Giant cell hepatitis with autoimmune hemolytic anemia in children: proposal for therapeutic approach. Journal of Pediatric Gastroenterology and Nutrition, 58:669–673, May 2014. URL: https://doi.org/10.1097/mpg.0000000000000270, doi:10.1097/mpg.0000000000000270. This article has 33 citations and is from a peer-reviewed journal.
+
+9. (paganelli2014anticd20treatmentof pages 1-2): Massimiliano Paganelli, Natacha Patey, Lee M. Bass, and Fernando Alvarez. Anti-cd20 treatment of giant cell hepatitis with autoimmune hemolytic anemia. Pediatrics, 134:e1206-e1210, Oct 2014. URL: https://doi.org/10.1542/peds.2014-0032, doi:10.1542/peds.2014-0032. This article has 23 citations and is from a highest quality peer-reviewed journal.
+
+10. (whitington2014humoralimmunemechanism pages 1-1): Peter F. Whitington, Miriam B. Vos, Lee M. Bass, Hector Melin‐Aldana, Rene Romero, Claude C. Roy, and Fernando Alvarez. Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia. Journal of Pediatric Gastroenterology and Nutrition, 58:74–80, Jan 2014. URL: https://doi.org/10.1097/mpg.0b013e3182a98dbe, doi:10.1097/mpg.0b013e3182a98dbe. This article has 39 citations and is from a peer-reviewed journal.
+
+11. (marsalli2016efficacyofintravenous pages 4-5): Giulia Marsalli, Silvia Nastasio, Marco Sciveres, Pier Luigi Calvo, Ugo Ramenghi, Simona Gatti, Veronica Albano, Sara Lega, Alessandro Ventura, and Giuseppe Maggiore. Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: a multicenter study. Clinics and research in hepatology and gastroenterology, 40 1:83-9, Feb 2016. URL: https://doi.org/10.1016/j.clinre.2015.03.009, doi:10.1016/j.clinre.2015.03.009. This article has 24 citations and is from a peer-reviewed journal.
+
+12. (marsalli2016efficacyofintravenous pages 6-7): Giulia Marsalli, Silvia Nastasio, Marco Sciveres, Pier Luigi Calvo, Ugo Ramenghi, Simona Gatti, Veronica Albano, Sara Lega, Alessandro Ventura, and Giuseppe Maggiore. Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: a multicenter study. Clinics and research in hepatology and gastroenterology, 40 1:83-9, Feb 2016. URL: https://doi.org/10.1016/j.clinre.2015.03.009, doi:10.1016/j.clinre.2015.03.009. This article has 24 citations and is from a peer-reviewed journal.
+
+13. (kim2020successfultreatmentof pages 5-6): Young Ho Kim, Ju Whi Kim, Eun Joo Lee, Gyeong Hoon Kang, Hyoung Jin Kang, Jin Soo Moon, and Jae Sung Ko. Successful treatment of a korean infant with giant cell hepatitis with autoimmune hemolytic anemia using rituximab. Pediatric Gastroenterology, Hepatology & Nutrition, 23:180-187, Mar 2020. URL: https://doi.org/10.5223/pghn.2020.23.2.180, doi:10.5223/pghn.2020.23.2.180. This article has 9 citations and is from a peer-reviewed journal.
+
+14. (marsalli2016efficacyofintravenous pages 2-3): Giulia Marsalli, Silvia Nastasio, Marco Sciveres, Pier Luigi Calvo, Ugo Ramenghi, Simona Gatti, Veronica Albano, Sara Lega, Alessandro Ventura, and Giuseppe Maggiore. Efficacy of intravenous immunoglobulin therapy in giant cell hepatitis with autoimmune hemolytic anemia: a multicenter study. Clinics and research in hepatology and gastroenterology, 40 1:83-9, Feb 2016. URL: https://doi.org/10.1016/j.clinre.2015.03.009, doi:10.1016/j.clinre.2015.03.009. This article has 24 citations and is from a peer-reviewed journal.
+
+15. (whitington2014humoralimmunemechanism pages 3-6): Peter F. Whitington, Miriam B. Vos, Lee M. Bass, Hector Melin‐Aldana, Rene Romero, Claude C. Roy, and Fernando Alvarez. Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia. Journal of Pediatric Gastroenterology and Nutrition, 58:74–80, Jan 2014. URL: https://doi.org/10.1097/mpg.0b013e3182a98dbe, doi:10.1097/mpg.0b013e3182a98dbe. This article has 39 citations and is from a peer-reviewed journal.
+
+16. (whitington2014humoralimmunemechanism pages 6-6): Peter F. Whitington, Miriam B. Vos, Lee M. Bass, Hector Melin‐Aldana, Rene Romero, Claude C. Roy, and Fernando Alvarez. Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia. Journal of Pediatric Gastroenterology and Nutrition, 58:74–80, Jan 2014. URL: https://doi.org/10.1097/mpg.0b013e3182a98dbe, doi:10.1097/mpg.0b013e3182a98dbe. This article has 39 citations and is from a peer-reviewed journal.
+
+17. (whitington2014humoralimmunemechanism pages 1-2): Peter F. Whitington, Miriam B. Vos, Lee M. Bass, Hector Melin‐Aldana, Rene Romero, Claude C. Roy, and Fernando Alvarez. Humoral immune mechanism of liver injury in giant cell hepatitis with autoimmune hemolytic anemia. Journal of Pediatric Gastroenterology and Nutrition, 58:74–80, Jan 2014. URL: https://doi.org/10.1097/mpg.0b013e3182a98dbe, doi:10.1097/mpg.0b013e3182a98dbe. This article has 39 citations and is from a peer-reviewed journal.

--- a/research/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md.citations.md
+++ b/research/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia-deep-research-falcon.md.citations.md
@@ -1,0 +1,494 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Giant Cell Hepatitis With Autoimmune Hemolytic Anemia
+- **MONDO ID:**  (if available)
+- **Category:** Autoimmune Disease
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Giant Cell Hepatitis With Autoimmune Hemolytic Anemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T22:18:02.304566
+
+1. maggiore2011giantcellhepatitis pages 1-2
+2. perezatayde1994coombspositiveautoimmunehemolytic pages 1-4
+3. bakula2014giantcellhepatitis pages 1-3
+4. whitington2014humoralimmunemechanism pages 2-3
+5. whitington2014humoralimmunemechanism pages 3-6
+6. marsalli2016efficacyofintravenous pages 2-3
+7. kim2020successfultreatmentof pages 5-6
+8. whitington2014humoralimmunemechanism pages 6-6
+9. raj2011giantcellhepatitis pages 1-2
+10. marsalli2016efficacyofintravenous pages 1-2
+11. kim2020successfultreatmentof pages 2-4
+12. cho2016giantcellhepatitis pages 1-2
+13. whitington2014humoralimmunemechanism pages 1-1
+14. marsalli2016efficacyofintravenous pages 4-5
+15. marsalli2016efficacyofintravenous pages 6-7
+16. whitington2014humoralimmunemechanism pages 1-2
+17. https://doi.org/10.1016/j.jpeds.2010.12.050.
+18. https://doi.org/10.1177/0009922810379501.
+19. https://doi.org/10.1097/MPG.0b013e3182a98dbe.
+20. https://doi.org/10.5223/pghn.2020.23.2.180
+21. https://doi.org/10.1111/ped.12874.
+22. https://doi.org/10.3109/15513819409022027.
+23. https://doi.org/10.1097/MPG.0000000000000270.
+24. https://doi.org/10.1542/peds.2014-0032.
+25. https://doi.org/10.1111/ped.12874
+26. https://doi.org/10.1097/MPG.0b013e3182a98dbe
+27. https://doi.org/10.5223/pghn.2020.23.2.180.
+28. https://doi.org/10.1097/MPG.0000000000000270
+29. https://doi.org/10.1016/j.clinre.2015.03.009
+30. https://doi.org/10.1016/j.jpeds.2010.12.050
+31. https://doi.org/10.5152/tjh.2010.55
+32. https://doi.org/10.3109/15513819409022027
+33. https://doi.org/10.1177/0009922810379501
+34. https://doi.org/10.1542/peds.2014-0032
+35. https://doi.org/10.1016/j.jpeds.2010.12.050,
+36. https://doi.org/10.1097/mpg.0b013e3182a98dbe,
+37. https://doi.org/10.1016/j.clinre.2015.03.009,
+38. https://doi.org/10.1177/0009922810379501,
+39. https://doi.org/10.5223/pghn.2020.23.2.180,
+40. https://doi.org/10.1111/ped.12874,
+41. https://doi.org/10.3109/15513819409022027,
+42. https://doi.org/10.1097/mpg.0000000000000270,
+43. https://doi.org/10.1542/peds.2014-0032,


### PR DESCRIPTION
## Summary

- Adds a new DISMECH disorder page for Giant Cell Hepatitis With Autoimmune Hemolytic Anemia (MONDO:1060166).
- Includes Falcon deep research artifacts and citation metadata.
- Adds PMID cache files generated with `just fetch-reference` for evidence used in the YAML.
- Models the combined syndrome with complement-mediated hepatocyte injury, Coombs-positive hemolysis, relapsing course, IVIG, rituximab, and liver transplantation evidence.

## Validation

- `just validate kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml` passed
- `just validate-references kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml` passed
- `just validate-terms kb/disorders/Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia.yaml` passed
- `just check-reference-cache-frontmatter` passed
- `just qc-deep-research --target-providers falcon --only Giant_Cell_Hepatitis_With_Autoimmune_Hemolytic_Anemia` passed with missing_refs=0 and missing_found_in=0

## Notes

No disease-specific clinical trials or genetic etiology were identified in the Falcon report, so those sections are intentionally left empty.