### PR TITLE
Curate Adenylosuccinate Lyase Deficiency pathograph

### DIFF
--- a/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
+++ b/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
@@ -247,6 +247,63 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "Biochemically this defect manifests by the presence in the biologic fluids of two dephosphorylated substrates of ADSL enzyme: succinylaminoimidazole carboxamide riboside (SAICAr) and succinyladenosine (S-Ado)."
       explanation: Review evidence directly links the ADSL purine-pathway defect to SAICAr and S-Ado accumulation.
+  - target: Secondary mitochondrial dysfunction
+    description: ADSL deficiency is associated with mitochondrial fragmentation, impaired respiration, and reduced ATP production downstream of the purine metabolism defect.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:40914938
+      reference_title: "ADSL deficiency is a secondary mitochondrial disease affecting organelle homeostasis and ERK2/AKT signaling in a linear genotype-phenotype relation."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "ADSLd is associated with mitochondrial dysfunction, including increased fragmentation, impaired respiration, and reduced ATP production. The severity of mitochondrial impairment correlates with ADSLd pathology"
+      explanation: Cell Reports 2025 links ADSL deficiency to mitochondrial dysfunction and disease severity as an alternative downstream mechanism.
+- name: Secondary mitochondrial dysfunction
+  description: >
+    ADSL deficiency is associated with secondary mitochondrial dysfunction,
+    including increased mitochondrial fragmentation, impaired respiration, and
+    reduced ATP production. The severity of mitochondrial impairment correlates
+    with ADSL deficiency pathology, especially in mitochondria-dependent tissues,
+    and mitochondrial dynamics or transport defects are linked to ERK2 and AKT
+    signaling suppression.
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  biological_processes:
+  - preferred_term: mitochondrion organization
+    term:
+      id: GO:0007005
+      label: mitochondrion organization
+    modifier: ABNORMAL
+  - preferred_term: aerobic respiration
+    term:
+      id: GO:0009060
+      label: aerobic respiration
+    modifier: DECREASED
+  - preferred_term: ATP biosynthetic process
+    term:
+      id: GO:0006754
+      label: ATP biosynthetic process
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:40914938
+    reference_title: "ADSL deficiency is a secondary mitochondrial disease affecting organelle homeostasis and ERK2/AKT signaling in a linear genotype-phenotype relation."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "ADSLd is associated with mitochondrial dysfunction, including increased fragmentation, impaired respiration, and reduced ATP production."
+    explanation: The Cell Reports 2025 study supports secondary mitochondrial dysfunction in ADSL deficiency.
+  - reference: PMID:40914938
+    reference_title: "ADSL deficiency is a secondary mitochondrial disease affecting organelle homeostasis and ERK2/AKT signaling in a linear genotype-phenotype relation."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "defects in mitochondrial dynamics and transport linked to ERK2 and AKT suppression."
+    explanation: The same study links mitochondrial dynamics and transport defects to ERK2/AKT signaling suppression.
 - name: Succinylpurine accumulation and neurotoxicity
   description: >
     Reduced ADSL activity causes intracellular accumulation of ADSL substrates

--- a/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
+++ b/kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Adenylosuccinate Lyase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-05T11:34:04Z'
+updated_date: '2026-05-07T21:40:52Z'
 synonyms:
 - ADSL deficiency
 - Adenylosuccinase deficiency
@@ -58,13 +58,13 @@ progression:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "fatal neonatal form has onset from birth and presents with fatal neonatal"
     explanation: Review evidence supports a fatal neonatal presentation.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "characterized by severe psychomotor retardation, microcephaly, early"
     explanation: Review evidence supports the severe childhood neurologic phenotype.
   - reference: DOI:10.1186/s13023-021-01731-6
@@ -145,13 +145,13 @@ pathophysiology:
   - reference: PMID:10888601
     reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: "Adenylosuccinate lyase (ADSL) is a bifunctional enzyme acting in de novo purine"
     explanation: Establishes the ADSL enzyme function affected in the disorder.
   - reference: PMID:10888601
     reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: "residual enzyme activity correlates with the severity of the clinical phenotype."
     explanation: Supports residual enzyme activity as a severity modifier.
   - reference: PMID:23714113
@@ -163,6 +163,40 @@ pathophysiology:
   downstream:
   - target: Purine biosynthesis and nucleotide-cycle disruption
     description: Loss of ADSL activity impairs ADSL-dependent purine pathway flux.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:10888601
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Adenylosuccinate lyase (ADSL) is a bifunctional enzyme acting in de novo purine synthesis and purine nucleotide recycling."
+      explanation: ADSL enzymatic deficiency directly impairs the two ADSL-dependent purine pathway activities.
+  - target: Reduced adenylosuccinate lyase activity
+    description: ADSL pathogenic variants reduce residual adenylosuccinate lyase enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:10888601
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "residual enzyme activity correlates with the severity of the clinical phenotype."
+      explanation: Mutant protein studies support reduced residual enzyme activity as the proximal biochemical abnormality.
+  - target: Brain structure and white matter abnormalities
+    description: ADSL deficiency is associated with cerebral atrophy, cerebellar atrophy, and white matter MRI abnormalities; the intervening mechanism is not specified by the cited clinical evidence.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/epi4.12837
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Imaging features present consistent findings of cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types."
+      explanation: Long-term follow-up and literature appraisal support structural brain involvement across ADSL deficiency types without establishing a specific toxic intermediate.
+  - target: Craniofacial dysmorphology
+    description: ADSL deficiency is associated with subtle craniofacial dysmorphisms; the intervening mechanism is not specified by the cited review.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25112391
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "ADSL deficiency has been reported to have some subtle dysmorphisms"
+      explanation: Review evidence supports craniofacial dysmorphism as an associated clinical branch without linking it to succinylpurine toxicity.
 - name: Purine biosynthesis and nucleotide-cycle disruption
   description: >
     ADSL catalyzes the conversion of SAICAR to AICAR in de novo purine synthesis
@@ -188,23 +222,31 @@ pathophysiology:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "catalyzes two non-sequential steps in the de novo synthesis of purine nucleotides"
     explanation: Review evidence describes the two ADSL-dependent purine-pathway reactions.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Deficient synthesis of purine nucleotides caused by ADSL deficiency"
     explanation: Review evidence describes deficient purine nucleotide synthesis as a plausible contributor while noting incomplete mechanistic certainty.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "ADSL also participates in the purine nucleotide cycle"
     explanation: Review evidence supports purine nucleotide-cycle impairment as another proposed mechanism.
   downstream:
   - target: Succinylpurine accumulation and neurotoxicity
+    description: Impaired ADSL-dependent purine flux causes buildup of the dephosphorylated ADSL substrates SAICAr and S-Ado.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25112391
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Biochemically this defect manifests by the presence in the biologic fluids of two dephosphorylated substrates of ADSL enzyme: succinylaminoimidazole carboxamide riboside (SAICAr) and succinyladenosine (S-Ado)."
+      explanation: Review evidence directly links the ADSL purine-pathway defect to SAICAr and S-Ado accumulation.
 - name: Succinylpurine accumulation and neurotoxicity
   description: >
     Reduced ADSL activity causes intracellular accumulation of ADSL substrates
@@ -228,13 +270,13 @@ pathophysiology:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "normally undetectable compounds, succinylaminoimidazole carboxamide riboside"
     explanation: Review evidence identifies SAICAr and S-Ado as abnormal compounds formed from the enzyme substrates.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "toxic effects of accumulating succinylpurines"
     explanation: Review evidence presents succinylpurine toxicity as a leading but incompletely proven pathogenesis hypothesis.
   - reference: PMID:23714113
@@ -249,6 +291,268 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: "perturbation in tyrosine metabolism and show that a lack of tyramine"
     explanation: C. elegans model evidence supports wider metabolic perturbation downstream of adsl deficiency.
+  downstream:
+  - target: Increased succinylpurines in body fluids
+    description: Accumulated SAICAr and S-Ado are detectable as increased succinylpurines in biofluids.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27504266
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "accumulation of SAICAr and succinyladenosine (S-Ado) in biofluids of affected individuals"
+      explanation: Human metabolomic profiling supports increased SAICAr and S-Ado in biofluids as the biochemical phenotype.
+  - target: Neurodevelopmental and epileptic encephalopathy
+    description: Succinylpurine toxicity is a leading but incompletely proven mechanism for the core neurologic phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25112391
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "The main pathogenic effect has been attributed to the toxic effects of accumulating succinylpurines"
+      explanation: Review evidence supports succinylpurine neurotoxicity as the leading hypothesis while noting incomplete proof in humans.
+- name: Neurodevelopmental and epileptic encephalopathy
+  description: >
+    ADSL deficiency primarily presents as a neurologic and neurobehavioral
+    disorder with developmental delay or regression, intellectual disability,
+    seizures, hypotonia, impaired speech, and autistic features.
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: ORPHA:46
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "A disorder of purine metabolism characterized by intellectual disability, psychomotor delay and/or regression, seizures, and autistic features."
+    explanation: Orphanet summarizes the core neurologic and neurobehavioral phenotype.
+  - reference: PMID:18830228
+    reference_title: "Misleading behavioural phenotype with adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patients with adenylosuccinate lyase deficiency show a variable combination of mental retardation, epilepsy and autistic features"
+    explanation: Case-report evidence supports intellectual disability, epilepsy, and autistic features as major neurologic manifestations.
+  downstream:
+  - target: Severe global developmental delay
+    description: Developmental delay is a core neurologic manifestation of ADSL deficiency.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011344 | Severe global developmental delay | Very frequent (99-80%)"
+      explanation: Orphanet supports severe global developmental delay as a very frequent phenotype.
+  - target: Intellectual disability
+    description: ADSL deficiency is associated with intellectual disability.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18830228
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "mental retardation, epilepsy and autistic features"
+      explanation: Case-report abstract supports intellectual disability as part of the neurologic phenotype.
+  - target: Seizure
+    description: ADSL neurologic disease frequently includes epilepsy and seizures.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/epi4.12837
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Epilepsy is present in 81.8% of the patients"
+      explanation: Long-term follow-up and literature appraisal quantify high epilepsy frequency in ADSL deficiency.
+  - target: Generalized hypotonia
+    description: ADSL deficiency is associated with axial and generalized hypotonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25112391
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Hypotonia (axial and generalized) is a common feature"
+      explanation: Review evidence supports generalized hypotonia as a common feature.
+  - target: Absent speech
+    description: ADSL deficiency can include absent or severely impaired speech.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18830228
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "global developmental delay, motor apraxia, severe speech deficits, seizures and"
+      explanation: Case-report abstract supports severe speech deficits in affected siblings.
+  - target: Autistic behavior
+    description: ADSL deficiency is associated with autistic features and behavioral disturbance.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18830228
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "mental retardation, epilepsy and autistic features"
+      explanation: Case-report abstract supports autistic features as part of the phenotype.
+- name: Brain structure and white matter abnormalities
+  description: >
+    Neuroimaging in ADSL deficiency can show cerebral atrophy, cerebellar
+    atrophy, and abnormal cerebral white matter signal or myelination.
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: DOI:10.1002/epi4.12837
+    reference_title: "Electroclinical features and phenotypic differences in adenylosuccinate lyase deficiency: Long-term follow-up of seven patients from four families and appraisal of the literature"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Imaging features present consistent findings of cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types."
+    explanation: Long-term follow-up and literature appraisal support the major neuroimaging pattern.
+  downstream:
+  - target: Microcephaly
+    description: ADSL deficiency is associated with microcephaly in severe neurologic presentations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25112391
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "characterized by severe psychomotor retardation, microcephaly, early onset of seizures, and autistic features."
+      explanation: Review evidence supports microcephaly as part of the severe neurologic phenotype.
+  - target: Hypointensity of cerebral white matter on MRI
+    description: ADSL deficiency is associated with cerebral white matter MRI abnormalities.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/epi4.12837
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "white matter abnormalities among the three types."
+      explanation: Long-term follow-up and literature appraisal support white matter abnormalities across ADSL deficiency types.
+  - target: Cerebral atrophy
+    description: ADSL deficiency is associated with cerebral atrophy, often with frontal predominance.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/epi4.12837
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types"
+      explanation: Long-term follow-up and literature appraisal support cerebral atrophy.
+  - target: Cerebellar atrophy
+    description: ADSL deficiency is associated with cerebellar atrophy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/epi4.12837
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "cerebral atrophy with frontal predominance, cerebellar atrophy, and white matter abnormalities among the three types"
+      explanation: Long-term follow-up and literature appraisal support cerebellar atrophy.
+- name: Craniofacial dysmorphology
+  description: >
+    ADSL deficiency has reported subtle craniofacial dysmorphisms, including
+    microcephaly-related head shape findings and characteristic facial features
+    cataloged by Orphanet.
+  evidence:
+  - reference: PMID:25112391
+    reference_title: "Adenylosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "ADSL deficiency has been reported to have some subtle dysmorphisms"
+    explanation: Review evidence supports subtle dysmorphisms as an associated feature.
+  downstream:
+  - target: Thin upper lip vermilion
+    description: ADSL deficiency is associated with thin upper lip vermilion in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000219 | Thin upper lip vermilion | Very frequent (99-80%)"
+      explanation: Orphanet supports thin upper lip vermilion as a very frequent phenotype.
+  - target: Brachycephaly
+    description: ADSL deficiency is associated with brachycephaly in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000248 | Brachycephaly | Very frequent (99-80%)"
+      explanation: Orphanet supports brachycephaly as a very frequent phenotype.
+  - target: Smooth philtrum
+    description: ADSL deficiency is associated with smooth philtrum in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000319 | Smooth philtrum | Very frequent (99-80%)"
+      explanation: Orphanet supports smooth philtrum as a very frequent phenotype.
+  - target: Long philtrum
+    description: ADSL deficiency is associated with long philtrum in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000343 | Long philtrum | Very frequent (99-80%)"
+      explanation: Orphanet supports long philtrum as a very frequent phenotype.
+  - target: Low-set ears
+    description: ADSL deficiency is associated with low-set ears in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000369 | Low-set ears | Very frequent (99-80%)"
+      explanation: Orphanet supports low-set ears as a very frequent phenotype.
+  - target: Anteverted nares
+    description: ADSL deficiency is associated with anteverted nares in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000463 | Anteverted nares | Very frequent (99-80%)"
+      explanation: Orphanet supports anteverted nares as a very frequent phenotype.
+  - target: Abnormal facial shape
+    description: ADSL deficiency is associated with abnormal facial shape in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001999 | Abnormal facial shape | Very frequent (99-80%)"
+      explanation: Orphanet supports abnormal facial shape as a very frequent phenotype.
+  - target: Short nose
+    description: ADSL deficiency is associated with short nose in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003196 | Short nose | Very frequent (99-80%)"
+      explanation: Orphanet supports short nose as a very frequent phenotype.
+  - target: Flat occiput
+    description: ADSL deficiency is associated with flat occiput in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0005469 | Flat occiput | Very frequent (99-80%)"
+      explanation: Orphanet supports flat occiput as a very frequent phenotype.
+  - target: Prominent metopic ridge
+    description: ADSL deficiency is associated with prominent metopic ridge in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:46
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0005487 | Prominent metopic ridge | Very frequent (99-80%)"
+      explanation: Orphanet supports prominent metopic ridge as a very frequent phenotype.
 phenotypes:
 - name: Severe global developmental delay
   frequency: VERY_FREQUENT
@@ -298,7 +602,7 @@ phenotypes:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "ADSL deficiency can cause onset of epilepsy in the first year of life."
     explanation: Review evidence supports early-onset epilepsy in ADSL deficiency.
   - reference: DOI:10.1002/epi4.12837
@@ -323,7 +627,7 @@ phenotypes:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Hypotonia (axial and generalized) is a common feature"
     explanation: Review evidence supports hypotonia as a common severe-form feature.
 - name: Absent speech
@@ -522,7 +826,7 @@ phenotypes:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Reported findings on brain MRI in ADSL deficiency include atrophy"
     explanation: Review evidence supports structural brain MRI abnormalities in ADSL deficiency.
   - reference: DOI:10.1002/epi4.12837
@@ -571,13 +875,13 @@ biochemical:
   - reference: PMID:10888601
     reference_title: "Human adenylosuccinate lyase (ADSL), cloning and characterization of full-length cDNA and its isoform, gene structure and molecular basis for ADSL deficiency in six patients."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: "residual enzyme activity correlates with the severity of the clinical phenotype."
     explanation: Patient-derived variant studies support reduced residual enzyme activity as central to the disorder.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "large decrease of ADSL activity"
     explanation: Review evidence supports decreased ADSL enzyme activity as diagnostic support.
 - name: Increased succinylpurines in body fluids
@@ -595,7 +899,7 @@ biochemical:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "presence of enormously elevated concentrations of their dephosphorylated forms"
     explanation: Review evidence supports elevated SAICAr and S-Ado in extracellular fluids.
   - reference: PMID:27504266
@@ -676,19 +980,19 @@ treatments:
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "To date, there is no specific and effective therapy"
     explanation: Review evidence indicates no established disease-specific effective therapy.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Treatment with anticonvulsive drugs"
     explanation: Review evidence supports seizure-directed pharmacotherapy.
   - reference: PMID:25112391
     reference_title: "Adenylosuccinate lyase deficiency."
     supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "A ketogenic diet could be considered a valid therapeutic option"
     explanation: Review evidence supports ketogenic diet consideration for refractory seizures, with monitoring.
 - name: Investigational allopurinol therapy


### PR DESCRIPTION
## Summary
- add typed/evidenced downstream edges from ADSL enzyme deficiency through purine-pathway disruption and succinylpurine accumulation
- add conservative neurologic, neuroimaging, and craniofacial branches to target all listed phenotypes and biochemical markers
- reclassify review-paper evidence from PMID:25112391 as `OTHER` and mutant enzyme assay evidence from PMID:10888601 as `IN_VITRO`

## Validation
- `just validate kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Adenylosuccinate_Lyase_Deficiency.yaml`
- local snippet audit: 99 checked, 0 missing/nonmatching
- local connectivity audit: 27/27 typed and evidenced edges; 20/20 phenotypes and 2/2 biochemical markers targeted
- `git diff --check`
- read-only subagent review found two initial overclaim blockers; both were addressed and re-review found no blockers
