### PR TITLE
Connect galactosemia mechanism branches

### DIFF
--- a/kb/disorders/Galactosemia.yaml
+++ b/kb/disorders/Galactosemia.yaml
@@ -1,6 +1,6 @@
 name: Galactosemia
 creation_date: '2026-02-06T03:39:54Z'
-updated_date: '2026-03-31T18:30:00Z'
+updated_date: '2026-05-08T23:55:19Z'
 category: Genetic
 synonyms:
 - Galactose intolerance
@@ -151,6 +151,24 @@ pathophysiology:
       evidence_source: IN_VITRO
       snippet: "GALT deficiency causes UDP-hexose deficit in human galactosemic cells."
       explanation: This cell study directly ties GALT deficiency to a UDP-hexose deficit.
+  - target: Galactitol accumulation
+    description: Deficiency of the transferase step can shunt galactose metabolism toward galactitol accumulation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:3043741
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Galactosemia is a disorder caused by a deficiency of any one of three possible \nenzymes involved in the metabolism of galactose: galactokinase, transferase or \nepimerase. Any single deficient enzyme can result in cataract through the \naccumulation of galactitol in the lens."
+      explanation: The review identifies transferase deficiency as a galactosemia mechanism that can lead to lens galactitol accumulation.
+  - target: Acute Hepatocellular Dysfunction
+    description: Untreated classic GALT-related galactosemia produces acute neonatal hepatocellular injury.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301691
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Classic galactosemia, which can result in \nlife-threatening complications including feeding problems, failure to thrive, \nhepatocellular damage, bleeding, and E coli sepsis in untreated infants."
+      explanation: GeneReviews links untreated classic galactosemia to hepatocellular damage in infants.
   evidence:
   - reference: PMID:33525536
     supports: SUPPORT


### PR DESCRIPTION
## Summary
- connect the Galactosemia GALT deficiency mechanism to the galactitol/cataract branch
- connect GALT-related untreated classic galactosemia to the acute hepatocellular dysfunction branch
- collapse the pathophysiology graph from 3 components to 1

## Validation
- `just validate kb/disorders/Galactosemia.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Galactosemia.yaml`
- `just check-enum-cache`
- `git diff --check`
- direct exact-snippet check against `references_cache/PMID_3043741.md` and `references_cache/PMID_20301691.md` for the newly added snippets

## Notes
- validation-generated cache/enum churn was restored; PR diff is scoped to `kb/disorders/Galactosemia.yaml`
- reviewer subagent found no blocker issues
- `just validate-references` reports 0 checks for this file, so changed snippets were checked directly against the local cache