### PR TITLE
Improve VLCAD deficiency pathograph

### DIFF
--- a/kb/disorders/VLCAD_Deficiency.yaml
+++ b/kb/disorders/VLCAD_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Very Long-Chain Acyl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T23:04:38Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-07T05:03:58Z'
 synonyms:
 - VLCAD deficiency
 - VLCADD
@@ -100,6 +100,17 @@ pathophysiology:
   downstream:
   - target: Impaired very-long-chain fatty acid beta-oxidation
     description: Reduced ACADVL activity blocks initial dehydrogenation of C12-C20 acyl-CoAs.
+  - target: VLCAD enzyme activity
+    description: Biallelic ACADVL dysfunction is reflected by reduced measured VLCAD enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38651394
+      reference_title: "Management and Outcomes of Very Long-Chain Acyl-CoA Dehydrogenase Deficiency (VLCAD Deficiency): A Retrospective Chart Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The study included 12 patients, 7 of whom had an enzyme activity of more than 10%, and 5 patients had an enzyme
+        activity of less than 10%.
+      explanation: Patient chart-review data document reduced VLCAD enzyme activity measurements.
 - name: Impaired very-long-chain fatty acid beta-oxidation
   description: 'Impaired mitochondrial oxidation of long-chain fatty acyl-CoA substrates (C12-C20), especially during fasting and other catabolic states, reduces acetyl-CoA generation, limits ATP production, and impairs hepatic ketogenesis.
 
@@ -123,6 +134,51 @@ pathophysiology:
   downstream:
   - target: Tissue energy deficit in high-demand organs
   - target: Lipotoxic metabolite accumulation
+  - target: Ketone bodies
+    description: Impaired hepatic long-chain FAO limits ketogenesis, producing the hypoketotic biochemical state.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The hepatic or hypoketotic hypoglycemic form typically presents during early childhood with hypoketotic hypoglycemia
+        and hepatomegaly, but without cardiomyopathy.
+      explanation: GeneReviews supports the hypoketotic state in VLCAD deficiency.
+  - target: Tetradecenoylcarnitine (C14:1)
+    description: Blocked long-chain beta-oxidation produces elevated C14:1 acylcarnitine, the principal diagnostic marker.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38651394
+      reference_title: "Management and Outcomes of Very Long-Chain Acyl-CoA Dehydrogenase Deficiency (VLCAD Deficiency): A Retrospective Chart Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: However, the newborn screening C14:1 value is the most sensitive predictor of low enzyme activity and may help
+        guide dietary management.
+      explanation: Patient data link C14:1 elevation at newborn screening to low VLCAD enzyme activity.
+  - target: Long-chain acylcarnitines (C14, C16, C18 species)
+    description: Impaired long-chain acyl-CoA oxidation leads to abnormal long-chain acylcarnitine profiles.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37367883
+      reference_title: "A Distinctive Metabolomics Profile and Potential Biomarkers for Very Long Acylcarnitine Dehydrogenase Deficiency (VLCADD) Diagnosis in Newborns."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Very long-chain acylcarnitine dehydrogenase deficiency (VLCADD) is a rare inherited metabolic disorder associated
+        with fatty acid β-oxidation and characterized by genetic mutations in the ACADVL gene and accumulations of
+        acylcarnitines.
+      explanation: Newborn metabolomics evidence supports accumulated acylcarnitines in VLCADD.
+  - target: Glucagon
+    description: FAO impairment is associated with reduced fasting glucagon concentrations in VLCAD patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:37512487
+      reference_title: "Low Fasting Concentrations of Glucagon in Patients with Very Long-Chain Acyl-CoA Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Low fasting concentrations of glucagon are present in patients with VLCAD and cannot be explained by altered stimuli
+        in plasma.
+      explanation: Patient data support reduced fasting glucagon downstream of VLCAD deficiency.
 - name: Tissue energy deficit in high-demand organs
   description: 'Energy deficiency affects myocardium, skeletal muscle, and liver. Impaired FAO reduces availability of reducing equivalents and acetyl-CoA for mitochondrial ATP production and hepatic ketogenesis, forcing compensatory reliance on glucose utilization and gluconeogenesis.
 
@@ -171,6 +227,171 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: Defects in mitochondrial fatty acid β-oxidation (FAO) impair metabolic flexibility, which is an essential process for energy homeostasis.
     explanation: Demonstrates impaired metabolic flexibility and energy homeostasis in VLCAD deficiency.
+  downstream:
+  - target: Hypoketotic hypoglycemia
+    description: Energy failure and impaired hepatic ketogenesis produce hypoketotic hypoglycemia during fasting or catabolic stress.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37512487
+      reference_title: "Low Fasting Concentrations of Glucagon in Patients with Very Long-Chain Acyl-CoA Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Hypoketotic hypoglycemia is a feared clinical complication and the treatment focuses on avoiding hypoglycemia.
+      explanation: Patient-focused clinical study supports hypoketotic hypoglycemia as an energy-balance complication.
+  - target: Cardiomyopathy
+    description: Myocardial energy deficit contributes to hypertrophic or dilated cardiomyopathy in severe VLCAD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Myocardial ATP deficit
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The severe early-onset cardiac and multiorgan failure form typically presents in the first months of life with
+        hypertrophic or dilated cardiomyopathy
+      explanation: GeneReviews supports cardiomyopathy in the severe energy-demand-organ phenotype.
+  - target: Rhabdomyolysis
+    description: Skeletal muscle energy deficit during exercise or catabolic stress predisposes to rhabdomyolysis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Exercise-induced muscle energy failure
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The later-onset episodic myopathic form presents with intermittent rhabdomyolysis provoked by exercise
+      explanation: GeneReviews supports exercise-provoked rhabdomyolysis in VLCAD.
+  - target: Hepatomegaly
+    description: Hepatic energy deficit and impaired fatty acid handling contribute to hepatomegaly in hepatic VLCAD presentations.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic metabolic decompensation
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The hepatic or hypoketotic hypoglycemic form typically presents during early childhood with hypoketotic hypoglycemia
+        and hepatomegaly
+      explanation: GeneReviews supports hepatomegaly in the hepatic VLCAD phenotype.
+  - target: Exercise intolerance
+    description: Reduced skeletal muscle energy production causes exercise intolerance in the myopathic form.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The later-onset episodic myopathic form presents with intermittent rhabdomyolysis provoked by exercise, muscle
+        cramps and/or pain, and/or exercise intolerance.
+      explanation: GeneReviews supports exercise intolerance in the myopathic form.
+  - target: Myalgia
+    description: Skeletal muscle energy failure manifests as muscle cramps and pain during myopathic episodes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The later-onset episodic myopathic form presents with intermittent rhabdomyolysis provoked by exercise, muscle
+        cramps and/or pain, and/or exercise intolerance.
+      explanation: GeneReviews supports muscle pain in the myopathic VLCAD form.
+  - target: Muscle weakness
+    description: Recurrent skeletal muscle energy stress can be associated with persistent weakness.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38015438
+      reference_title: "Long-term prognosis of fatty-acid oxidation disorders in adults: Optimism despite the limited effective therapies available."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The principal symptoms were acute muscle manifestations (rhabdomyolysis, exercise intolerance, myalgia), sometimes
+        associated with permanent muscle weakness.
+      explanation: Adult FAOD cohort evidence supports muscle weakness associated with myopathic manifestations.
+  - target: Lethargy
+    description: Acute substrate stress can precipitate lethargic metabolic decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic decompensation
+    evidence:
+    - reference: PMID:19333779
+      reference_title: "Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat loading in a patient detected through newborn screening."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: was admitted with emesis, severe lethargy, limpness in extremities, loss of muscle tone and an elevated CK level.
+      explanation: Case evidence directly supports severe lethargy during VLCAD decompensation after long-chain fat loading.
+  - target: Hyperammonemia
+    description: Severe neonatal metabolic decompensation may include secondary hyperammonemia.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Early childhood disease may manifest with hypoketotic hypoglycemia, hyperammonemia, lactic acidosis, and elevated
+        transaminases.
+      explanation: Review evidence directly supports hyperammonemia during early VLCAD disease.
+  - target: Lactic acidosis
+    description: Severe metabolic decompensation may include lactic acidosis in early-childhood VLCAD presentations.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Early childhood disease may manifest with hypoketotic hypoglycemia, hyperammonemia, lactic acidosis, and elevated
+        transaminases.
+      explanation: Review evidence directly supports lactic acidosis in early VLCAD disease.
+  - target: Muscular hypotonia
+    description: Systemic and skeletal-muscle energy deficit contributes to hypotonia in severe early-onset disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Skeletal muscle energy deficit
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The severe early-onset cardiac and multiorgan failure form typically presents in the first months of life with
+        hypertrophic or dilated cardiomyopathy, pericardial effusion, and arrhythmias, as well as hypotonia, hepatomegaly,
+        and intermittent hypoglycemia.
+      explanation: GeneReviews supports hypotonia in severe early-onset VLCAD.
+  - target: Seizure
+    description: Severe neurologic presentations in VLCAD can include status epilepticus and epileptic spasms.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:38157116
+      reference_title: "Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms Syndrome Secondary to Very Long Chain Acyl-CoA Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms Syndrome Secondary to Very Long Chain
+        Acyl-CoA Dehydrogenase Deficiency.
+      explanation: Case-report title supports status epilepticus and infantile epileptic spasms secondary to VLCAD deficiency.
+  - target: Elevated creatine kinase
+    description: Rhabdomyolysis from skeletal muscle energy failure raises serum creatine kinase.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Rhabdomyolysis
+    evidence:
+    - reference: PMID:38015438
+      reference_title: "Long-term prognosis of fatty-acid oxidation disorders in adults: Optimism despite the limited effective therapies available."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Episodes of rhabdomyolysis were frequent (84%), with a mean creatinine kinase level of 68,958 U/L
+      explanation: Adult FAOD cohort evidence links rhabdomyolysis episodes to elevated creatine kinase.
+  - target: Vomiting
+    description: Vomiting can accompany severe infantile metabolic decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic decompensation
+    evidence:
+    - reference: PMID:19333779
+      reference_title: "Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat loading in a patient detected through newborn screening."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: was admitted with emesis, severe lethargy, limpness in extremities, loss of muscle tone and an elevated CK level.
+      explanation: Case evidence supports emesis/vomiting during VLCAD decompensation after long-chain fat loading.
 - name: Lipotoxic metabolite accumulation
   description: 'Accumulating long-chain acylcarnitines (especially C14:1 and related C14-C18 species) and fatty acid intermediates may contribute directly to pathology through increased cellular permeability, inflammation, calcium signaling disruption, and arrhythmogenic potential.
 
@@ -194,6 +415,30 @@ pathophysiology:
     explanation: Demonstrates widespread metabolic disruption from accumulated toxic intermediates.
   downstream:
   - target: Secondary mitochondrial dysfunction and OXPHOS impairment
+  - target: Cardiac arrhythmia
+    description: Long-chain acylcarnitine accumulation is linked to arrhythmogenic cardiac involvement.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cardiac lipotoxicity
+    evidence:
+    - reference: PMID:20301763
+      reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The severe early-onset cardiac and multiorgan failure form typically presents in the first months of life with
+        hypertrophic or dilated cardiomyopathy, pericardial effusion, and arrhythmias
+      explanation: GeneReviews supports arrhythmias as part of severe cardiac VLCAD.
+  - target: Long-chain carboxylic and dicarboxylic acids
+    description: Lipotoxic substrate handling abnormalities include excess long-chain carboxylic and dicarboxylic acid intermediates.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Urine organic acids are notable for extremely reduced or absent ketones, with elevated long-chain carboxylic and
+        dicarboxylic acids.
+      explanation: Review evidence directly supports long-chain carboxylic and dicarboxylic acid accumulation in VLCAD.
 - name: Secondary mitochondrial dysfunction and OXPHOS impairment
   description: 'VLCAD interacts physically with OXPHOS supercomplexes; VLCAD deficiency disrupts these interactions and impairs electron transport chain function, worsening bioenergetics beyond the primary FAO defect.
 
@@ -245,6 +490,16 @@ pathophysiology:
     explanation: Metabolomics data consistent with oxidative stress in VLCADD newborns.
   downstream:
   - target: Immunometabolic dysregulation
+  - target: Glutathione
+    description: Oxidative stress in VLCAD deficiency is reflected by glutathione pathway vulnerability and altered glutathione levels.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36356723
+      reference_title: "Odd- and even-numbered medium-chained fatty acids protect against glutathione depletion in very long-chain acyl-CoA dehydrogenase deficiency."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: metabolic stress led to GSH depletion and decreased viability in VLCAD deficient cells
+      explanation: In vitro evidence directly supports glutathione depletion vulnerability in VLCAD-deficient cells.
 - name: Immunometabolic dysregulation
   description: 'VLCAD-deficient cells show impaired TLR4 signaling and reduced pro-inflammatory cytokine induction after LPS stimulation, connecting long-chain FAO to innate immune competence and helping explain why infection and inflammation trigger metabolic decompensation.
 
@@ -433,12 +688,12 @@ phenotypes:
       id: HP:0001254
       label: Lethargy
   evidence:
-  - reference: PMID:20301763
-    reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
-    supports: PARTIAL
+  - reference: PMID:19333779
+    reference_title: "Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat loading in a patient detected through newborn screening."
+    supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The severe early-onset cardiac and multiorgan failure form typically presents in the first months of life
-    explanation: Severe early multiorgan metabolic failure is consistent with lethargic crisis presentations.
+    snippet: was admitted with emesis, severe lethargy, limpness in extremities, loss of muscle tone and an elevated CK level.
+    explanation: Case evidence directly supports severe lethargy during VLCAD metabolic decompensation.
 - name: Hyperammonemia
   frequency: OCCASIONAL
   description: 'Secondary hyperammonemia during metabolic decompensation, resulting from impaired hepatic FAO support for ureagenesis.
@@ -451,8 +706,16 @@ phenotypes:
       label: Hyperammonemia
   notes: >-
     Hyperammonemia can occur during severe metabolic decompensation in FAODs, though it is less
-    prominent than in urea cycle disorders. The available VLCAD abstracts do not specifically
-    document hyperammonemia frequency.
+    prominent than in urea cycle disorders. The available evidence supports occurrence but does
+    not quantify hyperammonemia frequency in VLCAD.
+  evidence:
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Early childhood disease may manifest with hypoketotic hypoglycemia, hyperammonemia, lactic acidosis, and elevated
+      transaminases.
+    explanation: Review evidence directly supports hyperammonemia as an early VLCAD manifestation.
 - name: Lactic acidosis
   frequency: OCCASIONAL
   description: 'Elevated lactate during metabolic crises, reflecting impaired mitochondrial energy metabolism and compensatory anaerobic glycolysis.
@@ -464,12 +727,12 @@ phenotypes:
       id: HP:0003128
       label: Lactic acidosis
   evidence:
-  - reference: PMID:20301763
-    reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
-    supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
-    snippet: The severe early-onset cardiac and multiorgan failure form typically presents in the first months of life with hypertrophic or dilated cardiomyopathy, pericardial effusion, and arrhythmias, as well as hypotonia, hepatomegaly, and intermittent hypoglycemia.
-    explanation: Multiorgan metabolic failure in severe VLCAD is consistent with lactic acidosis.
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Early childhood disease may manifest with hypoketotic hypoglycemia, hyperammonemia, lactic acidosis, and elevated transaminases.
+    explanation: Review evidence directly supports lactic acidosis in early VLCAD disease.
 - name: Muscular hypotonia
   frequency: FREQUENT
   description: 'Generalized hypotonia, particularly in the severe neonatal form, reflecting systemic energy deficit in skeletal muscle.
@@ -489,7 +752,7 @@ phenotypes:
     explanation: Directly supports hypotonia in severe neonatal VLCAD.
 - name: Seizure
   frequency: OCCASIONAL
-  description: 'Seizures can occur secondary to severe hypoglycemia during metabolic decompensation.
+  description: 'Seizures, including status epilepticus or epileptic spasms, can occur as severe neurologic presentations in VLCAD deficiency.
 
     '
   phenotype_term:
@@ -498,12 +761,12 @@ phenotypes:
       id: HP:0001250
       label: Seizure
   evidence:
-  - reference: PMID:20301763
-    reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
-    supports: PARTIAL
+  - reference: PMID:38157116
+    reference_title: "Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms Syndrome Secondary to Very Long Chain Acyl-CoA Dehydrogenase Deficiency."
+    supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: intermittent hypoglycemia
-    explanation: Severe hypoglycemia in VLCAD can precipitate seizures.
+    snippet: Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms Syndrome Secondary to Very Long Chain Acyl-CoA Dehydrogenase Deficiency.
+    explanation: Case-report title supports seizure/status epilepticus as secondary to VLCAD deficiency.
 - name: Elevated creatine kinase
   frequency: VERY_FREQUENT
   description: 'Elevated serum CK during rhabdomyolysis episodes. In an adult cohort, mean CK was 68,958 U/L; pediatric cases report peaks up to 76,656 U/L.
@@ -533,8 +796,15 @@ phenotypes:
       label: Vomiting
   notes: >-
     Vomiting is a common symptom during metabolic decompensation in FAODs, triggered by fasting
-    or intercurrent illness. While clinically well-recognized, the available VLCAD abstracts
-    do not specifically document vomiting frequency.
+    or intercurrent illness. A VLCAD case report documents emesis during a severe decompensation
+    event, but frequency is not quantified.
+  evidence:
+  - reference: PMID:19333779
+    reference_title: "Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat loading in a patient detected through newborn screening."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: was admitted with emesis, severe lethargy, limpness in extremities, loss of muscle tone and an elevated CK level.
+    explanation: Case evidence supports emesis/vomiting during VLCAD metabolic decompensation.
 biochemical:
 - name: Tetradecenoylcarnitine (C14:1)
   presence: INCREASED
@@ -542,29 +812,29 @@ biochemical:
 
     '
   evidence:
-  - reference: PMID:37367883
-    reference_title: "A Distinctive Metabolomics Profile and Potential Biomarkers for Very Long Acylcarnitine Dehydrogenase Deficiency (VLCADD) Diagnosis in Newborns."
-    supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
-    snippet: VLCADD, developed in neonates or later adults, can be diagnosed using newborn bloodspot screening (NBS) or genetic sequencing.
-    explanation: Supports newborn screening as a VLCAD diagnostic approach, but does not explicitly name C14:1.
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Plasma acylcarnitine profile shows characteristic elevation of C14:1, C14:2, C14, and C12:1 species.
+    explanation: Review evidence directly supports C14:1 elevation in the characteristic VLCAD acylcarnitine profile.
 - name: Long-chain acylcarnitines (C14, C16, C18 species)
   presence: INCREASED
   context: 'Accumulation of a range of long-chain acylcarnitine species including C14, C14:2, C16, and C18 species reflects the impaired beta-oxidation of long-chain fatty acyl-CoA substrates. Systemic levels decrease with effective treatment.
 
     '
-- name: Free fatty acids
+- name: Long-chain carboxylic and dicarboxylic acids
   presence: INCREASED
-  context: 'Elevated long-chain free fatty acids and dicarboxylic acids accumulate due to impaired mitochondrial oxidation. Saturated and unsaturated dicarboxylic acids may act as metabolic inhibitors and mitochondrial uncouplers.
+  context: 'Elevated long-chain carboxylic and dicarboxylic acids accumulate due to impaired mitochondrial oxidation and are detectable on urine organic acid analysis during episodes.
 
     '
   evidence:
-  - reference: PMID:40149952
-    reference_title: "The Pathogenesis of Very Long-Chain Acyl-CoA Dehydrogenase Deficiency."
-    supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
-    snippet: Very long-chain acyl-CoA dehydrogenase deficiency (VLCADD) is a fatty acid β-oxidation disorder (FAOD) affecting 1 to 2 individuals per 100,000.
-    explanation: Supports VLCAD as a fatty acid oxidation disorder, but does not directly document elevated free fatty acids.
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Urine organic acids are notable for extremely reduced or absent ketones, with elevated long-chain carboxylic and dicarboxylic acids.
+    explanation: Review evidence directly supports elevated long-chain carboxylic and dicarboxylic acids in VLCAD.
 - name: Ketone bodies
   presence: DECREASED
   context: 'Inappropriately low ketone body production during fasting, reflecting impaired hepatic ketogenesis from reduced acetyl-CoA generation. This hypoketotic state underlies the characteristic hypoglycemia.
@@ -663,6 +933,18 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Tissue energy deficit in high-demand organs
+    treatment_effect: MODULATES
+    description: Avoiding fasting reduces catabolic long-chain fatty acid mobilization and preserves glucose availability.
+    evidence:
+    - reference: PMID:39203843
+      reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Dietary management consists of preventing periods of fasting and restricting fat intake by increasing carbohydrate
+        intake, while maintaining an adequate and uninterrupted caloric intake.
+      explanation: Nutritional guidance supports fasting prevention to maintain energy supply in FAODs.
   evidence:
   - reference: PMID:20301763
     reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
@@ -685,6 +967,18 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: ACADVL molecular function deficiency
+    treatment_effect: BYPASSES
+    description: Medium-chain triglycerides provide fatty-acid substrates that bypass the very-long-chain ACADVL enzyme block.
+    evidence:
+    - reference: PMID:40149952
+      reference_title: "The Pathogenesis of Very Long-Chain Acyl-CoA Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: symptomatic treatment comprising dietary management and supplementation with medium-chain fatty acids to bypass the
+        enzyme deficiency.
+      explanation: Review evidence directly supports medium-chain fatty acid supplementation as bypass therapy.
   evidence:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
@@ -701,6 +995,17 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Lipotoxic metabolite accumulation
+    treatment_effect: MODULATES
+    description: Restricting long-chain triglycerides reduces substrate flux into the blocked long-chain FAO pathway.
+    evidence:
+    - reference: PMID:39203843
+      reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: In long-chain deficits, long-chain triglyceride restriction should be 10% of total energy
+      explanation: Nutritional guidance supports reducing long-chain triglyceride exposure in long-chain FAODs.
   evidence:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
@@ -723,6 +1028,17 @@ treatments:
     term:
       id: MAXO:0000106
       label: nutritional supplementation
+  target_mechanisms:
+  - target: Tissue energy deficit in high-demand organs
+    treatment_effect: BYPASSES
+    description: Triheptanoin/heptanoate supplies gluconeogenic substrate and supports glucose production despite the long-chain FAO defect.
+    evidence:
+    - reference: PMID:37960342
+      reference_title: "Heptanoate Improves Compensatory Mechanism of Glucose Homeostasis in Mitochondrial Long-Chain Fatty Acid Oxidation Defect."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Heptanoate is a suitable substrate to induce glucose production in mitochondrial FAO defect.
+      explanation: Mouse-model evidence supports heptanoate as substrate support for glucose production in long-chain FAO defects.
   evidence:
   - reference: PMID:37960342
     reference_title: "Heptanoate Improves Compensatory Mechanism of Glucose Homeostasis in Mitochondrial Long-Chain Fatty Acid Oxidation Defect."
@@ -745,6 +1061,17 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Tissue energy deficit in high-demand organs
+    treatment_effect: BYPASSES
+    description: Intravenous glucose supplies carbohydrate energy during decompensation and suppresses lipolysis-driven fatty acid demand.
+    evidence:
+    - reference: PMID:39203843
+      reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The main measure in emergency hospital treatment is the administration of IV glucose.
+      explanation: Nutritional guidance supports IV glucose as emergency energy support.
   evidence:
   - reference: PMID:20301763
     reference_title: "Very Long-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
@@ -767,6 +1094,17 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Tissue energy deficit in high-demand organs
+    treatment_effect: BYPASSES
+    description: Pre-exercise MCT or carbohydrate loading provides alternative substrate before exertion and reduces myopathic crises.
+    evidence:
+    - reference: PMID:39203843
+      reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Patients at risk of rhabdomyolysis should ingest MCT or carbohydrates or a combination of both 20 min before exercise.
+      explanation: Nutritional guidance supports pre-exercise substrate loading for rhabdomyolysis prevention.
   evidence:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."

--- a/kb/disorders/VLCAD_Deficiency.yaml
+++ b/kb/disorders/VLCAD_Deficiency.yaml
@@ -160,14 +160,12 @@ pathophysiology:
     description: Impaired long-chain acyl-CoA oxidation leads to abnormal long-chain acylcarnitine profiles.
     causal_link_type: DIRECT
     evidence:
-    - reference: PMID:37367883
-      reference_title: "A Distinctive Metabolomics Profile and Potential Biomarkers for Very Long Acylcarnitine Dehydrogenase Deficiency (VLCADD) Diagnosis in Newborns."
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
-      snippet: Very long-chain acylcarnitine dehydrogenase deficiency (VLCADD) is a rare inherited metabolic disorder associated
-        with fatty acid β-oxidation and characterized by genetic mutations in the ACADVL gene and accumulations of
-        acylcarnitines.
-      explanation: Newborn metabolomics evidence supports accumulated acylcarnitines in VLCADD.
+      evidence_source: OTHER
+      snippet: Plasma acylcarnitine profile shows characteristic elevation of C14:1, C14:2, C14, and C12:1 species.
+      explanation: Review evidence supports the characteristic long-chain acylcarnitine profile in VLCAD deficiency.
   - target: Glucagon
     description: FAO impairment is associated with reduced fasting glucagon concentrations in VLCAD patients.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -955,7 +953,7 @@ treatments:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Dietary management consists of preventing periods of fasting and restricting fat intake by increasing carbohydrate intake, while maintaining an adequate and uninterrupted caloric intake.
     explanation: Expert nutritional review supports fasting avoidance as a primary intervention.
 - name: Medium-chain triglyceride supplementation
@@ -983,7 +981,7 @@ treatments:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: In long-chain deficits, long-chain triglyceride restriction should be 10% of total energy, with linoleic acid and linolenic acid intake of 3-4% and 0.5-1% (5/1-10/1 ratio), with medium-chain triglyceride supplementation at 10-25% of total energy
     explanation: Provides quantitative dietary guidance for MCT supplementation.
 - name: Long-chain fat restriction
@@ -1010,7 +1008,7 @@ treatments:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: In long-chain deficits, long-chain triglyceride restriction should be 10% of total energy, with linoleic acid and linolenic acid intake of 3-4% and 0.5-1%
     explanation: Directly supports quantitative LCT restriction guidance.
   - reference: PMID:38651394
@@ -1049,7 +1047,7 @@ treatments:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Trihepatnoin is a new therapeutic option with a good safety and efficacy profile.
     explanation: Expert review supports triheptanoin as a therapeutic option with good profile. Note "Trihepatnoin" is a typo in the original publication (correct spelling is triheptanoin).
 - name: Emergency glucose therapy
@@ -1082,7 +1080,7 @@ treatments:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: The main measure in emergency hospital treatment is the administration of IV glucose.
     explanation: Expert review confirms IV glucose as the primary emergency measure.
 - name: Pre-exercise carbohydrate or MCT loading
@@ -1109,7 +1107,7 @@ treatments:
   - reference: PMID:39203843
     reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Patients at risk of rhabdomyolysis should ingest MCT or carbohydrates or a combination of both 20 min before exercise.
     explanation: Directly supports pre-exercise caloric loading as a management strategy.
 - name: Supportive care for cardiomyopathy

--- a/references_cache/PMID_19333779.md
+++ b/references_cache/PMID_19333779.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:19333779"
+title: "Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat loading in a patient detected through newborn screening."
+authors:
+- Ficicioglu C
+- Hussa C
+journal: J Inherit Metab Dis
+year: '2009'
+doi: 10.1007/s10545-009-1143-7
+keywords:
+- "Acyl-CoA Dehydrogenase, Long-Chain/deficiency, genetics"
+- Age of Onset
+- Congenital Bone Marrow Failure Syndromes
+- "Diet, Fat-Restricted"
+- "Dietary Fats/administration & dosage, adverse effects"
+- Humans
+- Infant
+- "Infant Formula/administration & dosage"
+- "Infant, Newborn"
+- "Lipid Metabolism, Inborn Errors/diagnosis, diet therapy, genetics"
+- Male
+- Medical Errors
+- "Milk Proteins/administration & dosage"
+- "Mitochondrial Diseases/diagnosis, diet therapy, genetics"
+- "Muscular Diseases/diagnosis, diet therapy, genetics"
+- Neonatal Screening
+content_type: abstract_only
+---
+
+# Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat loading in a patient detected through newborn screening.
+**Authors:** Ficicioglu C, Hussa C
+**Journal:** J Inherit Metab Dis (2009)
+**DOI:** [10.1007/s10545-009-1143-7](https://doi.org/10.1007/s10545-009-1143-7)
+
+## Content
+
+1. J Inherit Metab Dis. 2009 Dec;32 Suppl 1:S187-90. doi:
+10.1007/s10545-009-1143-7. Epub 2009 Apr 4.
+
+Very long-chain acyl-CoA dehydrogenase deficiency: the effects of accidental fat
+loading in a patient detected through newborn screening.
+
+Ficicioglu C(1), Hussa C.
+
+Author information:
+(1)Department of Pediatrics, Section of Biochemical Genetics, The Children's
+Hospital of Philadelphia, University of Pennsylvania School of Medicine,
+Philadelphia, Pennsylvania 19104, USA. Ficicioglu@email.chop.edu
+
+Very long-chain acyl-CoA dehydrogenase deficiency (VLCADD) is an autosomal
+recessive disorder of fatty acid oxidation. The majority of patients with VLCADD
+can be detected through newborn screening (NBS) with elevated levels of the
+tetradecanoyl carnitine species. An 11-month-old infant, diagnosed with
+late-onset VLCADD (genotype: T848C/G1322A) through newborn screening at birth,
+was admitted with emesis, severe lethargy, limpness in extremities, loss of
+muscle tone and an elevated CK level. He was mistakenly given Ketocal formula
+(about 8 g/kg per day long-chain fat-over six times his usual intake) instead of
+his usual Monogen formula for 2.5 days before being admitted. Once admitted, he
+was started on Monogen and IV (10% dextrose) fluids. He was discharged home
+after four days in the hospital without any sequelae of this accidental fat
+loading event. The report highlights several important points about this
+particular case and more generally about patients with VLCADD detected through
+NBS: (1) the amount of time in which patients might become severely symptomatic
+and the nature of these symptoms after fat loading; (2) the time frame for
+complete recovery after beginning of treatment; (3) the importance of alerting
+home-care companies and families about formula delivery errors and their
+repercussions.
+
+DOI: 10.1007/s10545-009-1143-7
+PMID: 19333779 [Indexed for MEDLINE]

--- a/references_cache/PMID_38157116.md
+++ b/references_cache/PMID_38157116.md
@@ -1,0 +1,46 @@
+---
+reference_id: "PMID:38157116"
+title: Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms Syndrome Secondary to Very Long Chain Acyl-CoA Dehydrogenase Deficiency.
+authors:
+- Gowda VK
+- Siddiqa A
+- Srinivasan VM
+journal: Indian J Pediatr
+year: '2024'
+doi: 10.1007/s12098-023-05005-w
+keywords:
+- Humans
+- "Lipid Metabolism, Inborn Errors"
+- Status Epilepticus
+- Acyl-CoA Dehydrogenases
+- Spasm
+- "Spasms, Infantile"
+- Congenital Bone Marrow Failure Syndromes
+- Muscular Diseases
+- Mitochondrial Diseases
+content_type: abstract_only
+---
+
+# Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms Syndrome Secondary to Very Long Chain Acyl-CoA Dehydrogenase Deficiency.
+**Authors:** Gowda VK, Siddiqa A, Srinivasan VM
+**Journal:** Indian J Pediatr (2024)
+**DOI:** [10.1007/s12098-023-05005-w](https://doi.org/10.1007/s12098-023-05005-w)
+
+## Content
+
+1. Indian J Pediatr. 2024 May;91(5):521. doi: 10.1007/s12098-023-05005-w. Epub
+2023  Dec 29.
+
+Super-Refractory Status Epilepticus Progressing to Infantile Epileptic Spasms
+Syndrome Secondary to Very Long Chain Acyl-CoA Dehydrogenase Deficiency.
+
+Gowda VK(1), Siddiqa A(2), Srinivasan VM(2).
+
+Author information:
+(1)Department of Pediatric Neurology, Indira Gandhi Institute of Child Health,
+Near NIMHANS, Bengaluru, Karnataka, 560029, India. drknvraju08@gmail.com.
+(2)Department of Pediatric Neurology, Indira Gandhi Institute of Child Health,
+Near NIMHANS, Bengaluru, Karnataka, 560029, India.
+
+DOI: 10.1007/s12098-023-05005-w
+PMID: 38157116 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Connect VLCAD pathophysiology to all listed phenotypes and biochemical markers with evidence-backed downstream edges.
- Add target mechanisms for mechanism-modifying dietary/emergency interventions, including fasting avoidance, MCT, LCT restriction, triheptanoin, IV glucose, and pre-exercise substrate loading.
- Strengthen weak evidence for lethargy, vomiting, hyperammonemia, lactic acidosis, seizure/status epilepticus, C14:1, and long-chain carboxylic/dicarboxylic acid accumulation.

## Scope Notes
- Left supportive care for cardiomyopathy, newborn screening, and genetic counseling without target_mechanisms because they are supportive/diagnostic/counseling interventions rather than mechanism-modifying treatments.
- Added only fetched reference caches for PMIDs newly cited by this file.

## Validation
- `just validate kb/disorders/VLCAD_Deficiency.yaml` passed.
- Manual case-preserving snippet audit: 81 checks, 0 failures, 0 missing caches.
- Graph audit: 28 downstream edges; no dangling targets, no untargeted phenotypes, no untargeted biochemical markers, no isolated pathophysiology nodes, and no phenotype/biochemical edges missing evidence.