### PR TITLE
Improve LIPT1 Deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml
+++ b/kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Lipoyl Transferase 1 Deficiency
 creation_date: '2026-02-13T00:59:22Z'
-updated_date: '2026-05-05T19:08:08Z'
+updated_date: '2026-05-07T14:41:31Z'
 category: Mendelian
 description: >
   Lipoyl transferase 1 deficiency (OMIM 616299) is a rare autosomal recessive
@@ -13,10 +13,11 @@ description: >
   lipoylated upstream by the LIPT2-LIAS pathway. This results in combined
   dehydrogenase deficiency with lactic acidosis but typically normal glycine
   levels, distinguishing it biochemically from LIPT2 and LIAS deficiency.
-  Clinical presentation includes Leigh-like encephalopathy, seizures, dystonia,
-  spastic tetraparesis, and variable hepatic involvement. Onset is neonatal to
-  early infantile. Metabolic decompensation during febrile illness may
-  precipitate acute neurological deterioration.
+  Clinical presentation includes Leigh-like encephalopathy, early-onset
+  seizures, psychomotor retardation, abnormal muscle tone, severe lactic
+  acidosis, and occasionally syndromic congenital sideroblastic anemia. Onset
+  is neonatal to early infantile. Metabolic decompensation during febrile
+  illness may precipitate acute neurological deterioration.
 disease_term:
   preferred_term: lipoyl transferase 1 deficiency
   term:
@@ -70,11 +71,12 @@ inheritance:
       segregating on different alleles confirms recessive inheritance.
 prevalence:
 - population: Global reported patients
-  percentage: Unknown (5 reported cases by 2018)
+  percentage: Unknown (at least 6 reported patients by 2024)
   notes: >-
     No population-based prevalence study was identified. By 2018, the PubMed
     literature cited four patients from three families and described a fifth
-    case, indicating an ultra-rare disorder that may still be underdiagnosed.
+    case; a 2024 report described an additional patient with a homozygous LIPT1
+    variant and syndromic congenital sideroblastic anemia.
   evidence:
   - reference: PMID:29681092
     supports: SUPPORT
@@ -96,6 +98,16 @@ prevalence:
     explanation: >-
       The same report extends the published total to five cases, supporting an
       unknown but extremely low prevalence designation.
+  - reference: PMID:39547509
+    reference_title: "Engineered bacterial lipoate protein ligase A (lplA) restores lipoylation in cell models of lipoylation deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      a patient with a homozygous c.212C>T variant LIPT1 with a previously
+      uncharacterized syndromic congenital sideroblastic anemia.
+    explanation: >-
+      This 2024 report adds another described patient with biallelic LIPT1
+      disease and an expanded hematologic phenotype.
 pathophysiology:
 - name: Defective lipoyl relay via LIPT1 deficiency
   description: >
@@ -151,6 +163,30 @@ pathophysiology:
       explanation: >-
         The review directly connects LIPT1 loss to failed lipoyl transfer to
         the dehydrogenase E2 subunits.
+  - target: Lipoylated dehydrogenase E2 subunits
+    description: >-
+      Loss of LIPT1-mediated lipoyl transfer directly reduces lipoylated PDH
+      E2 and alpha-KGDH E2 subunits in patient-derived cells.
+    causal_link_type: DIRECT
+  - target: Erythroid lipoylation-deficient proliferation defect
+    description: >-
+      A homozygous LIPT1 sideroblastic anemia allele causes a
+      lipoylation-deficient phenotype and impaired low-glucose proliferation in
+      erythroid-lineage cells.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39547509
+      reference_title: "Engineered bacterial lipoate protein ligase A (lplA) restores lipoylation in cell models of lipoylation deficiency."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        K562 erythroleukemia cells engineered to harbor this missense LIPT1
+        allele recapitulate the lipoylation-deficient phenotype and exhibit
+        impaired proliferation in low glucose that is completely restored by
+        engineered lplA.
+      explanation: >-
+        Erythroid-lineage cells carrying the LIPT1 variant show the
+        lipoylation-deficient cellular phenotype and impaired proliferation.
   evidence:
   - reference: PMID:24256811
     reference_title: "Mutations in the lipoyltransferase LIPT1 gene cause a fatal disease associated with a specific lipoylation defect of the 2-ketoacid dehydrogenase complexes."
@@ -264,6 +300,21 @@ pathophysiology:
       explanation: >-
         The review directly links loss of pyruvate dehydrogenase activity to
         lactate accumulation in lipoic-acid metabolism disorders.
+  - target: Pyruvate and alpha-ketoglutarate dehydrogenase activity
+    description: >-
+      Failed lipoylation directly lowers pyruvate dehydrogenase and
+      alpha-ketoglutarate dehydrogenase activities.
+    causal_link_type: DIRECT
+  - target: Glycine
+    description: >-
+      Preserved GCSH lipoylation and glycine cleavage keep glycine normal or
+      near-normal in LIPT1 deficiency.
+    causal_link_type: DIRECT
+  - target: Increased urine lactate, ketoglutarate, and 2-oxoacid levels
+    description: >-
+      Reduced 2-ketoacid dehydrogenase activity produces increased urinary
+      lactate, ketoglutarate, and 2-oxoacid metabolites.
+    causal_link_type: DIRECT
   - target: Mitochondrial bioenergetic failure and lipid peroxidation
     description: >-
       Reduced PDH and alpha-KGDH activities impair cellular bioenergetics and
@@ -317,6 +368,74 @@ pathophysiology:
     explanation: >-
       Patient-derived LIPT1 fibroblast models show the downstream bioenergetic
       and oxidative injury state.
+  downstream:
+  - target: Seizures
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Bioenergetic failure in neuronal cells contributes to early-onset epileptic encephalopathy.
+    description: Severe mitochondrial energy failure contributes to seizures in reported LIPT1 deficiency.
+  - target: Global developmental delay
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired cellular respiration in developing neural tissue disrupts psychomotor development.
+    description: LIPT1-related mitochondrial dysfunction contributes to psychomotor retardation and poor neurocognitive outcomes.
+  - target: Abnormal muscle tone
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Mitochondrial energy failure in the nervous system and muscle disrupts motor tone.
+    description: Abnormal muscle tone is reported as part of the LIPT1 deficiency clinical spectrum.
+- name: Erythroid lipoylation-deficient proliferation defect
+  description: >
+    The LIPT1 c.212C>T sideroblastic anemia allele recapitulates a
+    lipoylation-deficient phenotype in erythroid-lineage cells and impairs
+    proliferation under low-glucose conditions, linking defective mitochondrial
+    lipoylation to the hematologic presentation.
+  genes:
+  - preferred_term: LIPT1
+    term:
+      id: hgnc:29569
+      label: LIPT1
+  cell_types:
+  - preferred_term: erythroid lineage cell
+    term:
+      id: CL:0000764
+      label: erythroid lineage cell
+  biological_processes:
+  - preferred_term: cell population proliferation
+    modifier: DECREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  evidence:
+  - reference: PMID:39547509
+    reference_title: "Engineered bacterial lipoate protein ligase A (lplA) restores lipoylation in cell models of lipoylation deficiency."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      K562 erythroleukemia cells engineered to harbor this missense LIPT1
+      allele recapitulate the lipoylation-deficient phenotype and exhibit
+      impaired proliferation in low glucose that is completely restored by
+      engineered lplA.
+    explanation: >-
+      Erythroid-lineage cell modeling supports a LIPT1-dependent
+      lipoylation-deficient proliferation defect.
+  downstream:
+  - target: Sideroblastic anemia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Erythroid lipoylation deficiency impairs mitochondrial metabolism and proliferation.
+    description: A homozygous LIPT1 variant has been reported with syndromic congenital sideroblastic anemia.
+    evidence:
+    - reference: PMID:39547509
+      reference_title: "Engineered bacterial lipoate protein ligase A (lplA) restores lipoylation in cell models of lipoylation deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        a patient with a homozygous c.212C>T variant LIPT1 with a previously
+        uncharacterized syndromic congenital sideroblastic anemia.
+      explanation: >-
+        Clinical report links the same LIPT1 allele to syndromic congenital
+        sideroblastic anemia.
 phenotypes:
 - name: Lactic acidosis
   description: >
@@ -388,64 +507,29 @@ phenotypes:
     explanation: >-
       Seizures can progress to epileptic encephalopathy, expanding the
       phenotypic spectrum of LIPT1 deficiency.
-- name: Dystonia
+- name: Abnormal muscle tone
   phenotype_term:
-    preferred_term: Dystonia
+    preferred_term: Abnormal muscle tone
     term:
-      id: HP:0001332
-      label: Dystonia
-  evidence:
-  - reference: PMID:24341803
-    reference_title: "Mutations in human lipoyltransferase gene LIPT1 cause a Leigh disease with secondary deficiency for pyruvate and alpha-ketoglutarate dehydrogenase."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      a boy who developed Leigh disease following a gastroenteritis and had
-      combined PDH and α-KGDH deficiency
-    explanation: >-
-      The index LIPT1 patient developed Leigh disease, which typically
-      includes dystonia as a prominent movement disorder feature.
-- name: Spasticity
-  phenotype_term:
-    preferred_term: Spasticity
-    term:
-      id: HP:0001257
-      label: Spasticity
-  evidence:
-  - reference: PMID:29681092
-    reference_title: "LIPT1 deficiency presenting as early infantile epileptic encephalopathy, Leigh disease, and secondary pyruvate dehydrogenase complex deficiency."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      commonly presenting with severe lactic acidosis resulting in neonatal
-      death and/or poor neurocognitive outcomes
-    explanation: >-
-      LIPT1 deficiency causes progressive encephalopathy with poor
-      neurocognitive outcomes including spasticity from upper motor neuron involvement.
-- name: Neonatal hypotonia
-  phenotype_term:
-    preferred_term: Neonatal hypotonia
-    term:
-      id: HP:0001319
-      label: Neonatal hypotonia
+      id: HP:0003808
+      label: Abnormal muscle tone
   evidence:
   - reference: PMID:39199267
     reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
-      a fatal condition characterized by lipoylation defects of the
-      2-ketoacid dehydrogenase complexes causing early-onset seizures,
-      psychomotor retardation, abnormal muscle tone, severe lactic acidosis
+      early-onset seizures, psychomotor retardation, abnormal muscle tone,
+      severe lactic acidosis
     explanation: >-
-      Gómez-Fernández et al. describe LIPT1 deficiency as causing abnormal
-      muscle tone among its cardinal features, consistent with neonatal hypotonia.
+      The abstract summarizes abnormal muscle tone as a reported feature of
+      LIPT1 deficiency.
 - name: Global developmental delay
   phenotype_term:
-    preferred_term: Profound global developmental delay
+    preferred_term: Global developmental delay
     term:
-      id: HP:0012736
-      label: Profound global developmental delay
+      id: HP:0001263
+      label: Global developmental delay
   evidence:
   - reference: PMID:29681092
     reference_title: "LIPT1 deficiency presenting as early infantile epileptic encephalopathy, Leigh disease, and secondary pyruvate dehydrogenase complex deficiency."
@@ -457,24 +541,33 @@ phenotypes:
     explanation: >-
       Poor neurocognitive outcomes are a recognized consequence of LIPT1
       deficiency across reported cases.
-- name: Vomiting
+  - reference: PMID:39199267
+    reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      early-onset seizures, psychomotor retardation, abnormal muscle tone,
+      severe lactic acidosis
+    explanation: >-
+      Psychomotor retardation supports the broader global developmental delay
+      phenotype mapping.
+- name: Sideroblastic anemia
   phenotype_term:
-    preferred_term: Vomiting
+    preferred_term: Sideroblastic anemia
     term:
-      id: HP:0002013
-      label: Vomiting
-- name: Respiratory insufficiency
-  phenotype_term:
-    preferred_term: Respiratory insufficiency
-    term:
-      id: HP:0002093
-      label: Respiratory insufficiency
-- name: Feeding difficulties
-  phenotype_term:
-    preferred_term: Feeding difficulties in infancy
-    term:
-      id: HP:0008872
-      label: Feeding difficulties in infancy
+      id: HP:0001924
+      label: Sideroblastic anemia
+  evidence:
+  - reference: PMID:39547509
+    reference_title: "Engineered bacterial lipoate protein ligase A (lplA) restores lipoylation in cell models of lipoylation deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      a patient with a homozygous c.212C>T variant LIPT1 with a previously
+      uncharacterized syndromic congenital sideroblastic anemia.
+    explanation: >-
+      Recent report expands the LIPT1 phenotype to include syndromic
+      congenital sideroblastic anemia.
 biochemical:
 - name: Lipoylated dehydrogenase E2 subunits
   presence: DECREASED
@@ -539,6 +632,21 @@ biochemical:
     explanation: >-
       Patient biochemical testing supports normal glycine levels and preserved
       glycine cleavage in LIPT1 deficiency.
+- name: Increased urine lactate, ketoglutarate, and 2-oxoacid levels
+  presence: INCREASED
+  context: >
+    Urinary lactate, ketoglutarate, and 2-oxoacid accumulation reflects the
+    downstream metabolic block from deficient 2-ketoacid dehydrogenase activity.
+  evidence:
+  - reference: PMID:39199267
+    reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      increased urine lactate, ketoglutarate, and 2-oxoacid levels.
+    explanation: >-
+      The clinical summary in the abstract lists increased urinary lactate,
+      ketoglutarate, and 2-oxoacid levels in LIPT1 deficiency.
 genetic:
 - name: LIPT1 loss-of-function variants
   association: Causative
@@ -622,16 +730,28 @@ genetic:
       Additional reported patient with a homozygous LIPT1 variant, expanding the
       phenotypic spectrum to include congenital sideroblastic anemia.
 treatments:
-- name: Supportive care
+- name: Lipoic acid supplementation (limited evidence)
   description: >
-    Management is primarily supportive with anticonvulsant therapy and
-    nutritional support. Lipoic acid supplementation has been tested in yeast
-    models and patient fibroblasts with limited improvement.
+    Lipoic acid supplementation has been tested in yeast models and patient
+    fibroblasts, with limited biochemical improvement and review-level evidence
+    arguing against established clinical benefit.
   treatment_term:
-    preferred_term: supportive care
+    preferred_term: pharmacotherapy
     term:
-      id: MAXO:0000950
-      label: supportive care
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: alpha-lipoic acid
+      term:
+        id: CHEBI:16494
+        label: lipoic acid
+  target_mechanisms:
+  - target: Combined alpha-ketoacid dehydrogenase deficiency with spared glycine cleavage
+    treatment_effect: MODULATES
+    description: >-
+      Lipoic acid supplementation may partially modulate downstream lactate
+      readouts in models, but it has not been established as clinically
+      effective for LIPT1 deficiency.
   evidence:
   - reference: PMID:24341803
     reference_title: "Mutations in human lipoyltransferase gene LIPT1 cause a Leigh disease with secondary deficiency for pyruvate and alpha-ketoglutarate dehydrogenase."


### PR DESCRIPTION
## Summary
- connect the LIPT1 lipoyl-relay defect to biochemical endpoints and downstream clinical phenotypes
- replace weakly supported over-specific phenotypes with directly supported abnormal muscle tone, global developmental delay, and sideroblastic anemia
- add an erythroid-lineage lipoylation/proliferation pathophysiology node for the 2024 sideroblastic anemia report
- retitle the limited lipoic-acid intervention so treatment evidence and target mechanism match the actual cited intervention

## Validation
- `just validate kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml`
- recursive normalized snippet audit: 46 snippets found in cache
- graph audit: 4 pathophysiology nodes, 12 downstream edges, all current phenotypes/biochemical findings targeted
- `uv run python -m dismech.graph --validate kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml`
- `git diff --check`

## Review
- subagent blocker review: no blockers found
- applied review suggestions by updating prevalence for the 2024 patient, adding edge-level evidence, and making the erythroid mechanism explicit

## Scope
- intentionally scoped to `kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml`
- restored generated cache churn after validation