### PR TITLE
Improve HMG aciduria pathograph

### DIFF
--- a/kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
+++ b/kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
@@ -1,7 +1,7 @@
 name: 3-Hydroxy-3-Methylglutaric Aciduria
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-05T08:31:14Z'
+updated_date: '2026-05-07T09:45:56Z'
 synonyms:
 - HMG-CoA lyase deficiency
 - HMGCLD
@@ -68,6 +68,9 @@ pathophysiology:
     '
   genes:
   - preferred_term: HMGCL
+    term:
+      id: hgnc:5005
+      label: HMGCL
   cell_types:
   - preferred_term: hepatocyte
     term:
@@ -87,8 +90,10 @@ pathophysiology:
     explanation: Supports HMGCL molecular deficiency as the initiating genetic and enzymatic defect.
   downstream:
   - target: Ketogenesis failure and energy crisis
+    causal_link_type: DIRECT
     description: Loss of HMGCL function blocks hepatic ketone body generation during catabolic states.
   - target: Leucine catabolic block and organic acid accumulation
+    causal_link_type: DIRECT
     description: Loss of HMGCL function also blocks leucine degradation, causing upstream toxic organic acid accumulation.
 - name: Ketogenesis failure and energy crisis
   description: 'Loss of HMGCL-mediated HMG-CoA cleavage abolishes ketogenesis, depriving brain and heart of essential energy substrates during fasting and catabolic stress. This produces hypoketotic hypoglycemia and metabolic acidosis during acute crises.
@@ -115,6 +120,35 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: More than 95% of patients presented with acute metabolic decompensation. Most patients manifested within the first year of life, 42.4% already neonatally.
     explanation: Systematic review of 211 patients demonstrates near-universal acute metabolic crises from ketogenesis failure.
+  downstream:
+  - target: Ketone bodies
+    causal_link_type: DIRECT
+    description: HMGCL deficiency blocks ketone body synthesis, producing absent or inappropriately low ketones during fasting and illness.
+  - target: Hypoglycemia
+    causal_link_type: DIRECT
+    description: Failure to generate ketone bodies during fasting leaves patients dependent on circulating glucose, causing hypoketotic hypoglycemia.
+  - target: Metabolic acidosis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acute catabolism combines impaired ketone production with organic acid accumulation.
+    description: Acute decompensation from ketogenesis failure and organic acid accumulation produces metabolic acidosis.
+  - target: Lethargy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hypoglycemia and metabolic acidosis impair cerebral energy availability during crisis.
+    description: Acute energy crisis causes reduced arousal and encephalopathic presentation.
+  - target: Vomiting
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Vomiting occurs during acute metabolic decompensation episodes.
+  - target: Cardiomyopathy
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Cardiac vulnerability may reflect loss of ketone-derived energy substrate during stress.
+  - target: Acute liver failure
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Severe metabolic decompensation can present atypically with fulminant liver failure.
+  - target: Hepatomegaly
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hepatomegaly is reported during acute metabolic crises and hepatic metabolic stress.
 - name: Leucine catabolic block and organic acid accumulation
   description: 'HMGCL is also required for leucine degradation. Blockade causes upstream accumulation of leucine-derived metabolites including 3-hydroxy-3-methylglutaric acid, 3-methylglutaconic acid, 3-methylglutaric acid, and 3-hydroxyisovaleric acid. Illness-driven leucine flux increases toxic metabolite excretion, implying leucine-derived toxicity is particularly prominent under inflammatory and catabolic stress.
 
@@ -147,7 +181,29 @@ pathophysiology:
     explanation: Confirms the clinical presentation from toxic metabolite accumulation.
   downstream:
   - target: Acyl-CoA disequilibrium and secondary hyperammonemia
+    causal_link_type: DIRECT
+    description: Blocked leucine degradation increases leucine-related acyl-CoAs and disrupts hepatic acyl-CoA balance.
   - target: HMG-mediated neurotoxicity via mitochondrial dysfunction
+    causal_link_type: DIRECT
+    description: Accumulation of 3-hydroxy-3-methylglutaric acid drives mitochondrial dysfunction in vulnerable brain regions.
+  - target: 3-Hydroxy-3-methylglutaric acid (HMG)
+    causal_link_type: DIRECT
+    description: Blocked HMG-CoA cleavage produces the characteristic accumulation of HMG.
+  - target: 3-Methylglutaconic acid (3-MGC)
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Upstream trans-3-methylglutaconyl-CoA is diverted to 3-methylglutaconic acid.
+    description: Leucine pathway blockade produces elevated urinary 3-methylglutaconic acid.
+  - target: 3-Methylglutaric acid (3-MGL)
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Accumulating leucine catabolism intermediates are converted to urinary organic acids.
+    description: Leucine catabolic block produces elevated urinary 3-methylglutaric acid.
+  - target: 3-Hydroxyisovalerylcarnitine (C5-OH)
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Upstream leucine-derived acyl-CoA species are conjugated to carnitine.
+    description: Blocked leucine catabolism raises C5-OH acylcarnitine, the newborn screening marker.
 - name: Acyl-CoA disequilibrium and secondary hyperammonemia
   description: 'Chronic HMGCL deficiency and acute crises each produce distinct abnormal hepatic acyl-CoA patterns. Leucine metabolite loading increases leucine-related acyl-CoAs while depleting acetyl-CoA. Acetyl-CoA depletion impairs N-acetylglutamate synthesis, which is required for urea cycle activation via carbamoyl phosphate synthetase 1, producing secondary hyperammonemia. This mechanism was confirmed by carglumate rescue of hyperammonemia in a liver-specific HMGCL knockout mouse model.
 
@@ -184,15 +240,27 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: KIC-induced hyperammonemia improved following administration of carglumate (N-carbamyl-L-glutamic acid), which substitutes for the product of an acetyl-CoA-dependent reaction essential for urea cycle function
     explanation: Confirms acetyl-CoA-linked mechanism for secondary hyperammonemia and carglumate responsiveness.
+  downstream:
+  - target: Acetyl-CoA
+    causal_link_type: DIRECT
+    description: Leucine metabolite loading in HMGCL-deficient hepatocytes reduces acetyl-CoA levels.
+  - target: Hyperammonemia
+    causal_link_type: DIRECT
+    description: Acetyl-CoA depletion limits N-acetylglutamate-dependent urea-cycle activation, causing secondary hyperammonemia.
+  - target: Hypoglycemia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Abnormal hepatic acyl-CoA balance impairs gluconeogenic response to pyruvate.
+    description: Acyl-CoA disequilibrium contributes to hypoglycemia during acute crises.
 - name: HMG-mediated neurotoxicity via mitochondrial dysfunction
   description: 'The major accumulating metabolite 3-hydroxy-3-methylglutaric acid (HMG) directly disrupts brain mitochondrial function. In neonatal rat brain, HMG exposure reduces succinate dehydrogenase and respiratory chain complex II-III and IV activity in the cerebral cortex and striatum, impairs antioxidant defenses, and increases DRP1 levels indicating mitochondrial fission. These mechanisms connect metabolite accumulation to the neurological vulnerability observed early in life.
 
     '
   biological_processes:
-  - preferred_term: mitochondrial electron transport, NADH to ubiquinone
+  - preferred_term: electron transport chain
     term:
-      id: GO:0006120
-      label: mitochondrial electron transport, NADH to ubiquinone
+      id: GO:0022900
+      label: electron transport chain
   - preferred_term: response to oxidative stress
     term:
       id: GO:0006979
@@ -234,9 +302,61 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: HMG-injected animals showed impaired performance in all sensorimotor tests examined.
     explanation: Links HMG exposure directly to neurodevelopmental impairment in an animal model.
+  downstream:
+  - target: Neurologic injury and neurodevelopmental sequelae
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - HMG disrupts brain mitochondrial bioenergetics, redox homeostasis, and mitochondrial dynamics.
+    description: HMG-mediated mitochondrial dysfunction contributes to neurologic injury and developmental vulnerability.
+- name: Neurologic injury and neurodevelopmental sequelae
+  description: 'Acute metabolic crises and accumulating organic acids injure vulnerable neural tissue, producing seizures, developmental and speech delay, hypotonia, and MRI abnormalities including leukoencephalopathy and rare cerebral atrophy.
+
+    '
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: PMID:35646072
+    reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Common neurological findings include seizures 17/62 (27.41%), hypotonic 3/62 (4.83%), speech delay 7/62 (11.29%), hyperactivity 4/62 (4.83%), developmental delay 6/62
+    explanation: Human cohort data support neurologic and neurodevelopmental sequelae of HMGCLD.
+  - reference: PMID:28396157
+    reference_title: "Coupled brain and urine spectroscopy - in vivo metabolomic characterization of HMG-CoA lyase deficiency in 5 patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Mild to extended abnormal white matter MRI signals were observed in all cases.
+    explanation: Brain MRI evidence supports white matter involvement in HMGCLD.
+  downstream:
+  - target: Seizures
+    causal_link_type: DIRECT
+    description: Seizures are part of the neurologic sequelae of HMGCLD.
+  - target: Global developmental delay
+    causal_link_type: DIRECT
+    description: Developmental delay is a neurodevelopmental sequela in a subset of patients.
+  - target: Speech delay
+    causal_link_type: DIRECT
+    description: Speech delay reflects neurodevelopmental involvement.
+  - target: Muscular hypotonia
+    causal_link_type: DIRECT
+    description: Hypotonia is reported among neurologic findings in HMGCLD cohorts.
+  - target: Leukoencephalopathy
+    causal_link_type: DIRECT
+    description: White matter signal abnormalities represent leukoencephalopathy on brain MRI.
+  - target: Cerebral atrophy
+    causal_link_type: DIRECT
+    description: Cerebral atrophy is a rare severe brain imaging sequela.
 phenotypes:
 - name: Metabolic acidosis
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   description: 'High-anion-gap metabolic acidosis during metabolic decompensation, reported in 79% of patients in a 62-patient Saudi cohort.
 
     '
@@ -259,7 +379,7 @@ phenotypes:
     snippet: More than 95% of patients presented with acute metabolic decompensation.
     explanation: Systematic review confirms near-universal metabolic decompensation with acidosis.
 - name: Hypoglycemia
-  frequency: VERY_FREQUENT
+  frequency: FREQUENT
   description: 'Hypoketotic or non-ketotic hypoglycemia is a cardinal feature, resulting from failure of ketogenesis during fasting. Reported in 61% of patients at initial diagnosis in a large cohort.
 
     '
@@ -282,7 +402,6 @@ phenotypes:
     snippet: In the first year of life infants with HMG-CoA-LD run a high risk of developing severe hypoglycaemia which can lead to death if prompt intervention does not occur.
     explanation: Foundational review emphasizing life-threatening hypoglycemia in infancy.
 - name: Hyperammonemia
-  frequency: FREQUENT
   description: 'Secondary hyperammonemia occurs during metabolic crises, sometimes exceeding 1000 umol/L. Mechanism involves acetyl-CoA depletion impairing N-acetylglutamate-dependent urea cycle activation.
 
     '
@@ -299,7 +418,7 @@ phenotypes:
     snippet: Hyperammonemia and hypoglycemia, cardinal features of many inborn errors of acyl-CoA metabolism, occurred spontaneously in some HLLKO mice and were inducible by administering KIC.
     explanation: Hyperammonemia demonstrated mechanistically in the liver-specific HMGCL KO mouse model.
 - name: Seizures
-  frequency: FREQUENT
+  frequency: OCCASIONAL
   description: 'Seizures occur in approximately 27% of patients, typically during metabolic decompensation or as a result of neurological injury.
 
     '
@@ -517,6 +636,11 @@ biochemical:
     explanation: Direct demonstration of acetyl-CoA depletion in HMGCL-deficient hepatocytes under leucine stress.
 genetic:
 - name: HMGCL pathogenic variants
+  gene_term:
+    preferred_term: HMGCL
+    term:
+      id: hgnc:5005
+      label: HMGCL
   inheritance:
   - name: Autosomal recessive
     evidence:
@@ -557,6 +681,10 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Leucine catabolic block and organic acid accumulation
+    treatment_effect: INHIBITS
+    description: Restricting dietary protein and leucine lowers substrate flux into the blocked leucine degradation pathway.
   evidence:
   - reference: PMID:36771238
     reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
@@ -579,6 +707,10 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Ketogenesis failure and energy crisis
+    treatment_effect: MODULATES
+    description: Avoiding fasting reduces the need for endogenous ketogenesis and preserves glucose availability during stress.
   evidence:
   - reference: PMID:3099065
     reference_title: "3-Hydroxy-3-methylglutaryl-coenzyme a lyase deficiency: a review."
@@ -595,6 +727,15 @@ treatments:
     term:
       id: MAXO:0010006
       label: carnitine supplementation
+    therapeutic_agent:
+    - preferred_term: carnitine
+      term:
+        id: CHEBI:17126
+        label: carnitine
+  target_mechanisms:
+  - target: Leucine catabolic block and organic acid accumulation
+    treatment_effect: MODULATES
+    description: Carnitine supplementation supports acylcarnitine formation and excretion of accumulating organic acid intermediates.
   evidence:
   - reference: PMID:36771238
     reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
@@ -611,6 +752,15 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: 3-hydroxybutyrate
+      term:
+        id: CHEBI:37054
+        label: 3-hydroxybutyrate
+  target_mechanisms:
+  - target: Ketogenesis failure and energy crisis
+    treatment_effect: BYPASSES
+    description: Exogenous 3-hydroxybutyrate supplies ketone substrate despite impaired endogenous ketogenesis.
   evidence:
   - reference: PMID:36771238
     reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
@@ -627,6 +777,26 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_phenotypes:
+  - preferred_term: Hypoglycemia
+    term:
+      id: HP:0001943
+      label: Hypoglycemia
+  - preferred_term: Metabolic acidosis
+    term:
+      id: HP:0001942
+      label: Metabolic acidosis
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  target_mechanisms:
+  - target: Ketogenesis failure and energy crisis
+    treatment_effect: BYPASSES
+    description: Acute dextrose-containing support supplies glucose during crises when ketogenesis is impaired.
+  - target: Acyl-CoA disequilibrium and secondary hyperammonemia
+    treatment_effect: MODULATES
+    description: Crisis management reduces catabolic leucine flux and treats downstream acidosis and hyperammonemia.
   evidence:
   - reference: PMID:3099065
     reference_title: "3-Hydroxy-3-methylglutaryl-coenzyme a lyase deficiency: a review."
@@ -649,6 +819,19 @@ treatments:
     term:
       id: MAXO:0000124
       label: disease screening
+  target_phenotypes:
+  - preferred_term: Metabolic acidosis
+    term:
+      id: HP:0001942
+      label: Metabolic acidosis
+  - preferred_term: Hypoglycemia
+    term:
+      id: HP:0001943
+      label: Hypoglycemia
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
   evidence:
   - reference: PMID:35646072
     reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
@@ -681,6 +864,20 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: carglumic acid
+      term:
+        id: CHEBI:71028
+        label: carglumic acid
+  target_phenotypes:
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  target_mechanisms:
+  - target: Acyl-CoA disequilibrium and secondary hyperammonemia
+    treatment_effect: BYPASSES
+    description: Carglumic acid substitutes for N-acetylglutamate to activate carbamoyl phosphate synthetase 1 when acetyl-CoA-dependent NAG synthesis is impaired.
   evidence:
   - reference: PMID:23861731
     reference_title: "A liver-specific defect of Acyl-CoA degradation produces hyperammonemia, hypoglycemia and a distinct hepatic Acyl-CoA pattern."


### PR DESCRIPTION
## Summary
- connect HMGCL deficiency mechanisms through ketogenesis failure, leucine-derived organic acid accumulation, acyl-CoA imbalance, neurologic injury, phenotypes, and biochemical findings
- add treatment mechanism/phenotype targets for dietary management, fasting avoidance, carnitine, exogenous ketone therapy, acute crisis care, newborn screening, and carglumic acid
- add HMGCL hgnc:5005 annotations and therapeutic-agent identifiers for carnitine, 3-hydroxybutyrate, and carglumic acid

## Validation
- just validate kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
- recursive normalized snippet audit: 42 snippets checked, all found in references_cache
- graph audit: no orphan downstream targets; no untargeted phenotypes or biochemical findings; genetic counseling intentionally has no target because it is family-risk management
- git diff --check

Note: generated cache churn from validation was restored before commit.