### PR TITLE
Improve holocarboxylase synthetase deficiency pathograph

### DIFF
--- a/kb/disorders/Holocarboxylase_Synthetase_Deficiency.yaml
+++ b/kb/disorders/Holocarboxylase_Synthetase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Holocarboxylase Synthetase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-07T19:20:44Z'
 synonyms:
 - HLCS deficiency
 - Biotin-responsive multiple carboxylase deficiency
@@ -47,6 +47,14 @@ pathophysiology:
   downstream:
   - target: Impaired HLCS-mediated protein biotinylation
     description: Reduced HLCS function impairs biotinylation of carboxylase apoproteins.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15992684
+      reference_title: "Molecular genetics of biotin metabolism: old vitamin, new science."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Its covalent attachment to carboxylases is catalyzed by holocarboxylase synthetase.
+      explanation: This review identifies HLCS as the enzyme that directly attaches biotin to carboxylases, supporting the immediate edge from HLCS molecular deficiency to impaired protein biotinylation.
 - name: Impaired HLCS-mediated protein biotinylation
   description: 'HLCS covalently links biotin to apocarboxylases to generate active holocarboxylases. Deficiency impairs this biotinylation step, reducing activation of biotin-dependent carboxylases.
 
@@ -59,6 +67,24 @@ pathophysiology:
   downstream:
   - target: Multiple carboxylase deficiency
     description: Reduced biotinylation leaves multiple carboxylases in low-activity apo forms.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:9350481
+      reference_title: "Multiple carboxylase deficiency: inherited and acquired disorders of biotin metabolism."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Acquired biotin deficiency and the two known congenital disorders of biotin metabolism, biotinidase and holocarboxylase synthetase (HCS) deficiency, all lead to deficiency of the 4 biotin-dependent carboxylases, i.e. to multiple carboxylase deficiency (MCD).
+      explanation: The review directly connects HCS deficiency to deficiency of the four biotin-dependent carboxylases.
+  - target: Cutaneous and hair involvement
+    description: Defective biotin-dependent enzyme activation is associated with cutaneous and hair manifestations in HLCS deficiency.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39194177
+      reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Clinical manifestations include severe metabolic acidosis, hyperammonemia, tachypnea, skin rash, alopecia, feeding problems, hypotonia, developmental delay, seizures, and, in severe cases, death.
+      explanation: The clinical abstract places skin rash and alopecia in the HLCS deficiency phenotype; the intervening tissue-level mechanisms are compressed in this edge.
   evidence:
   - reference: PMID:36890565
     reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
@@ -78,10 +104,40 @@ pathophysiology:
   downstream:
   - target: Disrupted gluconeogenesis and lactic acidosis
     description: PC dysfunction impairs pyruvate anaplerosis and glucose production.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired pyruvate carboxylase biotinylation and activity
+    evidence:
+    - reference: PMID:3918814
+      reference_title: "Rapid differential diagnosis of carboxylase deficiencies and evaluation for biotin-responsiveness in a single blood sample."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "multiple deficiencies of the 3 mitochondrial biotin-dependent carboxylases: propionyl-CoA (PCC), 3-methylcrotonyl-CoA (MCC) and pyruvate carboxylase (PC)"
+      explanation: The enzyme-assay paper identifies pyruvate carboxylase as one of the mitochondrial biotin-dependent carboxylases affected in multiple carboxylase deficiency.
   - target: Impaired leucine catabolism
     description: MCC dysfunction drives accumulation of leucine-pathway intermediates.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired 3-methylcrotonyl-CoA carboxylase biotinylation and activity
+    evidence:
+    - reference: PMID:3918814
+      reference_title: "Rapid differential diagnosis of carboxylase deficiencies and evaluation for biotin-responsiveness in a single blood sample."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "multiple deficiencies of the 3 mitochondrial biotin-dependent carboxylases: propionyl-CoA (PCC), 3-methylcrotonyl-CoA (MCC) and pyruvate carboxylase (PC)"
+      explanation: The enzyme-assay paper identifies 3-methylcrotonyl-CoA carboxylase as one of the mitochondrial biotin-dependent carboxylases affected in multiple carboxylase deficiency.
   - target: Impaired propionate metabolism
     description: PCC dysfunction drives accumulation of propionyl-derived metabolites.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired propionyl-CoA carboxylase biotinylation and activity
+    evidence:
+    - reference: PMID:3918814
+      reference_title: "Rapid differential diagnosis of carboxylase deficiencies and evaluation for biotin-responsiveness in a single blood sample."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "multiple deficiencies of the 3 mitochondrial biotin-dependent carboxylases: propionyl-CoA (PCC), 3-methylcrotonyl-CoA (MCC) and pyruvate carboxylase (PC)"
+      explanation: The enzyme-assay paper identifies propionyl-CoA carboxylase as one of the mitochondrial biotin-dependent carboxylases affected in multiple carboxylase deficiency.
   evidence:
   - reference: PMID:39194177
     reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
@@ -121,6 +177,49 @@ pathophysiology:
   downstream:
   - target: Secondary organic acidemia and ketotic decompensation
     description: Impaired carbohydrate flux contributes to metabolic decompensation under catabolic stress.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Pyruvate and lactate accumulation
+    - Impaired glucose production during catabolic stress
+    evidence:
+    - reference: PMID:32841162
+      reference_title: "Impaired glucose homeostasis and a novel HLCS pathogenic variant in holocarboxylase synthetase deficiency: a report of two cases and brief review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patient 1 was a 7-year-old girl with normal growth and development, presenting with severe hypoglycemia and metabolic acidosis.
+      explanation: Hypoglycemia together with metabolic acidosis supports the decompensation branch downstream of impaired gluconeogenesis.
+  - target: Lactic acidosis
+    description: Pyruvate carboxylase-related impairment manifests clinically as lactic acidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39194177
+      reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: An 8-day-old female neonate presented with severe lactic acidosis, necessitating sedation and mechanical ventilation.
+      explanation: The case directly documents severe lactic acidosis in HLCS deficiency.
+  - target: Hypoglycemia
+    description: Reduced gluconeogenic capacity can present as hypoglycemia during illness or poor intake.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Impaired gluconeogenesis during catabolic stress
+    evidence:
+    - reference: PMID:32841162
+      reference_title: "Impaired glucose homeostasis and a novel HLCS pathogenic variant in holocarboxylase synthetase deficiency: a report of two cases and brief review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patient 1 was a 7-year-old girl with normal growth and development, presenting with severe hypoglycemia and metabolic acidosis.
+      explanation: The report documents severe hypoglycemia in HLCS deficiency.
+  - target: Lactic acid
+    description: Lactate elevation is the biochemical counterpart of lactic acidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39634276
+      reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: urine organic acid analysis revealed elevations in lactate, 3-hydroxybutyric acid, 3-hydroxyisovaleric acid, acetoacetic acid, 3-methylcrotonylglycine, and methylcitric acid.
+      explanation: The case directly reports elevated lactate in urine organic acid analysis.
   evidence:
   - reference: PMID:32841162
     reference_title: "Impaired glucose homeostasis and a novel HLCS pathogenic variant in holocarboxylase synthetase deficiency: a report of two cases and brief review."
@@ -156,6 +255,46 @@ pathophysiology:
   downstream:
   - target: Secondary organic acidemia and ketotic decompensation
     description: Leucine-pathway metabolite accumulation contributes to acute metabolic crisis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - 3-hydroxyisovalerylcarnitine and 3-methylcrotonylglycine accumulation
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
+      explanation: Elevation of leucine-pathway metabolites supports this contribution to organic acidemia.
+  - target: 3-Hydroxyisovalerylcarnitine (C5-OH)
+    description: MCC pathway impairment increases the C5-OH acylcarnitine marker.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
+      explanation: The cohort directly reports increased C5-OH.
+  - target: 3-Hydroxyisovaleric acid
+    description: MCC pathway impairment increases urinary hydroxyisovalerate-class metabolites.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39634276
+      reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: urine organic acid analysis revealed elevations in lactate, 3-hydroxybutyric acid, 3-hydroxyisovaleric acid, acetoacetic acid, 3-methylcrotonylglycine, and methylcitric acid.
+      explanation: The case directly reports elevated 3-hydroxyisovaleric acid.
+  - target: 3-Methylcrotonylglycine
+    description: MCC pathway impairment increases urinary 3-methylcrotonylglycine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
+      explanation: The cohort directly reports increased urinary 3-methylcrotonylglycine.
   evidence:
   - reference: PMID:36890565
     reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
@@ -185,6 +324,36 @@ pathophysiology:
   downstream:
   - target: Secondary organic acidemia and ketotic decompensation
     description: Propionyl-derived metabolite accumulation contributes to decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - 3-hydroxypropionate and methylcitric acid accumulation
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
+      explanation: Elevation of propionate-pathway metabolites supports this contribution to organic acidemia.
+  - target: 3-Hydroxypropionate
+    description: PCC pathway impairment increases urinary 3-hydroxypropionate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
+      explanation: The cohort directly reports increased urinary 3-hydroxypropionate.
+  - target: Methylcitric acid
+    description: PCC pathway impairment increases urinary methylcitric acid.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
+      explanation: The cohort directly reports increased urinary methylcitric acid.
   evidence:
   - reference: PMID:36890565
     reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
@@ -199,8 +368,82 @@ pathophysiology:
   downstream:
   - target: Secondary hyperammonemia
     description: Acute metabolic stress can secondarily impair nitrogen handling.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: She received biotin and was stable until age 8 years when vomiting, severe acidosis, hypoglycemia, and hyperammonemia developed.
+      explanation: The case documents hyperammonemia arising during a severe acidotic decompensation; the precise nitrogen-handling intermediates are not specified in the abstract.
   - target: Glucose dysregulation and hyperglycemic ketoacidosis
     description: Stress-state management can unmask insulin secretion abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Secondary Krebs cycle disturbance in pancreatic beta cells
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We propose that secondary Krebs cycle disturbances affecting pancreatic beta cells impaired glucose-stimulated insulin secretion, resulting in insulinopenia.
+      explanation: The authors propose a Krebs cycle to beta-cell insulin secretion mechanism connecting decompensation to hyperglycemic ketoacidosis.
+  - target: Neurologic metabolic decompensation
+    description: Acidotic decompensation, organic acid accumulation, hypoglycemia, and hyperammonemia can produce acute neurologic dysfunction.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Severe metabolic acidosis
+    - Hypoglycemia
+    - Secondary hyperammonemia
+    evidence:
+    - reference: PMID:39391064
+      reference_title: "Case report: Two siblings with very late onset of holocarboxylase synthase deficiency and a mini-review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Holocarboxylase synthase (HCS) deficiency is an extremely rare metabolic disorder typically presenting as severe neonatal metabolic acidosis, lethargy, hypotonia, vomiting, and seizures.
+      explanation: The review links severe metabolic acidosis to acute neurologic features in typical presentations.
+  - target: Systemic feeding and growth involvement
+    description: Multisystem decompensation and chronic illness can include feeding difficulty and impaired growth.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39634276
+      reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
+      explanation: The abstract reports feeding difficulties and growth retardation as common clinical manifestations alongside metabolic acidosis.
+  - target: Metabolic acidosis
+    description: Organic acid accumulation manifests clinically as metabolic acidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39391064
+      reference_title: "Case report: Two siblings with very late onset of holocarboxylase synthase deficiency and a mini-review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Holocarboxylase synthase (HCS) deficiency is an extremely rare metabolic disorder typically presenting as severe neonatal metabolic acidosis, lethargy, hypotonia, vomiting, and seizures.
+      explanation: This directly supports metabolic acidosis as a manifestation of the decompensation state.
+  - target: Vomiting
+    description: Acute metabolic decompensation commonly presents with vomiting.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: An 11-month-old girl with severe acidosis, lethargy and vomiting, was diagnosed with holocarboxylase synthetase deficiency.
+      explanation: The acute decompensation case directly includes vomiting.
+  - target: Tachypnea
+    description: Severe acidosis can drive rapid breathing as respiratory compensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Respiratory compensation for metabolic acidosis
+    evidence:
+    - reference: PMID:39194177
+      reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Clinical manifestations include severe metabolic acidosis, hyperammonemia, tachypnea, skin rash, alopecia, feeding problems, hypotonia, developmental delay, seizures
+      explanation: The abstract lists tachypnea together with severe metabolic acidosis in HLCS deficiency.
   evidence:
   - reference: PMID:38550975
     reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
@@ -236,6 +479,17 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: She received biotin and was stable until age 8 years when vomiting, severe acidosis, hypoglycemia, and hyperammonemia developed.
     explanation: Documents hyperammonemia during acute HLCS decompensation.
+  downstream:
+  - target: Hyperammonemia
+    description: The secondary nitrogen-disposal disturbance manifests as elevated circulating ammonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: She received biotin and was stable until age 8 years when vomiting, severe acidosis, hypoglycemia, and hyperammonemia developed.
+      explanation: The case directly documents hyperammonemia during HLCS decompensation.
 - name: Glucose dysregulation and hyperglycemic ketoacidosis
   description: 'In some patients, secondary Krebs cycle disturbances may impair pancreatic beta-cell insulin secretion, leading to hyperglycemic ketoacidosis during glucose infusion therapy.
 
@@ -258,10 +512,182 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: We propose that secondary Krebs cycle disturbances affecting pancreatic beta cells impaired glucose-stimulated insulin secretion, resulting in insulinopenia.
     explanation: Provides mechanistic hypothesis for glucose dysregulation in HLCS decompensation.
+  downstream:
+  - target: Hyperglycemia
+    description: Impaired glucose-stimulated insulin secretion can cause hyperglycemia during glucose infusion.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Insulinopenia during decompensation
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Management with intravenous glucose aiming to stimulate anabolism led to hyperglycemic ketoacidosis.
+      explanation: Hyperglycemic ketoacidosis directly supports hyperglycemia in this branch.
+  - target: Ketoacidosis
+    description: Insulinopenia during decompensation can produce ketoacidosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Insulinopenia during decompensation
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Management with intravenous glucose aiming to stimulate anabolism led to hyperglycemic ketoacidosis.
+      explanation: The case directly reports ketoacidosis as part of the hyperglycemic decompensation state.
+- name: Neurologic metabolic decompensation
+  description: 'Severe acidotic crises, hypoglycemia, hyperammonemia, and organic acid accumulation can produce acute neurologic dysfunction, including lethargy, hypotonia, and seizures. Delayed or severe crises can also contribute to developmental delay.
+
+    '
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: PMID:39391064
+    reference_title: "Case report: Two siblings with very late onset of holocarboxylase synthase deficiency and a mini-review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Holocarboxylase synthase (HCS) deficiency is an extremely rare metabolic disorder typically presenting as severe neonatal metabolic acidosis, lethargy, hypotonia, vomiting, and seizures.
+    explanation: Lists acute neurologic manifestations in the typical severe acidotic presentation.
+  - reference: PMID:39194177
+    reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Clinical manifestations include severe metabolic acidosis, hyperammonemia, tachypnea, skin rash, alopecia, feeding problems, hypotonia, developmental delay, seizures, and, in severe cases, death.
+    explanation: Supports neurologic involvement including hypotonia, developmental delay, and seizures.
+  downstream:
+  - target: Seizures
+    description: Severe metabolic decompensation can produce seizures.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39391064
+      reference_title: "Case report: Two siblings with very late onset of holocarboxylase synthase deficiency and a mini-review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Holocarboxylase synthase (HCS) deficiency is an extremely rare metabolic disorder typically presenting as severe neonatal metabolic acidosis, lethargy, hypotonia, vomiting, and seizures.
+      explanation: The review lists seizures as part of the typical severe neonatal presentation.
+  - target: Lethargy
+    description: Severe metabolic decompensation can reduce alertness.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38550975
+      reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: An 11-month-old girl with severe acidosis, lethargy and vomiting, was diagnosed with holocarboxylase synthetase deficiency.
+      explanation: The acute decompensation case directly includes lethargy.
+  - target: Muscular hypotonia
+    description: Acute neurologic metabolic dysfunction can manifest as hypotonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39391064
+      reference_title: "Case report: Two siblings with very late onset of holocarboxylase synthase deficiency and a mini-review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Holocarboxylase synthase (HCS) deficiency is an extremely rare metabolic disorder typically presenting as severe neonatal metabolic acidosis, lethargy, hypotonia, vomiting, and seizures.
+      explanation: The review lists hypotonia as a typical presenting feature.
+  - target: Global developmental delay
+    description: Severe or delayed metabolic control can contribute to developmental delay.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39194177
+      reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Clinical manifestations include severe metabolic acidosis, hyperammonemia, tachypnea, skin rash, alopecia, feeding problems, hypotonia, developmental delay, seizures
+      explanation: The abstract lists developmental delay among clinical manifestations, though it does not specify the exact intervening injury mechanism.
+- name: Cutaneous and hair involvement
+  description: 'HLCS deficiency includes cutaneous and hair findings such as rash, alopecia, and sometimes generalized ichthyosis. The graph groups these findings as downstream consequences of impaired biotin-dependent enzyme activation while leaving the tissue-level intermediates unspecified.
+
+    '
+  locations:
+  - preferred_term: skin
+    term:
+      id: UBERON:0002097
+      label: skin of body
+  evidence:
+  - reference: PMID:39194177
+    reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Clinical manifestations include severe metabolic acidosis, hyperammonemia, tachypnea, skin rash, alopecia, feeding problems, hypotonia, developmental delay, seizures, and, in severe cases, death.
+    explanation: Lists rash and alopecia among the clinical manifestations of HLCS deficiency.
+  - reference: PMID:39194177
+    reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Despite receiving supportive care, no evident clinical improvement was observed, accompanied by the onset of generalized ichthyosis.
+    explanation: Documents generalized ichthyosis before biotin therapy in a neonatal case.
+  downstream:
+  - target: Skin rash
+    description: The cutaneous involvement includes eczematous or erythematous rash.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36890565
+      reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Among all the patients, 24 showed varying degrees of symptoms such as rash, vomiting, seizures, and drowsiness
+      explanation: The cohort reports rash among symptomatic HLCS deficiency patients.
+  - target: Alopecia
+    description: The hair involvement includes alopecia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32841162
+      reference_title: "Impaired glucose homeostasis and a novel HLCS pathogenic variant in holocarboxylase synthetase deficiency: a report of two cases and brief review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Typical manifestations of HCSD include eczema, alopecia, lactic acidosis and hyperammonemia.
+      explanation: The report lists alopecia as a typical manifestation.
+  - target: Ichthyosis
+    description: Severe cutaneous involvement may include generalized ichthyosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39194177
+      reference_title: "Dramatic Clinical Improvement With Biotin Mega-Dose Therapy in a Neonate With Holocarboxylase Synthetase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Despite receiving supportive care, no evident clinical improvement was observed, accompanied by the onset of generalized ichthyosis.
+      explanation: The neonatal case directly documents generalized ichthyosis.
+- name: Systemic feeding and growth involvement
+  description: 'Infantile HLCS deficiency can involve feeding difficulties and growth retardation as part of the multisystem clinical state. These endpoints may reflect systemic illness, poor intake, and recurrent decompensation rather than a single defined molecular intermediate.
+
+    '
+  evidence:
+  - reference: PMID:39634276
+    reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
+    explanation: Directly supports feeding and growth involvement in HLCS deficiency.
+  downstream:
+  - target: Feeding difficulties
+    description: Multisystem illness can present with feeding difficulties.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39634276
+      reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
+      explanation: The case report abstract directly lists feeding difficulties.
+  - target: Growth delay
+    description: Chronic feeding and systemic involvement can manifest as growth retardation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39634276
+      reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
+      explanation: The case report abstract directly lists growth retardation.
 phenotypes:
 - name: Metabolic acidosis
-  frequency: VERY_FREQUENT
-  description: 'High-anion-gap metabolic acidosis is the hallmark presenting feature, often severe and difficult to correct. It results from accumulation of organic acids from multiple blocked carboxylase pathways.
+  description: 'High-anion-gap metabolic acidosis is a recurring presenting feature, often severe and difficult to correct. It results from accumulation of organic acids from multiple blocked carboxylase pathways.
 
     '
   phenotype_term:
@@ -283,7 +709,6 @@ phenotypes:
     snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation, with predominant involvement of the nervous system, skin, and hair.
     explanation: Confirms metabolic acidosis as a common clinical manifestation.
 - name: Lactic acidosis
-  frequency: VERY_FREQUENT
   description: 'Lactic acidosis results from impaired pyruvate carboxylase function disrupting gluconeogenesis and TCA cycle anaplerosis. Severity can be extreme in neonatal presentations.
 
     '
@@ -306,8 +731,7 @@ phenotypes:
     snippet: Typical manifestations of HCSD include eczema, alopecia, lactic acidosis and hyperammonemia.
     explanation: Lists lactic acidosis among the typical manifestations of HLCS deficiency.
 - name: Seizures
-  frequency: FREQUENT
-  description: 'Seizures occur in acute metabolic decompensation, reflecting brain vulnerability to organic acid accumulation and energy failure. Seizures in HLCS deficiency may be particularly responsive to biotin therapy.
+  description: 'Seizures occur in acute metabolic decompensation, reflecting brain vulnerability to organic acid accumulation and energy failure.
 
     '
   phenotype_term:
@@ -329,8 +753,7 @@ phenotypes:
     snippet: Among all the patients, 24 showed varying degrees of symptoms such as rash, vomiting, seizures, and drowsiness
     explanation: Confirms seizures in the 28-patient Chinese cohort.
 - name: Skin rash
-  frequency: FREQUENT
-  description: 'Eczematous or erythematous skin rash is a hallmark dermatologic feature, often presenting early. It reflects cutaneous consequences of biotin cofactor deficiency and resolves with biotin therapy.
+  description: 'Eczematous or erythematous skin rash is a reported dermatologic feature, often presenting early. It reflects cutaneous consequences of biotin cofactor deficiency.
 
     '
   phenotype_term:
@@ -352,8 +775,7 @@ phenotypes:
     snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
     explanation: Confirms rash among common clinical manifestations of HLCS deficiency.
 - name: Alopecia
-  frequency: FREQUENT
-  description: 'Hair loss is a consistent clinical hallmark of HLCS deficiency, reflecting biotin deficiency at the level of hair follicle biology.
+  description: 'Hair loss is a reported clinical feature of HLCS deficiency, reflecting biotin deficiency at the level of hair follicle biology.
 
     '
   phenotype_term:
@@ -375,8 +797,7 @@ phenotypes:
     snippet: Typical manifestations of HCSD include eczema, alopecia, lactic acidosis and hyperammonemia.
     explanation: Confirms alopecia as a typical manifestation.
 - name: Hyperammonemia
-  frequency: FREQUENT
-  description: 'Hyperammonemia occurs during metabolic decompensation, likely from catabolic stress and secondary urea cycle impairment. Ammonia levels can be markedly elevated in neonatal presentations.
+  description: 'Hyperammonemia occurs during metabolic decompensation, likely from catabolic stress and secondary urea cycle impairment.
 
     '
   phenotype_term:
@@ -398,7 +819,6 @@ phenotypes:
     snippet: Typical manifestations of HCSD include eczema, alopecia, lactic acidosis and hyperammonemia.
     explanation: Confirms hyperammonemia as a typical manifestation of HLCS deficiency.
 - name: Lethargy
-  frequency: FREQUENT
   description: 'Reduced alertness and drowsiness during acute metabolic decompensation, which may progress to coma in untreated or severe cases.
 
     '
@@ -421,8 +841,7 @@ phenotypes:
     snippet: An 11-month-old girl with severe acidosis, lethargy and vomiting, was diagnosed with holocarboxylase synthetase deficiency.
     explanation: Confirms lethargy as a presenting symptom in a documented HLCS case.
 - name: Muscular hypotonia
-  frequency: FREQUENT
-  description: 'Generalized hypotonia is a common neurological finding, particularly during acute metabolic crises in neonates and infants.
+  description: 'Generalized hypotonia is a neurological finding, particularly during acute metabolic crises in neonates and infants.
 
     '
   phenotype_term:
@@ -444,8 +863,7 @@ phenotypes:
     snippet: Clinical manifestations include severe metabolic acidosis, hyperammonemia, tachypnea, skin rash, alopecia, feeding problems, hypotonia, developmental delay, seizures
     explanation: Confirms hypotonia among clinical manifestations.
 - name: Vomiting
-  frequency: FREQUENT
-  description: 'Recurrent vomiting with poor oral intake during metabolic instability is a common presenting symptom.
+  description: 'Vomiting with poor oral intake can occur during metabolic instability.
 
     '
   phenotype_term:
@@ -467,7 +885,6 @@ phenotypes:
     snippet: Holocarboxylase synthase (HCS) deficiency is an extremely rare metabolic disorder typically presenting as severe neonatal metabolic acidosis, lethargy, hypotonia, vomiting, and seizures.
     explanation: Lists vomiting among typical presenting features.
 - name: Tachypnea
-  frequency: FREQUENT
   description: 'Rapid breathing occurs as a compensatory response to metabolic acidosis during decompensation. Respiratory symptoms may be the initial presenting manifestation in some patients.
 
     '
@@ -490,7 +907,6 @@ phenotypes:
     snippet: Despite supportive treatment with antibiotics upon admission, the infant continued to experience rapid and deep breathing accompanied by groaning, and obvious wheezing.
     explanation: Supports respiratory distress with rapid breathing, which is compatible but not fully specific for tachypnea.
 - name: Global developmental delay
-  frequency: OCCASIONAL
   description: 'Developmental delay may occur, particularly in patients with delayed diagnosis or severe metabolic crises. Early biotin treatment is associated with normal developmental outcomes.
 
     '
@@ -513,8 +929,7 @@ phenotypes:
     snippet: After prompt supplement of biotin, both the clinical and biochemical symptoms were dramatically resolved and nearly all patients developed normal intelligence and physique on follow-up.
     explanation: Indicates developmental delay is preventable with early biotin therapy, implying it occurs when treatment is delayed.
 - name: Feeding difficulties
-  frequency: FREQUENT
-  description: 'Poor feeding and feeding intolerance are common in neonatal and infantile presentations, contributing to failure to thrive.
+  description: 'Poor feeding and feeding intolerance occur in neonatal and infantile presentations, contributing to failure to thrive.
 
     '
   phenotype_term:
@@ -536,7 +951,6 @@ phenotypes:
     snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
     explanation: Confirms feeding difficulties as a common manifestation.
 - name: Growth delay
-  frequency: OCCASIONAL
   description: 'Growth retardation may occur in the setting of chronic metabolic disease and feeding difficulties.
 
     '
@@ -553,7 +967,6 @@ phenotypes:
     snippet: Common clinical manifestations include metabolic acidosis, rash, feeding difficulties, and growth retardation
     explanation: Lists growth retardation among common clinical manifestations.
 - name: Hypoglycemia
-  frequency: OCCASIONAL
   description: 'Hypoglycemia results from impaired gluconeogenesis secondary to pyruvate carboxylase deficiency. Recurrent episodes may occur during intercurrent illness.
 
     '
@@ -575,8 +988,39 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: She received biotin and was stable until age 8 years when vomiting, severe acidosis, hypoglycemia, and hyperammonemia developed.
     explanation: Confirms hypoglycemia as a feature of acute decompensation in HLCS deficiency.
+- name: Hyperglycemia
+  description: 'Hyperglycemia can occur during acute decompensation when intravenous glucose is given to suppress catabolism and secondary insulin secretion defects emerge.
+
+    '
+  phenotype_term:
+    preferred_term: Hyperglycemia
+    term:
+      id: HP:0003074
+      label: Hyperglycemia
+  evidence:
+  - reference: PMID:38550975
+    reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Management with intravenous glucose aiming to stimulate anabolism led to hyperglycemic ketoacidosis.
+    explanation: Directly documents hyperglycemia as part of hyperglycemic ketoacidosis during HLCS decompensation.
+- name: Ketoacidosis
+  description: 'Ketoacidosis can occur during acute decompensation when secondary insulinopenia develops during glucose infusion.
+
+    '
+  phenotype_term:
+    preferred_term: Ketoacidosis
+    term:
+      id: HP:0001993
+      label: Ketoacidosis
+  evidence:
+  - reference: PMID:38550975
+    reference_title: "Insulin therapy in acute decompensation of holocarboxylase synthetase deficiency with hyperglycemia and ketoacidosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Management with intravenous glucose aiming to stimulate anabolism led to hyperglycemic ketoacidosis.
+    explanation: Directly documents ketoacidosis during HLCS decompensation.
 - name: Ichthyosis
-  frequency: OCCASIONAL
   description: 'Generalized ichthyosis has been observed as a severe dermatologic manifestation in neonatal HLCS deficiency.
 
     '
@@ -595,8 +1039,7 @@ phenotypes:
 biochemical:
 - name: 3-Hydroxyisovalerylcarnitine (C5-OH)
   presence: INCREASED
-  frequency: VERY_FREQUENT
-  context: 'C5-OH is the primary newborn screening marker for HLCS deficiency. In a 28-patient cohort, C5-OH was far beyond the cutoff in all patients at diagnosis and decreased dramatically with biotin therapy.
+  context: 'C5-OH is an acylcarnitine marker reported in HLCS deficiency. In a 28-patient cohort, C5-OH was increased in blood along with urinary organic acid abnormalities.
 
     '
   evidence:
@@ -605,10 +1048,9 @@ biochemical:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
-    explanation: Directly documents elevated C5-OH as a universal finding in HLCS deficiency patients.
+    explanation: Directly documents elevated C5-OH in HLCS deficiency patients.
 - name: Lactic acid
   presence: INCREASED
-  frequency: VERY_FREQUENT
   context: 'Lactic acidosis reflects impaired pyruvate carboxylase function and disrupted gluconeogenesis. Lactate levels can be severely elevated in neonatal presentations.
 
     '
@@ -619,28 +1061,26 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: An 8-day-old female neonate presented with severe lactic acidosis, necessitating sedation and mechanical ventilation.
     explanation: Documents severe lactic acidosis in neonatal HLCS deficiency.
-  - reference: PMID:36890565
-    reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+  - reference: PMID:39634276
+    reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
-    explanation: Lists pyruvate (and by extension lactate) among elevated urinary metabolites.
+    snippet: urine organic acid analysis revealed elevations in lactate, 3-hydroxybutyric acid, 3-hydroxyisovaleric acid, acetoacetic acid, 3-methylcrotonylglycine, and methylcitric acid.
+    explanation: Directly reports elevated lactate in urine organic acid analysis.
 - name: 3-Hydroxyisovaleric acid
   presence: INCREASED
-  frequency: VERY_FREQUENT
   context: 'Urinary 3-hydroxyisovaleric acid elevation reflects impaired 3-methylcrotonyl-CoA carboxylase (MCC) activity in the leucine catabolic pathway.
 
     '
   evidence:
-  - reference: PMID:36890565
-    reference_title: "Clinical, biochemical, and genetic analysis of 28 Chinese patients with holocarboxylase synthetase deficiency."
+  - reference: PMID:39634276
+    reference_title: "Case report: A case of holocarboxylase synthetase deficiency with respiratory tract as the initial symptom."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: The concentration of 3-hydroxyisovalerylcarnitine (C5-OH) in blood and pyruvate, 3-hydroxypropionate, methylcitric acid, 3-hydroxyvaleric acid, 3-methylcrotonylglycine in urine were increased greatly among affected individuals.
-    explanation: The source reports elevated urinary 3-hydroxyvaleric acid as part of the MCC-associated metabolite profile.
+    snippet: urine organic acid analysis revealed elevations in lactate, 3-hydroxybutyric acid, 3-hydroxyisovaleric acid, acetoacetic acid, 3-methylcrotonylglycine, and methylcitric acid.
+    explanation: The case directly reports elevated 3-hydroxyisovaleric acid.
 - name: Methylcitric acid
   presence: INCREASED
-  frequency: FREQUENT
   context: 'Elevated urinary methylcitric acid reflects propionyl-CoA carboxylase (PCC) deficiency and propionyl-CoA entry into the TCA cycle via citrate synthase.
 
     '
@@ -653,7 +1093,6 @@ biochemical:
     explanation: Directly documents elevated methylcitric acid in urine of HLCS deficiency patients.
 - name: 3-Methylcrotonylglycine
   presence: INCREASED
-  frequency: FREQUENT
   context: 'Urinary 3-methylcrotonylglycine is a conjugated metabolite reflecting impaired MCC activity in the leucine degradation pathway.
 
     '
@@ -666,7 +1105,6 @@ biochemical:
     explanation: Directly documents elevated 3-methylcrotonylglycine in urine.
 - name: 3-Hydroxypropionate
   presence: INCREASED
-  frequency: FREQUENT
   context: 'Urinary 3-hydroxypropionate elevation results from impaired propionyl-CoA carboxylase activity and propionate pathway dysfunction.
 
     '


### PR DESCRIPTION
## Summary
- Add typed, evidenced causal edges for the HLCS biotinylation defect through PC/PCC/MCC pathway branches, organic acidemia, neurologic, cutaneous, feeding/growth, glucose, phenotype, and biochemical endpoints.
- Add hyperglycemia and ketoacidosis phenotypes supported by cached PMID:38550975.
- Remove unsupported phenotype/biochemical frequency bands and keep the PR scoped to `Holocarboxylase_Synthetase_Deficiency.yaml`.

## Validation
- `just validate kb/disorders/Holocarboxylase_Synthetase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Holocarboxylase_Synthetase_Deficiency.yaml`
- Custom snippet audit: 109 evidence snippets checked, 0 missing/nonmatching snippets
- Connectivity audit: 12 pathophysiology nodes, 36/36 typed edges, 36/36 edges with evidence, 17/17 phenotypes targeted, 6/6 biochemical markers targeted
- Subagent review: no blockers found
