### PR TITLE
Align NAGS UCD review evidence source

### DIFF
--- a/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
+++ b/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
@@ -226,7 +226,7 @@ pathophysiology:
     - reference: PMID:33409766
       reference_title: "Management of late onset urea cycle disorders-a remaining challenge for the intensivist?"
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: Ammonia passes into the circulation and crosses the blood–brain barrier. The ammonia will exert a direct toxic effect on the neurotransmission responsible for part of the neurological symptomatology.
       explanation: UCD pathophysiology review links circulating ammonia to CNS neurotoxicity.
 - name: Impaired arginine-mediated NAGS regulation
@@ -298,7 +298,7 @@ pathophysiology:
     - reference: PMID:33409766
       reference_title: "Management of late onset urea cycle disorders-a remaining challenge for the intensivist?"
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: Ammonia diffuses freely across the blood–brain barrier and is converted with alanine to glutamine by glutamine synthase. Glutamine is the main intracellular osmole of the brain. Its accumulation causes the swelling of astrocytes during hyperammonemia
       explanation: Mechanistic UCD review supports the ammonia-to-astrocyte-glutamine osmotic injury step.
   - target: Encephalopathy
@@ -345,7 +345,7 @@ pathophysiology:
     - reference: PMID:33409766
       reference_title: "Management of late onset urea cycle disorders-a remaining challenge for the intensivist?"
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: Intra cranial hypertension appears inducing coma, cerebral engagement and death of the patient.
       explanation: Mechanistic UCD review links intracranial hypertension to coma and death.
   evidence:


### PR DESCRIPTION
## Summary\n- Follow-up to #2290.\n- Reclassifies the three PMID:33409766 NAGS mechanism snippets from `OTHER` to `HUMAN_CLINICAL`, matching Claude's approved-review suggestion that this paper is a clinical UCD review.\n\n## Validation\n- `just validate kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml`\n- `uv run python -m dismech.graph --validate kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml`\n- `git diff --check`\n- restored unrelated clinicaltrials reference-cache churn after validation