### PR TITLE
Connect MMDS9B neuropathy mechanisms

### DIFF
--- a/kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
+++ b/kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
@@ -1,7 +1,7 @@
 name: Multiple Mitochondrial Dysfunctions Syndrome 9B
 category: Genetic
 creation_date: "2026-03-23T00:00:00Z"
-updated_date: "2026-04-22T20:13:21Z"
+updated_date: "2026-05-08T23:27:12Z"
 synonyms:
 - MMDS9B
 - FDXR-related mitochondriopathy
@@ -381,6 +381,18 @@ pathophysiology:
         explanation: >
           Systematic review documenting frequency of peripheral neuropathy and ataxia
           in FDXR patients.
+    downstream:
+      - target: Peripheral Neuropathy
+        causal_link_type: DIRECT
+        evidence:
+          - reference: PMID:37046037
+            reference_title: "FDXR-associated disease: a challenging differential diagnosis with inflammatory peripheral neuropathy."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "significant incidence of sensorimotor peripheral polyneuropathy (22.72%)"
+            explanation: >
+              The review documents sensorimotor peripheral polyneuropathy as a clinical
+              manifestation of FDXR-associated disease.
   - name: Acute-Onset Peripheral Neuropathy
     description: >
       Some patients present with acute or subacute onset of peripheral neuropathy that
@@ -399,6 +411,18 @@ pathophysiology:
           FDXR-associated disease
         explanation: >
           Describes acute-onset neuropathy presentation that can mimic inflammatory peripheral neuropathy.
+    downstream:
+      - target: Peripheral Neuropathy
+        causal_link_type: DIRECT
+        evidence:
+          - reference: PMID:37046037
+            reference_title: "FDXR-associated disease: a challenging differential diagnosis with inflammatory peripheral neuropathy."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "RESULTS: Both patients presented with an acute-sub-acute onset of peripheral \nneuropathy and only in later stages of the disease developed the typical \nfeatures of FDXR-associated disease."
+            explanation: >
+              The acute-onset presentation is explicitly a peripheral neuropathy
+              presentation of FDXR-associated disease.
 phenotypes:
   - category: Neurological
     name: Optic Atrophy
@@ -501,6 +525,15 @@ phenotypes:
       term:
         id: HP:0009830
         label: Peripheral neuropathy
+    evidence:
+      - reference: PMID:37046037
+        reference_title: "FDXR-associated disease: a challenging differential diagnosis with inflammatory peripheral neuropathy."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: "significant incidence of sensorimotor peripheral polyneuropathy (22.72%)"
+        explanation: >
+          Systematic review documents peripheral polyneuropathy in reported FDXR
+          patients.
   - category: Neurological
     name: Nystagmus
     frequency: OCCASIONAL


### PR DESCRIPTION
## Summary
- connect the MMDS9B peripheral neuropathy mechanism nodes to the Peripheral Neuropathy phenotype
- add direct PMID:37046037 evidence to the new downstream edges and phenotype evidence block
- refresh the disorder updated_date

## Validation
- `just validate kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml`
- `just check-enum-cache`
- `git diff --check`
- direct exact-snippet check against `references_cache/PMID_37046037.md` for the two newly added snippets

## Notes
- validation-generated cache and enum churn was restored; PR diff is scoped to the disorder YAML only
- reviewer subagent found no blocker issues