### PR TITLE
Improve hereditary fructose intolerance pathograph connectivity

### DIFF
--- a/kb/disorders/Hereditary_Fructose_Intolerance.yaml
+++ b/kb/disorders/Hereditary_Fructose_Intolerance.yaml
@@ -103,26 +103,6 @@ pathophysiology:
       id: CL:0002306
       label: epithelial cell of proximal tubule
   downstream:
-  - target: Fructose-1-phosphate
-    description: Aldolase B deficiency causes intracellular fructose-1-phosphate accumulation after fructose ingestion.
-    causal_link_type: DIRECT
-    evidence:
-    - reference: PMID:31713637
-      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
-      supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
-      snippet: "ingestion of fructose results in accumulation of Fru 1P and"
-      explanation: This directly supports fructose-1-phosphate accumulation after fructose exposure in HFI.
-  - target: ATP
-    description: Fructose-1-phosphate trapping downstream of aldolase B deficiency depletes ATP.
-    causal_link_type: DIRECT
-    evidence:
-    - reference: PMID:31713637
-      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
-      supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
-      snippet: "depletion of ATP, which are believed to cause symptoms, such as nausea,"
-      explanation: This directly supports ATP depletion as part of the core fructose-exposure mechanism.
   - target: Fructose-1-phosphate accumulation and ATP depletion
     description: Loss of aldolase B causes fructose-1-phosphate accumulation with downstream ATP depletion after fructose ingestion.
     causal_link_type: DIRECT
@@ -164,6 +144,26 @@ pathophysiology:
       id: GO:0042593
       label: glucose homeostasis
   downstream:
+  - target: Fructose-1-phosphate
+    description: The Fru1P/ATP-depletion mechanism is measured biochemically as increased fructose-1-phosphate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31713637
+      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "ingestion of fructose results in accumulation of Fru 1P and"
+      explanation: This directly supports fructose-1-phosphate accumulation after fructose exposure in HFI.
+  - target: ATP
+    description: The Fru1P/ATP-depletion mechanism is measured biochemically as decreased ATP.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31713637
+      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "depletion of ATP, which are believed to cause symptoms, such as nausea,"
+      explanation: This directly supports ATP depletion as part of the core fructose-exposure mechanism.
   - target: Hypoglycemia
     description: Impaired hepatic glucose production after fructose exposure produces symptomatic hypoglycemia.
     causal_link_type: DIRECT
@@ -435,6 +435,10 @@ treatments:
     term:
       id: HP:0002013
       label: Vomiting
+  - preferred_term: Hepatomegaly
+    term:
+      id: HP:0002240
+      label: Hepatomegaly
 - name: Ketohexokinase inhibition (investigational)
   description: >
     Ketohexokinase-directed therapy is a preclinical, mechanism-based strategy

--- a/kb/disorders/Hereditary_Fructose_Intolerance.yaml
+++ b/kb/disorders/Hereditary_Fructose_Intolerance.yaml
@@ -1,6 +1,6 @@
 name: Hereditary Fructose Intolerance
 creation_date: '2026-04-21T04:43:27Z'
-updated_date: '2026-04-22T21:54:51Z'
+updated_date: '2026-05-08T00:00:00Z'
 category: Genetic
 synonyms:
 - HFI
@@ -38,7 +38,7 @@ inheritance:
     reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Hereditary fructose intolerance (HFI) is an inborn error of fructose metabolism of autosomal recessive inheritance caused by pathogenic variants in the ALDOB gene that lead to aldolase B deficiency in the liver, kidneys, and intestine."
+    snippet: "of autosomal recessive inheritance caused by pathogenic variants in the ALDOB"
     explanation: This directly supports autosomal recessive inheritance and identifies ALDOB as the causal gene.
 prevalence:
 - population: Carrier-frequency based estimate across gnomAD populations
@@ -51,20 +51,20 @@ prevalence:
     reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The data show that HFI has a wide distribution and an estimated prevalence of ~1:10,000."
+    snippet: "HFI has a wide distribution and an estimated prevalence of ~1:10,000."
     explanation: This database study provides a concise prevalence estimate for HFI.
 progression:
 - phase: Symptom onset after fructose introduction
   notes: >
     Symptoms usually emerge once fructose-containing foods are introduced,
     with gastrointestinal complaints, feeding difficulty, aversion to sweets,
-    and hypoglycemia becoming apparent in childhood.
+    and acute metabolic symptoms becoming apparent in childhood.
   evidence:
   - reference: PMID:36052111
     reference_title: "Hereditary fructose intolerance: A comprehensive review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Most commonly children are affected with gastrointestinal symptoms, feeding issues, aversion to sweets and hypoglycemia."
+    snippet: "are affected with gastrointestinal symptoms, feeding issues, aversion to sweets"
     explanation: This review summarizes the typical early symptomatic phase after dietary fructose exposure begins.
 - phase: Persistent hepatic steatosis despite dietary treatment
   notes: >
@@ -76,7 +76,7 @@ progression:
     reference_title: "Lipidomics uncovers metabolic manifestations related to liver steatosis and low-grade systemic inflammation in diet-treated hereditary fructose intolerance patients."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Indeed, significant liver steatosis, assessed by MRS proton density fat fraction (MRS-PDFF), was present in 75 % of HFI patients compared to 7 % in the control group."
+    snippet: "in 75 % of HFI patients compared to 7 % in the control group."
     explanation: This cohort study shows that clinically important liver disease can persist despite dietary treatment.
 pathophysiology:
 - name: Aldolase B deficiency
@@ -103,6 +103,26 @@ pathophysiology:
       id: CL:0002306
       label: epithelial cell of proximal tubule
   downstream:
+  - target: Fructose-1-phosphate
+    description: Aldolase B deficiency causes intracellular fructose-1-phosphate accumulation after fructose ingestion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31713637
+      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "ingestion of fructose results in accumulation of Fru 1P and"
+      explanation: This directly supports fructose-1-phosphate accumulation after fructose exposure in HFI.
+  - target: ATP
+    description: Fructose-1-phosphate trapping downstream of aldolase B deficiency depletes ATP.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31713637
+      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "depletion of ATP, which are believed to cause symptoms, such as nausea,"
+      explanation: This directly supports ATP depletion as part of the core fructose-exposure mechanism.
   - target: Fructose-1-phosphate accumulation and ATP depletion
     description: Loss of aldolase B causes fructose-1-phosphate accumulation with downstream ATP depletion after fructose ingestion.
     causal_link_type: DIRECT
@@ -111,14 +131,14 @@ pathophysiology:
       reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "In patients with HFI, ingestion of fructose results in accumulation of Fru 1P and depletion of ATP, which are believed to cause symptoms, such as nausea, vomiting, hypoglycemia, and liver and kidney failure."
+      snippet: "ingestion of fructose results in accumulation of Fru 1P and"
       explanation: This directly links aldolase B deficiency to Fru1P accumulation and ATP depletion after fructose exposure.
   evidence:
   - reference: PMID:34524712
     reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Hereditary fructose intolerance (HFI) is an inborn error of fructose metabolism of autosomal recessive inheritance caused by pathogenic variants in the ALDOB gene that lead to aldolase B deficiency in the liver, kidneys, and intestine."
+    snippet: "gene that lead to aldolase B deficiency in the liver, kidneys, and intestine."
     explanation: This supports ALDOB deficiency in liver, kidney, and intestine as the primary lesion in HFI.
 - name: Fructose-1-phosphate accumulation and ATP depletion
   description: >
@@ -152,7 +172,7 @@ pathophysiology:
       reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "In patients with HFI, ingestion of fructose results in accumulation of Fru 1P and depletion of ATP, which are believed to cause symptoms, such as nausea, vomiting, hypoglycemia, and liver and kidney failure."
+      snippet: "vomiting, hypoglycemia, and liver and kidney failure."
       explanation: This supports hypoglycemia as a direct metabolic consequence of Fru1P accumulation and ATP depletion.
   - target: Vomiting
     description: Acute gastrointestinal intolerance, including vomiting, is triggered by the toxic metabolic response to fructose ingestion.
@@ -162,7 +182,7 @@ pathophysiology:
       reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "In patients with HFI, ingestion of fructose results in accumulation of Fru 1P and depletion of ATP, which are believed to cause symptoms, such as nausea, vomiting, hypoglycemia, and liver and kidney failure."
+      snippet: "vomiting, hypoglycemia, and liver and kidney failure."
       explanation: This directly ties vomiting to the toxic metabolic consequences of fructose exposure in HFI.
   - target: Hepatomegaly
     description: Recurrent hepatocellular metabolic stress leads to liver enlargement and steatotic liver disease.
@@ -172,13 +192,13 @@ pathophysiology:
       reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "Patients manifest symptoms, such as ketotic hypoglycemia, vomiting, nausea, in addition to hepatomegaly and other liver and kidney dysfunctions."
+      snippet: "addition to hepatomegaly and other liver and kidney dysfunctions."
       explanation: This supports hepatomegaly as part of the downstream hepatic injury phenotype in HFI.
     - reference: PMID:41806524
       reference_title: "Lipidomics uncovers metabolic manifestations related to liver steatosis and low-grade systemic inflammation in diet-treated hereditary fructose intolerance patients."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "Indeed, significant liver steatosis, assessed by MRS proton density fat fraction (MRS-PDFF), was present in 75 % of HFI patients compared to 7 % in the control group."
+      snippet: "steatosis, assessed by MRS proton density fat fraction (MRS-PDFF), was present"
       explanation: Persistent steatosis in diet-treated patients supports chronic hepatic consequences downstream of the core metabolic defect.
   - target: Renal Tubular Dysfunction
     description: Renal aldolase B deficiency and fructose toxicity can produce proximal tubular dysfunction and chronic kidney injury.
@@ -188,14 +208,24 @@ pathophysiology:
       reference_title: "Hereditary fructose intolerance: A comprehensive review."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "Renal involvement usually occurs in the form of proximal renal tubular acidosis and may lead to chronic renal insufficiency."
+      snippet: "usually occurs in the form of proximal renal tubular acidosis and may lead to"
       explanation: This review supports renal tubular dysfunction as a clinically relevant downstream renal consequence in HFI.
+  - target: Transaminases
+    description: Hepatic metabolic injury from the core fructose toxicity mechanism can present as elevated transaminases.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36052111
+      reference_title: "Hereditary fructose intolerance: A comprehensive review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "transaminases, steatohepatitis and rarely liver failure."
+      explanation: The review directly lists transaminase elevation among liver manifestations of HFI.
   evidence:
   - reference: PMID:31713637
     reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "In patients with HFI, ingestion of fructose results in accumulation of Fru 1P and depletion of ATP, which are believed to cause symptoms, such as nausea, vomiting, hypoglycemia, and liver and kidney failure."
+    snippet: "ingestion of fructose results in accumulation of Fru 1P and"
     explanation: This review summarizes the central toxic metabolic mechanism linking fructose exposure to acute organ dysfunction.
 phenotypes:
 - name: Hypoglycemia
@@ -214,7 +244,7 @@ phenotypes:
     reference_title: "Hereditary fructose intolerance: A comprehensive review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Most commonly children are affected with gastrointestinal symptoms, feeding issues, aversion to sweets and hypoglycemia."
+    snippet: "and hypoglycemia. Liver manifestations include an asymptomatic increase of"
     explanation: This review identifies hypoglycemia as a common clinical manifestation in children with HFI.
 - name: Vomiting
   category: Gastrointestinal
@@ -232,7 +262,7 @@ phenotypes:
     reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Patients manifest symptoms, such as ketotic hypoglycemia, vomiting, nausea, in addition to hepatomegaly and other liver and kidney dysfunctions."
+    snippet: "Patients manifest symptoms, such as ketotic hypoglycemia, vomiting, nausea, in"
     explanation: This supports vomiting as a characteristic symptomatic response to fructose exposure in HFI.
 - name: Hepatomegaly
   category: Gastrointestinal
@@ -250,7 +280,7 @@ phenotypes:
     reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Patients manifest symptoms, such as ketotic hypoglycemia, vomiting, nausea, in addition to hepatomegaly and other liver and kidney dysfunctions."
+    snippet: "addition to hepatomegaly and other liver and kidney dysfunctions."
     explanation: This supports hepatomegaly as part of the core hepatic phenotype in HFI.
 - name: Renal Tubular Dysfunction
   category: Renal
@@ -267,7 +297,7 @@ phenotypes:
     reference_title: "Hereditary fructose intolerance: A comprehensive review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Renal involvement usually occurs in the form of proximal renal tubular acidosis and may lead to chronic renal insufficiency."
+    snippet: "usually occurs in the form of proximal renal tubular acidosis and may lead to"
     explanation: Proximal renal tubular acidosis is a specific form of renal tubular dysfunction in HFI.
 biochemical:
 - name: Fructose-1-phosphate
@@ -280,7 +310,7 @@ biochemical:
     reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "In patients with HFI, ingestion of fructose results in accumulation of Fru 1P and depletion of ATP, which are believed to cause symptoms, such as nausea, vomiting, hypoglycemia, and liver and kidney failure."
+    snippet: "ingestion of fructose results in accumulation of Fru 1P and"
     explanation: This directly supports fructose-1-phosphate accumulation as the core biochemical abnormality in HFI.
 - name: ATP
   presence: DECREASED
@@ -292,7 +322,7 @@ biochemical:
     reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "In patients with HFI, ingestion of fructose results in accumulation of Fru 1P and depletion of ATP, which are believed to cause symptoms, such as nausea, vomiting, hypoglycemia, and liver and kidney failure."
+    snippet: "depletion of ATP, which are believed to cause symptoms, such as nausea,"
     explanation: This directly supports ATP depletion as a key biochemical consequence of fructose exposure in HFI.
 - name: Transaminases
   presence: INCREASED
@@ -304,7 +334,7 @@ biochemical:
     reference_title: "Hereditary fructose intolerance: A comprehensive review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Liver manifestations include an asymptomatic increase of transaminases, steatohepatitis and rarely liver failure."
+    snippet: "transaminases, steatohepatitis and rarely liver failure."
     explanation: This review directly supports elevated transaminases as a liver biochemical feature of HFI.
 genetic:
 - name: ALDOB
@@ -322,7 +352,7 @@ genetic:
     reference_title: "Epidemiological aspects of hereditary fructose intolerance: A database study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Hereditary fructose intolerance (HFI) is an inborn error of fructose metabolism of autosomal recessive inheritance caused by pathogenic variants in the ALDOB gene that lead to aldolase B deficiency in the liver, kidneys, and intestine."
+    snippet: "of autosomal recessive inheritance caused by pathogenic variants in the ALDOB"
     explanation: This directly supports ALDOB as the causative gene in HFI.
 diagnosis:
 - name: Molecular genetic testing
@@ -351,9 +381,7 @@ diagnosis:
     reference_title: "Hereditary fructose intolerance: A comprehensive review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      For confirmation, a genetic test is favored over the measurement of
-      aldolase B activity in the liver biopsy specimen.
+    snippet: "genetic test is favored over"
     explanation: >-
       Review-level evidence directly supports molecular genetic testing as the
       preferred confirmatory diagnostic approach in HFI.
@@ -373,14 +401,40 @@ treatments:
     reference_title: "Dietary Patterns in a Nationwide Cohort of Patients with Hereditary Fructose Intolerance."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Treatment consists of a lifelong diet restricted in fructose, sucrose, and sorbitol (FSS)."
+    snippet: "Treatment consists of a lifelong diet"
     explanation: This cohort study directly states the standard lifelong dietary treatment for HFI.
   - reference: PMID:36052111
     reference_title: "Hereditary fructose intolerance: A comprehensive review."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "The crux of HFI management lies in the absolute avoidance of foods containing fructose, sucrose, and sorbitol (FSS)."
+    snippet: "absolute avoidance of foods containing fructose,"
     explanation: This independent review confirms strict FSS avoidance as the central management strategy.
+  target_mechanisms:
+  - target: Fructose-1-phosphate accumulation and ATP depletion
+    treatment_effect: INHIBITS
+    description: Avoiding fructose, sucrose, and sorbitol prevents the fructose-triggered Fru1P accumulation and ATP depletion mechanism.
+    evidence:
+    - reference: PMID:31713637
+      reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "prevented by a fructose-restricted diet."
+      explanation: The review states that sequelae of Fru1P accumulation and ATP depletion can be prevented by fructose restriction.
+    - reference: PMID:36052111
+      reference_title: "Hereditary fructose intolerance: A comprehensive review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "absolute avoidance of foods containing fructose,"
+      explanation: Independent review evidence supports strict dietary avoidance as the management mechanism.
+  target_phenotypes:
+  - preferred_term: Hypoglycemia
+    term:
+      id: HP:0001943
+      label: Hypoglycemia
+  - preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
 - name: Ketohexokinase inhibition (investigational)
   description: >
     Ketohexokinase-directed therapy is a preclinical, mechanism-based strategy
@@ -402,14 +456,14 @@ treatments:
       reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
       supports: SUPPORT
       evidence_source: MODEL_ORGANISM
-      snippet: "The liver phenotype in aldolase B-deficient mice was prevented by reduction in intrahepatic Fru 1P concentrations by crossing these mice with mice deficient for ketohexokinase, the enzyme that catalyzes the synthesis of Fru 1P."
+      snippet: "intrahepatic Fru 1P concentrations by crossing these mice with mice deficient"
       explanation: This provides model-organism proof of concept that blocking upstream Fru1P synthesis can rescue HFI liver pathology.
   evidence:
   - reference: PMID:31713637
     reference_title: "Recent advances in the pathogenesis of hereditary fructose intolerance: implications for its treatment and the understanding of fructose-induced non-alcoholic fatty liver disease."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "These new findings not only provide a potential novel treatment for HFI, but lend insight into the pathogenesis of fructose-induced non-alcoholic fatty liver disease (NAFLD), which has raised to epidemic proportions in Western society."
+    snippet: "findings not only provide a potential novel treatment for HFI"
     explanation: This review explicitly identifies ketohexokinase-directed Fru1P reduction as a potential novel treatment strategy for HFI.
 notes: >-
   HFI remains primarily a dietary management disorder. The strongest current


### PR DESCRIPTION
Summary:
- Add evidence-backed downstream links from ALDOB deficiency to fructose-1-phosphate, ATP, toxic Fru1P/ATP depletion, hepatic transaminase elevation, and treatment effects.
- Connect fructose/sucrose/sorbitol-restricted diet to the core toxic metabolite mechanism and acute phenotypes.
- Tighten all cached snippets to exact cached substrings.

Validation:
- just validate kb/disorders/Hereditary_Fructose_Intolerance.yaml
- uv run python -m dismech.graph --validate kb/disorders/Hereditary_Fructose_Intolerance.yaml
- just check-enum-cache
- git diff --check
- custom strict cached-snippet audit: 30 snippets checked, all exact
- subagent blocker review: HFI content PR-ready after restoring generated clinicaltrials cache churn

Scope:
- Final diff is limited to kb/disorders/Hereditary_Fructose_Intolerance.yaml.