### PR TITLE
Curate 3MCCD pathograph

### DIFF
--- a/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
+++ b/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 3-Methylcrotonyl-CoA Carboxylase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-05T11:34:04Z'
+updated_date: '2026-05-07T22:22:37Z'
 synonyms:
 - 3-MCC deficiency
 - 3-MCCD
@@ -149,6 +149,14 @@ pathophysiology:
   downstream:
   - target: Leucine catabolic block and diagnostic metabolite accumulation
     description: Loss of MCC activity blocks the 3-methylcrotonyl-CoA carboxylation step of leucine catabolism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40639867
+      reference_title: "3-methylcrotonyl-CoA carboxylase deficiency in a child with developmental regression and delay: call for early diagnosis and multidisciplinary approach."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Reduced 3-MCC enzyme activity results in impaired leucine metabolism"
+      explanation: Case-report abstract directly links reduced 3-MCC enzyme activity to impaired leucine metabolism.
 - name: Leucine catabolic block and diagnostic metabolite accumulation
   description: >
     Deficient 3-methylcrotonyl-CoA carboxylase activity impairs leucine
@@ -183,13 +191,94 @@ pathophysiology:
     explanation: Supports the core metabolic block and key biochemical consequences.
   downstream:
   - target: Stress-triggered metabolic decompensation
+    description: Impaired leucine metabolism can produce organic-aciduria-like metabolic crises in a subset of patients, especially under catabolic stress.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - increased metabolite burden during infection or fasting
+    evidence:
+    - reference: PMID:22642865
+      reference_title: "3-methylcrotonyl-CoA carboxylase deficiency: clinical, biochemical, enzymatic and molecular studies in 88 individuals."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "12 patients (5 of 53 identified by newborn screening) presented with acute metabolic decompensations."
+      explanation: Cohort evidence supports acute metabolic decompensation as an occasional downstream consequence of MCC deficiency.
   - target: Secondary mitochondrial dysfunction and oxidative stress
+    description: MCC-deficient patient fibroblasts show secondary mitochondrial dysfunction, oxidative stress, and disrupted energy homeostasis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27417235
+      reference_title: "A 3-methylcrotonyl-CoA carboxylase deficient human skin fibroblast transcriptome reveals underlying mitochondrial dysfunction and oxidative stress."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "hallmark of mitochondrial dysfunction, decreased antioxidant response and disruption of energy homeostasis"
+      explanation: Patient-derived fibroblast studies support secondary mitochondrial dysfunction and oxidative stress downstream of MCC deficiency.
+  - target: Elevated C5OH acylcarnitine
+    description: Blocked leucine catabolism raises blood C5OH acylcarnitine detected by newborn screening.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36822454
+      reference_title: "Newborn screening for 3-methylcrotonyl-CoA carboxylase deficiency in Zhejiang province, China."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All these 53 patients exhibited increased C5OH concentrations in blood."
+      explanation: Newborn-screening cohort directly supports elevated C5OH as a biochemical consequence.
+  - target: Increased urinary 3-hydroxyisovaleric acid and 3-methylcrotonylglycine
+    description: Diversion of leucine catabolic intermediates increases urinary 3-hydroxyisovaleric acid and 3-methylcrotonylglycine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36822454
+      reference_title: "Newborn screening for 3-methylcrotonyl-CoA carboxylase deficiency in Zhejiang province, China."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "94 % (50/53) of the patients had markedly increased urinary 3-hydroxyisovaleric acid and 3-methylcrotonylglycine."
+      explanation: Newborn-screening cohort directly supports the urinary diagnostic metabolite pattern.
+  - target: Secondary carnitine deficiency
+    description: Increased acylcarnitine formation can deplete free carnitine in a subset of patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - increased hydroxyisovalerylcarnitine formation and excretion
+    evidence:
+    - reference: PMID:36822454
+      reference_title: "Newborn screening for 3-methylcrotonyl-CoA carboxylase deficiency in Zhejiang province, China."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Twenty-three of 53 patients had secondary carnitine deficiency."
+      explanation: Cohort data support secondary carnitine deficiency in a subset of 3-MCCD patients.
+  - target: Organic aciduria
+    description: Urinary excretion of 3-hydroxyisovaleric acid and 3-methylcrotonylglycine manifests as organic aciduria.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36822454
+      reference_title: "Newborn screening for 3-methylcrotonyl-CoA carboxylase deficiency in Zhejiang province, China."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "patients had markedly increased urinary 3-hydroxyisovaleric acid and 3-methylcrotonylglycine"
+      explanation: Cohort evidence supports urinary organic acid elevation.
+  - target: Abnormal circulating leucine concentration
+    description: 3-MCCD is associated with abnormal leucine metabolism in Orphanet phenotype data.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0004357 | Abnormality of leucine metabolism | Very frequent (99-80%)"
+      explanation: Orphanet supports abnormal leucine metabolism as a very frequent phenotype.
+  - target: Hyperammonemia
+    description: Hyperammonemia is reported among specific biochemical symptoms linked to defective leucine catabolism in symptomatic MCCD.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25356967
+      reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Specific symptoms included ketoacidosis, hypoglycemia, hyperammonemia, coma, and plasma carnitine depletion with gross elevation of hydroxyisovaleryl-carnitine."
+      explanation: Human case-series evidence supports hyperammonemia among specific biochemical manifestations of defective leucine catabolism.
 - name: Stress-triggered metabolic decompensation
   description: >
     During infection, fasting, or other catabolic stress, increased leucine flux
-    and metabolite burden can exceed compensatory capacity, causing hypoglycemia,
-    metabolic acidosis, hyperammonemia, and encephalopathy or developmental
-    regression in susceptible patients.
+    and metabolite burden can exceed compensatory capacity, causing
+    organic-aciduria-like episodes with metabolic acidosis, hypoglycemia, and
+    infection-associated neurologic regression in susceptible patients.
   biological_processes:
   - preferred_term: response to starvation
     term:
@@ -217,6 +306,29 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "lead to a severe clinical phenotype resembling classical organic acidurias."
     explanation: Cohort evidence supports severe organic-aciduria-like decompensation in a subset of patients.
+  downstream:
+  - target: Hypoglycemia
+    description: Metabolic decompensation in 3-MCCD can include ketotic hypoglycemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40639867
+      reference_title: "3-methylcrotonyl-CoA carboxylase deficiency in a child with developmental regression and delay: call for early diagnosis and multidisciplinary approach."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "metabolic acidosis, ketotic hypoglycaemia and carnitine deficiency."
+      explanation: Case-report abstract directly supports hypoglycemia as part of metabolic decompensation.
+  - target: Developmental regression
+    description: Severe symptomatic 3-MCCD can present with developmental regression after infection-triggered decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - infection-triggered metabolic decompensation
+    evidence:
+    - reference: PMID:40639867
+      reference_title: "3-methylcrotonyl-CoA carboxylase deficiency in a child with developmental regression and delay: call for early diagnosis and multidisciplinary approach."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "underwent dramatic developmental regression at 11 months of age, following a respiratory tract infection."
+      explanation: Case-report abstract links respiratory infection-triggered illness with developmental regression.
 - name: Secondary mitochondrial dysfunction and oxidative stress
   description: >
     Patient-derived MCC-deficient fibroblasts show transcriptional and


### PR DESCRIPTION
## Summary
- Add typed, evidenced downstream causal edges for the 3MCCD pathograph, including MCC molecular function loss to leucine catabolic block, diagnostic metabolite accumulation, secondary mitochondrial/oxidative stress, stress-triggered decompensation, hypoglycemia, developmental regression, and hyperammonemia.
- Add exact human clinical / in vitro / structured-source evidence snippets for every new edge.
- Keep ORPHA-only phenotype frequency rows out of causal edges where they support disease-phenotype association but not mechanism-to-phenotype causality.

## Intentional Scope
- Did not link Abnormal cerebral vascular morphology, Abnormality of movement, Failure to thrive in infancy, Hypotonia, Respiratory insufficiency, or Spasticity into the pathograph because the available cached ORPHA rows do not support specific causal edges.
- No reference cache files are included; cited references were already cached and snippet-audited locally.

## Validation
- `just validate kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml`
- recursive local snippet audit: 55 checked, 0 errors
- connectivity audit: 11/11 downstream edges typed and evidenced; 5/11 phenotypes and 3/3 biochemical findings targeted
- `git diff --check`
