### PR TITLE
Curate MADD pathograph

### DIFF
--- a/kb/disorders/Multiple_Acyl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Multiple_Acyl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Multiple Acyl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-08T03:42:10Z'
 synonyms:
 - MADD
 - Glutaric aciduria type II
@@ -58,6 +58,26 @@ pathophysiology:
   downstream:
   - target: Impaired electron transfer from FAD-dependent dehydrogenases to ubiquinone
     description: Loss of ETF system activity blocks electron flow into the CoQ pool.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "It is inherited in an autosomal recessive manner and impairs electron transfer in the electron transport chain."
+      explanation: Supports impaired electron transfer as the direct functional consequence of inherited MADD.
+  - target: Oxidative stress and apoptosis in neuronal cells
+    description: ETFDH-mutant neuronal cell models show excessive apoptosis and neurite outgrowth defects through mitochondrial apoptosis signaling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - BCL-2/mitochondrial outer membrane permeabilization/apoptosis signaling
+    evidence:
+    - reference: PMID:39455656
+      reference_title: "ETFDH mutation involves excessive apoptosis and neurite outgrowth defect via Bcl2 pathway."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Our cellular models of MADD exhibit neurite growth defects and excessive apoptosis."
+      explanation: ETFDH-mutant cellular models support neuronal apoptosis and neurite pathology downstream of the molecular defect.
 - name: Impaired electron transfer from FAD-dependent dehydrogenases to ubiquinone
   description: 'Disrupted electron flow from multiple acyl-CoA dehydrogenases through the ETF/ETFDH system to the mitochondrial coenzyme Q pool blocks fatty acid beta-oxidation, branched-chain amino acid catabolism, and choline oxidation, causing accumulation of metabolic intermediates and energy deficit.
 
@@ -67,10 +87,12 @@ pathophysiology:
     term:
       id: GO:0006635
       label: fatty acid beta-oxidation
+    modifier: DECREASED
   - preferred_term: electron transport chain
     term:
       id: GO:0022900
       label: electron transport chain
+    modifier: DECREASED
   cell_types:
   - preferred_term: skeletal muscle fiber
     term:
@@ -94,7 +116,189 @@ pathophysiology:
     explanation: Supports downstream multi-pathway catabolic disruption from ETF system failure.
   downstream:
   - target: ETFDH-driven metabolon disruption and OXPHOS dysfunction
+    description: ETFDH deficiency disrupts the ETFDH-CIII-COQ2 organization that routes lipid-derived electrons into the respiratory chain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ETFDH-CIII-COQ2 metabolon destabilization
+    evidence:
+    - reference: PMID:38243131
+      reference_title: "An ETFDH-driven metabolon supports OXPHOS efficiency in skeletal muscle by regulating coenzyme Q homeostasis."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "We identify a complex (comprising ETFDH, CIII and the Q-biosynthesis regulator COQ2) that directs electrons from lipid substrates to the respiratory chain, thereby reducing electron leaks and reactive oxygen species production."
+      explanation: Identifies the metabolon that is disrupted when ETFDH-dependent electron flow is impaired.
+  - target: Systemic metabolic decompensation
+    description: Impaired mitochondrial fuel oxidation limits fasting energy production and ketogenesis, producing acute metabolic crises.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Reduced mitochondrial ATP production
+    - Impaired hepatic ketogenesis
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Multiple acyl-CoA dehydrogenase deficiency (MADD) is a rare inborn error of metabolism that results in impairment of mitochondrial β-oxidation of fatty acids."
+      explanation: Supports impaired fatty acid oxidation as the upstream metabolic defect leading to decompensation.
+  - target: Acylcarnitines (broad elevation)
+    description: Blocked ETF/ETFDH-dependent oxidation produces the broad acylcarnitine abnormalities used to diagnose MADD.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:17584774
+      reference_title: "ETFDH mutations as a major cause of riboflavin-responsive multiple acyl-CoA dehydrogenation deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Urine organic acid and plasma acyl-carnitine profiles indicated MADD."
+      explanation: Patient biochemical profiles support abnormal acylcarnitines downstream of ETF:QO dysfunction.
+  - target: Glutaric acid
+    description: Impaired ETF/ETF:QO electron transfer produces the glutaric aciduria biochemical hallmark of MADD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Organic acid accumulation
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The secondary deficiency of all primary mitochondrial FAD-dependent dehydrogenases leads to a complex and variable accumulation of metabolites, including glutaric acid"
+      explanation: Review evidence supports glutaric acid as one of the accumulated metabolites downstream of MADD.
   - target: Lipid storage myopathy
+    description: Impaired fatty acid oxidation in skeletal muscle causes lipid storage myopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38951975
+      reference_title: "Multiple Acyl-CoA Dehydrogenase Deficiency: Phenotypic and Genetic Features of a Malaysian Cohort."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Multiple acyl-CoA dehydrogenase deficiency (MADD) is an inherited disorder of fatty acid oxidation that causes lipid storage myopathy (LSM)."
+      explanation: Clinical cohort evidence directly links MADD fatty acid oxidation impairment to lipid storage myopathy.
+- name: Systemic metabolic decompensation
+  description: 'Catabolic stress and impaired mitochondrial fatty acid oxidation produce a systemic energy crisis, particularly in liver, heart, and brain. Reduced ketone generation, impaired fuel availability, and accumulated organic acids manifest as metabolic acidosis, hypoketotic hypoglycemia, hyperammonemia, encephalopathy, and cardiomyopathy in severe presentations.
+
+    '
+  biological_processes:
+  - preferred_term: generation of precursor metabolites and energy
+    term:
+      id: GO:0006091
+      label: generation of precursor metabolites and energy
+    modifier: DECREASED
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  - preferred_term: cardiac muscle cell
+    term:
+      id: CL:0000746
+      label: cardiac muscle cell
+  locations:
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  - preferred_term: heart
+    term:
+      id: UBERON:0000948
+      label: heart
+  chemical_entities:
+  - preferred_term: glucose
+    term:
+      id: CHEBI:17234
+      label: glucose
+    modifier: DECREASED
+  - preferred_term: ketone body
+    term:
+      id: CHEBI:73693
+      label: ketone body
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:37217231
+    reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Early-onset MADD is often associated with a high mortality with significant number of patients presenting with severe metabolic acidosis, non-ketotic hypoglycaemia and/or hyperammonaemic presentations."
+    explanation: Supports the acute metabolic crisis pattern in severe MADD.
+  downstream:
+  - target: Metabolic acidosis
+    description: Accumulated organic acids during decompensation produce severe metabolic acidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Early-onset MADD is often associated with a high mortality with significant number of patients presenting with severe metabolic acidosis, non-ketotic hypoglycaemia and/or hyperammonaemic presentations."
+      explanation: The clinical presentation explicitly includes severe metabolic acidosis.
+  - target: Hypoketotic hypoglycemia
+    description: Impaired fatty acid oxidation limits hepatic ketogenesis and fasting energy production, causing hypoketotic hypoglycemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Early-onset MADD is often associated with a high mortality with significant number of patients presenting with severe metabolic acidosis, non-ketotic hypoglycaemia and/or hyperammonaemic presentations."
+      explanation: The clinical presentation explicitly includes non-ketotic hypoglycemia.
+  - target: Hyperammonemia
+    description: Severe decompensation can include hyperammonemia, which contributes to acute neurologic deterioration.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Catabolic crisis
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Early-onset MADD is often associated with a high mortality with significant number of patients presenting with severe metabolic acidosis, non-ketotic hypoglycaemia and/or hyperammonaemic presentations."
+      explanation: The clinical presentation explicitly includes hyperammonemic presentations.
+  - target: Encephalopathy
+    description: Acute energy failure and hyperammonemia can progress to encephalopathy during metabolic crisis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hypoglycemia
+    - Hyperammonemia
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "This report describes a woman in her 30s who presented with acute-onset ataxia, confusion and hyperammonaemic encephalopathy requiring intubation."
+      explanation: Case evidence links hyperammonemic metabolic crisis to encephalopathy in MADD.
+  - target: Cardiomyopathy
+    description: Mitochondrial fuel oxidation failure can affect myocardium and contribute to cardiomyopathy in severe MADD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Myocardial energy deficit
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The clinical manifestations of MADD are highly variable and include exercise intolerance, myopathy, cardiomyopathy, encephalopathy, coma and death."
+      explanation: Clinical review evidence supports cardiomyopathy as part of the MADD phenotype spectrum.
+  - target: Respiratory insufficiency
+    description: Severe metabolic and neuromuscular involvement can include respiratory dysfunction requiring ventilatory support.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Respiratory dysfunction
+    - Metabolic crisis
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Respiratory dysfunction may be present."
+      explanation: Review evidence supports respiratory dysfunction as part of the MADD clinical spectrum.
+  - target: Vomiting
+    description: Metabolic decompensation may include recurrent or cyclical vomiting before overt neuromuscular presentation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17584774
+      reference_title: "ETFDH mutations as a major cause of riboflavin-responsive multiple acyl-CoA dehydrogenation deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "several had previously suffered cyclical vomiting."
+      explanation: Patient series evidence supports vomiting as part of the MADD presentation.
 - name: ETFDH-driven metabolon disruption and OXPHOS dysfunction
   description: 'Recent work demonstrates that ETFDH participates in a metabolon comprising ETFDH, respiratory chain complex III (CIII), and the CoQ biosynthesis regulator COQ2. This complex maintains coenzyme Q homeostasis, minimizes reduced-Q reductive stress, and supports OXPHOS efficiency. Loss of ETFDH causes CIII dysfunction, pathological QH2 accumulation, reductive stress, and increased ROS.
 
@@ -126,7 +330,18 @@ pathophysiology:
     snippet: We identify a complex (comprising ETFDH, CIII and the Q-biosynthesis regulator COQ2) that directs electrons from lipid substrates to the respiratory chain, thereby reducing electron leaks and reactive oxygen species production.
     explanation: Identifies the ETFDH-CIII-COQ2 metabolon supporting OXPHOS efficiency.
   downstream:
-  - target: Oxidative stress and apoptosis in neuronal cells
+  - target: GDF-15
+    description: Mitochondrial stress in riboflavin-responsive MADD is reflected by increased GDF-15 expression in muscle and serum.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Mitochondrial stress signaling
+    evidence:
+    - reference: PMID:38228875
+      reference_title: "A comparative study on riboflavin responsive multiple acyl-CoA dehydrogenation deficiency due to variants in FLAD1 and ETFDH gene."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Molecular study revealed that the expression of GDF15 gene in muscle and GDF15 protein in both serum and muscle was significantly increased in FLAD1-RRMADD and ETFDH-RRMADD groups."
+      explanation: Clinical muscle and serum data support GDF-15 as a downstream mitochondrial-stress biomarker in riboflavin-responsive MADD.
 - name: Oxidative stress and apoptosis in neuronal cells
   description: 'ETFDH mutations lead to oxidative stress, activation of the BCL-2 family/MOMP apoptotic signaling pathway, and neurite outgrowth defects. In cellular models, ETFDH mutations cause increased pro-apoptotic markers including BAX, cytochrome c, caspase-9 and caspase-3, linking mitochondrial redox disturbance to neurodegeneration.
 
@@ -153,6 +368,20 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: Our cellular models of MADD exhibit neurite growth defects and excessive apoptosis.
     explanation: Demonstrates apoptosis and neurite pathology in ETFDH mutation cellular models.
+  downstream:
+  - target: Peripheral neuropathy
+    description: Neurite outgrowth defects, axonal degeneration, and neuronal apoptosis provide a cellular mechanism for peripheral neuropathy in the MADD spectrum.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neurite outgrowth defects
+    - Axonal degeneration
+    evidence:
+    - reference: PMID:39455656
+      reference_title: "ETFDH mutation involves excessive apoptosis and neurite outgrowth defect via Bcl2 pathway."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Our cellular models of MADD exhibit neurite growth defects and excessive apoptosis."
+      explanation: Cellular model evidence supports a neuronal injury mechanism downstream of ETFDH mutation.
 - name: Lipid storage myopathy
   description: 'Defective fatty acid oxidation leads to pathological lipid droplet accumulation in skeletal muscle fibers, resulting in lipid storage myopathy. Late-onset MADD is the most common lipid storage myopathy.
 
@@ -185,6 +414,69 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: Multiple acyl-CoA dehydrogenase deficiency (MADD) is an inherited disorder of fatty acid oxidation that causes lipid storage myopathy (LSM).
     explanation: Confirms MADD causes lipid storage myopathy in a clinical cohort.
+  downstream:
+  - target: Proximal muscle weakness
+    description: Lipid storage myopathy injures skeletal muscle and produces the proximal limb weakness typical of late-onset MADD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Skeletal muscle lipid accumulation
+    - Myopathic fiber injury
+    evidence:
+    - reference: PMID:38951975
+      reference_title: "Multiple Acyl-CoA Dehydrogenase Deficiency: Phenotypic and Genetic Features of a Malaysian Cohort."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All 14 demonstrated proximal limb weakness, elevated serum creatine kinase levels, and myopathic changes in electromyography."
+      explanation: Clinical cohort evidence links MADD myopathy to proximal weakness.
+  - target: Elevated creatine kinase
+    description: Myopathic injury causes elevated serum creatine kinase.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Myopathic fiber injury
+    evidence:
+    - reference: PMID:38951975
+      reference_title: "Multiple Acyl-CoA Dehydrogenase Deficiency: Phenotypic and Genetic Features of a Malaysian Cohort."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All 14 demonstrated proximal limb weakness, elevated serum creatine kinase levels, and myopathic changes in electromyography."
+      explanation: The cohort shows elevated CK alongside myopathic changes in MADD.
+  - target: Creatine kinase
+    description: Skeletal muscle injury is reflected biochemically by increased serum creatine kinase.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Myopathic fiber injury
+    evidence:
+    - reference: PMID:38951975
+      reference_title: "Multiple Acyl-CoA Dehydrogenase Deficiency: Phenotypic and Genetic Features of a Malaysian Cohort."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All 14 demonstrated proximal limb weakness, elevated serum creatine kinase levels, and myopathic changes in electromyography."
+      explanation: Clinical cohort evidence supports CK elevation downstream of myopathic injury.
+  - target: Exercise intolerance
+    description: Skeletal muscle energy failure and lipid storage myopathy reduce exercise capacity.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Skeletal muscle energy deficit
+    evidence:
+    - reference: PMID:37217231
+      reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The clinical manifestations of MADD are highly variable and include exercise intolerance, myopathy, cardiomyopathy, encephalopathy, coma and death."
+      explanation: Clinical review evidence lists exercise intolerance and myopathy in the MADD phenotype spectrum.
+  - target: Rhabdomyolysis
+    description: Episodic skeletal muscle energy failure and myopathic injury can manifest as rhabdomyolysis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Skeletal muscle energy deficit
+    - Myopathic fiber injury
+    evidence:
+    - reference: PMID:39455656
+      reference_title: "ETFDH mutation involves excessive apoptosis and neurite outgrowth defect via Bcl2 pathway."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Various phenotypes, including episodic weakness or rhabdomyolysis, exercise intolerance, and peripheral neuropathy, have been reported in both muscular and neuronal contexts."
+      explanation: Published background in this mechanistic study summarizes rhabdomyolysis as part of the reported MADD phenotype spectrum.
 phenotypes:
 - name: Proximal muscle weakness
   frequency: VERY_FREQUENT
@@ -348,12 +640,12 @@ phenotypes:
   - reference: PMID:39455656
     reference_title: "ETFDH mutation involves excessive apoptosis and neurite outgrowth defect via Bcl2 pathway."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Various phenotypes, including episodic weakness or rhabdomyolysis, exercise intolerance, and peripheral neuropathy, have been reported in both muscular and neuronal contexts.
     explanation: Rhabdomyolysis is recognized among the phenotypic spectrum of MADD.
 - name: Respiratory insufficiency
   frequency: OCCASIONAL
-  description: 'Respiratory insufficiency requiring mechanical ventilation can occur in severe late-onset presentations. In one cohort, 3 of 14 patients required ventilation at first presentation.
+  description: 'Respiratory dysfunction may occur in MADD, particularly during severe metabolic or neuromuscular presentations. Acute hyperammonemic encephalopathy can require intubation during decompensation.
 
     '
   phenotype_term:
@@ -362,12 +654,18 @@ phenotypes:
       id: HP:0002093
       label: Respiratory insufficiency
   evidence:
-  - reference: PMID:38951975
-    reference_title: "Multiple Acyl-CoA Dehydrogenase Deficiency: Phenotypic and Genetic Features of a Malaysian Cohort."
-    supports: PARTIAL
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Respiratory dysfunction may be present."
+    explanation: Review evidence directly supports respiratory dysfunction in MADD.
+  - reference: PMID:37217231
+    reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
+    supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Three patients experienced a metabolic crisis at their presentation.
-    explanation: Metabolic crises in severe MADD can include respiratory compromise, though this snippet describes metabolic crisis broadly without specifying respiratory involvement.
+    snippet: "This report describes a woman in her 30s who presented with acute-onset ataxia, confusion and hyperammonaemic encephalopathy requiring intubation."
+    explanation: Case evidence supports ventilatory support during severe MADD decompensation.
 - name: Hepatomegaly
   frequency: OCCASIONAL
   description: 'Hepatomegaly and liver dysfunction are features of severe neonatal presentations of MADD.
@@ -399,7 +697,7 @@ phenotypes:
   - reference: PMID:39455656
     reference_title: "ETFDH mutation involves excessive apoptosis and neurite outgrowth defect via Bcl2 pathway."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Various phenotypes, including episodic weakness or rhabdomyolysis, exercise intolerance, and peripheral neuropathy, have been reported in both muscular and neuronal contexts.
     explanation: Peripheral neuropathy is part of the MADD phenotypic spectrum.
 - name: Vomiting
@@ -461,6 +759,12 @@ biochemical:
 
     '
   evidence:
+  - reference: PMID:29502916
+    reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "The secondary deficiency of all primary mitochondrial FAD-dependent dehydrogenases leads to a complex and variable accumulation of metabolites, including glutaric acid"
+    explanation: Review evidence directly supports glutaric acid accumulation in MADD.
   - reference: PMID:39273584
     reference_title: "Deep Intronic ETFDH Variants Represent a Recurrent Pathogenic Event in Multiple Acyl-CoA Dehydrogenase Deficiency."
     supports: SUPPORT
@@ -581,6 +885,13 @@ treatments:
     term:
       id: MAXO:0000106
       label: nutritional supplementation
+  target_mechanisms:
+  - target: Impaired electron transfer from FAD-dependent dehydrogenases to ubiquinone
+    treatment_effect: MODULATES
+    description: Riboflavin increases FAD availability and can improve riboflavin-responsive ETF:QO-dependent electron transfer.
+  - target: Lipid storage myopathy
+    treatment_effect: MODULATES
+    description: Improved flavoprotein function reduces the downstream myopathic phenotype in riboflavin-responsive MADD.
   evidence:
   - reference: PMID:17584774
     reference_title: "ETFDH mutations as a major cause of riboflavin-responsive multiple acyl-CoA dehydrogenation deficiency."
@@ -609,6 +920,10 @@ treatments:
     term:
       id: MAXO:0000106
       label: nutritional supplementation
+  target_mechanisms:
+  - target: Oxidative stress and apoptosis in neuronal cells
+    treatment_effect: INHIBITS
+    description: Cellular model evidence shows CoQ10 mitigates ETFDH-mutant apoptosis signaling and neurite outgrowth defects.
   evidence:
   - reference: PMID:39455656
     reference_title: "ETFDH mutation involves excessive apoptosis and neurite outgrowth defect via Bcl2 pathway."
@@ -647,6 +962,10 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Systemic metabolic decompensation
+    treatment_effect: MODULATES
+    description: Fasting avoidance and adequate nutrition reduce catabolic stress that precipitates systemic decompensation.
   evidence:
   - reference: PMID:37217231
     reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."
@@ -669,6 +988,10 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Systemic metabolic decompensation
+    treatment_effect: MODULATES
+    description: Acute dextrose and supportive care suppress catabolism and stabilize complications during metabolic crisis.
   evidence:
   - reference: PMID:37217231
     reference_title: "Late-onset multiple acyl-CoA dehydrogenase deficiency: an insidious presentation."


### PR DESCRIPTION
## Summary
- expand the MADD causal graph with typed, evidenced edges from ETF/ETFDH dysfunction to metabolic decompensation, lipid storage myopathy, neuronal apoptosis, respiratory involvement, and key biochemical outputs
- add a systemic metabolic decompensation pathophysiology node and connect it to acidosis, hypoketotic hypoglycemia, hyperammonemia, encephalopathy, cardiomyopathy, respiratory insufficiency, and vomiting
- add treatment mechanism targets for riboflavin, CoQ10, dietary management, and acute metabolic crisis management; correct two PMID:39455656 evidence-source classifications to OTHER where the cited text is background review text

## Validation
- just validate kb/disorders/Multiple_Acyl-CoA_Dehydrogenase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/Multiple_Acyl-CoA_Dehydrogenase_Deficiency.yaml
- recursive local snippet audit: 74 checks, 0 errors
- just check-enum-cache
- git diff --check

Note: the current reference-validator reports 0 checks for nested evidence in this file, so I also ran a recursive cache-backed snippet audit.