### PR TITLE
Improve alkaptonuria pathograph connectivity

### DIFF
--- a/kb/disorders/Alkaptonuria.yaml
+++ b/kb/disorders/Alkaptonuria.yaml
@@ -1,7 +1,7 @@
 name: Alkaptonuria
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-03T00:00:00Z'
+updated_date: '2026-05-08T00:00:00Z'
 synonyms:
 - Hereditary ochronosis
 - Homogentisic acid oxidase deficiency
@@ -88,7 +88,7 @@ inheritance:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Alkaptonuria is inherited in an autosomal recessive manner."
     explanation: GeneReviews confirms autosomal recessive inheritance.
 prevalence:
@@ -132,7 +132,7 @@ progression:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Ochronosis generally occurs after age 30 years;"
     explanation: GeneReviews supports delayed adult emergence of ochronosis and arthritis.
 pathophysiology:
@@ -168,7 +168,7 @@ pathophysiology:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Alkaptonuria is caused by deficiency of homogentisate"
     explanation: GeneReviews supports the initiating enzymatic block.
   - reference: PMID:30737480
@@ -178,8 +178,26 @@ pathophysiology:
     snippet: "Alkaptonuria (AKU) is a rare metabolic disorder caused by a deficient enzyme in"
     explanation: Large genotype cohort independently supports HGD enzyme deficiency as causal.
   downstream:
+  - target: Reduced homogentisate 1,2-dioxygenase activity
+    description: HGD loss of function reduces homogentisate 1,2-dioxygenase activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HGD | homogentisate 1,2-dioxygenase | hgnc:4892 | Disease-causing germline mutation(s) (loss of function) in"
+      explanation: Orphanet links HGD loss of function to the enzyme activity defect.
   - target: Homogentisic acid accumulation and oxidation
     description: Loss of HGD activity prevents normal homogentisic acid catabolism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:19862842
+      reference_title: "Mutation spectrum of homogentisic acid oxidase (HGD) in alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "AKU is caused by deficiency of homogentisic acid oxidase (HGD, EC 1.13.11.5), which leads to the accumulation of homogentisic acid (HGA)"
+      explanation: The cached article text links HGD deficiency to HGA accumulation.
 - name: Homogentisic acid accumulation and oxidation
   description: >
     The HGD block causes homogentisic acid to accumulate in urine and tissues.
@@ -207,23 +225,61 @@ pathophysiology:
   - reference: PMID:38453957
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "accumulation in body fluids and tissues leads to a multisystemic and highly"
     explanation: Recent disease primer supports systemic HGA accumulation as the central biochemical mechanism.
   - reference: PMID:19862842
     reference_title: "Mutation spectrum of homogentisic acid oxidase (HGD) in alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "AKU is caused by deficiency of homogentisic acid oxidase (HGD, EC 1.13.11.5), which leads to the accumulation of homogentisic acid (HGA)"
-    explanation: The mutation-spectrum study links HGD deficiency to HGA accumulation.
+    explanation: The article background links HGD deficiency to HGA accumulation.
   downstream:
+  - target: Elevated urinary homogentisic acid
+    description: Excess HGA is excreted in urine and forms the defining urinary phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0033704 | Elevated urinary homogentisic acid | Very frequent (99-80%)"
+      explanation: Orphanet reports elevated urinary HGA as a very frequent alkaptonuria phenotype.
+  - target: Increased urinary homogentisic acid
+    description: Urinary HGA measurement is the biochemical diagnostic correlate of systemic HGA accumulation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "based on the detection of a significant amount of HGA in the urine (usually 1 to"
+      explanation: GeneReviews identifies urinary HGA detection as the biochemical diagnostic marker.
+  - target: Dark urine
+    description: Urinary HGA oxidizes on standing or air exposure, darkening urine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "causing urine to darken when exposed to air"
+      explanation: Orphanet directly links HGA/BQA accumulation in urine to darkening on air exposure.
   - target: Ochronotic connective tissue degeneration
     description: Oxidized HGA-derived polymers deposit in collagen-rich tissues and cartilage.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:19862842
+      reference_title: "Mutation spectrum of homogentisic acid oxidase (HGD) in alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The clinical findings of AKU result from the reaction of homogentisic acid and its homopolymeric oxidation products, i.e., benzoquinones, with connective tissue components."
+      explanation: This supports the connective-tissue deposition mechanism downstream of oxidized HGA.
 - name: Ochronotic connective tissue degeneration
   description: >
     Oxidized HGA-derived pigment deposits in collagen-rich connective tissues,
-    especially cartilage. This ochronotic pigmentation drives cartilage
-    calcification, intervertebral disk disease, and painful spine and large-joint
+    especially cartilage. This ochronotic pigmentation is associated with
+    visible tissue discoloration and painful axial and large-joint
     osteoarthropathy.
   locations:
   - preferred_term: cartilage tissue
@@ -244,15 +300,64 @@ pathophysiology:
   - reference: PMID:38453957
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "pigment in collagen-rich connective tissues), and a painful and severe form of"
     explanation: Disease primer supports HGA-derived pigment deposition in connective tissue causing osteoarthropathy.
   - reference: PMID:19862842
     reference_title: "Mutation spectrum of homogentisic acid oxidase (HGD) in alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "The clinical findings of AKU result from the reaction of homogentisic acid and its homopolymeric oxidation products, i.e., benzoquinones, with connective tissue components."
     explanation: Mechanistic statement links oxidized HGA products to connective-tissue clinical findings.
+  downstream:
+  - target: Ochronosis
+    description: HGA-derived pigment deposition in connective tissue manifests as ochronosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38453957
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "ochronosis (HGA-derived"
+      explanation: Disease primer directly defines ochronosis as HGA-derived pigment in collagen-rich connective tissue.
+  - target: Pigmentation of the sclera
+    description: Ochronotic pigment can be visible as scleral pigmentation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "grey-blue coloration of the sclera and ear helix (ochronosis)"
+      explanation: Orphanet links ochronosis to scleral and ear-helix discoloration.
+  - target: Ochronotic osteoarthritis
+    description: Ochronotic connective-tissue degeneration produces disabling axial and peripheral joint disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "a disabling joint disease involving both the axial and peripheral joints (ochronotic arthropathy)"
+      explanation: Orphanet directly links ochronotic tissue disease to axial and peripheral arthropathy.
+    - reference: PMID:19862842
+      reference_title: "Mutation spectrum of homogentisic acid oxidase (HGD) in alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "patients later develop joint and spine arthritis in their thirties"
+      explanation: This background passage links ochronotic tissue involvement to later joint and spine arthritis.
+  - target: Arthralgia
+    description: Pain arises as part of severe ochronotic osteoarthropathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ochronotic osteoarthropathy
+    evidence:
+    - reference: PMID:38453957
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "painful and severe form of"
+      explanation: Disease primer links HGA-derived ochronosis to painful osteoarthropathy.
 phenotypes:
 - name: Elevated urinary homogentisic acid
   frequency: VERY_FREQUENT
@@ -272,7 +377,7 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "DIAGNOSIS/TESTING: The biochemical diagnosis of alkaptonuria in a proband is"
     explanation: GeneReviews identifies urinary HGA as the biochemical diagnostic marker.
 - name: Dark urine
@@ -293,7 +398,7 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "features of alkaptonuria are dark urine or urine that turns dark on standing,"
     explanation: GeneReviews lists dark urine as a major feature.
 - name: Ochronosis
@@ -314,7 +419,7 @@ phenotypes:
   - reference: PMID:38453957
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "debilitating disease whose main features are dark urine, ochronosis (HGA-derived"
     explanation: Disease primer identifies ochronosis as a main feature.
 - name: Ochronotic osteoarthritis
@@ -335,7 +440,7 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "the spine and larger joints."
     explanation: GeneReviews lists spine and large-joint arthritis as a major feature.
 - name: Arthralgia
@@ -356,12 +461,12 @@ phenotypes:
   - reference: PMID:38453957
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "painful and severe form of"
     explanation: Disease primer describes painful osteoarthropathy as a main feature.
 - name: Joint stiffness
   frequency: VERY_FREQUENT
-  description: Progressive ochronotic arthropathy commonly causes joint stiffness.
+  description: Joint stiffness is reported as a very frequent musculoskeletal manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Joint stiffness
     term:
@@ -376,7 +481,7 @@ phenotypes:
     explanation: Orphanet reports joint stiffness as very frequent.
 - name: Joint swelling
   frequency: VERY_FREQUENT
-  description: Joint swelling is a common manifestation of ochronotic joint disease.
+  description: Joint swelling is reported as a very frequent musculoskeletal manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Joint swelling
     term:
@@ -391,7 +496,7 @@ phenotypes:
     explanation: Orphanet reports joint swelling as very frequent.
 - name: Joint dislocation
   frequency: VERY_FREQUENT
-  description: Joint dislocation reflects advanced ochronotic cartilage and connective-tissue disease.
+  description: Joint dislocation is reported among very frequent musculoskeletal manifestations in alkaptonuria.
   phenotype_term:
     preferred_term: Joint dislocation
     term:
@@ -406,7 +511,7 @@ phenotypes:
     explanation: Orphanet reports joint dislocation as very frequent.
 - name: Back pain
   frequency: FREQUENT
-  description: Spine involvement in ochronotic arthropathy frequently causes back pain.
+  description: Back pain is reported as a frequent axial musculoskeletal manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Back pain
     term:
@@ -421,7 +526,7 @@ phenotypes:
     explanation: Orphanet reports back pain as frequent.
 - name: Intervertebral disk calcification
   frequency: VERY_FREQUENT
-  description: Ochronotic spine disease commonly includes calcified intervertebral disks.
+  description: Intervertebral disk calcification is reported as a very frequent spinal finding in alkaptonuria.
   phenotype_term:
     preferred_term: Intervertebral disk calcification
     term:
@@ -436,7 +541,7 @@ phenotypes:
     explanation: Orphanet reports intervertebral disk calcification as very frequent.
 - name: Cartilage calcification
   frequency: VERY_FREQUENT
-  description: Calcium deposition in cartilage is part of the ochronotic connective-tissue phenotype.
+  description: Cartilage calcification is reported as a very frequent structural manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Calcification of cartilage
     term:
@@ -451,7 +556,7 @@ phenotypes:
     explanation: Orphanet reports cartilage calcification as very frequent.
 - name: Cartilage destruction
   frequency: FREQUENT
-  description: Destruction of cartilage is a structural consequence of ochronotic connective-tissue disease.
+  description: Cartilage destruction is reported as a frequent structural manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Cartilage destruction
     term:
@@ -466,7 +571,7 @@ phenotypes:
     explanation: Orphanet reports cartilage destruction as frequent.
 - name: Tendon rupture
   frequency: FREQUENT
-  description: Tendon rupture is a frequent connective-tissue complication in alkaptonuria.
+  description: Tendon rupture is reported as a frequent manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Tendon rupture
     term:
@@ -482,12 +587,12 @@ phenotypes:
   - reference: PMID:38453957
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "include kidney and prostate stones, aortic stenosis, bone fractures, and tendon,"
     explanation: Disease primer lists tendon, ligament, and muscle ruptures among variable manifestations.
 - name: Thickened Achilles tendon
   frequency: FREQUENT
-  description: Achilles tendon thickening is a frequent tendon manifestation of ochronotic connective-tissue disease.
+  description: Achilles tendon thickening is reported as a frequent tendon manifestation in alkaptonuria.
   phenotype_term:
     preferred_term: Thickened Achilles tendon
     term:
@@ -518,8 +623,10 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "valve calcification or regurgitation and occasionally aortic dilatation; renal"
+    evidence_source: OTHER
+    snippet: |-
+      pigment in the sclera, ear cartilage, and skin of the hands; aortic or mitral
+      valve calcification or regurgitation and occasionally aortic dilatation; renal
     explanation: GeneReviews supports cardiac valve calcification as a manifestation.
 - name: Coronary artery calcification
   frequency: VERY_FREQUENT
@@ -539,7 +646,7 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "CT imaging to detect coronary artery calcification."
     explanation: GeneReviews surveillance guidance supports coronary artery calcification as a recognized manifestation.
 - name: Mitral valve calcification
@@ -560,8 +667,10 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: "aortic or mitral valve"
+    evidence_source: OTHER
+    snippet: |-
+      pigment in the sclera, ear cartilage, and skin of the hands; aortic or mitral
+      valve calcification or regurgitation and occasionally aortic dilatation; renal
     explanation: GeneReviews lists aortic or mitral valve calcification among manifestations.
 - name: Nephrolithiasis
   frequency: FREQUENT
@@ -581,7 +690,7 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "surgical intervention for prostate stones and renal"
     explanation: GeneReviews lists renal stones among other manifestations.
 - name: Hearing abnormality
@@ -632,7 +741,7 @@ phenotypes:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "pigment in the sclera, ear cartilage, and skin of the hands;"
     explanation: GeneReviews supports scleral pigmentation as a manifestation.
 - name: Aminoaciduria
@@ -660,7 +769,7 @@ biochemical:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "based on the detection of a significant amount of HGA in the urine (usually 1 to"
     explanation: GeneReviews provides the typical magnitude of urinary HGA excretion.
   - reference: ORPHA:56
@@ -678,7 +787,7 @@ biochemical:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Alkaptonuria is caused by deficiency of homogentisate"
     explanation: GeneReviews identifies reduced HGD activity as the causal enzyme deficiency.
   - reference: ORPHA:56
@@ -706,7 +815,7 @@ genetic:
     - reference: PMID:20301627
       reference_title: "Alkaptonuria."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: "to family members) is based on identification of biallelic pathogenic variants"
       explanation: GeneReviews supports biallelic HGD variants as the molecular diagnostic basis.
   variants:
@@ -772,6 +881,15 @@ treatments:
       evidence_source: HUMAN_CLINICAL
       snippet: "the study. u-HGA24 at 12 months was significantly decreased by 99·7% in the"
       explanation: SONIA 2 directly supports HGA-lowering as the treatment mechanism.
+  target_phenotypes:
+  - preferred_term: Elevated urinary homogentisic acid
+    term:
+      id: HP:0033704
+      label: Elevated urinary homogentisic acid
+  - preferred_term: Ochronosis
+    term:
+      id: HP:0030764
+      label: Ochronosis
   evidence:
   - reference: PMID:32822600
     reference_title: "Efficacy and safety of once-daily nitisinone for patients with alkaptonuria (SONIA 2): an international, multicentre, open-label, randomised controlled trial."


### PR DESCRIPTION
## Summary
- add an evidence-backed HGD -> HGA accumulation -> ochronotic tissue degeneration pathograph chain
- connect the strongest supported downstream clinical nodes: urinary HGA, dark urine, ochronosis, scleral pigmentation, ochronotic osteoarthritis, and arthralgia
- reclassify GeneReviews/Nat Rev Disease Primer/background mechanism snippets as OTHER and keep phenotype-list-only findings out of causal edges
- fix whitespace-sensitive snippets with exact cached substrings

## Validation
- just validate kb/disorders/Alkaptonuria.yaml
- uv run python -m dismech.graph --validate kb/disorders/Alkaptonuria.yaml
- just check-enum-cache
- strict local snippet audit: 75 snippets checked as exact cached substrings
- git diff --check