### PR TITLE
Improve multiple sulfatase deficiency pathograph

### DIFF
--- a/kb/disorders/Multiple_Sulfatase_Deficiency.yaml
+++ b/kb/disorders/Multiple_Sulfatase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Multiple Sulfatase Deficiency
 creation_date: "2026-05-06T22:35:33Z"
-updated_date: "2026-05-06T22:35:33Z"
+updated_date: "2026-05-07T03:30:08Z"
 category: Genetic
 parents:
 - Lysosomal Storage Disease
@@ -342,6 +342,9 @@ pathophysiology:
     snippet: "A complete loss of SUMF1 or FGE function results in decreased activity of all sulfatases rendering MSD a monogenetic disease"
     explanation: Review supports broad sulfatase activity reduction from SUMF1/FGE loss.
   downstream:
+  - target: Reduced multiple sulfatase activities
+    causal_link_type: DIRECT
+    description: Failed FGly-dependent activation produces simultaneous deficiency of multiple sulfatase activities.
   - target: Sulfated Substrate Lysosomal Storage
     causal_link_type: DIRECT
     description: Decreased sulfatase activities impair degradation of glycosaminoglycans and sulfatides.
@@ -372,6 +375,11 @@ pathophysiology:
     snippet: "FGE deficiency results in widespread tissue accumulation of multiple sulphated substrates."
     explanation: Systematic review supports tissue storage of sulfated substrates.
   downstream:
+  - target: Glycosaminoglycan and sulfatide accumulation
+    causal_link_type: DIRECT
+  - target: Mucopolysacchariduria
+    causal_link_type: DIRECT
+    description: Impaired degradation of sulfated glycosaminoglycans leads to urinary mucopolysaccharide excretion.
   - target: Neuroglial Lysosomal Dysfunction and Neurodegeneration
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
@@ -384,6 +392,33 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - connective-tissue and skeletal storage pathology
+  - target: Hepatomegaly
+    causal_link_type: DIRECT
+    description: Visceral lysosomal storage contributes to liver enlargement.
+  - target: Splenomegaly
+    causal_link_type: DIRECT
+    description: Visceral lysosomal storage contributes to spleen enlargement.
+  - target: Ichthyosis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Sulfatase deficiency and sulfated lipid/substrate storage produce the ichthyotic skin phenotype.
+  - target: Coarse hair
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hair changes are grouped with cutaneous storage manifestations.
+  - target: Coarse facial features
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Mucopolysaccharidosis-like storage produces coarse craniofacial features.
+  - target: Smooth philtrum
+    causal_link_type: UNKNOWN
+    description: Smooth philtrum is retained as a craniofacial manifestation with unresolved proximal mechanism.
+  - target: Anteverted nares
+    causal_link_type: UNKNOWN
+    description: Anteverted nares is retained as a craniofacial manifestation with unresolved proximal mechanism.
+  - target: Thick eyebrow
+    causal_link_type: UNKNOWN
+    description: Thick eyebrows are grouped with coarse craniofacial and hair manifestations.
+  - target: Depressed nasal bridge
+    causal_link_type: UNKNOWN
+    description: Depressed nasal bridge is retained as a craniofacial manifestation with unresolved proximal mechanism.
 - name: Neuroglial Lysosomal Dysfunction and Neurodegeneration
   description: >-
     Sulfatide and glycosaminoglycan storage disrupts central and peripheral
@@ -411,6 +446,32 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "MSD is an ultra-rare multisystem disorder with mainly neurologic, hearing and skin involvements."
     explanation: Systematic clinical survey supports neurologic involvement as a main disease domain.
+  downstream:
+  - target: Hydrocephalus
+    causal_link_type: UNKNOWN
+    description: Hydrocephalus is connected through central nervous system involvement, but the proximal mechanism is not separately modeled.
+  - target: Leukodystrophy
+    causal_link_type: DIRECT
+  - target: Microcephaly
+    causal_link_type: UNKNOWN
+    description: Microcephaly is modeled as a CNS growth/development manifestation of severe neurodevelopmental disease.
+  - target: Macrocephaly
+    causal_link_type: UNKNOWN
+    description: Macrocephaly is modeled as a CNS growth or hydrocephalus-related manifestation with unresolved proximal mechanism.
+  - target: Intellectual disability
+    causal_link_type: DIRECT
+  - target: Seizure
+    causal_link_type: DIRECT
+  - target: Global developmental delay
+    causal_link_type: DIRECT
+  - target: Neonatal hypotonia
+    causal_link_type: DIRECT
+  - target: Developmental regression
+    causal_link_type: DIRECT
+  - target: Abnormality of peripheral nerve conduction
+    causal_link_type: DIRECT
+  - target: Rapid neurologic deterioration
+    causal_link_type: DIRECT
 - name: Retinal and Auditory Degeneration
   description: >-
     MSD commonly affects sensory systems through retinal degeneration and
@@ -431,6 +492,21 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Leukodystrophy, neurosensorial hearing loss, and ichthyosis were the most frequent findings at diagnosis."
     explanation: Systematic review supports hearing loss as a frequent diagnostic finding.
+  downstream:
+  - target: Sensorineural hearing impairment
+    causal_link_type: DIRECT
+  - target: Visual impairment
+    causal_link_type: DIRECT
+  - target: Cataract
+    causal_link_type: UNKNOWN
+    description: Cataract is modeled as an ocular manifestation of MSD, with the proximal tissue mechanism not separately curated.
+  - target: Optic atrophy
+    causal_link_type: DIRECT
+  - target: Abnormality of retinal pigmentation
+    causal_link_type: DIRECT
+  - target: Corneal opacity
+    causal_link_type: UNKNOWN
+    description: Corneal opacity is modeled as an ocular storage manifestation with unresolved proximal mechanism.
 - name: Skeletal and Joint Storage Manifestations
   description: >-
     Mucopolysaccharidosis-like connective-tissue and skeletal storage pathology
@@ -446,6 +522,16 @@ pathophysiology:
     evidence_source: OTHER
     snippet: "Many individuals also have characteristic facial features consistent with MPS disorders, chondrodysplasia punctata, hepatosplenomegaly, and ichthyosis"
     explanation: Review supports MPS-like skeletal/connective-tissue involvement.
+  downstream:
+  - target: Joint stiffness
+    causal_link_type: DIRECT
+  - target: Short stature
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Skeletal storage and dysplasia contribute to impaired linear growth.
+  - target: Broad hallux phalanx
+    causal_link_type: DIRECT
+  - target: Broad thumb
+    causal_link_type: DIRECT
 phenotypes:
 - category: Neurologic
   name: Hydrocephalus


### PR DESCRIPTION
## Summary
- add downstream links from sulfatase activation failure to reduced sulfatase activities and sulfated-substrate storage biomarkers
- connect lysosomal storage, neuroglial dysfunction, retinal/auditory degeneration, and skeletal/joint storage mechanisms to all existing phenotype nodes
- use UNKNOWN or INDIRECT links for weaker craniofacial/head-size/ocular phenotype connections instead of overclaiming direct causality

## Validation
- just validate kb/disorders/Multiple_Sulfatase_Deficiency.yaml
- manual normalized snippet audit: 87 checks, 0 failures, 0 missing caches
- graph audit: 6 pathophysiology nodes, 31 phenotypes, 2 biochemical markers, 38 downstream edges, 0 dangling targets, 0 untargeted phenotype/biochemical nodes, 0 isolated pathophysiology nodes

## Review
- Subagent blocker review found no blockers and confirmed graph targets resolve, weaker links are conservatively typed, treatment target_mechanisms remain anchored to pathophysiology nodes, and no unrelated file churn remains.

## Scope
- Restored validation-generated clinicaltrials cache churn.
- Diff is scoped to kb/disorders/Multiple_Sulfatase_Deficiency.yaml.