### PR TITLE
Fix acute HCV evidence source and graph edge

### DIFF
--- a/kb/disorders/Acute_Hepatitis_C_Virus_Infection.yaml
+++ b/kb/disorders/Acute_Hepatitis_C_Virus_Infection.yaml
@@ -23,9 +23,6 @@ pathophysiology:
     Blood-borne HCV exposure establishes early viremia and infection of the
     liver; during this recent-infection phase, outcomes diverge toward
     spontaneous clearance or chronic viremia.
-  downstream:
-  - target: Elevated hepatic transaminases
-    description: Viral infection and immune recognition cause acute hepatocellular injury.
   cell_types:
   - preferred_term: hepatocyte
     term:
@@ -75,7 +72,7 @@ pathophysiology:
   - reference: PMID:25443342
     reference_title: Innate and adaptive immune responses in HCV infections.
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: >-
       the HCV NS3/4A protease can efficiently cleave and inactivate two
       important signalling molecules in the sensory pathways that react to HCV


### PR DESCRIPTION
## Summary
- Changes the PMID:25443342 NS3/4A cleavage evidence_source from HUMAN_CLINICAL to IN_VITRO.
- Removes a dangling downstream edge from the Acute HCV pathograph that targeted the phenotype-only node `Elevated hepatic transaminases`.

## Validation
- `just validate kb/disorders/Acute_Hepatitis_C_Virus_Infection.yaml`
- snippet audit: 10 snippets
- graph audit: 4 nodes, 2 edges, no dangling targets