### PR TITLE
Improve Wilson disease pathograph

### DIFF
--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-28T06:31:48Z'
+updated_date: '2026-05-07T06:25:47Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -61,12 +61,12 @@ prevalence:
   - reference: PMID:23518715
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Using this most conservative approach, the calculated frequency of individuals predicted to carry two mutant pathogenic ATP7B alleles is 1:7026 and thus still considerably higher than the typically reported prevalence of Wilson's disease of 1:30 000."
+    snippet: "Using this most conservative approach, the calculated frequency of individuals predicted to carry two mutant pathogenic ATP7B alleles is 1:7026 and thus still considerably higher than the typically reported prevalence of Wilson's disease of 1:30 000 (P = 0.00093)."
     explanation: This paper explicitly cites the conventional clinically recognized prevalence of Wilson disease as about 1 in 30,000.
   - reference: PMID:38565173
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Results:  The average age- and sex-adjusted prevalence and incidence of WD between 2010 and 2020 were 3.06/100,000 and 0.11/100,000, respectively."
+    snippet: "The average age- and sex-adjusted prevalence and incidence of WD between 2010 and 2020 were 3.06/100,000 and 0.11/100,000, respectively."
     explanation: A contemporary national claims analysis shows a clinically ascertained prevalence of 3.06 per 100,000 in Korea, consistent with rare-disease prevalence.
 - population: Orphanet worldwide and regional estimates
   percentage: 1-9 per 100,000 worldwide; 1-5 per 10,000 in China, Japan, and some specific populations
@@ -108,7 +108,7 @@ prevalence:
   - reference: PMID:23518715
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Using this most conservative approach, the calculated frequency of individuals predicted to carry two mutant pathogenic ATP7B alleles is 1:7026 and thus still considerably higher than the typically reported prevalence of Wilson's disease of 1:30 000."
+    snippet: "Using this most conservative approach, the calculated frequency of individuals predicted to carry two mutant pathogenic ATP7B alleles is 1:7026 and thus still considerably higher than the typically reported prevalence of Wilson's disease of 1:30 000 (P = 0.00093)."
     explanation: Independent UK sequencing data supports a similarly elevated genetic prevalence estimate relative to diagnosed cases.
 progression:
 - phase: Onset
@@ -363,6 +363,32 @@ pathophysiology:
     description: Chronic extrahepatic copper toxicity contributes to pathologic bone loss in a subset of patients.
   - target: Arthralgia
     description: Musculoskeletal copper deposition and bone disease contribute to arthralgia.
+  - target: Sunflower Cataract
+    description: Copper deposition in ocular tissues can produce the rare sunflower cataract phenotype.
+    causal_link_type: DIRECT
+  - target: Abnormality Of The Menstrual Cycle
+    description: Systemic copper disease and chronic hepatic dysfunction can disrupt reproductive cycling through incompletely resolved endocrine intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+  - target: Bone Pain
+    description: Copper-related skeletal disease and low bone mineral density can manifest with bone pain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Osteopenia, osteoporosis, osteomalacia, and renal tubular mineral dysregulation.
+  - target: Arthritis
+    description: Systemic copper-related musculoskeletal involvement includes arthritic manifestations in a subset of patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Musculoskeletal copper toxicity, arthropathy, and low bone-density complications.
+  - target: Joint Swelling
+    description: Musculoskeletal involvement can present with inflammatory or arthropathic joint swelling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Wilson disease arthropathy and related skeletal inflammation.
+  - target: Pathologic Fracture
+    description: Chronic skeletal involvement with osteopenia or osteoporosis increases vulnerability to pathologic fracture.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Osteopenia and osteoporosis.
 
 - name: Hepatocyte Injury
   description: >
@@ -443,6 +469,40 @@ pathophysiology:
     description: Proposed copper-dependent cell death pathways may amplify hepatocyte injury.
   - target: Ferroptosis
     description: Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.
+  - target: Hepatic Steatosis
+    description: Copper-mediated hepatic injury commonly produces steatosis on liver biopsy.
+    causal_link_type: DIRECT
+  - target: Acute Hepatitis
+    description: Acute hepatocellular injury can present with an acute hepatitis phenotype.
+    causal_link_type: DIRECT
+  - target: Elevated Circulating Hepatic Transaminase Concentration
+    description: Hepatocyte injury releases hepatic enzymes, producing elevated circulating transaminases.
+    causal_link_type: DIRECT
+  - target: Pruritus
+    description: Hepatic dysfunction and cholestatic intermediates can contribute to pruritus in Wilson disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic dysfunction and impaired bile-acid handling.
+  - target: Abdominal Pain
+    description: Hepatic inflammation and decompensation can present with abdominal pain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic inflammation, hepatomegaly, and acute liver decompensation.
+  - target: Failure To Thrive
+    description: Chronic hepatic disease and systemic illness can impair growth and weight gain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic liver disease, reduced intake, and systemic inflammatory illness.
+  - target: Weight Loss
+    description: Chronic hepatic disease and systemic illness can produce catabolic weight loss.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic liver disease, reduced intake, and systemic inflammatory illness.
+  - target: Anemia
+    description: Hepatic decompensation can contribute to anemia through hemolytic and advanced-liver-disease intermediates.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Coombs-negative hemolysis and advanced liver disease.
 
 - name: Hepatic Stellate Cell Activation
   conforms_to: fibrotic_response#Mesenchymal Cell Activation
@@ -517,6 +577,26 @@ pathophysiology:
   downstream:
   - target: Cirrhosis
     description: Progressive matrix deposition and architectural distortion manifest clinically as cirrhosis.
+  - target: Ascites
+    description: Cirrhotic architectural distortion can lead to portal hypertension and fluid accumulation as ascites.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cirrhosis and portal hypertension.
+  - target: Splenomegaly
+    description: Fibrotic progression to cirrhosis can produce portal-hypertension-associated splenomegaly.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cirrhosis, portal hypertension, and congestive splenic enlargement.
+  - target: Thrombocytopenia
+    description: Cirrhosis and portal hypertension can cause hypersplenism-associated thrombocytopenia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cirrhosis, portal hypertension, splenomegaly, and hypersplenism.
+  - target: Bruising Susceptibility
+    description: Advanced hepatic fibrosis can contribute to bruising through synthetic dysfunction and thrombocytopenia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cirrhosis, impaired coagulation factor synthesis, and thrombocytopenia.
 
 - name: Neurodegeneration
   description: >
@@ -593,6 +673,40 @@ pathophysiology:
     description: Severe neuropsychiatric involvement can manifest as psychosis.
   - target: Personality Changes
     description: Fronto-striatal and related network dysfunction can manifest as personality change.
+  - target: Intellectual Disability
+    description: Copper-related brain injury can cause cognitive dysfunction; the intellectual-disability HPO mapping is retained as a broader cognitive phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cognitive dysfunction from copper-related neural injury.
+  - target: Seizure
+    description: Structural and metabolic brain involvement can lower seizure threshold in a subset of patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Copper-related brain lesions and neuroinflammation.
+  - target: Gait Disturbance
+    description: Basal ganglia, cerebellar, and brainstem involvement can disrupt gait.
+    causal_link_type: DIRECT
+  - target: Clumsiness
+    description: Motor-circuit involvement can present clinically as clumsiness.
+    causal_link_type: DIRECT
+  - target: Excessive Salivation
+    description: Bulbar dysfunction and impaired swallowing can produce excessive salivation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Bulbar motor dysfunction and dysphagia.
+  - target: Proximal Lower Limb Muscle Weakness
+    description: Neurologic motor involvement and systemic muscle effects can present as proximal lower-limb weakness.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Extrapyramidal motor dysfunction and Wilson disease muscle involvement.
+  - target: Focal T2 Hyperintense Brainstem Lesion
+    description: Brainstem involvement on MRI reflects focal structural injury within neurologic Wilson disease.
+    causal_link_type: DIRECT
+  - target: Aggressive Behavior
+    description: Neuropsychiatric involvement can manifest with irritability and aggression.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Psychiatric manifestations of copper-related brain involvement.
 - name: Cuproptosis
   description: >
     Copper-dependent cell death has been proposed in Wilson disease, involving
@@ -1748,7 +1862,7 @@ biochemical:
   - reference: PMID:39139457
     reference_title: "Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets."
     supports: SUPPORT
-    snippet: "Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited."
+    snippet: "Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC)"
     explanation: Supports NCC as an established Wilson disease monitoring biomarker during chelation therapy.
 - name: 24-Hour Urinary Copper
   presence: Elevated
@@ -1762,7 +1876,7 @@ biochemical:
   - reference: PMID:39139457
     reference_title: "Non-ceruloplasmin copper and urinary copper in clinically stable Wilson disease: Alignment with recommended targets."
     supports: SUPPORT
-    snippet: "Chelator treatment of patients with Wilson disease (WD) is currently guided by measurements of non-ceruloplasmin-bound copper (NCC) and 24 h urinary copper excretion (UCE) but validation is limited."
+    snippet: "Only 14/69 (20%) fulfilled both the NCC-Sp and UCE targets."
     explanation: Supports 24-hour urinary copper excretion as a standard biomarker used to monitor Wilson disease therapy.
 - name: Hepatic Copper
   presence: Elevated
@@ -1829,6 +1943,17 @@ treatments:
     term:
       id: MAXO:0001224
       label: copper chelator agent therapy
+  target_mechanisms:
+  - target: Systemic Copper Distribution
+    treatment_effect: INHIBITS
+    description: D-penicillamine chelates circulating copper and increases urinary copper excretion, reducing toxic systemic copper exposure.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Patients with Wilson disease are well-treated first-line with copper chelators like D-penicillamine that facilitate the removal of circulating copper bound to albumin and increase in urinary copper excretion."
+      explanation: Directly supports D-penicillamine as a chelator that removes circulating copper and increases urinary excretion.
 - name: Trientine
   description: Alternative copper chelator, better tolerated than penicillamine.
   evidence:
@@ -1842,6 +1967,17 @@ treatments:
     term:
       id: MAXO:0001224
       label: copper chelator agent therapy
+  target_mechanisms:
+  - target: Systemic Copper Distribution
+    treatment_effect: INHIBITS
+    description: Trientine chelation sequesters copper to reduce free copper toxicity and systemic organ exposure.
+    evidence:
+    - reference: PMID:37741465
+      reference_title: "Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson's disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Current treatment protocols are limited to either sequestration of copper via chelation or reduction of copper absorption in the gut (zinc therapy). The goal of these strategies is to reduce free copper, redox stress, and cellular toxicity."
+      explanation: Supports copper chelation as a strategy that lowers free copper toxicity, which is the systemic mechanism targeted by trientine.
 - name: Zinc Acetate
   description: Blocks intestinal copper absorption, maintenance therapy.
   evidence:
@@ -1860,6 +1996,17 @@ treatments:
       term:
         id: CHEBI:62984
         label: zinc acetate
+  target_mechanisms:
+  - target: Hepatic Copper Accumulation
+    treatment_effect: INHIBITS
+    description: Zinc therapy reduces intestinal copper absorption, limiting copper flux that would otherwise feed hepatic accumulation.
+    evidence:
+    - reference: PMID:37741465
+      reference_title: "Therapeutic implications of impaired nuclear receptor function and dysregulated metabolism in Wilson's disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Current treatment protocols are limited to either sequestration of copper via chelation or reduction of copper absorption in the gut (zinc therapy)."
+      explanation: Supports zinc therapy as reducing gut copper absorption, thereby limiting downstream copper accumulation.
 - name: Low Copper Diet
   description: Adjunctive dietary measure; liver and shellfish are the foods most consistently recommended for avoidance.
   evidence:
@@ -1873,6 +2020,17 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Hepatic Copper Accumulation
+    treatment_effect: INHIBITS
+    description: Dietary copper restriction is an adjunct that limits copper re-accumulation, especially by avoiding the highest-copper foods.
+    evidence:
+    - reference: PMID:36010023
+      reference_title: "Low Copper Diet-A Therapeutic Option for Wilson Disease?"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "A lower copper intake only prevents the re-accumulation of copper."
+      explanation: Supports low copper intake as an adjunctive way to prevent copper re-accumulation rather than primary disease reversal.
 - name: Tetrathiomolybdate
   description: Investigational copper chelator that markedly reduces intestinal copper uptake and lowers hepatic and brain copper exposure.
   evidence:
@@ -1891,6 +2049,17 @@ treatments:
       term:
         id: CHEBI:30703
         label: tetrathiomolybdate(2-)
+  target_mechanisms:
+  - target: Systemic Copper Distribution
+    treatment_effect: INHIBITS
+    description: Tetrathiomolybdate limits copper exposure to liver and brain by inhibiting intestinal uptake and retaining copper in blood.
+    evidence:
+    - reference: PMID:38081365
+      reference_title: "Effects of tetrathiomolybdate on copper metabolism in healthy volunteers and in patients with Wilson disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "TTM effectively inhibited most intestinal 64Cu uptake and retained 64Cu in the blood stream, limiting the exposure of organs like the liver and brain to 64Cu."
+      explanation: Human tracer data directly support TTM as reducing organ copper exposure, including liver and brain exposure.
 - name: Liver Transplantation
   description: Curative for hepatic Wilson disease, reverses copper metabolism defect.
   evidence:
@@ -1909,6 +2078,17 @@ treatments:
     term:
       id: MAXO:0001175
       label: liver transplantation
+  target_mechanisms:
+  - target: Impaired Biliary Copper Excretion
+    treatment_effect: RESTORES
+    description: Liver transplantation replaces the ATP7B-deficient liver, restoring the hepatic copper-handling pathway that fails in Wilson disease.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: "Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Liver transplantation finally may thus be a life-saving approach and curative treatment of the disease by replacing the hepatic gene mutation."
+      explanation: Supports transplantation as replacing the hepatic genetic defect that causes impaired copper excretion.
 differential_diagnoses:
 - name: Autoimmune Hepatitis
   description: >


### PR DESCRIPTION
## Summary
- connect Wilson disease phenotypes that were not downstream of a mechanism
- add target_mechanisms for copper chelators, zinc, low-copper diet, tetrathiomolybdate, and liver transplantation
- tighten a few cached-reference snippets so the manual snippet audit is exact

## Validation
- just validate kb/disorders/Wilsons_Disease.yaml
- recursive cached snippet audit for kb/disorders/Wilsons_Disease.yaml
- graph audit: 0 untargeted phenotypes, 0 untargeted biochemical markers, 0 treatments without targets
- subagent review: no blockers