### PR TITLE
Connect ASL branches in urea cycle disorder graph

### DIFF
--- a/kb/disorders/Urea_Cycle_Disorder.yaml
+++ b/kb/disorders/Urea_Cycle_Disorder.yaml
@@ -1,7 +1,7 @@
 name: Urea Cycle Disorder
 category: Mendelian
 creation_date: '2026-02-16T23:59:29Z'
-updated_date: '2026-05-08T12:59:21Z'
+updated_date: '2026-05-08T22:59:02Z'
 synonyms:
 - Urea cycle disorders
 - UCD
@@ -114,6 +114,57 @@ pathophysiology:
   - target: Impaired hepatic ureagenesis and ammonia accumulation
     description: Loss of catalytic enzyme function reduces urea production and permits ammonia accumulation.
     causal_link_type: DIRECT
+  - target: Nitric oxide deficiency in ASL deficiency
+    description: ASL loss impairs systemic nitric oxide production through reduced endogenous arginine synthesis and impaired use of extracellular arginine.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - decreased endogenous arginine synthesis
+    - impaired extracellular arginine utilization for nitric oxide production
+    evidence:
+    - reference: PMID:22081021
+      reference_title: "Requirement of argininosuccinate lyase for systemic nitric oxide production."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: |-
+        Loss of Asl in both humans and mice leads to reduced NO
+        synthesis, owing to both decreased endogenous arginine synthesis and an impaired
+        ability to use extracellular arginine for NO production.
+      explanation: Supports the human ASL-deficiency component of the subtype-specific nitric oxide branch.
+    - reference: PMID:22081021
+      reference_title: "Requirement of argininosuccinate lyase for systemic nitric oxide production."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: |-
+        Loss of Asl in both humans and mice leads to reduced NO
+        synthesis, owing to both decreased endogenous arginine synthesis and an impaired
+        ability to use extracellular arginine for NO production.
+      explanation: Supports the mouse-model component of the subtype-specific nitric oxide branch.
+  - target: Hepatic glutathione dysregulation in ASL deficiency
+    description: ASL deficiency produces a subtype-specific hepatic redox branch with glutathione depletion and altered cysteine utilization.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38198573
+      reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Here, we describe the \ndysregulation of glutathione biosynthesis and upstream cysteine utilization in \nASL-deficient patients and mice"
+      explanation: Supports the patient component of ASL-associated glutathione and cysteine dysregulation.
+    - reference: PMID:38198573
+      reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Here, we describe the \ndysregulation of glutathione biosynthesis and upstream cysteine utilization in \nASL-deficient patients and mice"
+      explanation: Supports the mouse-model component of ASL-associated glutathione and cysteine dysregulation.
+  - target: Arginine and guanidino compound neurotoxicity in ARG1 deficiency
+    description: ARG1 loss creates the distal urea-cycle branch dominated by hyperargininemia and progressive spastic neurologic disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26467175
+      reference_title: "Arginase-1 deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "partial or complete loss of enzyme function"
+      explanation: Supports ARG1 loss of enzyme function as the upstream defect for the ARG1-specific hyperargininemia branch.
 - name: Impaired hepatic ureagenesis and ammonia accumulation
   description: 'The urea cycle is the main pathway for ammonia detoxification, localized to periportal hepatocytes. Reduced conversion of ammonia to urea causes accumulation of circulating ammonia and nitrogenous intermediates. Proximal mitochondrial defects (CPS1, OTC, NAGS) produce hyperammonemia with low citrulline and arginine, while distal cytosolic defects (ASS1, ASL, ARG1) cause accumulation of pathway intermediates with variable hyperammonemia.
 
@@ -451,6 +502,20 @@ pathophysiology:
   notes: 'This mechanism is specific to ASL deficiency and explains liver disease beyond ammonia toxicity. mRNA therapy has been shown to restore hepatic glutathione to near wild-type levels in preclinical models.
 
     '
+  downstream:
+  - target: Chronic UCD liver disease
+    description: ASL-associated glutathione depletion and antioxidant-pathway dysregulation contribute to the chronic liver-disease branch of argininosuccinic aciduria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - glutathione depletion
+    - down-regulated antioxidant pathways
+    evidence:
+    - reference: PMID:38198573
+      reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Human hASL mRNA encapsulated in lipid nanoparticles improved glutathione \nmetabolism and chronic liver disease."
+      explanation: Preclinical mRNA rescue links corrected glutathione metabolism with improved chronic liver disease in ASL deficiency.
 - name: Nitric oxide deficiency in ASL deficiency
   description: 'ASL participates in the citrulline-argininosuccinate-arginine recycling pathway that channels arginine to nitric oxide synthase. ASL deficiency impairs endogenous nitric oxide production, contributing to systemic vascular and neurological phenotypes that are independent of hyperammonemia, including hypertension and neurocognitive deficits.
 
@@ -465,7 +530,59 @@ pathophysiology:
     term:
       id: GO:0006809
       label: nitric oxide biosynthetic process
-  notes: Nitric oxide deficiency in ASL deficiency is a recognized subtype-specific mechanism, but a direct NO-focused quote was not available in the currently cited abstracts.
+  evidence:
+  - reference: PMID:22081021
+    reference_title: "Requirement of argininosuccinate lyase for systemic nitric oxide production."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: |-
+      Loss of Asl in both humans and mice leads to reduced NO
+      synthesis, owing to both decreased endogenous arginine synthesis and an impaired
+      ability to use extracellular arginine for NO production.
+    explanation: The abstract directly supports reduced nitric oxide synthesis in humans with ASL deficiency.
+  - reference: PMID:37490345
+    reference_title: "Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide-mediated dysregulation of claudin expression."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Previously, we have shown that \nargininosuccinate lyase deficiency (ASLD) is a novel model system to investigate \ncell-autonomous, nitric oxide synthase-dependent NO deficiency."
+    explanation: Supports a cell-autonomous nitric oxide deficiency mechanism in ASL-deficient systems.
+  downstream:
+  - target: Abnormality of movement
+    description: NO-mediated central catecholamine dysregulation is associated with the late-onset movement-disorder phenotype in ASA.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - NO-mediated downregulation of central catecholamine biosynthesis
+    evidence:
+    - reference: PMID:38044746
+      reference_title: "The incidence of movement disorder increases with age and contrasts with subtle and limited neuroimaging abnormalities in argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients present with developmental delay, \nepilepsy and movement disorder, associated with NO-mediated downregulation of \ncentral catecholamine biosynthesis."
+      explanation: Supports the NO-linked movement-disorder branch in argininosuccinic aciduria.
+  - target: Global developmental delay
+    description: Developmental delay occurs within the ASA neurological phenotype associated with NO-mediated central catecholamine dysregulation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - NO-mediated downregulation of central catecholamine biosynthesis
+    evidence:
+    - reference: PMID:38044746
+      reference_title: "The incidence of movement disorder increases with age and contrasts with subtle and limited neuroimaging abnormalities in argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients present with developmental delay, \nepilepsy and movement disorder, associated with NO-mediated downregulation of \ncentral catecholamine biosynthesis."
+      explanation: Supports developmental delay as part of the NO-associated ASA neurological phenotype.
+  - target: Seizures
+    description: Epilepsy occurs within the ASA neurological phenotype associated with NO-mediated central catecholamine dysregulation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - NO-mediated downregulation of central catecholamine biosynthesis
+    evidence:
+    - reference: PMID:38044746
+      reference_title: "The incidence of movement disorder increases with age and contrasts with subtle and limited neuroimaging abnormalities in argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients present with developmental delay, \nepilepsy and movement disorder, associated with NO-mediated downregulation of \ncentral catecholamine biosynthesis."
+      explanation: Supports epilepsy/seizures as part of the NO-associated ASA neurological phenotype.
 - name: Arginine and guanidino compound neurotoxicity in ARG1 deficiency
   description: 'ARG1 deficiency is a distal urea-cycle defect in which chronic hyperargininemia and related guanidino compound accumulation, rather than recurrent severe hyperammonemia alone, dominate the progressive neurologic phenotype. This subtype-specific toxic-metabolite mechanism explains spastic paraplegia-predominant disease.
 


### PR DESCRIPTION
## Summary
- connect ASL nitric oxide and hepatic glutathione branches to the upstream urea-cycle enzyme defect
- add downstream ASL-specific edges to chronic UCD liver disease and neurological features
- connect the ARG1-specific hyperargininemia branch to the shared enzyme-defect node so the pathophysiology graph is one component

## Validation
- just validate kb/disorders/Urea_Cycle_Disorder.yaml
- uv run python -m dismech.graph --validate kb/disorders/Urea_Cycle_Disorder.yaml
- just check-enum-cache
- git diff --check

Note: the file has pre-existing wrapped snippet audit failures from earlier curation; the new snippets introduced in this follow-up were checked against cached references.