### PR TITLE
Add IgG4-related sclerosing cholangitis curation

### DIFF
--- a/kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml
+++ b/kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml
@@ -94,6 +94,49 @@ description: >-
   histopathology, other-organ involvement, and response to immunosuppressive
   therapy after malignancy has been excluded.
 pathophysiology:
+- name: B Cell and Plasmablast Activation
+  description: >-
+    Upstream adaptive immune activation in IgG4-related hepatobiliary disease
+    includes B-cell and plasmablast expansion alongside T-cell immune features,
+    providing a mechanistic rationale for B-cell depletion therapy in relapsing
+    pancreaticobiliary IgG4-related disease.
+  cell_types:
+  - preferred_term: B cell
+    term:
+      id: CL:0000236
+      label: B cell
+  - preferred_term: plasmablast
+    term:
+      id: CL:0000980
+      label: plasmablast
+  - preferred_term: regulatory T cell
+    term:
+      id: CL:0000815
+      label: regulatory T cell
+  biological_processes:
+  - preferred_term: B cell activation
+    term:
+      id: GO:0042113
+      label: B cell activation
+  - preferred_term: humoral immune response
+    term:
+      id: GO:0006959
+      label: humoral immune response
+  downstream:
+  - target: IgG4-Rich Lymphoplasmacytic Bile Duct Inflammation
+  evidence:
+  - reference: PMID:27625195
+    reference_title: "IgG4-related hepatobiliary disease: an overview."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Insights into the genetic and immunological features of the disease have
+      increased over the past decade, with an emphasis on HLAs, T cells,
+      circulating memory B cells and plasmablasts, chemokine-mediated
+      trafficking, as well as the role of the innate immune system.
+    explanation: >-
+      This review supports upstream B-cell/plasmablast and T-cell immune
+      features in IgG4-related hepatobiliary disease.
 - name: IgG4-Rich Lymphoplasmacytic Bile Duct Inflammation
   description: >-
     IgG4-positive plasma cells and lymphocytes infiltrate the bile duct wall,
@@ -117,6 +160,8 @@ pathophysiology:
     term:
       id: GO:0006954
       label: inflammatory response
+  downstream:
+  - target: Bile Duct Fibrostenosis
   evidence:
   - reference: PMID:30575336
     reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
@@ -234,6 +279,24 @@ phenotypes:
     explanation: >-
       This directly supports jaundice as a common presentation of
       IgG4-related cholangitis.
+- category: Constitutional
+  name: Weight Loss
+  phenotype_term:
+    preferred_term: Weight loss
+    term:
+      id: HP:0001824
+      label: Weight loss
+  evidence:
+  - reference: PMID:40191403
+    reference_title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients often present with jaundice and weight loss, mimicking
+      hepatobiliary malignancies, such as cholangiocarcinoma, primary sclerosing
+      cholangitis, and pancreatic cancer.
+    explanation: >-
+      This directly supports weight loss as a presenting symptom.
 - category: Dermatological
   name: Pruritus
   phenotype_term:
@@ -393,8 +456,9 @@ genetic:
       strong human leucocyte antigen (HLA) signal in both PSC and IgG4-SC
       (HLA-DQB2, HLA-DPA1, HLA-F and HLA-DRA).
     explanation: >-
-      This omics study supports HLA-region susceptibility architecture without
-      implying Mendelian inheritance.
+      This human-sample omics study uses methylation/genotyping data and
+      computational meQTL analysis to support HLA-region susceptibility
+      architecture without implying Mendelian inheritance.
 diagnosis:
 - name: Integrated HISORt and IgG4-SC diagnostic criteria
   description: >-
@@ -563,6 +627,13 @@ treatments:
       term:
         id: NCIT:C1702
         label: Rituximab
+  target_mechanisms:
+  - target: B Cell and Plasmablast Activation
+    treatment_effect: INHIBITS
+    description: >-
+      Rituximab depletes CD20-positive B-cell lineage populations upstream of
+      IgG4-rich tissue inflammation and is used to prolong remission in
+      pancreaticobiliary IgG4-related disease.
   evidence:
   - reference: PMID:29526692
     reference_title: Rituximab Maintenance Therapy Reduces Rate of Relapse of Pancreaticobiliary Immunoglobulin G4-related Disease.
@@ -583,6 +654,32 @@ treatments:
     explanation: >-
       Supports maintenance rituximab as relapse-reducing in a pancreaticobiliary
       IgG4-RD cohort.
+- name: Azathioprine
+  description: >-
+    Steroid-sparing immunomodulator used as a remission-induction or
+    maintenance option when long-term immunosuppression is needed.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: azathioprine
+      term:
+        id: CHEBI:2948
+        label: azathioprine
+  evidence:
+  - reference: PMID:40191403
+    reference_title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Steroid-sparing agents for remission induction and maintenance therapy
+      comprise immunomodulators, such as azathioprine, as well as B-cell
+      depletion therapies, such as rituximab.
+    explanation: >-
+      This review supports azathioprine as a steroid-sparing immunomodulator
+      option in IgG4-related cholangitis.
 - name: Biliary Drainage or Stenting
   description: >-
     Endoscopic decompression is used selectively for clinically significant

--- a/kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml
+++ b/kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml
@@ -1,0 +1,647 @@
+name: IgG4-Related Sclerosing Cholangitis
+creation_date: "2026-05-07T02:02:26Z"
+updated_date: "2026-05-07T02:02:26Z"
+category: Autoimmune
+parents:
+- Autoimmune Disease
+- Liver Disease
+synonyms:
+- IgG4-related cholangitis
+- IgG4-associated sclerosing cholangitis
+disease_term:
+  preferred_term: IgG4-related sclerosing cholangitis
+  term:
+    id: MONDO:0018645
+    label: IgG4-related sclerosing cholangitis
+references:
+- reference: DOI:10.1002/jhbp.596
+  title: Clinical practice guidelines for IgG4-related sclerosing cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1002/jhbp.70056
+  title: Multicenter validation study of the clinical diagnostic criteria for IgG4-related sclerosing cholangitis 2020 in Japan
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1007/s00535-020-01714-7
+  title: "The long-term outcomes of patients with immunoglobulin G4-related sclerosing cholangitis: the Mayo Clinic experience"
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1016/j.cgh.2018.02.049
+  title: Rituximab maintenance therapy reduces rate of relapse of pancreaticobiliary immunoglobulin G4-related disease
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1016/j.cld.2015.08.004
+  title: New thoughts on immunoglobulin G4-related sclerosing cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1038/nrgastro.2016.132
+  title: "IgG4-related hepatobiliary disease: an overview"
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1053/j.gastro.2015.01.041
+  title: Association between HLA haplotypes and increased serum levels of IgG4 in patients with primary sclerosing cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1055/a-2588-3875
+  title: IgG4-related cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1093/gastro/goaf032
+  title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance"
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1136/flgastro-2018-101001
+  title: Diagnosis and management of IgG4-related disease
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1186/s13148-024-01803-x
+  title: Epigenetic age acceleration and methylation differences in IgG4-related cholangitis and primary sclerosing cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.1371/journal.pone.0232089
+  title: Management of biliary stricture in patients with IgG4-related sclerosing cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.3389/fmed.2026.1732637
+  title: "IgG4-related sclerosing cholangitis: navigating diagnostic dilemmas and the challenge of relapse"
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+- reference: DOI:10.5009/gnl18085
+  title: IgG4-related sclerosing cholangitis and primary sclerosing cholangitis
+  found_in:
+  - IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+  findings: []
+description: >-
+  Organ-specific biliary involvement of IgG4-related disease, characterized by
+  inflammatory and fibrostenotic lesions of the intrahepatic and/or
+  extrahepatic bile ducts. The disorder frequently co-occurs with type 1
+  autoimmune pancreatitis and can present with jaundice, cholestatic liver
+  tests, or bile-duct strictures that mimic primary sclerosing cholangitis or
+  cholangiocarcinoma. Diagnosis requires integration of imaging, serology,
+  histopathology, other-organ involvement, and response to immunosuppressive
+  therapy after malignancy has been excluded.
+pathophysiology:
+- name: IgG4-Rich Lymphoplasmacytic Bile Duct Inflammation
+  description: >-
+    IgG4-positive plasma cells and lymphocytes infiltrate the bile duct wall,
+    producing an immune-mediated cholangitis focused on the biliary tree rather
+    than a generic systemic IgG4-related disease entry.
+  cell_types:
+  - preferred_term: Plasma cell
+    term:
+      id: CL:0000786
+      label: plasma cell
+  - preferred_term: CD4-positive, alpha-beta T cell
+    term:
+      id: CL:0000624
+      label: CD4-positive, alpha-beta T cell
+  biological_processes:
+  - preferred_term: Immune response
+    term:
+      id: GO:0006955
+      label: immune response
+  - preferred_term: Inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  evidence:
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      IgG4-related sclerosing cholangitis (IgG4-SC) is a distinct type of
+      cholangitis frequently associated with autoimmune pancreatitis and
+      currently recognized as a biliary manifestation of IgG4-related disease.
+    explanation: >-
+      The guideline defines IgG4-SC as a distinct bile-duct manifestation of
+      IgG4-related disease, supporting the organ-specific scope of this entry.
+  - reference: PMID:26593290
+    reference_title: New Thoughts on Immunoglobulin G4-Related Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Immunoglobulin G4 (IgG4)-related sclerosing cholangitis (IgG4-SC) is the
+      biliary manifestation of the multisystem IgG4-related disease.
+    explanation: >-
+      This review independently supports the biliary manifestation framing.
+- name: Bile Duct Fibrostenosis
+  description: >-
+    Fibroinflammatory remodeling around affected bile ducts narrows the duct
+    lumen and causes cholestasis, biliary obstruction, and downstream liver
+    injury.
+  cell_types:
+  - preferred_term: Fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
+  biological_processes:
+  - preferred_term: Extracellular matrix organization
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  evidence:
+  - reference: PMID:30205418
+    reference_title: IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Sclerosing cholangitis (SC) is defined as a condition with progressive
+      stenosis and destruction of the bile ducts due to diffuse inflammation
+      and fibrosis and currently includes three categories: primary sclerosing
+      cholangitis (PSC), secondary cholangitis, and IgG4-related sclerosing
+      cholangitis (IgG4-SC).
+    explanation: >-
+      The guideline places IgG4-SC within fibrostenotic bile-duct disease and
+      supports bile-duct stenosis and fibrosis as core pathobiology.
+  - reference: PMID:27625195
+    reference_title: "IgG4-related hepatobiliary disease: an overview."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These diseases can present with biliary strictures and/or mass lesions,
+      making them difficult to differentiate from primary sclerosing
+      cholangitis (PSC) or other hepatobiliary malignancies.
+    explanation: >-
+      This review supports biliary strictures as a core manifestation of
+      IgG4-related hepatobiliary disease.
+progression:
+  - phase: Chronic relapsing fibroinflammatory disease
+    notes: >-
+      Disease often improves with corticosteroids but relapse is common and
+      fixed fibrotic strictures can require long-term surveillance or
+      endoscopic management.
+    evidence:
+    - reference: PMID:40191403
+      reference_title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        IRC responds well to corticosteroid therapy, though relapses are common,
+        necessitating long-term immunosuppressive treatment in many cases.
+      explanation: >-
+        This recent review supports a steroid-responsive but relapsing clinical
+        course.
+phenotypes:
+- category: Hepatobiliary
+  name: Sclerosing Cholangitis
+  diagnostic: true
+  phenotype_term:
+    preferred_term: Sclerosing cholangitis
+    term:
+      id: HP:0030991
+      label: Sclerosing cholangitis
+  evidence:
+  - reference: PMID:26593290
+    reference_title: New Thoughts on Immunoglobulin G4-Related Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      IgG4-SC presents with biliary strictures and/or masses that can bear a
+      striking similarity to other malignant and inflammatory diseases.
+    explanation: >-
+      The abstract supports sclerosing cholangitis with biliary strictures as
+      the central clinical phenotype.
+- category: Hepatobiliary
+  name: Jaundice
+  phenotype_term:
+    preferred_term: Jaundice
+    term:
+      id: HP:0000952
+      label: Jaundice
+  evidence:
+  - reference: PMID:40191403
+    reference_title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients often present with jaundice and weight loss, mimicking
+      hepatobiliary malignancies, such as cholangiocarcinoma, primary sclerosing
+      cholangitis, and pancreatic cancer.
+    explanation: >-
+      This directly supports jaundice as a common presentation of
+      IgG4-related cholangitis.
+- category: Dermatological
+  name: Pruritus
+  phenotype_term:
+    preferred_term: Pruritus
+    term:
+      id: HP:0000989
+      label: Pruritus
+  evidence:
+  - reference: PMID:30205418
+    reference_title: IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with SC present with cholestatic symptoms, including jaundice and
+      pruritus, and blood tests reveal elevation of cholestatic enzymes.
+    explanation: >-
+      This review supports pruritus as a cholestatic symptom relevant to
+      sclerosing cholangitis, including IgG4-SC.
+- category: Gastrointestinal
+  name: Abdominal Pain
+  phenotype_term:
+    preferred_term: Abdominal pain
+    term:
+      id: HP:0002027
+      label: Abdominal pain
+- category: Hepatobiliary
+  name: Cholestasis
+  phenotype_term:
+    preferred_term: Cholestasis
+    term:
+      id: HP:0001396
+      label: Cholestasis
+  evidence:
+  - reference: PMID:30205418
+    reference_title: IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      SC categories share similar clinical features, such as cholestasis.
+    explanation: >-
+      Supports cholestasis as a shared clinical feature of sclerosing
+      cholangitis categories, including IgG4-SC.
+- category: Gastrointestinal
+  name: Autoimmune Pancreatitis
+  notes: >-
+    Type 1 autoimmune pancreatitis commonly co-occurs and can help distinguish
+    IgG4-SC from PSC or cholangiocarcinoma.
+  phenotype_term:
+    preferred_term: Pancreatitis
+    term:
+      id: HP:0001733
+      label: Pancreatitis
+  evidence:
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      IgG4-related sclerosing cholangitis (IgG4-SC) is a distinct type of
+      cholangitis frequently associated with autoimmune pancreatitis and
+      currently recognized as a biliary manifestation of IgG4-related disease.
+    explanation: >-
+      The guideline supports frequent association with autoimmune pancreatitis.
+histopathology:
+- name: Transmural lymphoplasmacytic inflammation and fibrosis of bile ducts
+  diagnostic: true
+  description: >-
+    Affected large bile ducts show transmural lymphoplasmacytic inflammation
+    and fibrosis that thickens the duct wall; IgG4 immunostaining is supportive
+    but not sufficient alone.
+  finding_term:
+    preferred_term: transmural lymphoplasmacytic bile-duct inflammation and fibrosis
+  evidence:
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In intrahepatic and extrahepatic large bile ducts, transmural marked
+      lymphoplasmacytic infiltration and fibrosis are observed, which give rise
+      to bile duct wall thickening.
+    explanation: >-
+      This guideline statement directly supports the microscopic bile-duct
+      inflammatory and fibrotic pattern.
+- name: Storiform fibrosis and obliterative phlebitis
+  diagnostic: true
+  description: >-
+    Storiform fibrosis and obliterative phlebitis are diagnostically important
+    IgG4-RD-type tissue features when found in bile duct tissue.
+  finding_term:
+    preferred_term: storiform fibrosis and obliterative phlebitis
+  evidence:
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Notably, storiform fibrosis and obliterative phlebitis are important
+      histologic findings for diagnosing IgG4-SC.
+    explanation: >-
+      Supports these two findings as diagnostic histopathologic features.
+biochemical:
+- name: Serum IgG4
+  presence: Elevated
+  context: >-
+    Serum IgG4 elevation supports the diagnosis but is not specific and cannot
+    exclude PSC or cholangiocarcinoma by itself.
+  evidence:
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      An elevation of serum IgG4 levels is seen in most cases of IgG4-SC, so it
+      is useful for the diagnosis of IgG4-SC.
+    explanation: >-
+      Supports serum IgG4 as a useful diagnostic biochemical feature.
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      However, an elevation of serum IgG4 levels is not specific for the
+      diagnosis of IgG4-SC.
+    explanation: >-
+      Captures the limitation that IgG4 elevation is supportive but not
+      independently diagnostic.
+- name: Alkaline Phosphatase
+  presence: Elevated
+  context: Cholestatic liver enzyme pattern due to bile duct obstruction.
+  evidence:
+  - reference: PMID:30205418
+    reference_title: IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients with SC present with cholestatic symptoms, including jaundice and
+      pruritus, and blood tests reveal elevation of cholestatic enzymes.
+    explanation: >-
+      Supports cholestatic enzyme elevation; alkaline phosphatase is the
+      clinically emphasized cholestatic enzyme in this entry.
+genetic:
+- name: HLA-region methylation quantitative trait loci
+  association: Susceptibility Factor
+  relationship_type: SUSCEPTIBILITY
+  notes: >-
+    No monogenic cause is established. Recent whole-blood methylation and
+    genotyping data implicate HLA-region genetic variation in shaping the
+    methylome in IgG4-SC.
+  evidence:
+  - reference: PMID:39819503
+    reference_title: Epigenetic age acceleration and methylation differences in IgG4-related cholangitis and primary sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: >-
+      meQTL analyses to identify genetic determinants of methylation revealed a
+      strong human leucocyte antigen (HLA) signal in both PSC and IgG4-SC
+      (HLA-DQB2, HLA-DPA1, HLA-F and HLA-DRA).
+    explanation: >-
+      This omics study supports HLA-region susceptibility architecture without
+      implying Mendelian inheritance.
+diagnosis:
+- name: Integrated HISORt and IgG4-SC diagnostic criteria
+  description: >-
+    Diagnosis integrates histology, imaging/cholangiography, serum IgG4,
+    other-organ involvement, and response to immunosuppressive therapy, with
+    careful exclusion of malignancy.
+  results: >-
+    Bile-duct narrowing or wall thickening plus supportive serology,
+    histopathology, other IgG4-related organ involvement, and/or treatment
+    response supports IgG4-SC.
+  evidence:
+  - reference: PMID:40191403
+    reference_title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Accurate diagnosis is challenging due to the absence of pathognomonic
+      findings but can be achieved using the HISORt criteria (histology,
+      imaging, serology, other organ involvement, and response to
+      immunosuppressive therapy).
+    explanation: >-
+      Supports the integrated diagnostic framework and the absence of a single
+      pathognomonic test.
+  - reference: PMID:41500843
+    reference_title: Multicenter Validation Study of the Clinical Diagnostic Criteria for IgG4-Related Sclerosing Cholangitis 2020 in Japan.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      METHODS: We conducted a multicenter validation study to evaluate the
+      diagnostic performance of IgG4-SC2020 using clinical data collected from
+      1034 patients with IgG4-SC and 447 patients with mimickers, including 143
+      with pancreatic cancer, 157 with primary sclerosing cholangitis, and 147
+      with cholangiocarcinoma in Japan.
+    explanation: >-
+      Documents large-scale validation against the main differential mimics.
+  - reference: PMID:41500843
+    reference_title: Multicenter Validation Study of the Clinical Diagnostic Criteria for IgG4-Related Sclerosing Cholangitis 2020 in Japan.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The sensitivity of IgG4-SC2020 was significantly higher than that of
+      IgG4-SC2012 (99.0% vs. 89.1%; p < 0.001).
+    explanation: >-
+      Supports the improved performance of the 2020 criteria.
+- name: Bile IgG4 diagnostic biomarker research
+  description: >-
+    Bile IgG4 concentration is being evaluated as a diagnostic biomarker for
+    differentiating IgG4-SC from PSC, cholangiocarcinoma, and other biliary
+    strictures.
+  evidence:
+  - reference: clinicaltrials:NCT02616705
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The investigators aim to evaluate the sensitivity and specificity of bile
+      for the diagnosis of IgG4-SC.
+    explanation: >-
+      This completed observational study evaluates bile IgG4 as a diagnostic
+      biomarker rather than as treatment.
+differential_diagnoses:
+- name: Primary Sclerosing Cholangitis
+  disease_term:
+    preferred_term: primary sclerosing cholangitis
+    term:
+      id: MONDO:0013433
+      label: primary sclerosing cholangitis
+  description: >-
+    PSC can produce similar multifocal bile-duct strictures and cholestatic
+    symptoms but is usually not steroid-responsive and has different
+    comorbidity and outcome patterns.
+  distinguishing_features:
+  - IgG4-SC often co-occurs with autoimmune pancreatitis or other IgG4-related organ disease.
+  - PSC is strongly associated with inflammatory bowel disease and does not respond to steroid therapy.
+  evidence:
+  - reference: PMID:30205418
+    reference_title: IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Although the presentation of IgG4-SC and PSC are similar, the
+      comorbidities, treatment response, and outcomes differ significantly, and
+      therefore, it is strongly advisable to be familiar with these two diseases
+      to make a correct diagnosis.
+    explanation: >-
+      Supports PSC as a key mimic and highlights distinguishing clinical
+      dimensions.
+- name: Cholangiocarcinoma
+  disease_term:
+    preferred_term: cholangiocarcinoma
+    term:
+      id: MONDO:0019087
+      label: cholangiocarcinoma
+  description: >-
+    Cholangiocarcinoma can mimic focal or hilar IgG4-SC strictures and must be
+    excluded before steroid-response is used as diagnostic support.
+  distinguishing_features:
+  - Tissue sampling, cytology, imaging, and repeat evaluation are needed when malignancy remains possible.
+  - Steroid trials should be avoided when neoplasia has not been reasonably excluded.
+  evidence:
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cholangiographic findings of IgG4-SC involving the hilar and/or
+      intrahepatic bile ducts are similar to those of hilar cholangiocarcinoma
+      or primary sclerosing cholangitis (PSC).
+    explanation: >-
+      Supports cholangiocarcinoma as a central imaging mimic.
+  - reference: PMID:30575336
+    reference_title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      If IgG4-SC cannot be clinically ruled out, a patient must not be treated
+      with facile steroid therapy but should be referred to a specialized
+      medical facility.
+    explanation: >-
+      Supports caution with empiric steroid trials during the differential
+      diagnosis of malignant biliary disease.
+treatments:
+- name: Glucocorticoids
+  description: >-
+    First-line anti-inflammatory therapy for active IgG4-related sclerosing
+    cholangitis after diagnosis is secure and malignancy has been excluded.
+  treatment_term:
+    preferred_term: glucocorticoid therapy
+    term:
+      id: NCIT:C122080
+      label: Systemic Corticosteroid Therapy
+    therapeutic_agent:
+    - preferred_term: corticosteroid
+      term:
+        id: CHEBI:50858
+        label: corticosteroid
+  evidence:
+  - reference: PMID:26593290
+    reference_title: New Thoughts on Immunoglobulin G4-Related Sclerosing Cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Corticosteroids are the mainstay of treatment with good clinical,
+      biochemical, and radiological responses.
+    explanation: >-
+      Directly supports corticosteroids as first-line therapy.
+  - reference: PMID:40191403
+    reference_title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      IRC responds well to corticosteroid therapy, though relapses are common,
+      necessitating long-term immunosuppressive treatment in many cases.
+    explanation: >-
+      Supports both treatment response and the need to monitor for relapse.
+- name: Rituximab
+  description: >-
+    B-cell depletion therapy used for relapsing, steroid-dependent, or
+    refractory pancreaticobiliary IgG4-related disease, including IgG4-SC.
+  treatment_term:
+    preferred_term: immunotherapy
+    term:
+      id: NCIT:C15262
+      label: Immunotherapy
+    therapeutic_agent:
+    - preferred_term: rituximab
+      term:
+        id: NCIT:C1702
+        label: Rituximab
+  evidence:
+  - reference: PMID:29526692
+    reference_title: Rituximab Maintenance Therapy Reduces Rate of Relapse of Pancreaticobiliary Immunoglobulin G4-related Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thirty-seven patients (86%) were in steroid-free remission 6 months after
+      rituximab initiation.
+    explanation: >-
+      Supports rituximab efficacy in pancreaticobiliary IgG4-related disease.
+  - reference: PMID:29526692
+    reference_title: Rituximab Maintenance Therapy Reduces Rate of Relapse of Pancreaticobiliary Immunoglobulin G4-related Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A higher proportion of patients in group 1 had disease relapse (3-year
+      event rate, 45%) than in group 2 (3-year event rate, 11%) (P = .034).
+    explanation: >-
+      Supports maintenance rituximab as relapse-reducing in a pancreaticobiliary
+      IgG4-RD cohort.
+- name: Biliary Drainage or Stenting
+  description: >-
+    Endoscopic decompression is used selectively for clinically significant
+    obstructive jaundice, cholangitis, or dominant biliary strictures; stents
+    should be removed promptly when strictures improve after corticosteroids.
+  treatment_term:
+    preferred_term: therapeutic procedure
+    term:
+      id: NCIT:C49236
+      label: Therapeutic Procedure
+  evidence:
+  - reference: PMID:32353060
+    reference_title: Management of biliary stricture in patients with IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Twenty-eight patients (40.6%) were treated with EBD for biliary stricture
+      before CS initiation.
+    explanation: >-
+      Supports real-world use of endoscopic biliary drainage before
+      corticosteroid initiation in a subset of IgG4-SC patients.
+  - reference: PMID:32353060
+    reference_title: Management of biliary stricture in patients with IgG4-related sclerosing cholangitis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Obstructive jaundice can be treated safely with CS alone in patients
+      without infection.
+    explanation: >-
+      Supports selective, rather than automatic, stenting when obstructive
+      jaundice is present without infection.
+epidemiology:
+- name: Older male predominance
+  description: >-
+    Mayo Clinic cohort data show predominance in older men, consistent with the
+    Falcon report's guideline synthesis.
+  evidence:
+  - reference: PMID:32770464
+    reference_title: "The long-term outcomes of patients with immunoglobulin G4-related sclerosing cholangitis: the Mayo Clinic experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      RESULTS: We identified 89 patients with IgG4-SC; median age at diagnosis
+      was 67 years, 81% were males, and the median follow-up was 5.7 years.
+    explanation: >-
+      Supports older age and male predominance in a large single-center cohort.
+- name: Lower hepatobiliary event rate than matched PSC cohort
+  description: >-
+    Long-term outcomes appear more favorable than PSC in immunosuppressed
+    cohorts, though cirrhosis and cholangiocarcinoma still occur.
+  evidence:
+  - reference: PMID:32770464
+    reference_title: "The long-term outcomes of patients with immunoglobulin G4-related sclerosing cholangitis: the Mayo Clinic experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The probability of development of a hepatobiliary adverse event within 10
+      years was 11% in the IgG4-SC compared to 45% in the PSC group (P = 0.0001).
+    explanation: >-
+      Supports a lower long-term risk of cirrhosis or cholangiocarcinoma than
+      PSC in the matched Mayo cohort.
+datasets:

--- a/kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml
+++ b/kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml
@@ -1,6 +1,6 @@
 name: IgG4-Related Sclerosing Cholangitis
 creation_date: "2026-05-07T02:02:26Z"
-updated_date: "2026-05-07T02:02:26Z"
+updated_date: "2026-05-07T02:57:39Z"
 category: Autoimmune
 parents:
 - Autoimmune Disease

--- a/references_cache/PMID_26593290.md
+++ b/references_cache/PMID_26593290.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:26593290"
+title: New Thoughts on Immunoglobulin G4-Related Sclerosing Cholangitis.
+authors:
+- Smit WL
+- Culver EL
+- Chapman RW
+journal: Clin Liver Dis
+year: '2016'
+doi: 10.1016/j.cld.2015.08.004
+keywords:
+- "Autoimmune Diseases/diagnosis, drug therapy, immunology"
+- Chemokines/metabolism
+- "Cholangitis, Sclerosing/diagnosis, drug therapy, immunology"
+- Humans
+- Immunoglobulin G/immunology
+- Prognosis
+- "T-Lymphocytes, Helper-Inducer/immunology"
+- "T-Lymphocytes, Regulatory/immunology"
+content_type: abstract_only
+---
+
+# New Thoughts on Immunoglobulin G4-Related Sclerosing Cholangitis.
+**Authors:** Smit WL, Culver EL, Chapman RW
+**Journal:** Clin Liver Dis (2016)
+**DOI:** [10.1016/j.cld.2015.08.004](https://doi.org/10.1016/j.cld.2015.08.004)
+
+## Content
+
+1. Clin Liver Dis. 2016 Feb;20(1):47-65. doi: 10.1016/j.cld.2015.08.004. Epub
+2015  Oct 6.
+
+New Thoughts on Immunoglobulin G4-Related Sclerosing Cholangitis.
+
+Smit WL(1), Culver EL(2), Chapman RW(3).
+
+Author information:
+(1)Department of Gastroenterology and Hepatology, Academic Medical Center, 
+University of Amsterdam, Meibergdreef 9, Amsterdam 1105 AZ, The Netherlands; 
+Nuffield Department of Medicine, University of Oxford, Old Road Campus, Oxford 
+OX3 7BN, UK.
+(2)Translational Gastroenterology Unit, John Radcliffe Hospital, Headley Way, 
+Headington, Oxford OX3 9DU, UK; Nuffield Department of Medicine, University of 
+Oxford, Old Road Campus, Oxford OX3 7BN, UK.
+(3)Translational Gastroenterology Unit, John Radcliffe Hospital, Headley Way, 
+Headington, Oxford OX3 9DU, UK; Nuffield Department of Medicine, University of 
+Oxford, Old Road Campus, Oxford OX3 7BN, UK. Electronic address: 
+Roger.chapman@ndm.ox.ac.uk.
+
+Immunoglobulin G4 (IgG4)-related sclerosing cholangitis (IgG4-SC) is the biliary 
+manifestation of the multisystem IgG4-related disease. IgG4-SC presents with 
+biliary strictures and/or masses that can bear a striking similarity to other 
+malignant and inflammatory diseases. Diagnosis is based on a combination of 
+clinical, biochemical, radiological, and histologic findings with careful 
+exclusion of malignant disease. Corticosteroids are the mainstay of treatment 
+with good clinical, biochemical, and radiological responses. This review 
+provides a comprehensive overview of the current knowledge of the prevalence, 
+clinical features, radiology and histology findings, diagnosis, treatment, 
+natural history, and pathophysiology of IgG4-SC.
+
+Copyright © 2016 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.cld.2015.08.004
+PMID: 26593290 [Indexed for MEDLINE]

--- a/references_cache/PMID_27625195.md
+++ b/references_cache/PMID_27625195.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:27625195"
+title: "IgG4-related hepatobiliary disease: an overview."
+authors:
+- Culver EL
+- Chapman RW
+journal: Nat Rev Gastroenterol Hepatol
+year: '2016'
+doi: 10.1038/nrgastro.2016.132
+keywords:
+- Adrenal Cortex Hormones/therapeutic use
+- "Autoimmune Diseases/diagnosis, drug therapy"
+- B-Lymphocytes/immunology
+- "Biliary Tract Diseases/diagnosis, drug therapy, immunology"
+- CD4-Positive T-Lymphocytes/immunology
+- "Cholangiopancreatography, Endoscopic Retrograde"
+- "Cholangitis, Sclerosing/diagnosis, drug therapy"
+- "Diagnosis, Differential"
+- Forecasting
+- "Hepatitis, Autoimmune/diagnosis, drug therapy, immunology"
+- Humans
+- "Immunity, Innate"
+- Immunologic Memory/immunology
+- Immunosuppressive Agents/therapeutic use
+- "Pancreatitis/diagnosis, drug therapy, immunology"
+- "Paraproteinemias/diagnosis, drug therapy, immunology"
+- Recurrence
+- Risk Factors
+- Terminology as Topic
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# IgG4-related hepatobiliary disease: an overview.
+**Authors:** Culver EL, Chapman RW
+**Journal:** Nat Rev Gastroenterol Hepatol (2016)
+**DOI:** [10.1038/nrgastro.2016.132](https://doi.org/10.1038/nrgastro.2016.132)
+
+## Content
+
+1. Nat Rev Gastroenterol Hepatol. 2016 Oct;13(10):601-12. doi: 
+10.1038/nrgastro.2016.132. Epub 2016 Sep 14.
+
+IgG4-related hepatobiliary disease: an overview.
+
+Culver EL(1)(2)(3), Chapman RW(1)(2).
+
+Author information:
+(1)Translational Gastroenterology Unit, John Radcliffe Hospital, Headley Way, 
+Headington, Oxford, OX3 9DU, UK.
+(2)Nuffield Department of Medicine, Oxford University, Old Road Campus, 
+Headington, Oxford, OX3 7BN, UK.
+(3)Liver Transplant Unit, Royal Free Hospital, Pond Street, London, NW3 2QG, UK.
+
+IgG4-related hepatobiliary diseases are part of a multiorgan fibroinflammatory 
+condition termed IgG4-related disease, and include IgG4-related sclerosing 
+cholangitis (IgG4-SC) and IgG4-related hepatopathy. These diseases can present 
+with biliary strictures and/or mass lesions, making them difficult to 
+differentiate from primary sclerosing cholangitis (PSC) or other hepatobiliary 
+malignancies. Diagnosis is based on a combination of clinical, biochemical, 
+radiological and histological findings. However, a gold standard diagnostic test 
+is lacking, warranting the identification of more specific disease markers. 
+Novel assays - such as the serum IgG4:IgG1 ratio and IgG4:IgG RNA ratio (which 
+distinguish IgG4-SC from PSC with high serum IgG4 levels), and plasmablast 
+expansion to recognize IgG4-SC with normal serum IgG4 levels - require further 
+validation. Steroids and other immunosuppressive therapies can lead to clinical 
+and radiological improvement when given in the inflammatory phase of the 
+disease, but evidence for the efficacy of treatment regimens is limited. 
+Progressive fibrosclerotic disease, liver cirrhosis and an increased risk of 
+malignancy are now recognized outcomes. Insights into the genetic and 
+immunological features of the disease have increased over the past decade, with 
+an emphasis on HLAs, T cells, circulating memory B cells and plasmablasts, 
+chemokine-mediated trafficking, as well as the role of the innate immune system.
+
+DOI: 10.1038/nrgastro.2016.132
+PMID: 27625195 [Indexed for MEDLINE]

--- a/references_cache/PMID_29526692.md
+++ b/references_cache/PMID_29526692.md
@@ -1,0 +1,104 @@
+---
+reference_id: "PMID:29526692"
+title: Rituximab Maintenance Therapy Reduces Rate of Relapse of Pancreaticobiliary Immunoglobulin G4-related Disease.
+authors:
+- Majumder S
+- Mohapatra S
+- Lennon RJ
+- Piovezani Ramos G
+- Postier N
+- Gleeson FC
+- Levy MJ
+- Pearson RK
+- Petersen BT
+- Vege SS
+- Chari ST
+- Topazian MD
+- Witzig TE
+journal: Clin Gastroenterol Hepatol
+year: '2018'
+doi: 10.1016/j.cgh.2018.02.049
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Biliary Tract Diseases/complications, drug therapy, pathology"
+- "Drug-Related Side Effects and Adverse Reactions/epidemiology, pathology"
+- Female
+- Humans
+- "Immunoglobulin G4-Related Disease/drug therapy, pathology"
+- "Immunologic Factors/administration & dosage, adverse effects"
+- "Maintenance Chemotherapy/adverse effects, methods"
+- Male
+- Middle Aged
+- Minnesota
+- "Pancreatic Diseases/complications, drug therapy, pathology"
+- Retrospective Studies
+- "Rituximab/administration & dosage, adverse effects"
+- Secondary Prevention
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Rituximab Maintenance Therapy Reduces Rate of Relapse of Pancreaticobiliary Immunoglobulin G4-related Disease.
+**Authors:** Majumder S, Mohapatra S, Lennon RJ, Piovezani Ramos G, Postier N, Gleeson FC, Levy MJ, Pearson RK, Petersen BT, Vege SS, Chari ST, Topazian MD, Witzig TE
+**Journal:** Clin Gastroenterol Hepatol (2018)
+**DOI:** [10.1016/j.cgh.2018.02.049](https://doi.org/10.1016/j.cgh.2018.02.049)
+
+## Content
+
+1. Clin Gastroenterol Hepatol. 2018 Dec;16(12):1947-1953. doi: 
+10.1016/j.cgh.2018.02.049. Epub 2018 Mar 8.
+
+Rituximab Maintenance Therapy Reduces Rate of Relapse of Pancreaticobiliary 
+Immunoglobulin G4-related Disease.
+
+Majumder S(1), Mohapatra S(2), Lennon RJ(3), Piovezani Ramos G(4), Postier N(1), 
+Gleeson FC(1), Levy MJ(1), Pearson RK(1), Petersen BT(1), Vege SS(1), Chari 
+ST(1), Topazian MD(5), Witzig TE(6).
+
+Author information:
+(1)Division of Gastroenterology and Hepatology, Department of Medicine, Mayo 
+Clinic, Rochester, Minnesota.
+(2)Department of Internal Medicine, Saint Peter's University Hospital, Rutgers 
+Robert Wood Johnson School of Medicine, New Brunswick, New Jersey.
+(3)Department of Health Sciences Research, Mayo Clinic, Rochester, Minnesota.
+(4)Department of Internal Medicine, Mayo Clinic, Rochester, Minnesota.
+(5)Division of Gastroenterology and Hepatology, Department of Medicine, Mayo 
+Clinic, Rochester, Minnesota. Electronic address: topazian.mark@mayo.edu.
+(6)Division of Hematology and Oncology, Department of Medicine, Mayo Clinic, 
+Rochester, Minnesota.
+
+BACKGROUND & AIMS: IgG4-related disease (IgG4-RD), a multi-organ 
+fibroinflammatory syndrome, typically responds to steroids. However, some cases 
+are steroid resistant, and pancreaticobiliary IgG4-RD commonly relapses after 
+steroid withdrawal. Rituximab induces remission of IgG4-RD, but the need for and 
+safety of maintenance rituximab treatment are unknown. We compared outcomes of 
+patients with pancreaticobiliary IgG4-RD treated with or without maintenance 
+rituximab therapy.
+METHODS: We performed a retrospective study of patients with pancreaticobiliary 
+IgG4-RD treated with rituximab at the Mayo Clinic in Rochester, Minnesota, from 
+January 2005 through December 2015. The cohort was divided into patients who 
+received only rituximab induction therapy (group 1, n = 14) and patients who 
+received rituximab induction followed by maintenance therapy (group 2, n = 29). 
+We collected data on recurrence of IgG4-RD symptoms and findings, as well as 
+information on evaluations, treatment, and adverse events.
+RESULTS: Median follow-up times were similar between group 1 (34 mo) and group 2 
+(27 mo) (P = .99). Thirty-seven patients (86%) were in steroid-free remission 6 
+months after rituximab initiation. A higher proportion of patients in group 1 
+had disease relapse (3-year event rate, 45%) than in group 2 (3-year event rate, 
+11%) (P = .034). Younger age, higher IgG4 responder index score after induction 
+therapy, and increased serum levels of alkaline phosphatase at baseline or after 
+rituximab induction were associated with relapse. Infections developed in 6 of 
+43 patients, all in group 2 (P = .067 vs group 1); all but 1 occurred during 
+maintenance therapy.
+CONCLUSIONS: In a retrospective study of patients with pancreaticobiliary 
+IgG4-RD, we found rituximab maintenance therapy prolongs remission. Relapses are 
+uncommon among patients receiving maintenance therapy, but maintenance therapy 
+may increase risk of infection. Patients with factors that predict relapse could 
+be candidates for rituximab maintenance therapy.
+
+Copyright © 2018 AGA Institute. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.cgh.2018.02.049
+PMID: 29526692 [Indexed for MEDLINE]

--- a/references_cache/PMID_30205418.md
+++ b/references_cache/PMID_30205418.md
@@ -1,0 +1,55 @@
+---
+reference_id: "PMID:30205418"
+title: IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+authors:
+- Tanaka A
+journal: Gut Liver
+year: '2019'
+doi: 10.5009/gnl18085
+keywords:
+- "Cholangitis, Sclerosing/diagnosis, immunology"
+- "Cholestasis/diagnosis, etiology"
+- "Diagnosis, Differential"
+- Humans
+- "Immunoglobulin G4-Related Disease/complications, diagnosis"
+content_type: abstract_only
+---
+
+# IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+**Authors:** Tanaka A
+**Journal:** Gut Liver (2019)
+**DOI:** [10.5009/gnl18085](https://doi.org/10.5009/gnl18085)
+
+## Content
+
+1. Gut Liver. 2019 May 15;13(3):300-307. doi: 10.5009/gnl18085.
+
+IgG4-Related Sclerosing Cholangitis and Primary Sclerosing Cholangitis.
+
+Tanaka A(1).
+
+Author information:
+(1)Department of Medicine, Teikyo University School of Medicine, Tokyo, Japan.
+
+Sclerosing cholangitis (SC) is defined as a condition with progressive stenosis 
+and destruction of the bile ducts due to diffuse inflammation and fibrosis and 
+currently includes three categories: primary sclerosing cholangitis (PSC), 
+secondary cholangitis, and IgG4-related sclerosing cholangitis (IgG4-SC). SC 
+categories share similar clinical features, such as cholestasis. Patients with 
+SC present with cholestatic symptoms, including jaundice and pruritus, and blood 
+tests reveal elevation of cholestatic enzymes. Cholangiography, endoscopic or 
+magnetic, is inevitably required for making a diagnosis. Although the 
+presentation of IgG4-SC and PSC are similar, the comorbidities, treatment 
+response, and outcomes differ significantly, and therefore, it is strongly 
+advisable to be familiar with these two diseases to make a correct diagnosis. 
+Differentiation of cholangiocarcinoma from IgG4-SC and PSC is also extremely 
+important. In this review, the clinical characteristics, comorbidities, 
+treatment and outcomes of IgG4-SC and PSC will be outlined based on experience 
+mainly from Japan.
+
+DOI: 10.5009/gnl18085
+PMCID: PMC6529173
+PMID: 30205418 [Indexed for MEDLINE]
+
+Conflict of interest statement: CONFLICTS OF INTEREST No potential conflict of 
+interest relevant to this article was reported.

--- a/references_cache/PMID_30575336.md
+++ b/references_cache/PMID_30575336.md
@@ -1,0 +1,720 @@
+---
+reference_id: "PMID:30575336"
+title: Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+authors:
+- Kamisawa T
+- Nakazawa T
+- Tazuma S
+- Zen Y
+- Tanaka A
+- Ohara H
+- Muraki T
+- Inui K
+- Inoue D
+- Nishino T
+- Naitoh I
+- Itoi T
+- Notohara K
+- Kanno A
+- Kubota K
+- Hirano K
+- Isayama H
+- Shimizu K
+- Tsuyuguchi T
+- Shimosegawa T
+- Kawa S
+- Chiba T
+- Okazaki K
+- Takikawa H
+- Kimura W
+- Unno M
+- Yoshida M
+journal: J Hepatobiliary Pancreat Sci
+year: '2019'
+doi: 10.1002/jhbp.596
+keywords:
+- Algorithms
+- "Autoimmune Diseases/diagnosis, immunology"
+- "Cholangitis, Sclerosing/classification, complications, diagnosis, therapy"
+- Delphi Technique
+- Humans
+- Immunoglobulin G/immunology
+content_type: full_text_xml
+---
+
+# Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+**Authors:** Kamisawa T, Nakazawa T, Tazuma S, Zen Y, Tanaka A, Ohara H, Muraki T, Inui K, Inoue D, Nishino T, Naitoh I, Itoi T, Notohara K, Kanno A, Kubota K, Hirano K, Isayama H, Shimizu K, Tsuyuguchi T, Shimosegawa T, Kawa S, Chiba T, Okazaki K, Takikawa H, Kimura W, Unno M, Yoshida M
+**Journal:** J Hepatobiliary Pancreat Sci (2019)
+**DOI:** [10.1002/jhbp.596](https://doi.org/10.1002/jhbp.596)
+
+## Content
+
+1. J Hepatobiliary Pancreat Sci. 2019 Jan;26(1):9-42. doi: 10.1002/jhbp.596. Epub
+ 2019 Jan 18.
+
+Clinical practice guidelines for IgG4-related sclerosing cholangitis.
+
+Kamisawa T(1), Nakazawa T(2), Tazuma S(3), Zen Y(4), Tanaka A(5), Ohara H(6), 
+Muraki T(7), Inui K(8), Inoue D(9), Nishino T(10), Naitoh I(11), Itoi T(12), 
+Notohara K(13), Kanno A(14), Kubota K(15), Hirano K(16), Isayama H(17), Shimizu 
+K(18), Tsuyuguchi T(19), Shimosegawa T(20), Kawa S(21), Chiba T(22), Okazaki 
+K(23), Takikawa H(5), Kimura W(24), Unno M(25), Yoshida M(26).
+
+Author information:
+(1)Department of Internal Medicine, Tokyo Metropolitan, Komagome Hospital, 
+Tokyo, Japan.
+(2)Department of Gastroenterology, Japanese Red Cross Nagoya Daini Hospital, 
+Nagoya, Japan.
+(3)Department of General Internal Medicine, Hiroshima University Graduate School 
+of Biomedical & Health Science, Hiroshima, Japan.
+(4)Department of Diagnostic Pathology, Kobe University, Kobe, Japan.
+(5)Department of Medicine, Teikyo University School of Medicine, Tokyo, Japan.
+(6)Department of Community-Based Medical Education, Nagoya City University 
+Graduate School of Medical Sciences, Nagoya, Japan.
+(7)Department of Medicine, Gastroenterology, Shinshu University, Matsumoto, 
+Nagano, Japan.
+(8)Department of Gastroenterology, Second Teaching Hospital, Fujita Health 
+University, Nagoya, Japan.
+(9)Department of Radiology, Kanazawa University Graduate School of Medical 
+Sciences, Kanazawa, Japan.
+(10)Department of Gastroenterology, Tokyo Womens' Medical University Yachiyo 
+Medical Center, Yachiyo, Japan.
+(11)Department of Gastroenterology and Metabolism, Nagoya City University 
+Graduate School of Medical Sciences, Nagoya, Japan.
+(12)Department of Gastroenterology and Hepatology, Tokyo Medical University, 
+Tokyo, Japan.
+(13)Department of Anatomic Pathology, Kurashiki Central Hospital, Kurashiki, 
+Japan.
+(14)Division of Gastroenterology, Tohoku University Graduate School of Medicine, 
+Sendai, Japan.
+(15)Department of Endoscopy, Yokohama City University Hospital, Yokohama, Japan.
+(16)Department of Gastroenterology, Tokyo Takanawa Hospital, Tokyo, Japan.
+(17)Department of Gastroenterology, Graduate School of Medicine, Juntendo 
+University, Tokyo, Japan.
+(18)Department of Gastroenterology, Tokyo Womens' Medical University, Tokyo, 
+Japan.
+(19)Endoscopy Center, Chiba University Hospital, Chiba, Japan.
+(20)Division of Gastroenterology, South-Miyagi Medical Center, Ohgawara, Japan.
+(21)Department of Internal Medicine, Matsumoto Dental University, Matsumoto, 
+Japan.
+(22)Kansai Electric Power Hospital, Osaka, Japan.
+(23)The Third Department of Internal Medicine, Division of Gastroenterology and 
+Hepatology, Kansai Medical University, Moriguchi, Japan.
+(24)Faculty of Medicine, Departments of Gastroenterology and 
+Gastroenterological, General, Breast, and Thyroid Surgery, Yamagata University, 
+Yamagata, Japan.
+(25)Division of Hepato-Biliary Pancreatic Surgery, Tohoku University Graduate 
+School, of Medicine, Sendai, Japan.
+(26)Department of Hepato-Biliary-Pancreatic and Gastrointestinal Surgery, School 
+of Medicine, International University of Health and Welfare, Ichikawa, Japan.
+
+IgG4-related sclerosing cholangitis (IgG4-SC) is a distinct type of cholangitis 
+frequently associated with autoimmune pancreatitis and currently recognized as a 
+biliary manifestation of IgG4-related disease. Although clinical diagnostic 
+criteria of IgG4-SC were established in 2012, differential diagnosis from 
+primary sclerosing cholangitis and cholangiocarcinoma is sometimes difficult. 
+Furthermore, no practical guidelines for IgG4-SC are available. Because the 
+evidence level of most articles retrieved through searching the PubMed, Cochrane 
+Library, and Igaku Chuo Zasshi databases was below C based on the systematic 
+review evaluation system of clinical practice guidelines MINDS 2014, we 
+developed consensus guidelines using the modified Delphi approach. Three 
+committees (a guideline creating committee, an expert panelist committee for 
+rating statements according to the modified Delphi method, and an evaluating 
+committee) were organized. Eighteen clinical questions (CQs) with clinical 
+statements were developed regarding diagnosis (14 CQs) and treatment (4 CQs). 
+Recommendation levels for clinical statements were set using the modified Delphi 
+approach. The guidelines explain methods for accurate diagnosis, and safe and 
+appropriate treatment of IgG4-SC.
+
+© 2018 The Authors. Journal of Hepato-Biliary-Pancreatic Sciences published by 
+John Wiley & Sons Australia, Ltd on behalf of Japanese Society of 
+Hepato-Biliary-Pancreatic Surgery.
+
+DOI: 10.1002/jhbp.596
+PMCID: PMC6590186
+PMID: 30575336 [Indexed for MEDLINE]
+
+Conflict of interest statement: None declared.
+
+IgG4‐related sclerosing cholangitis (IgG4‐SC) is a distinct type of cholangitis characterized by elevation of serum IgG4 levels, dense infiltration of IgG4‐positive plasma cells and lymphocytes, with fibrosis and obliterative phlebitis in the bile duct wall 1. IgG4‐SC, which is frequently associated with autoimmune pancreatitis (AIP), is currently recognized as a biliary manifestation of a systemic disorder termed IgG4‐related disease 2.
+
+IgG4‐SC is diagnosed via a combination of imaging, serological, and histopathological findings, coexistence of other IgG4‐related diseases, and effectiveness of steroid therapy according to clinical diagnostic criteria of IgG4‐SC 2012 3. Cholangiographic findings of IgG4‐SC involving the hilar and/or intrahepatic bile ducts are similar to those of hilar cholangiocarcinoma or primary sclerosing cholangitis (PSC). Some IgG4‐SC cases were resected on suspicion of cholangiocarcinoma. PSC is a progressive and chronic disease with poor prognosis and does not respond to steroid therapy. Therefore, IgG4‐SC should be differentiated from the two diseases. However, no previous guidelines for IgG4‐SC have been published. The present guidelines describe methods for the accurate diagnosis, and safe and appropriate treatment of IgG4‐SC based on specialized gastroenterological knowledge, skills, and experience. Although gastroenterologists are the primary target users of these clinical practice guidelines, we cover a wide range of clinical issues for general clinicians, as various IgG4‐related diseases are frequently associated with IgG4‐SC. To understand characteristic features of IgG4‐SC, background questions for concept, etiology, epidemiology and prognosis were described. Adults are the primary patients addressed in the guidelines, and children are excluded.
+
+The guidelines describe currently accepted standard management but do not force medical action. Appropriate management of patients should be determined based on the situation of each institute and patient.
+
+A total of 234 and 2,340 publications published between 1991 and March 2017 were retrieved from a search of the PubMed database using the key words “IgG4‐related sclerosing cholangitis” and “autoimmune pancreatitis”, respectively. There was only one randomized controlled trial report, and the evidence level of the other publications was below grade C (low quality) 4. Therefore, we developed consensus guidelines using the modified Delphi approach 5, 6. This method, which provides panelists with the opportunity to discuss their judgements between the ratings’ rounds, is suitable for the development of consensus guideline statement.
+
+To establish the consensus guidelines, three committees were organized, as follows: a guideline‐creation committee for developing clinical questions (CQs) and statements (pancreatobiliary specialist [n = 16], radiologist [n = 1], and pathologist [n = 2]), an expert panelist committee for rating statements according to the modified Delphi method (pancreatobiliary specialist [n = 9] and pathologist [n = 1]), and an evaluation committee (pancreatobiliary special physician [n = 2], pancreatobiliary special surgeon [n = 2], gastroenterologist [n = 1], and guideline‐development specialist [n = 1]) (Appendix 1). As there are only a few IgG4‐SC specialists, eight creation specialists doubled as expert panelists. However, these panelists did not assess items with which they were involved.
+
+The guideline‐creation committee proposed 18 CQs for diagnosis (14 CQs) and treatment (4 CQs) in consideration of PICO format, which described the population, intervention, control, and outcomes.
+
+Key words were extracted from the CQs, and academic papers were collected. A literature search was performed using the PubMed (MEDLINE), Cochrane Library, and Igaku Chuo Zasshi databases covering the period between 1995 and March 2017. Additionally, we searched the reference lists of articles identified by this search strategy and selected those that we judged to be relevant. Review articles and book chapters are cited to provide readers with more details and references. The search formula for each CQ will be available at the homepage of the Japan Biliary Association (http://www.tando.gr.jp/).
+
+The guidelines were developed with the use of system of the clinical practice guidelines MINDS 2014 to evaluate strength of systematic reviews 4. The quality of evidence was graded as A (high), B (moderate), C (low), or D (very low).
+
+The guideline‐creation committee members developed, evaluated, and revised statements and comments for the CQs. The revised draft was also evaluated and revised through a review meeting of the guideline committee. The draft was discussed at a symposium and special session held on 29 September 2017, during the 53rd Annual Meeting of the Japan Biliary Association.
+
+Ratings for statements and comments pertaining to each CQ were developed using the modified Delphi approach. Ratings were on a 9‐point scale, with 1 being highly inappropriate and 9 being highly appropriate. A clinical statement receiving a median score greater than 7 from the panel was regarded as valid. The creating specialists revised some of the statements and comments after discussion with expert panelists. The revised statements and comments were then rated again. Based on the two‐round modified Delphi approach, final statements and comments were developed.
+
+The strength of recommendations was classified as high (strong) (recommendation 1) or low (weak) (recommendation 2), as determined according to the following factors: quality of the evidence, patient's preferences, benefits and harms (risks), and cost. A recommendation was applied when more than 70% of the expert specialists (Delphi method) agreed. The use of “We recommend—” was adopted as the style for a strong recommendation. “We suggest—” was adopted as the style for a weak recommendation.
+
+The revised draft after the modified Delphi approach was evaluated by the evaluation committee using AGREE II 7. After final modifications were made, public comments were invited on the website of the Japan Biliary Association. Based on these public comments, some comments were modified.
+
+
+IgG4‐SC is SC induced via an autoimmune mechanism and responds dramatically to steroid therapy. Most cases are associated with systemic IgG4‐related diseases such as AIP.
+
+
+IgG4‐SC is SC induced via an autoimmune mechanism and responds dramatically to steroid therapy. Most cases are associated with systemic IgG4‐related diseases such as AIP.
+
+
+Comment: IgG4‐SC is SC that responds dramatically to steroid therapy, with good clinical prognosis. Differential diagnosis from PSC, cholangiocarcinoma, pancreatic cancer, and secondary SC is necessary because these conditions show similar cholangiograms to IgG4‐SC. IgG4‐SC is a biliary manifestation of IgG4‐related diseases because it is associated with systemic IgG4‐related diseases such as AIP 8. The etiology is thought to involve an autoimmune mechanism because various antibodies are detected and the disease responds well to steroid therapy 9. IgG4‐SC is diagnosed according to clinical diagnostic criteria of IgG4‐SC 2012 3. It is treated by steroid therapy in the same manner as AIP.
+
+Since the 1970s, cases of SC associated with chronic pancreatitis have been published overseas and in Japan. In most of these reports, pancreatic disease was diagnosed as chronic pancreatitis and biliary disease as PSC. Waldram et al. reported two SC cases associated with chronic pancreatitis, diabetes and Sjögren syndrome in 1975 10. Sjögren et al. reported two PSC cases that responded to steroid therapy 11.
+
+In 1991, Kawaguchi et al. reported lymphoplasmacytic sclerosing pancreatitis with cholangitis as a variant of PSC in Japan by studying surgical specimens 12. Since 1996, some cases of SC meeting the diagnostic criteria of PSC but showing a better clinical course than classic PSC have been reported. These were reported as “atypical PSC” in order to discriminate them from classic PSC 13. The atypical PSC cases showed characteristic findings such as onset at older age, good response to steroid therapy, biliary drainage, no association with ulcerative colitis, and frequent association with characteristic chronic pancreatitis. After the concept of AIP was established, these cases have been reported as “sclerosing cholangitis with autoimmune pancreatitis” 14. After the concept of IgG4‐related diseases was established and isolated SC without AIP was reported, these cases have been reported as IgG4‐SC 15.
+
+The term “IgG4‐associated sclerosing cholangitis” has also been used 16. “IgG4‐related sclerosing cholangitis” became the formal name at the 1st International Symposium on IgG4‐related disease, with establishment of uniform international nomenclature and pathologic characteristics of IgG4‐related disease 17.
+
+
+Classifications based on cholangiograms and the association with AIP have been used.
+
+
+Classifications based on cholangiograms and the association with AIP have been used.
+
+Inclusion of type 1 IgG4‐SC into the IgG4‐SC category has been disputed.
+
+
+Comment: Cholangiographic classification, which is useful for differential diagnosis, is the prevailing method 18 (Fig. 1). Type 1 IgG4‐SC involves stenosis only in the lower bile duct and thus should be differentiated from pancreatic cancer and cholangiocarcinoma 1. Type 2 IgG4‐SC, in which stenosis is diffusely distributed throughout the intrahepatic and extrahepatic bile ducts, should be differentiated from PSC and is further subdivided into two subtypes: type 2a, characterized by stricture of the intrahepatic bile ducts with prestenotic dilation; and type 2b, characterized by stricture of the intrahepatic bile ducts without prestenotic dilation and reduced bile duct branches, which should be discriminated from the “pruned‐tree” appearance in PSC. Type 3 IgG4‐SC is characterized by stenosis in the hilar hepatic lesions and lower bile duct. Type 4 IgG4‐SC presents with strictures of the bile duct only in the hilar hepatic lesions. The cholangiographic findings of types 3 and 4 IgG4‐SC should be discriminated from those of cholangiocarcinoma. A national survey performed in 2015 reported that the frequencies of the types of IgG4‐SC are 64% (type 1), 5% (type 2a), 8% (type 2b), 10% (type 3), and 10% (type 4) 19. Some type 2 cases can be differentiated from PSC by endoscopic retrograde cholangiography (ERC) findings but not differentiated from cholangiocarcinoma, which exhibits diffuse and invasive development. Types 3 and 4, which exhibit localized stenosis, should be carefully differentiated from cholangiocarcinoma using bile duct biopsy and intraductal ultrasonography (IDUS) 20. IgG4‐SC cases with stenosis at hilar hepatic lesions are sometimes associated with IgG4‐related inflammatory hepatic pseudotumors 15.
+
+Cholangiographic classification of IgG4‐SC referred from Reference 18
+
+
+IgG4‐SC is also classified based on the presence or absence of association with AIP. IgG4‐SC is frequently associated with AIP. When IgG4‐SC is not associated with AIP, this is referred to as “isolated IgG4‐SC” 21. A Japanese multicenter study conducted by nine major hospitals of the IgG4‐related disease group of the Research Program of Intractable Diseases supported by the Ministry of Health, Labour, and Welfare of Japan reported that only 15 of 344 IgG4‐SC cases (4.4%) were not associated with AIP (2 of 246 type 1 IgG4‐SC cases [0.8%]; 5 of 56 type 2 IgG4‐SC cases [8.9%]; 8 of 42 type 3 and 4 IgG4‐SC cases [19.0%]) 22. Type 3 and 4 IgG4‐SC cases showed lower frequencies of association with AIP. A national survey performed in 2013 reported that isolated IgG4‐related SC included three cases of type 1, three cases of type 2, four cases of type 3, 22 cases of type 4, and 11 cases of other types 23. Type 4 is the most frequent type not associated with AIP. Isolated type 4 IgG4‐SC is very difficult to discriminate from cholangiocarcinoma. A case series reported five cases of isolated type 1 IgG4‐SC 24. Three of the five cases involved surgical resection of cholangiocarcinoma at the lower bile duct. The other two cases were diagnosed correctly as isolated type 1 IgG4‐SC, obviating the need for surgical resection based on high serum IgG4 levels and diffuse wall thickening in the bile duct.
+
+Inclusion of the type 1 disease in the IgG4‐SC categories has been disputed. Some researchers claim that the type 1 disease should not be classified as IgG4‐SC for the following reasons:
+The stricture of the lower bile duct is caused by compression due to AIP 25. This claim is based on the fact that type 1 IgG4‐SC was not found in some cases of focal‐type AIP with only body and tail involvement.The frequency of IgG4‐SC increases when type 1 IgG4‐SC is included in the IgG4‐SC category in epidemiologic surveys.In the international consensus diagnostic criteria, IgG4‐SC with extrapancreatic stenosis is regarded as additional organ involvement, which is useful in the diagnosis of AIP 26.
+
+
+The stricture of the lower bile duct is caused by compression due to AIP 25. This claim is based on the fact that type 1 IgG4‐SC was not found in some cases of focal‐type AIP with only body and tail involvement.
+
+The frequency of IgG4‐SC increases when type 1 IgG4‐SC is included in the IgG4‐SC category in epidemiologic surveys.
+
+In the international consensus diagnostic criteria, IgG4‐SC with extrapancreatic stenosis is regarded as additional organ involvement, which is useful in the diagnosis of AIP 26.
+
+By contrast, others claim that type 1 IgG4‐SC should be included as a class of IgG4‐SC for the following reasons:
+Pathologic examination of the bile duct wall obtained from surgically resected samples showed abundant infiltration of IgG4‐positive plasma cells, storiform fibrosis, and obstructive phlebitis, which are characteristics of IgG4‐SC inflammation 15.Thickening of the bile duct wall is observed continuously from the intrapancreatic to extrapancreatic bile ducts 20.Isolated type 1 IgG4‐SC exhibiting no AIP findings has been reported 24.
+
+
+Pathologic examination of the bile duct wall obtained from surgically resected samples showed abundant infiltration of IgG4‐positive plasma cells, storiform fibrosis, and obstructive phlebitis, which are characteristics of IgG4‐SC inflammation 15.
+
+Thickening of the bile duct wall is observed continuously from the intrapancreatic to extrapancreatic bile ducts 20.
+
+Isolated type 1 IgG4‐SC exhibiting no AIP findings has been reported 24.
+
+Indeed, it is difficult to identify the major factor contributing to the thickening of the bile duct wall – inflammation of the bile duct or compression due to AIP. Comments on diagnostic criteria of IgG4‐SC based on working group debates indicate that most cases of IgG4‐SC associated with AIP exhibit stricture of the lower bile duct caused by both thickening of the bile duct wall itself and pancreatic inflammation and edema 3.
+
+
+SC is classified as PSC, IgG4‐SC, or secondary SC according to the disease concept and clinical features. PSC is an idiopathic, progressive, and chronic intrahepatic cholestasis caused by fibrous stenosis of the intrahepatic and extrahepatic bile ducts and does not respond to steroid therapy, whereas IgG4‐SC does respond to steroid therapy. PSC is positioned different from secondary SC, which should be treated etiologically.
+
+
+SC is classified as PSC, IgG4‐SC, or secondary SC according to the disease concept and clinical features. PSC is an idiopathic, progressive, and chronic intrahepatic cholestasis caused by fibrous stenosis of the intrahepatic and extrahepatic bile ducts and does not respond to steroid therapy, whereas IgG4‐SC does respond to steroid therapy. PSC is positioned different from secondary SC, which should be treated etiologically.
+
+
+Comment: SC is classified as PSC, IgG4‐SC, or secondary SC according to the disease concept and clinical features. PSC is an idiopathic, progressive, chronic intrahepatic cholestasis caused by fibrous stenosis of the intrahepatic and extrahepatic bile ducts. To correctly diagnose PSC, IgG4‐SC and secondary SC must be ruled out 27, 28, 29. IgG4‐SC and PSC show similar imaging of the bile ducts, although their disease concept, pathophysiology, therapy, and prognosis are different; therefore, it is important to distinguish these two diseases.
+
+IgG4‐SC has been reported in patients over age 60 years most commonly in association with an increase in serum IgG4 levels, whereas two peaks in age distribution were clearly observed in PSC patients with an approximately 10% increase in serum IgG4 levels 22, 23, 30. PSC is complicated by inflammatory bowel diseases such as ulcerative colitis. The prevalence of inflammatory bowel diseases in PSC patients is as high as 60–80% in Western countries and 34% in Japan 23, 31, 32. In contrast, IgG4‐SC is often complicated by AIP, sclerosing sialadenitis, and retroperitoneal fibrosis, but not inflammatory bowel diseases.
+
+Pathologic characteristics of PSC include fibrous obliterative cholangitis, so‐called “onion‐skin lesions,” whereas IgG4‐positive plasma cells infiltrate the portal area in IgG4‐SC 33. IgG4‐SC responds to steroid therapy. In contrast, PSC is non‐responsive to steroids and immune‐suppressive agents, and currently, liver transplantation is the only effective treatment 34, 35, 36.
+
+It is necessary to rule out the following features of secondary SC with obvious pathogenesis, including infection, cholangiocarcinomas, previous surgery or trauma involving the biliary tract, common bile duct stones and chronic inflammation, congenital biliary anatomic defects, corrosive cholangitis, ischemic bile duct stenosis, AIDS‐related cholangitis, and biliary injury caused by intra‐arterial chemotherapy 27, 31. Secondary SC should be principally treated etiologically 37, 38.
+
+
+In intrahepatic and extrahepatic large bile ducts, transmural marked lymphoplasmacytic infiltration and fibrosis are observed, which give rise to bile duct wall thickening. Notably, storiform fibrosis and obliterative phlebitis are important histologic findings for diagnosing IgG4‐SC.An increase in IgG4‐positive cells is characteristic but not specific; thus, a diagnosis of IgG4‐SC needs to be established based on histologic findings.
+
+
+In intrahepatic and extrahepatic large bile ducts, transmural marked lymphoplasmacytic infiltration and fibrosis are observed, which give rise to bile duct wall thickening. Notably, storiform fibrosis and obliterative phlebitis are important histologic findings for diagnosing IgG4‐SC.
+
+An increase in IgG4‐positive cells is characteristic but not specific; thus, a diagnosis of IgG4‐SC needs to be established based on histologic findings.
+
+
+Comment: IgG4‐SC primarily involves the intrahepatic and extrahepatic large bile ducts and is characterized by transmural marked lymphoplasmacytic infiltration and fibrosis, which gives rise to duct wall thickening (Fig. 2) 15, 21, 39, 40, 41. In contrast to PSC, in which the focus of inflammation is the epithelium, no cell damage or inflammatory cell infiltration is observed in the epithelium. Similar to IgG4‐related disease in other organs, eosinophilic infiltration, storiform fibrosis (Fig. 3), and/or obliterative phlebitis (Fig. 4) are commonly identified, and the latter two are particularly regarded as diagnostically important. Storiform fibrosis is an irregular swirling arrangement of collagen 39, and inflammatory cells are commonly observed. Obliterative phlebitis is an inflammatory lesion with inflammatory cells and fibrosis that involves and obliterates the venous lumen 39. IgG4‐SC lesions involve not only the bile duct walls but also the peribiliary adipose tissue, peripheral nerves, and portal regions of the liver 15, 42. There are no histologic differences between IgG4‐SC with and without AIP 21, 42.
+
+Histological findings of transmural inflammatory cell infiltration and fibrosis in the bile duct of IgG4‐SC (arrow). (Scale: 100 μm)
+
+Histological findings of storiform fibrosis in the bile duct of IgG4‐SC. (Scale: 100 μm)
+
+Histological findings of obliterative phlebitis (arrows) in the bile duct of IgG4‐SC. (Scale: 100 μm)
+
+Infiltration of numerous IgG4‐positive cells (Fig. 5) is characteristic of – but not specific to – IgG4‐SC. In PSC, numerous IgG4‐positive cells can also be identified, notably in the inflamed large bile ducts, with marked inflammatory cell infiltration 43, 44, 45. In a study of 122 explanted livers with PSC, >50 IgG4‐positive cells per high power field (HPF) were observed in 15.6% of the patients 45. In contrast to IgG4‐SC, however, IgG4‐positive cells are rare in the peripheral portal tracts in PSC. Numerous IgG4‐positive cells may also appear in cholangiocarcinomas 46, 47, and >50 IgG4‐positive cells per HPF were found in 9% of 54 resected specimens 46. Thus, the diagnosis of IgG4‐SC is difficult to establish based on IgG4‐immunostaining alone, and histologic findings must be thoroughly evaluated.
+
+Immunohistochemical findings of infiltration of numerous IgG4‐positive cells in the bile duct of IgG4‐SC. IgG4‐immunostaining. (Scale: 100 μm)
+
+According to clinical diagnostic criteria of IgG4‐SC 2012 3, the diagnosis can be definitively made based on histologic findings if three of the following four conditions are identified: (1) marked lymphoplasmacytic infiltration and fibrosis; (2) >10 IgG4‐positive plasma cells per HPF; (3) storiform fibrosis; and (4) obliterative phlebitis. A cut‐off of >10 IgG4‐positive cells per HPF was adopted to make a biopsy‐based diagnosis of IgG4‐SC possible. In contrast, a consensus statement on the pathology of IgG4‐related disease 48 indicated that >50 IgG4‐positive cells per HPF in resected specimens and >10/HPF in biopsy samples as well as an IgG4/IgG‐positive cell ratio >40% need to be satisfied, and lesions are regarded as histologically highly suggestive of IgG4‐related disease if two of the following three conditions are additionally satisfied: (1) marked lymphoplasmacytic infiltration; (2) storiform fibrosis; and (3) obliterative phlebitis. IgG4‐SC cases that do not satisfy the requirement for an IgG4/IgG‐positive cell ratio >40% have been reported 21, however.
+
+
+IgG4‐SC sometimes presents with mass‐forming cholangitis, particularly around the hilar bile duct. These cases are referred to as hepatic inflammatory pseudotumors. The mass lesions consist of expanded periductal connective tissue with involvement of the liver parenchyma being uncommon.
+
+
+IgG4‐SC sometimes presents with mass‐forming cholangitis, particularly around the hilar bile duct. These cases are referred to as hepatic inflammatory pseudotumors. The mass lesions consist of expanded periductal connective tissue with involvement of the liver parenchyma being uncommon.
+
+
+Comment: Some patients with IgG4‐SC present with a hilar mass, imaging features of which mimic hilar cholangiocarcinomas 15, 49. Such cases are called IgG4‐related hepatic inflammatory pseudotumors. However, hepatic inflammatory pseudotumors are heterogeneous in nature and not always IgG4‐related. They are classified into lymphoplasmacytic and fibro‐inflammatory types based on histologic findings, with the former corresponding to IgG4‐related disease 50. Lymphoplasmacytic‐type pseudotumors typically develop in hilar bile ducts, whereas fibro‐inflammatory‐type lesions more commonly affect the liver parenchyma. Although a study based on surgically treated patients suggested that the lymphoplasmacytic type accounts for 37% of hepatic pseudotumors, the exact relative frequency is unknown 50.
+
+
+Although the exact etiology is unknown, autoimmunity is the most suspected cause of IgG4‐SC.
+
+
+Although the exact etiology is unknown, autoimmunity is the most suspected cause of IgG4‐SC.
+
+
+Comment: Of several hypotheses that have been proposed as a potential pathogenetic mechanism of IgG4‐SC, an autoimmune theory is currently regarded as most likely correct. This possibility is supported by the occasional detection of autoantibodies in patients with IgG4‐SC, known disease‐susceptible HLA haplotypes for AIP, and good response to corticosteroids 9, 51. In addition, injection of IgG isolated from patients with AIP into neonatal mice was shown to induce pancreatic injury, suggesting a potential pathogenetic effect of IgG 52. An Italian research group raised the possibility that Helicobacter pylori infection initiates an immune reaction leading to the production of antibodies against the plasminogen‐binding protein of Helicobacter pylori, and these antibodies could behave as autoantibodies against the pancreatic acinar cells via molecular mimicry 53. However, another study could not validate these findings 54. Other potential pathogenetic models include allergy, paraneoplastic syndrome, and immune complex deposition 55, 56.
+
+
+In Japan, the number of patients with IgG4‐SC is estimated at approximately 2,500, according to an epidemiologic study of AIP.
+
+
+In Japan, the number of patients with IgG4‐SC is estimated at approximately 2,500, according to an epidemiologic study of AIP.
+
+
+Comment: To date, no epidemiologic study of IgG4‐SC has been reported. Regarding AIP, another IgG4‐related disease, an epidemiologic study in 2011 estimated the prevalence and incidence as 4.6 and 1.4 per 100,000 population, respectively 57. As IgG4‐SC was present as a comorbidity in 39% of patients with AIP, the prevalence and incidence of IgG4‐SC in patients with AIP were extrapolated as 1.8 and 0.5 per 100,000 population, respectively. According to a nationwide survey for IgG4‐SC in 2015 19, approximately 10% of patients with IgG4‐SC are not diagnosed as having AIP. Collectively, the total prevalence of IgG4‐SC was estimated as 2.0 per 100,000 population, and the number of patients with IgG4‐SC was thus calculated as 2,500.
+
+Case series of IgG4‐SC have been reported from the United States, the United Kingdom, and Japan (Table 1) 16, 19, 58. IgG4‐SC is a male‐dominant disease, with males accounting for 80% of all patients. All reports agree regarding the age at highest risk for developing IgG4‐SC, indicating an average or median age at diagnosis of 60–70 years. In case series from Japan, age at diagnosis ranged from 23.0 to 88.5 years, and no childhood or adolescent patients were reported 19, unlike in the case of PSC 23. Jaundice was the most prevalent symptom at diagnosis in reports from the United States and the United Kingdom, observed in more than 70% of all patients. Jaundice was the most prevalent symptom in Japan as well, but it was observed in only 35% of patients; notably, 28% of patients were diagnosed without any apparent symptoms 19. AIP was noted as a comorbidity in 90% of patients with IgG4‐SC in all case series.
+
+Comparison of clinical features of IgG4‐related sclerosing cholangitis
+
+
+AIP autoimmune pancreatitis
+
+Average (the United States), median (the United Kingdom, Japan)
+
+
+The outcome is probably excellent, as treatment with corticosteroids is effective in most cases of IgG4‐SC. However, as the long‐term outcome remains unclear, further studies are warranted.
+
+
+The outcome is probably excellent, as treatment with corticosteroids is effective in most cases of IgG4‐SC. However, as the long‐term outcome remains unclear, further studies are warranted.
+
+
+Comment: The outcome of patients with IgG4‐SC has been investigated in retrospective cohorts in the United States 16, the United Kingdom 58, and Japan 19. Sample size, follow‐up period, corticosteroid treatment, and outcomes are summarized in Table 2.
+
+Comparison of treatment and prognosis of IgG4‐related sclerosing cholangitis
+
+
+LT liver transplantation, N/A not available
+
+The average follow‐up period of patients treated with corticosteroids
+
+The proportion in 115 patients with autoimmune pancreatitis, including those without IgG4‐SC
+
+Progression to cirrhosis was noted in 5.2% in the United Kingdom cohort and 7.5% in the United States cohort. Mortality due to liver or bile duct problems was found in only one case in the United States cohort and two cases (liver failure and cholangiocarcinoma) and one case involving liver transplantation in the United Kingdom. In Japan, only four cases (two cholangiocarcinoma and two hepatic failure) were recorded, accounting for 0.8%, which was lower than the United States and United Kingdom rates 19, 58. Therefore, poor outcomes, including liver or bile duct disease mortality and liver transplantation, can be avoided with corticosteroid treatment in most cases of IgG4‐SC, and the outcome is excellent. However, the follow‐up period remains insufficient to provide conclusive results, and potential biases associated with retrospective designs might be present in these case series. In this regard, the long‐term outcome remains unclear, and further studies are warranted.
+
+In the United Kingdom report, the risk of all‐cause death was increased compared with matched national statistics (OR = 2.07, CI = 1.07–3.55, P = 0.02). However, cancer‐related mortality was not increased compared with the national studies (incidence ratio 1.95, CI = 0.6–4.51, P = 0.17); whether mortality is increased (and its cause if so) in patients with IgG4‐SC remains to be elucidated.
+
+
+IgG4‐SC is not considered a risk factor for cholangiocarcinoma because cholangiocarcinoma rarely occurs during the follow‐up period.
+
+
+IgG4‐SC is not considered a risk factor for cholangiocarcinoma because cholangiocarcinoma rarely occurs during the follow‐up period.
+
+
+Comment: It is pathologically difficult to differentiate between cholangiocarcinoma associated with IgG4 and cholangiocarcinoma arising from IgG4‐SC, as 32% to 43% of patients with biliary tract cancer exhibit >10 IgG4‐positive plasma cells per HPF within and around cancerous nests 59. Three patients with cholangiocarcinoma and IgG4‐SC have been reported 60, 61, 62; two patients were diagnosed concurrently, and one patient was diagnosed with cholangiocarcinoma during the follow‐up period of IgG4‐SC treatment 62. Hirano et al. reported 14 patients with malignancy among 113 cases of IgG4‐related disease; however, cholangiocarcinoma occurred in only one patient 1.7 years after diagnosis of IgG4‐related disease (AIP) 63. Shiokawa et al. 55 also reported that among 108 patients with AIP, cholangiocarcinoma occurred in only one patient 5.6 years after the diagnosis during the follow‐up period; malignant disease occurred in 15 patients during the same period. A retrospective cohort study of 527 patients with IgG4‐SC in Japan 19 showed that four patients developed cholangiocarcinoma; two of the four patients were diagnosed at the same time, whereas the remaining two patients were diagnosed 4 months and 4 years after the diagnosis of IgG4‐SC, respectively.
+
+Cholangiocarcinoma arising from IgG4‐SC is thought to be a rare complication. However, evaluating the risk of cholangiocarcinoma will require longer cohort studies, as IgG4‐SC is a relatively new concept for clinicians.
+
+Algorithm for diagnosis and treatment of IgG4‐SC referred from Reference 18
+
+
+Algorithm for diagnosis and treatment of IgG4‐SC referred from Reference 18
+
+
+Algorithm for diagnosis and treatment of IgG4‐SC referred from Reference 18
+
+
+Algorithm for diagnosis and treatment of IgG4‐SC referred from Reference 18
+
+
+IgG4‐SC is suspected when diffuse or segmental stenosis of the bile duct with wall thickening is seen and/or the serum IgG4 level is high. The diagnosis of IgG4‐SC is based on clinical diagnostic criteria of IgG4‐SC 2012. When associated with AIP or other IgG4‐related diseases, the diagnosis is straightforward. If not or association of these diseases is not definite, differential diagnosis can be difficult due to the challenge of obtaining a sufficient sample for the diagnosis of IgG4‐SC by bile duct biopsy. IgG4‐SC cholangiograms are similar to those for PSC and cholangiocarcinoma. Type 1 IgG4‐SC produces stenosis only in the lower bile duct (intrapancreatic duct) and thus should be differentiated from pancreatic cancer and cholangiocarcinoma. Type 2 IgG4‐SC, in which stenosis is diffusely distributed throughout the intrahepatic and extrahepatic bile ducts, should be differentiated from PSC. Type 3 IgG4‐SC is characterized by stenosis in the hilar hepatic lesions and lower bile duct. Type 4 IgG4‐SC presents with strictures of the bile duct only in the hilar hepatic lesions. The cholangiographic findings of types 3 and 4 IgG4‐SC should be discriminated from those of cholangiocarcinoma (Fig. 6).
+
+In the diagnosis of type 1 IgG4‐SC, pancreatic cancer should be ruled out by endoscopic ultrasonography‐guided fine‐needle aspiration (EUS‐FNA) when the pancreatic mass of pancreas head is detected. Then, cholangiocarcinoma should be ruled out by bile duct biopsy under ERC. When IDUS and/or biopsy of the ampulla of Vater shows characteristic findings for IgG4‐SC, steroid trial is suggested. If these examinations do not show characteristic findings or steroid trial is not effective, re‐evaluation or surgical operation is selected. Surgical operation is indicated when malignant cells are detected or malignant diseases cannot be ruled out after careful re‐evaluation (Fig. 7).
+
+In the diagnosis of type 2 IgG4‐SC, when characteristic cholangiogram is obtained, steroid trial is suggested. If combination of IDUS, peroral cholangioscopy (POCS), bile duct biopsy and biopsy of the ampulla of Vater reveals characteristic findings for IgG4‐SC in cases without characteristic cholangiogram, steroid trial is also suggested. If these examinations do not show characteristic findings or steroid trial is not effective, other sclerosing cholangitis or cholangiocarcinoma should be considered (Fig. 8).
+
+In the diagnosis of types 3 and 4 IgG4‐SC, cholangiocarcinoma should be ruled out by bile duct biopsy under ERC. If malignant cells are not detected and IDUS, POCS and/or biopsy of the ampullary of Vater shows characteristic findings for IgG4‐SC, steroid trial is suggested. If these examinations do not show characteristic findings or steroid trial is not effective, re‐evaluation or surgical operation is selected. Surgical operation is indicated when malignant cells are detected or malignant diseases cannot be ruled out after careful re‐evaluation (Fig. 9).
+
+Summary of imaging findings suggestive of IgG4‐SC
+
+
+Imaging reflects the characteristic pathologic findings, such as submucosal inflammation with little change in the epithelium and wall thickening diffusely spreading to non‐stenotic bile ducts in cholangiograms. In addition, these findings are dramatically improved with steroid therapy.
+
+Two aspects should be evaluated: distribution and character of stenosis, and wall thickness.
+
+Ruling out malignant diseases using biopsy and cytology under ERC is necessary in localized stenosis.
+
+Evaluation of cholangiographic differences is necessary in diffuse stenosis.
+
+Diffuse wall thickening with preserved epithelium in stenotic and non‐stenotic lesions is a characteristic finding for IgG4‐SC.
+
+Schematic illustration of treatment of IgG4‐SC
+
+
+Oral prednisolone at 0.6 mg/kg/day is recommended for initial remission induction therapy, with gradual reduction to a maintenance dose of 5 mg/day by 2–3 months. Maintenance dose should be continued for at least 3 years.
+
+Patients with comfortable radiological and serological improvement can stop steroids. After treatment is discontinued, patients should be followed up for relapse.
+
+
+We recommend that diagnosis of IgG4‐SC be based on the following four criteria: characteristic biliary imaging findings, elevation of serum IgG4 levels, coexistence of IgG4‐related diseases, except those of the biliary tract, and characteristic histopathologic features (Recommendation 1, level C).In a specialized facility in which detailed examinations such as endoscopic biliary biopsy and EUS‐FNA can be performed, we suggest evaluating the effectiveness of steroid therapy as an optional extra diagnostic criterion to confirm a diagnosis of IgG4‐SC after negative work‐up for malignancy (Recommendation 2, level D).
+
+
+We recommend that diagnosis of IgG4‐SC be based on the following four criteria: characteristic biliary imaging findings, elevation of serum IgG4 levels, coexistence of IgG4‐related diseases, except those of the biliary tract, and characteristic histopathologic features (Recommendation 1, level C).
+
+In a specialized facility in which detailed examinations such as endoscopic biliary biopsy and EUS‐FNA can be performed, we suggest evaluating the effectiveness of steroid therapy as an optional extra diagnostic criterion to confirm a diagnosis of IgG4‐SC after negative work‐up for malignancy (Recommendation 2, level D).
+
+
+Comment: As IgG4‐SC exhibits various cholangiographic features similar to those of PSC, pancreatic cancer, and cholangiocarcinoma, the differential diagnosis of IgG4‐SC from these three progressive or malignant diseases is very important.
+
+Two sets of diagnostic criteria for IgG4‐SC have been proposed. The HISORt (histology, imaging, serology, other organ involvement, and response to steroid therapy) criteria were originally developed for AIP and adapted for IgG4‐SC 16. In 2012, a second set of diagnostic criteria for IgG4‐SC was proposed by a Japanese group 3 (Table 3). Diagnosis of IgG4‐SC is based on the following four criteria: (1) characteristic biliary imaging findings; (2) elevation of serum IgG4 levels; (3) coexistence of IgG4‐related diseases, except those of the biliary tract; and (4) characteristic histopathologic features. As it is sometimes difficult to obtain sufficient biopsy specimens of the bile duct from patients suffering from IgG4‐SC, evaluation of the effectiveness of steroid therapy is an optional extra diagnostic criterion to confirm a diagnosis of IgG4‐SC. However, efforts should be made to collect sufficient tissue samples for diagnosis, and easy steroid trials should be avoided. The effectiveness of steroid therapy should be cautiously evaluated, as some malignant lesions improve after steroid administration 64. If neoplastic lesions cannot be clinically ruled out after steroid therapy, a re‐evaluation should be performed to rule out malignant cholangiopancreatic diseases.
+
+Clinical diagnostic criteria of IgG4‐related sclerosing cholangitis 2012 3
+
+
+It is necessary to exclude PSC, malignant diseases such as pancreatic or biliary cancers, and secondary sclerosing cholangitis caused by the diseases with obvious pathogenesis. If IgG4‐SC cannot be clinically ruled out, a patient must not be treated with facile steroid therapy but should be referred to a specialized medical facility.
+
+IgG4‐SC is frequently associated with AIP 16, and this association is useful for diagnosis of IgG4‐SC 1. However, it is particularly difficult to accurately diagnose IgG4‐SC in the absence of AIP 21, 24, 65. Occasionally, IgG4‐SC is associated with other systemic IgG4‐related diseases, including IgG4‐related dacryoadenitis/sialadenitis, IgG4‐related retroperitoneal fibrosis, and IgG4‐related kidney disease 66. These associations can also assist diagnosis of IgG4‐SC. We use diagnostic criteria for IgG4‐SC for diagnosis of IgG4‐SC 3, and we use comprehensive diagnostic criteria for IgG4‐related disease 2011 67 for diagnosis of other IgG4‐related diseases without organ specific diagnostic criteria. In contrast to PSC, inflammatory bowel disease is rarely observed in patients with IgG4‐SC 68.
+
+It should be noted that an elevated serum IgG4 level is also observed in conditions such as atopic dermatitis, pemphigus, and asthma; in particular, elevated serum IgG4 levels are observed in PSC and some malignant cholangiopancreatic diseases (e.g. pancreatic cancer and cholangiocarcinoma) 22, 69, 70.
+
+IgG4‐SC with strictures of the bile duct in the hilar hepatic lesions must be discriminated from hilar cholangiocarcinoma. In these cases, endoscopic procedures such as endoscopic ultrasonography (EUS), IDUS, cytologic examination, and/or biopsy of the bile duct are useful for correct diagnosis 21, 24, 65.
+
+
+We recommend an examination of serum IgG4 levels for the diagnosis of IgG4‐SC (Recommendation 1, level C).We suggest an examination of serum IgG4 levels for differential diagnosis from cholangiocarcinoma (Recommendation 2, level D).We suggest an examination of serum IgG4 levels for differential diagnosis from PSC (Recommendation 2, level D).
+
+
+We recommend an examination of serum IgG4 levels for the diagnosis of IgG4‐SC (Recommendation 1, level C).
+
+We suggest an examination of serum IgG4 levels for differential diagnosis from cholangiocarcinoma (Recommendation 2, level D).
+
+We suggest an examination of serum IgG4 levels for differential diagnosis from PSC (Recommendation 2, level D).
+
+
+Comment: An elevation of serum IgG4 levels is seen in 90% of IgG4‐SC cases 22, 71. Conversely, no elevation of serum IgG4 level is seen in 10% of cases 22, 71. However, as an elevation of serum IgG4 levels is also seen in 8–14% of cholangiocarcinoma cases 22, 69, IgG4‐SC cannot be diagnosed based solely on an elevated serum IgG4 level (sensitivity 64–90%, specificity 87–93%) 22, 69. A cut‐off of ≥206 mg/dL could be useful for types 3 and 4 IgG4‐SC to distinguish them from cholangiocarcinoma 22 because types 3 and 4 IgG4‐SC are known to mimic cholangiocarcinoma.
+
+An elevation of serum IgG4 levels is also seen in 9–22% of PSC cases 22, 23, 43, 70, 71, 72, 73, 74, 75, 76, 77. It was reported that a cut‐off of ≥117 mg/dl has a sensitivity of 92% and specificity of 88% 22; with a cut‐off of ≥140 mg/dl, it had a sensitivity of 90% and specificity of 85%; and with a cut‐off of ≥280 mg/dl, it had a sensitivity of 70% and specificity of 98% 71. The optimal cut‐off value was reported to be 250 mg/dl, with a sensitivity of 67–89% and specificity of 95% 71.
+
+Serum IgG4 has been assayed by two world‐wide systems, Binding‐Site system 22 and Siemens system 71. In Japan, only Binding‐Site system is available, whereas in Europe and the United States, both Binding‐Site and Siemens systems are used. Serum IgG4 levels of Siemens system was reported to be 60% higher than those of Binding‐Site system due to difference of standards for both systems 72. Accordingly, serum IgG4 assay with Siemens system may bring about false positive, if cut‐off of Binding‐Site system (≥140 mg/dl), is applied 71.
+
+An elevation of serum IgG4 levels is seen in most cases of IgG4‐SC, so it is useful for the diagnosis of IgG4‐SC. However, an elevation of serum IgG4 levels is not specific for the diagnosis of IgG4‐SC. Cholangiocarcinoma and PSC cannot be excluded solely based on an elevation of serum IgG4 levels.
+
+
+We suggest ultrasonography for diagnosis of IgG4‐SC (Recommendation 2, level D).We suggest EUS for differential diagnosis from cholangiocarcinoma (Recommendation 2, level D).
+
+
+We suggest ultrasonography for diagnosis of IgG4‐SC (Recommendation 2, level D).
+
+We suggest EUS for differential diagnosis from cholangiocarcinoma (Recommendation 2, level D).
+
+
+Comment: Only a few reports have described ultrasonographic findings for IgG4‐SC 78, 79, 80, 81. Before the disease concept of IgG4‐SC was established, Kamisawa et al. reported observing bile duct and gallbladder wall thickening in 60% of patients with AIP 78. Koyama et al. reported characteristic bile duct and gallbladder wall thickening (Fig. 12) on ultrasonography in 37.8% of patients with AIP 79. Characteristic wall thickening was reported as laminar structures or low echoic thickening of the wall 80, 81. Koyama et al. 79 divided patients into two groups according to ultrasonographic findings of bile duct wall thickening: (1) three‐layer type, involving marked wall thickening apparent on ultrasonography as high‐low‐high echo of the bile duct wall; and (2) parenchymal‐echo type, involving a thickened wall that occupies the entire lumen of the bile duct with appearance of parenchymal echo in the bile duct. They also reported rapid improvement in bile duct stenosis after steroid therapy but delayed improvement of the bile duct and gallbladder wall thickening 79.
+
+Ultrasonographic image of IgG4‐SC. Ultrasonography detects marked wall thickening in the extrahepatic bile duct (arrows)
+
+Ultrasonography can detect wall thickening from the intrahepatic to extrahepatic bile ducts but cannot detect wall thickening of the intrapancreatic bile duct. It is difficult to distinguish IgG4‐SC from PSC or cholangiocarcinoma using only ultrasonography. Nakamura et al. reported that the characteristic ultrasonographic findings of PSC include a homogeneous, high‐low‐high echo of the bile duct wall thickening, and in cases of severe wall thickening, the lumen of the bile duct becomes indistinct 82. These findings are similar to those of IgG4‐SC (Fig. 13); thus, the differential diagnosis of both is difficult. Du et al. reported ultrasonographically determined wall thickening in 3 of 21 (14.3%) patients with IgG4‐SC, occupying lesions in seven patients (33%), and dilation in 18 patients (85.7%). In contrast, ultrasonography revealed wall thickening in 11 of 194 (5.7%) patients with cholangiocarcinoma, occupying lesions in 70 patients (36.1%), and dilation in 137 patients (70.6%). There were no significant differences between IgG4‐SC and cholangiocarcinoma 83. In one case report, ultrasonography detected a low echoic tumor in the liver, and the patient was diagnosed as having IgG4‐SC based on pathologic examinations of resected specimens 84. It is difficult to diagnose IgG4‐SC using only ultrasonography.
+
+
+EUS image of IgG4‐SC. EUS shows a homogeneous, high‐low‐high echo of the bile duct wall thickening (arrows)
+
+Ultrasonography is a useful modality for detecting wall thickening of the bile duct in patients with IgG4‐SC. Furthermore, ultrasonography can detect pancreatic swelling at the same time in patients with AIP. As ultrasonography is non‐invasive, it is proposed for use in the diagnosis of IgG4‐SC.
+
+Few reports have described EUS findings of IgG4‐SC 83, 85, 86. Du et al. 83 reported the EUS revealed wall thickening in 17 of 18 (94.4%) patients with IgG4‐SC, occupying lesions in one patient (5.6%), and dilation in 10 patients (55.6%). On the other hand, EUS revealed wall thickening in only 3 of 10 (30%) patients with cholangiocarcinoma, occupying lesions in eight patients (80%), and dilation in five patients (50%). There were significant differences between IgG4‐SC and cholangiocarcinoma 83. Du et al. reported observing thickened walls significantly more frequently in IgG4‐SC cases than in cholangiocarcinoma, and significantly more occupying lesions were observed in cholangiocarcinoma than IgG4‐SC cases 83. They concluded that EUS is an effective imaging tool for diagnosis of IgG4‐SC and cholangiocarcinoma 83.
+
+Naitoh et al. reported that thickened walls detected by ultrasonography, computed tomography (CT), EUS, and IDUS involve circular‐symmetrical thickening, smooth outer and inner margins, and homogeneous internal echo at the stenotic area of the bile duct 86. Sometimes, wall thickening is observed in the bile duct without obvious stenosis and wall thickening is observed in the gallbladder, too. Because EUS can detect characteristic findings of IgG4‐SC and thus facilitate a differential diagnosis from cholangiocarcinoma, EUS is proposed for use in differential diagnosis from cholangiocarcinoma.
+
+
+In order to detect dilation or stenosis of bile ducts and obtain a complete image of the biliary system, we suggest contrast‐enhanced CT and MRI/magnetic resonance cholangiopancreatography (MRCP) (Recommendation 2, level D).For differential diagnosis of PSC or cholangiocarcinoma, we suggest contrast‐enhanced CT and MRI/MRCP (Recommendation 2, level D).
+
+
+In order to detect dilation or stenosis of bile ducts and obtain a complete image of the biliary system, we suggest contrast‐enhanced CT and MRI/magnetic resonance cholangiopancreatography (MRCP) (Recommendation 2, level D).
+
+For differential diagnosis of PSC or cholangiocarcinoma, we suggest contrast‐enhanced CT and MRI/MRCP (Recommendation 2, level D).
+
+
+Comment: CT and MRI enable objective detection of biliary abnormalities, including dilatation or wall thickening of bile ducts, and are considered useful for identifying bile duct lesions (Fig. 14). Additionally, T2‐weighted images or MRCP enable non‐invasive imaging of the complete biliary system and determination of the distribution or degree of biliary strictures. As such, CT and MRI are considered useful for providing clues that can aid in the diagnosis of IgG4‐SC (Fig. 15). In terms of differential diagnosis of other biliary diseases, such as PSC or cholangiocarcinoma in particular, CT and MRI have both advantages and limitations. In IgG4‐SC, biliary inflammation occurs transmurally, preserving the epithelial layer almost intact. In contrast, PSC mainly involves the luminal side, including the epithelium, and cholangiocarcinoma arises from the epithelial layer and grows invasively 39, 87. There are several differences regarding the primary locations of these conditions; however, it is challenging to demonstrate these differences by CT or MRI. To date, characteristic reported imaging findings for IgG4‐SC include: (1) concentric bile duct wall thickening extending along the long axis; (2) smooth inner/outer margins; (3) visibility of patent bile duct in the strictures and mildness of upper bile duct dilatation; and (4) continuous bile duct wall thickening covering intrahepatic and extrahepatic bile ducts. However, the prevalence of these findings varies depending on the report; more reliable findings other than the abnormalities in the pancreas (presence of AIP) have yet to be reported 87, 88, 89, 90, 91. Although Kim et al. reported that MRCP can detect characteristic findings for PSC, such as multiple intrahepatic bile duct stenosis or pruned‐tree appearance, the spatial resolution of MRCP falls short of that of ERC 92. Furthermore, for detailed evaluation of bile duct wall thickening, EUS or IDUS provides more information than MRCP. However, considering the ability to non‐invasively obtain a complete image of the biliary and pancreatic ducts and evaluate the concentricity of bile duct wall thickening, the degree of upstream bile duct dilatation, and the invasiveness of the lesion, it is reasonable to consider that contrast‐enhanced CT or MRI/MRCP could contribute to the diagnosis of IgG4‐SC when compared with ERC or IDUS. Additionally, IgG4‐SC is usually accompanied by extra‐bile duct lesions, the presence of which can sometimes contribute to the diagnosis 93. For systemic screening of IgG4‐related lesions, it is worth performing contrast‐enhanced CT. Furthermore, adding high‐contrast‐resolution MRI (fat‐suppressed T1‐weighted, or diffusion‐weighted images) or MRCP, which can provide complete imaging of the pancreas ducts, can sometimes reveal pancreatic lesions (e.g. AIP) not apparent in contrast‐enhanced CT scans. CT and MRI/MRCP are relatively well‐known diagnostic modality for general population. CT and MRI scanners are distributing nationwide and available for all patients. Although imaging protocol and quality for biliary imaging have been standardized, radiation exposure should be concerned in repeated CT examinations. Consequently, when IgG4‐SC is suspected in clinical settings, systemic screening using contrast‐enhanced CT and detailed evaluation of the bile ducts and pancreas using MRI/MRCP could aid in the diagnosis.
+
+
+CT image of IgG4‐SC. Contrast‐enhanced CT (delayed image) demonstrates concentric wall thickening of the hilar bile duct (arrows)
+
+
+CT and MRCP images of IgG4‐SC. (a) In CT, the hilar bile duct shows marked thickening (arrow). (b) MRCP demonstrates bile duct strictures in the hilar bile duct (arrows)
+
+
+AIP is the disease most frequently associated with IgG4‐SC, recognized in about 90% of patients with IgG4‐SC. Apart from AIP, IgG4‐SC is associated with dacryoadenitis, sialadenitis, retroperitoneal fibrosis, kidney lesions, pulmonary lesions, lymph node lesions, and vascular lesions (aorta and coronary arteries). We suggest consideration of these IgG4‐related lesions (Recommendation 2, level D).
+
+
+AIP is the disease most frequently associated with IgG4‐SC, recognized in about 90% of patients with IgG4‐SC. Apart from AIP, IgG4‐SC is associated with dacryoadenitis, sialadenitis, retroperitoneal fibrosis, kidney lesions, pulmonary lesions, lymph node lesions, and vascular lesions (aorta and coronary arteries). We suggest consideration of these IgG4‐related lesions (Recommendation 2, level D).
+
+
+Comment: Although there are not many reports describing analyses of a large number of patients with IgG4‐SC, the most frequent associated disease is AIP (87–92%) 16, 19. On the other hand, IgG4‐SC is also the disease most frequently associated with AIP. Lower bile duct strictures are observed in about 80% of patients with AIP. In AIP cases with pancreatic head lesions, lower bile duct strictures often occur because of pancreatitis or pancreatic edema; therefore, the association between IgG4‐SC and AIP may be very close (Fig. 16) 25, 94. In addition to AIP, IgG4‐SC is known to be associated with dacryoadenitis (Fig. 17), sialadenitis, retroperitoneal fibrosis (Fig. 18), as well as kidney, pulmonary, lymph node, and vascular (aorta and coronary artery) lesions. However, an association with inflammatory bowel diseases is rare 16, 19, 23. Considering that IgG4‐SC is a systemic IgG4‐related disease, all lesions regarded as IgG4‐related disease may be associated diseases of IgG4‐SC. That is, associated diseases of IgG4‐SC can occur in various organs, including the central nervous system (hypophysitis and hypertrophic pachymeningitis), thyroid, liver, gastrointestinal tract, prostate, eyes, skin, and mammary glands 67.
+
+
+ERCP image of a patient with AIP in which the lesion was limited to the pancreatic head. Narrowing of the main pancreatic duct in the head (arrows) and strictures of the lower bile ducts are recognized
+
+IgG4‐related dacryoadenitis. Swelling of right and left lacrimal glands (right > left) is recognized (arrows)
+
+
+CT image of IgG4‐related retroperitoneal fibrosis. Soft‐tissue mass surrounding the abdominal aorta is recognized (arrow)
+
+
+ERC shows diffuse or segmental stricture of the intrahepatic and/or extrahepatic bile ducts (Recommendation 2, level D).ERC is useful for differentiation between IgG4‐SC and PSC (Recommendation 2, level D).
+
+
+ERC shows diffuse or segmental stricture of the intrahepatic and/or extrahepatic bile ducts (Recommendation 2, level D).
+
+ERC is useful for differentiation between IgG4‐SC and PSC (Recommendation 2, level D).
+
+
+Comment: Biliary tract imaging in IgG4‐SC reveals diffuse or segmental stricture of the intrahepatic and/or extrahepatic bile ducts. Although MRCP provides useful information, stricture of the bile duct should be assessed by direct cholangiography (i.e. by ERC or percutaneous transhepatic cholangiography). In clinical practice, ERC is recommended as the most useful diagnostic imaging modality for diagnosing IgG4‐SC 3, 95.
+
+The characteristic features of IgG4‐SC can be classified into four types based on the region of strictures as revealed by cholangiography and differential diagnosis (Fig. 19) (refer to Fig. 1).
+
+Cholangiographic classification of IgG4‐SC and the differential diagnosis of IgG4‐SC referred from Reference 3
+
+
+The main cause of biliary strictures in IgG4‐SC is severe lymphoplasmacytic infiltration into the bile ducts in the long region, resulting in long strictures. The main cause of the biliary stricture in PSC, by comparison, is obliterative fibrosis, which results in short strictures and bile duct loss 27, 95, 96 (Fig. 20). The characteristic cholangiographic findings of IgG4‐SC may allow differentiation between IgG4‐SC and PSC. The dominant cholangiographic findings of PSC, including band‐like strictures (short strictures of 1–2 mm) (Figs 20, 21a), beaded appearance (Figs 20, 21b), pruned‐tree appearance (Figs 20, 22a), or diverticulum‐like outpouching (Figs 20, 22b), are rarely observed in IgG4‐SC. By contrast, the characteristic cholangiographic findings of IgG4‐SC are lower bile duct stricture (Figs 20, 23) and dilatation after a confluent stricture (Figs 20, 24) 96, 97. Sometimes it is difficult to distinguish between type 2b IgG4‐SC and PSC based on the cholangiographic findings when the only cholangiographic finding in PSC is a pruned‐tree appearance. When IgG4‐SC is associated with AIP, pancreatography shows narrowing of the main pancreatic duct, which is characteristic of AIP.
+
+Schematic illustration comparing the cholangiographic findings in PSC and IgG4‐SC referred from Reference 3
+
+
+Cholangiogram of PSC showing (a) band‐like strictures and (b) beaded appearance (arrows)
+
+Cholangiogram of PSC showing (a) pruned‐tree appearance and (b) diverticulum‐like outpouching (arrows)
+
+Cholangiopancreatogram of type 1 IgG4‐SC showing the lower bile duct stricture and irregular narrowing of the main pancreatic duct (arrows)
+
+Cholangiogram of (a) type 2a IgG4‐SC showing dilatation after a confluent stricture (arrow) and (b) type 2b IgG4‐SC showing no dilatation after a confluent stricture (arrows)
+
+IgG4‐SC with localized bile duct stricture must be differentiated from cholangiocarcinoma. Cholangiography cannot be used to differentiate between the hilar hepatic strictures of type 3 (Fig. 25) or type 4 IgG4‐SC and hilar cholangiocarcinoma. The diagnostic procedures that are useful for making the differential diagnosis between types 3 and 4 IgG4‐SC and cholangiocarcinoma are endoscopic modalities such as EUS, IDUS, and bile duct cytology and/or biopsy 16, 20, 65, 98, 99 (Fig. 19). Type 1 IgG4‐SC must be differentiated from lower bile duct cancer and pancreatic cancer (Fig. 19). Diagnosis of IgG4‐SC associated with AIP is relatively easy when endoscopic retrograde pancreatography shows narrowing of the main pancreatic duct, which is characteristic of AIP, but it is very difficult to make the differential diagnosis between isolated IgG4‐SC and lower bile duct cancer 24.
+
+Cholangiogram of type 3 IgG4‐SC showing the hilar hepatic and lower bile duct strictures (arrows)
+
+Endoscopic transpapillary bile duct biopsy is performed to rule out cholangiocarcinoma, but it is difficult to obtain sufficient biliary tract tissue to evaluate for the characteristic histologic findings of IgG4‐SC (i.e. storiform fibrosis and obliterative phlebitis). A commonly used cut‐off value for IgG4‐positive plasma cell infiltration is 10 cells per HPF. Reports of the sensitivity of transpapillary bile duct biopsy as a basis for making a diagnosis of IgG4‐SC have ranged from 18 to 88% 16, 20, 100.
+
+
+We recommend determination of the serum IgG4 level, concomitant diseases, cholangiogram, bile duct wall findings of contrast‐enhanced CT or IDUS, mucosal findings of POCS, pathologic findings of biopsy or brush cytology, and clinical course for the differential diagnosis of IgG4‐SC from cholangiocarcinoma (Recommendation 1, level D).
+
+
+We recommend determination of the serum IgG4 level, concomitant diseases, cholangiogram, bile duct wall findings of contrast‐enhanced CT or IDUS, mucosal findings of POCS, pathologic findings of biopsy or brush cytology, and clinical course for the differential diagnosis of IgG4‐SC from cholangiocarcinoma (Recommendation 1, level D).
+
+
+Comment: The differential diagnosis of IgG4‐SC is often difficult. Cases involving types 1, 3, and 4 disease are difficult to distinguish from cholangiocarcinoma (Fig. 19). The sensitivity and specificity in the diagnosis of IgG4‐SC based on cholangiogram by endoscopic retrograde cholangiopancreatography (ERCP) are 45% and 88% 101. Diagnosis by cholangiogram using ERCP combined with CT and MRI has a sensitivity of 70–90% and specificity of 73–87% 101, 102. However, a cholangiogram is crucial for differential diagnosis of IgG4‐SC from PSC because of specific findings. Several points facilitate a differential diagnosis of IgG4‐SC based on cholangiogram findings. Some cholangiocarcinomas exhibit high serum IgG4 levels, as in IgG4‐SC; the sensitivity and specificity of IgG4 level determination for the diagnosis are 64–100% and 81–88%, respectively, with an IgG4 cut‐off level of 140 mg/dl 68, 102. A higher cut‐off level of 560 mg/dl (four times the upper normal limit) provides for more reliable differential diagnosis of IgG4‐SC from cholangiocarcinoma, with a sensitivity of 17% and specificity of 99% 69.
+
+IgG4‐SC is often accompanied by the IgG4‐related disease AIP 1, 103. Then, the presence of concomitant IgG4‐related disease suggests the possibility of IgG4‐SC, thus warranting screening of the whole body.
+
+Contrast‐enhanced CT is useful for differential diagnosis, and homogeneous enhancement of the bile duct walls in the arterial phase is characteristic of IgG4‐SC. By contrast, in cases involving cholangiocarcinoma, the bile duct wall is enhanced in two layers. Smoothness of the inner lumen and the outer layer is also characteristic of IgG4‐SC 88, 104, 105. An additional advantage of contrast‐enhanced CT is that it enables the detection of tumor invasion and metastatic lesions outside the bile ducts.
+
+IDUS is useful for differential diagnosis in conjunction with ERCP. Wall thickening in the non‐stricture areas is characteristic of IgG4‐SC, and a sensitivity of 95–100%, specificity of 91%, and accuracy of 94% were reported with a wall thickness cut‐off of 0.8 mm in non‐stricture areas 1, 20. Findings of tortuous and dilated arteries in the bile duct by POCS are features of IgG4‐SC, and partially dilated arteries were detected in a case of cholangiocarcinoma 106.
+
+Biopsy is recommended for differential diagnosis, but the sensitivity for detecting malignancy (55–72%) was low 1, 20. In addition, IgG4 staining also showed low sensitivity (18–52%) for biopsy specimens in IgG4‐SC cases 20, 100. There was a report of an increase in the rate of positive IgG4 staining to 72% with additional papillary biopsy; however, papillary biopsy is considered a supplementary method and should not be performed alone 100. Simultaneous performance of brush cytology at strictures and bile fluid cytology were shown to be favorable for improving the diagnostic utility of bile duct biopsy.
+
+Elevation in bile fluid IgG4 levels has been reported in cases of IgG4‐SC but not PSC and cholangiocarcinoma, with sensitivity and specificity values of 100% at a cut‐off level of 113 mg/dl 107. There is a possibility monitoring of bile IgG4 levels will be useful for differential diagnosis.
+
+Most reports regarding the differential diagnosis of IgG4‐SC and cholangiocarcinoma discussed in this section were characterized by small sample sizes and low evidence levels. A review of these reports suggests that IgG4‐SC should be distinguished from cholangiocarcinoma using a variety of methods because the diagnostic utility of each modality alone is insufficient.
+
+
+We recommend consideration of age of onset, serum IgG4 level, coexisting diseases, image findings of biliary trees, liver histology, responsiveness to steroid therapy, and clinical course to differentially diagnose IgG4‐SC from PSC (Recommendation 1, level D).
+
+
+We recommend consideration of age of onset, serum IgG4 level, coexisting diseases, image findings of biliary trees, liver histology, responsiveness to steroid therapy, and clinical course to differentially diagnose IgG4‐SC from PSC (Recommendation 1, level D).
+
+
+Comment: PSC is a chronic inflammatory liver disease with poor prognosis characterized by progressive fibrosis of intrahepatic and extrahepatic bile ducts terminally leading to liver failure via cholestatic cirrhosis 27, 108, 109. Although PSC and IgG4‐SC exhibit similar cholangiograms, these diseases recently became distinguishable with the establishment of their etiology. As the therapeutic strategies and prognoses of these diseases differ, the differential diagnosis is of great importance.
+
+PSC and IgG4‐SC exhibit clinical differences related to (1) age of onset, (2) serum IgG4 levels, (3) coexisting diseases, (4) image findings of biliary trees, (5) liver histology, (6) responsiveness to steroid therapy, and (7) clinical course (Table 4).
+
+Differential characteristics of IgG4‐SC and PSC
+
+
+UDCA ursodeoxycholic acid
+
+Whereas IgG4‐SC primarily affects elderly patients over 60 years of age, there are two peaks in the age distribution in PSC, one in younger (20–30 years old) patients and the other in more elderly patients 30.
+
+The serum IgG4 level is frequently elevated in IgG4‐SC but not in PSC. A multicenter survey in Japan demonstrated a diagnostic sensitivity for IgG4‐SC of 89.9% when a cut‐off value of 135 mg/dl was employed 22. In a subsequent nationwide survey, serum IgG4 levels were elevated in 83.9% of IgG4‐SC cases 110. In contrast, high serum IgG4 levels were observed in only 11.5% and 12.9% of PSC cases in these two reports, suggesting that a serum IgG4 level is a reliable biomarker for distinguishing IgG4‐SC from PSC. However, the diagnosis of IgG4‐SC should not be made solely on the basis of serum IgG4 levels, as false‐positive results are observed in approximately 10% of PSC cases.
+
+PSC is frequently accompanied by inflammatory bowel diseases such as ulcerative colitis, with a prevalence of 60–80% in Western countries 31, 32. A Japanese nationwide survey in 2013 reported a lower incidence of inflammatory bowel disease in PSC patients of 34%. However, endoscopic examination of the colorectum is recommended in PSC patients, regardless of the absence of symptoms of inflammatory bowel disease 23, as inflammatory bowel disease is occasionally diagnosed after a definitive diagnosis of PSC 31, 32. In contrast, IgG4‐SC is associated with AIP as well as other IgG4‐related diseases such as sialadenitis and retroperitoneal fibrosis at a high prevalence 23, but it is rarely associated with inflammatory bowel disease.
+
+Typical imaging findings of biliary trees in PSC include band‐like strictures, beaded appearance, pruned‐tree appearance, and diverticulum‐like outpouching 95, 96. Differential features on cholangiography include longer strictures in IgG4‐SC than in PSC 1, 3, 18, 96, 97. IDUS findings of irregular inner margins reflecting ductal epithelial damage and diverticulum‐like outpouching are significantly more frequent in PSC 111, 112. This is in contrast to the findings of homogenous thickening of the inner low‐echoic layer without destruction of the three‐layer structure frequently observed in IgG4‐SC. Typical POCS findings in PSC include multiple lesions involving scarring and pseudodiverticula 113, 114.
+
+Important liver histology findings in PSC include periductal onion‐skin fibrosis and fibrous obliterative cholangitis 33, although these are not specific for PSC. For the differential diagnosis of IgG4‐SC from PSC, fibrous cholangitis is a potential finding of PSC, whereas abundant IgG4‐positive plasma cell infiltration in portal areas is suggestive of IgG4‐SC.
+
+With regard to medical treatment, patients with IgG4‐SC are treated effectively with corticosteroids, whereas extensive evidence suggests there are no satisfactory agents for treating PSC. Although ursodeoxycholic acid is widely used in patients with PSC, guidelines in Western countries indicate that its clinical benefit is uncertain. In addition, high‐dose ursodeoxycholic acid reportedly has no beneficial effect 34, 35, 36. PSC leads to liver failure via cholestatic cirrhosis with disease duration of more than 10 years and occasionally leads to cholangiocarcinoma, suggesting poor prognosis. Hence, liver transplantation remains the only established therapy.
+
+
+We suggest performing bile duct biopsy for the diagnosis of IgG4‐SC (Recommendation 2, level D).We suggest performing bile duct biopsy for differential diagnosis from cholangiocarcinoma (Recommendation 2, level D).
+
+
+We suggest performing bile duct biopsy for the diagnosis of IgG4‐SC (Recommendation 2, level D).
+
+We suggest performing bile duct biopsy for differential diagnosis from cholangiocarcinoma (Recommendation 2, level D).
+
+
+Comment: The diagnosis of IgG4‐SC warrants bile duct biopsy to differentiate it from other diseases, particularly cholangiocarcinoma. However, definitive diagnoses of IgG4‐SC by bile duct biopsy are sporadic. The histopathology of IgG4‐SC is characterized by diffuse lymphoplasmacytic infiltration extending from the bile duct mucosa to the serous membrane, storiform fibrosis, obstructive phlebitis, and eosinophilic infiltration, whereas the histopathology of the bile duct epithelium is often normal. In other words, histopathologically, a definitive diagnosis of IgG4‐SC by bile duct biopsy, requires the collection of samples containing the bile duct stroma. Ghazale et al. reported pathologic diagnosis of IgG4‐SC in 14 of 16 patients (88%) by bile duct biopsy 16. In contrast, Kawakami et al. 100, Naitoh et al. 20, and Hirano et al. 25 reported diagnosis of IgG4‐SC by bile duct biopsy in 15 of 29 patients (52%), 3 of 17 patients (18%), and 0 of 5 patients (0%), respectively, which cannot be considered as good outcomes (Table 5). The poor ability to diagnose IgG4‐SC by bile duct biopsy may be attributed to the fact that the endoscopic bile duct samples are often small, and collecting samples containing the bile duct stroma using biopsy forceps is challenging. Although immunostaining for IgG4 is performed to more effectively use the small samples collected, satisfactory results have yet to be obtained.
+
+Usefulness of bile duct biopsy for the diagnosis of IgG4‐SC
+
+When we observe localized stenosis, excluding cholangiocarcinoma is necessary. Refer to CQI‐7 for differential diagnosis from cholangiocarcinoma.
+
+
+Histopathology of endoscopic biopsy samples taken from the ampulla of Vater for IgG4‐immunostaining can be useful as a supplemental tool for the diagnosis of IgG4‐SC. We suggest this technique for use in cases involving a swollen ampulla associated with pancreatic head involvement due to AIP in particular (Recommendation 2, level D).
+
+
+Histopathology of endoscopic biopsy samples taken from the ampulla of Vater for IgG4‐immunostaining can be useful as a supplemental tool for the diagnosis of IgG4‐SC. We suggest this technique for use in cases involving a swollen ampulla associated with pancreatic head involvement due to AIP in particular (Recommendation 2, level D).
+
+
+Comment: Supplemental endoscopic biopsy histopathology using IgG4‐immunostaining could contribute to the diagnosis of IgG4‐SC in cases in which the ampulla of Vater is swollen 115 (Fig. 26a) and there is positive histopathologic evidence of infiltration (i.e. >10 IgG4‐positive plasma cells per HPF) 116 (Fig. 26b).
+
+(a) Endoscopic image showing a swollen ampulla of Vater of a patient with IgG4‐SC. (b) Immunohistochemical findings of abundant infiltration of IgG4‐positive plasma cells in biopsy specimen taken from the ampulla of Vater of a patient with IgG4‐SC
+
+
+Features such as swollen ampulla and abundant infiltration of IgG4‐positive plasma cells are regarded as indicative of pancreatic head involvement associated with AIP rather than diagnostic of IgG4‐SC 117. There is no consensus criterion regarding endoscopic biopsy in the diagnosis of IgG4‐related disease. Additionally, endoscopic biopsy histopathology of samples taken from the ampulla of Vater is regarded as an option in the diagnosis of AIP as proposed in the international consensus diagnostic criteria 26. Supplemental endoscopic biopsy samples taken from the ampulla of Vater are useful for differential diagnosis of IgG4‐SC from PSC 118; however, endoscopic biopsy histopathology itself should not be relied on for final diagnosis of IgG4‐related diseases. One case report described isolated‐type IgG4‐related disease of the ampulla of Vater 119. Although there are no consensus diagnostic criteria available regarding the ampulla of Vater in IgG4‐related disease, it could be considered in diagnosis if there are typical endoscopic findings such as swollen ampulla of Vater associated with hooding‐fold bulging 115 and biopsy histopathologic results indicating infiltration with abundant IgG4‐positive plasma cells 116. Endoscopic findings such as a swollen ampulla of Vater and endoscopic biopsy results showing abundant IgG4‐positive plasma cell infiltration were noted in 40–80% of patients with IgG4‐SC associated with AIP 120, 121, 122. On the other hand, it would be almost impossible for the use of endoscopic biopsy histopathology to reveal stromal features of IgG4‐SC, including storiform fibrosis and obliterative phlebitis. Isolated IgG4‐SC not associated with AIP is rare 15. Furthermore, Matsubayashi reported that only 1 of 7 isolated IgG4‐SC patients presented with a swollen ampulla of Vater. That author also described the usefulness of characterizing ampulla features in diagnosing IgG4‐SC 123. Additionally, as the tissue acquisition from the affected bile ducts in IgG4‐SC patients are challenging at poor outcomes (Table 5), the feasible result taken from the ampulla, which anatomically connected to the bile duct, could be a surrogate to attest it 124. Therefore, the biopsy of the ampulla is useful. For the aforementioned reasons, ampullary features such as typical endoscopic findings indicative of pancreatic head lesions in AIP can potentially contribute to the diagnosis of IgG4‐SC; such findings would also be positive in patients with isolated‐type IgG4‐SC.
+
+
+We suggest IDUS for the differential diagnosis from cholangiocarcinoma or PSC (Recommendation 2, level D).
+
+
+We suggest IDUS for the differential diagnosis from cholangiocarcinoma or PSC (Recommendation 2, level D).
+
+
+Comment: Endoscopic transpapillary IDUS is a reliable procedure to obtain high‐resolution images of the bile duct wall after ERCP. IDUS is performed by inserting a small‐caliber ultrasonic probe into the bile duct. IDUS is widely used for evaluation of bile duct stones, differential diagnosis of indeterminate biliary strictures, and superficial spread of cholangiocarcinoma. IDUS should be performed before biliary drainage, as such drainage often causes mechanical inflammation of the bile duct. IDUS findings of IgG4‐SC include circular‐symmetrical wall thickening, smooth outer and inner margins, and homogeneous internal echo in the biliary stricture (Fig. 27a) 20, 85. The most characteristic IDUS finding of IgG4‐SC is wall thickening in non‐strictures of the bile duct, which appears normal on a cholangiogram (Fig. 27b) 20. IDUS findings of IgG4‐SC reflect pathologic changes of the bile duct in which fibro‐inflammation is primarily observed in the stroma of the bile duct walls, whereas the bile duct epithelium remains intact 3.
+
+
+IDUS image of (a) biliary stricture and (b) non‐biliary stricture in a patient with IgG4‐SC
+
+
+IDUS findings in strictures and non‐strictures of the bile duct differ between IgG4‐SC and cholangiocarcinoma 3, 20, 125, 126, 127, 128, 129. IDUS findings of cholangiocarcinoma include asymmetric wall thickening, notched outer margins, rough inner margins, and homogeneous internal echo in the biliary stricture. The most characteristic IDUS finding of IgG4‐SC is wall thickening in non‐strictures of the bile duct, as mentioned above. By contrast, bile duct wall thickening is not observed in non‐stricture sites in cholangiocarcinoma due to the absence of cancer there. One study revealed that a bile duct wall thickness of 0.8 mm is the optimal cut‐off for differentiating IgG4‐SC from cholangiocarcinoma, according to receiver operating characteristic curve analysis 20. In that study 20, no cholangiocarcinoma cases exhibiting a bile duct wall thickness greater than 1 mm were noted; therefore, this cut‐off can be used to completely exclude cholangiocarcinoma from IgG4‐SC diagnoses. The most useful IDUS finding for differentiating between IgG4‐SC and cholangiocarcinoma is that wall thickness continuously spreads from the lower bile duct to the upper bile duct in most IgG4‐SC cases.
+
+Most cases of IgG4‐SC with intrapancreatic bile duct strictures exhibit bile duct wall thickening. This IDUS finding is useful in the differential diagnosis from pancreatic cancer because intrapancreatic bile duct strictures are considered to be caused primarily by extrinsic compression due to pancreatic enlargement 25, 94. Both intrapancreatic bile duct thickening and extrinsic compression due to pancreatic enlargement influence intrapancreatic bile duct strictures. The degree of influence produced by these two factors might differ in each IgG4‐SC case. Upstream (middle and upper) bile duct thickening is often observed in IgG4‐SC but not in pancreatic cancer. An IDUS finding of upstream bile duct thickening is useful in the differential diagnosis between AIP (IgG4‐SC) and pancreatic cancer.
+
+Typical IDUS findings of PSC include circular‐asymmetric wall thickening, irregular inner margins, unclear outer margins, diverticulum‐like outpouching, heterogeneous internal echo, and the disappearance of three layers. These findings differ from those of IgG4‐SC 111, 112. Irregular inner margins, diverticulum‐like outpouching, and the disappearance of three layers are specific findings for distinguishing IgG4‐SC from PSC according to IDUS. Diverticulum‐like outpouching is considered to be the most objective finding on ERCP 112. IDUS is more useful than ERCP for the early detection of diverticulum‐like outpouching, which is specific to PSC.
+
+IDUS is recommended for the differential diagnosis of IgG4‐SC from cholangiocarcinoma, pancreatic cancer, or PSC, especially in patients undergoing ERCP, because IDUS can be performed after ERC.
+
+
+Lesions of IgG4‐SC may be obtained by liver biopsy, but specific histologic features are rarely observed (Recommendation 2, level D).
+
+
+Lesions of IgG4‐SC may be obtained by liver biopsy, but specific histologic features are rarely observed (Recommendation 2, level D).
+
+
+Comment: Lesional tissues are obtained by liver biopsy in about 25% of IgG4‐SC cases 129, 130. This happens more frequently in cases with intrahepatic bile duct involvement using a 14‐G needle 129. In most cases, however, the obtained tissues reveal non‐specific histologic findings, such as lymphoplasmacytic and occasional eosinophilic infiltration in the peripheral portal regions, sometimes with periportal, intralobular, and central perivenular inflammatory cell infiltration 97, 129, 131, 132. Cholangitis similar to that in the large bile ducts, storiform fibrosis, and obliterative phlebitis are usually absent. The presence of portal‐based fibro‐inflammatory nodules in the portal tracts, resembling the findings of IgG4‐related inflammatory pseudotumors, is pathognomonic 131 but rarely observed in liver biopsies.
+
+The standard for increased IgG4‐positive cells in the liver biopsy is >10 cells per HPF in the clinical diagnostic criteria for IgG4‐SC 3 and consensus statement on the pathology of IgG4‐related disease 48; in the latter, an IgG4/IgG‐positive cell ratio >40% also needs to be satisfied. IgG4‐positive cells in the liver biopsy are significantly more numerous in IgG4‐SC compared with PSC and cholangiocarcinomas 97, 103. In one study, >10 IgG4‐positive cells per HPF was reported in 6 of 10 IgG4‐SC cases but in none of 16 PSC cases 131. The IgG4‐positive/mononuclear cell ratio and IgG4/IgG‐positive cell ratio were reported to be significantly higher in IgG4‐SC than PSC 133. Although not previously studied with liver biopsy specimens, numerous IgG4‐positive cells may also be observed in cholangiocarcinomas; therefore, sufficient attention should be paid to incorrectly diagnose false‐negative samples of cholangiocarcinoma as IgG4‐SC based solely on IgG4‐immunostaining.
+
+In terms of distinguishing IgG4‐SC from PSC in a liver biopsy sample, advanced fibrosis corresponding to stages 3 and 4 would be observed only in PSC and not in IgG4‐SC 14, 97. Fibrous cholangitis is significantly more frequent in PSC but can be detected in IgG4‐SC as well 97, 129, 131.
+
+Complications, such as severe pain, vasovagal syncope, and hemorrhage, occur infrequently after a liver biopsy.
+
+
+We suggest the use of POCS for differentiating between cholangiocarcinoma and PSC (Recommendation 2, level D).
+
+
+We suggest the use of POCS for differentiating between cholangiocarcinoma and PSC (Recommendation 2, level D).
+
+
+Comment: The detailed structure of the surface of the bile duct mucous membrane can be macroscopically observed using POCS. When combined with narrow‐band imaging, observation of blood vessels using POCS is useful as a diagnostic aid 113. According to a report comparing POCS images of IgG4‐SC, cholangitis, and PSC 106, a small number of cases of IgG4‐SC characteristically exhibited a high frequency of dilated and tortuous vessels, and in many instances, there was no fibrous scar tissue (Fig. 28). In IgG4‐SC, inflammation is primarily submucosal 15; therefore, it is said that the appearance of congestion in the mucosal veins, where there is relatively little inflammation, can be perceived macroscopically. By contrast, in PSC, blood vessel distribution is poor, and scarring with pseudodiverticulum‐like changes is often seen. In cholangiocarcinoma, irregular mucosal changes and large new blood vessels (particularly enlarged vessels) are often observed. However, differentiation based on POCS images alone can be difficult. In the diagnosis of cholangiocarcinoma, when bile duct biopsy under fluoroscopic guidance is difficult, specimens can be collected with greater reliability by POCS biopsy.
+
+
+POCS image of dilated and tortuous vessels in IgG4‐SC referred from Reference 112
+
+
+
+We suggest that steroid trials should be carried out only by experts familiar with AIP and IgG4‐SC or in patients with diagnostically challenging cases of IgG4‐SC without AIP or other organ involvement only after exclusion of cholangiocarcinoma (Recommendation 2, level D).The effectiveness of steroid trials for diagnosing IgG4‐SC should be assessed by confirming resolution of findings on bile duct images obtained using ERCP/MRCP after 1 or 2 weeks of steroid administration at a dose of 0.4–0.6 mg/kg. In the absence of amelioration, we suggest re‐evaluation, including resection of cases suspicious for cancer (Recommendation 2, level D).
+
+
+We suggest that steroid trials should be carried out only by experts familiar with AIP and IgG4‐SC or in patients with diagnostically challenging cases of IgG4‐SC without AIP or other organ involvement only after exclusion of cholangiocarcinoma (Recommendation 2, level D).
+
+The effectiveness of steroid trials for diagnosing IgG4‐SC should be assessed by confirming resolution of findings on bile duct images obtained using ERCP/MRCP after 1 or 2 weeks of steroid administration at a dose of 0.4–0.6 mg/kg. In the absence of amelioration, we suggest re‐evaluation, including resection of cases suspicious for cancer (Recommendation 2, level D).
+
+
+Comment: There are no reports of randomized controlled steroid trials for the diagnosis for IgG4‐SC. Only one paper regarding AIP and a few case reports have been published 134, 135. A steroid trial conducted for differential diagnosis of AIP and pancreatic cancer stated that steroid trials should be carried out only by pancreatobiliary subspecialists after the exclusion of potential malignancy 26. This would also apply to the use of steroid trials in the diagnosis of IgG4‐SC, which should be attempted only after excluding biliary malignancy.
+
+Steroid trials would be appropriate for use by pancreatobiliary subspecialists in diagnostically challenging cases mimicking PSC and/or cholangiocarcinoma. Almost all cases of IgG4‐SC are associated with AIP, and cases that are not associated with AIP are often accompanied by involvement of other organs. These diagnostic clues could facilitate a correct diagnosis of IgG4‐SC without evaluation of histopathologic evidence in bile duct samples 15. However, a steroid trial would be acceptable in diagnostically challenging patients with IgG4‐SC with a slight relationship with AIP and/or patients with isolated‐type IgG4‐SC without other organ involvement. Steroid trials might also be appropriate in patients with elevated serum IgG4 levels who present with typical cholangiogram results indicative of IgG4‐SC 18. The effectiveness of steroid trials for diagnosing IgG4‐SC should be assessed by confirming resolution of findings on bile duct images obtained using ERCP/MRCP after 1 or 2 weeks of steroid administration at a dose of 0.4–0.6 mg/kg 16, 136. The Mayo Clinic group 16 and Iwasaki et al. 136 validated the use of steroid trials for diagnosing IgG4‐SC. The efficacy of steroid treatment should be evaluated within a week or so using serum data, and CT and MRCP or ERCP imaging findings should be assessed 1 to 2 weeks after the trial. In the absence of amelioration, re‐evaluation, including resection of cases suspicious for cancer, should be proposed.
+
+
+We recommend steroid therapy for almost all IgG4‐SC patients. Immediate steroid therapy should be considered for IgG4‐SC patients with obstructive jaundice, acute cholangitis, and symptomatic extrabiliary IgG4‐related diseases (Recommendation 1, level D).
+
+
+We recommend steroid therapy for almost all IgG4‐SC patients. Immediate steroid therapy should be considered for IgG4‐SC patients with obstructive jaundice, acute cholangitis, and symptomatic extrabiliary IgG4‐related diseases (Recommendation 1, level D).
+
+
+Comment: Steroid therapy is recommended as the standard treatment for IgG4‐related disease 2, 137, 138. According to a nationwide survey in Japan, about 88% of IgG4‐SC patients receive steroid therapy 19. The steroid‐treated IgG4‐SC remission rate is 90% 19.
+
+According to the Japanese consensus guidelines for AIP, the indications for steroid therapy in AIP are the presence of symptoms (e.g. obstructive jaundice, abdominal pain, and back pain) and the presence of symptomatic extrapancreatic lesions 139. Furthermore, based on the international consensus guidance statement on the management and treatment of IgG4‐related disease, proximal biliary strictures as well as associated symptomatic IgG4‐related diseases, including aortitis, retroperitoneal fibrosis, tubulointerstitial nephritis, pachymeningitis, pericarditis, and diffuse pancreatic enlargement, have been reported as indications for urgent steroid therapy, which may include combination therapy consisting of higher steroid doses and other mechanical interventions, such as biliary stenting 138. Thus, it is recommended that almost all IgG4‐SC patients receive steroid therapy. Immediate steroid therapy should be considered in IgG4‐SC patients with obstructive jaundice, acute cholangitis, and symptomatic extrabiliary IgG4‐related diseases 138.
+
+It was reported that jaundice in some IgG4‐SC cases without acute cholangitis can be safely treated and effectively managed with steroid therapy alone, without any need for biliary stenting 140. However, biliary drainage should be considered in IgG4‐SC cases with acute cholangitis diagnosed based on the 2013 Tokyo Guidelines 126, 141, 142.
+
+Biliary stricture relapse has been reported in IgG4‐SC patients during steroid tapering or after withdrawal of steroid treatment, and development of new biliary strictures has been reported in untreated IgG4‐SC patients 16, 40, 143, 144. Relapse rates reportedly range from 16% 16 to 53% 144. Bile duct strictures reportedly improve to varying degrees after steroid treatment, but mild bile duct strictures can persist in some IgG4‐SC patients 16, 40. Consequently, steroid treatment is also recommended for asymptomatic IgG4‐SC patients with elevated serum hepatobiliary enzyme levels. Differential diagnosis between cholangiocarcinoma and pancreatic cancer should be made before starting steroid therapy in IgG4‐SC patients.
+
+
+We suggest performing biliary drainage in cases involving obstructive jaundice due to biliary stenosis (Recommendation 2, level D).Steroid therapy can be initiated without biliary drainage in cases involving mild jaundice without cholangitis in patients for whom the diagnosis is definite and pathologic approaches to the biliary stenosis are unnecessary (Recommendation 2, level D).
+
+
+We suggest performing biliary drainage in cases involving obstructive jaundice due to biliary stenosis (Recommendation 2, level D).
+
+Steroid therapy can be initiated without biliary drainage in cases involving mild jaundice without cholangitis in patients for whom the diagnosis is definite and pathologic approaches to the biliary stenosis are unnecessary (Recommendation 2, level D).
+
+
+Comment: In IgG4‐SC, it is important to differentiate bile duct invasion by pancreatic cancer or lower bile duct cancer in cases involving stenosis of the lower bile duct and to differentiate from hilar cholangiocarcinoma in cases involving stenosis of the upper or hilar bile duct. Regarding differential diagnosis, ERCP and related procedures play an important role. Many IgG4‐SC patients undergo ERCP, IDUS, transpapillary bile duct biopsy, and/or bile cytology with/without brushing, with ultimate insertion of an endoscopic nasobiliary drainage tube or plastic stent to relieve cholestasis and prevent cholangitis in a single session 138, 142, 145. According to one Japanese study 146 and an international survey 147, biliary drainage before starting steroids were underwent in 77% and 71% of AIP patients who presented with obstructive jaundice, respectively.
+
+On the other hand, in a study of 15 AIP patients, Bi et al. of the Mayo Clinic 140 reported that obstructive jaundice was safely and effectively treated with steroids alone without biliary stenting. Follow‐up serum liver tests at a mean of 4 days (range 1–14 days) after starting steroids showed rapid reduction in all measures: 54.9% decrease in aspartate aminotransferase (AST), 51.6% decrease in alanine aminotransferase (ALT), 33% decrease in alkaline phosphatase (ALP), and 47.2% decrease in total bilirubin (TB). By 15 to 45 days after steroid treatment, all patients had normal AST, three patients had ALT more than 1.5 × ULN (upper limit of normal), one patient had ALP more than 1.5 × ULN, and only one patient had TB more than 1.5 × ULN. No patients showed any infectious complications such as cholangitis during steroid treatment. Therefore, steroid therapy alone in a closely monitored setting under the guidance of an experienced pancreatologist is recommended for AIP patients with obstructive jaundice whose diagnosis is certain, thereby avoiding ERCP and its potential complications such as pancreatitis.
+
+Iwasaki et al. 136 reported 75%, 89%, and 83% decreases in serum levels of ALT, ALP, and TB, respectively, around 5 days after starting steroids in 19 patients with IgG4‐SC who were treated with steroids without biliary drainage, and the levels were halved in 63%, 89%, and 67% around 10 days after starting steroids. Bile duct stenosis improved in all patients except one on ERC performed 1–4 weeks after starting steroids.
+
+The above data suggest that as IgG4‐SC improves rapidly with steroids, steroid therapy can be initiated without ERC or biliary drainage in cases involving mild jaundice without cholangitis in patients for whom the diagnosis is definite and pathologic approaches to the biliary stenosis are unnecessary, such as in cases of stenosis of the lower bile duct associated with elevated serum IgG4 levels and diffuse enlargement of the pancreas 94, 148.
+
+
+We suggest oral prednisolone at 0.6 mg/kg/day (usual dose: 30–40 mg/day) for 2–4 weeks for initial remission‐induction therapy (Recommendation 2, level D).We suggest that the dose of prednisolone is reduced by 5 mg every 1–2 weeks after induction of remission, while confirming the response to steroid therapy by laboratory tests and imaging studies (e.g. ultrasonography, CT, or MRCP), and then gradually tapered further to the maintenance level by 2–3 months (Recommendation 2, level D).Although the recommended maintenance dose is 5 mg/day, adjusting the dose within the range of approximately 5 mg/day based on the patient's response is suggested (Recommendation 2, level D).After remission has been maintained for 3 years, it is possible to consider further reducing or discontinuing steroid therapy, but we suggest that this should be done carefully because there is a high risk of relapse (Recommendation 2, level C).We recommend periodic assessment of symptoms, analysis of objective findings such as jaundice, and biochemistry tests, serum IgG/IgG4 levels, and imaging findings after the initiation of steroid therapy as well as after discontinuation of therapy. Care should be taken to identify relapse, exclude malignancy, and control adverse reactions to steroid therapy while managing the clinical course of these patients (Recommendation 1, level D).
+
+
+We suggest oral prednisolone at 0.6 mg/kg/day (usual dose: 30–40 mg/day) for 2–4 weeks for initial remission‐induction therapy (Recommendation 2, level D).
+
+We suggest that the dose of prednisolone is reduced by 5 mg every 1–2 weeks after induction of remission, while confirming the response to steroid therapy by laboratory tests and imaging studies (e.g. ultrasonography, CT, or MRCP), and then gradually tapered further to the maintenance level by 2–3 months (Recommendation 2, level D).
+
+Although the recommended maintenance dose is 5 mg/day, adjusting the dose within the range of approximately 5 mg/day based on the patient's response is suggested (Recommendation 2, level D).
+
+After remission has been maintained for 3 years, it is possible to consider further reducing or discontinuing steroid therapy, but we suggest that this should be done carefully because there is a high risk of relapse (Recommendation 2, level C).
+
+We recommend periodic assessment of symptoms, analysis of objective findings such as jaundice, and biochemistry tests, serum IgG/IgG4 levels, and imaging findings after the initiation of steroid therapy as well as after discontinuation of therapy. Care should be taken to identify relapse, exclude malignancy, and control adverse reactions to steroid therapy while managing the clinical course of these patients (Recommendation 1, level D).
+
+
+Comment:
+
+
+1) Initial remission induction
+
+There have been few studies on steroid therapy for IgG4‐SC. Steroid therapy is indicated for patients who have AIP with symptoms, jaundice, and bile duct involvement. The standard treatment schedule recommended by the Japanese clinical guidelines for AIP 139 and the international consensus diagnostic criteria 148 is oral prednisolone (0.6 mg/kg/day) for 2–4 weeks as initial remission‐induction therapy, with subsequent tapering by 5 mg/day every 1–2 weeks and reduction to the maintenance dose by 2–3 months after the start of treatment, observing the patient's response throughout 146, 149. The Mayo Clinic also proposed a treatment schedule that starts with 4 weeks of oral prednisone at 40 mg/day, followed by tapering at 5 mg/week until discontinuation at 11 weeks 16, 150. In a Japanese multicenter study, biliary drainage was performed in 242/314 patients who had obstructive jaundice among 563 patients with AIP in order to compare a starting dose of 40 mg/day or 30 mg/day of oral prednisolone in 459 patients treated with steroids, but there was no difference of the time to remission or the relapse rate 146. Although there are reports of an observable effect even at low steroid doses (≤20 mg/day) in diabetic patients who are at risk of exacerbation of diabetes by steroid therapy 19, 151, patient selection bias cannot be ruled out in retrospective studies. It was also reported that steroid pulse therapy is more effective for improving early bile duct lesions compared with oral steroids when it is desirable to obtain a response in a short period 152, 153.
+
+2) Dose reduction after remission induction
+
+After induction of remission, the response to steroids is confirmed by laboratory tests and imaging studies. Steroid therapy is continued, with the dose gradually being tapered if other diseases are excluded, including cholangiocarcinoma, pancreatic cancer, and PSC. If improvement is not achieved by steroid therapy and the possibility of another disease is considered to be high, it is necessary to promptly review the diagnosis. After induction of remission with steroid therapy, the standard method is to reduce the dose of prednisolone by 5 mg every 1–2 weeks until the maintenance dose (5–10 mg/day) is finally reached at 2–3 months after starting treatment. Since it has been reported that there is a risk of relapse of SC, the steroid dose should be reduced while regularly checking for recurrence by monitoring symptoms and signs, biochemistry data, IgG/IgG4 levels, and imaging findings (e.g. ultrasonography, CT, MRCP, or ERCP). After prednisolone is reduced to 15 mg/day, the dose is reduced further at longer intervals in some cases 146. While pancreatic enlargement associated with AIP almost always improves after remission is achieved by steroid therapy, bile duct stenosis persists in 58% of patients with persistent elevation of IgG4 versus 27% of patients with normal IgG4 levels 146.
+
+3) Maintenance therapy
+
+A randomized controlled trial of steroid maintenance therapy was performed in 49 Japanese patients with AIP after induction of remission to compare maintenance therapy (5–7.5 mg/day) between a group treated for 3 years and a group in which therapy was discontinued at 26 weeks. It was found that the relapse rate up to 3 years was 23.3% in the former group versus 57.9% in the latter, and the long‐term maintenance therapy group had a significantly lower risk of relapse, with no serious steroid‐related adverse events 154. In a retrospective multicenter study of 510 patients with AIP 155, the relapse rate achieved with standard steroid therapy for AIP 139 was 10% at 1 year, 11% at 2 years, 25.8% at 3 years, 30.9% at 4 years, and 35.1% at 5 years, finally reaching a plateau at 43% after 7 years. When maintenance therapy was performed with a steroid dose of 2.5–10 mg/day, the relapse rate was significantly lower in the group that received ongoing maintenance therapy than in the group with withdrawal of therapy (30.3% vs. 45.2%). Also, when administration of oral prednisolone at various doses (0, 2.5, 5, 7.5, or 10 mg/day) was compared, the risk of relapse was the lowest at 5 mg/day (26.1%), and there were no significant differences between 5 mg, 7.5 mg, and 10 mg/day. Discontinuing steroid therapy in the short term has been the general policy in other countries. However, a retrospective study of 30 patients with SC performed at the Mayo Clinic showed that starting oral prednisone at 40 mg/day with tapering by 5 mg/week until discontinuation at 11 weeks resulted in a recurrence rate of 53% after a median of 3 months and 71% within 6 months 16. In a prospective study of IgG4‐SC performed in the United Kingdom, oral prednisolone was initiated at 30 mg/day for 2 weeks and then reduced by 5 mg every 2 weeks, resulting in a remission rate of 82%. However, 18% of the patients had no response to steroid therapy, and 35% developed recurrence after a median of 4 months 135. From these results, the consensus in Japan is that continuing long‐term maintenance therapy at a dose of approximately 5 mg/day for 3 years is desirable to prevent recurrence 139, 146, but there is no agreement regarding discontinuation of steroid therapy or further dose reduction after 3 years. Hirano et al. 156 performed a prospective trial in 21 patients with AIP who discontinued maintenance therapy after 3 years, and they found relapse in 48% of the patients during follow‐up for 43 months. Based on these results, they recommended that long‐term maintenance therapy should be continued beyond 3 years. A Japanese multicenter study of adverse events associated with steroid therapy reported an area under the curve of 0.717 when the cut‐off value for the total steroid dose was set at 6,405 mg 155. To avoid adverse reactions caused by long‐term administration of corticosteroids, the standard recommendation is to consider continuation of therapy, dose reduction, or discontinuation after 3 years, as the risk of infection increases with long‐term administration at 10 mg/day, and the risk of steroid‐associated osteoporosis is significantly increased when the total steroid dose reaches or exceeds 6,405 mg. In IgG4‐SC patients, we should carefully consider steroid dose reduction, maintenance therapy, and the duration of treatment for those with SC, as it has a high risk of relapse.
+
+
+We recommend both re‐administration and increasing the dose of steroids for treating relapse in IgG4‐SC patients (Recommendation 1, level D).Immunomodulatory drugs and rituximab are useful in some relapse cases. However, treatment with these drugs is not covered by the medical insurance system in Japan (level C).
+
+
+We recommend both re‐administration and increasing the dose of steroids for treating relapse in IgG4‐SC patients (Recommendation 1, level D).
+
+Immunomodulatory drugs and rituximab are useful in some relapse cases. However, treatment with these drugs is not covered by the medical insurance system in Japan (level C).
+
+
+Comment: Relapse of IgG4‐SC is generally defined as a reappearance of symptoms after remission (during maintenance steroid therapy or after steroid withdrawal), with the development or aggravation of bile duct strictures, and/or other organ involvement (e.g. AIP, IgG4‐related dacryoadenitis/sialadenitis, IgG4‐related retroperitoneal fibrosis) with abnormalities on imaging, and/or elevation of serum IgG4 levels 157, 158. Re‐elevation of serum IgG4 levels alone without symptoms or with the presence of bile duct strictures is not considered to be relapse 157, 158.
+
+Disease relapse occurs in 30–57% of IgG4‐SC patients either during maintenance steroid therapy or after the discontinuation of steroids, particularly in the first couple of years 58, 147. Relapse rates after steroid therapy are similar to those reported after surgery 16. In a retrospective cohort study of 507 patients with IgG4‐SC in Japan, relapse with restenosis of the bile ducts was noted in 104 patients (19%), and the cumulative rate of relapse was 1.6%, 7.6%, and 16.5% at 1, 3, and 5 years after diagnosis, respectively 19. Known risk factors predictive of a relapse include high serum IgG4 level at diagnosis, the presence of proximal extrahepatic/intrahepatic or multiple bile duct strictures, and thicker bile duct walls during the initial attack 16, 147, 157, 159.
+
+Both re‐administration and increasing the dose of steroids have been shown to be effective in treating relapse patients 139, 157. In Western countries, in addition to the re‐administration of steroids, immunomodulatory drugs such as azathioprine, 6‐mercaptopurine, mycophenolate mofetil, and methotrexate have been administered as steroid‐sparing agents for treating relapse in IgG4‐SC patients 16, 58, 135, 141, 157. However, the benefits of the additional immunomodulators in reducing time to further relapse are uncertain, and as these drugs are associated with serious side‐effects, their use should be considered with caution 157.
+
+Rituximab, a monoclonal anti‐CD20 antibody leading to B‐cell depletion, is reportedly effective for treatment of IgG4‐SC resistant to steroid and immunomodulator therapy. According to the limited data available, disease response is obtained in 80–90% of IgG4‐SC patients, including many with difficult‐to‐treat disease 157, 160, 161, 162.
+
+In international consensus statements for the treatment of AIP, immunomodulatory drugs or rituximab is recommended for relapse AIP as steroid‐sparing agents. However, treatment with these drugs for IgG4‐related diseases including IgG4‐SC is not covered by the medical insurance system in Japan 148.
+
+None declared.

--- a/references_cache/PMID_32353060.md
+++ b/references_cache/PMID_32353060.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:32353060"
+title: Management of biliary stricture in patients with IgG4-related sclerosing cholangitis.
+authors:
+- Miyazawa M
+- Takatori H
+- Kawaguchi K
+- Kitamura K
+- Arai K
+- Matsuda K
+- Urabe T
+- Inamura K
+- Komura T
+- Mizuno H
+- Fuchizaki U
+- Yamashita T
+- Sakai Y
+- Yamashita T
+- Mizukoshi E
+- Honda M
+- Kaneko S
+journal: PLoS One
+year: '2020'
+doi: 10.1371/journal.pone.0232089
+keywords:
+- Adrenal Cortex Hormones/therapeutic use
+- Aged
+- Bile Ducts/surgery
+- Biliary Tract Surgical Procedures/methods
+- Cholangitis/etiology
+- "Cholangitis, Sclerosing/complications, surgery, therapy"
+- Cholestasis/complications
+- "Constriction, Pathologic/complications, surgery"
+- Device Removal/adverse effects
+- Drainage/adverse effects
+- Female
+- Humans
+- Immunoglobulin G
+- "Jaundice, Obstructive/drug therapy, etiology, therapy"
+- Male
+- Middle Aged
+- Retrospective Studies
+- Risk Factors
+- "Sphincterotomy, Endoscopic/adverse effects"
+- Stents/adverse effects
+content_type: abstract_only
+---
+
+# Management of biliary stricture in patients with IgG4-related sclerosing cholangitis.
+**Authors:** Miyazawa M, Takatori H, Kawaguchi K, Kitamura K, Arai K, Matsuda K, Urabe T, Inamura K, Komura T, Mizuno H, Fuchizaki U, Yamashita T, Sakai Y, Yamashita T, Mizukoshi E, Honda M, Kaneko S
+**Journal:** PLoS One (2020)
+**DOI:** [10.1371/journal.pone.0232089](https://doi.org/10.1371/journal.pone.0232089)
+
+## Content
+
+1. PLoS One. 2020 Apr 30;15(4):e0232089. doi: 10.1371/journal.pone.0232089. 
+eCollection 2020.
+
+Management of biliary stricture in patients with IgG4-related sclerosing 
+cholangitis.
+
+Miyazawa M(1), Takatori H(1), Kawaguchi K(1), Kitamura K(1), Arai K(1), Matsuda 
+K(2), Urabe T(3), Inamura K(4), Komura T(5), Mizuno H(6), Fuchizaki U(7), 
+Yamashita T(1), Sakai Y(1), Yamashita T(1), Mizukoshi E(1), Honda M(1), Kaneko 
+S(1).
+
+Author information:
+(1)Department of gastroenterology, Kanazawa University Hospital, Kanazawa, 
+Japan.
+(2)Department of internal medicine, Toyama Prefectural Central Hospital, Toyama, 
+Japan.
+(3)Department of gastroenterology, Public Central Hospital of Matto Ishikawa, 
+Hakusan, Japan.
+(4)Department of internal medicine, Tonami General Hospital, Tonami, Japan.
+(5)Department of gastroenterology, National Hospital Organization Kanazawa 
+Medical Center, Kanazawa, Japan.
+(6)Department of gastroenterology, Toyama City Hospital, Toyama, Japan.
+(7)Department of gastroenterology, Keiju Medical Center, Nanao, Japan.
+
+BACKGROUND: We aimed to determine the optimal approach with endoscopic biliary 
+drainage (EBD) and corticosteroid (CS) for the treatment of IgG4-related 
+sclerosing cholangitis (ISC).
+METHODS: To evaluate the safety of EBD for treatment of biliary stricture caused 
+by ISC, we assessed the risk of stent dislodgement and sought to determine the 
+most appropriate time for stent removal. We also assessed the safety of 
+treatment with CS alone for patients with obstructive jaundice, and the rate of 
+and risk factors for biliary tract complications.
+RESULTS: Sixty-nine patients with ISC treated with CS were enrolled. 
+Twenty-eight patients (40.6%) were treated with EBD for biliary stricture before 
+CS initiation. Intentional stent removal was performed in thirteen (46.4%) after 
+confirming CS-induced improvement. Eleven of thirteen patients (84.6%) underwent 
+stent removal within 1 month after CS initiation and all their stent removals 
+were safely carried out without early (within two weeks) recurrence of 
+obstructive jaundice. Ten of twenty-eight patients (35.7%) experienced 
+spontaneous stent dislodgement after CS initiation, and seven (70%) of them 
+developed stent dislodgement two weeks to two months after CS initiation. Among 
+forty-one patients treated with CS alone without EBD, 10 patients had 
+obstructive jaundice at the time of CS initiation and all of them achieved 
+clinical improvement without biliary tract infection. During the follow-up, 
+three patients (4.3%), all of whom had undergone EBD, developed bile-duct 
+stones, while none of those treated with CS alone developed bile-duct stones (p 
+= 0.032). Long-term biliary stenting was a risk factor for bile-duct stones.
+CONCLUSIONS: Biliary stent removal should be carried out within 2 weeks after CS 
+initiation if biliary stricture improves to prevent stent dislodgement. 
+Obstructive jaundice can be treated safely with CS alone in patients without 
+infection. Clinicians should be aware of the possibility of bile-duct stones in 
+patients treated with EBD.
+
+DOI: 10.1371/journal.pone.0232089
+PMCID: PMC7192452
+PMID: 32353060 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_32770464.md
+++ b/references_cache/PMID_32770464.md
@@ -1,0 +1,104 @@
+---
+reference_id: "PMID:32770464"
+title: "The long-term outcomes of patients with immunoglobulin G4-related sclerosing cholangitis: the Mayo Clinic experience."
+authors:
+- Ali AH
+- Bi Y
+- Machicado JD
+- Garg S
+- Lennon RJ
+- Zhang L
+- Takahashi N
+- Carey EJ
+- Lindor KD
+- Buness JG
+- Tabibian JH
+- Chari ST
+journal: J Gastroenterol
+year: '2020'
+doi: 10.1007/s00535-020-01714-7
+keywords:
+- Aged
+- Bile Duct Neoplasms/epidemiology
+- Cholangiocarcinoma/epidemiology
+- "Cholangitis, Sclerosing/diagnosis, drug therapy, immunology"
+- Cohort Studies
+- Female
+- Follow-Up Studies
+- Humans
+- "Immunoglobulin G4-Related Disease/diagnosis, drug therapy, immunology"
+- "Immunosuppressive Agents/administration & dosage"
+- Liver Cirrhosis/epidemiology
+- Male
+- Middle Aged
+- "Prednisone/administration & dosage"
+- Retrospective Studies
+- Survival Rate
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# The long-term outcomes of patients with immunoglobulin G4-related sclerosing cholangitis: the Mayo Clinic experience.
+**Authors:** Ali AH, Bi Y, Machicado JD, Garg S, Lennon RJ, Zhang L, Takahashi N, Carey EJ, Lindor KD, Buness JG, Tabibian JH, Chari ST
+**Journal:** J Gastroenterol (2020)
+**DOI:** [10.1007/s00535-020-01714-7](https://doi.org/10.1007/s00535-020-01714-7)
+
+## Content
+
+1. J Gastroenterol. 2020 Nov;55(11):1087-1097. doi: 10.1007/s00535-020-01714-7. 
+Epub 2020 Aug 8.
+
+The long-term outcomes of patients with immunoglobulin G4-related sclerosing 
+cholangitis: the Mayo Clinic experience.
+
+Ali AH(#)(1), Bi Y(#)(2), Machicado JD(3), Garg S(1), Lennon RJ(4), Zhang L(5), 
+Takahashi N(6), Carey EJ(7), Lindor KD(7)(8), Buness JG(9), Tabibian JH(10)(11), 
+Chari ST(12).
+
+Author information:
+(1)Division of Gastroenterology and Hepatology, Mayo Clinic College of Medicine, 
+200 1st St SW, Rochester, MN, 55905, USA.
+(2)Division of Gastroenterology and Hepatology, Mayo Clinic, Jacksonville, FL, 
+USA.
+(3)Division of Gastroenterology and Hepatology, Mayo Clinic Health System, Eau 
+Claire, WI, USA.
+(4)Division of Biomedical Statistics and Informatics, Mayo Clinic, Rochester, 
+MN, USA.
+(5)Department of Pathology, Mayo Clinic, Rochester, MN, USA.
+(6)Department of Radiology, Mayo Clinic, Rochester, MN, USA.
+(7)Division of Gastroenterology and Hepatology, Mayo Clinic, Phoenix, AZ, USA.
+(8)Arizona State University, Tempe, AZ, USA.
+(9)Arizona College of Osteopathic Medicine, Midwestern University, Glendale, AZ, 
+USA.
+(10)Division of Gastroenterology, Olive View-UCLA Medical Center, Sylmar, CA, 
+USA.
+(11)David Geffen School of Medicine at UCLA, Los Angeles, CA, USA.
+(12)Division of Gastroenterology and Hepatology, Mayo Clinic College of 
+Medicine, 200 1st St SW, Rochester, MN, 55905, USA. Chari.Suresh@mayo.edu.
+(#)Contributed equally
+
+BACKGROUND: The long-term outcomes of immunoglobulin G4-related sclerosing 
+cholangitis (IgG4-SC) are not well known.
+METHODS: The outcomes of patients with IgG4-SC at Mayo Clinic (1999-2018) were 
+compared to an age- and gender-matched (1:1 ratio) group of patients with 
+primary sclerosing cholangitis (PSC).
+RESULTS: We identified 89 patients with IgG4-SC; median age at diagnosis was 
+67 years, 81% were males, and the median follow-up was 5.7 years. Seventy-eight 
+patients received prednisone for induction of remission, and 53 received at 
+least one other immunosuppressive agent for maintenance of remission. Of the 
+IgG4-SC group, 10 died (median time from diagnosis until death was 6.5 years): 2 
+due to cirrhosis, 3 due to cholangiocarcinoma (CCA), and 5 due to 
+non-hepatobiliary causes. Eleven patients in the PSC group underwent liver 
+transplantation, while none did in the IgG4-SC group. The incidence of a 
+hepatobiliary adverse event (cirrhosis or CCA) was 3.4 times greater in the PSC 
+compared to the IgG4-SC group (events per 1000 person-years: 52.6; 95% CI 38-73; 
+vs. 15.6; 95% CI 7-32). The probability of development of a hepatobiliary 
+adverse event within 10 years was 11% in the IgG4-SC compared to 45% in the PSC 
+group (P = 0.0001). The overall survival tended to be higher in the IgG4-SC 
+compared to the PSC group (10-year: 79% vs. 68%, respectively; P = 0.11).
+CONCLUSIONS: In a cohort of IgG4-SC patients, 88% of whom were treated with 
+immunosuppressive drugs, the risk of cirrhosis and CCA was significantly lower 
+compared to an age- and gender-matched group with PSC.
+
+DOI: 10.1007/s00535-020-01714-7
+PMID: 32770464 [Indexed for MEDLINE]

--- a/references_cache/PMID_39819503.md
+++ b/references_cache/PMID_39819503.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:39819503"
+title: Epigenetic age acceleration and methylation differences in IgG4-related cholangitis and primary sclerosing cholangitis.
+authors:
+- Noble A
+- Motta R
+- Cabras S
+- Flores BM
+- Nowak J
+- Glapa-Nowak A
+- Geremia A
+- Satsangi J
+- Culver E
+journal: Clin Epigenetics
+year: '2025'
+doi: 10.1186/s13148-024-01803-x
+keywords:
+- Humans
+- "Cholangitis, Sclerosing/genetics"
+- DNA Methylation
+- Male
+- Female
+- Middle Aged
+- "Epigenesis, Genetic"
+- Adult
+- Aged
+- Immunoglobulin G
+- "Colitis, Ulcerative/genetics"
+- Case-Control Studies
+- Age Factors
+- Immunoglobulin G4-Related Disease/genetics
+- Cholangitis/genetics
+content_type: abstract_only
+---
+
+# Epigenetic age acceleration and methylation differences in IgG4-related cholangitis and primary sclerosing cholangitis.
+**Authors:** Noble A, Motta R, Cabras S, Flores BM, Nowak J, Glapa-Nowak A, Geremia A, Satsangi J, Culver E
+**Journal:** Clin Epigenetics (2025)
+**DOI:** [10.1186/s13148-024-01803-x](https://doi.org/10.1186/s13148-024-01803-x)
+
+## Content
+
+1. Clin Epigenetics. 2025 Jan 16;17(1):6. doi: 10.1186/s13148-024-01803-x.
+
+Epigenetic age acceleration and methylation differences in IgG4-related 
+cholangitis and primary sclerosing cholangitis.
+
+Noble A(#)(1), Motta R(#)(1), Cabras S(1), Flores BM(1), Nowak J(2), Glapa-Nowak 
+A(2), Geremia A(1), Satsangi J(#)(3)(4), Culver E(#)(1).
+
+Author information:
+(1)Translational Gastroenterology and Liver Unit, John Radcliffe Hospital, 
+Headley Way, Headington, Oxford, OX3 9DU, UK.
+(2)Department of Pediatric Gastroenterology and Metabolic Diseases, Poznan 
+University of Medical Sciences, Poznan, Poland.
+(3)Translational Gastroenterology and Liver Unit, John Radcliffe Hospital, 
+Headley Way, Headington, Oxford, OX3 9DU, UK. jack.satsangi@ndm.ox.ac.uk.
+(4)Nuffield Department of Medicine, University of Oxford, Oxford, UK. 
+jack.satsangi@ndm.ox.ac.uk.
+(#)Contributed equally
+
+BACKGROUND: IgG4-related cholangitis (IgG4-SC) and primary sclerosing 
+cholangitis (PSC) are chronic fibro-inflammatory hepatobiliary conditions, with 
+genetic, environmental, and immunologic risk factors, in which epigenetic 
+alterations may provide insights into pathophysiology and novel biomarkers. This 
+study is the first to assess methylation signatures in IgG4-SC.
+RESULTS: Whole blood DNA methylation profiling and genotyping was performed in 
+264 individuals; 47 with IgG4-SC, 65 with PSC, 64 with ulcerative colitis (UC), 
+and 88 healthy controls. We identified 19 significant methylation differences 
+between IgG4-SC and controls and 38 between PSC and controls. IgG4-SC and PSC 
+shared 8 probes. Inflammatory genes (including CEP97, IFNAR1, TXK, HERC6, 
+C5orf36, PYY, and MTRNR2L1) were predominantly involved in dysregulated 
+methylation. Epigenetic age acceleration was observed in patients with IgG4-SC, 
+but not in those with PSC or UC. meQTL analyses to identify genetic determinants 
+of methylation revealed a strong human leucocyte antigen (HLA) signal in both 
+PSC and IgG4-SC (HLA-DQB2, HLA-DPA1, HLA-F and HLA-DRA).
+CONCLUSIONS: We identify novel epigenetic alterations in IgG4-SC and PSC, with 
+biological age acceleration in IgG4-SC, providing insights into disease 
+pathogenesis, and highlight the role of genetic variation especially within the 
+HLA region in shaping the methylome.
+
+© 2024. The Author(s).
+
+DOI: 10.1186/s13148-024-01803-x
+PMCID: PMC11740490
+PMID: 39819503 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Ethics approval and consent to 
+participate: Ethical approval for the study was obtained from the Research 
+Ethics Committee Oxfordshire (10/H0604/51) and the Oxford Radcliffe Biobank 
+(19/SC/0173). Competing interests: EC provides educational material and consults 
+for Amgen (Horizon Therapeutics), Zenus BioPharma, Falk Pharma, Ipsen, Mirum, 
+Intercept, Advance Therapeutics and Moderna. JS has received lecture fees from 
+Takeda and from the Falk Foundation.

--- a/references_cache/PMID_40191403.md
+++ b/references_cache/PMID_40191403.md
@@ -1,0 +1,71 @@
+---
+reference_id: "PMID:40191403"
+title: "Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance."
+authors:
+- Herta T
+- Schröder M
+- Geisel D
+- Engelmann C
+- Tacke F
+journal: Gastroenterol Rep (Oxf)
+year: '2025'
+doi: 10.1093/gastro/goaf032
+content_type: abstract_only
+---
+
+# Management of IgG4-related cholangitis: diagnosis, therapy, and long-term surveillance.
+**Authors:** Herta T, Schröder M, Geisel D, Engelmann C, Tacke F
+**Journal:** Gastroenterol Rep (Oxf) (2025)
+**DOI:** [10.1093/gastro/goaf032](https://doi.org/10.1093/gastro/goaf032)
+
+## Content
+
+1. Gastroenterol Rep (Oxf). 2025 Apr 4;13:goaf032. doi: 10.1093/gastro/goaf032. 
+eCollection 2025.
+
+Management of IgG4-related cholangitis: diagnosis, therapy, and long-term 
+surveillance.
+
+Herta T(1)(2), Schröder M(1), Geisel D(3), Engelmann C(1), Tacke F(1).
+
+Author information:
+(1)Department of Hepatology and Gastroenterology, Charité-Universitätsmedizin 
+Berlin, Campus Virchow-Klinikum (CVK) and Campus Charité Mitte (CCM), Berlin, 
+Germany.
+(2)Berlin Institute of Health at Charité-Universitätsmedizin Berlin, BIH 
+Biomedical Innovation Academy, BIH Charité Clinician Scientist Program, Berlin, 
+Germany.
+(3)Department of Radiology, Charité-Universitätsmedizin Berlin, Berlin, Germany.
+
+IgG4-related cholangitis (IRC) is a chronic cholestatic liver disease that often 
+occurs concomitantly with autoimmune pancreatitis type 1. Both conditions are 
+manifestations of IgG4-related disease, a systemic autoimmune-mediated 
+fibroinflammatory disorder. Patients often present with jaundice and weight 
+loss, mimicking hepatobiliary malignancies, such as cholangiocarcinoma, primary 
+sclerosing cholangitis, and pancreatic cancer. Accurate diagnosis is challenging 
+due to the absence of pathognomonic findings but can be achieved using the 
+HISORt criteria (histology, imaging, serology, other organ involvement, and 
+response to immunosuppressive therapy). Early diagnosis is critical to avoid 
+unnecessary surgery and prevent progression to liver fibrosis or cirrhosis. IRC 
+responds well to corticosteroid therapy, though relapses are common, 
+necessitating long-term immunosuppressive treatment in many cases. 
+Steroid-sparing agents for remission induction and maintenance therapy comprise 
+immunomodulators, such as azathioprine, as well as B-cell depletion therapies, 
+such as rituximab. This review provides a structured clinical overview of the 
+diagnosis, differential diagnosis, and therapy, including novel therapeutic 
+options, such as inebilizumab, for this rare yet severe condition. A key focus 
+is on long-term surveillance strategies, which include laboratory tests, imaging 
+(contrast-enhanced magnetic resonance imaging/magnetic resonance 
+cholangiopancreatography, ultrasound, endosonography), and, particularly in 
+patients with fibrotic bile duct strictures, endoscopy (endoscopic retrograde 
+cholangiopancreatography, cholangioscopy).
+
+© The Author(s) 2025. Published by Oxford University Press and Sixth Affiliated 
+Hospital of Sun Yat-sen University.
+
+DOI: 10.1093/gastro/goaf032
+PMCID: PMC11972112
+PMID: 40191403
+
+Conflict of interest statement: The authors declare that there is no conflict of 
+interests in this work.

--- a/references_cache/PMID_41500843.md
+++ b/references_cache/PMID_41500843.md
@@ -1,0 +1,131 @@
+---
+reference_id: "PMID:41500843"
+title: Multicenter Validation Study of the Clinical Diagnostic Criteria for IgG4-Related Sclerosing Cholangitis 2020 in Japan.
+authors:
+- Naitoh I
+- Nakazawa T
+- Kubota K
+- Nishino T
+- Nakamura A
+- Inoue D
+- Sano T
+- Kikuta K
+- Kurita Y
+- Chiba K
+- Ikeura T
+- Matsubayashi H
+- Ishikawa T
+- Kuwatani M
+- Kamisawa T
+- Yasuda I
+- Kawano M
+- Masamune A
+- Japan Pancreatitis Study Group
+journal: J Hepatobiliary Pancreat Sci
+year: '2026'
+doi: 10.1002/jhbp.70056
+keywords:
+- Humans
+- "Cholangitis, Sclerosing/diagnosis, immunology"
+- Japan
+- Male
+- Female
+- Middle Aged
+- Aged
+- Immunoglobulin G/blood
+- Immunoglobulin G4-Related Disease/diagnosis
+- Sensitivity and Specificity
+- Bile Duct Neoplasms/diagnosis
+- Cholangiocarcinoma/diagnosis
+- "Diagnosis, Differential"
+- Pancreatic Neoplasms/diagnosis
+- Retrospective Studies
+- Adult
+content_type: abstract_only
+---
+
+# Multicenter Validation Study of the Clinical Diagnostic Criteria for IgG4-Related Sclerosing Cholangitis 2020 in Japan.
+**Authors:** Naitoh I, Nakazawa T, Kubota K, Nishino T, Nakamura A, Inoue D, Sano T, Kikuta K, Kurita Y, Chiba K, Ikeura T, Matsubayashi H, Ishikawa T, Kuwatani M, Kamisawa T, Yasuda I, Kawano M, Masamune A, Japan Pancreatitis Study Group
+**Journal:** J Hepatobiliary Pancreat Sci (2026)
+**DOI:** [10.1002/jhbp.70056](https://doi.org/10.1002/jhbp.70056)
+
+## Content
+
+1. J Hepatobiliary Pancreat Sci. 2026 Apr;33(4):294-303. doi: 10.1002/jhbp.70056.
+ Epub 2026 Jan 7.
+
+Multicenter Validation Study of the Clinical Diagnostic Criteria for 
+IgG4-Related Sclerosing Cholangitis 2020 in Japan.
+
+Naitoh I(1), Nakazawa T(2), Kubota K(3), Nishino T(4), Nakamura A(5), Inoue 
+D(6), Sano T(7), Kikuta K(7), Kurita Y(3), Chiba K(8), Ikeura T(9), Matsubayashi 
+H(10), Ishikawa T(11), Kuwatani M(12), Kamisawa T(13), Yasuda I(14), Kawano 
+M(15), Masamune A(7); Japan Pancreatitis Study Group.
+
+Collaborators: Pancreatitis Study Group J, Abe Y, Irisawa A, Tanaka H, Ohno E, 
+Maruo T, Ueki T, Suzuki R, Takagi T, Ohira H, Tanoue S, Ido A, Komori T, Atsuo 
+K, Horibe M, Iwasaki E, Tsujimae M, Kodama Y, Uchida K, Ueno M, Notohara K, 
+Kakehashi S, Fujimori N, Nakatani E, Hori Y, Yoshida M, Kawashima H, Hayashi K, 
+Terai S, Morimoto K, Sato R, Matsumoto K, Kato H, Masaki Y, Nakase H, Arizumi T, 
+Tanaka A, Matusmoto R, Takikawa T, Tonozuka R, Itoi T, Hirano K, Hayashi N.
+
+Author information:
+(1)Department of Gastroenterology, Nagoya City University Midori Municipal 
+Hospital, Nagoya, Japan.
+(2)Department of Gastroenterology and Metabolism, Nagoya City University 
+Graduate School of Medical Sciences, Nagoya, Japan.
+(3)Department of Gastroenterology and Hepatology, Yokohama City University 
+Hospital, Yokohama, Japan.
+(4)Department of Gastroenterology, Tokyo Women's Medical University Yachiyo 
+Medical Center, Yachiyo, Japan.
+(5)Department of Medicine, Gastroenterology, Shinshu University, Matsumoto, 
+Nagano, Japan.
+(6)Department of Radiology, Kanazawa University Hospital, Kanazawa, Japan.
+(7)Division of Gastroenterology, Tohoku University Graduate School of Medicine, 
+Sendai, Japan.
+(8)Department of Internal Medicine, Tokyo Metropolitan Komagome Hospital, Tokyo, 
+Japan.
+(9)Third Department of Internal Medicine, Division of Gastroenterology and 
+Hepatology, Kansai Medical University, Hirakata, Japan.
+(10)Division of Endoscopy, Shizuoka Cancer Center, Shizuoka, Japan.
+(11)Department of Gastroenterology and Hepatology, Nagoya University Graduate 
+School of Medicine, Nagoya, Japan.
+(12)Department of Gastroenterology and Hepatology, Hokkaido University Hospital, 
+Sapporo, Japan.
+(13)Division of Gastroenterology and Center of IgG4-Related Disease, Department 
+of Internal Medicine, Tokyo Metropolitan Komagome Hospital, Tokyo, Japan.
+(14)Third Department of Internal Medicine, University of Toyama, Toyama, Japan.
+(15)Department of Hematology & Immunology, Kanazawa Medical University, 
+Kahoku-Gun, Japan.
+
+BACKGROUND: The diagnostic performance of clinical diagnostic criteria for 
+IgG4-related sclerosing cholangitis 2020 (IgG4-SC2020) has not been fully 
+validated since its proposal as a revision of the 2012 criteria (IgG4-SC2012).
+METHODS: We conducted a multicenter validation study to evaluate the diagnostic 
+performance of IgG4-SC2020 using clinical data collected from 1034 patients with 
+IgG4-SC and 447 patients with mimickers, including 143 with pancreatic cancer, 
+157 with primary sclerosing cholangitis, and 147 with cholangiocarcinoma in 
+Japan.
+RESULTS: The sensitivity of IgG4-SC2020 was significantly higher than that of 
+IgG4-SC2012 (99.0% vs. 89.1%; p < 0.001). The specificities of both IgG4-SC2020 
+and IgG4-SC2012 were 100% for pancreatic cancer and cholangiocarcinoma. For 
+primary sclerosing cholangitis, the specificities of IgG4-SC2020 and IgG4-SC2012 
+were 97.5% and 100%, respectively, with no significant difference (p = 0.123). A 
+total of 113 patients who could not be diagnosed according to the IgG4-SC2012 
+were successfully diagnosed using IgG4-SC2020. These diagnostic improvements 
+were attributed to the inclusion of MRCP findings (n = 97), the absence of 
+neoplastic cells on histology (n = 15), and the presence of IgG4-related kidney 
+lesions (n = 1).
+CONCLUSIONS: This Japanese multicenter validation study demonstrated that the 
+diagnostic performance of IgG4-SC2020 was superior to that of IgG4-SC2012.
+TRIAL REGISTRATION: UMIN Clinical Trials Registry (UMIN-CTR), UMIN000052984.
+
+© 2026 The Author(s). Journal of Hepato‐Biliary‐Pancreatic Sciences published by 
+John Wiley & Sons Australia, Ltd on behalf of Japanese Society of 
+Hepato‐Biliary‐Pancreatic Surgery.
+
+DOI: 10.1002/jhbp.70056
+PMCID: PMC13113202
+PMID: 41500843 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/clinicaltrials_NCT02616705.md
+++ b/references_cache/clinicaltrials_NCT02616705.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT02616705
+title: Bile Usefulness for Detecting IgG4-related Sclerosing Cholangitis
+content_type: summary
+---
+
+# Bile Usefulness for Detecting IgG4-related Sclerosing Cholangitis
+
+## Content
+
+Immunoglobulin G4-related disease (IgG4-RD) is an uncommon inflammatory disorder that may affect multiple organ systems, including the biliary tree. IgG4-sclerosing cholangitis (IgG4-SC) can be difficult to distinguish from primary sclerosing cholangitis (PSC) or cholangiocarcinoma (CCA). The investigators aim to evaluate the sensitivity and specificity of bile for the diagnosis of IgG4-SC. Bile samples of patients with biliary strictures of various causes, including IgG4-SC, PSC, and CCA, will be collected during clinical cholangiography procedures. IgG4 will be measured in bile specimens and bile IgG4 concentrations compared between IgG4-SC, PSC, CCA, and other types of biliary strictures.

--- a/research/IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
+++ b/research/IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md
@@ -1,0 +1,1295 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-06T22:04:10.418988'
+end_time: '2026-05-06T22:24:30.309673'
+duration_seconds: 1219.89
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: IgG4-Related Sclerosing Cholangitis
+  mondo_id: ''
+  category: Autoimmune
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 41
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** IgG4-Related Sclerosing Cholangitis
+- **MONDO ID:**  (if available)
+- **Category:** Autoimmune
+
+## Research Objectives
+
+Please provide a comprehensive research report on **IgG4-Related Sclerosing Cholangitis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** IgG4-Related Sclerosing Cholangitis
+- **MONDO ID:**  (if available)
+- **Category:** Autoimmune
+
+## Research Objectives
+
+Please provide a comprehensive research report on **IgG4-Related Sclerosing Cholangitis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Disease Characteristics Report: IgG4-Related Sclerosing Cholangitis (IgG4-SC)
+
+### Executive summary
+IgG4-related sclerosing cholangitis (IgG4-SC), also termed IgG4-related cholangitis (IRC), is a chronic cholestatic fibroinflammatory disease of the bile ducts and a hepatobiliary manifestation of systemic IgG4-related disease (IgG4-RD). It frequently co-occurs with type 1 autoimmune pancreatitis (AIP) and can mimic primary sclerosing cholangitis (PSC) or cholangiocarcinoma (CCA), making multimodal diagnosis essential. Corticosteroids are highly effective for induction but relapse is common; B-cell depletion (rituximab) reduces relapse in relapsing pancreaticobiliary IgG4-RD cohorts, and large observational cohorts/registries are actively evaluating outcomes and diagnostic biomarkers. (herta2025managementofigg4related pages 1-2, ali2020thelongtermoutcomes pages 1-2, majumder2018rituximabmaintenancetherapy pages 1-2)
+
+| Domain | Finding (with numeric values) | Evidence type (guideline/cohort/review) | Key source (author year journal) | URL | Citation ID |
+|---|---|---|---|---|---|
+| Epidemiology/demographics | Estimated prevalence in Japan: **2.0 per 100,000** (~2,500 patients); extrapolated prevalence/incidence among AIP patients: **1.8 per 100,000** and **0.5 per 100,000** | Guideline | Kamisawa et al. 2019, *J Hepatobiliary Pancreat Sci* | https://doi.org/10.1002/jhbp.596 | (kamisawa2019clinicalpracticeguidelines pages 6-7) |
+| Epidemiology/demographics | IgG4-SC is strongly male-predominant: **~80% male**; reported age at diagnosis generally **60–70 years**, range **23.0–88.5 years** | Guideline/review | Kamisawa et al. 2019, *J Hepatobiliary Pancreat Sci* | https://doi.org/10.1002/jhbp.596 | (kamisawa2019clinicalpracticeguidelines pages 6-7) |
+| Epidemiology/demographics | Mayo cohort: median age at diagnosis **67 years**; **81% male** (72/89); median follow-up **5.7 years** | Cohort | Ali et al. 2020, *Journal of Gastroenterology* | https://doi.org/10.1007/s00535-020-01714-7 | (ali2020thelongtermoutcomes pages 2-4) |
+| Organ association | Concomitant autoimmune pancreatitis (AIP) is frequent: **~90%** in guideline summary; **72%** had past/present pancreatitis in Mayo cohort | Guideline/cohort | Kamisawa et al. 2019; Ali et al. 2020 | https://doi.org/10.1002/jhbp.596 ; https://doi.org/10.1007/s00535-020-01714-7 | (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 2-4) |
+| Diagnostic framework | **HISORt** framework = Histology, Imaging, Serology, Other organ involvement, Response to therapy | Review | Herta et al. 2025, *Gastroenterology Report* | https://doi.org/10.1093/gastro/goaf032 | (herta2025managementofigg4related pages 1-2) |
+| Diagnostic histology thresholds | Suggestive/definitive histology thresholds: **>10 IgG4+ plasma cells/HPF** in biopsy or **>50/HPF** in resection; **IgG4+/IgG+ ratio >0.4 (40%)** | Review | Herta et al. 2025, *Gastroenterology Report*; Smit et al. 2016, *Clinics in Liver Disease* | https://doi.org/10.1093/gastro/goaf032 ; https://doi.org/10.1016/j.cld.2015.08.004 | (herta2025managementofigg4related pages 1-2, smit2016newthoughtson pages 6-8) |
+| Diagnostic serology | Serum IgG4 elevated in **~80%** of patients; **>4× ULN** is highly specific but insensitive; modest elevation can occur in **10–15%** of PSC/CCA | Review | Ren et al. 2026, *Frontiers in Medicine* | https://doi.org/10.3389/fmed.2026.1732637 | (ren2026igg4relatedsclerosingcholangitis pages 2-3) |
+| Diagnostic classification | Japanese **IgG4-SC2020** criteria comprise **6 domains**: bile-duct narrowing, bile-duct wall thickening, serology, pathology, other-organ involvement, and treatment/response | Validation study | Naitoh et al. 2026, *J Hepatobiliary Pancreat Sci* | https://doi.org/10.1002/jhbp.70056 | (naitoh2026multicentervalidationstudy pages 2-2) |
+| Diagnostic performance | In **1,034 IgG4-SC** cases and **447 mimickers**, sensitivity of IgG4-SC2020 vs 2012 was **99.0% vs 89.1%**; specificity was **100%** for pancreatic cancer and cholangiocarcinoma, and **97.5% vs 100%** for PSC | Validation study | Naitoh et al. 2026, *J Hepatobiliary Pancreat Sci* | https://doi.org/10.1002/jhbp.70056 | (naitoh2026multicentervalidationstudy pages 1-2) |
+| Imaging phenotype | Cholangiographic subtype frequencies in Japanese survey: type 1 **64%**, type 2a **5%**, type 2b **8%**, type 3 **10%**, type 4 **10%** | Guideline | Kamisawa et al. 2019, *J Hepatobiliary Pancreat Sci* | https://doi.org/10.1002/jhbp.596 | (kamisawa2019clinicalpracticeguidelines pages 2-4) |
+| Outcome/prognosis | Hepatobiliary adverse events were lower than in PSC: **15.6 vs 52.6 events/1000 person-years**; **10-year hepatobiliary event probability 11% vs 45%** | Cohort | Ali et al. 2020, *Journal of Gastroenterology* | https://doi.org/10.1007/s00535-020-01714-7 | (ali2020thelongtermoutcomes pages 1-2) |
+| Survival | **10-year survival 79%** in IgG4-SC vs **68%** in matched PSC cohort | Cohort | Ali et al. 2020, *Journal of Gastroenterology* | https://doi.org/10.1007/s00535-020-01714-7 | (ali2020thelongtermoutcomes pages 1-2) |
+| Cirrhosis/cancer outcomes | Progression to cirrhosis reported at **~5.2–7.5%**; lifetime cholangiocarcinoma risk in Mayo cohort **3.4%** | Cohort/reviewed cohort findings | Ali et al. 2020, *Journal of Gastroenterology* | https://doi.org/10.1007/s00535-020-01714-7 | (ali2020thelongtermoutcomes pages 7-8) |
+| Relapse after steroids | Post-steroid relapse reported as **40%** after an **11-week** steroid course; another study cited **50%** relapse at median **4.6 months** after stopping first steroid course | Review | Hegade et al. 2019, *Frontline Gastroenterology* | https://doi.org/10.1136/flgastro-2018-101001 | (hegade2019diagnosisandmanagement pages 5-6, hegade2019diagnosisandmanagement pages 4-5) |
+| Relapse risk summary | Reviews summarize relapse in **30–50%** of patients despite high initial steroid responsiveness | Review | Ren et al. 2026, *Frontiers in Medicine* | https://doi.org/10.3389/fmed.2026.1732637 | (ren2026igg4relatedsclerosingcholangitis pages 2-3) |
+| Rituximab outcomes | In pancreaticobiliary IgG4-RD, **86%** achieved steroid-free remission at **6 months** after rituximab; **3-year relapse/event rate 45%** with induction alone vs **11%** with maintenance (**P=.034**) | Cohort | Majumder et al. 2018, *Clin Gastroenterol Hepatol* | https://doi.org/10.1016/j.cgh.2018.02.049 | (majumder2018rituximabmaintenancetherapy pages 1-2) |
+| Biliary drainage outcomes | In 69 CS-treated patients, **40.6%** underwent endoscopic biliary drainage before CS; spontaneous stent dislodgement occurred in **35.7%** after CS; bile-duct stones developed in **4.3%**, all in EBD-treated patients | Cohort | Miyazawa et al. 2020, *PLoS ONE* | https://doi.org/10.1371/journal.pone.0232089 | (miyazawa2020managementofbiliary pages 1-2) |
+
+
+*Table: This table summarizes evidence-backed epidemiology, diagnostic criteria, and outcome statistics for IgG4-related sclerosing cholangitis/IgG4-related cholangitis. It is useful as a quick-reference artifact for disease knowledge base curation and clinical comparison with PSC and cholangiocarcinoma.*
+
+---
+
+## 1. Disease Information
+
+### 1.1 What is the disease?
+IgG4-SC is an immune-mediated chronic fibroinflammatory cholangitis characterized by bile-duct strictures and wall thickening, lymphoplasmacytic inflammation rich in IgG4-positive plasma cells, fibrosis, and a typically strong response to glucocorticoids. It is widely recognized as the biliary manifestation of IgG4-RD and frequently occurs with type 1 AIP. (kamisawa2019clinicalpracticeguidelines pages 2-4, ali2020thelongtermoutcomes pages 1-2, beuers2025igg4relatedcholangitis pages 1-3)
+
+### 1.2 Key identifiers (OMIM, Orphanet, ICD-10/ICD-11, MeSH, MONDO)
+* **ICD-10 / ICD-11 / MeSH / MONDO / Orphanet / OMIM:** Not explicitly provided in the full-text evidence retrievable in this run; therefore these IDs cannot be asserted here without external ontology lookups. (hegade2019diagnosisandmanagement pages 1-2)
+
+### 1.3 Synonyms and alternative names
+* **IgG4-related cholangitis (IRC)** (synonym/alternative name) (herta2025managementofigg4related pages 1-2, beuers2025igg4relatedcholangitis pages 1-3)
+* **IgG4-associated cholangitis** (common earlier terminology in reviews; overlaps with IgG4-SC/IRC concept) (cargill2017igg4relatedsclerosingcholangitis pages 2-4)
+* Broader/related historical umbrella terms for IgG4-RD include **IgG4-related sclerosing disease**, **IgG4-multiorgan lymphoproliferative syndrome**, etc. (hegade2019diagnosisandmanagement pages 1-2)
+
+### 1.4 Evidence source type (individual vs aggregated)
+The report is derived from **aggregated disease-level resources** (clinical practice guidelines, multicenter diagnostic validation, and large cohorts) and selected trial registry entries. (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 1-2, naitoh2026multicentervalidationstudy pages 1-2, NCT02616705 chunk 1)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (mechanistic)
+IgG4-SC is best understood as an **immune-mediated, antigen-driven fibroinflammatory disease** in genetically susceptible individuals. Mechanistically, a dysregulated adaptive immune response (including Th2/Treg-skewed cytokine milieu) promotes B-cell activation and expansion of IgG4+ B cells/plasmablasts, contributing to chronic inflammation and progressive fibrosis. (ren2026igg4relatedsclerosingcholangitis pages 2-3, smit2016newthoughtson pages 12-14)
+
+### 2.2 Risk factors
+
+#### Demographic
+* Predominantly affects **older men** (guideline summary: ~80% male; typical age at diagnosis ~60–70 years; Mayo cohort median 67 years, 81% male). (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 2-4)
+
+#### Clinical
+* Strong association with **type 1 autoimmune pancreatitis (AIP)** (≈90% concomitance in guideline summary; 72% with past/present pancreatitis in Mayo cohort). (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 2-4)
+
+#### Environmental/occupational (evidence limited)
+Occupational antigen exposure has been proposed in some cohorts (e.g., high rates of “blue-collar” work reported in certain populations), but robust causal data for IgG4-SC specifically were not available in the retrieved excerpts. (tanaka2019igg4relatedsclerosingcholangitis pages 1-2)
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+Not established in the retrieved evidence. However, the conceptual model emphasizes genetic susceptibility and environmental triggers acting together. (ren2026igg4relatedsclerosingcholangitis pages 2-3)
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotypes (with suggested HPO terms)
+Common presentations and laboratory abnormalities include:
+
+1. **Obstructive jaundice** (HPO: *Jaundice* **HP:0000952**) (herta2025managementofigg4related pages 1-2, kamisawa2019clinicalpracticeguidelines pages 6-7)
+2. **Upper abdominal pain/discomfort** (HPO: *Abdominal pain* **HP:0002027**) (herta2025managementofigg4related pages 1-2, ali2020thelongtermoutcomes pages 2-4)
+3. **Cholestatic liver enzyme elevation** (HPO: *Elevated alkaline phosphatase* **HP:0003155**; *Elevated gamma-glutamyltransferase* **HP:0031304**) (ali2020thelongtermoutcomes pages 2-4)
+4. **Biliary strictures** (HPO: *Bile duct stenosis* **HP:0031783** [term mapping may vary]) (kamisawa2019clinicalpracticeguidelines pages 2-4, naitoh2026multicentervalidationstudy pages 2-2)
+5. **Weight loss** (HPO: *Weight loss* **HP:0001824**)—also contributes to malignancy mimicry (herta2025managementofigg4related pages 1-2)
+
+Phenotype characteristics:
+* Typical onset: **adult/older adult** (no pediatric cases reported in Japan guideline summary). (kamisawa2019clinicalpracticeguidelines pages 6-7)
+* Variable severity; a meaningful fraction may be **asymptomatic at diagnosis (28%)** in Japanese experience. (kamisawa2019clinicalpracticeguidelines pages 6-7)
+
+### 3.2 Quality of life impact
+Specific QoL instruments (SF-36/EQ-5D/PROMIS) were not reported in the retrieved evidence for IgG4-SC.
+
+---
+
+## 4. Genetic/Molecular Information
+
+### 4.1 Causal genes
+No **monogenic causal gene** for IgG4-SC was identified in the retrieved evidence; the condition is best supported as **complex immune-mediated** with susceptibility signals rather than Mendelian inheritance. (ren2026igg4relatedsclerosingcholangitis pages 2-3)
+
+### 4.2 Susceptibility genetics / loci (strength: moderate)
+* Whole-blood methylation/genotyping study in IgG4-SC showed a strong **HLA-region** signal in meQTL analyses, implicating loci including **HLA-DQB2, HLA-DPA1, HLA-F, HLA-DRA** in shaping methylation patterns. (noble2025epigeneticageacceleration pages 1-2)
+* Related PSC research demonstrates that elevated IgG4 in PSC associates with specific HLA haplotypes (lower HLA-B*08; higher HLA-B*07 and DRB1*15), underscoring shared immunogenetic architecture relevant for differential diagnosis contexts. (berntsen2015associationbetweenhla pages 1-1)
+
+### 4.3 Epigenetic information (recent “omics”)
+Noble et al. profiled whole-blood DNA methylation in **47 IgG4-SC**, 65 PSC, 64 UC, 88 controls and found:
+* **19** significant methylation differences vs controls in IgG4-SC (38 in PSC).
+* **Epigenetic age acceleration** in IgG4-SC (not PSC/UC).
+* Dysregulated methylation in inflammatory genes including **IFNAR1, TXK, HERC6**, etc. (noble2025epigeneticageacceleration pages 1-2)
+
+### 4.4 Chromosomal abnormalities
+Not reported.
+
+---
+
+## 5. Environmental Information
+No specific toxins, lifestyle exposures, or infectious triggers were established in the retrieved evidence for IgG4-SC. (ren2026igg4relatedsclerosingcholangitis pages 2-3)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Current mechanistic model (causal chain)
+1. **Predisposition/trigger:** genetic susceptibility and possible environmental triggers (incompletely defined). (ren2026igg4relatedsclerosingcholangitis pages 2-3)
+2. **Immune activation:** Th2/Treg-skewed responses with B-cell activation; oligoclonal expansion of IgG4+ plasmablasts. (ren2026igg4relatedsclerosingcholangitis pages 2-3, smit2016newthoughtson pages 12-14)
+3. **Tissue inflammation:** lymphoplasmacytic infiltrate rich in IgG4+ plasma cells; formation of fibroinflammatory lesions causing biliary wall thickening/strictures. (herta2025managementofigg4related pages 1-2, smit2016newthoughtson pages 6-8)
+4. **Fibrosis and remodeling:** storiform fibrosis and profibrotic cytokine signaling (e.g., TGF-β) contribute to progressive stricturing and potential secondary biliary cirrhosis in a minority. (ren2026igg4relatedsclerosingcholangitis pages 2-3, ali2020thelongtermoutcomes pages 7-8)
+
+### 6.2 Key immune cells (suggested CL terms)
+* **CD4-positive T cell** (CL:0000624)
+* **Regulatory T cell (Treg)** (CL:0000815)
+* **B cell** (CL:0000236)
+* **Plasmablast/plasma cell** (CL:0000980 / CL:0000786)
+Mechanistic support for T-cell/B-cell involvement and plasmablast expansion is described in mechanistic reviews. (ren2026igg4relatedsclerosingcholangitis pages 2-3, smit2016newthoughtson pages 12-14)
+
+### 6.3 Key biological processes (suggested GO terms)
+* **GO:0006954 inflammatory response**
+* **GO:0006955 immune response**
+* **GO:0042113 B cell activation**
+* **GO:0006959 humoral immune response**
+* **GO:0042060 wound healing / fibrosis-related processes** (fibrogenesis)
+These are consistent with the described immune activation and fibroinflammatory phenotype. (ren2026igg4relatedsclerosingcholangitis pages 2-3, smit2016newthoughtson pages 12-14)
+
+### 6.4 Histopathology (defining features)
+Diagnostic histology requires combinations of:
+* Dense lymphoplasmacytic infiltrate
+* Storiform fibrosis
+* Obliterative phlebitis
+with IgG4+ plasma cell thresholds of **>10/HPF (biopsy)** or **>50/HPF (resection)** and **IgG4+/IgG+ ratio >0.4**. (herta2025managementofigg4related pages 1-2, smit2016newthoughtson pages 6-8)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/tissue level (suggested UBERON terms)
+* **Extrahepatic bile duct** (UBERON:0003707)
+* **Intrahepatic bile duct** (UBERON:0003708)
+* **Liver** (UBERON:0002107)
+* Often associated organ involvement: **pancreas** (UBERON:0001264) via type 1 AIP. (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 2-4)
+
+### 7.2 Localization patterns
+IgG4-SC has diverse cholangiographic patterns; Japanese guidance describes four cholangiographic types, with national survey frequencies: type 1 **64%**, type 2a **5%**, type 2b **8%**, type 3 **10%**, type 4 **10%**. (kamisawa2019clinicalpracticeguidelines pages 2-4)
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset
+Typically adult/older adult onset; Japan guideline reports no pediatric/adolescent cases. (kamisawa2019clinicalpracticeguidelines pages 6-7)
+
+### 8.2 Progression/course
+Course is often responsive to steroids but **relapsing**. Reviews cite relapse rates commonly **30–50%** despite high initial response, and post-steroid relapse rates around **40–50%** in cited studies. (ren2026igg4relatedsclerosingcholangitis pages 2-3, hegade2019diagnosisandmanagement pages 4-5)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology
+Japan guideline estimates prevalence **2.0 per 100,000** (~2,500 patients) and extrapolated prevalence/incidence based on AIP data of **1.8 per 100,000** and **0.5 per 100,000**, respectively. (kamisawa2019clinicalpracticeguidelines pages 6-7)
+
+### 9.2 Population demographics
+* Sex ratio: ~80% male (Japan guideline), 81% male in Mayo cohort. (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 2-4)
+* Typical age: 60–70s. (kamisawa2019clinicalpracticeguidelines pages 6-7, ali2020thelongtermoutcomes pages 2-4)
+
+### 9.3 Inheritance pattern
+No Mendelian inheritance is established; evidence supports a complex immune-mediated condition with genetic susceptibility signals. (ren2026igg4relatedsclerosingcholangitis pages 2-3)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical criteria and diagnostic frameworks
+
+#### HISORt
+HISORt integrates **Histology, Imaging, Serology, Other organ involvement, and Response to therapy**; it is emphasized because no single pathognomonic test exists and mimics are common. (herta2025managementofigg4related pages 1-2, smit2016newthoughtson pages 6-8)
+
+#### Japanese clinical diagnostic criteria (2012; revision 2020)
+The IgG4-SC2020 criteria include six domains: bile-duct narrowing, bile-duct wall thickening, serology, pathology, other-organ involvement, and response to treatment. (naitoh2026multicentervalidationstudy pages 2-2)
+
+A multicenter validation (Japan; 1,034 IgG4-SC and 447 mimickers) found sensitivity **99.0%** (2020) vs **89.1%** (2012) while maintaining specificity **100%** vs pancreatic cancer and cholangiocarcinoma, and **97.5%** vs PSC (2020). (naitoh2026multicentervalidationstudy pages 1-2)
+
+### 10.2 Key diagnostic thresholds and pitfalls
+* Serum IgG4 elevated in ~80% but not diagnostic alone; modest elevations can occur in **10–15%** of PSC/CCA; **>4× ULN** is highly specific but insensitive. (ren2026igg4relatedsclerosingcholangitis pages 2-3)
+* Histology cutoffs: >10/HPF biopsy; >50/HPF resection; IgG4+/IgG+ >0.4. (herta2025managementofigg4related pages 1-2)
+* Tissue pitfalls: IgG4+ cells can appear in PSC/CCA biopsies; thus malignancy must be excluded carefully. (herta2025managementofigg4related pages 1-2, smit2016newthoughtson pages 6-8)
+
+### 10.3 Differential diagnosis
+Primary mimickers:
+* **Cholangiocarcinoma (CCA)**
+* **Primary sclerosing cholangitis (PSC)**
+The need to differentiate these is a central theme across guidelines and diagnostic reviews. (herta2025managementofigg4related pages 1-2, kamisawa2019clinicalpracticeguidelines pages 2-4, ren2026igg4relatedsclerosingcholangitis pages 2-3)
+
+### 10.4 Biomarker development and real-world diagnostic implementation
+* ClinicalTrials.gov observational cohort NCT02616705 assessed **bile IgG4 concentration** as a diagnostic biomarker to distinguish IgG4-SC from PSC/CCA and other strictures (enrollment 511; completed 2019-09-30). (NCT02616705 chunk 1)
+
+---
+
+## 11. Outcome / Prognosis
+
+### 11.1 Cohort outcomes
+In the Mayo Clinic IgG4-SC cohort (n=89; 1999–2018), hepatobiliary adverse events occurred less frequently than in matched PSC patients: **15.6 vs 52.6 events/1000 person-years**, with **10-year hepatobiliary event probability 11% vs 45%**. Ten-year survival was **79%** in IgG4-SC vs **68%** in PSC (trend). (ali2020thelongtermoutcomes pages 1-2)
+
+### 11.2 Cirrhosis and cholangiocarcinoma risk
+The Mayo experience excerpt reports progression to cirrhosis in ~**5.2–7.5%** across reports and an estimated lifetime CCA risk of **3.4%** in that cohort; CCA cases occurred 1.5–5.8 years after IgG4-SC diagnosis in that cohort. (ali2020thelongtermoutcomes pages 7-8)
+
+### 11.3 Prognostic factors
+Relapse risk is highlighted as substantial; in pancreaticobiliary IgG4-RD cohorts, relapse risk relates to factors such as younger age and higher post-induction disease activity indices (IgG4-RI) and alkaline phosphatase in one rituximab maintenance analysis. (majumder2018rituximabmaintenancetherapy pages 1-2)
+
+---
+
+## 12. Treatment
+
+### 12.1 First-line: glucocorticoids
+Steroids are first-line once diagnosis is confirmed.
+
+**Evidence-supported regimens and relapse statistics:**
+* Expert centers use prednisolone **0.5 mg/kg (30–40 mg/day) for 2–4 weeks**, then taper by **5 mg steps**. (hegade2019diagnosisandmanagement pages 5-6)
+* Reported post-steroid relapse rates include **40%** after an 11-week course and **50%** at median **4.6 months** after stopping first course in cited studies. (hegade2019diagnosisandmanagement pages 4-5)
+
+**MAXO suggestions:**
+* MAXO: *glucocorticoid therapy* (term label varies by MAXO release).
+
+### 12.2 Steroid-sparing immunomodulators
+Steroid-sparing regimens listed in hepatobiliary IgG4-RD review include:
+* Azathioprine **2 mg/kg daily**
+* Mycophenolate mofetil **750–1,000 mg BID**
+* Methotrexate **10–25 mg weekly** (+ folate)
+* Tacrolimus (target level **4–11 ng/mL**)
+* Rituximab **1,000 mg at week 0 and week 2** (B-cell depletion) (culver2016igg4relatedhepatobiliarydisease pages 7-8)
+
+**MAXO suggestions:**
+* MAXO: *immunosuppressive agent administration*.
+
+### 12.3 B-cell depletion: rituximab (real-world implementation)
+In pancreaticobiliary IgG4-RD cohorts:
+* 6-month steroid-free remission after rituximab: **86%**.
+* 3-year relapse/event rate **45%** (induction only) vs **11%** (maintenance) (P=.034).
+* Clinically significant infections occurred in **6/43**, largely during maintenance. (majumder2018rituximabmaintenancetherapy pages 1-2)
+
+**MAXO suggestions:**
+* MAXO: *rituximab therapy* / *B cell depletion therapy*.
+
+### 12.4 Endoscopic management of biliary strictures (real-world)
+In a 69-patient IgG4-SC cohort treated with corticosteroids:
+* **40.6%** underwent endoscopic biliary drainage (EBD) before steroids.
+* Planned stent removal: **84.6%** of removals occurred within 1 month after steroids with no early recurrence.
+* Spontaneous stent dislodgement occurred in **35.7%** after steroids; **70%** of dislodgements occurred between 2 weeks and 2 months.
+* Bile-duct stones developed in **4.3%** (all in EBD group), and none in steroid-only group (p=0.032). (miyazawa2020managementofbiliary pages 1-2)
+
+Supporting visual tables are available from the paper’s extracted tables. (miyazawa2020managementofbiliary media 3f18bf73, miyazawa2020managementofbiliary media a80fe471, miyazawa2020managementofbiliary media 500893f9)
+
+**MAXO suggestions:**
+* MAXO: *endoscopic biliary stenting*; *endoscopic stent removal*.
+
+### 12.5 Emerging/novel therapies
+Recent reviews note emerging B-cell–targeting approaches (e.g., anti-CD19), but IgG4-SC–specific primary efficacy data were not retrievable in this run. (herta2025managementofigg4related pages 1-2)
+
+---
+
+## 13. Prevention
+No established primary prevention strategies are described in the retrieved evidence. Secondary/tertiary prevention centers on early diagnosis to avoid unnecessary surgery and prevent fibrotic complications, plus surveillance for relapse and biliary complications. (herta2025managementofigg4related pages 1-2)
+
+---
+
+## 14. Other Species / Natural Disease
+No naturally occurring animal disease or zoonotic aspects were identified in the retrieved evidence.
+
+---
+
+## 15. Model Organisms
+No specific animal models or in vitro models of IgG4-SC were identified in the retrieved evidence.
+
+---
+
+## Recent developments and latest research emphasis (2023–2025 within retrieved sources)
+* **Diagnostic criteria modernization**: IgG4-SC2020 criteria show markedly improved sensitivity vs 2012 while maintaining high specificity in a large Japanese multicenter validation (published 2026, but directly relevant to the “current understanding”). (naitoh2026multicentervalidationstudy pages 1-2)
+* **Epigenetic/omics**: First whole-blood methylation study in IgG4-SC identifies disease-specific methylation differences and epigenetic age acceleration; HLA-region meQTL signals suggest genotype–methylome relationships. (noble2025epigeneticageacceleration pages 1-2)
+* **Real-world diagnostic biomarker efforts**: NCT02616705 tests bile IgG4 as a biomarker to distinguish IgG4-SC from PSC/CCA/other strictures in a large prospective cohort (completed 2019; continued relevance for implementation). (NCT02616705 chunk 1)
+
+---
+
+## Direct abstract-supported quotations (for key claims)
+* IgG4-SC definition/diagnostic challenge and need for consensus guidance: “IgG4‐related sclerosing cholangitis (IgG4‐SC) is a distinct type of cholangitis frequently associated with autoimmune pancreatitis and currently recognized as a biliary manifestation of IgG4‐related disease.” (kamisawa2019clinicalpracticeguidelines pages 2-4)
+* HISORt-based diagnostic concept and relapse: “Diagnosis is challenging due to the absence of pathognomonic findings but can be achieved using the HISORt criteria (histology, imaging, serology, other organ involvement, and response to immunosuppressive therapy).” (herta2025managementofigg4related pages 1-2)
+* Steroid response but relapse: “IgG4-SC often has a good response to initial steroid therapy, but a high relapse rate during follow-up.” (majumder2018rituximabmaintenancetherapy pages 1-2)
+
+---
+
+## Limitations of this evidence package
+* Formal ontology identifiers (MONDO/MeSH/Orphanet/ICD) and many ontology mappings (HPO/GO/CL/UBERON/MAXO) were not explicitly provided in retrieved full-text sources; ontology suggestions are therefore limited to widely used terms and should be validated against the relevant ontology releases.
+* Several key 2023–2024 primary papers/guidelines relevant to IgG4-SC may be unobtainable in this run (e.g., certain systematic reviews/meta-analyses and some 2023 nationwide relapse/cancer-risk studies), so some “latest” claims (e.g., anti-CD19 trial outcomes in IgG4-RD) are discussed only at a high level.
+
+
+
+References
+
+1. (herta2025managementofigg4related pages 1-2): Toni Herta, Maik Schröder, Dominik Geisel, Cornelius Engelmann, and Frank Tacke. Management of igg4-related cholangitis: diagnosis, therapy, and long-term surveillance. Gastroenterology Report, Apr 2025. URL: https://doi.org/10.1093/gastro/goaf032, doi:10.1093/gastro/goaf032. This article has 1 citations and is from a peer-reviewed journal.
+
+2. (ali2020thelongtermoutcomes pages 1-2): Ahmad Hassan Ali, Yan Bi, Jorge D. Machicado, Sushil Garg, Ryan J. Lennon, Lizhi Zhang, Naoki Takahashi, Elizabeth J. Carey, Keith D. Lindor, J. Gage Buness, James H. Tabibian, and Suresh T. Chari. The long-term outcomes of patients with immunoglobulin g4-related sclerosing cholangitis: the mayo clinic experience. Journal of Gastroenterology, 55:1087-1097, Aug 2020. URL: https://doi.org/10.1007/s00535-020-01714-7, doi:10.1007/s00535-020-01714-7. This article has 37 citations and is from a domain leading peer-reviewed journal.
+
+3. (majumder2018rituximabmaintenancetherapy pages 1-2): Shounak Majumder, Sonmoon Mohapatra, Ryan J. Lennon, Guilherme Piovezani Ramos, Neil Postier, Ferga C. Gleeson, Michael J. Levy, Randall K. Pearson, Bret T. Petersen, Santhi Swaroop Vege, Suresh T. Chari, Mark D. Topazian, and Thomas E. Witzig. Rituximab maintenance therapy reduces rate of relapse of pancreaticobiliary immunoglobulin g4-related disease. Clinical Gastroenterology and Hepatology, 16:1947-1953, Dec 2018. URL: https://doi.org/10.1016/j.cgh.2018.02.049, doi:10.1016/j.cgh.2018.02.049. This article has 101 citations and is from a domain leading peer-reviewed journal.
+
+4. (kamisawa2019clinicalpracticeguidelines pages 6-7): Terumi Kamisawa, Takahiro Nakazawa, Susumu Tazuma, Yoh Zen, Atsushi Tanaka, Hirotaka Ohara, Takashi Muraki, Kazuo Inui, Dai Inoue, Takayoshi Nishino, Itaru Naitoh, Takao Itoi, Kenji Notohara, Atsushi Kanno, Kensuke Kubota, Kenji Hirano, Hiroyuki Isayama, Kyoko Shimizu, Toshio Tsuyuguchi, Tooru Shimosegawa, Shigeyuki Kawa, Tsutomu Chiba, Kazuichi Okazaki, Hajime Takikawa, Wataru Kimura, Michiaki Unno, and Masahiro Yoshida. Clinical practice guidelines for igg4‐related sclerosing cholangitis. Journal of Hepato-Biliary-Pancreatic Sciences, 26:9-42, Jan 2019. URL: https://doi.org/10.1002/jhbp.596, doi:10.1002/jhbp.596. This article has 225 citations and is from a peer-reviewed journal.
+
+5. (ali2020thelongtermoutcomes pages 2-4): Ahmad Hassan Ali, Yan Bi, Jorge D. Machicado, Sushil Garg, Ryan J. Lennon, Lizhi Zhang, Naoki Takahashi, Elizabeth J. Carey, Keith D. Lindor, J. Gage Buness, James H. Tabibian, and Suresh T. Chari. The long-term outcomes of patients with immunoglobulin g4-related sclerosing cholangitis: the mayo clinic experience. Journal of Gastroenterology, 55:1087-1097, Aug 2020. URL: https://doi.org/10.1007/s00535-020-01714-7, doi:10.1007/s00535-020-01714-7. This article has 37 citations and is from a domain leading peer-reviewed journal.
+
+6. (smit2016newthoughtson pages 6-8): Wouter L. Smit, Emma L. Culver, and Roger W. Chapman. New thoughts on immunoglobulin g4-related sclerosing cholangitis. Clinics in liver disease, 20 1:47-65, Feb 2016. URL: https://doi.org/10.1016/j.cld.2015.08.004, doi:10.1016/j.cld.2015.08.004. This article has 21 citations and is from a peer-reviewed journal.
+
+7. (ren2026igg4relatedsclerosingcholangitis pages 2-3): Xiangxiang Ren, Xiaoshi Jin, Litao Liu, and Meng Zhang. Igg4-related sclerosing cholangitis: navigating diagnostic dilemmas and the challenge of relapse. Frontiers in Medicine, 13:1732637, Feb 2026. URL: https://doi.org/10.3389/fmed.2026.1732637, doi:10.3389/fmed.2026.1732637. This article has 0 citations.
+
+8. (naitoh2026multicentervalidationstudy pages 2-2): Itaru Naitoh, Takahiro Nakazawa, Kensuke Kubota, Takayoshi Nishino, Akira Nakamura, Dai Inoue, Takanori Sano, Kazuhiro Kikuta, Yusuke Kurita, Kazuro Chiba, Tsukasa Ikeura, Hiroyuki Matsubayashi, Takuya Ishikawa, Masaki Kuwatani, Terumi Kamisawa, Ichiro Yasuda, Mitsuhiro Kawano, and Atsushi Masamune. Multicenter validation study of the clinical diagnostic criteria for <scp>igg4</scp> ‐related sclerosing cholangitis 2020 in japan. Journal of Hepato-Biliary-Pancreatic Sciences, 33:294-303, Jan 2026. URL: https://doi.org/10.1002/jhbp.70056, doi:10.1002/jhbp.70056. This article has 3 citations and is from a peer-reviewed journal.
+
+9. (naitoh2026multicentervalidationstudy pages 1-2): Itaru Naitoh, Takahiro Nakazawa, Kensuke Kubota, Takayoshi Nishino, Akira Nakamura, Dai Inoue, Takanori Sano, Kazuhiro Kikuta, Yusuke Kurita, Kazuro Chiba, Tsukasa Ikeura, Hiroyuki Matsubayashi, Takuya Ishikawa, Masaki Kuwatani, Terumi Kamisawa, Ichiro Yasuda, Mitsuhiro Kawano, and Atsushi Masamune. Multicenter validation study of the clinical diagnostic criteria for <scp>igg4</scp> ‐related sclerosing cholangitis 2020 in japan. Journal of Hepato-Biliary-Pancreatic Sciences, 33:294-303, Jan 2026. URL: https://doi.org/10.1002/jhbp.70056, doi:10.1002/jhbp.70056. This article has 3 citations and is from a peer-reviewed journal.
+
+10. (kamisawa2019clinicalpracticeguidelines pages 2-4): Terumi Kamisawa, Takahiro Nakazawa, Susumu Tazuma, Yoh Zen, Atsushi Tanaka, Hirotaka Ohara, Takashi Muraki, Kazuo Inui, Dai Inoue, Takayoshi Nishino, Itaru Naitoh, Takao Itoi, Kenji Notohara, Atsushi Kanno, Kensuke Kubota, Kenji Hirano, Hiroyuki Isayama, Kyoko Shimizu, Toshio Tsuyuguchi, Tooru Shimosegawa, Shigeyuki Kawa, Tsutomu Chiba, Kazuichi Okazaki, Hajime Takikawa, Wataru Kimura, Michiaki Unno, and Masahiro Yoshida. Clinical practice guidelines for igg4‐related sclerosing cholangitis. Journal of Hepato-Biliary-Pancreatic Sciences, 26:9-42, Jan 2019. URL: https://doi.org/10.1002/jhbp.596, doi:10.1002/jhbp.596. This article has 225 citations and is from a peer-reviewed journal.
+
+11. (ali2020thelongtermoutcomes pages 7-8): Ahmad Hassan Ali, Yan Bi, Jorge D. Machicado, Sushil Garg, Ryan J. Lennon, Lizhi Zhang, Naoki Takahashi, Elizabeth J. Carey, Keith D. Lindor, J. Gage Buness, James H. Tabibian, and Suresh T. Chari. The long-term outcomes of patients with immunoglobulin g4-related sclerosing cholangitis: the mayo clinic experience. Journal of Gastroenterology, 55:1087-1097, Aug 2020. URL: https://doi.org/10.1007/s00535-020-01714-7, doi:10.1007/s00535-020-01714-7. This article has 37 citations and is from a domain leading peer-reviewed journal.
+
+12. (hegade2019diagnosisandmanagement pages 5-6): Vinod S Hegade, Maria B Sheridan, and Matthew T Huggett. Diagnosis and management of igg4-related disease. Frontline Gastroenterology, 10:275-283, Oct 2019. URL: https://doi.org/10.1136/flgastro-2018-101001, doi:10.1136/flgastro-2018-101001. This article has 46 citations and is from a peer-reviewed journal.
+
+13. (hegade2019diagnosisandmanagement pages 4-5): Vinod S Hegade, Maria B Sheridan, and Matthew T Huggett. Diagnosis and management of igg4-related disease. Frontline Gastroenterology, 10:275-283, Oct 2019. URL: https://doi.org/10.1136/flgastro-2018-101001, doi:10.1136/flgastro-2018-101001. This article has 46 citations and is from a peer-reviewed journal.
+
+14. (miyazawa2020managementofbiliary pages 1-2): Masaki Miyazawa, Hajime Takatori, Kazunori Kawaguchi, Kazuya Kitamura, Kuniaki Arai, Koichiro Matsuda, Takeshi Urabe, Katsuhisa Inamura, Takuya Komura, Hideki Mizuno, Uichiro Fuchizaki, Taro Yamashita, Yoshio Sakai, Tatsuya Yamashita, Eishiro Mizukoshi, Masao Honda, and Shuichi Kaneko. Management of biliary stricture in patients with igg4-related sclerosing cholangitis. PLoS ONE, 15:e0232089, Apr 2020. URL: https://doi.org/10.1371/journal.pone.0232089, doi:10.1371/journal.pone.0232089. This article has 18 citations and is from a peer-reviewed journal.
+
+15. (beuers2025igg4relatedcholangitis pages 1-3): Ulrich Beuers and David C. Trampert. Igg4-related cholangitis. Seminars in Liver Disease, May 2025. URL: https://doi.org/10.1055/a-2588-3875, doi:10.1055/a-2588-3875. This article has 1 citations and is from a peer-reviewed journal.
+
+16. (hegade2019diagnosisandmanagement pages 1-2): Vinod S Hegade, Maria B Sheridan, and Matthew T Huggett. Diagnosis and management of igg4-related disease. Frontline Gastroenterology, 10:275-283, Oct 2019. URL: https://doi.org/10.1136/flgastro-2018-101001, doi:10.1136/flgastro-2018-101001. This article has 46 citations and is from a peer-reviewed journal.
+
+17. (cargill2017igg4relatedsclerosingcholangitis pages 2-4): T. Cargill, E. Culver, and R. Chapman. Igg4-related sclerosing cholangitis. Biliary Disease, pages 243-261, Jan 2017. URL: https://doi.org/10.1007/978-3-319-50168-0\_12, doi:10.1007/978-3-319-50168-0\_12. This article has 29 citations.
+
+18. (NCT02616705 chunk 1): Lewis R. Roberts. Bile Usefulness for Detecting IgG4-related Sclerosing Cholangitis. Mayo Clinic. 2015. ClinicalTrials.gov Identifier: NCT02616705
+
+19. (smit2016newthoughtson pages 12-14): Wouter L. Smit, Emma L. Culver, and Roger W. Chapman. New thoughts on immunoglobulin g4-related sclerosing cholangitis. Clinics in liver disease, 20 1:47-65, Feb 2016. URL: https://doi.org/10.1016/j.cld.2015.08.004, doi:10.1016/j.cld.2015.08.004. This article has 21 citations and is from a peer-reviewed journal.
+
+20. (tanaka2019igg4relatedsclerosingcholangitis pages 1-2): Atsushi Tanaka. Igg4-related sclerosing cholangitis and primary sclerosing cholangitis. Gut and Liver, 13:300-307, May 2019. URL: https://doi.org/10.5009/gnl18085, doi:10.5009/gnl18085. This article has 84 citations and is from a peer-reviewed journal.
+
+21. (noble2025epigeneticageacceleration pages 1-2): Alexandra Noble, Rodrigo Motta, Silvia Cabras, Belen Moron Flores, Jan Nowak, Aleksandra Glapa-Nowak, Alessandra Geremia, Jack Satsangi, and Emma Culver. Epigenetic age acceleration and methylation differences in igg4-related cholangitis and primary sclerosing cholangitis. Clinical Epigenetics, Jan 2025. URL: https://doi.org/10.1186/s13148-024-01803-x, doi:10.1186/s13148-024-01803-x. This article has 2 citations and is from a peer-reviewed journal.
+
+22. (berntsen2015associationbetweenhla pages 1-1): Natalie L. Berntsen, Olav Klingenberg, Brian D. Juran, Maria Benito de Valle, Björn Lindkvist, Konstantinos N. Lazaridis, Kirsten Muri Boberg, Tom H. Karlsen, and Johannes Roksund Hov. Association between hla haplotypes and increased serum levels of igg4 in patients with primary sclerosing cholangitis. Gastroenterology, 148 5:924-927.e2, May 2015. URL: https://doi.org/10.1053/j.gastro.2015.01.041, doi:10.1053/j.gastro.2015.01.041. This article has 59 citations and is from a highest quality peer-reviewed journal.
+
+23. (culver2016igg4relatedhepatobiliarydisease pages 7-8): Emma L. Culver and Roger W. Chapman. Igg4-related hepatobiliary disease: an overview. Nature Reviews Gastroenterology &Hepatology, 13:601-612, Oct 2016. URL: https://doi.org/10.1038/nrgastro.2016.132, doi:10.1038/nrgastro.2016.132. This article has 109 citations.
+
+24. (miyazawa2020managementofbiliary media 3f18bf73): Masaki Miyazawa, Hajime Takatori, Kazunori Kawaguchi, Kazuya Kitamura, Kuniaki Arai, Koichiro Matsuda, Takeshi Urabe, Katsuhisa Inamura, Takuya Komura, Hideki Mizuno, Uichiro Fuchizaki, Taro Yamashita, Yoshio Sakai, Tatsuya Yamashita, Eishiro Mizukoshi, Masao Honda, and Shuichi Kaneko. Management of biliary stricture in patients with igg4-related sclerosing cholangitis. PLoS ONE, 15:e0232089, Apr 2020. URL: https://doi.org/10.1371/journal.pone.0232089, doi:10.1371/journal.pone.0232089. This article has 18 citations and is from a peer-reviewed journal.
+
+25. (miyazawa2020managementofbiliary media a80fe471): Masaki Miyazawa, Hajime Takatori, Kazunori Kawaguchi, Kazuya Kitamura, Kuniaki Arai, Koichiro Matsuda, Takeshi Urabe, Katsuhisa Inamura, Takuya Komura, Hideki Mizuno, Uichiro Fuchizaki, Taro Yamashita, Yoshio Sakai, Tatsuya Yamashita, Eishiro Mizukoshi, Masao Honda, and Shuichi Kaneko. Management of biliary stricture in patients with igg4-related sclerosing cholangitis. PLoS ONE, 15:e0232089, Apr 2020. URL: https://doi.org/10.1371/journal.pone.0232089, doi:10.1371/journal.pone.0232089. This article has 18 citations and is from a peer-reviewed journal.
+
+26. (miyazawa2020managementofbiliary media 500893f9): Masaki Miyazawa, Hajime Takatori, Kazunori Kawaguchi, Kazuya Kitamura, Kuniaki Arai, Koichiro Matsuda, Takeshi Urabe, Katsuhisa Inamura, Takuya Komura, Hideki Mizuno, Uichiro Fuchizaki, Taro Yamashita, Yoshio Sakai, Tatsuya Yamashita, Eishiro Mizukoshi, Masao Honda, and Shuichi Kaneko. Management of biliary stricture in patients with igg4-related sclerosing cholangitis. PLoS ONE, 15:e0232089, Apr 2020. URL: https://doi.org/10.1371/journal.pone.0232089, doi:10.1371/journal.pone.0232089. This article has 18 citations and is from a peer-reviewed journal.

--- a/research/IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md.citations.md
+++ b/research/IgG4-Related_Sclerosing_Cholangitis-deep-research-falcon.md.citations.md
@@ -1,0 +1,492 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** IgG4-Related Sclerosing Cholangitis
+- **MONDO ID:**  (if available)
+- **Category:** Autoimmune
+
+## Research Objectives
+
+Please provide a comprehensive research report on **IgG4-Related Sclerosing Cholangitis** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-06T22:24:30.309673
+
+1. kamisawa2019clinicalpracticeguidelines pages 6-7
+2. ali2020thelongtermoutcomes pages 2-4
+3. naitoh2026multicentervalidationstudy pages 2-2
+4. naitoh2026multicentervalidationstudy pages 1-2
+5. kamisawa2019clinicalpracticeguidelines pages 2-4
+6. ali2020thelongtermoutcomes pages 1-2
+7. ali2020thelongtermoutcomes pages 7-8
+8. majumder2018rituximabmaintenancetherapy pages 1-2
+9. miyazawa2020managementofbiliary pages 1-2
+10. hegade2019diagnosisandmanagement pages 1-2
+11. noble2025epigeneticageacceleration pages 1-2
+12. berntsen2015associationbetweenhla pages 1-1
+13. hegade2019diagnosisandmanagement pages 5-6
+14. hegade2019diagnosisandmanagement pages 4-5
+15. smit2016newthoughtson pages 6-8
+16. smit2016newthoughtson pages 12-14
+17. term mapping may vary
+18. https://doi.org/10.1002/jhbp.596
+19. https://doi.org/10.1007/s00535-020-01714-7
+20. https://doi.org/10.1093/gastro/goaf032
+21. https://doi.org/10.1016/j.cld.2015.08.004
+22. https://doi.org/10.3389/fmed.2026.1732637
+23. https://doi.org/10.1002/jhbp.70056
+24. https://doi.org/10.1136/flgastro-2018-101001
+25. https://doi.org/10.1016/j.cgh.2018.02.049
+26. https://doi.org/10.1371/journal.pone.0232089
+27. https://doi.org/10.1093/gastro/goaf032,
+28. https://doi.org/10.1007/s00535-020-01714-7,
+29. https://doi.org/10.1016/j.cgh.2018.02.049,
+30. https://doi.org/10.1002/jhbp.596,
+31. https://doi.org/10.1016/j.cld.2015.08.004,
+32. https://doi.org/10.3389/fmed.2026.1732637,
+33. https://doi.org/10.1002/jhbp.70056,
+34. https://doi.org/10.1136/flgastro-2018-101001,
+35. https://doi.org/10.1371/journal.pone.0232089,
+36. https://doi.org/10.1055/a-2588-3875,
+37. https://doi.org/10.1007/978-3-319-50168-0\_12,
+38. https://doi.org/10.5009/gnl18085,
+39. https://doi.org/10.1186/s13148-024-01803-x,
+40. https://doi.org/10.1053/j.gastro.2015.01.041,
+41. https://doi.org/10.1038/nrgastro.2016.132,


### PR DESCRIPTION
## Summary

Adds a new DISMECH disorder page for IgG4-related sclerosing cholangitis (MONDO:0018645), scoped to organ-specific biliary disease rather than generic IgG4-related disease or primary sclerosing cholangitis.

The entry includes:

- Falcon deep research artifacts and DOI provenance links
- PMID-backed evidence for bile-duct inflammation/fibrostenosis, cholestatic phenotypes, histopathology, diagnostics, differentials, outcomes, and treatments
- Reference caches generated only with `just fetch-reference`
- Diagnostic biomarker evidence from ClinicalTrials.gov NCT02616705

## Validation

Passed locally:

- `just validate kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml`
- `just validate-references kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml`
- `just validate-terms kb/disorders/IgG4-Related_Sclerosing_Cholangitis.yaml`
- `just check-reference-cache-frontmatter`
- `just qc-deep-research --target-providers falcon --only IgG4-Related_Sclerosing_Cholangitis`
- `git diff --check -- <staged disorder files>`

Deep research QC reports one target provider (`falcon`), as requested for this assignment, and zero missing references / zero missing `found_in` links.

## Notes

I restored unrelated generated churn before staging, including term-cache files and unrelated clinical trial cache files. The PR stages only the disorder YAML, Falcon research/citations artifacts, and reference caches directly cited by the YAML.
