### PR TITLE
Connect abetalipoproteinemia vitamin branches

### DIFF
--- a/kb/disorders/Abetalipoproteinemia.yaml
+++ b/kb/disorders/Abetalipoproteinemia.yaml
@@ -1,6 +1,6 @@
 name: Abetalipoproteinemia
 creation_date: '2026-05-04T05:21:52Z'
-updated_date: '2026-05-04T06:03:00Z'
+updated_date: '2026-05-09T00:11:53Z'
 category: Mendelian
 description: >
   Abetalipoproteinemia is a severe autosomal recessive disorder of
@@ -260,6 +260,26 @@ pathophysiology:
     description: Hemolysis and vitamin-related hematologic effects can contribute to hyperbilirubinemia.
   - target: Hypoalbuminemia
     description: Chronic malabsorption can be accompanied by low albumin in Orphanet phenotype data.
+  - target: Vitamin E-Linked Neurologic and Retinal Injury
+    description: Persistent deficiency of fat-soluble vitamins contributes to retinal degeneration and neurologic injury.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18611256
+      reference_title: "Abetalipoproteinemia: two case reports and literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "deficiency of fat-soluble vitamins is associated with\ndevelopment of atypical retinitis pigmentosa, coagulopathy, posterior column\nneuropathy and myopathy."
+      explanation: This clinical review links fat-soluble vitamin deficiency to retinal and neurologic complications.
+  - target: Vitamin K-Related Coagulation Abnormality
+    description: Fat-soluble vitamin malabsorption includes vitamin K deficiency, which can increase INR and prolong coagulation testing.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30358967
+      reference_title: "Abetalipoproteinemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Malabsorption of fat-soluble vitamins (A, D, E, and K) can\nresult in an increased international normalized ratio (INR)."
+      explanation: GeneReviews directly links fat-soluble vitamin malabsorption, including vitamin K, to increased INR.
 - name: Vitamin E-Linked Neurologic and Retinal Injury
   description: >
     Persistent fat-soluble vitamin deficiency, especially vitamin E deficiency,


### PR DESCRIPTION
## Summary
- connect fat/fat-soluble vitamin malabsorption to the vitamin E-linked neurologic and retinal injury branch
- connect fat/fat-soluble vitamin malabsorption to the vitamin K-related coagulation branch
- collapse the pathophysiology graph from 3 components to 1

## Validation
- `just validate kb/disorders/Abetalipoproteinemia.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Abetalipoproteinemia.yaml`
- `just check-enum-cache`
- `git diff --check`
- direct exact-snippet check against `references_cache/PMID_18611256.md` and `references_cache/PMID_30358967.md` for the newly added snippets

## Notes
- fetched/rebased onto current `origin/main` before commit/push
- validation-generated ClinicalTrials cache churn was restored; PR diff is scoped to `kb/disorders/Abetalipoproteinemia.yaml`
- reviewer subagent found no blocker issues
- `validate-references` reports 0 checks for this file, so changed snippets were checked directly against the local cache