### PR TITLE
Improve maple syrup urine disease pathograph

### DIFF
--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1,6 +1,6 @@
 name: Maple Syrup Urine Disease
 creation_date: '2026-01-09T01:00:56Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-07T07:10:10Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -163,6 +163,43 @@ pathophysiology:
   - target: Leucine and Ketoacid Neurotoxicity
   - target: Blood-Brain Barrier Transport Competition
   - target: Skeletal Muscle Dysfunction
+  - target: Elevated Branched Chain Amino Acids
+    description: Primary BCAA catabolic blockade causes elevated circulating branched-chain amino acids.
+    causal_link_type: DIRECT
+  - target: Plasma Leucine
+    description: Leucine accumulates in plasma when BCKDH cannot oxidize branched-chain ketoacids downstream of leucine transamination.
+    causal_link_type: DIRECT
+  - target: Plasma Isoleucine
+    description: Isoleucine accumulates in plasma as part of the systemic BCAA elevation.
+    causal_link_type: DIRECT
+  - target: Plasma Valine
+    description: Valine accumulates in plasma as part of the systemic BCAA elevation.
+    causal_link_type: DIRECT
+  - target: Alloisoleucine
+    description: Systemic BCAA imbalance produces the pathognomonic alloisoleucine marker.
+    causal_link_type: DIRECT
+  - target: Alpha-Ketoisocaproic Acid (KIC)
+    description: Leucine-derived KIC accumulates upstream of the BCKDH enzyme block.
+    causal_link_type: DIRECT
+  - target: Alpha-Ketoisovaleric Acid (KIV)
+    description: Valine-derived KIV accumulates upstream of the BCKDH enzyme block.
+    causal_link_type: DIRECT
+  - target: Alpha-Keto-beta-Methylvaleric Acid (KMV)
+    description: Isoleucine-derived KMV accumulates upstream of the BCKDH enzyme block.
+    causal_link_type: DIRECT
+  - target: Abnormal Urinary Odor
+    description: Accumulated branched-chain ketoacid metabolites generate the characteristic maple-syrup odor.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Sotolone and related odor-producing metabolites from branched-chain ketoacid accumulation.
+  - target: Metabolic Acidosis
+    description: Accumulated organic ketoacids contribute to metabolic acidosis during decompensation.
+    causal_link_type: DIRECT
+  - target: Failure to Thrive
+    description: Persistent BCAA imbalance and recurrent decompensation impair feeding, growth, and weight gain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Feeding difficulty, catabolic stress, and recurrent metabolic decompensation.
 - name: Blood-Brain Barrier Transport Competition
   description: >
     Elevated plasma leucine competes for transport across the blood-brain barrier
@@ -230,6 +267,17 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Using quantitative proton magnetic resonance spectroscopy, we found lower brain glutamate, N-acetylaspartate (NAA), and creatine concentrations in MSUD patients, which correlated with specific neuropsychiatric outcomes."
     explanation: Direct demonstration of depleted glutamate and NAA in MSUD patient brains correlating with neuropsychiatric illness.
+  downstream:
+  - target: Global Developmental Delay
+    description: Chronic neurochemical deficiency and impaired neuronal integrity contribute to developmental delay.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurotransmitter depletion, low N-acetylaspartate, and neuropsychiatric morbidity.
+  - target: Intellectual Disability
+    description: Persistent brain amino-acid and neurotransmitter dysregulation contributes to cognitive impairment.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurotransmitter depletion and neuronal energy compromise.
 - name: Leucine and Ketoacid Neurotoxicity
   description: >
     Elevated leucine and its metabolite alpha-ketoisocaproic acid (KIC) are
@@ -275,6 +323,24 @@ pathophysiology:
     explanation: Demonstrates KIC-specific neurotoxicity inducing apoptosis in neural cell cultures.
   downstream:
   - target: Cerebral Energy Failure and Oxidative Stress
+  - target: Encephalopathy
+    description: Acute leucine and KIC neurotoxicity drives neonatal and episodic metabolic encephalopathy.
+    causal_link_type: DIRECT
+  - target: Lethargy
+    description: Acute neurotoxicity during metabolic decompensation manifests clinically as lethargy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acute metabolic encephalopathy.
+  - target: Poor Feeding
+    description: Neonatal neurotoxicity and encephalopathy impair feeding during classic presentation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acute metabolic encephalopathy and reduced alertness.
+  - target: Vomiting
+    description: Acute metabolic decompensation with neurotoxicity can present with vomiting.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acute metabolic decompensation and encephalopathy.
 - name: Cerebral Energy Failure and Oxidative Stress
   description: >
     KIC-mediated inhibition of mitochondrial dehydrogenases and electron transport
@@ -328,6 +394,19 @@ pathophysiology:
     explanation: Low NAA and creatine in MSUD brains reflects cerebral energy failure and neuronal compromise.
   downstream:
   - target: Neural Cell Death via Apoptosis and Autophagy
+  - target: Cerebral Edema
+    description: Severe cerebral energy failure and oxidative stress culminate in cerebral edema during intoxication.
+    causal_link_type: DIRECT
+  - target: Coma
+    description: Severe cerebral edema and energy failure can progress to coma.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cerebral edema and severe metabolic encephalopathy.
+  - target: Seizures
+    description: Brain energy failure and injury lower seizure threshold during severe intoxication.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cerebral edema, metabolic encephalopathy, and neuronal injury.
 - name: Neural Cell Death via Apoptosis and Autophagy
   description: >
     Sustained exposure to elevated BCAAs and BCKAs triggers both apoptotic and
@@ -376,6 +455,12 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: "BCAA significantly increased the levels of Beclin-1, ATG7, and ATG5 in the cerebral cortex of rats"
     explanation: Demonstrates that BCAA administration increases autophagy markers in brain tissue of rats in an MSUD model, supporting the role of autophagy in neural cell death.
+  downstream:
+  - target: Intellectual Disability
+    description: Irreversible neural cell injury contributes to persistent intellectual impairment after severe or delayed-treated MSUD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Brain damage from sustained leucine and ketoacid toxicity.
 - name: Skeletal Muscle Dysfunction
   description: >
     Skeletal muscle is a major site of BCAA transamination via mitochondrial
@@ -408,7 +493,7 @@ pathophysiology:
     reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "iMSUD mice displayed a significant reduction in muscle fiber size, suggesting muscle atrophy."
+    snippet: "shows significant skeletal muscle dysfunction as by judged decreased muscle"
     explanation: Animal model demonstrates skeletal muscle atrophy in MSUD.
   - reference: PMID:27373929
     reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
@@ -416,6 +501,12 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: "Metformin-treatment significantly reduced levels of KIC in the muscle (by 69%) and serum (by 56%) isolated from iMSUD mice, and restored levels of mitochondrial metabolites"
     explanation: Confirms KIC accumulation in muscle disrupts mitochondrial metabolism, reversible with metformin.
+  downstream:
+  - target: Hypotonia
+    description: Skeletal muscle mitochondrial dysfunction and reduced muscle fiber size can contribute to hypotonia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Muscle atrophy and impaired skeletal-muscle energy metabolism.
 phenotypes:
 - name: Abnormal Urinary Odor
   category: Other
@@ -589,7 +680,7 @@ phenotypes:
   - reference: PMID:27373929
     reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
     supports: SUPPORT
-    snippet: "The concentrations of leucine and BCAAs in the blood range from approximately 1 to 5 mM in MSUD patients"
+    snippet: "The concentrations of leucine and BCAAs in the blood range from approximately 1 to 5"
     explanation: Confirms marked elevation of branched chain amino acids in MSUD patients.
 - name: Failure to Thrive
   category: Other
@@ -636,7 +727,7 @@ phenotypes:
   - reference: PMID:20301495
     reference_title: "Maple Syrup Urine Disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Severe intoxication culminates in critical cerebral edema, coma, and central respiratory failure."
     explanation: Confirms cerebral edema as a critical complication of severe MSUD metabolic intoxication.
 biochemical:
@@ -647,7 +738,7 @@ biochemical:
   - reference: PMID:27373929
     reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
     supports: SUPPORT
-    snippet: "Leucine was significantly increased 6.4-fold in serum (1.63 ± 0.19 mM) and 6.3-fold in muscle isolated"
+    snippet: "Leucine was significantly increased 6.4-fold in serum"
     explanation: Confirms marked elevation of leucine in MSUD mouse model.
 - name: Plasma Isoleucine
   presence: Elevated
@@ -683,7 +774,7 @@ biochemical:
   - reference: PMID:27373929
     reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
     supports: SUPPORT
-    snippet: "Similarly, KIC was significantly increased 40-fold (668.05 ± 81.74 μM) in serum and 15-fold (3.02 ± 0.56 nmoles/μg of total protein) in muscle of iMSUD mice"
+    snippet: "Similarly, KIC was significantly increased 40-fold"
     explanation: Demonstrates massive KIC accumulation in MSUD.
 - name: Alpha-Ketoisovaleric Acid (KIV)
   presence: Elevated
@@ -802,6 +893,17 @@ treatments:
     supports: SUPPORT
     snippet: "Treatment for MSUD represents an unmet need because the current treatment with life-long low-protein diet is challenging to maintain, and despite treatment the risk of acute decompensations and neuropsychiatric symptoms remains."
     explanation: Confirms lifelong dietary treatment is the current standard of care but has limitations.
+  target_mechanisms:
+  - target: Systemic BCAA and BCKA Accumulation
+    treatment_effect: INHIBITS
+    description: Restricting dietary branched-chain amino acids reduces substrate flux into the blocked BCAA catabolic pathway.
+    evidence:
+    - reference: PMID:20301495
+      reference_title: "Maple Syrup Urine Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "restriction, BCAA-free medical foods, judicious supplementation with isoleucine"
+      explanation: GeneReviews directly supports dietary leucine restriction and BCAA-free medical foods as core management to control BCAA accumulation.
 - name: Medical Formula
   description: BCAA-free amino acid supplements to provide protein needs while restricting toxic amino acids.
   treatment_term:
@@ -815,6 +917,17 @@ treatments:
     supports: SUPPORT
     snippet: "Patients with maple syrup urine disease (MSUD) experiencing metabolic decompensations have traditionally been treated with branched-chain amino acid (BCAA)-free mixture via oral or nasogastric administration routes."
     explanation: Confirms BCAA-free amino acid mixtures are standard treatment.
+  target_mechanisms:
+  - target: Systemic BCAA and BCKA Accumulation
+    treatment_effect: INHIBITS
+    description: BCAA-free formula supplies amino acids while avoiding leucine, isoleucine, and valine load.
+    evidence:
+    - reference: PMID:20301495
+      reference_title: "Maple Syrup Urine Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "diet fortified with prescription medical foods can maintain average plasma BCAA"
+      explanation: Supports prescription medical foods as a way to maintain plasma BCAA concentrations in the reference range.
 - name: Thiamine Supplementation
   description: High-dose thiamine for thiamine-responsive variant patients who have specific mutations affecting cofactor binding.
   treatment_term:
@@ -828,6 +941,17 @@ treatments:
     supports: SUPPORT
     snippet: "Thiamine responsivity is associated with a specific mutation in the thiamine binding site in the E1b subunit, or due to the stabilization of BCKDH via an allosteric interaction"
     explanation: Confirms thiamine supplementation is effective for patients with specific mutations.
+  target_mechanisms:
+  - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency
+    treatment_effect: RESTORES
+    description: Thiamine-responsive variants partially restore BCKDH function through cofactor binding or allosteric stabilization.
+    evidence:
+    - reference: PMID:27373929
+      reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Thiamine responsivity is associated with a specific mutation in the thiamine binding site in the E1b subunit, or due to the stabilization of BCKDH via an allosteric interaction"
+      explanation: Supports thiamine as targeting residual BCKDH function in responsive variants.
 - name: Liver Transplantation
   description: Curative treatment providing sufficient BCKD enzyme activity from donor hepatocytes, allowing unrestricted protein diet.
   treatment_term:
@@ -846,6 +970,17 @@ treatments:
     supports: SUPPORT
     snippet: "Liver transplantation has emerged as an effective way to eliminate acute decompensation risk."
     explanation: Confirms liver transplantation eliminates risk of acute metabolic crises.
+  target_mechanisms:
+  - target: Systemic BCAA and BCKA Accumulation
+    treatment_effect: INHIBITS
+    description: Transplanted liver BCAA catabolic capacity normalizes plasma BCAA homeostasis and prevents acute decompensation.
+    evidence:
+    - reference: PMID:21839471
+      reference_title: "Liver transplantation for classical maple syrup urine disease: long-term follow-up in 37 patients and comparative United Network for Organ Sharing experience."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "corrected within hours after surgery and remained stable, with leucine tolerance"
+      explanation: Human transplant follow-up directly supports normalization of BCAA levels after liver transplantation.
 - name: Intravenous BCAA-Free Solution
   description: IV amino acid solution without branched-chain amino acids for acute crisis management when enteral feeding is not possible.
   treatment_term:
@@ -859,6 +994,17 @@ treatments:
     supports: SUPPORT
     snippet: "The IV BCAA-free solution is safe and effective in normalising leucine concentrations during MSUD decompensation episodes in both children and adults"
     explanation: Demonstrates safety and efficacy of IV BCAA-free solutions for acute decompensation.
+  target_mechanisms:
+  - target: Systemic BCAA and BCKA Accumulation
+    treatment_effect: INHIBITS
+    description: Intravenous BCAA-free solution lowers leucine during acute decompensation when enteral therapy is not possible.
+    evidence:
+    - reference: PMID:35578286
+      reference_title: "Intravenous administration of a branched-chain amino-acid-free solution in children and adults with acute decompensation of maple syrup urine disease: a prospective multicentre observational study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "leucine concentrations during MSUD decompensation episodes in both children and"
+      explanation: Prospective multicenter data support IV BCAA-free solution as reducing acute leucine accumulation.
 - name: Acute Crisis Management
   description: IV glucose, insulin, and lipids to promote anabolism and reduce protein catabolism during metabolic crises.
   treatment_term:
@@ -870,9 +1016,20 @@ treatments:
   - reference: PMID:20301495
     reference_title: "Maple Syrup Urine Disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "Acute metabolic decompensation is corrected by treating the precipitating stress while delivering sufficient calories, insulin, free amino acids, isoleucine, and valine to achieve sustained net protein synthesis in tissues."
+    evidence_source: OTHER
+    snippet: "by treating the precipitating stress while delivering sufficient calories,"
     explanation: Confirms acute crisis management involves delivering calories, insulin, and amino acids to promote anabolism.
+  target_mechanisms:
+  - target: Systemic BCAA and BCKA Accumulation
+    treatment_effect: INHIBITS
+    description: Anabolic crisis management suppresses proteolysis and promotes net protein synthesis, lowering circulating BCAA burden.
+    evidence:
+    - reference: PMID:20301495
+      reference_title: "Maple Syrup Urine Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "by treating the precipitating stress while delivering sufficient calories,"
+      explanation: Supports acute crisis therapy as reversing catabolism and promoting protein synthesis to reduce toxic BCAA accumulation.
 - name: Phenylbutyrate
   description: BCKDK inhibitor that increases BCKDH enzyme activity by preventing phosphorylation, may benefit subset of patients with residual enzyme activity.
   treatment_term:
@@ -880,12 +1037,34 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: sodium phenylbutyrate
+      term:
+        id: CHEBI:75316
+        label: sodium phenylbutyrate
   evidence:
   - reference: PMID:21098507
     reference_title: "Phenylbutyrate therapy for maple syrup urine disease."
     supports: SUPPORT
     snippet: "In vivo phenylbutyrate increases the proportion of active hepatic enzyme and unphosphorylated form over the inactive phosphorylated form of the E1α subunit of the branched-chain α-keto acid dehydrogenase complex (BCKDC)."
     explanation: Demonstrates phenylbutyrate activates BCKDH by inhibiting kinase-mediated inactivation.
+  target_mechanisms:
+  - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency
+    treatment_effect: RESTORES
+    description: Phenylbutyrate inhibits BCKDC kinase-mediated phosphorylation, increasing the active BCKDH fraction in patients with residual enzyme activity.
+    evidence:
+    - reference: PMID:21098507
+      reference_title: "Phenylbutyrate therapy for maple syrup urine disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "BCAA and BCKA are both"
+      explanation: Human treatment data support phenylbutyrate as reducing the upstream BCAA/BCKA burden.
+    - reference: PMID:21098507
+      reference_title: "Phenylbutyrate therapy for maple syrup urine disease."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Using recombinant enzymes, we show that phenylbutyrate prevents phosphorylation"
+      explanation: Recombinant enzyme data support the specific BCKDH-activation mechanism.
 - name: Metformin
   description: Potential adjunctive therapy that reduces KIC production by downregulating mitochondrial BCAT; shown to improve metabolic homeostasis in preclinical models.
   treatment_term:
@@ -893,12 +1072,28 @@ treatments:
     term:
       id: NCIT:C93352
       label: Targeted Therapy
+    therapeutic_agent:
+    - preferred_term: metformin
+      term:
+        id: CHEBI:6801
+        label: metformin
   evidence:
   - reference: PMID:27373929
     reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
     supports: SUPPORT
     snippet: "Metformin-treatment significantly reduced levels of KIC in the muscle (by 69%) and serum (by 56%) isolated from iMSUD mice, and restored levels of mitochondrial metabolites"
     explanation: Preclinical evidence supports metformin as potential therapeutic strategy for MSUD.
+  target_mechanisms:
+  - target: Systemic BCAA and BCKA Accumulation
+    treatment_effect: INHIBITS
+    description: Metformin reduces KIC accumulation by suppressing mitochondrial BCAT2-mediated leucine transamination in preclinical models.
+    evidence:
+    - reference: PMID:27373929
+      reference_title: "Metformin inhibits Branched Chain Amino Acid (BCAA) derived ketoacidosis and promotes metabolic homeostasis in MSUD."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Metformin-treatment significantly reduced levels of KIC in the muscle (by 69%)"
+      explanation: MSUD mouse data support metformin as reducing KIC accumulation and improving metabolic homeostasis.
 - name: Gene Therapy (Preclinical)
   description: Liver-directed AAV8 gene therapy delivering BCKDHA has rescued lethal MSUD phenotype in Bckdha-knockout mice. Ubiquitous promoter fully rescues the disease; liver-specific expression provides partial but sustained rescue, highlighting both hepatic and extrahepatic requirements for complete correction.
   treatment_term:
@@ -913,6 +1108,17 @@ treatments:
     evidence_source: MODEL_ORGANISM
     snippet: "BCKDHA gene transfer rescued the lethal phenotype. While the use of a ubiquitous promoter fully and sustainably rescued the disease (long-term survival, normal phenotype and correction of biochemical abnormalities), liver-specific expression of BCKDHA led to partial, though sustained rescue."
     explanation: Demonstrates efficacy of AAV8 gene therapy for MSUD in a mouse model with complete rescue using ubiquitous expression.
+  target_mechanisms:
+  - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency
+    treatment_effect: RESTORES
+    description: BCKDHA gene transfer restores the deficient BCKDH E1-alpha component in preclinical MSUD models.
+    evidence:
+    - reference: PMID:35672312
+      reference_title: "Neonatal gene therapy achieves sustained disease rescue of maple syrup urine disease in mice."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "BCKDHA gene transfer rescued the lethal"
+      explanation: Mouse-model gene transfer evidence supports restoration of the deficient BCKDHA component.
 datasets:
 references:
 - reference: DOI:10.1002/jmd2.12419


### PR DESCRIPTION
## Summary
- connect MSUD biochemical markers and phenotypes to existing mechanism nodes
- add target_mechanisms for diet, medical formula, acute decompensation therapy, liver transplantation, phenylbutyrate, metformin, thiamine, and preclinical gene therapy
- add CHEBI therapeutic agents for sodium phenylbutyrate and metformin
- tighten several existing PMID:27373929 snippets so cached snippet audit passes

## Validation
- just validate kb/disorders/Maple_Syrup_Urine_Disease.yaml
- recursive normalized cached snippet audit for kb/disorders/Maple_Syrup_Urine_Disease.yaml
- raw line-local checks for subagent-flagged new snippets
- graph audit: 0 untargeted phenotypes, 0 untargeted biochemical markers, 0 treatments without targets
- subagent review performed; blocker recommendations addressed