### PR TITLE
Improve inherited threoninemia pathograph connectivity

### DIFF
--- a/kb/disorders/Inherited_Threoninemia.yaml
+++ b/kb/disorders/Inherited_Threoninemia.yaml
@@ -366,8 +366,9 @@ phenotypes:
   frequency: OCCASIONAL
   description: >
     Secondary hyperglycinemia with a non-ketotic hyperglycinemia phenotype
-    has been reported in a patient with threonine dehydratase deficiency,
-    proposed to result from competitive inhibition at serine hydroxymethyltransferase.
+    has been reported in a patient with threonine dehydratase deficiency; the
+    biochemical mechanism linking threonine accumulation to glycine excess is
+    proposed but not established from abstract-level evidence.
   phenotype_term:
     preferred_term: Nonketotic hyperglycinemia
     term:

--- a/kb/disorders/Inherited_Threoninemia.yaml
+++ b/kb/disorders/Inherited_Threoninemia.yaml
@@ -1,7 +1,7 @@
 name: Inherited Threoninemia
 category: Mendelian
 creation_date: '2026-03-11T00:00:00Z'
-updated_date: '2026-05-05T21:41:25Z'
+updated_date: '2026-05-08T00:00:00Z'
 synonyms:
 - Hyperthreoninaemia
 - Hyperthreoninemia
@@ -13,10 +13,10 @@ description: >
   and cerebrospinal fluid. First described in 1978, the condition is proposed to
   result from deficient hepatic threonine dehydratase (EC 4.2.1.16) activity,
   blocking conversion of threonine to 2-ketobutyrate. Excess threonine may secondarily
-  perturb glycine-serine-threonine interconversion at serine hydroxymethyltransferase,
-  potentially causing secondary hyperglycinemia and a non-ketotic hyperglycinemia-like
-  neurological phenotype. Clinical features reported in affected individuals include
-  seizures, intellectual disability, failure to thrive, lethargy, and feeding
+  be associated with secondary hyperglycinemia and a non-ketotic hyperglycinemia-like
+  neurological phenotype, although the exact biochemical bridge is not established
+  from cached abstract evidence. Clinical features reported in affected individuals
+  include seizures, intellectual disability, failure to thrive, lethargy, and feeding
   difficulties. A separate phenotypic association with Leber congenital amaurosis
   and hepatomegaly has been reported in siblings with hyperthreoninemia, though the
   causal relationship remains uncertain. No causative gene has been identified at
@@ -125,7 +125,134 @@ pathophysiology:
       The authors explicitly frame this as the first documented inborn error
       of threonine metabolism.
   downstream:
-  - target: Secondary hyperglycinemia via glycine-serine-threonine interconversion
+  - target: Systemic threonine accumulation
+    description: >
+      Loss of hepatic threonine dehydratase activity blocks threonine catabolism,
+      allowing threonine to accumulate systemically.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:6434824
+      reference_title: "Threonine dehydratase deficiency: a probable cause of non-ketotic hyperglycinaemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Threonine dehydratase was undetectable in a liver autopsy specimen,
+        which was obtained within 1 h of death and immediately frozen at -70 degrees C.
+      explanation: >
+        The undetectable liver enzyme activity supports the primary metabolic
+        block that permits systemic threonine accumulation.
+- name: Systemic threonine accumulation
+  description: >
+    The threonine catabolic block is reflected clinically by elevated threonine
+    in serum/plasma and urine, with cerebrospinal fluid elevation reported in
+    the index threonine dehydratase deficiency case. Published evidence remains
+    limited to the original enzyme-deficiency report, a sibling report with
+    hyperthreoninemia and hyperthreoninuria, and screening detection of
+    threoninemia as a rare amino acid disorder.
+  biological_processes:
+  - preferred_term: threonine catabolic process
+    term:
+      id: GO:0006567
+      label: L-threonine catabolic process
+    modifier: DECREASED
+  chemical_entities:
+  - preferred_term: L-threonine
+    term:
+      id: CHEBI:16857
+      label: L-threonine
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:3083684
+    reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      Her serum threonine level was increased (2.0 to 5.3 mg/dl;
+      normal, 0.78 to 1.82 mg/dl).
+    explanation: >
+      Documents elevated circulating threonine in a patient with reported
+      hyperthreoninemia.
+  - reference: PMID:3083684
+    reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+      and mental and physical retardation.
+    explanation: >
+      Documents concurrent systemic and urinary threonine excess in an affected
+      sibling.
+  - reference: PMID:15168722
+    reference_title: "Amino acid disorders in mental retardation: a two-decade study from Andhra Pradesh."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >
+      A new metabolic defect threoninemia was also detected.
+    explanation: >
+      Screening data support threoninemia as a rare detected amino acid
+      metabolic defect.
+  downstream:
+  - target: Hyperthreoninemia
+    description: Circulating threonine elevation is the defining biochemical phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Her serum threonine level was increased (2.0 to 5.3 mg/dl;
+        normal, 0.78 to 1.82 mg/dl).
+      explanation: >
+        Directly supports the edge from systemic threonine accumulation to
+        hyperthreoninemia.
+  - target: Plasma threonine
+    description: Plasma or serum threonine is the measurable circulating biomarker.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Her serum threonine level was increased (2.0 to 5.3 mg/dl;
+        normal, 0.78 to 1.82 mg/dl).
+      explanation: >
+        Quantitative serum threonine elevation supports plasma/serum threonine
+        as the principal biomarker.
+  - target: Hyperthreoninuria
+    description: Excess systemic threonine can be excreted in urine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+        and mental and physical retardation.
+      explanation: >
+        Directly reports urinary threonine excess in a sibling with
+        hyperthreoninemia.
+  - target: Urinary threonine
+    description: Urinary threonine elevation is the biochemical correlate of hyperthreoninuria.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+        and mental and physical retardation.
+      explanation: >
+        Supports urinary threonine as an elevated biochemical marker.
+  - target: NKH-like secondary hyperglycinemia
+    description: >
+      Threonine dehydratase deficiency is reported together with a classical
+      NKH-like presentation, but the cached abstract does not establish the
+      precise biochemical bridge.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:6434824
       reference_title: "Threonine dehydratase deficiency: a probable cause of non-ketotic hyperglycinaemia."
@@ -133,18 +260,17 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: >
         A patient with classical symptoms of non-ketotic hyperglycinaemia (NKH)
-        is presented. Threonine dehydratase was undetectable in a liver autopsy specimen
+        is presented.
       explanation: >
-        The coexistence of undetectable threonine dehydratase and NKH symptoms
-        supports the downstream causal link from threonine accumulation to
-        hyperglycinemia.
-- name: Secondary hyperglycinemia via glycine-serine-threonine interconversion
+        The index threonine dehydratase deficiency case is explicitly presented
+        as an NKH-like disorder.
+- name: NKH-like secondary hyperglycinemia
   description: >
-    Excess threonine from the primary catabolic block competes at serine
-    hydroxymethyltransferase (EC 2.1.2.1), disrupting glycine-serine-threonine
-    interconversion. This competition reduces normal glycine-to-serine flux and
-    contributes to secondary hyperglycinemia, producing a non-ketotic
-    hyperglycinemia-like neurological phenotype.
+    Threonine dehydratase deficiency was reported as a probable cause and new
+    explanation for non-ketotic hyperglycinemia. The cached abstract supports
+    the association between the threonine metabolic block and an NKH-like
+    presentation, while the exact molecular route from threonine excess to
+    secondary hyperglycinemia remains unresolved in abstract-level evidence.
   biological_processes:
   - preferred_term: glycine metabolic process
     term:
@@ -170,9 +296,10 @@ pathophysiology:
       A patient with classical symptoms of non-ketotic hyperglycinaemia (NKH)
       is presented.
     explanation: >
-      The patient presented with classical NKH symptoms, consistent with
-      the proposed mechanism of secondary hyperglycinemia from disrupted
-      glycine-serine-threonine interconversion caused by excess threonine.
+      The patient presented with classical NKH symptoms in the setting of
+      undetectable threonine dehydratase, supporting an NKH-like secondary
+      hyperglycinemia mechanism without specifying the precise biochemical
+      bridge.
   downstream:
   - target: Nonketotic hyperglycinemia
     description: Secondary glycine accumulation manifests clinically as an NKH-like phenotype.
@@ -257,6 +384,54 @@ phenotypes:
     explanation: >
       The index patient for threonine dehydratase deficiency presented with
       classical NKH symptoms alongside threoninemia.
+  sequelae:
+  - target: Seizures
+    description: Seizures are part of the NKH symptom complex invoked for the index case.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:6301756
+      reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >
+        The salient features of nonketotic hyperglycinemia include apnea, feeding
+        difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+        significant developmental delay, and, in most instances, early death.
+      explanation: >
+        This review enumerates seizures among salient NKH features, supporting
+        the specific symptom branch inferred from the index threoninemia case's
+        NKH-like presentation.
+  - target: Lethargy
+    description: Lethargy is part of the NKH symptom complex invoked for the index case.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:6301756
+      reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >
+        The salient features of nonketotic hyperglycinemia include apnea, feeding
+        difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+        significant developmental delay, and, in most instances, early death.
+      explanation: >
+        This review enumerates lethargy among salient NKH features, supporting
+        the symptom branch inferred from the index threoninemia case.
+  - target: Feeding difficulties
+    description: Feeding difficulties are part of the NKH symptom complex invoked for the index case.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:6301756
+      reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >
+        The salient features of nonketotic hyperglycinemia include apnea, feeding
+        difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+        significant developmental delay, and, in most instances, early death.
+      explanation: >
+        This review enumerates feeding difficulties among salient NKH features,
+        supporting a broader feeding-difficulty node rather than a more specific
+        poor-suck claim not stated in the cached threoninemia abstract.
 - category: Clinical
   name: Seizures
   frequency: OCCASIONAL
@@ -280,6 +455,18 @@ phenotypes:
       The abstract describes classical NKH symptoms without enumerating them
       individually. Seizures are a hallmark of NKH and are inferred from
       this presentation.
+  - reference: PMID:6301756
+    reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: >
+      The salient features of nonketotic hyperglycinemia include apnea, feeding
+      difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+      significant developmental delay, and, in most instances, early death.
+    explanation: >
+      Contextual NKH review evidence enumerates seizures among salient features,
+      strengthening the specific symptom inferred from the index threoninemia
+      case's NKH-like presentation.
 - category: Clinical
   name: Intellectual disability
   frequency: OCCASIONAL
@@ -358,17 +545,31 @@ phenotypes:
       The abstract describes classical NKH symptoms without enumerating them
       individually. Lethargy is a hallmark of NKH and is inferred from this
       presentation.
+  - reference: PMID:6301756
+    reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: >
+      The salient features of nonketotic hyperglycinemia include apnea, feeding
+      difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+      significant developmental delay, and, in most instances, early death.
+    explanation: >
+      Contextual NKH review evidence enumerates lethargy among salient features,
+      strengthening the symptom inferred from the index threoninemia case's
+      NKH-like presentation.
 - category: Clinical
-  name: Poor suck
+  name: Feeding difficulties
   frequency: OCCASIONAL
   description: >
-    Feeding difficulty (failure to suck) was reported in the neonatal
-    presentation of threonine dehydratase deficiency.
+    Feeding difficulties are included in the NKH symptom complex used to
+    interpret the neonatal presentation of threonine dehydratase deficiency.
+    The cached threoninemia abstract does not enumerate the specific feeding
+    sign, so this node is curated at the broader HP feeding-difficulties level.
   phenotype_term:
-    preferred_term: Poor suck
+    preferred_term: Feeding difficulties
     term:
-      id: HP:0002033
-      label: Poor suck
+      id: HP:0011968
+      label: Feeding difficulties
   evidence:
   - reference: PMID:6434824
     reference_title: "Threonine dehydratase deficiency: a probable cause of non-ketotic hyperglycinaemia."
@@ -379,8 +580,19 @@ phenotypes:
       is presented.
     explanation: >
       The abstract describes classical NKH symptoms without enumerating them
-      individually. Poor suck is a hallmark neonatal NKH symptom and is
-      inferred from this presentation.
+      individually. Feeding difficulty is inferred as part of the broader
+      NKH-like presentation.
+  - reference: PMID:6301756
+    reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+    supports: PARTIAL
+    evidence_source: OTHER
+    snippet: >
+      The salient features of nonketotic hyperglycinemia include apnea, feeding
+      difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+      significant developmental delay, and, in most instances, early death.
+    explanation: >
+      Contextual NKH review evidence directly lists feeding difficulties among
+      salient NKH features.
 - category: Clinical
   name: Failure to thrive
   frequency: OCCASIONAL
@@ -509,6 +721,17 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_phenotypes:
+  - preferred_term: Hyperthreoninemia
+    term:
+      id: HP:0003354
+      label: Hyperthreoninemia
+  target_mechanisms:
+  - target: Systemic threonine accumulation
+    treatment_effect: INHIBITS
+    description: >
+      Restricting dietary threonine is intended to reduce the substrate load
+      feeding systemic threonine accumulation.
 - name: Anticonvulsant therapy
   description: >
     Anticonvulsant agents for seizure management in patients with
@@ -518,6 +741,11 @@ treatments:
     term:
       id: MAXO:0000167
       label: anticonvulsant agent therapy
+  target_phenotypes:
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
 notes: >-
   Inherited threoninemia is one of the rarest documented inborn errors of
   metabolism. The literature consists of only a handful of case reports from

--- a/references_cache/PMID_6301756.md
+++ b/references_cache/PMID_6301756.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:6301756"
+title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+authors:
+- Langan TJ
+- Pueschel SM
+journal: Curr Probl Pediatr
+year: '1983'
+doi: 10.1016/0045-9380(83)90016-6
+keywords:
+- "Amino Acid Metabolism, Inborn Errors/metabolism, pathology, therapy"
+- Animals
+- Benzoates/therapeutic use
+- Biological Transport
+- Brain/pathology
+- Carboxy-Lyases/metabolism
+- "Dietary Proteins/administration & dosage"
+- Glycine/metabolism
+- Humans
+- Hydrogen/metabolism
+- Methylmalonyl-CoA Decarboxylase
+- Mice
+- Proteins/metabolism
+- Rats
+- "Receptors, Cell Surface/metabolism"
+- "Receptors, Glycine"
+- Salicylates/therapeutic use
+- Serine/metabolism
+- Strychnine/therapeutic use
+content_type: abstract_only
+---
+
+# Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations.
+**Authors:** Langan TJ, Pueschel SM
+**Journal:** Curr Probl Pediatr (1983)
+**DOI:** [10.1016/0045-9380(83)90016-6](https://doi.org/10.1016/0045-9380(83)90016-6)
+
+## Content
+
+1. Curr Probl Pediatr. 1983 Jan;13(3):1-30. doi: 10.1016/0045-9380(83)90016-6.
+
+Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic
+considerations.
+
+Langan TJ, Pueschel SM.
+
+The salient features of nonketotic hyperglycinemia include apnea, feeding
+difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+significant developmental delay, and, in most instances, early death. The
+pathogenesis of the biochemical defect leading to increased glycine
+concentration in blood, urine, and CSF is likely to concern derangements of the
+glycine cleavage enzyme and/or transport mechanisms of glycine. Our current
+state of knowledge of this disorder is incomplete. Therapeutic attempts, as
+described in Table 2, have been largely unsuccessful. Further basic research on
+the underlying biochemical perturbation, including additional documentation of
+the glycine cleavage enzyme deficiency patterns, of substrate inhibition of key
+metabolic pathways, and of glycine transport aberrations, as well as
+investigations of new pharmacologic approaches, will be a challenge for
+investigators in this field. It is hoped that new knowledge in these areas will
+eventually lead to reduction of morbidity and mortality in children with
+nonketotic hyperglycinemia.
+
+DOI: 10.1016/0045-9380(83)90016-6
+PMID: 6301756 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Adds a systemic threonine accumulation mechanism to connect hepatic threonine dehydratase deficiency with threonine biomarkers and the NKH-like branch.
- Replaces the overly specific poor-suck phenotype with broader feeding difficulties supported by contextual NKH review evidence.
- Adds treatment links for dietary threonine restriction and anticonvulsant therapy while leaving uncertain retinal/hepatic/growth associations unconnected.
- Fetched PMID:6301756 via `just fetch-reference`; no reference cache files were hand-edited.

## Review Notes
- Pre-PR subagent review flagged over-specified SHMT/interconversion and CSF-threonine graph edges. I removed the CSF-threonine graph edge and softened the NKH bridge to indirect/unknown with no SHMT intermediate claim.
- PMID:6301756 is classified `OTHER` because it is a review/context source, not primary threoninemia patient evidence.

## Validation
- `just validate kb/disorders/Inherited_Threoninemia.yaml` passed; reference validator reports `Total checks: 0` as expected.
- `uv run python -m dismech.graph --validate kb/disorders/Inherited_Threoninemia.yaml` passed.
- `just check-enum-cache` passed.
- explicit snippet audit: 37 checked, 0 failures.
- `git diff --check` passed.
- Restored unrelated ClinicalTrials cache churn after validation.

## Graph Delta
- Before: 18 nodes, 2 edges, 16 components.
- After: 19 nodes, 13 edges, 7 components, no orphan targets.
