### PR TITLE
Improve Tyrosinemia Type I pathograph

### DIFF
--- a/kb/disorders/Tyrosinemia_Type_I.yaml
+++ b/kb/disorders/Tyrosinemia_Type_I.yaml
@@ -1,7 +1,7 @@
 name: Tyrosinemia Type I
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-02-28T02:50:35Z'
+updated_date: '2026-05-07T11:13:27Z'
 synonyms:
 - Hepatorenal tyrosinemia
 - HT-1
@@ -37,6 +37,14 @@ pathophysiology:
     '
   genes:
   - preferred_term: FAH
+    term:
+      id: hgnc:3579
+      label: FAH
+  molecular_functions:
+  - preferred_term: fumarylacetoacetase activity
+    term:
+      id: GO:0004334
+      label: fumarylacetoacetase activity
   biological_processes:
   - preferred_term: tyrosine catabolic process
     term:
@@ -62,7 +70,13 @@ pathophysiology:
     explanation: Directly supports FAH deficiency as the initiating molecular defect.
   downstream:
   - target: Toxic fumarylacetoacetate and maleylacetoacetate accumulation
+    causal_link_type: DIRECT
     description: FAH block causes upstream toxic tyrosine-pathway metabolites to accumulate.
+  - target: Tyrosine
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired terminal tyrosine catabolism and nitisinone treatment both increase tyrosine-pathway substrate burden.
+    description: Defective tyrosine catabolism contributes to elevated tyrosine, particularly during HPD inhibition with nitisinone.
 - name: Toxic fumarylacetoacetate and maleylacetoacetate accumulation
   description: 'FAH deficiency causes accumulation of fumarylacetoacetate (FAA) and maleylacetoacetate (MAA), with secondary
     formation of succinylacetone (SA). FAA is highly reactive and mutagenic, reacting with glutathione and protein sulfhydryl
@@ -93,11 +107,32 @@ pathophysiology:
       of toxic metabolites such as fumaryl and maleylacetoacetate, which can damage the liver, kidneys, and nervous system.
     explanation: Directly supports toxic-metabolite accumulation downstream of FAH deficiency.
   downstream:
+  - target: Fumarylacetoacetate (FAA)
+    causal_link_type: DIRECT
+    description: FAH deficiency directly increases the toxic substrate fumarylacetoacetate.
+  - target: Succinylacetone (SA)
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Accumulated fumarylacetoacetate and maleylacetoacetate generate succinylacetone through alternative routes.
+    description: Toxic tyrosine intermediates produce the pathognomonic metabolite succinylacetone.
   - target: FAA-induced mitochondrial apoptosis in hepatocytes
+    causal_link_type: DIRECT
     description: FAA reactivity drives mitochondrial injury and caspase-mediated hepatocyte apoptosis.
   - target: Succinylacetone inhibition of heme biosynthesis
+    causal_link_type: DIRECT
     description: Succinylacetone accumulation perturbs ALAD-linked heme biosynthesis and contributes to porphyria-like crises.
+  - target: Renal proximal tubule toxic injury
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Toxic tyrosine-pathway metabolites damage renal tissue as well as liver.
+    description: Tyrosine-pathway metabolite toxicity causes renal tubular injury and Fanconi-like tubulopathy.
+  - target: Neurocognitive impairment
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Toxic metabolite effects on the nervous system and long-term treatment factors contribute to neurocognitive risk.
   - target: Persistent hepatocarcinogenic programs under NTBC therapy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Residual FAH deficiency leaves hepatic stress and regenerative programs despite upstream HPD blockade.
     description: Residual FAH deficiency leaves chronic pro-oncogenic hepatic stress despite upstream metabolic blockade by NTBC.
 - name: FAA-induced mitochondrial apoptosis in hepatocytes
   description: 'Fumarylacetoacetate directly triggers mitochondrial outer membrane permeabilization with release of cytochrome
@@ -136,6 +171,107 @@ pathophysiology:
     snippet: We also found that caspase inhibitors were highly effective in preventing the liver failure induced by HGA in
       the double-mutant mice.
     explanation: Proves caspase-mediated apoptosis is the mechanism of hepatocyte injury in tyrosinemia.
+  downstream:
+  - target: Acute liver failure
+    causal_link_type: DIRECT
+    description: Caspase-mediated hepatocyte death causes acute hepatic failure in severe or untreated HT-1.
+  - target: Coagulopathy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatocyte apoptosis causes hepatic synthetic failure.
+    description: Acute hepatic failure impairs coagulation factor synthesis.
+  - target: Hepatomegaly
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Hepatic injury and regenerative stress can present with enlarged liver.
+- name: Renal proximal tubule toxic injury
+  description: 'Accumulated tyrosine-pathway metabolites injure kidney tissue, especially the proximal tubule, causing a Fanconi-like renal phenotype with phosphate wasting. This renal tubular mechanism explains renal tubular dysfunction and secondary hypophosphatemic rickets in HT-1.
+
+    '
+  biological_processes:
+  - preferred_term: cellular response to toxic substance
+    term:
+      id: GO:0097237
+      label: cellular response to toxic substance
+  cell_types:
+  - preferred_term: proximal tubule epithelial cell
+    term:
+      id: CL:0002306
+      label: epithelial cell of proximal tubule
+  locations:
+  - preferred_term: proximal tubule
+    term:
+      id: UBERON:0004134
+      label: proximal tubule
+  evidence:
+  - reference: PMID:38505790
+    reference_title: "Decoding hepatorenal tyrosinemia type 1: Unraveling the impact of early detection, NTBC, and the role of liver transplantation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: This leads to the accumulation of toxic metabolites such as fumaryl and maleylacetoacetate, which can damage the liver, kidneys, and nervous system.
+    explanation: Directly links toxic metabolite accumulation to kidney injury in HT-1.
+  downstream:
+  - target: Renal tubular dysfunction
+    causal_link_type: DIRECT
+    description: Toxic injury to proximal tubule epithelium produces Fanconi-like renal tubular dysfunction.
+  - target: Rickets
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Proximal tubular phosphate wasting causes hypophosphatemic rickets.
+    description: Renal Fanconi syndrome causes phosphate wasting and secondary rickets.
+- name: Chronic hepatic injury and regeneration
+  description: 'Untreated or late-treated HT-1 produces chronic hepatic injury with regeneration, fibrosis, cirrhosis, and malignant transformation risk. Continuous NTBC reduces acute toxicity but does not restore FAH activity, so residual liver-disease and HCC-associated programs can persist.
+
+    '
+  biological_processes:
+  - preferred_term: liver regeneration
+    term:
+      id: GO:0097421
+      label: liver regeneration
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  evidence:
+  - reference: PMID:38132825
+    reference_title: "A False-Negative Newborn Screen for Tyrosinemia Type 1-Need for Re-Evaluation of Newborn Screening with Succinylacetone."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Undiagnosed and untreated tyrosinemia type 1 (TT1) individuals carry a significant risk for developing liver fibrosis, cirrhosis and hepatocellular carcinoma (HCC).
+    explanation: Directly links untreated HT-1 to fibrosis, cirrhosis, and HCC.
+  - reference: PMID:36980965
+    reference_title: "Hereditary Tyrosinemia Type 1 Mice under Continuous Nitisinone Treatment Display Remnants of an Uncorrected Liver Disease Phenotype."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: The differentially expressed genes were enriched in toxicological gene classes related to liver disease, liver damage, liver regeneration and liver cancer, in particular HCC.
+    explanation: Mouse transcriptomics supports persistent hepatic injury, regeneration, and HCC-related programs under NTBC.
+  downstream:
+  - target: Hepatic fibrosis
+    causal_link_type: DIRECT
+    description: Chronic hepatic injury in untreated HT-1 produces fibrosis.
+  - target: Hepatic cirrhosis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Progressive fibrosis remodels hepatic architecture.
+    description: Chronic hepatic injury and fibrosis can progress to cirrhosis.
+  - target: Hepatocellular carcinoma
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic hepatocyte injury and regeneration create pro-oncogenic stress.
+    description: Chronic liver injury and regeneration increase HCC risk.
+  - target: Failure to thrive
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Chronic liver disease and metabolic instability impair growth.
+  - target: Edema
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Liver synthetic dysfunction and portal-hypertensive physiology can cause fluid retention.
+    description: Advanced hepatic disease can cause peripheral edema or ascites.
 - name: Succinylacetone inhibition of heme biosynthesis
   description: 'Succinylacetone (SA) is a competitive inhibitor of delta-aminolevulinic acid dehydratase (ALAD), blocking
     the heme biosynthetic pathway and causing accumulation of delta-aminolevulinic acid (ALA). This produces porphyria-like
@@ -152,8 +288,28 @@ pathophysiology:
     term:
       id: CL:0000182
       label: hepatocyte
-  notes: SA-mediated ALAD inhibition and porphyria-like crises are established mechanistic features in HT-1, but an ALAD/ALA-specific
-    quote was not available in the currently cited abstracts.
+  evidence:
+  - reference: PMID:6826727
+    reference_title: "Hereditary tyrosinemia and the heme biosynthetic pathway. Profound inhibition of delta-aminolevulinic acid dehydratase activity by succinylacetone."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Our data indicate that succinylacetone is an extremely potent competitive inhibitor of ALA dehydratase in human as well as in animal tissues.
+    explanation: Biochemical evidence directly supports succinylacetone inhibition of ALA dehydratase.
+  - reference: PMID:6826727
+    reference_title: "Hereditary tyrosinemia and the heme biosynthetic pathway. Profound inhibition of delta-aminolevulinic acid dehydratase activity by succinylacetone."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: patients with this hereditary disease excrete excessive amounts of delta-aminolevulinic acid (ALA) in urine and that certain patients have an accompanying clinical syndrome resembling that of acute intermittent porphyria (AIP).
+    explanation: Patient observations connect HT-1 to ALA accumulation and porphyria-like neurovisceral crises.
+  downstream:
+  - target: Delta-aminolevulinic acid (ALA)
+    causal_link_type: DIRECT
+    description: ALAD inhibition increases ALA accumulation.
+  - target: Peripheral neuropathy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ALA accumulation produces porphyria-like neurovisceral crises.
+    description: Porphyria-like crises in HT-1 can include peripheral neuropathy.
 - name: Persistent hepatocarcinogenic programs under NTBC therapy
   description: 'Although nitisinone prevents acute toxicity by blocking upstream toxic metabolite formation, it does not restore
     FAH activity. Transcriptomic analysis in FAH-deficient mice under continuous NTBC revealed persistent enrichment of genes
@@ -162,10 +318,10 @@ pathophysiology:
 
     '
   biological_processes:
-  - preferred_term: liver development
+  - preferred_term: liver regeneration
     term:
-      id: GO:0001889
-      label: liver development
+      id: GO:0097421
+      label: liver regeneration
   cell_types:
   - preferred_term: hepatocyte
     term:
@@ -185,9 +341,24 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: NTBC does not restore the enzymatic defects inflicted by the disease nor does it cure HT1.
     explanation: Confirms NTBC does not cure the underlying enzymatic deficiency.
+  downstream:
+  - target: Hepatocellular carcinoma
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Persistent liver-disease and HCC-associated transcriptional programs remain under NTBC.
+    description: Residual hepatic disease programs under NTBC support sustained HCC risk.
+  - target: Alpha-fetoprotein (AFP)
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - AFP is used as a marker of hepatic disease activity and HCC surveillance.
+    description: Persistent HCC risk motivates AFP surveillance in HT-1.
+  - target: Elevated alpha-fetoprotein
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic injury and HCC risk drive AFP monitoring.
+    description: AFP elevation is tracked as a marker of disease activity and malignant transformation risk.
 phenotypes:
 - name: Acute liver failure
-  frequency: FREQUENT
   description: 'Acute hepatic decompensation is a hallmark of untreated or severe HT-1, driven by FAA-mediated oxidative damage
     and caspase-dependent apoptosis of hepatocytes. In untreated acute-form HT-1, liver failure typically presents in the
     first months of life.
@@ -214,7 +385,6 @@ phenotypes:
       HCC or evidence of histologically proven dysplastic liver nodule(s)
     explanation: Confirms acute liver failure as an indication for liver transplantation in HT-1.
 - name: Hepatic fibrosis
-  frequency: FREQUENT
   description: 'Progressive liver fibrosis and cirrhosis develop in untreated or late-treated HT-1. Even false-negative NBS
     cases have presented with cirrhosis years later.
 
@@ -233,7 +403,6 @@ phenotypes:
       fibrosis, cirrhosis and hepatocellular carcinoma (HCC).
     explanation: Directly lists liver fibrosis as a significant risk in untreated HT-1.
 - name: Hepatic cirrhosis
-  frequency: FREQUENT
   description: 'Cirrhosis develops progressively in untreated HT-1 as a consequence of chronic hepatocyte injury and regeneration.
     A case of false-negative NBS presented at age 9 with HCC in a cirrhotic liver.
 
@@ -258,7 +427,6 @@ phenotypes:
       recessive inheritance of tyrosinemia type 1.
     explanation: Confirms cirrhosis in a late-presenting HT-1 patient.
 - name: Hepatocellular carcinoma
-  frequency: OCCASIONAL
   description: 'HCC is the most feared long-term complication of HT-1. Risk persists even under NTBC therapy, necessitating
     lifelong surveillance with alpha-fetoprotein monitoring and liver imaging.
 
@@ -277,7 +445,6 @@ phenotypes:
       the risk of hepatocellular carcinoma (HCC).
     explanation: Confirms HCC as a recognized risk requiring monitoring.
 - name: Renal tubular dysfunction
-  frequency: FREQUENT
   description: 'Proximal renal tubular dysfunction with a Fanconi-like syndrome is a core manifestation, resulting from toxic
     metabolite damage to renal tubular epithelial cells. May manifest as aminoaciduria, phosphaturia, glycosuria, and renal
     tubular acidosis.
@@ -304,7 +471,6 @@ phenotypes:
       with comorbidities involving the renal and neurologic systems
     explanation: Renal involvement is a defining feature of hepatorenal tyrosinemia.
 - name: Rickets
-  frequency: OCCASIONAL
   description: 'Hypophosphatemic rickets develops secondary to renal tubular phosphate wasting in the context of Fanconi-like
     tubulopathy.
 
@@ -314,10 +480,14 @@ phenotypes:
     term:
       id: HP:0002748
       label: Rickets
-  notes: Rickets in HT-1 is secondary to renal tubular phosphate wasting, but a rickets-specific quote was not available in
-    the currently cited abstracts.
+  evidence:
+  - reference: PMID:20301688
+    reference_title: "Tyrosinemia Type I."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: liver dysfunction and renal tubular dysfunction associated with growth failure and rickets.
+    explanation: GeneReviews directly lists rickets in association with renal tubular dysfunction in untreated HT-1.
 - name: Peripheral neuropathy
-  frequency: OCCASIONAL
   description: 'Porphyria-like neurovisceral crises with peripheral neuropathy result from succinylacetone-mediated inhibition
     of ALAD and accumulation of delta-aminolevulinic acid. Episodes mimic acute intermittent porphyria.
 
@@ -328,6 +498,12 @@ phenotypes:
       id: HP:0009830
       label: Peripheral neuropathy
   evidence:
+  - reference: PMID:20301688
+    reference_title: "Tyrosinemia Type I."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
+    explanation: GeneReviews directly lists peripheral neuropathy during HT-1 neurologic crises.
   - reference: PMID:28771246
     reference_title: "Diagnosis and treatment of tyrosinemia type I: a US and Canadian consensus group review and recommendations."
     supports: SUPPORT
@@ -336,7 +512,6 @@ phenotypes:
       with comorbidities involving the renal and neurologic systems
     explanation: Neurologic system involvement includes neuropathic crises.
 - name: Neurocognitive impairment
-  frequency: OCCASIONAL
   description: 'Long-term neurocognitive impairment is a recognized risk in HT-1 patients, even those treated early with NTBC.
     Neurocognitive assessment and therapy are recommended in clinical follow-up.
 
@@ -355,7 +530,6 @@ phenotypes:
       and therapy.
     explanation: Directly states neurocognitive impairment as a long-term risk in HT-1.
 - name: Failure to thrive
-  frequency: FREQUENT
   description: 'Poor growth and failure to thrive occur in untreated or poorly controlled HT-1 due to chronic liver disease,
     renal dysfunction, and metabolic instability.
 
@@ -366,6 +540,12 @@ phenotypes:
       id: HP:0001508
       label: Failure to thrive
   evidence:
+  - reference: PMID:20301688
+    reference_title: "Tyrosinemia Type I."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: liver dysfunction and renal tubular dysfunction associated with growth failure and rickets.
+    explanation: GeneReviews directly supports growth failure in untreated HT-1.
   - reference: PMID:39050308
     reference_title: "Hereditary Tyrosinemia Type-1 With Late Presentation: A Case Report."
     supports: SUPPORT
@@ -374,7 +554,6 @@ phenotypes:
       lower limb edema, and an enlarged liver with parenchymal disease.
     explanation: Case demonstrates growth and nutritional compromise in untreated HT-1.
 - name: Hepatomegaly
-  frequency: FREQUENT
   description: 'Liver enlargement is common in HT-1 due to hepatocellular injury, regeneration nodules, and progressive liver
     disease.
 
@@ -393,7 +572,6 @@ phenotypes:
       lower limb edema, and an enlarged liver with parenchymal disease.
     explanation: Documents hepatomegaly in a late-presenting HT-1 patient.
 - name: Coagulopathy
-  frequency: FREQUENT
   description: 'Hepatic synthetic dysfunction leads to coagulopathy, which is one of the earliest signs of liver failure in
     acute-form HT-1.
 
@@ -411,7 +589,6 @@ phenotypes:
     snippet: Tyrosinemia type I (hepatorenal tyrosinemia, HT-1) is an autosomal recessive condition resulting in hepatic failure
     explanation: Coagulopathy is a direct consequence of hepatic failure in HT-1.
 - name: Elevated alpha-fetoprotein
-  frequency: VERY_FREQUENT
   description: 'Alpha-fetoprotein (AFP) is markedly elevated in HT-1 and serves as both a diagnostic and monitoring biomarker.
     AFP should decrease after NTBC initiation; rising or persistently elevated AFP raises suspicion for hepatocellular carcinoma
     or treatment non-adherence.
@@ -422,10 +599,14 @@ phenotypes:
     term:
       id: HP:0006254
       label: Elevated circulating alpha-fetoprotein concentration
-  notes: AFP is a central diagnostic and surveillance biomarker in HT-1 clinical practice, but AFP-specific wording was not
-    available in the currently cited abstracts.
+  evidence:
+  - reference: PMID:17008115
+    reference_title: "Tyrosinemia type I treated by NTBC: how does AFP predict liver cancer?"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: A rise of alpha-fetoprotein (AFP) is an indicator of liver cancer.
+    explanation: Directly supports AFP elevation as a clinically important HT-1 surveillance finding.
 - name: Edema
-  frequency: OCCASIONAL
   description: 'Peripheral edema and ascites may occur due to hepatic synthetic failure with hypoalbuminemia.
 
     '
@@ -485,16 +666,26 @@ biochemical:
     AFP should decline after NTBC therapy; failure to decline or subsequent rise raises suspicion for HCC or non-adherence.
 
     '
-  notes: AFP monitoring is standard in HT-1 management, but AFP-specific wording was not available in the currently cited
-    abstracts.
+  evidence:
+  - reference: PMID:17008115
+    reference_title: "Tyrosinemia type I treated by NTBC: how does AFP predict liver cancer?"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Apart from a rise of AFP, a slow AFP decrease, and never normalizing levels of AFP are important predictors of liver cancer development in further life.
+    explanation: Establishes AFP trajectory as a biomarker for liver cancer risk in NTBC-treated HT-1.
 - name: Delta-aminolevulinic acid (ALA)
   presence: INCREASED
   context: 'ALA accumulates due to succinylacetone-mediated inhibition of ALAD in the heme biosynthetic pathway. Elevated
     urinary ALA is associated with porphyria-like neurovisceral crises.
 
     '
-  notes: ALA accumulation via SA-mediated ALAD inhibition is a recognized mechanism, but an ALA-specific quote was not available
-    in the currently cited abstracts.
+  evidence:
+  - reference: PMID:6826727
+    reference_title: "Hereditary tyrosinemia and the heme biosynthetic pathway. Profound inhibition of delta-aminolevulinic acid dehydratase activity by succinylacetone."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: patients with this hereditary disease excrete excessive amounts of delta-aminolevulinic acid (ALA) in urine
+    explanation: Directly supports increased ALA excretion in hereditary tyrosinemia.
 - name: Fumarylacetoacetate (FAA)
   presence: INCREASED
   context: 'FAA is the direct toxic substrate accumulating due to FAH deficiency. It is highly reactive and mutagenic, causing
@@ -511,6 +702,11 @@ biochemical:
     explanation: Demonstrates direct toxicity of FAA at the mitochondrial level.
 genetic:
 - name: FAH deficiency
+  gene_term:
+    preferred_term: FAH
+    term:
+      id: hgnc:3579
+      label: FAH
   inheritance:
   - name: Autosomal recessive
     description: 'HT-1 follows autosomal recessive inheritance. Carrier parents have a 25% recurrence risk per pregnancy.
@@ -563,13 +759,17 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: nitisinone
+      term:
+        id: CHEBI:50378
+        label: nitisinone
   evidence:
   - reference: PMID:38505790
     reference_title: "Decoding hepatorenal tyrosinemia type 1: Unraveling the impact of early detection, NTBC, and the role of liver transplantation."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: NTBC or nitisinone has significantly improved the management of HT-1, particularly when initiated before the
-      onset of symptoms.
+    snippet: has significantly improved the management of HT-1, particularly when initiated before the onset of symptoms.
     explanation: Supports NTBC as the transformative therapy for HT-1.
   - reference: PMID:36980965
     reference_title: "Hereditary Tyrosinemia Type 1 Mice under Continuous Nitisinone Treatment Display Remnants of an Uncorrected Liver Disease Phenotype."
@@ -579,6 +779,26 @@ treatments:
       from severe illness and death. However, despite its demonstrated benefits, HT1 patients under continuous NTBC therapy
       are at risk to develop HCC
     explanation: Confirms NTBC efficacy but notes residual HCC risk.
+  target_phenotypes:
+  - preferred_term: Acute hepatic failure
+    term:
+      id: HP:0006554
+      label: Acute hepatic failure
+  - preferred_term: Hepatocellular carcinoma
+    term:
+      id: HP:0001402
+      label: Hepatocellular carcinoma
+  target_mechanisms:
+  - target: Toxic fumarylacetoacetate and maleylacetoacetate accumulation
+    treatment_effect: INHIBITS
+    description: Nitisinone inhibits HPD upstream of FAH, reducing formation of FAA, MAA, and succinylacetone.
+    evidence:
+    - reference: PMID:36980965
+      reference_title: "Hereditary Tyrosinemia Type 1 Mice under Continuous Nitisinone Treatment Display Remnants of an Uncorrected Liver Disease Phenotype."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Nitisinone (NTBC), a potent inhibitor of the 4-hydroxyphenylpyruvate dioxygenase (HPD) enzyme, rescues HT1 patients from severe illness and death.
+      explanation: Directly supports upstream HPD inhibition as the therapeutic mechanism that prevents severe HT-1 illness.
 - name: Dietary tyrosine and phenylalanine restriction
   description: 'Low-tyrosine, low-phenylalanine diet is essential in combination with NTBC therapy, since NTBC causes upstream
     accumulation of tyrosine. Specialized medical formulas provide essential amino acids while restricting tyrosine and phenylalanine
@@ -605,6 +825,17 @@ treatments:
     snippet: NTBC combined with dietary therapy, if initiated early, can provide liver transplant (LT) free survival and reduce
       the risk of hepatocellular carcinoma (HCC).
     explanation: Confirms dietary therapy as part of the standard treatment combination.
+  target_mechanisms:
+  - target: Toxic fumarylacetoacetate and maleylacetoacetate accumulation
+    treatment_effect: MODULATES
+    description: Dietary restriction reduces tyrosine and phenylalanine substrate flux and helps control upstream tyrosine accumulation during NTBC therapy.
+    evidence:
+    - reference: PMID:28771246
+      reference_title: "Diagnosis and treatment of tyrosinemia type I: a US and Canadian consensus group review and recommendations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: There was strong consensus in favor of NBS for HT-1, using blood succinylacetone as a marker, followed by diagnostic confirmation and early treatment with NTBC and diet.
+      explanation: Consensus guidance supports diet as part of early HT-1 treatment after diagnosis.
 - name: Liver transplantation
   description: 'Liver transplantation is curative for the hepatic manifestations of HT-1 but does not correct renal FAH deficiency,
     and residual SA production by the kidneys may persist. Indications include acute liver failure, HCC or dysplastic nodules,
@@ -632,6 +863,26 @@ treatments:
     snippet: The patient is currently undergoing treatment with capsule nitisinone 5 mg, which inhibits the second step of
       tyrosine degradation to prevent tyrosinemia, along with a restricted protein diet, while awaiting liver transplantation.
     explanation: Confirms liver transplantation as a treatment option for severe cases.
+  target_phenotypes:
+  - preferred_term: Acute hepatic failure
+    term:
+      id: HP:0006554
+      label: Acute hepatic failure
+  - preferred_term: Hepatocellular carcinoma
+    term:
+      id: HP:0001402
+      label: Hepatocellular carcinoma
+  target_mechanisms:
+  - target: Fumarylacetoacetate hydrolase deficiency
+    treatment_effect: RESTORES
+    description: Liver transplantation replaces FAH-deficient liver tissue, correcting hepatic manifestations while leaving extrahepatic FAH deficiency uncorrected.
+    evidence:
+    - reference: PMID:38505790
+      reference_title: "Decoding hepatorenal tyrosinemia type 1: Unraveling the impact of early detection, NTBC, and the role of liver transplantation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patients failing medical treatment (eg, due to non-adherence), and who develop acute liver failure (ALF), have HCC or evidence of histologically proven dysplastic liver nodule(s), or experience poor quality of life secondary to severe dietary restrictions are currently indicated for LT.
+      explanation: HT-1 liver transplantation is reserved for hepatic failure, HCC, dysplastic nodules, or failed medical management.
 - name: Newborn screening
   description: 'NBS for HT-1 using dried blood spot succinylacetone measurement is recommended, as it is superior to tyrosine-based
     screening. Early identification enables pre-symptomatic NTBC initiation for optimal long-term outcomes.
@@ -663,6 +914,15 @@ treatments:
     snippet: While SA was long considered to be elevated in every TT1 patient, here we present a recent false-negative SA
       TT1 screen.
     explanation: Highlights that NBS can have rare false negatives requiring protocol optimization.
+  target_phenotypes:
+  - preferred_term: Acute hepatic failure
+    term:
+      id: HP:0006554
+      label: Acute hepatic failure
+  - preferred_term: Hepatocellular carcinoma
+    term:
+      id: HP:0001402
+      label: Hepatocellular carcinoma
 - name: Supportive care
   description: 'Acute and chronic supportive management includes correction of coagulopathy, electrolyte management for renal
     tubular dysfunction, vitamin D and phosphate supplementation for rickets, and monitoring of liver and renal function.
@@ -681,6 +941,23 @@ treatments:
     snippet: Children with HT-1 require frequent monitoring of liver and renal function to assess disease progression and
       treatment compliance.
     explanation: Supports ongoing monitoring and supportive care in HT-1 management.
+  target_phenotypes:
+  - preferred_term: Renal Fanconi syndrome
+    term:
+      id: HP:0001994
+      label: Renal Fanconi syndrome
+  - preferred_term: Rickets
+    term:
+      id: HP:0002748
+      label: Rickets
+  - preferred_term: Abnormality of coagulation
+    term:
+      id: HP:0001928
+      label: Abnormality of coagulation
+  - preferred_term: Edema
+    term:
+      id: HP:0000969
+      label: Edema
 - name: Genetic counseling
   description: 'Genetic counseling for affected families, including discussion of autosomal recessive inheritance, 25% recurrence
     risk, carrier testing, and prenatal or preimplantation genetic diagnosis options.
@@ -716,6 +993,11 @@ treatments:
     snippet: They are also at risk of long-term neurocognitive impairment, which highlights the need for neurocognitive assessment
       and therapy.
     explanation: Directly recommends neurocognitive assessment and therapy for HT-1 patients.
+  target_phenotypes:
+  - preferred_term: Cognitive impairment
+    term:
+      id: HP:0100543
+      label: Cognitive impairment
 notes: 'HT-1 is classified into acute (presentation before 6 months), subacute (6-12 months), and chronic (after 12 months)
   forms based on age of presentation. The acute form, presenting with liver failure in early infancy, carries the worst prognosis
   without treatment. With universal newborn screening and early NTBC therapy, the natural history has been dramatically altered.

--- a/references_cache/PMID_17008115.md
+++ b/references_cache/PMID_17008115.md
@@ -1,0 +1,71 @@
+---
+reference_id: "PMID:17008115"
+title: "Tyrosinemia type I treated by NTBC: how does AFP predict liver cancer?"
+authors:
+- Koelink CJ
+- van Hasselt P
+- van der Ploeg A
+- van den Heuvel-Eibrink MM
+- Wijburg FA
+- Bijleveld CM
+- van Spronsen FJ
+journal: Mol Genet Metab
+year: '2006'
+doi: 10.1016/j.ymgme.2006.07.009
+keywords:
+- Child
+- "Child, Preschool"
+- Cyclohexanones/therapeutic use
+- Enzyme Inhibitors/therapeutic use
+- Female
+- Humans
+- Infant
+- Liver Neoplasms/etiology
+- Male
+- Nitrobenzoates/therapeutic use
+- Prognosis
+- "Tyrosinemias/complications, drug therapy"
+- alpha-Fetoproteins/analysis
+content_type: abstract_only
+---
+
+# Tyrosinemia type I treated by NTBC: how does AFP predict liver cancer?
+**Authors:** Koelink CJ, van Hasselt P, van der Ploeg A, van den Heuvel-Eibrink MM, Wijburg FA, Bijleveld CM, van Spronsen FJ
+**Journal:** Mol Genet Metab (2006)
+**DOI:** [10.1016/j.ymgme.2006.07.009](https://doi.org/10.1016/j.ymgme.2006.07.009)
+
+## Content
+
+1. Mol Genet Metab. 2006 Dec;89(4):310-5. doi: 10.1016/j.ymgme.2006.07.009. Epub
+2006 Sep 27.
+
+Tyrosinemia type I treated by NTBC: how does AFP predict liver cancer?
+
+Koelink CJ(1), van Hasselt P, van der Ploeg A, van den Heuvel-Eibrink MM,
+Wijburg FA, Bijleveld CM, van Spronsen FJ.
+
+Author information:
+(1)Section of Metabolic Diseases, Beatrix Children's Hospital, University
+Medical Center Groningen, University of Groningen, Groningen, 9700 RB Groningen,
+The Netherlands.
+
+BACKGROUND: Tyrosinemia type I is associated with an increased risk of liver
+cancer development. The formation of the pathogenic fumarylacetoacetate is
+prevented by 2-(2-nitro-4-3 trifluoro-methylbenzoyl)-1,3-cyclohexanedione
+(NTBC). Still, some patients with NTBC treatment develop liver cancer. A rise of
+alpha-fetoprotein (AFP) is an indicator of liver cancer.
+AIM: To study the predictive value of AFP in tyrosinemia type I patients for the
+discrimination between patients at high and low risk of liver cancer
+development.
+METHODS: We examined the course of AFP values of 11 Dutch patients with
+tyrosinemia type I treated by NTBC, of whom four were diagnosed with liver
+cancer.
+RESULTS: The four patients with liver cancer had a course of AFP different from
+the other patients in either velocity of the decrease of AFP, achieving normal
+AFP and/or having a rise of AFP concentrations.
+CONCLUSION: Apart from a rise of AFP, a slow AFP decrease, and never normalizing
+levels of AFP are important predictors of liver cancer development in further
+life.
+
+DOI: 10.1016/j.ymgme.2006.07.009
+PMID: 17008115 [Indexed for MEDLINE]

--- a/references_cache/PMID_20301688.md
+++ b/references_cache/PMID_20301688.md
@@ -1,0 +1,108 @@
+---
+reference_id: "PMID:20301688"
+title: Tyrosinemia Type I.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Ficicioglu C
+year: '1993'
+content_type: abstract_only
+---
+
+# Tyrosinemia Type I.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Ficicioglu C
+
+## Content
+
+1. Tyrosinemia Type I.
+
+Ficicioglu C(1).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2006 Jul 24 [updated 2025 Nov 20].
+
+Author information:
+(1)The Children's Hospital of Philadelphia;, Division of Human Genetics and
+Metabolism, Perelman School of Medicine at the University of Pennsylvania,
+Philadelphia, Pennsylvania
+
+CLINICAL CHARACTERISTICS: Untreated tyrosinemia type I usually presents either
+in young infants with severe liver involvement or later in the first year with
+liver dysfunction and renal tubular dysfunction associated with growth failure
+and rickets. Untreated children may have repeated, often unrecognized,
+neurologic crises lasting one to seven days that can include change in mental
+status, abdominal pain, peripheral neuropathy, and/or respiratory failure
+requiring mechanical ventilation. Death in the untreated child usually occurs
+before age ten years, typically from liver failure, neurologic crisis, or
+hepatocellular carcinoma. Newborn screening / early diagnosis and combined
+treatment with nitisinone and a low-tyrosine diet has resulted in a greater than
+90% survival rate, normal growth, improved liver function, prevention of
+cirrhosis, correction of renal tubular acidosis, and improvement in secondary
+rickets.
+DIAGNOSIS/TESTING: The diagnosis of tyrosinemia type I can be established in a
+proband by identification of increased succinylacetone concentration in the
+blood and urine or biallelic pathogenic variants in FAH by molecular genetic
+testing.
+MANAGEMENT: Targeted therapies: Nitisinone; low-phenylalanine, low-tyrosine
+diet; liver transplantation for children with severe liver failure at
+presentation and failure to respond to nitisinone therapy or malignant changes
+in hepatic tissue. Supportive care: Additional treatment (especially for those
+not receiving nitisinone) includes: antihypertensive medications and/or referral
+to nephrologist for management of hypertension; correction of metabolic
+acidosis, restoring calcium and phosphate balance, and 25-hydroxyvitamin D
+supplementation for osteoporosis/rickets; management of liver disease per
+hepatologist; treatment of hepatocellular carcinoma per oncologist/hepatologist;
+nutrition support per metabolic dietician; frequent feeds and avoidance of
+fasting to prevent hypoglycemia; developmental services and educational support
+as needed; provide written protocols and letters for emergency management;
+transitional care plan. Acute inpatient treatment for neurologic crises includes
+intravenous glucose, antihypertensives, analgesics, correction of hyponatremia,
+and prompt nitisinone therapy, with crises prevented by strict long-term
+adherence and monitoring. Surveillance: Plasma concentrations of methionine,
+phenylalanine, and tyrosine, blood and urine succinylacetone concentrations,
+blood nitisinone concentration, complete blood count, serum alpha-fetoprotein,
+routine coagulation tests, liver enzymes, and bilirubin concentrations should be
+measured per age-related recommendations. Liver imaging annually or as
+clinically indicated to assess for hepatocellular carcinoma. Blood urea nitrogen
+and creatinine, urine phosphate, calcium, and protein-to-creatinine ratio, and
+kidney ultrasound as clinically indicated to evaluate for kidney disease. Wrist
+radiographs as clinically indicated to evaluate for rickets. Developmental
+assessment at each visit or as clinically indicated. Neuropsychological testing
+should be done before school age and then as indicated. Assess for
+ophthalmologic manifestations at each visit with slit lamp examination if
+symptomatic. Psychosocial assessment at each visit or as clinically indicated.
+Agents/circumstances to avoid: Excessive dietary protein or protein malnutrition
+inducing catabolic state; prolonged fasting; catabolic illness (intercurrent
+infection, brief febrile illness post vaccination); inadequate caloric provision
+during other stressors, especially when fasting is involved (surgery or
+procedure requiring fasting/anesthesia). Evaluation of relatives at risk:
+Testing of at-risk sibs of any age is warranted to allow for early diagnosis and
+prompt initiation of treatment. Prenatal testing (if the familial FAH pathogenic
+variants are known) may be performed via amniocentesis or chorionic villus
+sampling. If prenatal testing was not performed, then – in parallel with NBS –
+urine and blood succinylacetone should be analyzed as soon as possible after
+birth to enable the earliest possible diagnosis and initiation of therapy (FAH
+molecular genetic testing can be performed if the familial pathogenic variants
+are known). Pregnancy management: Limited data exist on the use of nitisinone
+during human pregnancy; however, at least two women have given birth to healthy
+infants while receiving therapeutic doses of nitisinone.
+GENETIC COUNSELING: Tyrosinemia type I is inherited in an autosomal recessive
+manner. If both parents are known to be heterozygous for an FAH pathogenic
+variant, each sib of an affected individual has at conception a 25% chance of
+being affected, a 50% chance of being an asymptomatic carrier, and a 25% chance
+of being unaffected and not a carrier. Once the FAH pathogenic variants have
+been identified in an affected family member, molecular genetic carrier testing
+for at-risk relatives and prenatal/preimplantation genetic testing for
+tyrosinemia type I are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 20301688

--- a/references_cache/PMID_6826727.md
+++ b/references_cache/PMID_6826727.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:6826727"
+title: Hereditary tyrosinemia and the heme biosynthetic pathway. Profound inhibition of delta-aminolevulinic acid dehydratase activity by succinylacetone.
+authors:
+- Sassa S
+- Kappas A
+journal: J Clin Invest
+year: '1983'
+doi: 10.1172/jci110809
+keywords:
+- "Amino Acid Metabolism, Inborn Errors/enzymology"
+- Animals
+- Cattle
+- Chick Embryo
+- Erythrocytes/enzymology
+- Heme/biosynthesis
+- Heptanoates/pharmacology
+- Heptanoic Acids/pharmacology
+- Humans
+- In Vitro Techniques
+- Liver/enzymology
+- Mice
+- "Mice, Inbred BALB C"
+- "Porphobilinogen Synthase/antagonists & inhibitors"
+- Species Specificity
+- Tyrosine/blood
+content_type: abstract_only
+---
+
+# Hereditary tyrosinemia and the heme biosynthetic pathway. Profound inhibition of delta-aminolevulinic acid dehydratase activity by succinylacetone.
+**Authors:** Sassa S, Kappas A
+**Journal:** J Clin Invest (1983)
+**DOI:** [10.1172/jci110809](https://doi.org/10.1172/jci110809)
+
+## Content
+
+1. J Clin Invest. 1983 Mar;71(3):625-34. doi: 10.1172/jci110809.
+
+Hereditary tyrosinemia and the heme biosynthetic pathway. Profound inhibition of
+delta-aminolevulinic acid dehydratase activity by succinylacetone.
+
+Sassa S, Kappas A.
+
+Succinylacetone (4,6-dioxoheptanoic acid) is an abnormal metabolite produced in
+patients with hereditary tyrosinemia as a consequence of an inherited deficiency
+of fumarylacetoacetate hydrolase. It is known that patients with this hereditary
+disease excrete excessive amounts of delta-aminolevulinic acid (ALA) in urine
+and that certain patients have an accompanying clinical syndrome resembling that
+of acute intermittent porphyria (AIP). In order to elucidate the relation of
+succinylacetone to the heme biosynthetic pathway, we have examined the effects
+of this metabolite on the cellular heme content of cultured avian hepatocytes
+and on the activity of purified ALA dehydratase from normal human erythrocytes
+and from mouse and bovine liver. Our data indicate that succinylacetone is an
+extremely potent competitive inhibitor of ALA dehydratase in human as well as in
+animal tissues. By using purified preparations of the enzyme from human
+erythrocytes and mouse and bovine liver, an inhibitor constant ranging from 2 x
+10(-7) M to 3 x 10(-7) M was obtained. In cultured hepatocytes, succinylacetone
+also inhibited ALA dehydratase activity, decreased the cellular content of heme
+and cytochrome P-450, and greatly potentiated the induction response of ALA
+synthase to drugs such as phenobarbital, chemicals such as
+allylisopropylacetamide and 3,5-dicarbethoxy-1,4-dihydrocollidine, and natural
+steroids such as etiocholanolone. Four patients with hereditary tyrosinemia have
+been studied and all were found to have greatly depressed levels of erythrocyte
+ALA dehydratase activity and elevated concentrations of this inhibitor in urine.
+These findings indicate that tyrosinemia is a disorder of special
+pharmacogenetic interest because succinylacetone, an abnormal product of the
+tyrosine metabolic pathway, resulting from the primary gene defect of the
+disease, profoundly inhibits heme biosynthesis in normal cells through a
+blockade at the ALA dehydratase level, leading to clinical and metabolic
+consequences that mimic another genetic disease, AIP.
+
+DOI: 10.1172/jci110809
+PMCID: PMC436912
+PMID: 6826727 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- connect the Tyrosinemia Type I pathograph from FAH molecular dysfunction through toxic tyrosine intermediates, renal tubule injury, hepatic apoptosis and regeneration, succinylacetone-mediated heme biosynthesis disruption, biomarkers, and clinical phenotypes
- add FAH gene and fumarylacetoacetase molecular-function terms, remove unsupported phenotype frequency bands, and add treatment target mechanisms or phenotypes for nitisinone, diet, transplantation, screening, supportive care, and neurocognitive therapy
- fetch supporting cached references for succinylacetone and ALA dehydratase, AFP surveillance, and GeneReviews clinical and treatment support

## Validation
- just validate kb/disorders/Tyrosinemia_Type_I.yaml
- recursive normalized snippet audit: 53 snippets all found in cache
- graph audit: 7 pathophysiology nodes, 24 downstream edges, no orphan downstream targets, no untargeted phenotypes or biochemical nodes, only Genetic counseling intentionally without target
- git diff --check
- subagent blocker review: clean

## Scope
- kb/disorders/Tyrosinemia_Type_I.yaml
- references_cache/PMID_17008115.md
- references_cache/PMID_20301688.md
- references_cache/PMID_6826727.md