### PR TITLE
Connect Farber retinal storage branch

### DIFF
--- a/kb/disorders/Farber_Disease.yaml
+++ b/kb/disorders/Farber_Disease.yaml
@@ -1,7 +1,7 @@
 name: Farber Disease
 category: Mendelian
 creation_date: "2026-05-05T11:17:39Z"
-updated_date: "2026-05-05T11:17:39Z"
+updated_date: "2026-05-09T01:26:56Z"
 synonyms:
 - Acid ceramidase deficiency
 - Farber lipogranulomatosis
@@ -293,6 +293,25 @@ pathophysiology:
     description: Ceramide storage can involve CNS cell types and contribute to neurologic disease.
   - target: Respiratory system involvement
     description: Multisystem ceramide storage can involve the respiratory system.
+  - target: Retinal ceramide storage and macrophage activation
+    description: >
+      Tissue ceramide storage extends to the retina, where acid ceramidase
+      restoration reduces ceramide accumulation and macrophage activation in a
+      Farber disease mouse model.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:35902747
+      reference_title: rAAV-mediated over-expression of acid ceramidase prevents retinopathy in a mouse model of Farber lipogranulomatosis.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >
+        ASAH1 over-expression significantly reduces central retinal thickening,
+        ceramide accumulation, macrophage activation and limits fundus
+        hyper-reflectivity and auto-fluorescence in FD mice
+      explanation: >
+        In the Farber mouse retina, restoring ASAH1 reduces ceramide accumulation
+        and macrophage activation, supporting retinal storage pathology as a
+        tissue-specific branch of the ceramide storage mechanism.
 - name: Lipid-laden macrophage granulomas
   description: >
     Storage disease recruits and activates macrophages, producing granuloma-like


### PR DESCRIPTION
## Summary
- Connect the Farber retinal ceramide storage/macrophage branch to the main lysosomal ceramide storage pathograph.
- Add evidence on the new edge from PMID:35902747 showing ASAH1 over-expression reduces retinal ceramide accumulation and macrophage activation in Farber mice.
- Improves Farber pathophysiology graph from 2 components to 1.

## Validation
- `just validate kb/disorders/Farber_Disease.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Farber_Disease.yaml`
- `just check-enum-cache`
- `git diff --check`
- direct exact snippet audit for PMID:35902747

Unrelated clinical-trials cache normalization produced by validation was restored before commit.