### PR TITLE
Connect GSD I subtype branches

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_Type_I.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Glycogen Storage Disease Type I
 creation_date: '2026-03-08T12:00:00Z'
-updated_date: '2026-05-05T10:48:54Z'
+updated_date: '2026-05-09T00:36:17Z'
 category: Mendelian
 description: >
   Glycogen storage disease type I (GSD I), also known as von Gierke disease, is an
@@ -174,6 +174,26 @@ pathophysiology:
   - target: Hepatic steatosis
     description: Excess hepatic glucose-6-phosphate flux promotes fat accumulation in the liver.
     causal_link_type: DIRECT
+  - target: Neutropenia and neutrophil dysfunction in GSD Ib
+    description: In GSD Ib, SLC37A4/G6PT deficiency links the shared glucose-homeostasis defect to neutropenia and neutrophil dysfunction.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:31705665
+      reference_title: "Glycogen storage disease type Ib: role of glucose-6-phosphate transporter in cell metabolism and function."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Glycogen storage disease type Ib (GSD-Ib)\nis an autosomal recessive disorder characterized by hypoglycemia, excessive\nglycogen accumulation in the liver and kidney, neutropenia, neutrophil\ndysfunction, and inflammatory bowel disease. GSD-Ib is caused by a deficiency of\nglucose-6-phosphate transporter (G6PT)."
+      explanation: This review ties GSD Ib metabolic disease and neutrophil dysfunction to the same G6PT deficiency.
+  - target: Platelet and von Willebrand factor dysfunction
+    description: GSD I can include platelet and von Willebrand factor dysfunction, with intermediate mechanisms unresolved in the cached evidence.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Impaired\nplatelet function and development of reduced or dysfunctional von Willebrand\nfactor can lead to a bleeding tendency with frequent epistaxis and menorrhagia\nin females."
+      explanation: GeneReviews supports the platelet/von Willebrand factor bleeding branch as part of GSD I.
 - name: Secondary metabolic derangements
   description: >
     The block in glucose-6-phosphate hydrolysis leads to accumulation of metabolic


### PR DESCRIPTION
## Summary
- connect the GSD Ib neutrophil dysfunction branch to the shared glucose-6-phosphate hydrolysis defect
- connect the platelet/von Willebrand factor bleeding branch to the GSD I pathophysiology graph with unknown intermediates
- collapse the pathophysiology graph from 3 components to 1

## Validation
- `just validate kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`
- `just check-enum-cache`
- `git diff --check`
- direct exact-snippet check against `references_cache/PMID_31705665.md` and `references_cache/PMID_20301489.md` for the newly added snippets

## Notes
- fetched current `origin/main` before commit/push
- validation-generated ClinicalTrials cache churn was restored; PR diff is scoped to `kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`
- reviewer subagent found no blocker issues
- `validate-references` reports 0 checks for this file, so changed snippets were checked directly against the local cache