### PR TITLE
Improve CPT2 deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
+++ b/kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Carnitine Palmitoyltransferase II Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-07T17:05:32Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -57,11 +57,108 @@ pathophysiology:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: CPT (carnitine palmitoyltransferase) II muscle deficiency is the most common form of muscle fatty acid metabolism disorders.
     explanation: Directly supports impaired fatty acid oxidation as the core defect in CPT II deficiency.
   downstream:
+  - target: Long-chain acylcarnitines (C16, C18:1)
+    description: CPT2 impairment blocks reconversion of long-chain acylcarnitines to long-chain acyl-CoA, producing the characteristic plasma long-chain acylcarnitine signature.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The plasma acylcarnitine profile shows elevated C16, C18:1, and C18:2 carnitine species.
+      explanation: Review-level CPT2 deficiency summary identifies elevated long-chain acylcarnitines as the biochemical consequence of the CPT2 block.
+  - target: Free carnitine (C0)
+    description: Long-chain acyl group trapping as acylcarnitine esters can reduce the free carnitine pool in symptomatic patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Accumulated long-chain acyl groups are esterified to carnitine when CPT2 cannot efficiently regenerate acyl-CoA in the mitochondrial matrix.
+    evidence:
+    - reference: PMID:38650450
+      reference_title: "Clinical characteristics and genetic analysis of six children with carnitine palmitoyltransferase 2 deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Five children presented with decreased free carnitine and elevated levels of palmitoyl and octadecenoyl carnitines.
+      explanation: Human pediatric CPT2 cases show decreased free carnitine alongside elevated long-chain acylcarnitines.
+  - target: Palmitoyl-carnitine in muscle
+    description: CPT2-deficient oxidative skeletal muscle accumulates palmitoyl-carnitine, providing the upstream substrate for LCAC-mediated calcium handling injury.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39182841
+      reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Cpt2Sk-/- soleus had decreased calcium uptake and significant accumulation of palmitoyl-carnitine, suggesting that LCACs and calcium dyshomeostasis are linked in skeletal muscle.
+      explanation: Muscle-specific Cpt2-deficient mice accumulate palmitoyl-carnitine in oxidative muscle.
   - target: LCAC-mediated calcium dyshomeostasis in skeletal muscle
+    description: Accumulated LCACs, including palmitoyl-carnitine, inhibit sarcoplasmic reticulum calcium uptake in CPT2-deficient muscle.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Long-chain acylcarnitine accumulation links the mitochondrial beta-oxidation block to sarcoplasmic reticulum calcium uptake defects.
+    evidence:
+    - reference: PMID:39182841
+      reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Cpt2Sk-/- soleus had decreased calcium uptake and significant accumulation of palmitoyl-carnitine, suggesting that LCACs and calcium dyshomeostasis are linked in skeletal muscle.
+      explanation: Cpt2-deficient mouse soleus links palmitoyl-carnitine accumulation to reduced calcium uptake.
+    - reference: PMID:39182841
+      reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Exposing isolated sarcoplasmic reticulum to long-chain acylcarnitines (LCACs) inhibited calcium uptake.
+      explanation: Isolated sarcoplasmic reticulum data directly support LCAC inhibition of calcium uptake.
+  - target: Hypoketotic hypoglycemia
+    description: Severe hepatic long-chain FAO impairment reduces fasting energy and ketone production, producing hypoketotic hypoglycemia in neonatal and infantile forms.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic fatty acid oxidation failure lowers acetyl-CoA supply for ketogenesis and fasting energy homeostasis.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: A severe neonatal form presents in the first few days after birth with cardiomyopathy, hypoketotic hypoglycemia, multiorgan dysfunction and failure (including liver and heart), neuronal migration defects, and cystic kidneys.
+      explanation: Review-level CPT2 deficiency summary links severe CPT2 deficiency to hypoketotic hypoglycemia.
+  - target: Cardiomyopathy
+    description: Cardiac long-chain FAO dependence makes severe CPT2 deficiency manifest as cardiomyopathy and heart failure.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cardiomyocyte energy failure occurs when long-chain fatty acid oxidation cannot meet cardiac energy demand.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: A severe neonatal form presents in the first few days after birth with cardiomyopathy, hypoketotic hypoglycemia, multiorgan dysfunction and failure (including liver and heart), neuronal migration defects, and cystic kidneys.
+      explanation: Review-level CPT2 deficiency summary includes cardiomyopathy and heart involvement in severe disease.
+  - target: Liver dysfunction
+    description: Hepatic long-chain FAO failure contributes to liver dysfunction or failure in severe neonatal and infantile CPT2 deficiency.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic energy failure during fasting or illness impairs liver function in severe CPT2 deficiency.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Later-onset, infantile disease is characterized by liver failure, cardiomyopathy, myopathy, and ketotic hypoglycemia in the first year of life.
+      explanation: Review-level CPT2 deficiency summary supports liver failure as a severe infantile manifestation.
+  - target: Metabolic myofiber injury and rhabdomyolysis
+    description: In skeletal muscle, long-chain FAO failure creates ATP stress and toxic lipid intermediate accumulation that lead to episodic myofiber breakdown.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ATP deficit and accumulated long-chain lipid intermediates impair muscle contraction and myofiber integrity under stress.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Partial deficiency of CPT2 activity typically leads to episodes of recurrent rhabdomyolysis in adolescence or adulthood, the most common phenotype in this disorder.
+      explanation: Review-level CPT2 deficiency summary links partial CPT2 activity to recurrent rhabdomyolysis.
 - name: Thermolability of mutant CPT-II enzyme
   description: 'The common myopathic variant p.Ser113Leu produces an enzyme with near-normal baseline activity but marked thermolability at elevated temperatures (40-45 degrees C) and abnormal sensitivity to inhibition by malonyl-CoA. This provides a mechanistic rationale for fever- and exertion-triggered metabolic crises, as the mutant enzyme loses activity precisely when fatty acid oxidation demand is greatest.
 
@@ -75,17 +172,26 @@ pathophysiology:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: OTHER
     snippet: the wild-type and the S113L variants showed the same enzymatic activity. However, the mutated enzyme showed an abnormal thermal destabilization at 40 and 45 °C and an abnormal sensitivity to inhibition by malony-CoA.
     explanation: Demonstrates thermolability of S113L variant and abnormal malonyl-CoA sensitivity using recombinant enzymes.
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: OTHER
     snippet: The thermolability of the mutant enzyme might explain why symptoms in muscle CPT II deficiency mainly occur during prolonged exercise, infections and exposure to cold.
     explanation: Links thermolability mechanism to clinical trigger factors.
   downstream:
   - target: Impaired mitochondrial long-chain fatty acid oxidation
+    description: Heat- and inhibitor-sensitive CPT2 variants lose functional activity during stress, reducing cellular beta-oxidation and ATP generation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28054946
+      reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Cultured fibroblasts of three types of CPT II variants (p.V368I (heterozygous); p.V368I (homozygous); p.F352C (heterozygous) + p.V368I (homozygous)) showed decreased enzyme activities, cellular β-oxidation and ATP generation.
+      explanation: Review-level evidence links thermolabile CPT2 variants to reduced beta-oxidation and ATP generation.
 - name: LCAC-mediated calcium dyshomeostasis in skeletal muscle
   description: 'In CPT2-deficient muscle, accumulation of long-chain acylcarnitines (LCACs), particularly palmitoyl-carnitine, directly inhibits sarcoplasmic reticulum calcium uptake, disrupts excitation-contraction coupling structures, and increases mitochondrial calcium stress and permeability transition pore susceptibility. This leads to contractile dysfunction and myofiber injury beyond simple energy failure.
 
@@ -112,6 +218,130 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: Exposing isolated sarcoplasmic reticulum to long-chain acylcarnitines (LCACs) inhibited calcium uptake.
     explanation: Directly demonstrates LCAC-mediated inhibition of SR calcium uptake in CPT2-deficient muscle model.
+  downstream:
+  - target: Metabolic myofiber injury and rhabdomyolysis
+    description: LCAC-driven calcium uptake impairment and contractile proteome disruption compromise muscle structure and function.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39182841
+      reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Our data demonstrate that loss of CPT2 and mLCFAO compromise muscle structure and function due to excessive mitochondrial biogenesis, downregulation of the contractile proteome, and disruption of calcium homeostasis.
+      explanation: The Cpt2-deficient mouse study supports muscle structural and functional injury downstream of calcium homeostasis disruption.
+- name: Metabolic myofiber injury and rhabdomyolysis
+  description: 'During metabolic stress, CPT2-deficient skeletal muscle cannot meet energy demands from long-chain fatty acid oxidation and accumulates lipid intermediates. The resulting ATP stress, calcium dyshomeostasis, and contractile structure disruption lead to episodic myofiber injury, rhabdomyolysis, leakage of creatine kinase and myoglobin, and secondary renal risk.
+
+    '
+  biological_processes:
+  - preferred_term: muscle contraction
+    term:
+      id: GO:0006936
+      label: muscle contraction
+    modifier: DECREASED
+  cell_types:
+  - preferred_term: skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  evidence:
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Partial deficiency of CPT2 activity typically leads to episodes of recurrent rhabdomyolysis in adolescence or adulthood, the most common phenotype in this disorder.
+    explanation: Review-level CPT2 deficiency summary supports recurrent rhabdomyolysis as the main skeletal-muscle outcome of partial CPT2 activity.
+  - reference: PMID:39182841
+    reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: Our data demonstrate that loss of CPT2 and mLCFAO compromise muscle structure and function due to excessive mitochondrial biogenesis, downregulation of the contractile proteome, and disruption of calcium homeostasis.
+    explanation: Cpt2-deficient mouse muscle data provide mechanistic support for muscle structural and contractile injury.
+  downstream:
+  - target: Rhabdomyolysis
+    description: Metabolic myofiber injury manifests clinically as recurrent rhabdomyolysis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Partial deficiency of CPT2 activity typically leads to episodes of recurrent rhabdomyolysis in adolescence or adulthood, the most common phenotype in this disorder.
+      explanation: Review-level CPT2 deficiency summary directly supports rhabdomyolysis downstream of partial CPT2 activity.
+  - target: Myalgia
+    description: Recurrent myofiber metabolic injury produces attacks of muscle pain.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28054946
+      reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Clinical features are attacks of muscle weakness, myalgia, pain and rhabdomyolysis with or without renal failure.
+      explanation: Review-level clinical summary places myalgia in the same attack phenotype as rhabdomyolysis.
+  - target: Muscle weakness
+    description: Acute myofiber dysfunction during attacks manifests as episodic muscle weakness.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28054946
+      reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Clinical features are attacks of muscle weakness, myalgia, pain and rhabdomyolysis with or without renal failure.
+      explanation: Review-level clinical summary includes muscle weakness during CPT2 attack episodes.
+  - target: Episodic muscle stiffness
+    description: Attack-related contractile dysfunction manifests as stiffness and cramps during exercise or febrile illness.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37933340
+      reference_title: "Myopathic Carnitine Palmitoyltransferase II (CPT II) Deficiency: A Rare Cause of Acute Kidney Injury and Cardiomyopathy."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The latter is characterized by muscle pain and weakness and stiffness, typically triggered by exercise or febrile illnesses
+      explanation: Human clinical case-report summary links myopathic CPT2 attacks to muscle stiffness.
+  - target: Myoglobinuria
+    description: Rhabdomyolysis releases myoglobin from damaged myofibers into urine.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Myofiber breakdown releases myoglobin that is filtered by the kidney.
+    evidence:
+    - reference: PMID:28054946
+      reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The main clinical symptoms in patients with muscle carnitine palmitoyl transferase II deficiency are attacks of myalgia and myoglobinuria, possibly leading to renal failure.
+      explanation: Review-level clinical summary links attack-related muscle symptoms to myoglobinuria and renal failure risk.
+  - target: Elevated creatine kinase
+    description: Damaged skeletal muscle releases creatine kinase into serum during rhabdomyolysis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: CK levels are high during rhabdomyolysis but may return to normal or be only mildly elevated when affected individuals are well.
+      explanation: Review-level CPT2 deficiency summary directly links rhabdomyolysis episodes to high CK.
+  - target: Creatine kinase
+    description: Serum CK rises as a biochemical marker of attack-related myofiber injury.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: CK levels are high during rhabdomyolysis but may return to normal or be only mildly elevated when affected individuals are well.
+      explanation: Review-level CPT2 deficiency summary supports increased CK as a biochemical marker during rhabdomyolysis.
+  - target: Acute kidney injury
+    description: Massive rhabdomyolysis can cause AKI through myoglobin-mediated renal injury.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Myoglobin release during rhabdomyolysis injures renal tubules and can require renal replacement therapy.
+    evidence:
+    - reference: PMID:37933340
+      reference_title: "Myopathic Carnitine Palmitoyltransferase II (CPT II) Deficiency: A Rare Cause of Acute Kidney Injury and Cardiomyopathy."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: One of the most common complications is acute kidney injury (AKI) following massive rhabdomyolysis, which is managed with aggressive fluid therapy
+      explanation: Human clinical summary directly identifies AKI as a complication following massive rhabdomyolysis.
 - name: Carnitine shuttle disruption
   description: 'CPT-II is the final enzyme of the three-component carnitine shuttle that transports long-chain fatty acids into the mitochondrial matrix. CPT-I on the outer mitochondrial membrane converts acyl-CoA to acylcarnitine, CACT translocates acylcarnitine across the inner membrane, and CPT-II regenerates acyl-CoA inside the mitochondrion. Loss of CPT-II activity blocks this shuttle at its terminal step.
 
@@ -130,11 +360,20 @@ pathophysiology:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: The carnitine palmitoyltransferase (CPT) system consists of two enzymes, CPT I and CPT II, and is involved in the transport of long-chain fatty acids into the mitochondrial compartment. The enzymes are located in the outer (CPT I) and inner mitochondrial membrane (CPT II).
     explanation: Describes the carnitine shuttle system and localization of CPT-I and CPT-II.
   downstream:
   - target: Impaired mitochondrial long-chain fatty acid oxidation
+    description: Loss of the terminal CPT2 step prevents long-chain acylcarnitines from being regenerated as mitochondrial acyl-CoA substrates for beta-oxidation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: CPT2 is located on the inner surface of the inner mitochondrial membrane and catalyzes conversion of long-chain acylcarnitines back into long-chain acyl-CoA species with return of carnitine to the cytoplasm.
+      explanation: Review-level mechanistic summary directly defines the CPT2 shuttle reaction that supplies long-chain acyl-CoA for beta-oxidation.
 phenotypes:
 - name: Rhabdomyolysis
   frequency: VERY_FREQUENT
@@ -150,13 +389,13 @@ phenotypes:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Clinical features are attacks of muscle weakness, myalgia, pain and rhabdomyolysis with or without renal failure.
     explanation: Directly lists rhabdomyolysis as a clinical feature of muscle CPT II deficiency.
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Following the main clinical symptoms were myoglobinuria (86%) and muscle weakness (76%)
     explanation: Quantifies myoglobinuria at 86% in a cohort of 50 patients.
 - name: Myalgia
@@ -173,7 +412,7 @@ phenotypes:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Almost all patients (94%) described attacks of myalgia.
     explanation: Quantifies myalgia at 94% in cohort study of 50 patients.
   - reference: PMID:37933340
@@ -196,7 +435,7 @@ phenotypes:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Following the main clinical symptoms were myoglobinuria (86%) and muscle weakness (76%)
     explanation: Quantifies muscle weakness at 76% in myopathic CPT II cohort.
 - name: Myoglobinuria
@@ -213,7 +452,7 @@ phenotypes:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Following the main clinical symptoms were myoglobinuria (86%) and muscle weakness (76%)
     explanation: Quantifies myoglobinuria at 86% in myopathic CPT II deficiency cohort.
   - reference: PMID:37933340
@@ -236,7 +475,7 @@ phenotypes:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Clinical features are attacks of muscle weakness, myalgia, pain and rhabdomyolysis with or without renal failure.
     explanation: Lists renal failure as a complication of rhabdomyolysis in CPT II deficiency.
   - reference: PMID:37933340
@@ -286,23 +525,28 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: The first two are early-onset severe disorders presenting with marked hypoketotic hypoglycemia, cardiomyopathy, and liver dysfunction.
     explanation: Identifies cardiomyopathy as a feature of severe early-onset CPT II deficiency.
-- name: Hepatomegaly
-  frequency: OCCASIONAL
-  description: 'Liver enlargement observed in severe infantile and neonatal forms as part of the hepatocardiomuscular presentation, reflecting impaired hepatic fatty acid oxidation and lipid accumulation.
+- name: Liver dysfunction
+  description: 'Decreased liver function and liver failure occur in severe neonatal and infantile CPT2 deficiency as part of the hepatocardiomuscular presentation, reflecting impaired hepatic long-chain fatty acid oxidation during metabolic stress.
 
     '
   phenotype_term:
-    preferred_term: Hepatomegaly
+    preferred_term: Liver dysfunction
     term:
-      id: HP:0002240
-      label: Hepatomegaly
+      id: HP:0001410
+      label: Decreased liver function
   evidence:
   - reference: PMID:37933340
     reference_title: "Myopathic Carnitine Palmitoyltransferase II (CPT II) Deficiency: A Rare Cause of Acute Kidney Injury and Cardiomyopathy."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: The first two are early-onset severe disorders presenting with marked hypoketotic hypoglycemia, cardiomyopathy, and liver dysfunction.
-    explanation: Liver dysfunction in early-onset forms is consistent with hepatomegaly.
+    explanation: Human clinical summary identifies liver dysfunction in severe early-onset CPT II deficiency.
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Later-onset, infantile disease is characterized by liver failure, cardiomyopathy, myopathy, and ketotic hypoglycemia in the first year of life.
+    explanation: Review-level CPT2 deficiency summary supports liver failure in infantile disease.
 - name: Elevated creatine kinase
   frequency: VERY_FREQUENT
   description: 'Markedly elevated serum creatine kinase during rhabdomyolysis episodes, reflecting skeletal muscle damage. CK levels normalize between episodes.
@@ -383,6 +627,12 @@ biochemical:
   - reference: PMID:39182841
     reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
     supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: Cpt2Sk-/- soleus had decreased calcium uptake and significant accumulation of palmitoyl-carnitine, suggesting that LCACs and calcium dyshomeostasis are linked in skeletal muscle.
+    explanation: Cpt2-deficient mouse soleus directly supports palmitoyl-carnitine accumulation in skeletal muscle.
+  - reference: PMID:39182841
+    reference_title: "Loss of mitochondria long-chain fatty acid oxidation impairs skeletal muscle contractility by disrupting myofibril structure and calcium homeostasis."
+    supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: Exposing isolated sarcoplasmic reticulum to long-chain acylcarnitines (LCACs) inhibited calcium uptake.
     explanation: Directly supports palmitoyl-carnitine-mediated inhibition of calcium handling in muscle.
@@ -394,7 +644,7 @@ genetic:
     - reference: PMID:28054946
       reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: The disease follows an autosomal recessive mode of inheritance.
       explanation: Directly states autosomal recessive inheritance for CPT II deficiency.
   variants:
@@ -406,7 +656,7 @@ genetic:
     - reference: PMID:28054946
       reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: In approximately 90% the molecular basis is a p. S113L mutation in homozygous or heterozygous state with an allele frequency of 60%–70%
       explanation: Quantifies S113L prevalence and allele frequency in myopathic CPT II cohort.
   - name: CPT2 - c.338C>T and c.482G>A compound heterozygote
@@ -421,7 +671,7 @@ genetic:
     - reference: PMID:28054946
       reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: In addition there are more than 60 mostly private mutations
       explanation: Documents the breadth of private CPT2 mutations beyond S113L.
     - reference: PMID:38650450
@@ -437,7 +687,7 @@ genetic:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: 'Three phenotypes of CPT II deficiency are known: a lethal neonatal form, a severe infantile hepatocardiomuscular form, and a mild myopathic form'
     explanation: Describes the three clinical phenotypes of CPT II deficiency.
   - reference: PMID:39429887
@@ -455,7 +705,7 @@ environmental:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: The most common trigger factors were exercise (87%) and infection (62%).
     explanation: Quantifies exercise as the most common trigger at 87%.
 - name: Fasting
@@ -466,7 +716,7 @@ environmental:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Trigger factors are prolonged exercise, fasting, fever and exposure to cold
     explanation: Lists fasting as a recognized trigger factor.
 - name: Fever and infection
@@ -477,13 +727,13 @@ environmental:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: The most common trigger factors were exercise (87%) and infection (62%).
     explanation: Infection is the second most common trigger at 62%.
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: OTHER
     snippet: the mutated enzyme showed an abnormal thermal destabilization at 40 and 45 °C
     explanation: Thermolability of S113L variant at fever-range temperatures explains fever as a trigger.
 - name: Cold exposure
@@ -494,7 +744,7 @@ environmental:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Trigger factors are prolonged exercise, fasting, fever and exposure to cold
     explanation: Lists cold exposure among recognized trigger factors.
 treatments:
@@ -517,7 +767,7 @@ treatments:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Trigger factors are prolonged exercise, fasting, fever and exposure to cold
     explanation: Identification of trigger factors directly supports avoidance strategy.
 - name: High-carbohydrate, low-fat diet
@@ -637,7 +887,7 @@ treatments:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: The disease follows an autosomal recessive mode of inheritance.
     explanation: Autosomal recessive inheritance directly supports the role of genetic counseling for carrier and recurrence risk assessment.
 clinical_trials:

--- a/kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
+++ b/kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
@@ -172,7 +172,7 @@ pathophysiology:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: IN_VITRO
     snippet: the wild-type and the S113L variants showed the same enzymatic activity. However, the mutated enzyme showed an abnormal thermal destabilization at 40 and 45 °C and an abnormal sensitivity to inhibition by malony-CoA.
     explanation: Demonstrates thermolability of S113L variant and abnormal malonyl-CoA sensitivity using recombinant enzymes.
   - reference: PMID:28054946
@@ -189,7 +189,7 @@ pathophysiology:
     - reference: PMID:28054946
       reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: IN_VITRO
       snippet: Cultured fibroblasts of three types of CPT II variants (p.V368I (heterozygous); p.V368I (homozygous); p.F352C (heterozygous) + p.V368I (homozygous)) showed decreased enzyme activities, cellular β-oxidation and ATP generation.
       explanation: Review-level evidence links thermolabile CPT2 variants to reduced beta-oxidation and ATP generation.
 - name: LCAC-mediated calcium dyshomeostasis in skeletal muscle

--- a/kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
+++ b/kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
@@ -733,7 +733,7 @@ environmental:
   - reference: PMID:28054946
     reference_title: "Muscle Carnitine Palmitoyltransferase II Deficiency: A Review of Enzymatic Controversy and Clinical Features."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: IN_VITRO
     snippet: the mutated enzyme showed an abnormal thermal destabilization at 40 and 45 °C
     explanation: Thermolability of S113L variant at fever-range temperatures explains fever as a trigger.
 - name: Cold exposure


### PR DESCRIPTION
## Summary
- Add edge-level causal evidence and causal_link_type values across the CPT2 deficiency pathograph.
- Add a metabolic myofiber injury/rhabdomyolysis mechanism to connect the long-chain FAO defect and LCAC calcium dyshomeostasis to muscle, renal, CK, and myoglobin phenotypes.
- Replace the weak hepatomegaly claim with the supported Liver dysfunction phenotype, and reclassify review-derived PMID:28054946 evidence as OTHER.

## Validation
- just validate kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
- just check-reference-cache-frontmatter
- uv run python -m dismech.graph --validate kb/disorders/Carnitine_Palmitoyltransferase_II_Deficiency.yaml
- custom whitespace-normalized snippet audit: 72 snippets checked, 0 missing
- custom graph audit: 19 downstream edges; all targets resolve; all edges have causal_link_type and edge evidence; all phenotypes and biochemical findings targeted
- subagent blocker review: no important blockers found