### PR TITLE
Improve ALDH18A1 De Barsy pathograph connectivity

### DIFF
--- a/kb/disorders/ALDH18A1_De_Barsy_Spectrum.yaml
+++ b/kb/disorders/ALDH18A1_De_Barsy_Spectrum.yaml
@@ -1,6 +1,6 @@
 name: ALDH18A1-Related Spastic Paraplegia and Neurocutaneous Spectrum
 creation_date: "2026-04-04T00:00:00Z"
-updated_date: "2026-05-08T16:21:17Z"
+updated_date: "2026-05-08T22:31:41Z"
 category: Mendelian
 description: >
   ALDH18A1-related spastic paraplegia and neurocutaneous spectrum encompasses
@@ -50,7 +50,10 @@ has_subtypes:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "we also identified monoallelic ALDH18A1 mutations segregating in three independent families with autosomal dominant pure or complex hereditary spastic paraplegia, as well as in two sporadic patients"
+    snippet: |-
+      identified monoallelic ALDH18A1 mutations segregating in three independent
+      families with autosomal dominant pure or complex hereditary spastic paraplegia,
+      as well as in two sporadic patients.
     explanation: Establishes SPG9A as an autosomal dominant form of ALDH18A1-related spastic paraplegia.
 - name: SPG9B
   display_name: Spastic Paraplegia 9B (Autosomal Recessive)
@@ -63,12 +66,16 @@ has_subtypes:
   - reference: PMID:31402623
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "SPG9B associates with partial P5CS deficiency and that it is clinically more severe than SPG9A, as reflected in onset age, disability, cognitive status, growth, and dysmorphic traits"
+    snippet: |-
+      conclude that both mutations are disease-causing, that SPG9B associates with
+      partial P5CS deficiency and that it is clinically more severe than SPG9A, as
+      reflected in onset age, disability, cognitive status, growth, and dysmorphic
+      traits.
     explanation: Clinical comparison confirms SPG9B is more severe than SPG9A across multiple clinical domains.
   - reference: PMID:36067040
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "These four patients exhibit variable developmental delay, neurological deficits and loose skin."
+    snippet: "developmental delay, neurological deficits and loose skin."
     explanation: Homozygous ALDH18A1 patients demonstrate the overlap of neurological and cutaneous features in recessive disease.
 inheritance:
 - name: Autosomal Dominant (SPG9A)
@@ -84,7 +91,9 @@ inheritance:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "we also identified monoallelic ALDH18A1 mutations segregating in three independent families with autosomal dominant pure or complex hereditary spastic paraplegia"
+    snippet: |-
+      identified monoallelic ALDH18A1 mutations segregating in three independent
+      families with autosomal dominant pure or complex hereditary spastic paraplegia,
     explanation: Identifies monoallelic ALDH18A1 mutations in autosomal dominant pedigrees.
 - name: Autosomal Recessive (SPG9B / ARCL3A)
   inheritance_term:
@@ -99,12 +108,18 @@ inheritance:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "we report two families with autosomal recessive transmission of ALDH18A1 mutations, and predominant complex hereditary spastic paraplegia with marked cognitive impairment, without any cutaneous abnormality"
+    snippet: |-
+      families with autosomal recessive transmission of ALDH18A1 mutations, and
+      predominant complex hereditary spastic paraplegia with marked cognitive
+      impairment, without any cutaneous abnormality.
     explanation: Identifies biallelic ALDH18A1 mutations in autosomal recessive spastic paraplegia families.
   - reference: PMID:24767728
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Autosomal recessive cutis laxa (ARCL) is a connective tissue disorder characterized by wrinkled, inelastic skin, frequently associated with a neurologic involvement and multisystem disease."
+    snippet: |-
+      Autosomal recessive cutis laxa (ARCL) is a connective tissue disorder
+      characterized by wrinkled, inelastic skin, frequently associated with a
+      neurologic involvement and multisystem disease.
     explanation: Confirms autosomal recessive inheritance for ALDH18A1-related cutis laxa.
 genetic:
 - name: ALDH18A1
@@ -131,21 +146,73 @@ genetic:
   - reference: PMID:29754261
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Mutations in ALDH18A1 can cause autosomal recessive and dominant hereditary spastic paraplegia and autosomal recessive and dominant cutis laxa."
+    snippet: |-
+      Mutations in ALDH18A1 can cause autosomal recessive and dominant hereditary
+      spastic paraplegia and autosomal recessive and dominant cutis laxa.
     explanation: Establishes that ALDH18A1 mutations cause both dominant and recessive forms of spastic paraplegia and cutis laxa.
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "ALDH18A1 encodes delta-1-pyrroline-5-carboxylate synthase (P5CS), an enzyme that catalyses the first and common step of proline and ornithine biosynthesis from glutamate."
+    snippet: |-
+      catalyses the first and common step of proline and ornithine biosynthesis from
+      glutamate.
     explanation: Defines the enzymatic function of the ALDH18A1 gene product.
 pathophysiology:
+- name: Dominant-negative disruption of P5CS oligomer (SPG9A)
+  description: >
+    In the autosomal dominant form, heterozygous missense mutations do not abolish
+    P5CS protein production but are proposed to disrupt P5CS oligomer architecture
+    via a dominant-negative effect, reducing enzymatic activity despite normal
+    protein localization.
+  gene:
+    preferred_term: ALDH18A1
+    modifier: ABNORMAL
+    term:
+      id: hgnc:9722
+      label: ALDH18A1
+  evidence:
+  - reference: PMID:31402623
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "leading to the proposal that dominant mutations cause ALDH18A1 pathologies by a dominant negative effect"
+    explanation: Literature review within this study proposes that dominant ALDH18A1 mutations cause disease through a dominant-negative mechanism.
+  downstream:
+  - target: P5CS deficiency and proline biosynthesis impairment
+- name: P5CS oligomerization and protein stability defects
+  description: >
+    Biallelic ALDH18A1 variants can reduce P5CS oligomer incorporation, protein
+    stability, or both, producing a partial loss-of-function state in patient
+    cells.
+  gene:
+    preferred_term: ALDH18A1
+    modifier: DECREASED
+    term:
+      id: hgnc:9722
+      label: ALDH18A1
+  evidence:
+  - reference: PMID:36067040
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "reduced incorporation of the monomer into P5CS oligomers."
+    explanation: Patient-cell and complemented-cell experiments show impaired oligomer assembly for a homozygous ALDH18A1 variant.
+  - reference: PMID:25077174
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: |-
+      mutations alter a conserved C-terminal domain of the encoded protein and reduce
+      protein stability as determined through Western blot analysis of patient
+      fibroblasts.
+    explanation: Patient fibroblast Western blotting supports reduced P5CS protein stability for ARCL3A-associated variants.
+  downstream:
+  - target: P5CS deficiency and proline biosynthesis impairment
+  - target: Cellular lipid droplet dysregulation
 - name: P5CS deficiency and proline biosynthesis impairment
   description: >
-    Loss-of-function mutations in ALDH18A1 reduce P5CS enzymatic activity, impairing
-    the de novo biosynthesis of proline and ornithine from glutamate. Proline
-    deficiency disrupts collagen synthesis and connective tissue integrity, while
-    ornithine deficiency can impair the urea cycle. The severity of P5CS deficiency
-    correlates with clinical severity (SPG9B > SPG9A).
+    Loss-of-function mutations in ALDH18A1 reduce P5CS enzymatic activity and
+    impair de novo biosynthesis of proline and ornithine from glutamate. Human
+    plasma amino-acid studies and patient-cell metabolomics show reduced
+    glutamate-derived metabolites, providing the metabolic bridge to downstream
+    antioxidant, extracellular-matrix, and neurodevelopmental abnormalities.
   gene:
     preferred_term: ALDH18A1
     modifier: DECREASED
@@ -167,15 +234,24 @@ pathophysiology:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Low levels of plasma ornithine, citrulline, arginine and proline in four individuals from two families suggested P5CS deficiency."
+    snippet: |-
+      as well as in two sporadic patients. Low levels of plasma ornithine, citrulline,
+      arginine and proline in four individuals from two families suggested P5CS
+      deficiency.
     explanation: Metabolic profiling demonstrates reduced amino acid levels downstream of P5CS.
   - reference: PMID:36067040
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: "we identified reduced abundance of glutamate and several metabolites derived from glutamate, including proline and glutathione"
+    snippet: |-
+      identified reduced abundance of glutamate and several metabolites derived from
+      glutamate, including proline and glutathione.
     explanation: Metabolomics in patient fibroblasts confirms broad impairment of glutamate-derived amino acid and antioxidant pathways.
   downstream:
   - target: Antioxidant metabolism impairment
+  - target: Extracellular matrix-related cellular dysregulation
+  - target: Neurodevelopmental and corticospinal motor-system involvement
+  - target: Plasma proline
+  - target: Glutathione and putrescine
 - name: Antioxidant metabolism impairment
   description: >
     P5CS deficiency leads to reduced glutathione levels and decreased polyamine
@@ -192,26 +268,84 @@ pathophysiology:
   - reference: PMID:36067040
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: "Biosynthesis of the polyamine putrescine, derived from ornithine, was also decreased in patient fibroblasts, highlighting the functional consequence on another metabolic pathway involved in antioxidant responses in the cell."
+    snippet: |-
+      Biosynthesis of the polyamine
+      putrescine, derived from ornithine, was also decreased in patient fibroblasts,
+      highlighting the functional consequence on another metabolic pathway involved in
+      antioxidant responses in the cell.
     explanation: Decreased putrescine biosynthesis demonstrates P5CS deficiency impacts antioxidant pathways beyond proline synthesis.
-- name: Dominant-negative disruption of P5CS oligomer (SPG9A)
+  downstream:
+  - target: Glutathione and putrescine
+- name: Extracellular matrix-related cellular dysregulation
   description: >
-    In the autosomal dominant form, heterozygous missense mutations do not abolish
-    P5CS protein production but are proposed to disrupt P5CS oligomer architecture
-    via a dominant-negative effect, reducing enzymatic activity despite normal
-    protein localization.
-  gene:
-    preferred_term: ALDH18A1
-    modifier: DECREASED
+    Impaired P5CS function is associated with extracellular matrix-related
+    transcript changes in patient fibroblasts and with the wrinkled, inelastic
+    skin phenotype of ALDH18A1-related cutis laxa.
+  biological_processes:
+  - preferred_term: extracellular matrix organization
     term:
-      id: hgnc:9722
-      label: ALDH18A1
+      id: GO:0030198
+      label: extracellular matrix organization
+    modifier: ABNORMAL
   evidence:
-  - reference: PMID:31402623
+  - reference: PMID:36067040
     supports: SUPPORT
-    evidence_source: OTHER
-    snippet: "leading to the proposal that dominant mutations cause ALDH18A1 pathologies by a dominant negative effect"
-    explanation: Literature review within this study proposes that dominant ALDH18A1 mutations cause disease through a dominant-negative mechanism.
+    evidence_source: IN_VITRO
+    snippet: |-
+      revealed transcript abundance changes in several metabolic and extracellular
+      matrix-related genes, adding further insight into pathogenic processes
+      associated with impaired P5CS function.
+    explanation: Patient fibroblast transcriptomics link impaired P5CS function to extracellular matrix-related cellular dysregulation.
+  - reference: PMID:24767728
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: |-
+      Autosomal recessive cutis laxa (ARCL) is a connective tissue disorder
+      characterized by wrinkled, inelastic skin, frequently associated with a
+      neurologic involvement and multisystem disease.
+    explanation: Clinical description anchors the extracellular matrix-related cellular findings to cutis laxa connective-tissue disease.
+  downstream:
+  - target: Cutis laxa
+- name: Neurodevelopmental and corticospinal motor-system involvement
+  description: >
+    ALDH18A1-related P5CS deficiency produces a neurological disease spectrum
+    spanning hereditary spastic paraplegia, cognitive impairment, developmental
+    delay, and microcephaly, with recessive SPG9B generally more severe than
+    dominant SPG9A.
+  evidence:
+  - reference: PMID:26026163
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: |-
+      Hereditary spastic paraplegias are heterogeneous neurological disorders
+      characterized by a pyramidal syndrome with symptoms predominantly affecting the
+      lower limbs.
+    explanation: Clinical series establishes the corticospinal motor-system phenotype framing ALDH18A1-associated hereditary spastic paraplegia.
+  - reference: PMID:36067040
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "developmental delay, neurological deficits and loose skin."
+    explanation: Homozygous ALDH18A1 cases support neurodevelopmental involvement in the recessive spectrum.
+  downstream:
+  - target: Spastic paraplegia
+  - target: Spastic paraplegia with cognitive impairment
+  - target: Intellectual disability
+  - target: Global developmental delay
+  - target: Microcephaly
+- name: Cellular lipid droplet dysregulation
+  description: >
+    ALDH18A1-mutant fibroblasts show enlarged lipid droplets after oleate loading,
+    a cellular phenotype similar to findings reported in Warburg Micro syndrome
+    models.
+  evidence:
+  - reference: PMID:25077174
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: |-
+      Patient fibroblasts exhibit a lipid droplet phenotype similar to
+      that recently reported in Warburg Micro syndrome, a disorder with similar
+      features but hitherto unrelated cellular etiology.
+    explanation: Patient fibroblast assays identify lipid droplet dysregulation as a cellular consequence associated with ALDH18A1 loss of function.
 phenotypes:
 - category: Neurological
   name: Spastic paraplegia
@@ -229,7 +363,9 @@ phenotypes:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "we also identified monoallelic ALDH18A1 mutations segregating in three independent families with autosomal dominant pure or complex hereditary spastic paraplegia"
+    snippet: |-
+      identified monoallelic ALDH18A1 mutations segregating in three independent
+      families with autosomal dominant pure or complex hereditary spastic paraplegia,
     explanation: Spastic paraplegia is the defining feature of SPG9A, ranging from pure to complex forms.
 - category: Neurological
   name: Spastic paraplegia with cognitive impairment
@@ -246,7 +382,10 @@ phenotypes:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "we report two families with autosomal recessive transmission of ALDH18A1 mutations, and predominant complex hereditary spastic paraplegia with marked cognitive impairment, without any cutaneous abnormality"
+    snippet: |-
+      families with autosomal recessive transmission of ALDH18A1 mutations, and
+      predominant complex hereditary spastic paraplegia with marked cognitive
+      impairment, without any cutaneous abnormality.
     explanation: SPG9B is characterized by complex HSP with prominent cognitive impairment.
 - category: Neurological
   name: Intellectual disability
@@ -263,7 +402,11 @@ phenotypes:
   - reference: PMID:31402623
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "SPG9B associates with partial P5CS deficiency and that it is clinically more severe than SPG9A, as reflected in onset age, disability, cognitive status, growth, and dysmorphic traits"
+    snippet: |-
+      conclude that both mutations are disease-causing, that SPG9B associates with
+      partial P5CS deficiency and that it is clinically more severe than SPG9A, as
+      reflected in onset age, disability, cognitive status, growth, and dysmorphic
+      traits.
     explanation: Cognitive impairment is a defining feature distinguishing SPG9B severity from SPG9A.
 - category: Neurological
   name: Global developmental delay
@@ -279,7 +422,7 @@ phenotypes:
   - reference: PMID:36067040
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "These four patients exhibit variable developmental delay, neurological deficits and loose skin."
+    snippet: "developmental delay, neurological deficits and loose skin."
     explanation: Developmental delay is a consistent feature of biallelic ALDH18A1 disease.
 - category: Dermatological
   name: Cutis laxa
@@ -297,7 +440,11 @@ phenotypes:
   - reference: PMID:24767728
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Features of our patient that have been described in literature included cutis laxa on hands and feet, visible veins on thorax and abdomen, joint laxity, failure to thrive, short stature, microcephaly, and severe developmental and speech delay."
+    snippet: |-
+      Features of our patient that
+      have been described in literature included cutis laxa on hands and feet, visible
+      veins on thorax and abdomen, joint laxity, failure to thrive, short stature,
+      microcephaly, and severe developmental and speech delay.
     explanation: Cutis laxa is a recognized feature of ARCL3A with variable distribution.
 - category: Ophthalmological
   name: Cataracts
@@ -330,7 +477,11 @@ phenotypes:
   - reference: PMID:24767728
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Features of our patient that have been described in literature included cutis laxa on hands and feet, visible veins on thorax and abdomen, joint laxity, failure to thrive, short stature, microcephaly, and severe developmental and speech delay."
+    snippet: |-
+      Features of our patient that
+      have been described in literature included cutis laxa on hands and feet, visible
+      veins on thorax and abdomen, joint laxity, failure to thrive, short stature,
+      microcephaly, and severe developmental and speech delay.
     explanation: Short stature and failure to thrive are consistent features of ARCL3A.
 - category: Neurological
   name: Microcephaly
@@ -360,12 +511,17 @@ biochemical:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Low levels of plasma ornithine, citrulline, arginine and proline in four individuals from two families suggested P5CS deficiency."
+    snippet: |-
+      as well as in two sporadic patients. Low levels of plasma ornithine, citrulline,
+      arginine and proline in four individuals from two families suggested P5CS
+      deficiency.
     explanation: Plasma amino acid profiling reveals P5CS deficiency biomarkers in affected individuals.
   - reference: PMID:29754261
     supports: PARTIAL
     evidence_source: HUMAN_CLINICAL
-    snippet: "This young man has spastic paraplegia with onset in childhood and temporal lobe epilepsy, but normal levels of proline, ornithine and arginine."
+    snippet: |-
+      childhood and temporal lobe epilepsy, but normal levels of proline, ornithine
+      and arginine.
     explanation: Demonstrates that amino acid levels may be normal when mutations affect the G5PR domain.
 - name: Glutathione and putrescine
   presence: Decreased
@@ -377,7 +533,10 @@ biochemical:
   - reference: PMID:36067040
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: "we identified reduced abundance of glutamate and several metabolites derived from glutamate, including proline and glutathione. Biosynthesis of the polyamine putrescine, derived from ornithine, was also decreased in patient fibroblasts"
+    snippet: |-
+      identified reduced abundance of glutamate and several metabolites derived from
+      glutamate, including proline and glutathione. Biosynthesis of the polyamine
+      putrescine, derived from ornithine, was also decreased in patient fibroblasts,
     explanation: Comprehensive metabolomics reveals impaired amino acid and antioxidant metabolism in ALDH18A1-deficient cells.
 treatments:
 - name: Genetic Counseling
@@ -394,7 +553,11 @@ treatments:
   - reference: PMID:26026163
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "we therefore suggest including amino acid chromatography in the clinico-genetic work-up of hereditary spastic paraplegia, particularly in dominant cases, as the associated phenotype is not distinct from other causative genes"
+    snippet: |-
+      we therefore suggest including
+      amino acid chromatography in the clinico-genetic work-up of hereditary spastic
+      paraplegia, particularly in dominant cases, as the associated phenotype is not
+      distinct from other causative genes.
     explanation: Authors recommend metabolic screening as part of the diagnostic approach for HSP.
 - name: Supportive Care
   description: >


### PR DESCRIPTION
## Summary
- connect dominant-negative and recessive ALDH18A1/P5CS defects into the P5CS deficiency mechanism
- add extracellular matrix, neurodevelopmental/corticospinal, and lipid-droplet cellular nodes with cached evidence
- tighten PMID snippets in this file to exact cached substrings and keep the PR scoped to the YAML only

## Validation
- just validate kb/disorders/ALDH18A1_De_Barsy_Spectrum.yaml
- uv run python -m dismech.graph --validate kb/disorders/ALDH18A1_De_Barsy_Spectrum.yaml
- strict exact snippet audit: 39 snippets exact
- git diff --check