### PR TITLE
Improve AGAT Deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/AGAT_Deficiency.yaml
+++ b/kb/disorders/AGAT_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: AGAT Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-05T08:31:14Z'
+updated_date: '2026-05-07T13:58:28Z'
 synonyms:
 - L-arginine:glycine amidinotransferase deficiency
 - Arginine:glycine amidinotransferase deficiency
@@ -110,7 +110,11 @@ pathophysiology:
     explanation: Confirms GATM encodes AGAT and places it in creatine synthesis.
   downstream:
   - target: Reduced guanidinoacetate and creatine biosynthesis
+    causal_link_type: DIRECT
     description: Loss of AGAT activity reduces production of guanidinoacetate, the creatine precursor.
+  - target: Reduced tissue arginine:glycine amidinotransferase activity
+    causal_link_type: DIRECT
+    description: Biallelic GATM loss directly reduces measurable tissue AGAT enzymatic activity.
 - name: Reduced guanidinoacetate and creatine biosynthesis
   description: >
     AGAT normally converts arginine and glycine to guanidinoacetate, which is
@@ -146,7 +150,60 @@ pathophysiology:
     snippet: "and low creatine levels in body fluids in l-arginine:glycine amidinotransferase"
     explanation: Review evidence supports the AGAT deficiency diagnostic biochemical pattern of low guanidinoacetate with low creatine.
   downstream:
+  - target: Decreased urine guanidinoacetic acid level
+    causal_link_type: DIRECT
+    description: Reduced AGAT product formation directly lowers guanidinoacetate in urine and plasma.
+  - target: Reduced circulating creatine concentration
+    causal_link_type: DIRECT
+    description: Impaired endogenous creatine synthesis lowers creatine in plasma and urine.
   - target: Cerebral creatine depletion and impaired energy buffering
+    causal_link_type: DIRECT
+    description: Low systemic creatine synthesis produces low or undetectable cerebral creatine stores.
+  - target: Peripheral creatine depletion and treatable myopathy
+    causal_link_type: DIRECT
+    description: Low endogenous creatine synthesis also depletes skeletal muscle creatine stores.
+- name: Peripheral creatine depletion and treatable myopathy
+  description: >
+    Reduced creatine availability in skeletal muscle impairs the creatine and
+    phosphocreatine energy buffer, producing a treatable myopathy with
+    progressive proximal weakness that can improve with oral creatine
+    supplementation.
+  biological_processes:
+  - preferred_term: creatine metabolism
+    term:
+      id: GO:0006600
+      label: creatine metabolic process
+  cell_types:
+  - preferred_term: skeletal muscle cell
+    term:
+      id: CL:0000188
+      label: cell of skeletal muscle
+  chemical_entities:
+  - preferred_term: creatine
+    term:
+      id: CHEBI:16919
+      label: creatine
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:23770102
+    reference_title: "Creatine deficiency syndrome. A treatable myopathy due to arginine-glycine amidinotransferase (AGAT) deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Examination showed an important language delay, a progressive proximal muscular weakness in the lower limbs with Gowers sign and myopathic electromyography."
+    explanation: Case report directly links AGAT deficiency to progressive proximal weakness and myopathic EMG.
+  - reference: PMID:26490222
+    reference_title: "Arginine:glycine amidinotransferase (AGAT) deficiency: clinical features and long term outcomes in 16 patients diagnosed worldwide."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Treatment with creatine monohydrate (100-800 mg/kg/day) resulted in almost complete restoration of brain creatine levels and significant improvement of myopathy."
+    explanation: International cohort shows the myopathy is treatment responsive after creatine supplementation.
+  downstream:
+  - target: Muscle weakness
+    causal_link_type: DIRECT
+    description: Skeletal muscle creatine depletion manifests as progressive proximal weakness.
+  - target: Myopathy
+    causal_link_type: DIRECT
+    description: Impaired muscle creatine buffering produces the AGAT deficiency myopathy.
 - name: Cerebral creatine depletion and impaired energy buffering
   description: >
     Reduced creatine synthesis lowers brain creatine stores. Because the brain
@@ -194,6 +251,40 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Furthermore, significant brain atrophy was demonstrated, despite creatine"
     explanation: Recent family study suggests additional structural brain involvement may persist despite treatment in some patients.
+  downstream:
+  - target: Reduced brain creatine level by MRS
+    causal_link_type: DIRECT
+    description: Cerebral creatine depletion is measured directly as reduced brain creatine on magnetic resonance spectroscopy.
+  - target: Global developmental delay
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired phosphocreatine energy buffering in the developing brain disrupts neurodevelopmental function.
+    description: Brain creatine deficiency contributes to global developmental delay.
+  - target: Cognitive impairment
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired brain energy buffering disrupts cognition and adaptive development.
+    description: Cerebral creatine depletion contributes to cognitive impairment.
+  - target: Delayed speech and language development
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurodevelopmental energy-buffering deficits impair speech and language development.
+    description: Language delay is a common manifestation of cerebral creatine deficiency.
+  - target: Atypical behavior
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurodevelopmental dysfunction from cerebral creatine deficiency can alter behavior.
+    description: Behavioral abnormalities are part of the cerebral creatine deficiency spectrum.
+  - target: Hypotonia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Central and motor developmental consequences of creatine deficiency alter tone and motor function.
+    description: Hypotonia is an occasional motor manifestation of AGAT deficiency.
+  - target: Seizure
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Brain creatine depletion and associated structural or functional abnormalities can lower seizure threshold in some families.
+    description: Seizures are an expanded-spectrum manifestation of AGAT deficiency.
 phenotypes:
 - name: Global developmental delay
   frequency: VERY_FREQUENT
@@ -457,6 +548,34 @@ treatments:
   - target: Cerebral creatine depletion and impaired energy buffering
     treatment_effect: RESTORES
     description: Creatine supplementation bypasses impaired endogenous synthesis by supplying creatine directly.
+  - target: Peripheral creatine depletion and treatable myopathy
+    treatment_effect: RESTORES
+    description: Creatine supplementation restores the muscle creatine pool that supports phosphocreatine energy buffering.
+  target_phenotypes:
+  - preferred_term: Reduced brain creatine level by MRS
+    term:
+      id: HP:0025051
+      label: Reduced brain creatine level by MRS
+  - preferred_term: Muscle weakness
+    term:
+      id: HP:0001324
+      label: Muscle weakness
+  - preferred_term: Myopathy
+    term:
+      id: HP:0003198
+      label: Myopathy
+  - preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  - preferred_term: Cognitive impairment
+    term:
+      id: HP:0100543
+      label: Cognitive impairment
+  - preferred_term: Delayed speech and language development
+    term:
+      id: HP:0000750
+      label: Delayed speech and language development
   evidence:
   - reference: PMID:20301745
     reference_title: "Creatine Deficiency Disorders."
@@ -501,6 +620,31 @@ treatments:
   - target: Cerebral creatine depletion and impaired energy buffering
     treatment_effect: MODULATES
     description: Supportive care addresses neurodevelopmental and neurologic consequences of cerebral creatine deficiency.
+  target_phenotypes:
+  - preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  - preferred_term: Cognitive impairment
+    term:
+      id: HP:0100543
+      label: Cognitive impairment
+  - preferred_term: Delayed speech and language development
+    term:
+      id: HP:0000750
+      label: Delayed speech and language development
+  - preferred_term: Atypical behavior
+    term:
+      id: HP:0000708
+      label: Atypical behavior
+  - preferred_term: Hypotonia
+    term:
+      id: HP:0001252
+      label: Hypotonia
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
   evidence:
   - reference: PMID:20301745
     reference_title: "Creatine Deficiency Disorders."


### PR DESCRIPTION
## Summary
- add causal link types and downstream targets from GATM/AGAT deficiency to biochemical endpoints
- add a skeletal-muscle creatine depletion/myopathy mechanism instead of routing myopathy through the brain node
- connect cerebral creatine depletion to neurodevelopmental phenotypes and add treatment phenotype targets for creatine and supportive care

## Validation
- `just validate kb/disorders/AGAT_Deficiency.yaml`
- recursive normalized snippet audit: 46 snippets found in cache
- graph audit: 4 pathophysiology nodes, 15 downstream edges, all phenotypes/biochemical findings targeted
- `git diff --check`

## Scope
- intentionally scoped to `kb/disorders/AGAT_Deficiency.yaml`
- restored generated ClinicalTrials cache churn after validation