### PR TITLE
Add Hypoplasminogenemia disorder curation

### DIFF
--- a/kb/disorders/Hypoplasminogenemia.yaml
+++ b/kb/disorders/Hypoplasminogenemia.yaml
@@ -1,0 +1,484 @@
+name: Hypoplasminogenemia
+creation_date: "2026-05-07T12:56:42Z"
+updated_date: "2026-05-07T12:56:42Z"
+category: Mendelian
+disease_term:
+  preferred_term: hypoplasminogenemia
+  term:
+    id: MONDO:0009009
+    label: hypoplasminogenemia
+synonyms:
+- plasminogen deficiency type 1
+- congenital plasminogen deficiency type I
+- type 1 plasminogen deficiency
+- PLGD-1
+parents:
+- Coagulation Disorder
+- Hereditary Hematologic Disorder
+description: >-
+  Hypoplasminogenemia is an autosomal recessive PLG-related disorder in which
+  low plasminogen antigen and activity impair plasmin-mediated fibrinolysis and
+  wound healing on mucosal surfaces. The disease produces fibrin-rich ligneous
+  pseudomembranes, most often ligneous conjunctivitis, and can involve the
+  periodontium, respiratory tract, genitourinary tract, gastrointestinal tract,
+  and central nervous system.
+inheritance:
+- name: Autosomal recessive
+  inheritance_term:
+    preferred_term: autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  evidence:
+  - reference: PMID:21174000
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Homozygous or compound-heterozygous mutations in the plasminogen (PLG) gene were found in 16 of 23 patients (70%), three of which were novel mutations reported here for the first time (C166Y, Y264S, IVS10-7T/G)."
+    explanation: >-
+      The patient series identifies biallelic PLG genotypes in most severe
+      hypoplasminogenemia cases, supporting recessive inheritance.
+pathophysiology:
+- name: PLG-Related Plasminogen Deficiency
+  description: >-
+    Biallelic pathogenic PLG variants reduce plasminogen antigen and activity,
+    limiting the substrate available for plasmin generation.
+  gene:
+    preferred_term: PLG
+    term:
+      id: hgnc:9071
+      label: PLG
+  biological_processes:
+  - preferred_term: plasminogen activation
+    term:
+      id: GO:0031639
+      label: plasminogen activation
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:21174000
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Here we report the molecular genetic and clinical findings on 23 new cases with severe hypoplasminogenaemia."
+    explanation: >-
+      This case series directly studies severe hypoplasminogenemia and its PLG
+      molecular basis.
+  - reference: PMID:27976734
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Although plasminogen is a key protein in fibrinolysis and several mutations in the plasminogen gene (PLG) have been identified that result in plasminogen deficiency, there are conflicting reports to associate it with the risk of thrombosis."
+    explanation: >-
+      This supports PLG variants as the genetic cause of plasminogen deficiency
+      while distinguishing fibrinolysis biology from uncertain thrombosis risk.
+  downstream:
+  - target: Impaired Fibrinolysis
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37506226
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "We reason that the role of fibrin in periodontitis becomes most evident in individuals with the Mendelian genetic defect, congenital plasminogen (PLG) deficiency, who are predisposed to severe periodontitis in childhood due to a defect in fibrinolysis."
+      explanation: >-
+        This review links congenital PLG deficiency to defective fibrinolysis in
+        a clinically affected mucosal tissue.
+- name: Impaired Fibrinolysis
+  description: >-
+    Reduced plasmin activity impairs fibrin degradation and extravascular wound
+    repair, so fibrin persists after mucosal injury or inflammation.
+  biological_processes:
+  - preferred_term: fibrinolysis
+    term:
+      id: GO:0042730
+      label: fibrinolysis
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:21174000
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Inherited severe hypoplasminogenaemia is a multisystemic disorder leading to deficient extravascular fibrinolysis."
+    explanation: >-
+      The abstract directly states that inherited severe hypoplasminogenemia
+      causes deficient extravascular fibrinolysis.
+  downstream:
+  - target: Ligneous Mucosal Pseudomembrane Formation
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - impaired fibrin degradation
+    - defective mucosal wound healing
+    evidence:
+    - reference: PMID:21174000
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "As a clinical consequence wound healing capacity of mucous membranes is markedly impaired leading to ligneous conjunctivitis and several other manifestations."
+      explanation: >-
+        This connects deficient extravascular fibrinolysis to impaired mucosal
+        wound healing and ligneous lesions.
+- name: Ligneous Mucosal Pseudomembrane Formation
+  description: >-
+    Persistent fibrin-rich deposits form thick pseudomembranes on mucosal
+    surfaces. The conjunctiva is the hallmark site, but airway, oral,
+    genitourinary, gastrointestinal, and tympanic mucosa can also be involved.
+  cell_types:
+  - preferred_term: conjunctival epithelial cell
+    term:
+      id: CL:1000432
+      label: conjunctival epithelial cell
+  biological_processes:
+  - preferred_term: wound healing
+    term:
+      id: GO:0042060
+      label: wound healing
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:39372655
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Plasminogen deficiency type 1 (PLGD-1, hypoplasminogenemia) is an ultra-rare, lifelong disease associated with development of fibrinous lesions in multiple organ systems."
+    explanation: >-
+      This recent clinical case series supports multisystem fibrinous lesion
+      formation as a core disease mechanism.
+phenotypes:
+- category: Ophthalmologic
+  name: Ligneous Conjunctivitis
+  description: >-
+    Chronic or recurrent conjunctival pseudomembranes are the hallmark clinical
+    manifestation and can cause progressive visual morbidity.
+  phenotype_term:
+    preferred_term: conjunctival membrane
+    term:
+      id: HP:0034814
+      label: Conjunctival membrane
+  evidence:
+  - reference: PMID:37612758
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Ligneous Conjunctivitis (LC) is the most common clinical manifestation of Type I Plasminogen deficiency (T1PD; OMIM# 217090), and it is characterized by the formation of pseudomembranes (due to deposition of fibrin) on the conjunctivae leading to progressive vision loss."
+    explanation: >-
+      This directly supports conjunctival pseudomembranes as the most common
+      manifestation and links them to vision loss.
+- category: Dental
+  name: Severe Periodontitis
+  description: >-
+    Mucosal fibrin persistence predisposes affected children to severe
+    periodontitis and early tooth loss.
+  phenotype_term:
+    preferred_term: severe periodontitis
+    term:
+      id: HP:0000166
+      label: Severe periodontitis
+  evidence:
+  - reference: PMID:37506226
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We reason that the role of fibrin in periodontitis becomes most evident in individuals with the Mendelian genetic defect, congenital plasminogen (PLG) deficiency, who are predisposed to severe periodontitis in childhood due to a defect in fibrinolysis."
+    explanation: >-
+      This supports childhood severe periodontitis as a mucosal consequence of
+      PLG deficiency.
+- category: Dental
+  name: Premature Loss of Teeth
+  description: >-
+    Severe ligneous periodontal disease can lead to premature tooth loss.
+  phenotype_term:
+    preferred_term: premature loss of teeth
+    term:
+      id: HP:0006480
+      label: Premature loss of teeth
+  evidence:
+  - reference: PMID:37506226
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We reason that the role of fibrin in periodontitis becomes most evident in individuals with the Mendelian genetic defect, congenital plasminogen (PLG) deficiency, who are predisposed to severe periodontitis in childhood due to a defect in fibrinolysis."
+    explanation: >-
+      The abstract supports severe childhood periodontitis; tooth loss is a
+      downstream clinical consequence of severe periodontal destruction, so this
+      is marked partial rather than direct support.
+- category: Respiratory
+  name: Airway Obstruction
+  description: >-
+    Fibrinous lesions can develop in the respiratory tract and compromise
+    respiratory function, sometimes producing life-threatening airway disease.
+  phenotype_term:
+    preferred_term: airway obstruction
+    term:
+      id: HP:0006536
+      label: Airway obstruction
+  evidence:
+  - reference: PMID:39372655
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Depending on lesion location, clinical manifestations of PLGD-1 can result in acute and/or chronic respiratory airway disease which can compromise respiratory function leading to life-threatening events."
+    explanation: >-
+      This supports clinically important respiratory tract involvement and
+      airway compromise in PLGD-1.
+- category: Respiratory
+  name: Respiratory Insufficiency
+  description: >-
+    Severe respiratory lesions can impair respiratory function and may require
+    disease-targeted replacement therapy.
+  phenotype_term:
+    preferred_term: respiratory insufficiency
+    term:
+      id: HP:0002093
+      label: Respiratory insufficiency
+  evidence:
+  - reference: PMID:39372655
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Early recognition and effective treatment of airway obstruction caused by fibrinous lesions are critical to prevent morbidity due to respiratory compromise."
+    explanation: >-
+      This supports respiratory compromise as a consequence of airway fibrinous
+      lesions.
+- category: Neurologic
+  name: Hydrocephalus
+  description: >-
+    Congenital or occlusive hydrocephalus is reported in a subset of severe
+    hypoplasminogenemia cases.
+  phenotype_term:
+    preferred_term: hydrocephalus
+    term:
+      id: HP:0000238
+      label: Hydrocephalus
+  evidence:
+  - reference: PMID:21174000
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Compared to 79 previously published cases, clinical manifestations of the current group of patients showed higher percentages of ligneous periodontitis, congenital hydrocephalus, and involvement of the female genital tract."
+    explanation: >-
+      The 23-patient series identifies congenital hydrocephalus among clinical
+      manifestations enriched in the cohort.
+- category: Reproductive
+  name: Female Genital Tract Involvement
+  description: >-
+    Ligneous lesions can involve the female genital tract and contribute to
+    reproductive morbidity in affected individuals.
+  phenotype_term:
+    preferred_term: abnormality of the female genitalia
+    term:
+      id: HP:0010460
+      label: Abnormality of the female genitalia
+  evidence:
+  - reference: PMID:21174000
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Compared to 79 previously published cases, clinical manifestations of the current group of patients showed higher percentages of ligneous periodontitis, congenital hydrocephalus, and involvement of the female genital tract."
+    explanation: >-
+      This supports female genital tract involvement as a documented clinical
+      manifestation.
+biochemical:
+- name: Low Plasminogen Activity
+  presence: PRESENT
+  notes: >-
+    Type 1 plasminogen deficiency is characterized clinically by low functional
+    plasminogen activity together with low plasminogen antigen; routine PT/aPTT
+    testing may be unrevealing, so targeted plasminogen assays are diagnostic.
+  evidence:
+  - reference: DOI:10.1111/hae.14849
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All subjects achieved the targeted ≥ 10% increase in trough plasminogen activity above baseline through Week 12."
+    explanation: >-
+      The replacement-therapy trial uses trough plasminogen activity as a
+      biochemical endpoint in subjects with type 1 plasminogen deficiency.
+genetic:
+- name: PLG
+  gene_term:
+    preferred_term: PLG
+    term:
+      id: hgnc:9071
+      label: PLG
+  association: Biallelic Pathogenic Variant
+  features: >-
+    PLG encodes plasminogen. Reported pathogenic alleles include homozygous and
+    compound-heterozygous variants that reduce plasminogen activity and antigen.
+  evidence:
+  - reference: PMID:21174000
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Homozygous or compound-heterozygous mutations in the plasminogen (PLG) gene were found in 16 of 23 patients (70%), three of which were novel mutations reported here for the first time (C166Y, Y264S, IVS10-7T/G)."
+    explanation: >-
+      The cohort directly supports PLG as the causal gene and documents the
+      biallelic variant pattern.
+  - reference: PMID:27976734
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The whole PLG was tested using Next Generation Sequencing (NGS) and 5 putative pathogenic mutations were found (after in silico predictions) and associated with plasminogen deficiency."
+    explanation: >-
+      Independent family sequencing supports pathogenic PLG variants as the
+      genetic basis of plasminogen deficiency.
+treatments:
+- name: Intravenous Plasminogen Replacement
+  description: >-
+    Plasminogen, human-tvmh replacement restores circulating plasminogen
+    activity and is disease-targeted therapy for visible and non-visible lesions
+    in type 1 plasminogen deficiency.
+  treatment_term:
+    preferred_term: infusion procedure
+    term:
+      id: MAXO:0000757
+      label: infusion procedure
+  target_mechanisms:
+  - target: PLG-Related Plasminogen Deficiency
+    treatment_effect: RESTORES
+    description: Replacement therapy restores plasminogen substrate for plasmin generation.
+  - target: Impaired Fibrinolysis
+    treatment_effect: RESTORES
+    description: Increased plasminogen activity supports restoration of fibrinolytic capacity.
+  evidence:
+  - reference: DOI:10.1111/hae.14849
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The primary efficacy endpoint was achieved, as 100% of subjects (n = 11) with visible and assessable non‐visible lesions at baseline demonstrated ≥ 50% improvement after 48 weeks of study drug treatment with plasminogen, human‐tvmh."
+    explanation: >-
+      Phase 2/3 clinical evidence supports systemic plasminogen replacement for
+      lesion improvement in type 1 plasminogen deficiency.
+  - reference: DOI:10.1111/hae.14849
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All subjects achieved the targeted ≥ 10% increase in trough plasminogen activity above baseline through Week 12."
+    explanation: >-
+      This supports the biochemical restoration mechanism of intravenous
+      plasminogen replacement.
+- name: Plasminogen Replacement for Respiratory Lesions
+  description: >-
+    Intravenous plasminogen, human-tvmh can resolve or greatly improve severe
+    respiratory complications due to airway fibrinous lesions.
+  treatment_term:
+    preferred_term: infusion procedure
+    term:
+      id: MAXO:0000757
+      label: infusion procedure
+  target_phenotypes:
+  - preferred_term: airway obstruction
+    term:
+      id: HP:0006536
+      label: Airway obstruction
+  - preferred_term: respiratory insufficiency
+    term:
+      id: HP:0002093
+      label: Respiratory insufficiency
+  target_mechanisms:
+  - target: Ligneous Mucosal Pseudomembrane Formation
+    treatment_effect: MODULATES
+    description: Replacement therapy can clear or reduce fibrinous airway lesions.
+  evidence:
+  - reference: PMID:39372655
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Presented here is a case series of one adult and three pediatric patients with severe respiratory complications of PLGD-1 successfully managed by infusions of plasminogen, human-tvmh replacement therapy."
+    explanation: >-
+      This directly supports systemic replacement therapy for severe airway
+      complications.
+  - reference: PMID:39372655
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patients' respiratory symptoms were resolved or greatly improved, and treatment was generally well tolerated."
+    explanation: >-
+      The case series reports clinical improvement of respiratory symptoms with
+      replacement therapy.
+- name: Topical Plasminogen Eye Drops
+  description: >-
+    Topical plasminogen has been used to prevent recurrent conjunctival
+    pseudomembranes in ligneous conjunctivitis, including long-term pediatric
+    follow-up after ocular surgery.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: conjunctival membrane
+    term:
+      id: HP:0034814
+      label: Conjunctival membrane
+  target_mechanisms:
+  - target: Ligneous Mucosal Pseudomembrane Formation
+    treatment_effect: MODULATES
+    description: Topical replacement targets local fibrin-rich membrane recurrence.
+  evidence:
+  - reference: PMID:37612758
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Treatment with topical purified plasminogen is used to prevent pseudomembranes formation (Blood 108:3021-3026, 2006, Ophthalmology 129:955-957, 2022)."
+    explanation: >-
+      This supports topical plasminogen as a local treatment strategy for
+      conjunctival pseudomembrane prevention.
+  - reference: PMID:37612758
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patient showed a progressive response to the topical plasminogen, with a complete absence of pseudomembrane formation at a twelve-year follow-up, despite using an ocular prosthesis."
+    explanation: >-
+      Long-term follow-up supports durable control of conjunctival membranes in
+      one pediatric case.
+clinical_trials:
+- name: NCT02690714
+  phase: PHASE_II
+  status: COMPLETED
+  description: >-
+    Phase 2/3 open-label repeat-dose trial evaluating pharmacokinetics,
+    efficacy, and safety of intravenous Prometic plasminogen in pediatric and
+    adult subjects with hypoplasminogenemia.
+  target_phenotypes:
+  - preferred_term: conjunctival membrane
+    term:
+      id: HP:0034814
+      label: Conjunctival membrane
+  - preferred_term: airway obstruction
+    term:
+      id: HP:0006536
+      label: Airway obstruction
+  evidence:
+  - reference: clinicaltrials:NCT02690714
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This is a Phase 2/3 pivotal study to evaluate pharmacokinetics (PK), efficacy, and safety of Prometic Plasminogen (Human) Intravenous Lyophilized Solution, the investigational medicinal product (IMP), in pediatric and adult subjects with hypoplasminogenemia."
+    explanation: >-
+      ClinicalTrials.gov identifies this pivotal intravenous plasminogen study
+      in pediatric and adult hypoplasminogenemia.
+- name: NCT01554956
+  phase: PHASE_II
+  status: COMPLETED
+  description: >-
+    Historically controlled phase 2/3 clinical trial evaluating topical human
+    plasminogen eye drops in patients diagnosed with ligneous conjunctivitis.
+  target_phenotypes:
+  - preferred_term: conjunctival membrane
+    term:
+      id: HP:0034814
+      label: Conjunctival membrane
+  evidence:
+  - reference: clinicaltrials:NCT01554956
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Kedrion Human Plasminogen, a sterile human plasma-derived plasminogen preparation for topical ocular use will be evaluated for the indication of treatment of ligneous conjunctivitis."
+    explanation: >-
+      ClinicalTrials.gov supports topical plasminogen eye drops as a clinical
+      trial intervention for ligneous conjunctivitis.
+animal_models:
+- species: dog
+  genotype: PLG exon 1 deletion
+  category: NATURAL
+  description: >-
+    A Maltese dog with a large PLG deletion and absent plasminogen activity has
+    been reported as a spontaneous comparative model of ligneous membranitis.
+  evidence:
+  - reference: PMID:34370320
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "A large deletion in the Plasminogen gene is associated with ligneous membranitis in a Maltese dog."
+    explanation: >-
+      The Falcon report identified a natural canine PLG-deficiency case as a
+      comparative animal model; this title-level abstract cache supports the
+      model relationship after reference fetch.
+diagnosis:
+- name: Plasminogen Activity and Antigen Testing
+  description: >-
+    Diagnosis is supported by targeted measurement of plasminogen activity and
+    antigen, with type 1 disease showing low activity and low antigen.
+  evidence:
+  - reference: DOI:10.1111/hae.14849
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All subjects achieved the targeted ≥ 10% increase in trough plasminogen activity above baseline through Week 12."
+    explanation: >-
+      The pivotal treatment study uses trough plasminogen activity as a
+      disease-relevant biochemical endpoint, supporting clinical measurement of
+      plasminogen activity.
+datasets:

--- a/kb/disorders/Hypoplasminogenemia.yaml
+++ b/kb/disorders/Hypoplasminogenemia.yaml
@@ -314,6 +314,8 @@ treatments:
     term:
       id: MAXO:0000757
       label: infusion procedure
+    therapeutic_agent:
+    - preferred_term: plasminogen
   target_mechanisms:
   - target: PLG-Related Plasminogen Deficiency
     treatment_effect: RESTORES
@@ -345,6 +347,8 @@ treatments:
     term:
       id: MAXO:0000757
       label: infusion procedure
+    therapeutic_agent:
+    - preferred_term: plasminogen
   target_phenotypes:
   - preferred_term: airway obstruction
     term:
@@ -383,6 +387,8 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: plasminogen
   target_phenotypes:
   - preferred_term: conjunctival membrane
     term:
@@ -462,7 +468,7 @@ animal_models:
   - reference: PMID:34370320
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "A large deletion in the Plasminogen gene is associated with ligneous membranitis in a Maltese dog."
+    snippet: "This study provides a spontaneous animal model for LM associated with complete plasminogen deficiency and provides a method for detecting affected or carrier dogs."
     explanation: >-
       The Falcon report identified a natural canine PLG-deficiency case as a
       comparative animal model; this title-level abstract cache supports the
@@ -473,12 +479,11 @@ diagnosis:
     Diagnosis is supported by targeted measurement of plasminogen activity and
     antigen, with type 1 disease showing low activity and low antigen.
   evidence:
-  - reference: DOI:10.1111/hae.14849
+  - reference: PMID:27976734
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "All subjects achieved the targeted ≥ 10% increase in trough plasminogen activity above baseline through Week 12."
+    snippet: "In type I, both plasminogen activity and antigen levels are decreased."
     explanation: >-
-      The pivotal treatment study uses trough plasminogen activity as a
-      disease-relevant biochemical endpoint, supporting clinical measurement of
-      plasminogen activity.
+      This directly supports the diagnostic distinction that type 1
+      plasminogen deficiency has both low activity and low antigen.
 datasets:

--- a/references_cache/DOI_10.1111_hae.14849.md
+++ b/references_cache/DOI_10.1111_hae.14849.md
@@ -1,0 +1,24 @@
+---
+reference_id: "DOI:10.1111/hae.14849"
+title: "Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1"
+authors:
+- Amy D. Shapiro
+- Charles Nakar
+- Joseph M. Parker
+- Karen Thibaudeau
+- Roberto Crea
+- Per Morten Sandset
+journal: Haemophilia
+year: '2023'
+doi: 10.1111/hae.14849
+content_type: abstract_only
+---
+
+# Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1
+**Authors:** Amy D. Shapiro, Charles Nakar, Joseph M. Parker, Karen Thibaudeau, Roberto Crea, Per Morten Sandset
+**Journal:** Haemophilia (2023)
+**DOI:** [10.1111/hae.14849](https://doi.org/10.1111/hae.14849)
+
+## Content
+
+AbstractAimAn open‐label phase 2/3 study of plasminogen, human‐tvmh administered intravenously in paediatric and adult subjects with type 1 plasminogen deficiency was conducted. Interim data was previously reported. The final data on 15 subjects who completed the study up to a maximum of 124 weeks are reported here.MethodsThe primary objectives were to evaluate efficacy of plasminogen replacement therapy on clinically evident or visible lesions during 48 weeks of dosing and to achieve an increase in trough plasminogen activity levels by at least an absolute 10% above baseline during 12 weeks of treatment.ResultsThe primary efficacy endpoint was achieved, as 100% of subjects (n = 11) with visible and assessable non‐visible lesions at baseline demonstrated ≥ 50% improvement after 48 weeks of study drug treatment with plasminogen, human‐tvmh. All subjects achieved the targeted ≥ 10% increase in trough plasminogen activity above baseline through Week 12. Plasminogen, human‐tvmh at a dose of 6.6 mg/kg administered every 2–5 days for 48 weeks and every 1–7 days for up to 124 weeks was well tolerated.ConclusionThis study provides additional evidence regarding the long‐term safety and clinical utility of replacement therapy with human plasminogen for the treatment of children and adults with type 1 plasminogen deficiency. Plasminogen, human‐tvmh received marketing approval on June 4, 2021. This trial was registered at www.clinicaltrials.gov as #NCT02690714.

--- a/references_cache/PMID_21174000.md
+++ b/references_cache/PMID_21174000.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:21174000"
+title: Identification of three novel plasminogen (PLG) gene mutations in a series of 23 patients with low PLG activity.
+authors:
+- Klammt J
+- Kobelt L
+- Aktas D
+- Durak I
+- Gokbuget A
+- Hughes Q
+- Irkec M
+- Kurtulus I
+- Lapi E
+- Mechoulam H
+- Mendoza-Londono R
+- Palumbo JS
+- Steitzer H
+- Tabbara KF
+- Ozbek Z
+- Pucci N
+- Sotomayor T
+- Sturm M
+- Drogies T
+- Ziegler M
+- Schuster V
+journal: Thromb Haemost
+year: '2011'
+doi: 10.1160/TH10-04-0216
+keywords:
+- Blood Coagulation Disorders/genetics
+- Child
+- "Child, Preschool"
+- Female
+- Heterozygote
+- Humans
+- Hydrocephalus/genetics
+- Infant
+- "Infant, Newborn"
+- Male
+- "Models, Biological"
+- Mutation
+- Pedigree
+- Periodontitis/genetics
+- "Plasminogen/biosynthesis, genetics"
+content_type: abstract_only
+---
+
+# Identification of three novel plasminogen (PLG) gene mutations in a series of 23 patients with low PLG activity.
+**Authors:** Klammt J, Kobelt L, Aktas D, Durak I, Gokbuget A, Hughes Q, Irkec M, Kurtulus I, Lapi E, Mechoulam H, Mendoza-Londono R, Palumbo JS, Steitzer H, Tabbara KF, Ozbek Z, Pucci N, Sotomayor T, Sturm M, Drogies T, Ziegler M, Schuster V
+**Journal:** Thromb Haemost (2011)
+**DOI:** [10.1160/TH10-04-0216](https://doi.org/10.1160/TH10-04-0216)
+
+## Content
+
+1. Thromb Haemost. 2011 Mar;105(3):454-60. doi: 10.1160/TH10-04-0216. Epub 2010
+Dec  21.
+
+Identification of three novel plasminogen (PLG) gene mutations in a series of 23 
+patients with low PLG activity.
+
+Klammt J(1), Kobelt L, Aktas D, Durak I, Gokbuget A, Hughes Q, Irkec M, Kurtulus 
+I, Lapi E, Mechoulam H, Mendoza-Londono R, Palumbo JS, Steitzer H, Tabbara KF, 
+Ozbek Z, Pucci N, Sotomayor T, Sturm M, Drogies T, Ziegler M, Schuster V.
+
+Author information:
+(1)Hospital for Children and Adolescents, University of Leipzig, Leipzig, 
+Germany.
+
+Inherited severe hypoplasminogenaemia is a multisystemic disorder leading to 
+deficient extravascular fibrinolysis. As a clinical consequence wound healing 
+capacity of mucous membranes is markedly impaired leading to ligneous 
+conjunctivitis and several other manifestations. Here we report the molecular 
+genetic and clinical findings on 23 new cases with severe hypoplasminogenaemia. 
+Homozygous or compound-heterozygous mutations in the plasminogen (PLG) gene were 
+found in 16 of 23 patients (70%), three of which were novel mutations reported 
+here for the first time (C166Y, Y264S, IVS10-7T/G). Compared to 79 previously 
+published cases, clinical manifestations of the current group of patients showed 
+higher percentages of ligneous periodontitis, congenital hydrocephalus, and 
+involvement of the female genital tract. In contrast, involvement of the 
+gastrointestinal or urogenital tract was not observed in any of the cases. 
+Patients originated to a large extent (61%) from Turkey and the Middle East, and 
+showed a comparably frequent occurrence of consanguinity of affected families 
+and a greater female to male ratio than was derived from previous reports in the 
+literature. Individual treatment of ligneous conjunctivitis included topical 
+plasminogen or heparin eye drops, topical or systemic fresh frozen plasma, and 
+surgical removal of ligneous pseudomembranes, mostly with modest or transient 
+efficacy. In conclusion, the present study underscores the broad range of 
+clinical manifestations in PLG-deficient patients with a trend to regional 
+differences. Transmission of genetic and clinical data to the recently 
+established Plasminogen Deficiency Registry should help to determine the 
+prevalence of the disease and to develop more efficient treatment strategies.
+
+DOI: 10.1160/TH10-04-0216
+PMID: 21174000 [Indexed for MEDLINE]

--- a/references_cache/PMID_27976734.md
+++ b/references_cache/PMID_27976734.md
@@ -1,0 +1,147 @@
+---
+reference_id: "PMID:27976734"
+title: The Unravelling of the Genetic Architecture of Plasminogen Deficiency and its Relation to Thrombotic Disease.
+authors:
+- Martin-Fernandez L
+- Marco P
+- Corrales I
+- Pérez R
+- Ramírez L
+- López S
+- Vidal F
+- Soria JM
+journal: Sci Rep
+year: '2016'
+doi: 10.1038/srep39255
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Female
+- Genetic Variation
+- High-Throughput Nucleotide Sequencing
+- Humans
+- Male
+- Middle Aged
+- Phenotype
+- "Plasminogen/chemistry, deficiency, genetics"
+- "Polymorphism, Genetic"
+- Risk Factors
+- "Sequence Analysis, DNA"
+- "Thromboembolism/genetics, pathology"
+- Young Adult
+content_type: full_text_xml
+---
+
+# The Unravelling of the Genetic Architecture of Plasminogen Deficiency and its Relation to Thrombotic Disease.
+**Authors:** Martin-Fernandez L, Marco P, Corrales I, Pérez R, Ramírez L, López S, Vidal F, Soria JM
+**Journal:** Sci Rep (2016)
+**DOI:** [10.1038/srep39255](https://doi.org/10.1038/srep39255)
+
+## Content
+
+1. Sci Rep. 2016 Dec 15;6:39255. doi: 10.1038/srep39255.
+
+The Unravelling of the Genetic Architecture of Plasminogen Deficiency and its 
+Relation to Thrombotic Disease.
+
+Martin-Fernandez L(1), Marco P(2), Corrales I(3)(4), Pérez R(1), Ramírez 
+L(3)(4), López S(1), Vidal F(3)(4), Soria JM(1).
+
+Author information:
+(1)Unit of Genomics of Complex Diseases, Biomedical Research Institute Sant Pau 
+(IIB-Sant Pau), Barcelona, Spain.
+(2)Department of Haematology, Hospital General Universitario, Alicante, Spain.
+(3)Congenital Coagulopathies, Blood and Tissue Bank, Barcelona, Spain.
+(4)Molecular Diagnosis and Therapy, Vall d'Hebron Research Institute, 
+Universitat Autònoma de Barcelona (VHIR-UAB), Barcelona, Spain.
+
+Although plasminogen is a key protein in fibrinolysis and several mutations in 
+the plasminogen gene (PLG) have been identified that result in plasminogen 
+deficiency, there are conflicting reports to associate it with the risk of 
+thrombosis. Our aim was to unravel the genetic architecture of PLG in families 
+with plasminogen deficiency and its relationship with spontaneous thrombotic 
+events in these families. A total of 13 individuals from 4 families were 
+recruited. Their genetic risk profile of thromboembolism was characterized using 
+the Thrombo inCode kit. Only one family presented genetic risk of 
+thromboembolism (homozygous carrier of F12 rs1801020 and F13A1 rs5985). The 
+whole PLG was tested using Next Generation Sequencing (NGS) and 5 putative 
+pathogenic mutations were found (after in silico predictions) and associated 
+with plasminogen deficiency. Although we can not find genetic risk factors of 
+thrombosis in 3 of 4 families, even the mutations associated with plasminogen 
+deficiency do not cosegregated with thrombosis, we can not exclude plasminogen 
+deficiency as a susceptibility risk factor for thrombosis, since thrombosis is a 
+multifactorial and complex disease where unknown genetic risk factors, in 
+addition to plasminogen deficiency, within these families may explain the 
+thrombotic tendency.
+
+DOI: 10.1038/srep39255
+PMCID: PMC5157013
+PMID: 27976734 [Indexed for MEDLINE]
+
+The plasminogen protein plays a pivotal role in fibrinolysis and wound healing. Briefly, this protein generates the active enzyme plasmin by tissue-type plasminogen activator (t-PA) or urokinase-type plasminogen activator (u-PA). Plasmin, which is a serine protease enzyme, is essential for the dissolution of blood clots in a fibrin-dependent manner. In addition, plasmin has different substrate specificities and functions that are important in wound healing, such as other matrix glycoproteins or the activation of matrix metalloproteinases1. The plasminogen protein is encoded by the PLG gene, which is located on Chromosome 6q26, has 19 exons and is 51,861 bp in length (http://genome.ucsc.edu/; February 2009 release of the human genome, GRCh37/hg19)2. Numerous mutations have been described in the PLG locus that cause plasminogen deficiency, such as missense, nonsense, frameshift, splice site, deletion and insertion mutations34.
+
+Plasminogen deficiency is a rare disorder that has been classified as type I or hypoplasminogenemia, described first by Hasegawa et al. in ref. 5, and type II or dysplasminogenemia, which was described for the first time by Aoki et al. in ref. 6. In type I, both plasminogen activity and antigen levels are decreased. In contrast, type II is characterized by decreased plasminogen activity but normal antigen levels47. Both functional and antigen assays have been used in clinical diagnosis. Molecular genetic analysis has supported the clinical diagnosis, and identified individuals at risk for plasminogen deficiency. It may be used also for prenatal diagnosis8. Currently, different approaches have been reported for testing for genetic mutations: single-strand conformation polymorphism analysis of PCR products encompassing exons and intron boundaries, restriction fragment length polymorphism technique and Sanger sequencing of both PCR amplicons of exons and flanking intronic regions and long range (LR) PCR amplicons4910.
+
+Plasminogen deficiency results in a reduction in the degradation of fibrin and thus affects wound healing. For example, ligneous conjunctivitis, congenital occlusive hydrocephalus and juvenile colloid milium have been reported13. Among these, ligneous conjunctivitis is the most common and is characterized by chronic tearing, erythema of the conjunctiva and white, yellow-white, or red thick masses with a wood-like consistency. This chronic conjunctivitis is associated with homozygous or compound heterozygous type I patients. Of note, heterozygous type I and type II patients are asymptomatic3. Some studies611 suggested that there was an association between plasminogen deficiency and thrombosis due to impaired fibrinolysis. However, these studies involved few patients of sympthomatic thrombophilia. In addition, most family studies showed that only the probands had thrombosis. It is noteworthy that some risk factors of thrombosis such as activated protein C (APC) resistance were unknown when this association was reported12. More recent reports supports the hypothesis that this disorder by itself is not a risk factor of venous or arterial thrombosis31213. Also, it is suggested that the diminished plasminogen capability of fibrinolysis may be compensated by the action of alternative enzymes in the blood3.
+
+In our study, we identified 4 Spanish patients that had suffered spontaneous thrombotic events. We identified a plasminogen deficiency in these patients and in several of their relatives. Our aims were to characterize the genetic risk factors of thromboembolism in these families and to detect the genetic mutations that were involved in the plasminogen deficiency. We used a new method to diagnose the deficiency based on Next Generation Sequencing (NGS) of PLG. We evaluated also the relation of these causal genetic mutations to the thrombotic outcomes to elucidate the role of plasminogen deficiency in thrombotic disease.
+
+A total of 13 individuals from 4 Spanish families (A, B, C and D) were recruited at the Hospital General Universitario de Alicante. These families were selected through probands with a positive history of spontaneous thrombosis and plasminogen deficiency. The latter was defined as a functional activity below 72% (normal range, 72% to 127%). The characterization of these families is presented in Table 1. Clinical manifestations related to plasminogen deficiency were not identified and no classification of type I or type II was performed. All of the probands and one relative had experienced a spontaneous deep venous thrombosis of the legs or an arterial thrombotic event. The number of individuals per family varied from 1 to 5 and they ranged in age from 13 to 74 years. A total of 9 individuals were selected from the 4 families for genetic analysis, which included the probands and individuals with the lowest functional plasminogen deficiency values. At least 2 relatives of every family were selected for inclusion, except for one family with no relatives.
+
+The study is part of the clinical routine of the Hospital General Universitario de Alicante for thrombophilia patients conducted in accordance with the Good Practice Guidelines that included an informed consent from all individuals prior to inclusion. The studies were conducted in accordance with the Declaration of Helsinki.
+
+Blood samples were obtained from the antecubital vein and anticoagulated with 3.8% sodium citrate in the proportion 1:10. The blood samples were centrifuged for 10 minutes at 3,500 g within 15 minutes after collection. The poor-platelet plasma (PPP) samples were immediately frozen and stored at −80 °C until tested. DNA was extracted from whole blood collected in EDTA using a standard salting out procedure14. The functional plasminogen activity was performed in PPP using a chromogenic substrate assay, activated by tissue plasminogen activator (Instrumentation Laboratory, Werfen Group, MA, USA).
+
+The Thrombo inCode (TiC) kit (Ferrer in Code, Barcelona, Spain) was used to determine the genetic profile of thrombosis. The TiC kit identified the alleles of 12 genetic variants: F5 (rs6025, rs118203906, rs118203905), F2 rs1799963, F12 rs1801020, F13A1 rs5985, SERPINC1 rs121909548, SERPINA10 rs2232698 and the A1 blood group (rs8176719, rs7853989, rs8176743 and rs8176750). This genetic profile has been validated and reported in the literature15. The TiC kit was applied by Taqman assays run in an ABI 7500 instrument according to manufacturer’s instructions.
+
+A total of 55,184 bp of the PLG locus (GRCh37/hg19 chr6:161,123,225-161,175,085; NM_000301.3) were amplified using 7 LR-PCR amplicons. The primer sequences, positions and PCR amplicon size are shown in Table 2. The PCR primers were designed to specifically amplify the PLG and to avoid co-amplifications in view of the high homology between PLG, LPA family genes, pseudogenes and plasminogen-like genes10. The overlapped PCR amplicons covered all of the exons, introns, 5′-UTR, 3′-UTR and approximately 1,500 bp of the 5′-promoter region. The PCR amplicons designed were tested for target specificity by Sanger sequencing as described below.
+
+LR-PCR amplicons were generated using the SequalPrep Long PCR Kit with dNTPs (Invitrogen, Thermo Fisher Scientific Inc., MA, USA). The LR-PCR mix solution contained ~50 ng of DNA, SequalPrep 1X reaction buffer, 0.4 μl of dimethylsulfoxide (DMSO), SequalPrep 1X enhancer B, 0.75 μM of forward and reverse primers and 1.8 units of SequalPrep Long Polymerase in a total volume of 20 μl. After initial denaturation at 94 °C for 2 minutes (min), 10 cycles of 94 °C for 10 seconds (sec), 64 °C for 30 sec, and 68 °C for 18 min were performed, followed by 22 cycles of 94 °C for 10 sec, 64 °C for 30 sec, and 68 °C for 18 min (+20 sec/cycle). In addition, an elongation step at 72 °C for 5 min was performed.
+
+Every PCR amplicon was run on 0.7% agarose gel electrophoresis and visualized using SYBR safe (Invitrogen, Thermo Fisher Scientific Inc.). PCR amplicons were quantified by the Qubit technology (Invitrogen, Thermo Fisher Scientific Inc.) and a normalized pool of the 7 PCR amplicons was prepared for each individual by mixing equimolar amounts. Finally, the PCR pools were adjusted at 0.2 ng/μl for preparing the libraries.
+
+The sequencing libraries were prepared from pooled PCR amplicons using the Nextera XT DNA Sample Preparation kit (Illumina, San Diego, CA, USA) with double indexing, following the standard manufacturer’s protocol. We obtained 9 paired-end libraries that were pooled and run simultaneously on an Illumina Miseq sequencing system (Illumina) by the Miseq sequencing reagent kit v2 of 300 cycles (2 × 150 bp paired-end) (Illumina).
+
+Indexed sequences were de-multiplexed and analyzed individually. The NGS pipeline output, paired sequence files (fastq files format), was used as input for the analysis with the CLC Genomic Workbench (v.6.5) software (CLC Bio - Qiagen, Aarhus, Denmark). The raw data were trimmed with length (minimum 25 bp; maximum 500 bp), ambiguous nucleotide (maximum 2) and quality score (0.05) filters. CLC Genomic Workbench software permitted the alignment of the trimmed reads against the human genome reference (hg19) and in silico analysis. Read mapping was performed with specific parameter setting (mismatch count, 2; indel count, 3; length fraction, 0.7; similarity fraction, 0.9). Indels and structural variants tool was used to identify insertions and deletions, inversions, translocations and tandem duplications, applying standard settings. Moreover, adjusted parameters for quality-based variant detection were as follows: minimum coverage, 30x; minimum variant frequency, 25%. Quality-based variant detection results in variant call format (VCF) file were used as input for the Illumina VariantStudio Data Analysis (v.2.1) Software (Illumina) to annotate variants.
+
+For structural variants, we used the following filter parameters to detect pathogenic variations: a) minimum variant ratio, 0.25, b) minimum mapping scores fraction, 0.6, c) consider intronic structural variants located <30 bp from exon flanking boundaries, d) allele frequency from our own NGS variants database of 110 individuals, ≤5%, and e) co-segregation in the family.
+
+The following criteria were applied to identify putative pathogenic mutations within single nucleotide variants (SNV) and small insertions and deletions: a) whether the variant was rare: allele frequency ≤1% from 1000 Genomes (April 2012 v.3)16 and NHLBI Exome Variant Server (June 2013 ESP6500SI-V2), b) location referring to Variant Effect Predictor (v.2.8) database: intronic mutations located <30 bp into flanking intronic sequence of each exon were included, c) allele frequency from our own NGS variants database of 110 individuals, ≤5%, in the case of variants not annotated in 1000 Genomes (April 2012 v.3)16, and d) co-segregation in the family.
+
+We defined as “new” those putative pathogenic mutations that were not reported in the literature related to the plasminogen deficiency disorder. The amino acid numbering and the nomenclature used for the description of the sequence variations follows the international recommendations of the Human Genome Variation Society (HGVS; http://www.HGVS.org).
+
+Putative pathogenic mutations were validated by Sanger sequencing17 in probands and family members. The sequences were mapped against the PLG locus (GRCh37/hg19 chr6:161,123,225-161,175,085; NM_000301.3) using the CLC Genomic Workbench (v.6.5) software.
+
+The in silico prediction that evaluate functional effects of putative pathogenic mutations was performed using the Alamut Visual (v.2.6.1) software (Interactive Biosoftware, Rouen, France). Changes in splicing sites were predicted using NNSplice and Human Splicing Finder tools. For splicing variants interpretation, a splicing site change was considered as potentially deleterious when a variation between the native and the mutation score of more than 10% was observed in both algorithms18. Missense prediction tools included SIFT, PolyPhen-2, Align GVGD and Mutation Taster. Evolutionary conservation scores were obtained using phyloP and Grantham distances. Interpretation of predictive structural effects of new missense mutations was investigated by using the Project HOPE software19.
+
+We characterized the alleles of 12 genetic variants located within F2, F5, F12, F13A1, ABO, SERPINA10 and SERPINC1 loci, included in the TiC kit. Based on these results, all of the individuals were reported as not at genetic risk of thrombotic disease except for the proband of Family D (Table 3). This individual was homozygous for the alleles c.-4T in the F12 (rs1801020), also known as 46 T risk allele1520, and c.103 G>G of the F13A1 (rs5985), also known as Val34 risk allele15.
+
+We amplified 55,184 bp encompassing the PLG locus using LR-PCR from 9 individuals. These LR-PCR amplicons were analysed by NGS. Briefly, the percentage of the mapped positions with a depth of coverage above 30x was 95% and the median coverage per individual was 212x. In total, 237 potential structural variants and 301 unique SNV and small insertions and deletions were called. Among the latter, the percentage of indels and exonic variants was 12.6% (38) and 3.7% (11), respectively, and the 55.5% (167) had an allele frequency ≤1% from all population of 1000 Genomes (April 2012 v.3) and from four populations of 1000 Genomes (American, East Asian, African and European). In addition, the 47.8% (144) of the variants had not been reported in dbSNP (v. 137) and 143 out of 144 were within the introns.
+
+We identified 5 putative pathogenic mutations, including 3 missense variations and 2 potential splicing site mutations (1 synonymous and 1 intronic variants) reported in Table 3. Within the family members, the 5 candidate mutations were confirmed by Sanger sequencing if genomic DNA was available. Also, we performed in silico predictions (Table 4). Specifically, any structural variant passed through the filtering criteria for putative pathogenic structural variant detection.
+
+In Family A, which was composed of 3 members, the proband was compound heterozygous in trans for p.Lys38Glu (in exon 2) and p.Gly712Arg (in exon 18) missense variations in PLG. This individual had a functional plasminogen activity level of 24%. The variant p.Lys38Glu was also heterozygous in the son with a level of functional plasminogen activity of 67% while another son who was heterozygous for the p.Gly712Arg variation had a functional plasminogen activity of 58%. Of note, both missense variations have been described previously1321 in association with plasminogen deficiency.
+
+The p.Lys38Glu variation was identified also in Family B. This missense mutation was detected as heterozygous in 4 of the 5 members. These 4 individuals included the proband with a functional plasminogen activity level of 47% and 3 family members with functional plasminogen activity level of 58%, 50% and 67%. In contrast, the non-carrier family member showed a normal level of functional plasminogen activity (82%).
+
+In Family C, the new putative pathogenic variation p.Arg261Cys (in exon 7) was heterozygous in 3 of the family members. The functional plasminogen activity was low in these individuals, who included the proband (68%), his sibling (64%) and his mother (64%), in comparison to the level detected in the maternal aunt of the proband, who was a non-carrier family member (101%). The effects of this missense mutation predicted by SIFT, Polyphen-2, Align GDGV and Mutation Taster were deleterious, probably damaging, most likely interfering with protein function and disease causing, respectively. In addition, it was reported as a highly conserved nucleotide and there were large physicochemical differences between Arg and Cys. Project HOPE software revealed differences between the native and the mutant residues in size and charge. The cysteine residue was smaller than the native arginine residue and the positive charge of the arginine was lost as a result of this mutation. Furthermore, the mutated cysteine was located very close to a residue that makes a cysteine bond, and despite this bond which itself is not mutated, it could be affected by the mutation located in its vicinity. The missense variation p.Arg261Cys was characterized as part of a Kringle domain with hydrolase activity, which is essential for the activity of the protein and involved in protein-protein interactions.
+
+The last proband (Family D) had a functional plasminogen activity of 55%. The mutational analysis showed that this individual was compound heterozygous for two potential splice site mutations. Specifically, the p.Lys4Lys synonymous variant in exon 1, which was located in the signal peptide, and the c.1878-6 T>C variant in intron 15. To investigate in silico functional consequences of these new putative pathogenic mutations predictive changes in splicing sites were analyzed. By doing so, no alterations at the donor splice site of exon 1 or at the natural acceptor splice site of exon 16 were detected for the synonymous and the intronic variants, respectively.
+
+We present the molecular characterization of 13 individuals from 4 plasminogen deficiency families, in which the probands had suffered a thrombotic event. Since there is doubt as to whether plasminogen deficiency is a risk factor of thrombotic disease by itself or in combination with other abnormalities1, we genotyped 12 genetic risk factors of thrombosis coded by F2, F5, F12, F13A1, ABO, SERPINA10 and SERPINC1 loci to evaluate the putative role of plasminogen deficiency phenotype in thrombotic disease. We identified a genetic risk profile of thromboembolism in Family D. The proband was homozygous for the risk alleles in F12 (rs1801020) and F13 (rs5985). Interestingly, this individual had positive antiphospholipid antibodies also that might have acted as a risk factor in her ischemic stroke. In contrast, Families A, B and C did not show genetic risk profiles of thromboembolism despite suffering thrombotic episodes. Thus, plasminogen deficiency could not be ruled out as an additional risk factor. It is noteworthy that thromboembolism is a common disease with more than 60% of the variation due to genetic risk factors2223. However, genetic scores explain only 15% of the variance15, so there is still a “missing heritability” that might have hampered the discrimination of plasminogen deficiency as an additional risk factor of thrombotic disease. Also, whether individuals of these families other than the probands will suffer a thrombotic event in the future is not known.
+
+We sequenced the whole PLG locus with good coverage of high quality reads to identify the genetic variants that might be involved in the functional plasminogen deficiency of these families using the NGS methodology. Recent advances in NGS have provided high-throughput, economical, sensitive and faster sequencing methodologies2425. Because of these advantages, and the fact that many samples can be analyzed simultaneously, NGS is ideal for targeted diagnostic sequencing of monogenic diseases where genetic heterogeneity is expected. New pathogenic mutations have been discovered using NGS2627 but to our knowledge, no publications have explored the genetic basis of plasminogen deficiency using NGS. We performed whole gene sequencing to exhaustively examine not only exons but also non-coding regions (promoter, introns, UTR) that might be involved in regulatory functions282930. In addition, LR-PCR provided a fast and cost-effective technique for avoiding the amplification of plasminogen pseudogenes3132. Also, LR-PCR in combination with paired-end sequencing allowed us to use algorithms to accurately detect structural variants and avoid the use of additional analyses as MLPA (multiplex ligation-dependent probe amplification) or MAPH (multiplex amplifiable probe hybridization).
+
+We have identified 5 putative pathogenic mutations, which are in concordance with the levels of plasminogen functional activity by intrafamilial analyses. In particular, the mutation p.Lys38Glu (K19E, old nomenclature) has been described1321 widely as the most common molecular genetic defect in association with type I. This mutation has been identified in homozygous, compound heterozygous and heterozygous state4 but it is not known why this mutation and others in the PLG leads to diverse clinical conditions8. In addition, the missense variation p.Gly712Arg (G693R, old nomenclature) has been described in heterozygous state related to type II plasminogen deficiency21. Interestingly, we have identified both the p.Lys38Glu and p.Gly712Arg variants as compound heterozygous in one individual. In contrast, for the first time to our knowledge the p.Arg261Cys variation is described in association with plasminogen deficiency. This missense variation was classified as deleterious using in silico predictions. Several structural effects in the plasminogen protein have been suggested by Project HOPE. Specifically, changes in size and charge between the native and the mutated residue were predicted, which could cause loss of protein-protein interactions. In addition, Project HOPE software predicted that p.Arg261Cys mutation could disturb the interaction between domains, which might affect the protein’s function also. This variant has been listed previously as variant 6:161137789 C / T in the Exome Aggregation Consortium (ExAC) Browser (Cambridge, MA, http://exac.broadinstitute.org) with an allele frequency of 5.771 × 10−5. It is noteworthy that another variation in the same amino acid (c.782 G>A, p.Arg261His, rs4252187) has been annotated in NCBI dbSNP (v.146, http://www.ncbi.nlm.nih.gov/SNP/). Also, we identified the synonymous p.Lys4Lys and the intronic c.1878-6 T>C variation in one individual as new putative pathogenic mutations in association with plasminogen deficiency. Both genetic variations were not predicted by in silico analyses to change the splice site natural junction. Despite this, synonymous and intronic variations could cause alterations in protein expression and function3334. Thus, further analyses are needed to determine the functional characterization of these mutations.
+
+It is important to note that we identified the whole spectrum of genetic variability of the PLG structural gene in these families. However, we did not observe a clear association between the genotype, the number or the type of putative pathogenic mutations in PLG with the thrombotic phenotype of these individuals. Moreover, we can not find genetic risk factors of thrombosis in 3 of 4 families. These observations provide us with a scenario where we can not confirm neither exclude plasminogen deficiency as a susceptibility risk factor for thrombosis.
+
+Our view is that thrombosis is a multifactorial and complex disease where several genetic risk factors with environmental situations increase the susceptibility to develop a thromboembolic event. Therefore, in these families unknown genetic risk factors, in addition to plasminogen deficiency, may explain the thrombotic tendency in concrete clinical situations. Thus, we believe that it may be useful the evaluation of plasminogen deficiency in individuals that had suffered a spontaneous thrombotic event and had a negative routing thrombophilia test.
+
+It is important to emphasize that, from a clinical point of view, we detected putative pathogenic mutations that explain the plasminogen deficiency. In these sense, our NGS approach clearly contributed to the genetic knowledge of plasminogen deficiency. We believe that NGS has the potential to identify and characterize the molecular basis of a wide variety of disorders in addition to plasminogen deficiency.
+
+How to cite this article: Martin-Fernandez, L. et al. The Unravelling of the Genetic Architecture of Plasminogen Deficiency and its Relation to Thrombotic Disease. Sci. Rep.
+6, 39255; doi: 10.1038/srep39255 (2016).
+
+Publisher’s note: Springer Nature remains neutral with regard to jurisdictional claims in published maps and institutional affiliations.

--- a/references_cache/PMID_34370320.md
+++ b/references_cache/PMID_34370320.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:34370320"
+title: A large deletion in the Plasminogen gene is associated with ligneous membranitis in a Maltese dog.
+authors:
+- Turba ME
+- Ostan PC
+- Ghetti S
+- Dajbychova M
+- Dondi F
+- Gentilini F
+journal: Anim Genet
+year: '2021'
+doi: 10.1111/age.13130
+keywords:
+- Animals
+- Breeding
+- "Conjunctivitis/genetics, veterinary"
+- Dog Diseases/genetics
+- Dogs/genetics
+- Male
+- "Plasminogen/deficiency, genetics"
+- "Skin Diseases, Genetic/genetics, veterinary"
+content_type: abstract_only
+---
+
+# A large deletion in the Plasminogen gene is associated with ligneous membranitis in a Maltese dog.
+**Authors:** Turba ME, Ostan PC, Ghetti S, Dajbychova M, Dondi F, Gentilini F
+**Journal:** Anim Genet (2021)
+**DOI:** [10.1111/age.13130](https://doi.org/10.1111/age.13130)
+
+## Content
+
+1. Anim Genet. 2021 Oct;52(5):767-771. doi: 10.1111/age.13130. Epub 2021 Aug 9.
+
+A large deletion in the Plasminogen gene is associated with ligneous membranitis 
+in a Maltese dog.
+
+Turba ME(1), Ostan PC(2), Ghetti S(3), Dajbychova M(4), Dondi F(3), Gentilini 
+F(3).
+
+Author information:
+(1)Genefast srl, Forlì, 47122, Italy.
+(2)Ambulatorio Veterinario Associato Visionvet, San Giovanni in Persiceto, 
+Bologna, 40017, Italy.
+(3)Department of Veterinary Medical Sciences, University of Bologna, Ozzano 
+dell'Emilia, Bologna, 40064, Italy.
+(4)Genomia, Plzen, 31200, Czech Republic.
+
+Ligneous membranitis/conjunctivitis (LM, OMIM 217090) is a hereditary disorder 
+caused by a congenital plasminogen (PLG) deficiency. In veterinary medicine, LM 
+(OMIA 002020-9615) has rarely been reported in Golden Retrievers, Yorkshire 
+Terriers, Doberman Pinschers and Scottish Terriers. In the latter breed, an A>T 
+variation in an intron donor site of the PLG gene (PLG, c.1256+2T>A) has been 
+found to be the sole causative molecular defect reported to date in dogs. Owing 
+to the absence of plasmin enzymatic clearance which in turn depends on the lack 
+of its proenzyme plasminogen, fibrin deposits tend to accumulate in viscous 
+membranes on the eyes, triggering and sustaining an intense inflammatory 
+response. A case of LM was diagnosed in a 7-month-old male Maltese dog. The dog 
+was examined for severe recurrent conjunctivitis. A diagnosis of ligneous 
+conjunctivitis was made by an ophthalmologist after a thorough eye examination 
+and was confirmed by a complete lack of plasma activity of plasminogen. The main 
+local signs were redness of the conjunctiva with persistent membranes having 
+ligneous (wood-like) membranes on the eyes. The disease was associated with a 
+complex rearrangement involving the plasminogen gene loci, causing the complete 
+deletion of exon 1. This study provides a spontaneous animal model for LM 
+associated with complete plasminogen deficiency and provides a method for 
+detecting affected or carrier dogs.
+
+© 2021 The Authors. Animal Genetics published by John Wiley & Sons Ltd on behalf 
+of Stichting International Foundation for Animal Genetics.
+
+DOI: 10.1111/age.13130
+PMCID: PMC9290685
+PMID: 34370320 [Indexed for MEDLINE]

--- a/references_cache/PMID_37506226.md
+++ b/references_cache/PMID_37506226.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:37506226"
+title: Plasmin-Mediated Fibrinolysis in Periodontitis Pathogenesis.
+authors:
+- Silva LM
+- Divaris K
+- Bugge TH
+- Moutsopoulos NM
+journal: J Dent Res
+year: '2023'
+doi: 10.1177/00220345231171837
+keywords:
+- Humans
+- Fibrinolysis/physiology
+- Fibrinolysin
+- Plasminogen/genetics
+- Fibrin/physiology
+- Periodontitis/genetics
+- Hemostatics
+content_type: abstract_only
+---
+
+# Plasmin-Mediated Fibrinolysis in Periodontitis Pathogenesis.
+**Authors:** Silva LM, Divaris K, Bugge TH, Moutsopoulos NM
+**Journal:** J Dent Res (2023)
+**DOI:** [10.1177/00220345231171837](https://doi.org/10.1177/00220345231171837)
+
+## Content
+
+1. J Dent Res. 2023 Aug;102(9):972-978. doi: 10.1177/00220345231171837. Epub 2023
+ Jul 28.
+
+Plasmin-Mediated Fibrinolysis in Periodontitis Pathogenesis.
+
+Silva LM(1)(2), Divaris K(3)(4), Bugge TH(2), Moutsopoulos NM(1).
+
+Author information:
+(1)Oral Immunity and Infection Section, National Institute of Dental and 
+Craniofacial Research, National Institutes of Health, Bethesda, MD, USA.
+(2)Proteases and Tissue Remodeling Section, National Institute of Dental and 
+Craniofacial Research, National Institutes of Health, Bethesda, MD, USA.
+(3)Division of Pediatric and Public Health, Adams School of Dentistry, 
+University of North Carolina-Chapel Hill, Chapel Hill, NC,USA.
+(4)Department of Epidemiology, Gillings School of Global Public Health, 
+University of North Carolina-Chapel Hill, Chapel Hill, NC, USA.
+
+The hemostatic and inflammatory systems work hand in hand to maintain 
+homeostasis at mucosal barrier sites. Among the factors of the hemostatic 
+system, fibrin is well recognized for its role in mucosal homeostasis, wound 
+healing, and inflammation. Here, we present a basic overview of the fibrinolytic 
+system, discuss fibrin as an innate immune regulator, and provide recent work 
+uncovering the role of fibrin-neutrophil activation as a regulator of 
+mucosal/periodontal homeostasis. We reason that the role of fibrin in 
+periodontitis becomes most evident in individuals with the Mendelian genetic 
+defect, congenital plasminogen (PLG) deficiency, who are predisposed to severe 
+periodontitis in childhood due to a defect in fibrinolysis. Consistent with 
+plasminogen deficiency being a risk factor for periodontitis, recent genomics 
+studies uncover genetic polymorphisms in PLG, encoding plasminogen, being 
+significantly associated with periodontal disease, and suggesting PLG variants 
+as candidate risk indicators for common forms of periodontitis.
+
+DOI: 10.1177/00220345231171837
+PMCID: PMC10477773
+PMID: 37506226 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declared no potential conflicts of 
+interest with respect to the research, authorship, and/or publication of this 
+article.

--- a/references_cache/PMID_37612758.md
+++ b/references_cache/PMID_37612758.md
@@ -1,0 +1,97 @@
+---
+reference_id: "PMID:37612758"
+title: "Long-term follow-up in a pediatric patient with Ligneous Conjunctivitis due to PLG gene mutation in topical plasminogen treatment after successful use of ocular prosthesis for aesthetic rehabilitation: a case report."
+authors:
+- Panfili FM
+- Valente P
+- Ficari A
+- Cortellessa F
+- Vecchio D
+- Gonfiantini MV
+- Buonuomo PS
+- Colafati GS
+- Agolini E
+- Bartuli M
+- Modugno AC
+- Macchiaiolo M
+journal: Ital J Pediatr
+year: '2023'
+doi: 10.1186/s13052-023-01503-x
+keywords:
+- Adolescent
+- Plasminogen/deficiency
+- Female
+- Mutation
+- Esthetics
+- Follow-Up Studies
+- Humans
+- "Eye, Artificial"
+- Conjunctivitis
+- "Skin Diseases, Genetic"
+content_type: abstract_only
+---
+
+# Long-term follow-up in a pediatric patient with Ligneous Conjunctivitis due to PLG gene mutation in topical plasminogen treatment after successful use of ocular prosthesis for aesthetic rehabilitation: a case report.
+**Authors:** Panfili FM, Valente P, Ficari A, Cortellessa F, Vecchio D, Gonfiantini MV, Buonuomo PS, Colafati GS, Agolini E, Bartuli M, Modugno AC, Macchiaiolo M
+**Journal:** Ital J Pediatr (2023)
+**DOI:** [10.1186/s13052-023-01503-x](https://doi.org/10.1186/s13052-023-01503-x)
+
+## Content
+
+1. Ital J Pediatr. 2023 Aug 23;49(1):101. doi: 10.1186/s13052-023-01503-x.
+
+Long-term follow-up in a pediatric patient with Ligneous Conjunctivitis due to 
+PLG gene mutation in topical plasminogen treatment after successful use of 
+ocular prosthesis for aesthetic rehabilitation: a case report.
+
+Panfili FM(1)(2), Valente P(3), Ficari A(1), Cortellessa F(2), Vecchio D(2), 
+Gonfiantini MV(2), Buonuomo PS(2), Colafati GS(4), Agolini E(5), Bartuli M(6), 
+Modugno AC(7), Macchiaiolo M(8).
+
+Author information:
+(1)Academic Department of Pediatrics, Bambino Gesù Children's Hospital, IRCCS, 
+Rome, Italy.
+(2)Rare Diseases and Medical Genetics Unit, Bambino Gesù Children's Hospital, 
+IRCCS, Pediatric Department, Piazza Di Sant'Onofrio, 4, 00165, Rome, Italy.
+(3)Ophthalmology Department, Bambino Gesù Children's Hospital, IRCCS Pediatric 
+Hospital, Rome, Italy.
+(4)Department of Imaging, Neuroradiology Unit, IRCCS Bambino Gesù Children's 
+Hospital, Rome, Italy.
+(5)Laboratory of Medical Genetics Translational Cytogenomics Research Unit, 
+Bambino Gesù Children's Hospital, IRCCS, Rome, Italy.
+(6)University of Rome "La Sapienza", Rome, Italy.
+(7)Ocularistica Italiana, Rome, Italy.
+(8)Rare Diseases and Medical Genetics Unit, Bambino Gesù Children's Hospital, 
+IRCCS, Pediatric Department, Piazza Di Sant'Onofrio, 4, 00165, Rome, Italy. 
+marina.macchiaiolo@opbg.net.
+
+BACKGROUND: Ligneous Conjunctivitis (LC) is the most common clinical 
+manifestation of Type I Plasminogen deficiency (T1PD; OMIM# 217090), and it is 
+characterized by the formation of pseudomembranes (due to deposition of fibrin) 
+on the conjunctivae leading to progressive vision loss. In past times, patients 
+with LC were treated with surgery, topical anti-inflammatory, cytostatic agents, 
+and systemic immunosuppressive drugs with limited results (Blood 108:3021-3026, 
+2006, Ophthalmology 129:955-957, 2022, Surv Ophthalmol 48:369-388, 2003, Blood 
+131:1301-1310, 2018). The surgery can also trigger the development of membranes, 
+as observed in patients needing ocular prosthesis (Surv Ophthalmol 48:369-388, 
+2003). Treatment with topical purified plasminogen is used to prevent 
+pseudomembranes formation (Blood 108:3021-3026, 2006, Ophthalmology 129:955-957, 
+2022).
+CASE PRESENTATION: We present the case of a sixteen-year-old girl with LC with 
+severe left eye involvement. We reported the clinical conditions of the patient 
+before and after the use of topical plasminogen eye drops and described the 
+treatment schedule allowing the surgical procedure for the pseudomembranes 
+debulking and the subsequent use of ocular prosthesis for aesthetic 
+rehabilitation.
+CONCLUSIONS: The patient showed a progressive response to the topical 
+plasminogen, with a complete absence of pseudomembrane formation at a 
+twelve-year follow-up, despite using an ocular prosthesis.
+
+© 2023. Società Italiana di Pediatria.
+
+DOI: 10.1186/s13052-023-01503-x
+PMCID: PMC10463973
+PMID: 37612758 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest. The 
+authors declare that they have no competing interests.

--- a/references_cache/PMID_39372655.md
+++ b/references_cache/PMID_39372655.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:39372655"
+title: "Case Report: Respiratory lesions successfully treated with intravenous plasminogen, human-tvmh, replacement therapy in four patients with plasminogen deficiency type 1."
+authors:
+- Nakar C
+- McDaniel H
+- Parker JM
+- Thibaudeau K
+- Thukral N
+- Shapiro AD
+journal: Front Pediatr
+year: '2024'
+doi: 10.3389/fped.2024.1465166
+content_type: abstract_only
+---
+
+# Case Report: Respiratory lesions successfully treated with intravenous plasminogen, human-tvmh, replacement therapy in four patients with plasminogen deficiency type 1.
+**Authors:** Nakar C, McDaniel H, Parker JM, Thibaudeau K, Thukral N, Shapiro AD
+**Journal:** Front Pediatr (2024)
+**DOI:** [10.3389/fped.2024.1465166](https://doi.org/10.3389/fped.2024.1465166)
+
+## Content
+
+1. Front Pediatr. 2024 Sep 20;12:1465166. doi: 10.3389/fped.2024.1465166. 
+eCollection 2024.
+
+Case Report: Respiratory lesions successfully treated with intravenous 
+plasminogen, human-tvmh, replacement therapy in four patients with plasminogen 
+deficiency type 1.
+
+Nakar C(1), McDaniel H(2), Parker JM(3), Thibaudeau K(4), Thukral N(1), Shapiro 
+AD(1).
+
+Author information:
+(1)Indiana Hemophilia & Thrombosis Center, Indianapolis, IN, United States.
+(2)Vanderbilt University Medical Center, Nashville, TN, United States.
+(3)Consultant to Kedrion Biopharma Inc., Fort Lee, NJ, United States.
+(4)Global Medical Affairs, Kedrion SpA, Laval, QC, Canada.
+
+Plasminogen deficiency type 1 (PLGD-1, hypoplasminogenemia) is an ultra-rare, 
+lifelong disease associated with development of fibrinous lesions in multiple 
+organ systems. Depending on lesion location, clinical manifestations of PLGD-1 
+can result in acute and/or chronic respiratory airway disease which can 
+compromise respiratory function leading to life-threatening events. Early 
+recognition and effective treatment of airway obstruction caused by fibrinous 
+lesions are critical to prevent morbidity due to respiratory compromise. 
+However, physicians may not be familiar with the clinical presentation and 
+management of PLGD-1, causing delays in diagnosis and treatment and potentially 
+contributing to morbidity. Presented here is a case series of one adult and 
+three pediatric patients with severe respiratory complications of PLGD-1 
+successfully managed by infusions of plasminogen, human-tvmh replacement 
+therapy. Patients' respiratory symptoms were resolved or greatly improved, and 
+treatment was generally well tolerated. In all patients, baseline plasminogen 
+activity was substantially increased with plasminogen replacement therapy 
+administered initially every one to two days followed by extended interval 
+dosing as symptoms were controlled or resolved. All four described cases support 
+the clinical benefit of replacement therapy with plasminogen, human-tvmh in the 
+resolution of life-threatening respiratory complications associated with PLGD-1. 
+Clinical manifestations in addition to respiratory lesions were also improved or 
+resolved with continued treatment.
+
+© 2024 Nakar, McDaniel, Parker, Thibaudeau, Thukral and Shapiro.
+
+DOI: 10.3389/fped.2024.1465166
+PMCID: PMC11449724
+PMID: 39372655
+
+Conflict of interest statement: Authors CN and AS received research funding from 
+Kedrion SpA, authors HM and JP were consultants to Kedrion SpA, and author KT 
+was employed by Kedrion SpA. The authors declare that this study received 
+funding from Prometic Biotherapeutics and Kedrion SpA. The funders had the 
+following involvement in the study: the design and conduct of the study, 
+collection, management, analysis, and interpretation of the data, preparation, 
+review, approval of and decision to submit the manuscript for publication. 
+Prometic Biotherapeutics was acquired by Kedrion in October 2021 and merged with 
+Kedrion in 2023. CN: Research funding – Kedrion SpA (legacy Prometic 
+Biotherapeutics). HM: was a consultant to Kedrion SpA and clinical trial 
+investigator (legacy Prometic Biotherapeutics). JP: Consultant to Kedrion, SpA. 
+KT: Current employee of Kedrion, SpA. AS: Research funding – Agios, BioMarin, 
+Bioverativ, Daiichi Sankyo, Genentech/Roche, Glover Blood Therapeutics, Kedrion 
+Biopharma, Novartis, Novo Nordisk, Pfizer, Prometic Biotherapeutics, Takeda, 
+Regeneron, Be Biopharma; Consultancy – Bioverativ, Prometic Biotherapeutics, 
+Novo Nordisk Membership on entity's Board of Directors or advisory committees – 
+Bioverativ, Genentech/Roche, Novo Nordisk, Takeda, Novo Nordisk Hemophilia 
+Foundation Speakers Bureau – Novo Nordisk, Genentech/Roche, Bioverativ. The 
+remaining author declares that the research was conducted in the absence of any 
+commercial or financial relationships that could be construed as a potential 
+conflict of interest

--- a/references_cache/clinicaltrials_NCT01554956.md
+++ b/references_cache/clinicaltrials_NCT01554956.md
@@ -1,0 +1,13 @@
+---
+reference_id: clinicaltrials:NCT01554956
+title: A Historically Controlled Phase II/III Study to Evaluate Efficacy and Safety of Kedrion Human Plasminogen Eye Drop Preparation in Patients Diagnosed With Ligneous Conjunctivitis
+content_type: summary
+---
+
+# A Historically Controlled Phase II/III Study to Evaluate Efficacy and Safety of Kedrion Human Plasminogen Eye Drop Preparation in Patients Diagnosed With Ligneous Conjunctivitis
+
+## Content
+
+Kedrion Human Plasminogen, a sterile human plasma-derived plasminogen preparation for topical ocular use will be evaluated for the indication of treatment of ligneous conjunctivitis.
+
+KB046 will be an open-label, historically controlled clinical trial. At least 10 subjects with ligneous conjunctivitis, for approximately 20 eyes, will be treated and assessed. All subjects will receive the investigational medicinal product (IMP) for 12 to 48 weeks, with a possibility for extended treatment (Continuation segment)

--- a/references_cache/clinicaltrials_NCT02690714.md
+++ b/references_cache/clinicaltrials_NCT02690714.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT02690714
+title: "A Phase 2/3, Open-Label, Repeat-Dose Study of the Pharmacokinetics, Efficacy, and Safety of Prometic Plasminogen Intravenous Infusion in Subjects With Hypoplasminogenemia"
+content_type: summary
+---
+
+# A Phase 2/3, Open-Label, Repeat-Dose Study of the Pharmacokinetics, Efficacy, and Safety of Prometic Plasminogen Intravenous Infusion in Subjects With Hypoplasminogenemia
+
+## Content
+
+This is a Phase 2/3 pivotal study to evaluate pharmacokinetics (PK), efficacy, and safety of Prometic Plasminogen (Human) Intravenous Lyophilized Solution, the investigational medicinal product (IMP), in pediatric and adult subjects with hypoplasminogenemia.

--- a/research/Hypoplasminogenemia-deep-research-falcon.md
+++ b/research/Hypoplasminogenemia-deep-research-falcon.md
@@ -1,0 +1,1262 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-07T08:59:14.771227'
+end_time: '2026-05-07T09:31:19.148794'
+duration_seconds: 1924.38
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Hypoplasminogenemia
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 42
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Hypoplasminogenemia
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Hypoplasminogenemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Hypoplasminogenemia
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Hypoplasminogenemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Comprehensive Disease Characteristics Report: Hypoplasminogenemia (Type 1 Plasminogen Deficiency)
+
+## Executive summary
+Hypoplasminogenemia—also called **type 1 plasminogen deficiency (PLGD-1)**—is an ultra-rare, autosomal recessive disorder caused by **biallelic pathogenic variants in *PLG*** that reduce **plasminogen antigen and activity** and thereby impair fibrinolysis and tissue remodeling. The hallmark phenotype is **ligneous disease**, i.e., **fibrin-rich “wood-like” pseudomembranes** on mucosal surfaces (most commonly the conjunctiva), with potentially life-threatening airway involvement. Since 2021, **intravenous plasma-derived human plasminogen (plasminogen, human‑tvmh; Ryplazim)** has become a disease-targeted replacement therapy with evidence for durable lesion control in a phase 2/3 study and post-approval case series. (shapiro2023plasminogenhuman‐tvmhfor pages 1-2, nakar2024casereportrespiratory pages 1-2)
+
+---
+
+## 1. Disease information
+### 1.1 Overview (what is the disease?)
+Type 1 congenital plasminogen deficiency (hypoplasminogenemia) is defined by **low plasminogen antigen and low functional plasminogen activity**, leading to **impaired fibrin clearance** and accumulation of **fibrin-rich pseudomembranes** on mucosal surfaces (“ligneous” lesions). A 2023 review summarizes that type I disease is autosomal recessive and results in decreased antigenic and functional plasminogen with mucosal fibrin deposition. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+
+**Abstract-supported key concept quote (2023 review):** “*The hemostatic and inflammatory systems work hand in hand to maintain homeostasis at mucosal barrier sites… fibrin is well recognized for its role in mucosal homeostasis, wound healing, and inflammation*.” (silva2023plasminmediatedfibrinolysisin pages 1-2)
+
+### 1.2 Key identifiers
+- **MONDO:** **MONDO_0009009 (hypoplasminogenemia)** (OpenTargets). (OpenTargets Search: plasminogen deficiency,hypoplasminogenemia-PLG)
+- **OMIM disease:** **Type 1 plasminogen deficiency / hypoplasminogenemia = OMIM #217090**. (panfili2023longtermfollowupin pages 1-3)
+- **OMIM gene:** ***PLG* = OMIM #173350**. (panfili2023longtermfollowupin pages 1-3)
+
+*Not retrieved in the current tool evidence (therefore not reported here to avoid guessing):* Orphanet ID, ICD-10/ICD-11 codes, MeSH descriptor.
+
+### 1.3 Synonyms / alternative names
+- Type 1 plasminogen deficiency; congenital plasminogen deficiency type I; **PLGD‑1**; “true plasminogen deficiency”; ligneous disease due to plasminogen deficiency. (panfili2023longtermfollowupin pages 1-3, nakar2024casereportrespiratory pages 1-2)
+
+### 1.4 Evidence sources
+The information in this report is derived from **peer-reviewed reviews and case reports/series**, plus **ClinicalTrials.gov trial records** and **OpenTargets disease–gene association**. (OpenTargets Search: plasminogen deficiency,hypoplasminogenemia-PLG, NCT02690714 chunk 1, nakar2024casereportrespiratory pages 1-2)
+
+---
+
+## 2. Etiology
+### 2.1 Disease causal factors
+- **Genetic cause (primary):** biallelic pathogenic variants in ***PLG*** (chromosome **6q26**) that reduce plasminogen antigen and activity (type I). (panfili2023longtermfollowupin pages 1-3, martinfernandez2016theunravellingof pages 1-2)
+
+### 2.2 Risk factors
+#### Genetic risk factors
+- **Autosomal recessive inheritance** for severe PLGD‑1 (homozygous/compound heterozygous), supported by multiple series. (klammt2011identificationofthree pages 3-4, klammt2011identificationofthree pages 1-2)
+- **Consanguinity** is commonly reported in case series enriched from certain regions (e.g., Turkey in one series). (klammt2011identificationofthree pages 1-2)
+
+#### Environmental/clinical triggers (non-genetic)
+- Local triggers for mucosal lesion development/worsening (especially in oral disease) include **irritation, infection, poor hygiene, and surgery** in a 2023 review of ligneous periodontitis. (bektaskayhan2023ligneousperiodontitisassociated pages 1-2)
+
+### 2.3 Protective factors
+Not established in the retrieved sources.
+
+### 2.4 Gene–environment interactions
+Evidence in retrieved texts is suggestive (trauma/infection/surgery as triggers), but no quantitative gene–environment interaction studies were retrieved. (bektaskayhan2023ligneousperiodontitisassociated pages 1-2)
+
+---
+
+## 3. Phenotypes
+### 3.1 Core phenotype: ligneous conjunctivitis / keratoconjunctivitis
+- **Most frequent manifestation:** ligneous conjunctivitis (LC) affects **>80%** of symptomatic PLGD‑1 patients in a 2024 case series background and is **80%** in a large cited cohort summarized in a 2023 review. (nakar2024casereportrespiratory pages 1-2, silva2023plasminmediatedfibrinolysisin pages 1-2)
+- LC lesions are described as **fibrin-rich, “woody” pseudomembranes** on tarsal/palpebral conjunctiva; can bleed and threaten vision through corneal scarring/perforation. (alghubaishi2023recurrentmeningitisand pages 2-4, nasiri2023plasminogendeficiencya pages 3-4)
+
+**Suggested HPO terms** (not tool-validated here):
+- Ligneous conjunctivitis / membranous conjunctivitis; conjunctival pseudomembrane; corneal scarring; vision impairment.
+
+### 3.2 Oral/periodontal phenotypes
+- **Ligneous gingivitis** reported as **34%** in a large study summarized by a 2023 review; type I deficiency predisposes to **early-onset severe periodontitis in childhood**. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+- In a 2023 gingival-lesion literature review, ages for gingival cases spanned **1–66 years**, with a strong female predominance in reported cases (74.3% female in that review). (bektaskayhan2023ligneousperiodontitisassociated pages 2-3)
+
+**Suggested HPO terms:** gingival enlargement; periodontitis; early tooth loss.
+
+### 3.3 Respiratory tract involvement
+- **Frequency:** respiratory lesions in **~20–30%** of PLGD‑1 patients (2024 case series background). (nakar2024casereportrespiratory pages 1-2)
+- Can involve the **tracheobronchial tree** causing cough/stridor/wheeze/dyspnea and **life‑threatening airway obstruction**; severe manifestations often in infants/young children. (nakar2024casereportrespiratory pages 1-2)
+
+**Image-based evidence (real-world implementation):** bronchoscopy shows obstructing ligneous plaques pre-treatment and resolution after 10 days of IV plasminogen replacement. (nakar2024casereportrespiratory media f6ed748e)
+
+**Suggested HPO terms:** airway obstruction; stridor; bronchial obstruction; recurrent pneumonia.
+
+### 3.4 Genitourinary and gastrointestinal mucosal lesions
+Mucosal lesions can occur in **urinary and genital systems** and **gastrointestinal tract**, described across reviews and clinical trial background. (silva2023plasminmediatedfibrinolysisin pages 1-2, shapiro2023plasminogenhuman‐tvmhfor pages 2-2)
+
+**Suggested HPO terms:** cervicitis; infertility; gastrointestinal pseudomembranes.
+
+### 3.5 Ear involvement
+Middle ear/tympanic membrane involvement (e.g., otitis media/hearing loss) is described in a 2023 case review. (nasiri2023plasminogendeficiencya pages 3-4)
+
+**Suggested HPO terms:** otitis media; hearing impairment.
+
+### 3.6 Central nervous system (CNS) involvement
+- **Congenital/occlusive hydrocephalus** is repeatedly reported in type I disease, including 2023 case reviews and a 2023 pediatric case report background. (nasiri2023plasminogendeficiencya pages 1-3, panfili2023longtermfollowupin pages 1-3)
+- **Recurrent meningitis** has been described in association with severe disease in a 2023 case report. (alghubaishi2023recurrentmeningitisand pages 2-4)
+
+**Suggested HPO terms:** hydrocephalus; meningitis.
+
+### 3.7 Quality of life impact
+- The phase 2/3 plasminogen replacement study reported quality of life (0–10 scale) was **improved or maintained in 93%** through week 48. (shapiro2023plasminogenhuman‐tvmhfor pages 5-6)
+
+---
+
+## 4. Genetic / molecular information
+### 4.1 Causal gene(s)
+- **Primary causal gene:** ***PLG* (plasminogen)**. (klammt2011identificationofthree pages 3-4, martinfernandez2016theunravellingof pages 1-2)
+
+### 4.2 Variant spectrum and molecular consequences
+- Variant types causing type I deficiency include **missense, splice-site, frameshift, nonsense**, and larger deletions/structural variants; allelic heterogeneity is substantial. (klammt2011identificationofthree pages 3-4, martinfernandez2016theunravellingof pages 1-2)
+- In a 23‑patient series, **16/23 (70%)** carried **homozygous or compound-heterozygous *PLG* mutations**, supporting recessive inheritance for severe hypoplasminogenemia. (klammt2011identificationofthree pages 3-4)
+- Functional impact includes **reduced plasminogen activity** (e.g., <5% to 57% in one series; normal ~75–120%). (klammt2011identificationofthree pages 3-4)
+
+**Examples (variant + functional correlation):**
+- *PLG* c.763G>A (p.Glu255Lys) homozygous: proband activity **2.50%**; heterozygous parents **41.02%** and **54.07%**. (xu2021novelhomozygousmutation pages 1-3)
+- *PLG* c.2095T>C (p.Cys699Arg) homozygous: plasminogen level **15%** (normal 75–150% in that report). (alghubaishi2023recurrentmeningitisand pages 2-4)
+- Review tables summarize many missense variants with measured antigen/activity and predicted pathogenicity; reference ranges cited include antigen **6–25 mg/dL** and activity **70–140%**. (britorobinson2024plasminogenmissensevariants pages 14-15)
+
+### 4.3 Modifier genes
+No definitive modifier genes for ligneous disease penetrance/severity were established in retrieved sources. Some studies consider other thrombosis-risk loci (e.g., *F12*, *F13A1*) in families with thrombotic events, but this is not established as a modifier of ligneous disease itself. (martinfernandez2016theunravellingof pages 4-5)
+
+### 4.4 Epigenetics / chromosomal abnormalities
+Not established in the retrieved sources.
+
+### 4.5 Suggested GO (biological process) and CL (cell type) terms
+Based on disease mechanism described in reviews (defective fibrinolysis and mucosal wound healing) (silva2023plasminmediatedfibrinolysisin pages 1-2):
+- **GO processes (suggested):** fibrinolysis; wound healing; extracellular matrix organization; inflammatory response.
+- **CL terms (suggested):** mucosal epithelial cell; neutrophil (given discussion of fibrin–neutrophil activation in periodontal homeostasis). (silva2023plasminmediatedfibrinolysisin pages 1-2)
+
+---
+
+## 5. Environmental information
+Not a primary driver in Mendelian PLGD‑1. Local environmental/clinical factors (infection, irritation, surgery) may precipitate lesions in mucosa, especially oral tissues. (bektaskayhan2023ligneousperiodontitisassociated pages 1-2)
+
+---
+
+## 6. Mechanism / pathophysiology
+### 6.1 Current understanding (causal chain)
+1. **Biallelic *PLG* pathogenic variants** → reduced plasminogen antigen/activity (type I). (martinfernandez2016theunravellingof pages 1-2, klammt2011identificationofthree pages 3-4)
+2. **Defective plasmin-mediated fibrinolysis** → impaired fibrin clearance and abnormal wound healing. (silva2023plasminmediatedfibrinolysisin pages 1-2, nasiri2023plasminogendeficiencya pages 3-4)
+3. **Accumulation of amorphous fibrin-rich material in lamina propria** → pseudomembranous “ligneous” lesions on mucosal surfaces. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+4. **Site-specific lesion burden** (conjunctiva, gingiva, airway, GU/GI mucosa) → organ dysfunction (vision loss, tooth loss, airway obstruction, infertility, etc.). (shapiro2023plasminogenhuman‐tvmhfor pages 2-2, nakar2024casereportrespiratory pages 1-2)
+
+### 6.2 Tissue/cell processes highlighted in recent reviews
+A 2023 review emphasizes interplay of hemostasis and inflammation at mucosal barriers and highlights fibrin’s role in mucosal homeostasis and periodontitis susceptibility in PLG deficiency. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+
+---
+
+## 7. Anatomical structures affected
+### Organ/system level (representative)
+- **Eye/conjunctiva:** ligneous conjunctivitis (most common). (silva2023plasminmediatedfibrinolysisin pages 1-2)
+- **Oral cavity/periodontium:** ligneous gingivitis/periodontitis; early tooth loss. (silva2023plasminmediatedfibrinolysisin pages 1-2, bektaskayhan2023ligneousperiodontitisassociated pages 1-2)
+- **Respiratory tract (larynx/trachea/bronchi):** obstructive ligneous lesions. (nakar2024casereportrespiratory pages 1-2)
+- **Genitourinary tract:** cervix/uterus/vagina and other mucosa. (silva2023plasminmediatedfibrinolysisin pages 1-2, alghubaishi2023recurrentmeningitisand pages 2-4)
+- **GI tract:** mucosal lesions. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+- **CNS:** hydrocephalus (subset). (panfili2023longtermfollowupin pages 1-3, alghubaishi2023recurrentmeningitisand pages 2-4)
+
+**Suggested UBERON terms** (not tool-validated): conjunctiva; gingiva; trachea/bronchus; uterine cervix; gastrointestinal tract.
+
+---
+
+## 8. Temporal development
+- **Onset:** typically **infancy/childhood**; mean reported onset **13–16 years** in an ophthalmology case series report; **<20%** present in the 4th–5th decades. (almeida2024ligneousconjunctivitisfreshfrozen pages 1-3)
+- **Course:** often chronic/relapsing with recurrence after surgical excision when replacement is not provided; spontaneous remission has been described in a minority. (alghubaishi2023recurrentmeningitisand pages 2-4, panfili2023longtermfollowupin pages 1-3)
+
+---
+
+## 9. Inheritance and population
+### 9.1 Inheritance
+- **Autosomal recessive** for severe type I PLGD‑1 (homozygous or compound heterozygous). (klammt2011identificationofthree pages 3-4, alghubaishi2023recurrentmeningitisand pages 2-4)
+
+### 9.2 Epidemiology (statistics)
+- **Severe type I PLGD (homozygous/compound heterozygous):** estimated **~1.6 per 1,000,000** in Europe. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+- **Heterozygous carrier frequency:** **~0.3–0.4%** in the general population (as summarized in a 2023 review). (silva2023plasminmediatedfibrinolysisin pages 1-2)
+
+*Note:* Some papers repeat the 0.3–0.4% figure ambiguously; the 2023 J Dent Res review explicitly applies 0.3–0.4% to heterozygous mutations. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+
+---
+
+## 10. Diagnostics
+### 10.1 Clinical tests
+- **Key laboratory confirmation:** measure both
+  - **plasminogen activity** (commonly chromogenic assay; e.g., tPA-activated assays), and
+  - **plasminogen antigen**
+  to classify **type I vs type II**. (martinfernandez2016theunravellingof pages 1-2, alghafry2025inheriteddisordersof pages 5-6)
+
+### 10.2 Distinguishing type I vs type II
+- **Type I (hypoplasminogenemia):** low activity + low antigen. (martinfernandez2016theunravellingof pages 1-2, alghafry2025inheriteddisordersof pages 5-6)
+- **Type II (dysplasminogenemia):** low activity with normal antigen; rarely symptomatic. (silva2023plasminmediatedfibrinolysisin pages 1-2, martinfernandez2016theunravellingof pages 1-2)
+
+### 10.3 Routine labs often normal / non-diagnostic
+Conventional coagulation tests (e.g., platelet count, PT, aPTT, factor levels, fibrinogen, vWF) can be normal and are not diagnostic; targeted plasminogen assays are needed. (alghafry2025inheriteddisordersof pages 5-6)
+
+### 10.4 Genetic testing
+- Confirmatory genetic testing via sequencing of *PLG* (Sanger, WES/WGS, NGS; long-range PCR approaches may help avoid homology/pseudogene issues) is used for definitive diagnosis and family studies. (xu2021novelhomozygousmutation pages 1-3, martinfernandez2016theunravellingof pages 2-3)
+
+### 10.5 Suggested differential diagnosis
+Not comprehensively enumerated in retrieved texts. Clinically, LC can be misdiagnosed as nonspecific conjunctivitis early; persistent/recurrent pseudomembranes plus low plasminogen support PLGD‑1. (nasiri2023plasminogendeficiencya pages 3-4)
+
+---
+
+## 11. Outcome / prognosis
+- Severity varies with lesion location and burden. Untreated disease can cause major morbidity (blindness, airway obstruction, complications of hydrocephalus) and can be fatal, as emphasized in clinical trial background and case literature. (shapiro2023plasminogenhuman‐tvmhfor pages 2-2, alghubaishi2023recurrentmeningitisand pages 2-4)
+- Replacement therapy can produce rapid resolution of life-threatening airway disease in reported cases. (nakar2024casereportrespiratory pages 1-2, nakar2024casereportrespiratory media f6ed748e)
+
+---
+
+## 12. Treatment
+### 12.1 Pharmacotherapy / replacement therapy (current standard)
+#### Intravenous plasminogen, human‑tvmh (Ryplazim)
+- **Trial evidence:** open-label phase 2/3 study (15 subjects) with treatment up to **124 weeks**; dosing **6.6 mg/kg** with individualized intervals. (shapiro2023plasminogenhuman‐tvmhfor pages 1-2)
+  - **Efficacy:** in participants with visible assessable lesions, **100% (n=11)** had **≥50% improvement at 48 weeks**; all met the co-primary biochemical endpoint of **≥10% absolute trough plasminogen activity increase** through week 12. (shapiro2023plasminogenhuman‐tvmhfor pages 1-2)
+  - **Non-visible lesions:** high proportion resolved among assessed lesions during follow-up (table excerpt). (shapiro2023plasminogenhuman‐tvmhfor pages 4-5)
+  - **Safety:** treatment-emergent bleeding AEs in **5/15 (33%)**, mild/short; no neutralizing antibodies detected. (shapiro2023plasminogenhuman‐tvmhfor pages 7-8)
+  - **QoL:** improved/maintained in **93%** through week 48. (shapiro2023plasminogenhuman‐tvmhfor pages 5-6)
+
+- **Real-world application (respiratory lesions):** case series of four patients with severe airway disease; rapid clinical improvement and lesion resolution documented, including bronchoscopy resolution by day 10 and durable outpatient/home infusion regimens. (nakar2024casereportrespiratory pages 2-3, nakar2024casereportrespiratory media f6ed748e)
+
+**MAXO (suggested):** plasminogen replacement therapy; intravenous drug administration.
+
+### 12.2 Topical/local approaches (when commercial plasminogen eyedrops unavailable)
+- **Membrane excision + topical/subconjunctival FFP + topical heparin:** 2024 report of two LC cases with no recurrence at **12 months**; detailed preparation/storage protocol for FFP aliquots and intensive postoperative regimen. (almeida2024ligneousconjunctivitisfreshfrozen pages 1-3)
+- **Topical plasminogen drops compounded from FFP:** 2023 pediatric case report describes ethics-approved topical plasminogen formulation with durable absence of pseudomembranes at **12‑year follow-up**, enabling prosthesis use after debulking surgery. (panfili2023longtermfollowupin pages 1-3)
+- **Allogeneic donor plasma drops (clinical trial N-of-1):** protocol NCT05404932 uses donor plasma drops 1–2 drops every 1–5 hours for 2–6 months with safety monitoring (Canada). (NCT05404932 chunk 1)
+
+**MAXO (suggested):** topical plasma administration; conjunctival membrane excision.
+
+### 12.3 Clinical trials and registries (real-world implementation)
+- **NCT02690714:** IV plasminogen 6.6 mg/kg, phase 2/3; endpoints include trough plasminogen activity and lesion improvement. (NCT02690714 chunk 1)
+- **NCT01554956:** plasminogen eye drops for LC, phase 2/3, enrollment 12; results posted 2023‑01‑25; endpoint includes prevention of pseudomembrane relapse. (NCT01554956 chunk 1)
+- **NCT03797495 (HISTORY):** observational registry/biobank planned 100 affected individuals to define natural history and correlate factors with disease expression/severity; includes centralized activity/antigen and genetic testing. (NCT03797495 chunk 1)
+
+---
+
+## 13. Prevention
+No primary prevention is established for Mendelian PLGD‑1. Secondary/tertiary prevention is primarily via:
+- early recognition of characteristic mucosal lesions and
+- genetic counseling / family testing in autosomal recessive disease. (alghubaishi2023recurrentmeningitisand pages 2-4, xu2021novelhomozygousmutation pages 1-3)
+
+---
+
+## 14. Other species / natural disease
+- A naturally occurring canine ligneous membranitis/conjunctivitis case (Maltese dog) was linked to a **large *PLG* rearrangement deleting exon 1** and complete lack of plasminogen activity; article frames this as a **spontaneous animal model**. (turba2021alargedeletion pages 1-2)
+  - **OMIA:** canine ligneous membranitis is referenced as **OMIA 002020‑9615** in the dog paper. (turba2021alargedeletion pages 1-2)
+
+---
+
+## 15. Model organisms
+The retrieved evidence directly supports:
+- **Spontaneous dog model** (above). (turba2021alargedeletion pages 1-2)
+Additional model organism claims (e.g., engineered Plg−/− mice) are mentioned in case-report literature but were not retrieved as primary full-text evidence here; therefore not expanded to avoid overstatement. (xu2021novelhomozygousmutation pages 1-3)
+
+---
+
+## Recent developments (2023–2024 highlights)
+1. **Mechanistic consolidation at mucosal barriers:** 2023 review integrates fibrin biology with mucosal/periodontal homeostasis and emphasizes Mendelian PLG deficiency as a natural experiment for understanding severe early-onset periodontitis. (silva2023plasminmediatedfibrinolysisin pages 1-2)
+2. **Expanded therapeutic evidence for IV plasminogen replacement:** 2023 phase 2/3 trial provides long-term (to 124 weeks) efficacy, safety, and QoL outcomes supporting replacement therapy as disease-modifying. (shapiro2023plasminogenhuman‐tvmhfor pages 1-2, shapiro2023plasminogenhuman‐tvmhfor pages 7-8)
+3. **Post-approval real-world respiratory rescue:** 2024 case series documents rapid reversal of life-threatening airway lesions, supported by imaging/bronchoscopy and biomarker changes. (nakar2024casereportrespiratory pages 1-2, nakar2024casereportrespiratory media f6ed748e, nakar2024casereportrespiratory media 11094d94)
+4. **Continued innovation in topical/local therapy when commercial drops unavailable:** 2024 ophthalmology case series reports standardized FFP/heparin perioperative protocol with 12-month recurrence-free follow-up; N-of-1 trial protocols formalize donor plasma drops. (almeida2024ligneousconjunctivitisfreshfrozen pages 1-3, NCT05404932 chunk 1)
+
+---
+
+## Limitations of this report (evidence gaps in retrieved texts)
+- Orphanet/ICD/MeSH identifiers, and contemporary large prospective cohort statistics (beyond the commonly cited Tefs et al. frequencies summarized in 2023–2024 reviews) were not retrieved in the tool-accessible full texts for this run.
+- Formal differential diagnosis lists and validated ontology IDs for HPO/GO/UBERON/MAXO terms were not pulled from dedicated ontology databases in the available evidence; terms provided are suggestions based on phenotype descriptions.
+
+---
+
+## Key source list (URLs and publication dates)
+- Silva LM et al. **“Plasmin-Mediated Fibrinolysis in Periodontitis Pathogenesis.”** *Journal of Dental Research*. **2023-07**. https://doi.org/10.1177/00220345231171837 (silva2023plasminmediatedfibrinolysisin pages 1-2)
+- Shapiro AD et al. **“Plasminogen, human‑tvmh for the treatment of children and adults with plasminogen deficiency type 1.”** *Haemophilia*. **2023-09**. https://doi.org/10.1111/hae.14849 (shapiro2023plasminogenhuman‐tvmhfor pages 1-2)
+- Nakar C et al. **“Respiratory lesions successfully treated with intravenous plasminogen, human‑tvmh…”** *Frontiers in Pediatrics*. **2024-09**. https://doi.org/10.3389/fped.2024.1465166 (nakar2024casereportrespiratory pages 1-2)
+- de Almeida ICGB, Marback PMF. **“Ligneous conjunctivitis: Fresh-frozen plasma and heparin…”** *Arq Bras Oftalmol*. **2024-03**. https://doi.org/10.5935/0004-2749.2022-0288 (almeida2024ligneousconjunctivitisfreshfrozen pages 1-3)
+- Brito-Robinson T et al. **“Plasminogen missense variants…”** *Frontiers in Cardiovascular Medicine*. **2024-06**. https://doi.org/10.3389/fcvm.2024.1406953 (britorobinson2024plasminogenmissensevariants pages 15-16)
+- ClinicalTrials.gov **NCT02690714** (2016; results posted 2021): https://clinicaltrials.gov/study/NCT02690714 (NCT02690714 chunk 1)
+- ClinicalTrials.gov **NCT01554956** (2013; results posted 2023-01-25): https://clinicaltrials.gov/study/NCT01554956 (NCT01554956 chunk 1)
+- ClinicalTrials.gov **NCT03797495** (2018): https://clinicaltrials.gov/study/NCT03797495 (NCT03797495 chunk 1)
+
+
+References
+
+1. (shapiro2023plasminogenhuman‐tvmhfor pages 1-2): Amy D. Shapiro, Charles Nakar, Joseph M. Parker, Karen Thibaudeau, Roberto Crea, and Per Morten Sandset. Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1. Haemophilia, 29:1556-1564, Sep 2023. URL: https://doi.org/10.1111/hae.14849, doi:10.1111/hae.14849. This article has 15 citations and is from a peer-reviewed journal.
+
+2. (nakar2024casereportrespiratory pages 1-2): Charles Nakar, Heather McDaniel, Joseph M. Parker, Karen Thibaudeau, Neelam Thukral, and Amy D. Shapiro. Case report: respiratory lesions successfully treated with intravenous plasminogen, human-tvmh, replacement therapy in four patients with plasminogen deficiency type 1. Frontiers in Pediatrics, Sep 2024. URL: https://doi.org/10.3389/fped.2024.1465166, doi:10.3389/fped.2024.1465166. This article has 2 citations.
+
+3. (silva2023plasminmediatedfibrinolysisin pages 1-2): L.M. Silva, K. Divaris, T.H. Bugge, and N.M. Moutsopoulos. Plasmin-mediated fibrinolysis in periodontitis pathogenesis. Journal of Dental Research, 102:972-978, Jul 2023. URL: https://doi.org/10.1177/00220345231171837, doi:10.1177/00220345231171837. This article has 17 citations and is from a highest quality peer-reviewed journal.
+
+4. (OpenTargets Search: plasminogen deficiency,hypoplasminogenemia-PLG): Open Targets Query (plasminogen deficiency,hypoplasminogenemia-PLG, 3 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+5. (panfili2023longtermfollowupin pages 1-3): Filippo Maria Panfili, Paola Valente, Andrea Ficari, Fabiana Cortellessa, Davide Vecchio, Michaela Veronika Gonfiantini, Paola Sabrina Buonuomo, Giovanna Stefania Colafati, Emanuele Agolini, Maria Bartuli, Alessandra Claudia Modugno, and Marina Macchiaiolo. Long-term follow-up in a pediatric patient with ligneous conjunctivitis due to plg gene mutation in topical plasminogen treatment after successful use of ocular prosthesis for aesthetic rehabilitation: a case report. Italian Journal of Pediatrics, Aug 2023. URL: https://doi.org/10.1186/s13052-023-01503-x, doi:10.1186/s13052-023-01503-x. This article has 2 citations and is from a peer-reviewed journal.
+
+6. (NCT02690714 chunk 1):  A Study of Prometic Plasminogen IV Infusion in Subjects With Hypoplasminogenemia. Prometic Biotherapeutics, Inc.. 2016. ClinicalTrials.gov Identifier: NCT02690714
+
+7. (martinfernandez2016theunravellingof pages 1-2): Laura Martin-Fernandez, Pascual Marco, Irene Corrales, Raquel Pérez, Lorena Ramírez, Sonia López, Francisco Vidal, and José Manuel Soria. The unravelling of the genetic architecture of plasminogen deficiency and its relation to thrombotic disease. Scientific Reports, Dec 2016. URL: https://doi.org/10.1038/srep39255, doi:10.1038/srep39255. This article has 24 citations and is from a peer-reviewed journal.
+
+8. (klammt2011identificationofthree pages 3-4): Jürgen Klammt, Louise Kobelt, Dilek Aktas, Ismet Durak, Aslan Gokbuget, Quintin Hughes, Murat Irkec, Idil Kurtulus, Elisabetta Lapi, Hadas Mechoulam, Roberto Mendoza-Londono, Joseph Palumbo, Hansjörg Steitzer, Khalid Tabbara, Zeynep Ozbek, Neri Pucci, Talia Sotomayor, Marian Sturm, Tim Drogies, Maike Ziegler, and Volker Schuster. Identification of three novel plasminogen (plg) gene mutations in a series of 23 patients with low plg activity. Thrombosis and Haemostasis, 105:454-460, Jan 2011. URL: https://doi.org/10.1160/th10-04-0216, doi:10.1160/th10-04-0216. This article has 60 citations and is from a domain leading peer-reviewed journal.
+
+9. (klammt2011identificationofthree pages 1-2): Jürgen Klammt, Louise Kobelt, Dilek Aktas, Ismet Durak, Aslan Gokbuget, Quintin Hughes, Murat Irkec, Idil Kurtulus, Elisabetta Lapi, Hadas Mechoulam, Roberto Mendoza-Londono, Joseph Palumbo, Hansjörg Steitzer, Khalid Tabbara, Zeynep Ozbek, Neri Pucci, Talia Sotomayor, Marian Sturm, Tim Drogies, Maike Ziegler, and Volker Schuster. Identification of three novel plasminogen (plg) gene mutations in a series of 23 patients with low plg activity. Thrombosis and Haemostasis, 105:454-460, Jan 2011. URL: https://doi.org/10.1160/th10-04-0216, doi:10.1160/th10-04-0216. This article has 60 citations and is from a domain leading peer-reviewed journal.
+
+10. (bektaskayhan2023ligneousperiodontitisassociated pages 1-2): Kıvanç Bektaş-Kayhan, Revan Birke Koca-Ünsal, Bora Başaran, and Tiraje Çelkan. Ligneous periodontitis associated with plasminogen deficiency: a review of the literature with two additional cases. Cyprus Journal of Medical Sciences, 7:718-730, Jan 2023. URL: https://doi.org/10.4274/cjms.2022.2021-194, doi:10.4274/cjms.2022.2021-194. This article has 1 citations.
+
+11. (alghubaishi2023recurrentmeningitisand pages 2-4): Somayah A Alghubaishi, Muhammad Saeed, Fadi Abujamous, Hussam Osman, and Badriah G Alasmari. Recurrent meningitis and its rare association with ligneous conjunctivitis and congenital plasminogen deficiency. Cureus, Sep 2023. URL: https://doi.org/10.7759/cureus.44813, doi:10.7759/cureus.44813. This article has 0 citations.
+
+12. (nasiri2023plasminogendeficiencya pages 3-4): Abdulrahman Nasiri, Marwa Nassar, and Hazzaa Alzahrani. Plasminogen deficiency: a case report and review. Cureus, Sep 2023. URL: https://doi.org/10.7759/cureus.45676, doi:10.7759/cureus.45676. This article has 3 citations.
+
+13. (bektaskayhan2023ligneousperiodontitisassociated pages 2-3): Kıvanç Bektaş-Kayhan, Revan Birke Koca-Ünsal, Bora Başaran, and Tiraje Çelkan. Ligneous periodontitis associated with plasminogen deficiency: a review of the literature with two additional cases. Cyprus Journal of Medical Sciences, 7:718-730, Jan 2023. URL: https://doi.org/10.4274/cjms.2022.2021-194, doi:10.4274/cjms.2022.2021-194. This article has 1 citations.
+
+14. (nakar2024casereportrespiratory media f6ed748e): Charles Nakar, Heather McDaniel, Joseph M. Parker, Karen Thibaudeau, Neelam Thukral, and Amy D. Shapiro. Case report: respiratory lesions successfully treated with intravenous plasminogen, human-tvmh, replacement therapy in four patients with plasminogen deficiency type 1. Frontiers in Pediatrics, Sep 2024. URL: https://doi.org/10.3389/fped.2024.1465166, doi:10.3389/fped.2024.1465166. This article has 2 citations.
+
+15. (shapiro2023plasminogenhuman‐tvmhfor pages 2-2): Amy D. Shapiro, Charles Nakar, Joseph M. Parker, Karen Thibaudeau, Roberto Crea, and Per Morten Sandset. Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1. Haemophilia, 29:1556-1564, Sep 2023. URL: https://doi.org/10.1111/hae.14849, doi:10.1111/hae.14849. This article has 15 citations and is from a peer-reviewed journal.
+
+16. (nasiri2023plasminogendeficiencya pages 1-3): Abdulrahman Nasiri, Marwa Nassar, and Hazzaa Alzahrani. Plasminogen deficiency: a case report and review. Cureus, Sep 2023. URL: https://doi.org/10.7759/cureus.45676, doi:10.7759/cureus.45676. This article has 3 citations.
+
+17. (shapiro2023plasminogenhuman‐tvmhfor pages 5-6): Amy D. Shapiro, Charles Nakar, Joseph M. Parker, Karen Thibaudeau, Roberto Crea, and Per Morten Sandset. Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1. Haemophilia, 29:1556-1564, Sep 2023. URL: https://doi.org/10.1111/hae.14849, doi:10.1111/hae.14849. This article has 15 citations and is from a peer-reviewed journal.
+
+18. (xu2021novelhomozygousmutation pages 1-3): Liyan Xu, Yajie Sun, Kaili Yang, Dongqing Zhao, Yiqiang Wang, and Shengwei Ren. Novel homozygous mutation of plasminogen in ligneous conjunctivitis: a case report and literature review. Ophthalmic Genetics, 42:105-109, Jan 2021. URL: https://doi.org/10.1080/13816810.2020.1867753, doi:10.1080/13816810.2020.1867753. This article has 7 citations and is from a peer-reviewed journal.
+
+19. (britorobinson2024plasminogenmissensevariants pages 14-15): Teresa Brito-Robinson, Yetunde A. Ayinuola, Victoria A. Ploplis, and Francis J. Castellino. Plasminogen missense variants and their involvement in cardiovascular and inflammatory disease. Frontiers in Cardiovascular Medicine, Jun 2024. URL: https://doi.org/10.3389/fcvm.2024.1406953, doi:10.3389/fcvm.2024.1406953. This article has 6 citations and is from a peer-reviewed journal.
+
+20. (martinfernandez2016theunravellingof pages 4-5): Laura Martin-Fernandez, Pascual Marco, Irene Corrales, Raquel Pérez, Lorena Ramírez, Sonia López, Francisco Vidal, and José Manuel Soria. The unravelling of the genetic architecture of plasminogen deficiency and its relation to thrombotic disease. Scientific Reports, Dec 2016. URL: https://doi.org/10.1038/srep39255, doi:10.1038/srep39255. This article has 24 citations and is from a peer-reviewed journal.
+
+21. (almeida2024ligneousconjunctivitisfreshfrozen pages 1-3): Isabela Costa Guerra Barreto de Almeida and Patrícia Maria Fernandes Marback. Ligneous conjunctivitis: fresh-frozen plasma and heparin use intra-and postoperatively, a report of two cases. Arquivos Brasileiros de Oftalmologia, Mar 2024. URL: https://doi.org/10.5935/0004-2749.2022-0288, doi:10.5935/0004-2749.2022-0288. This article has 5 citations and is from a peer-reviewed journal.
+
+22. (alghafry2025inheriteddisordersof pages 5-6): Maha Al-Ghafry, Mouhamed Yazan Abou-Ismail, and Suchitra S. Acharya. Inherited disorders of the fibrinolytic pathway: pathogenic phenotypes and diagnostic considerations of extremely rare disorders. Seminars in Thrombosis and Hemostasis, 51:227-235, Sep 2025. URL: https://doi.org/10.1055/s-0044-1789596, doi:10.1055/s-0044-1789596. This article has 12 citations and is from a peer-reviewed journal.
+
+23. (martinfernandez2016theunravellingof pages 2-3): Laura Martin-Fernandez, Pascual Marco, Irene Corrales, Raquel Pérez, Lorena Ramírez, Sonia López, Francisco Vidal, and José Manuel Soria. The unravelling of the genetic architecture of plasminogen deficiency and its relation to thrombotic disease. Scientific Reports, Dec 2016. URL: https://doi.org/10.1038/srep39255, doi:10.1038/srep39255. This article has 24 citations and is from a peer-reviewed journal.
+
+24. (shapiro2023plasminogenhuman‐tvmhfor pages 4-5): Amy D. Shapiro, Charles Nakar, Joseph M. Parker, Karen Thibaudeau, Roberto Crea, and Per Morten Sandset. Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1. Haemophilia, 29:1556-1564, Sep 2023. URL: https://doi.org/10.1111/hae.14849, doi:10.1111/hae.14849. This article has 15 citations and is from a peer-reviewed journal.
+
+25. (shapiro2023plasminogenhuman‐tvmhfor pages 7-8): Amy D. Shapiro, Charles Nakar, Joseph M. Parker, Karen Thibaudeau, Roberto Crea, and Per Morten Sandset. Plasminogen, human‐tvmh for the treatment of children and adults with plasminogen deficiency type 1. Haemophilia, 29:1556-1564, Sep 2023. URL: https://doi.org/10.1111/hae.14849, doi:10.1111/hae.14849. This article has 15 citations and is from a peer-reviewed journal.
+
+26. (nakar2024casereportrespiratory pages 2-3): Charles Nakar, Heather McDaniel, Joseph M. Parker, Karen Thibaudeau, Neelam Thukral, and Amy D. Shapiro. Case report: respiratory lesions successfully treated with intravenous plasminogen, human-tvmh, replacement therapy in four patients with plasminogen deficiency type 1. Frontiers in Pediatrics, Sep 2024. URL: https://doi.org/10.3389/fped.2024.1465166, doi:10.3389/fped.2024.1465166. This article has 2 citations.
+
+27. (NCT05404932 chunk 1): Sarah Tehseen. Treatment of Ligneous Conjunctivitis in Children With Plasminogen Deficiency. University of Saskatchewan. 2022. ClinicalTrials.gov Identifier: NCT05404932
+
+28. (NCT01554956 chunk 1):  Efficacy/Safety of Human Plasminogen Eye Drop in Ligneous Conjunctivitis Patients. Kedrion S.p.A.. 2013. ClinicalTrials.gov Identifier: NCT01554956
+
+29. (NCT03797495 chunk 1): Amy D Shapiro, MD. Study of Individuals Affected With Hypoplasminogenemia. Indiana Hemophilia &Thrombosis Center, Inc.. 2018. ClinicalTrials.gov Identifier: NCT03797495
+
+30. (turba2021alargedeletion pages 1-2): M. E. Turba, P. C. Ostan, S. Ghetti, M. Dajbychova, F. Dondi, and F. Gentilini. A large deletion in the plasminogen gene is associated with ligneous membranitis in a maltese dog. Animal Genetics, 52:767-771, Aug 2021. URL: https://doi.org/10.1111/age.13130, doi:10.1111/age.13130. This article has 2 citations and is from a domain leading peer-reviewed journal.
+
+31. (nakar2024casereportrespiratory media 11094d94): Charles Nakar, Heather McDaniel, Joseph M. Parker, Karen Thibaudeau, Neelam Thukral, and Amy D. Shapiro. Case report: respiratory lesions successfully treated with intravenous plasminogen, human-tvmh, replacement therapy in four patients with plasminogen deficiency type 1. Frontiers in Pediatrics, Sep 2024. URL: https://doi.org/10.3389/fped.2024.1465166, doi:10.3389/fped.2024.1465166. This article has 2 citations.
+
+32. (britorobinson2024plasminogenmissensevariants pages 15-16): Teresa Brito-Robinson, Yetunde A. Ayinuola, Victoria A. Ploplis, and Francis J. Castellino. Plasminogen missense variants and their involvement in cardiovascular and inflammatory disease. Frontiers in Cardiovascular Medicine, Jun 2024. URL: https://doi.org/10.3389/fcvm.2024.1406953, doi:10.3389/fcvm.2024.1406953. This article has 6 citations and is from a peer-reviewed journal.

--- a/research/Hypoplasminogenemia-deep-research-falcon.md.citations.md
+++ b/research/Hypoplasminogenemia-deep-research-falcon.md.citations.md
@@ -1,0 +1,493 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Hypoplasminogenemia
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Hypoplasminogenemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-07T09:31:19.148794
+
+1. silva2023plasminmediatedfibrinolysisin pages 1-2
+2. panfili2023longtermfollowupin pages 1-3
+3. klammt2011identificationofthree pages 1-2
+4. bektaskayhan2023ligneousperiodontitisassociated pages 1-2
+5. bektaskayhan2023ligneousperiodontitisassociated pages 2-3
+6. nakar2024casereportrespiratory pages 1-2
+7. nasiri2023plasminogendeficiencya pages 3-4
+8. alghubaishi2023recurrentmeningitisand pages 2-4
+9. klammt2011identificationofthree pages 3-4
+10. xu2021novelhomozygousmutation pages 1-3
+11. britorobinson2024plasminogenmissensevariants pages 14-15
+12. martinfernandez2016theunravellingof pages 4-5
+13. almeida2024ligneousconjunctivitisfreshfrozen pages 1-3
+14. alghafry2025inheriteddisordersof pages 5-6
+15. turba2021alargedeletion pages 1-2
+16. britorobinson2024plasminogenmissensevariants pages 15-16
+17. martinfernandez2016theunravellingof pages 1-2
+18. nasiri2023plasminogendeficiencya pages 1-3
+19. martinfernandez2016theunravellingof pages 2-3
+20. nakar2024casereportrespiratory pages 2-3
+21. https://doi.org/10.1177/00220345231171837
+22. https://doi.org/10.1111/hae.14849
+23. https://doi.org/10.3389/fped.2024.1465166
+24. https://doi.org/10.5935/0004-2749.2022-0288
+25. https://doi.org/10.3389/fcvm.2024.1406953
+26. https://clinicaltrials.gov/study/NCT02690714
+27. https://clinicaltrials.gov/study/NCT01554956
+28. https://clinicaltrials.gov/study/NCT03797495
+29. https://doi.org/10.1111/hae.14849,
+30. https://doi.org/10.3389/fped.2024.1465166,
+31. https://doi.org/10.1177/00220345231171837,
+32. https://doi.org/10.1186/s13052-023-01503-x,
+33. https://doi.org/10.1038/srep39255,
+34. https://doi.org/10.1160/th10-04-0216,
+35. https://doi.org/10.4274/cjms.2022.2021-194,
+36. https://doi.org/10.7759/cureus.44813,
+37. https://doi.org/10.7759/cureus.45676,
+38. https://doi.org/10.1080/13816810.2020.1867753,
+39. https://doi.org/10.3389/fcvm.2024.1406953,
+40. https://doi.org/10.5935/0004-2749.2022-0288,
+41. https://doi.org/10.1055/s-0044-1789596,
+42. https://doi.org/10.1111/age.13130,


### PR DESCRIPTION
## Summary

Adds a new DISMECH curation page for Hypoplasminogenemia (MONDO:0009009), also known as plasminogen deficiency type 1.

The entry includes:

- PLG/autosomal recessive genetic framing
- fibrinolysis and mucosal pseudomembrane pathophysiology
- ophthalmologic, periodontal, respiratory, CNS, and reproductive phenotypes
- plasminogen replacement treatments and two clinical trial records
- Falcon deep-research report and citation artifact
- cache-backed evidence snippets from PMIDs, ClinicalTrials.gov, and one DOI-only trial publication

## Validation

- `just validate kb/disorders/Hypoplasminogenemia.yaml` passed
- `just validate-references kb/disorders/Hypoplasminogenemia.yaml` passed; repo validator reported 0 checks, so I also ran a supplemental YAML-aware local cache snippet check and confirmed all 27 snippets are present after whitespace normalization
- `just validate-terms kb/disorders/Hypoplasminogenemia.yaml` passed
- `just check-reference-cache-frontmatter` passed
- `just qc-deep-research --target-providers falcon --only Hypoplasminogenemia` exited 0; it reports missing cache coverage for unused citations in the Falcon report, while the YAML-cited references are cached

## Notes

I restored unrelated generated cache churn before staging, including the repeated clinical trial caches for NCT02616705, NCT03201432, NCT03902353, NCT05593757, and NCT05885932. I did not hand-edit reference cache files.
