### PR TITLE
Improve GAMT deficiency pathograph

### DIFF
--- a/kb/disorders/Guanidinoacetate_Methyltransferase_Deficiency.yaml
+++ b/kb/disorders/Guanidinoacetate_Methyltransferase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Guanidinoacetate Methyltransferase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-07T08:15:26Z'
 synonyms:
 - GAMT deficiency
 - Cerebral creatine deficiency syndrome type 2
@@ -28,6 +28,9 @@ pathophysiology:
     '
   genes:
   - preferred_term: GAMT
+    term:
+      id: hgnc:4136
+      label: GAMT
   cell_types:
   - preferred_term: hepatocyte
     term:
@@ -47,6 +50,7 @@ pathophysiology:
     explanation: Supports GAMT molecular dysfunction as the initiating defect.
   downstream:
   - target: Deficient creatine biosynthesis
+    causal_link_type: DIRECT
     description: Reduced GAMT activity blocks conversion of guanidinoacetate to creatine.
 - name: Deficient creatine biosynthesis
   description: 'Blocked conversion of guanidinoacetate to creatine causes systemic and cerebral creatine depletion, impairing the creatine/phosphocreatine energy shuttle needed for rapid ATP regeneration in high-energy-demand tissues.
@@ -80,6 +84,25 @@ pathophysiology:
     explanation: Confirms cerebral creatine depletion and GAA accumulation as the dual mechanism of disease.
   downstream:
   - target: Guanidinoacetate neurotoxicity
+    causal_link_type: DIRECT
+    description: Blocked methylation leaves guanidinoacetate upstream of GAMT to accumulate to neurotoxic levels.
+  - target: Impaired neuronal energy homeostasis
+    causal_link_type: DIRECT
+    description: Cerebral creatine depletion compromises the creatine/phosphocreatine ATP-buffering system in brain.
+  - target: Guanidinoacetate
+    causal_link_type: DIRECT
+    description: Failure to convert guanidinoacetate to creatine causes elevated guanidinoacetate in biofluids and brain.
+  - target: Creatine
+    causal_link_type: DIRECT
+    description: Failure of the final creatine biosynthesis step lowers systemic and cerebral creatine.
+  - target: Creatine on brain MRS
+    causal_link_type: DIRECT
+    description: Cerebral creatine depletion is detected as reduced creatine on proton brain MRS.
+  - target: Creatinine
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Reduced creatine availability lowers downstream creatinine generation.
+    description: Low creatinine reflects reduced creatine available for spontaneous conversion to creatinine.
 - name: Guanidinoacetate neurotoxicity
   description: 'Guanidinoacetate (GAA) accumulates in brain, CSF, blood, and urine due to blocked conversion to creatine. GAA is neurotoxic and may alter inhibitory neurotransmission, compounding the effects of cerebral energy deficiency.
 
@@ -118,6 +141,15 @@ pathophysiology:
     explanation: Supports GAA toxicity as a distinct pathophysiological mechanism beyond creatine deficiency alone.
   downstream:
   - target: Impaired neuronal energy homeostasis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Elevated guanidinoacetate perturbs neuronal metabolism and inhibitory neurotransmission.
+    description: Guanidinoacetate toxicity compounds the neuronal energy deficit from cerebral creatine depletion.
+  - target: Neurodevelopmental and movement disorder expression
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Elevated guanidinoacetate contributes to neuronal dysfunction alongside cerebral creatine depletion.
+    description: Guanidinoacetate toxicity contributes to the clinical neurologic phenotype.
 - name: Impaired neuronal energy homeostasis
   description: 'The creatine/phosphocreatine system serves as a critical ATP buffer and energy shuttle in neurons. Creatine deficiency impairs rapid ATP regeneration during fluctuating energy demands, contributing to neurodevelopmental dysfunction, seizure susceptibility, and disrupted neurite outgrowth and neurotransmission.
 
@@ -150,6 +182,87 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: Creatine deficiency disorders are inborn errors of creatine metabolism, an energy homeostasis molecule.
     explanation: Explicitly identifies creatine as an energy homeostasis molecule, supporting the energy-deficit mechanism.
+  downstream:
+  - target: Neurodevelopmental and movement disorder expression
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Loss of the creatine/phosphocreatine ATP buffer affects high-energy neural systems.
+    description: Neuronal energy disruption contributes to developmental, seizure, speech, behavioral, and motor manifestations.
+- name: Neurodevelopmental and movement disorder expression
+  description: 'Combined cerebral creatine depletion and guanidinoacetate accumulation produce the core neurologic presentation of GAMT deficiency, including developmental impairment, epilepsy, speech disturbance, behavioral features, motor findings, hypotonia, involuntary movements, and basal ganglia abnormalities.
+
+    '
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  - preferred_term: basal ganglion
+    term:
+      id: UBERON:0002420
+      label: basal ganglion
+  evidence:
+  - reference: PMID:38469086
+    reference_title: "Long term follow-up in GAMT deficiency - Correlation of therapy regimen, biochemical and in vivo brain proton MR spectroscopy data."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: intellectual disability, seizures, speech disturbances and movement disorders.
+    explanation: Directly connects cerebral creatine depletion and GAA accumulation to intellectual disability, seizures, speech disturbance, and movement disorder.
+  - reference: PMID:37465909
+    reference_title: "Evidence and Recommendation for Guanidinoacetate Methyltransferase Deficiency Newborn Screening."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Untreated, GAMT deficiency is associated with hypotonia, significant intellectual disability, limited speech development, recurrent seizures, behavior problems, and involuntary movements.
+    explanation: Supports the untreated neurologic phenotype, including intellectual disability, limited speech, and recurrent seizures.
+  - reference: PMID:19289269
+    reference_title: "Guanidinoacetate methyltransferase deficiency (GAMT)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: The MRI scan shows an increased signal in the globus pallidus,
+    explanation: Supports basal ganglia involvement as part of the neurologic expression of GAMT deficiency.
+  downstream:
+  - target: Global developmental delay
+    causal_link_type: DIRECT
+    description: Developmental delay is part of the core neurodevelopmental expression of GAMT deficiency.
+  - target: Intellectual disability
+    causal_link_type: DIRECT
+    description: Intellectual disability is a core clinical result of cerebral creatine depletion and GAA accumulation.
+  - target: Delayed speech and language development
+    causal_link_type: DIRECT
+    description: Speech and language delay are prominent neurodevelopmental manifestations.
+  - target: Absent speech
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Severe limited speech development can progress to absent or extremely limited speech.
+    description: Absent speech represents the severe end of GAMT-associated speech and language impairment.
+  - target: Seizures
+    causal_link_type: DIRECT
+    description: Seizures are a core manifestation of the combined creatine-depletion and GAA-toxicity neurologic phenotype.
+  - target: Behavioral abnormality
+    causal_link_type: DIRECT
+    description: Behavioral problems are among the dominant clinical domains in GAMT deficiency.
+  - target: Autism
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Autistic features are part of the broader behavioral phenotype.
+    description: Autistic behavior is a reported subset of GAMT-associated behavioral abnormalities.
+  - target: Movement abnormality
+    causal_link_type: DIRECT
+    description: Movement disorder is part of the reported neurologic presentation.
+  - target: Muscular hypotonia
+    causal_link_type: DIRECT
+    description: Hypotonia is part of the untreated neurologic presentation.
+  - target: Involuntary movements
+    causal_link_type: DIRECT
+    description: Involuntary movements are reported among untreated neurologic features.
+  - target: Abnormality of the globus pallidus
+    causal_link_type: DIRECT
+    description: Globus pallidus signal abnormality reflects basal ganglia involvement in GAMT deficiency.
 phenotypes:
 - name: Global developmental delay
   frequency: VERY_FREQUENT
@@ -250,8 +363,7 @@ phenotypes:
     snippet: Other symptoms include learning disorders, autistic behaviour, epileptic seizures, and movement disorders.
     explanation: Lists epileptic seizures among core symptoms of GAMT deficiency.
 - name: Behavioral abnormality
-  frequency: FREQUENT
-  description: 'Behavioral disturbances are common and include autistic features, self-mutilation, hyperactivity, and other severe behavioral disorders. Behavioral problems were noted in approximately 75% in a clinical review.
+  description: 'Behavioral disturbances are common and include autistic features, self-mutilation, hyperactivity, and other severe behavioral disorders.
 
     '
   phenotype_term:
@@ -455,15 +567,13 @@ biochemical:
   context: 'Low urinary creatinine reflects the underlying creatine depletion state. Creatine-to-creatinine ratio in urine helps distinguish GAMT deficiency from creatine transporter deficiency.
 
     '
-  evidence:
-  - reference: PMID:36856349
-    reference_title: "Creatine Deficiency Disorders: Phenotypes, Genotypes, Diagnosis, and Treatment Outcomes."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: The diagnosis can be suspected by elevated guanidinoacetate and low creatine levels in body fluids in guanidinoacetate methyltransferase deficiency
-    explanation: Low creatine in body fluids would be accompanied by low creatinine as a downstream metabolite.
 genetic:
 - name: GAMT pathogenic variants
+  gene_term:
+    preferred_term: GAMT
+    term:
+      id: hgnc:4136
+      label: GAMT
   inheritance:
   - name: Autosomal recessive
     evidence:
@@ -511,6 +621,18 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: creatine
+      term:
+        id: CHEBI:16919
+        label: creatine
+  target_mechanisms:
+  - target: Deficient creatine biosynthesis
+    treatment_effect: BYPASSES
+    description: Oral creatine supplies the downstream product of the blocked GAMT reaction and raises cerebral creatine.
+  - target: Impaired neuronal energy homeostasis
+    treatment_effect: MODULATES
+    description: Repleting cerebral creatine supports the creatine/phosphocreatine energy buffer in brain, though brain creatine may remain below control ranges.
   evidence:
   - reference: PMID:24268530
     reference_title: "Guanidinoacetate methyltransferase (GAMT) deficiency: outcomes in 48 individuals and recommendations for diagnosis, treatment and monitoring."
@@ -539,6 +661,15 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: ornithine
+      term:
+        id: CHEBI:18257
+        label: ornithine
+  target_mechanisms:
+  - target: Guanidinoacetate neurotoxicity
+    treatment_effect: INHIBITS
+    description: Ornithine supplementation is used as substrate-reduction therapy to lower toxic GAA levels.
   evidence:
   - reference: PMID:24268530
     reference_title: "Guanidinoacetate methyltransferase (GAMT) deficiency: outcomes in 48 individuals and recommendations for diagnosis, treatment and monitoring."
@@ -567,6 +698,10 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Guanidinoacetate neurotoxicity
+    treatment_effect: INHIBITS
+    description: Restricting protein and arginine reduces precursor flux into guanidinoacetate synthesis.
   evidence:
   - reference: PMID:24268530
     reference_title: "Guanidinoacetate methyltransferase (GAMT) deficiency: outcomes in 48 individuals and recommendations for diagnosis, treatment and monitoring."
@@ -589,6 +724,15 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: sodium benzoate
+      term:
+        id: CHEBI:113455
+        label: sodium benzoate
+  target_mechanisms:
+  - target: Guanidinoacetate neurotoxicity
+    treatment_effect: INHIBITS
+    description: Sodium benzoate reduces glycine availability, limiting substrate input into guanidinoacetate production.
   evidence:
   - reference: PMID:24268530
     reference_title: "Guanidinoacetate methyltransferase (GAMT) deficiency: outcomes in 48 individuals and recommendations for diagnosis, treatment and monitoring."
@@ -605,6 +749,19 @@ treatments:
     term:
       id: MAXO:0000124
       label: disease screening
+  target_phenotypes:
+  - preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  - preferred_term: Intellectual disability
+    term:
+      id: HP:0001249
+      label: Intellectual disability
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
   evidence:
   - reference: PMID:37465909
     reference_title: "Evidence and Recommendation for Guanidinoacetate Methyltransferase Deficiency Newborn Screening."
@@ -621,6 +778,16 @@ treatments:
     term:
       id: MAXO:0000167
       label: anticonvulsant agent therapy
+    therapeutic_agent:
+    - preferred_term: anticonvulsant agent
+      term:
+        id: NCIT:C264
+        label: Anticonvulsant Agent
+  target_phenotypes:
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
   evidence:
   - reference: PMID:19289269
     reference_title: "Guanidinoacetate methyltransferase deficiency (GAMT)."
@@ -659,6 +826,13 @@ treatments:
     term:
       id: MAXO:0001001
       label: gene therapy
+  target_mechanisms:
+  - target: GAMT molecular function deficiency
+    treatment_effect: RESTORES
+    description: AAV-mediated GAMT delivery is designed to restore hepatocyte GAMT expression in preclinical models.
+  - target: Deficient creatine biosynthesis
+    treatment_effect: RESTORES
+    description: Restoring GAMT expression normalizes plasma creatine and reduces GAA in the mouse model.
   notes: 'Gene therapy for GAMT deficiency remains investigational and is not yet available clinically. Both liver-directed and CNS-directed AAV vector approaches are being explored in preclinical models.
 
     '


### PR DESCRIPTION
## Summary
- connect GAMT deficiency mechanisms through creatine depletion, guanidinoacetate toxicity, neurologic expression, phenotypes, and biochemical findings
- add treatment mechanism/phenotype targets and therapeutic-agent identifiers where appropriate
- add the GAMT gene term with lowercase hgnc CURIE

## Validation
- just validate kb/disorders/Guanidinoacetate_Methyltransferase_Deficiency.yaml
- recursive normalized snippet audit: 56 snippets checked, all found in references_cache
- graph audit: no untargeted phenotypes or biochemical findings; genetic counseling intentionally has no mechanism target
- reviewer subagent: no blockers after follow-up review