### PR TITLE
Improve Acute Intermittent Porphyria pathograph connectivity

### DIFF
--- a/kb/disorders/Acute_Intermittent_Porphyria.yaml
+++ b/kb/disorders/Acute_Intermittent_Porphyria.yaml
@@ -1,6 +1,6 @@
 name: Acute Intermittent Porphyria
 creation_date: '2026-04-21T04:42:02Z'
-updated_date: '2026-04-22T21:54:51Z'
+updated_date: '2026-05-07T15:50:32Z'
 category: Mendelian
 synonyms:
 - AIP
@@ -38,7 +38,7 @@ inheritance:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Acute intermittent porphyria (AIP) is transmitted as an autosomal
       dominant disorder with incomplete penetrance.
@@ -55,7 +55,7 @@ prevalence:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Recent population studies suggest that the prevalence of asymptomatic
       heterozygotes for a mutant AIP gene may be in the range of 1 in 2,000.
@@ -73,7 +73,7 @@ mechanistic_hypotheses:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Biochemical abnormalities are thought to result from primary defects of
       porphobilinogen deaminase (PBGD; also called hydroxymethyl bilane
@@ -93,7 +93,7 @@ mechanistic_hypotheses:
   - reference: PMID:35067977
     reference_title: "RNAi therapy with givosiran significantly reduces attack rates in acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       The clinical manifestations of AHP are attributed to the accumulation of
       the heme precursor 5-aminolevulinic acid (ALA) and porphobilinogen (PBG).
@@ -145,9 +145,23 @@ pathophysiology:
       places it at the third step of heme biosynthesis.
   downstream:
   - target: Triggered hepatic ALAS1 induction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >-
       The partial HMBS block creates attack susceptibility when hepatic ALAS1 is
       induced by physiologic or environmental stressors.
+    evidence:
+    - reference: PMID:29498764
+      reference_title: "Recurrent attacks of acute hepatic porphyria: major role of the chronic inflammatory response in the liver."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Acute intermittent porphyria (AIP) is an inherited disorder of haem
+        metabolism characterized by life-threatening acute neurovisceral attacks
+        due to the induction of hepatic δ-aminolevulinic acid synthase 1 (ALAS1)
+        associated with hydroxymethylbilane synthase (HMBS) deficiency.
+      explanation: >-
+        Human recurrent-AIP study background directly ties acute attack biology
+        to hepatic ALAS1 induction in the setting of HMBS deficiency.
 - name: Triggered hepatic ALAS1 induction
   description: >-
     Porphyrogenic triggers increase hepatic ALAS1 expression, pushing pathway
@@ -172,7 +186,7 @@ pathophysiology:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Biochemical abnormalities are thought to result from primary defects of
       porphobilinogen deaminase (PBGD; also called hydroxymethyl bilane
@@ -196,9 +210,28 @@ pathophysiology:
       setting of HMBS deficiency.
   downstream:
   - target: Hepatic ALA and PBG accumulation
+    causal_link_type: DIRECT
     description: >-
       Increased ALAS1-driven upstream flux leads to overproduction of ALA and
       PBG across the partial HMBS block.
+    evidence:
+    - reference: PMID:9516674
+      reference_title: "Acute intermittent porphyria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Biochemical abnormalities are thought to result from primary defects of
+        porphobilinogen deaminase (PBGD; also called hydroxymethyl bilane
+        synthase), the third enzyme of the heme synthesis pathway, and
+        consecutive hepatic overexpression of the first enzyme of the pathway,
+        5-aminolevulinate synthase. As a result of these enzymatic disturbances,
+        heme precursors are synthesized in excess in the liver, and massive
+        amounts of compounds upstream of the enzymatic block are excreted in
+        urine.
+      explanation: >-
+        Review evidence supports the mechanistic link between the HMBS/PBGD
+        block, hepatic ALAS1 overexpression, excess hepatic heme precursors, and
+        urinary excretion of upstream compounds.
 - name: Hepatic ALA and PBG accumulation
   description: >-
     Increased upstream pathway flux in the setting of partial HMBS deficiency
@@ -229,7 +262,7 @@ pathophysiology:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       As a result of these enzymatic disturbances, heme precursors are
       synthesized in excess in the liver, and massive amounts of compounds
@@ -240,7 +273,7 @@ pathophysiology:
   - reference: PMID:35067977
     reference_title: "RNAi therapy with givosiran significantly reduces attack rates in acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       The clinical manifestations of AHP are attributed to the accumulation of
       the heme precursor 5-aminolevulinic acid (ALA) and porphobilinogen (PBG).
@@ -248,10 +281,60 @@ pathophysiology:
       This review identifies ALA and PBG accumulation as the proximate toxic
       biochemical lesion driving clinical disease.
   downstream:
+  - target: Urinary 5-aminolevulinic acid
+    causal_link_type: DIRECT
+    description: >-
+      Hepatic overproduction and systemic spillover of ALA produces increased
+      urinary ALA during acute attacks.
+    evidence:
+    - reference: PMID:19327613
+      reference_title: >-
+        Plasma porphobilinogen as a sensitive biomarker to monitor the clinical
+        and therapeutic course of acute intermittent porphyria attacks.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        During an acute attack the heme precursors porphobilinogen (PBG) and
+        5-aminolevulinic acid (ALA) are produced in high amounts by the liver and
+        are found in high concentrations in plasma and urine.
+      explanation: >-
+        Patient attack monitoring directly supports hepatic ALA production with
+        increased urinary ALA.
+  - target: Urinary porphobilinogen
+    causal_link_type: DIRECT
+    description: >-
+      Hepatic overproduction and systemic spillover of PBG produces increased
+      urinary PBG during acute attacks.
+    evidence:
+    - reference: PMID:19327613
+      reference_title: >-
+        Plasma porphobilinogen as a sensitive biomarker to monitor the clinical
+        and therapeutic course of acute intermittent porphyria attacks.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        During an acute attack the heme precursors porphobilinogen (PBG) and
+        5-aminolevulinic acid (ALA) are produced in high amounts by the liver and
+        are found in high concentrations in plasma and urine.
+      explanation: >-
+        Patient attack monitoring directly supports hepatic PBG production with
+        increased urinary PBG.
   - target: Neurovisceral attack susceptibility
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >-
       Excess precursor burden is linked to acute autonomic, peripheral, and
       central neurologic dysfunction.
+    evidence:
+    - reference: PMID:35067977
+      reference_title: "RNAi therapy with givosiran significantly reduces attack rates in acute intermittent porphyria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        The clinical manifestations of AHP are attributed to the accumulation of
+        the heme precursor 5-aminolevulinic acid (ALA) and porphobilinogen (PBG).
+      explanation: >-
+        Review evidence supports accumulated ALA and PBG as the upstream driver
+        of acute hepatic porphyria manifestations.
 - name: Neurovisceral attack susceptibility
   description: >-
     Acute attacks manifest as abdominal pain and neurologic dysfunction,
@@ -271,7 +354,7 @@ pathophysiology:
   - reference: PMID:33786855
     reference_title: "Porphyric neuropathy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Acute hepatic porphyrias are inherited metabolic disorders that may
       present with polyneuropathy, which if not diagnosed early can lead to
@@ -279,6 +362,139 @@ pathophysiology:
     explanation: >-
       This review supports severe neuropathic weakness as a clinically relevant
       downstream consequence of acute hepatic porphyria attacks.
+  downstream:
+  - target: Abdominal pain
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - autonomic and visceral pain pathways during acute neurovisceral crises
+    description: >-
+      Abdominal pain is the most common clinical expression of acute
+      neurovisceral crises.
+    evidence:
+    - reference: PMID:19292878
+      reference_title: "Acute intermittent porphyria--impact of mutations found in the hydroxymethylbilane synthase gene on biochemical and enzymatic protein properties."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Clinical features include autonomous, central, motor or sensory symptoms,
+        but the most common clinical presentation is abdominal pain caused by
+        neurovisceral crises.
+      explanation: >-
+        This patient-based molecular study's clinical summary directly connects
+        neurovisceral crises to abdominal pain.
+  - target: Nausea and vomiting
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - gastrointestinal involvement during acute AIP episodes
+    description: >-
+      Gastrointestinal neurovisceral attacks commonly include nausea and
+      vomiting alongside abdominal pain.
+    evidence:
+    - reference: PMID:33139977
+      reference_title: >-
+        Acute intermittent porphyria: focus on possible mechanisms of acute and
+        chronic manifestations.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Acute AIP episodes may present with abdominal pain, nausea, and vomiting,
+        and repeated episodes may result in a series of chronic injuries.
+      explanation: >-
+        Review evidence supports nausea and vomiting as components of acute AIP
+        episodes.
+  - target: Tachycardia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - autonomic overactivity during acute attacks
+    description: >-
+      Autonomic overactivity during attacks produces tachycardia and other
+      dysautonomic manifestations.
+    evidence:
+    - reference: PMID:4723462
+      reference_title: >-
+        Acute intermittent porphyria: response of tachycardia and hypertension to
+        propranolol.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In four young adult patients with acute attacks of acute intermittent
+        porphyria tachycardia and hypertension were prominent features of the
+        illness.
+      explanation: >-
+        Case-series evidence directly supports tachycardia during acute AIP
+        attacks.
+  - target: Peripheral neuropathy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - acute to subacute motor-predominant axonal porphyric neuropathy
+    description: >-
+      Acute hepatic porphyria attacks can progress to motor-predominant
+      porphyric neuropathy.
+    evidence:
+    - reference: PMID:33786855
+      reference_title: "Porphyric neuropathy."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Acute hepatic porphyrias are inherited metabolic disorders that may
+        present with polyneuropathy, which if not diagnosed early can lead to
+        quadriparesis, respiratory weakness, and death.
+      explanation: >-
+        Review evidence supports polyneuropathy as a neurologic manifestation of
+        acute hepatic porphyrias.
+  - target: Muscle weakness
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - motor-predominant porphyric neuropathy causing quadriparesis or respiratory weakness
+    description: >-
+      Motor-predominant porphyric neuropathy can cause quadriparesis and
+      respiratory weakness in severe attacks.
+    evidence:
+    - reference: PMID:33786855
+      reference_title: "Porphyric neuropathy."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Acute hepatic porphyrias are inherited metabolic disorders that may
+        present with polyneuropathy, which if not diagnosed early can lead to
+        quadriparesis, respiratory weakness, and death.
+      explanation: >-
+        Review evidence supports severe weakness as a downstream consequence of
+        porphyric neuropathy.
+  - target: Hyponatremia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - autonomic and hypothalamic-pituitary dysregulation with inappropriate antidiuretic hormone secretion
+    description: >-
+      Acute AIP presentations can include SIADH-associated hyponatremia as part
+      of the neurovisceral attack spectrum.
+    evidence:
+    - reference: PMID:26366103
+      reference_title: "An update of clinical management of acute intermittent porphyria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        The clinical criteria of an acute attack include the paroxysmal nature
+        and various combinations of symptoms, such as abdominal pain, autonomic
+        dysfunction, hyponatremia, muscle weakness, or mental symptoms, in the
+        absence of other obvious causes.
+      explanation: >-
+        Clinical management review evidence explicitly includes hyponatremia
+        among acute attack criteria.
+    - reference: PMID:25796467
+      reference_title: >-
+        Abdominal pain and syndrome of inappropriate antidiuretic hormone
+        secretion as clinical presentation of acute intermittent porphyria.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Acute intermittent porphyria (AIP) is a rare condition characterized by
+        abdominal pain and a wide range of nonspecific symptoms. We report the
+        case of a woman with abdominal pain and syndrome of inappropriate
+        antidiuretic hormone secretion (SIADH) as clinical presentation of AIP.
+      explanation: >-
+        Case-report evidence supports SIADH as an acute AIP presentation,
+        matching the intermediate mechanism for hyponatremia.
 phenotypes:
 - name: Abdominal pain
   description: >-
@@ -314,7 +530,7 @@ phenotypes:
   - reference: PMID:33786855
     reference_title: "Porphyric neuropathy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Acute hepatic porphyrias are inherited metabolic disorders that may
       present with polyneuropathy, which if not diagnosed early can lead to
@@ -335,7 +551,7 @@ phenotypes:
   - reference: PMID:33786855
     reference_title: "Porphyric neuropathy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Acute hepatic porphyrias are inherited metabolic disorders that may
       present with polyneuropathy, which if not diagnosed early can lead to
@@ -381,7 +597,7 @@ phenotypes:
       Acute intermittent porphyria: focus on possible mechanisms of acute and
       chronic manifestations.
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Acute AIP episodes may present with abdominal pain, nausea, and vomiting,
       and repeated episodes may result in a series of chronic injuries.
@@ -485,7 +701,7 @@ environmental:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       These symptoms occur during acute attacks, which are often precipitated
       by drugs, alcohol, low caloric intake, or infections.
@@ -553,7 +769,7 @@ treatments:
   - reference: PMID:33786855
     reference_title: "Porphyric neuropathy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: >-
       Timely treatment with intravenous heme, carbohydrate loading, and
       avoidance of porphyrinogenic medications can prevent further neurological
@@ -585,7 +801,7 @@ treatments:
     - reference: PMID:35067977
       reference_title: "RNAi therapy with givosiran significantly reduces attack rates in acute intermittent porphyria."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: >-
         The results of clinical trials have shown that givosiran treatment
         leads to a rapid and sustained reduction of ALAS1 mRNA, decreased heme

--- a/references_cache/PMID_26366103.md
+++ b/references_cache/PMID_26366103.md
@@ -1,0 +1,66 @@
+---
+reference_id: "PMID:26366103"
+title: An update of clinical management of acute intermittent porphyria.
+authors:
+- Pischik E
+- Kauppinen R
+journal: Appl Clin Genet
+year: '2015'
+doi: 10.2147/TACG.S48605
+content_type: abstract_only
+---
+
+# An update of clinical management of acute intermittent porphyria.
+**Authors:** Pischik E, Kauppinen R
+**Journal:** Appl Clin Genet (2015)
+**DOI:** [10.2147/TACG.S48605](https://doi.org/10.2147/TACG.S48605)
+
+## Content
+
+1. Appl Clin Genet. 2015 Sep 1;8:201-14. doi: 10.2147/TACG.S48605. eCollection
+2015.
+
+An update of clinical management of acute intermittent porphyria.
+
+Pischik E(1), Kauppinen R(2).
+
+Author information:
+(1)Porphyria Research Unit, Division of Endocrinology, Department of Medicine,
+University Central Hospital of Helsinki, Helsinki, Finland ; Department of
+Neurology, Consultative and Diagnostic Centre with Polyclinics, St Petersburg,
+Russia.
+(2)Porphyria Research Unit, Division of Endocrinology, Department of Medicine,
+University Central Hospital of Helsinki, Helsinki, Finland.
+
+Acute intermittent porphyria (AIP) is due to a deficiency of the third enzyme,
+the hydroxymethylbilane synthase, in heme biosynthesis. It manifests with
+occasional neuropsychiatric crises associated with overproduction of porphyrin
+precursors, aminolevulinic acid and porphobilinogen. The clinical criteria of an
+acute attack include the paroxysmal nature and various combinations of symptoms,
+such as abdominal pain, autonomic dysfunction, hyponatremia, muscle weakness, or
+mental symptoms, in the absence of other obvious causes. Intensive abdominal
+pain without peritoneal signs, acute peripheral neuropathy, and encephalopathy
+usually with seizures or psychosis are the key symptoms indicating possible
+acute porphyria. More than fivefold elevation of urinary porphobilinogen
+excretion together with typical symptoms of an acute attack is sufficient to
+start a treatment. Currently, the prognosis of the patients with AIP is good,
+but physicians should be aware of a potentially fatal outcome of the disease.
+Mutation screening and identification of type of acute porphyria can be done at
+the quiescent phase of the disease. The management of patients with AIP include
+following strategies: A, during an acute attack: 1) treatment with heme
+preparations, if an acute attack is severe or moderate; 2) symptomatic treatment
+of autonomic dysfunctions, polyneuropathy and encephalopathy; 3) exclusion of
+precipitating factors; and 4) adequate nutrition and fluid therapy. B, during
+remission: 1) exclusion of precipitating factors (education of patients and
+family doctors), 2) information about on-line drug lists, and 3) mutation
+screening for family members and education about precipitating factors in
+mutation-positive family members. C, management of patients with recurrent
+attacks: 1) evaluation of the lifestyle, 2) evaluation of hormonal therapy in
+women, 3) prophylactic heme therapy, and 4) liver transplantation in patients
+with severe recurrent attacks. D, follow-up of the AIP patients for long-term
+complications: chronic hypertension, chronic kidney insufficiency, chronic pain
+syndrome, and hepatocellular carcinoma.
+
+DOI: 10.2147/TACG.S48605
+PMCID: PMC4562648
+PMID: 26366103


### PR DESCRIPTION
## Summary
- add causal link types and edge-level evidence throughout the AIP mechanism graph
- connect hepatic ALA/PBG accumulation to urinary ALA/PBG and neurovisceral attack susceptibility
- connect neurovisceral attack susceptibility to all current clinical phenotypes with explicit edge evidence
- reclassify review evidence sources as OTHER and add cached PMID:26366103 for hyponatremia support

## Validation
- just validate kb/disorders/Acute_Intermittent_Porphyria.yaml
- just validate-references kb/disorders/Acute_Intermittent_Porphyria.yaml
- just check-reference-cache-frontmatter
- uv run python -m dismech.graph --validate kb/disorders/Acute_Intermittent_Porphyria.yaml
- custom recursive snippet audit: 45 snippets checked, all found in cache
- custom graph audit: 4 pathophysiology nodes, 11 downstream edges, 6/6 phenotypes and 2/2 biochemical endpoints targeted, all edges have causal_link_type and edge evidence

Note: local validators repeatedly normalized unrelated clinicaltrials cache files; I restored that generated churn before commit.