### PR TITLE
Improve propionic acidemia pathograph

### DIFF
--- a/kb/disorders/Propionic_Acidemia.yaml
+++ b/kb/disorders/Propionic_Acidemia.yaml
@@ -1,7 +1,7 @@
 name: Propionic Acidemia
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-02-28T01:15:00Z'
+updated_date: '2026-05-07T04:11:38Z'
 synonyms:
 - Propionic aciduria
 - PA
@@ -104,6 +104,232 @@ pathophysiology:
     description: Systemic propionate excess increases cardiac propionyl-CoA load and oxidative injury.
   - target: Renal mitochondrial quality control impairment
     description: Metabolite stress perturbs renal mitochondrial homeostasis, including fission-mitophagy balance.
+  - target: Metabolic acidosis
+    description: Accumulated organic acids directly drive high-anion-gap metabolic acidosis during decompensation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: It is frequently accompanied by metabolic acidosis with anion gap, lactic acidosis, ketonuria, hypoglycemia,
+        hyperammonemia, and cytopenias.
+      explanation: GeneReviews links PA decompensation to metabolic acidosis.
+  - target: Vomiting
+    description: Acute toxic metabolite accumulation and metabolic decompensation produce gastrointestinal symptoms including vomiting.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic decompensation
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: may experience a more insidious onset with the development of multiorgan complications including vomiting, protein
+        intolerance, failure to thrive, hypotonia, developmental delays or regression, movement disorders, or cardiomyopathy.
+      explanation: GeneReviews supports vomiting as part of PA multiorgan disease.
+  - target: Lethargy
+    description: Systemic metabolic decompensation and energy stress reduce alertness during acute crises.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic decompensation
+    - Progressive encephalopathy
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: this is followed by progressive encephalopathy manifesting as lethargy, seizures, or coma that can result in death.
+      explanation: GeneReviews supports lethargy downstream of PA metabolic encephalopathy.
+  - target: Failure to thrive
+    description: Recurrent catabolic crises, restricted intake, and chronic metabolite stress impair growth.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Recurrent metabolic decompensation
+    - Feeding intolerance
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: may experience a more insidious onset with the development of multiorgan complications including vomiting, protein
+        intolerance, failure to thrive, hypotonia, developmental delays or regression, movement disorders, or cardiomyopathy.
+      explanation: GeneReviews supports failure to thrive as part of PA multiorgan disease.
+  - target: Global developmental delay
+    description: Brain energy stress and recurrent metabolic injury contribute to delayed neurodevelopment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurometabolic injury
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: may experience a more insidious onset with the development of multiorgan complications including vomiting, protein
+        intolerance, failure to thrive, hypotonia, developmental delays or regression, movement disorders, or cardiomyopathy.
+      explanation: GeneReviews supports developmental delay or regression in PA.
+  - target: Intellectual disability
+    description: Metabolic and mitochondrial stress biomarkers track with more severe intellectual disability in PA.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurometabolic injury
+    - Mitochondrial stress
+    evidence:
+    - reference: PMID:38200289
+      reference_title: "Intellectual disability and autism in propionic acidemia: a biomarker-behavioral investigation implicating dysregulated mitochondrial biology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Higher concentrations of plasma propionylcarnitine, plasma total 2-methylcitrate, serum erythropoietin, and mitochondrial
+        biomarkers plasma FGF21 and GDF15 were associated with a more severe ID profile.
+      explanation: Patient biomarker data link PA metabolic/mitochondrial stress markers with more severe intellectual disability.
+  - target: Autism spectrum disorder
+    description: PA is associated with autism spectrum disorder, but the causal intermediates remain incompletely resolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:38200289
+      reference_title: "Intellectual disability and autism in propionic acidemia: a biomarker-behavioral investigation implicating dysregulated mitochondrial biology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Only two parameters, increased serum erythropoietin and decreased plasma glutamine, were associated with ASD.
+      explanation: Patient biomarker data support an association between PA biochemical abnormalities and ASD.
+  - target: Seizures
+    description: Acute and chronic neurometabolic injury can lower seizure threshold in PA.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurometabolic injury
+    - Progressive encephalopathy
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: this is followed by progressive encephalopathy manifesting as lethargy, seizures, or coma that can result in death.
+      explanation: GeneReviews supports seizures downstream of PA metabolic encephalopathy.
+  - target: Basal ganglia necrosis
+    description: Metabolic stroke-like injury from toxic metabolite accumulation affects basal ganglia structures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic stroke
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Manifestations of neonatal-onset and late-onset PA over time can include growth impairment, intellectual disability,
+        seizures, basal ganglia lesions, pancreatitis, cardiomyopathy, and chronic kidney disease.
+      explanation: GeneReviews supports basal ganglia lesions as a PA manifestation.
+  - target: Pancreatitis
+    description: Organic acidemia-related metabolic stress contributes to episodic pancreatic inflammation.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Manifestations of neonatal-onset and late-onset PA over time can include growth impairment, intellectual disability,
+        seizures, basal ganglia lesions, pancreatitis, cardiomyopathy, and chronic kidney disease.
+      explanation: GeneReviews supports pancreatitis as a PA manifestation.
+  - target: Optic atrophy
+    description: Chronic mitochondrial and neurometabolic stress provides a mechanistic route to optic nerve degeneration.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Other rarely reported complications include optic atrophy, sensorineural hearing loss, and premature ovarian insufficiency.
+      explanation: GeneReviews supports optic atrophy as a rare PA complication.
+  - target: Hearing impairment
+    description: Chronic metabolic disease burden is associated with late-onset hearing loss in PA.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Other rarely reported complications include optic atrophy, sensorineural hearing loss, and premature ovarian insufficiency.
+      explanation: GeneReviews supports hearing loss as a rare PA complication.
+  - target: Rhabdomyolysis
+    description: Severe metabolic decompensation can injure skeletal muscle and produce rhabdomyolysis.
+    causal_link_type: UNKNOWN
+    intermediate_mechanisms:
+    - Severe metabolic decompensation
+    evidence:
+    - reference: PMID:37689673
+      reference_title: "Prevalence of propionic acidemia in China."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: intellectual disability, seizures, basal ganglia lesions, pancreatitis, cardiomyopathy, arrhythmias, adaptive
+        immune defects, rhabdomyolysis, optic atrophy, hearing loss, premature ovarian failure, and chronic kidney disease
+      explanation: A clinical review lists rhabdomyolysis among PA complications.
+  - target: Propionylcarnitine (C3)
+    description: Excess propionyl-CoA is conjugated with carnitine, producing elevated propionylcarnitine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Newborns with PA tested by expanded newborn screening (NBS) have elevated C3 (propionylcarnitine).
+      explanation: GeneReviews supports elevated C3 as a direct PA biochemical marker.
+  - target: 2-Methylcitric acid
+    description: Propionyl-CoA excess is diverted into methylcitric acid formation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Testing of urine organic acids in persons who are symptomatic or those detected by NBS reveals elevated 3-hydroxypropionate
+        and the presence of methylcitrate, tiglylglycine, propionylglycine, and lactic acid.
+      explanation: GeneReviews supports methylcitrate as a PA biochemical marker.
+  - target: Glycine
+    description: Disrupted propionate metabolism is reflected in the classical hyperglycinemia biochemical profile.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Secondary glycine metabolism disruption
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Testing of plasma amino acids generally reveals elevated glycine.
+      explanation: GeneReviews supports elevated glycine as a PA biochemical marker.
+  - target: 3-Hydroxypropionate
+    description: Accumulated propionyl-CoA-derived metabolites include urinary 3-hydroxypropionate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Testing of urine organic acids in persons who are symptomatic or those detected by NBS reveals elevated 3-hydroxypropionate
+        and the presence of methylcitrate, tiglylglycine, propionylglycine, and lactic acid.
+      explanation: GeneReviews supports elevated 3-hydroxypropionate as a PA biochemical marker.
+  - target: Propionylglycine
+    description: Propionyl-CoA excess is conjugated with glycine, producing elevated propionylglycine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Testing of urine organic acids in persons who are symptomatic or those detected by NBS reveals elevated 3-hydroxypropionate
+        and the presence of methylcitrate, tiglylglycine, propionylglycine, and lactic acid.
+      explanation: GeneReviews supports propionylglycine as a PA biochemical marker.
+  - target: FGF21 and GDF15
+    description: Mitochondrial stress signaling in PA is reflected by increased FGF21 and GDF15.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Mitochondrial stress response
+    evidence:
+    - reference: PMID:38200289
+      reference_title: "Intellectual disability and autism in propionic acidemia: a biomarker-behavioral investigation implicating dysregulated mitochondrial biology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Higher concentrations of plasma propionylcarnitine, plasma total 2-methylcitrate, serum erythropoietin, and mitochondrial
+        biomarkers plasma FGF21 and GDF15 were associated with a more severe ID profile.
+      explanation: Patient biomarker data support FGF21 and GDF15 as mitochondrial stress markers in PA.
 - name: Secondary NAG deficiency and hyperammonemia
   description: 'Hyperammonemia in PA is related to secondary deficiency of N-acetylglutamate (NAG), the allosteric activator
     of carbamoyl phosphate synthetase 1 (CPS1), which is an irreversible rate-limiting enzyme in the urea cycle. CPS1 inhibition
@@ -123,6 +349,18 @@ pathophysiology:
     snippet: Hyperammonemia is related to a secondary deficiency of N-acetylglutamate (NAG), the activator of carbamoyl phosphate
       synthetase 1, which is an irreversible rate-limiting enzyme in the urea cycle.
     explanation: Directly explains the mechanism of secondary hyperammonemia in PA via NAG/CPS1 pathway.
+  downstream:
+  - target: Hyperammonemia
+    description: Secondary NAG deficiency reduces CPS1 activation and impairs ureagenesis, causing hyperammonemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39695809
+      reference_title: "Role of carglumic acid in the long-term management of propionic and methylmalonic acidurias."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Hyperammonemia is related to a secondary deficiency of N-acetylglutamate (NAG), the activator of carbamoyl phosphate
+        synthetase 1, which is an irreversible rate-limiting enzyme in the urea cycle.
+      explanation: Review evidence directly links secondary NAG deficiency to hyperammonemia in PA/MMA.
 - name: Cardiac oxidative stress via circulating propionate
   description: 'In PA, accumulated propionyl-CoA and diminished hepatic propionate clearance lead to elevated circulating
     propionate. Gut microbiome-derived propionate is the primary cardiac propionyl-CoA source, and prolonged exposure induces
@@ -201,6 +439,21 @@ pathophysiology:
     snippet: We observed a steep reduction of PGC-1-α, the key mediator modulating mitochondrial functions and a counter actor
       of mitochondrial fission.
     explanation: PGC-1-alpha reduction links mitochondrial dysfunction to CKD pathogenesis.
+  downstream:
+  - target: Chronic kidney disease
+    description: Impaired renal mitochondrial quality control drives progressive kidney dysfunction in PA.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Altered mitochondrial fission
+    - Reduced mitophagy
+    evidence:
+    - reference: PMID:39681572
+      reference_title: "Renal phenotyping in a hypomorphic murine model of propionic aciduria reveals common pathomechanisms in organic acidurias."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Our results suggest that impairment of mitochondrial homeostasis and quality control are involved in CKD development
+        in PA.
+      explanation: Model-organism evidence directly links renal mitochondrial quality-control impairment to CKD development.
 - name: Cardiac multi-mechanism pathogenesis
   description: 'Cardiac complications in PA involve multiple cellular pathways including impaired substrate delivery to TCA
     cycle, secondary mitochondrial electron transport chain dysfunction, oxidative stress, coenzyme Q10 deficiency, metabolic
@@ -231,6 +484,37 @@ pathophysiology:
       to TCA cycle and TCA dysfunction, secondary mitochondrial electron transport chain dysfunction and oxidative stress,
       coenzyme Q10 deficiency, metabolic reprogramming, carnitine deficiency, cardiac excitation-contraction coupling alteration'
     explanation: Comprehensive review identifying multiple cardiac pathogenetic mechanisms in PA.
+  downstream:
+  - target: Dilated cardiomyopathy
+    description: PA cardiac mitochondrial and metabolic pathway disruption culminates in dilated cardiomyopathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Mitochondrial electron transport chain dysfunction
+    - Oxidative stress
+    - Coenzyme Q10 deficiency
+    evidence:
+    - reference: PMID:37110221
+      reference_title: "Understanding the Pathogenesis of Cardiac Complications in Patients with Propionic Acidemia and Exploring Therapeutic Alternatives for Those Who Are Not Eligible or Are Waiting for Liver Transplantation."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: '12 potential disease-specific or non-disease-specific pathogenetic mechanisms, namely: impaired substrate delivery
+        to TCA cycle and TCA dysfunction, secondary mitochondrial electron transport chain dysfunction and oxidative stress,
+        coenzyme Q10 deficiency, metabolic reprogramming, carnitine deficiency, cardiac excitation-contraction coupling alteration'
+      explanation: Review evidence supports multiple PA cardiac mechanisms that can contribute to cardiomyopathy.
+  - target: Prolonged QT interval
+    description: Cardiac metabolic and excitation-contraction abnormalities provide the mechanistic basis for QT prolongation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cardiac excitation-contraction coupling alteration
+    evidence:
+    - reference: PMID:37110221
+      reference_title: "Understanding the Pathogenesis of Cardiac Complications in Patients with Propionic Acidemia and Exploring Therapeutic Alternatives for Those Who Are Not Eligible or Are Waiting for Liver Transplantation."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: '12 potential disease-specific or non-disease-specific pathogenetic mechanisms, namely: impaired substrate delivery
+        to TCA cycle and TCA dysfunction, secondary mitochondrial electron transport chain dysfunction and oxidative stress,
+        coenzyme Q10 deficiency, metabolic reprogramming, carnitine deficiency, cardiac excitation-contraction coupling alteration'
+      explanation: Review evidence supports excitation-contraction and metabolic cardiac mechanisms relevant to QT prolongation.
 phenotypes:
 - name: Metabolic acidosis
   frequency: VERY_FREQUENT
@@ -681,6 +965,18 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Toxic metabolite burden and mitochondrial stress
+    treatment_effect: MODULATES
+    description: Restricting propiogenic amino acid intake lowers substrate flux into the blocked PCC pathway and limits toxic metabolite production.
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Individualized dietary management should be directed by an experienced physician and metabolic dietician to control
+        the intake of propiogenic substrates and to guide increased caloric intake during illness to prevent catabolism
+      explanation: GeneReviews directly supports dietary management as substrate-control therapy in PA.
   evidence:
   - reference: PMID:25205257
     reference_title: "Proposed guidelines for the diagnosis and management of methylmalonic and propionic acidemia."
@@ -697,6 +993,18 @@ treatments:
     term:
       id: MAXO:0010006
       label: carnitine supplementation
+  target_mechanisms:
+  - target: Toxic metabolite burden and mitochondrial stress
+    treatment_effect: MODULATES
+    description: Carnitine supports detoxification of propionyl groups through propionylcarnitine formation and excretion.
+    evidence:
+    - reference: PMID:6725560
+      reference_title: "L-carnitine enhances excretion of propionyl coenzyme A as propionylcarnitine in propionic acidemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Treatment with L-carnitine greatly enhanced the formation and excretion of short-chain acylcarnitines in three
+        patients with propionic acidemia and in three normal controls.
+      explanation: Patient evidence supports carnitine-mediated acylcarnitine excretion in PA.
   evidence:
   - reference: PMID:25205257
     reference_title: "Proposed guidelines for the diagnosis and management of methylmalonic and propionic acidemia."
@@ -714,6 +1022,18 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Secondary NAG deficiency and hyperammonemia
+    treatment_effect: BYPASSES
+    description: Carglumic acid bypasses secondary NAG deficiency by stimulating the first step of the urea cycle and reducing hyperammonemia.
+    evidence:
+    - reference: PMID:30522498
+      reference_title: "Hyperammonaemia in classic organic acidaemias: a review of the literature and two case histories."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Treatment with N-carbamyl-L-glutamate can rapidly normalise ammonia levels by stimulating the first step of the
+        urea cycle.
+      explanation: The review describes the urea-cycle stimulation mechanism of carglumic acid/N-carbamyl-L-glutamate.
   evidence:
   - reference: PMID:39695809
     reference_title: "Role of carglumic acid in the long-term management of propionic and methylmalonic acidurias."
@@ -738,13 +1058,24 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Secondary NAG deficiency and hyperammonemia
+    treatment_effect: MODULATES
+    description: Nitrogen-scavenger pharmacotherapy lowers ammonia burden downstream of impaired ureagenesis.
+    evidence:
+    - reference: PMID:30522498
+      reference_title: "Hyperammonaemia in classic organic acidaemias: a review of the literature and two case histories."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: It may also include the administration of ammonia scavengers such as sodium benzoate or sodium phenylbutyrate.
+      explanation: The organic-acidemia hyperammonemia review directly supports ammonia scavengers as therapy for this branch.
   evidence:
-  - reference: PMID:25205257
-    reference_title: "Proposed guidelines for the diagnosis and management of methylmalonic and propionic acidemia."
-    supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
-    snippet: Patients present either shortly after birth with acute deterioration, metabolic acidosis and hyperammonemia
-    explanation: Presence of hyperammonemia supports use of ammonia-directed pharmacotherapy.
+  - reference: PMID:30522498
+    reference_title: "Hyperammonaemia in classic organic acidaemias: a review of the literature and two case histories."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: It may also include the administration of ammonia scavengers such as sodium benzoate or sodium phenylbutyrate.
+    explanation: Directly supports ammonia scavengers as ammonia-lowering pharmacotherapy in organic acidemia hyperammonemia.
 - name: Acute decompensation management
   description: 'Emergency supportive care with reversal of catabolism via high glucose infusion, cessation of protein intake,
     and correction of metabolic acidosis.
@@ -755,13 +1086,35 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Toxic metabolite burden and mitochondrial stress
+    treatment_effect: MODULATES
+    description: Emergency reversal of catabolism and temporary protein cessation reduce acute substrate-driven toxic metabolite production.
+    evidence:
+    - reference: PMID:22593918
+      reference_title: "Propionic Acidemia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: reverse catabolism by providing intravenous glucose and lipids; manage protein intake to reduce propiogenic precursors;
+        remove toxic compounds using intravenous carnitine
+      explanation: GeneReviews directly supports reversal of catabolism, precursor reduction, and toxic-compound removal during acute PA management.
+  - target: Secondary NAG deficiency and hyperammonemia
+    treatment_effect: MODULATES
+    description: Acute decompensation protocols include correction of hyperammonemia during crises.
+    evidence:
+    - reference: PMID:30522498
+      reference_title: "Hyperammonaemia in classic organic acidaemias: a review of the literature and two case histories."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Correcting metabolic imbalance and hyperammonaemia are critical to prevent brain damage in affected patients.
+      explanation: The review supports hyperammonemia correction as an acute management target in organic acidemias.
   evidence:
-  - reference: PMID:25205257
-    reference_title: "Proposed guidelines for the diagnosis and management of methylmalonic and propionic acidemia."
+  - reference: PMID:22593918
+    reference_title: "Propionic Acidemia."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: Patients present either shortly after birth with acute deterioration, metabolic acidosis and hyperammonemia
-    explanation: Supports crisis-focused supportive management during acute deterioration.
+    evidence_source: OTHER
+    snippet: The treatment of individuals with acutely decompensated PA is a medical emergency
+    explanation: GeneReviews supports emergency management for acute PA decompensation.
 - name: Liver transplantation
   description: 'Considered for severe recurrent decompensation and poor metabolic control. LT improves metabolic stability
     but does not fully correct the biochemical defect since PCC is expressed in extrahepatic tissues.
@@ -772,6 +1125,17 @@ treatments:
     term:
       id: MAXO:0001175
       label: liver transplantation
+  target_mechanisms:
+  - target: Toxic metabolite burden and mitochondrial stress
+    treatment_effect: MODULATES
+    description: Liver transplantation improves hepatic propionate handling and metabolic stability, while extrahepatic PCC deficiency remains.
+    evidence:
+    - reference: PMID:33093405
+      reference_title: "Liver Transplantation for Propionic Acidemia: Evidence From a Systematic Review and Meta-analysis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The pooled estimate rates were 0.98 (95% CI, 0.88-1.00) for metabolic stability
+      explanation: Systematic-review evidence directly supports improved metabolic stability after liver transplantation.
   evidence:
   - reference: PMID:33093405
     reference_title: "Liver Transplantation for Propionic Acidemia: Evidence From a Systematic Review and Meta-analysis."
@@ -790,6 +1154,18 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Cardiac multi-mechanism pathogenesis
+    treatment_effect: MODULATES
+    description: Standard cardiac medications and coenzyme Q10 target the downstream cardiomyopathy and electrophysiology branch rather than the upstream PCC defect.
+    evidence:
+    - reference: PMID:37110221
+      reference_title: "Understanding the Pathogenesis of Cardiac Complications in Patients with Propionic Acidemia and Exploring Therapeutic Alternatives for Those Who Are Not Eligible or Are Waiting for Liver Transplantation."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The guidelines for the management of patients affected by propionic acidemia (PA) recommend standard cardiac
+        therapy in the presence of cardiac complications.
+      explanation: The cardiac-complication guideline recommendation supports targeting the cardiac pathogenesis branch.
   evidence:
   - reference: PMID:37110221
     reference_title: "Understanding the Pathogenesis of Cardiac Complications in Patients with Propionic Acidemia and Exploring Therapeutic Alternatives for Those Who Are Not Eligible or Are Waiting for Liver Transplantation."

--- a/references_cache/PMID_22593918.md
+++ b/references_cache/PMID_22593918.md
@@ -1,0 +1,123 @@
+---
+reference_id: "PMID:22593918"
+title: Propionic Acidemia.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Galarreta Aima CI
+- Shchelochkov OA
+- Jerves Serrano T
+- Venditti CP
+year: '1993'
+content_type: abstract_only
+---
+
+# Propionic Acidemia.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Galarreta Aima CI, Shchelochkov OA, Jerves Serrano T, Venditti CP
+
+## Content
+
+1. Propionic Acidemia.
+
+Galarreta Aima CI(1), Shchelochkov OA(1), Jerves Serrano T(2), Venditti CP(1).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2012 May 17 [updated 2024 Sep 26].
+
+Author information:
+(1)National Human Genome Research Institute, National Institutes of Health,
+Bethesda, Maryland
+(2)Department of Genetics, Yale School of Medicine, New Haven, Connecticut
+
+CLINICAL CHARACTERISTICS: The spectrum of propionic acidemia (PA) ranges from
+neonatal onset to late-onset disease. Neonatal-onset PA, the most common form,
+is characterized by a healthy newborn with poor feeding and decreased arousal in
+the first few days of life, followed by progressive encephalopathy of
+unexplained origin. Without prompt diagnosis (often through newborn screening)
+and management, this is followed by progressive encephalopathy manifesting as
+lethargy, seizures, or coma that can result in death. It is frequently
+accompanied by metabolic acidosis with anion gap, lactic acidosis, ketonuria,
+hypoglycemia, hyperammonemia, and cytopenias. Individuals with late-onset PA may
+remain asymptomatic and suffer a metabolic crisis under catabolic stress (e.g.,
+illness, surgery, fasting) or may experience a more insidious onset with the
+development of multiorgan complications including vomiting, protein intolerance,
+failure to thrive, hypotonia, developmental delays or regression, movement
+disorders, or cardiomyopathy. Isolated cardiomyopathy can be observed on rare
+occasions in the absence of clinical metabolic decompensation or neurocognitive
+deficits. Manifestations of neonatal-onset and late-onset PA over time can
+include growth impairment, intellectual disability, seizures, basal ganglia
+lesions, pancreatitis, cardiomyopathy, and chronic kidney disease. Other rarely
+reported complications include optic atrophy, sensorineural hearing loss, and
+premature ovarian insufficiency.
+DIAGNOSIS/TESTING: PA is caused by deficiency of propionyl-coenzyme A
+carboxylase (PCC), the enzyme that catalyzes the conversion of propionyl-CoA to
+methylmalonyl-CoA. Newborns with PA tested by expanded newborn screening (NBS)
+have elevated C3 (propionylcarnitine). Testing of urine organic acids in persons
+who are symptomatic or those detected by NBS reveals elevated
+3-hydroxypropionate and the presence of methylcitrate, tiglylglycine,
+propionylglycine, and lactic acid. Testing of plasma amino acids generally
+reveals elevated glycine. Confirmation of the diagnosis relies on detection of
+biallelic pathogenic variants in PCCA or PCCB by molecular genetic testing, or
+detection of deficient PCC enzymatic activity. In individuals with equivocal
+molecular genetic test results, a combination of enzymatic and molecular
+diagnostics may be necessary.
+MANAGEMENT: Treatment of manifestations: The treatment of individuals with
+acutely decompensated PA is a medical emergency: treat precipitating factors
+such as infection, dehydration, vomiting; reverse catabolism by providing
+intravenous glucose and lipids; manage protein intake to reduce propiogenic
+precursors; remove toxic compounds using intravenous carnitine, and when
+necessary nitrogen scavenger medications and/or extracorporeal detoxification;
+transfer to a center with biochemical genetics expertise and the ability to
+support urgent hemodialysis, especially if hyperammonemia is present. Prevention
+of primary manifestations: Individualized dietary management should be directed
+by an experienced physician and metabolic dietician to control the intake of
+propiogenic substrates and to guide increased caloric intake during illness to
+prevent catabolism, typically by using specialized medical food. Gastrostomy
+tube placement is an effective strategy to facilitate the administration of
+medications and nutrition during acute decompensations and to improve adherence
+in chronic management of PA. Medications may include L-carnitine supplementation
+to enhance excretion of propionic acid and oral metronidazole to reduce
+propionate production by gut bacteria. Orthotopic liver transplantation may be
+indicated in those with frequent metabolic decompensations, uncontrollable
+hyperammonemia, and/or poor growth. Prevention of secondary complications:
+Consistent evaluation of the protein prescription, depending on age, sex, level
+of physical activity, severity of disorder, and presence of other factors such
+as intercurrent illness, surgery, and growth spurts to avoid insufficient or
+excessive protein intake is necessary. Excessive protein restriction or
+overreliance on medical foods can result in deficiency of essential amino acids
+and impaired growth, as well as catabolism-induced metabolic decompensation.
+Surveillance: Monitor affected individuals with a catabolic stressor (fasting,
+fever, illness, injury, and surgery) closely to prevent and/or detect and manage
+metabolic decompensations early. Regularly assess: (1) growth, nutritional
+status, feeding ability, and psychomotor development; (2) vision and hearing;
+(3) cardiac function for signs of cardiomyopathy and prolonged QT interval; (4)
+metabolic status by monitoring routine chemistries, plasma ammonia, plasma amino
+acids, and plasma carnitine levels; (5) complete blood count; and (6) kidney
+function. Agents/circumstances to avoid: Avoid prolonged fasting, catabolic
+stressors, and excessive protein intake. Lactated Ringer's solution is not
+recommended in individuals with organic acidemias. In individuals with QT
+abnormalities, avoid medications that can prolong the QT interval. Neuroleptic
+antiemetics (e.g., promethazine) can mask symptoms of progressive encephalopathy
+and are best avoided. Evaluation of relatives at risk: Testing of at-risk sibs
+of an affected individual is warranted to allow for early diagnosis and
+treatment.
+GENETIC COUNSELING: PA is inherited in an autosomal recessive manner. If both
+parents are known to be heterozygous for a PCCA or PCCB pathogenic variant, each
+sib of an affected individual has at conception a 25% chance of being affected,
+a 50% chance of being an asymptomatic carrier, and a 25% chance of inheriting
+neither of the familial pathogenic variants. Once the PCCA or PCCB pathogenic
+variants have been identified in an affected family member, molecular genetic
+carrier testing of at-risk relatives and prenatal/preimplantation genetic
+testing are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 22593918

--- a/references_cache/PMID_6725560.md
+++ b/references_cache/PMID_6725560.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:6725560"
+title: L-carnitine enhances excretion of propionyl coenzyme A as propionylcarnitine in propionic acidemia.
+authors:
+- Roe CR
+- Millington DS
+- Maltby DA
+- Bohan TP
+- Hoppel CL
+journal: J Clin Invest
+year: '1984'
+doi: 10.1172/JCI111387
+keywords:
+- Acyl Coenzyme A/urine
+- Adolescent
+- Carboxy-Lyases/deficiency
+- "Carnitine/analogs & derivatives, metabolism, urine"
+- Child
+- "Child, Preschool"
+- Humans
+- Infant
+- Male
+- Mass Spectrometry/methods
+- "Metabolism, Inborn Errors/metabolism"
+- Methylmalonyl-CoA Decarboxylase
+- Propionates/metabolism
+content_type: abstract_only
+---
+
+# L-carnitine enhances excretion of propionyl coenzyme A as propionylcarnitine in propionic acidemia.
+**Authors:** Roe CR, Millington DS, Maltby DA, Bohan TP, Hoppel CL
+**Journal:** J Clin Invest (1984)
+**DOI:** [10.1172/JCI111387](https://doi.org/10.1172/JCI111387)
+
+## Content
+
+1. J Clin Invest. 1984 Jun;73(6):1785-8. doi: 10.1172/JCI111387.
+
+L-carnitine enhances excretion of propionyl coenzyme A as propionylcarnitine in
+propionic acidemia.
+
+Roe CR, Millington DS, Maltby DA, Bohan TP, Hoppel CL.
+
+Treatment with L-carnitine greatly enhanced the formation and excretion of
+short-chain acylcarnitines in three patients with propionic acidemia and in
+three normal controls. The use of fast atom bombardment mass spectrometry and
+linked scanning at constant magnetic (B) to electric (E) field ratio identified
+the acylcarnitine as propionylcarnitine in patients with propionic acidemia. The
+normal children excreted mostly acetylcarnitine. Propionic acidemia and other
+organic acidurias are characterized by the intramitochondrial accumulation of
+short-chain acyl-Coenzyme A (CoA) compounds. The substrate specificity of the
+carnitine acetyltransferase enzyme and its steady state nature appears to
+facilitate elimination of propionyl groups while restoring the acyl-CoA:free CoA
+ratio in the mitochondrion. We suggest that L-carnitine may be a useful
+therapeutic approach for elimination of toxic acyl CoA compounds in several of
+these disorders.
+
+DOI: 10.1172/JCI111387
+PMCID: PMC437091
+PMID: 6725560 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Connected Propionic Acidemia mechanisms to all existing phenotype and biochemical outputs with edge-specific evidence.
- Added mechanism targets for substrate-control, carnitine, carglumic acid, ammonia-scavenger, acute decompensation, liver transplant, and cardiac therapies.
- Added generated caches for two newly cited PMIDs: GeneReviews PA (PMID:22593918) and L-carnitine propionylcarnitine excretion (PMID:6725560).

## Validation
- `just validate kb/disorders/Propionic_Acidemia.yaml`
- Manual case-preserving snippet audit: 80 checks, 0 failures, 0 missing
- Graph audit: 28 downstream edges; no dangling targets; no untargeted phenotypes/biochemical markers; no isolated pathophysiology nodes
- Subagent blocker review: no blockers after fixes

## Scope notes
- Restored unrelated validation cache churn.
- Genetic counseling and newborn screening intentionally do not have `target_mechanisms` because they do not modulate a disease mechanism node.