### PR TITLE
Connect IBDD low penetrance branch

### DIFF
--- a/kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Isobutyryl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-07T23:41:43Z'
+updated_date: '2026-05-09T02:08:31Z'
 synonyms:
 - IBDD
 - IBD deficiency
@@ -107,6 +107,33 @@ pathophysiology:
       evidence_source: IN_VITRO
       snippet: "human recombinant enzyme had highest activity with isobutyryl-CoA"
       explanation: Review evidence supports ACAD8 as the enzyme directly responsible for the isobutyryl-CoA dehydrogenation step in valine catabolism.
+  - target: Largely asymptomatic course
+    description: >
+      ACAD8-related isobutyryl-CoA dehydrogenase deficiency is most often a
+      low-penetrance biochemical phenotype detected by newborn screening rather
+      than a consistently symptomatic clinical disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:41606743
+      reference_title: "Isobutyryl-coenzyme a dehydrogenase deficiency: disease, or non-disease?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Isobutyryl-coenzyme A dehydrogenase deficiency (IBDD) is a rare inborn
+        error of valine metabolism caused by variants in the ACAD8 gene.
+      explanation: >
+        Literature synthesis roots IBDD in ACAD8 variants.
+    - reference: PMID:41606743
+      reference_title: "Isobutyryl-coenzyme a dehydrogenase deficiency: disease, or non-disease?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Of these 172 individuals, 146 were asymptomatic at follow-up, whereas 26
+        presented with diverse, non-specific manifestations
+      explanation: >
+        The same synthesis quantifies the low-penetrance clinical outcome
+        downstream of ACAD8-related IBDD without implying that ACAD8 deficiency
+        causes enzyme redundancy itself.
 - name: Impaired mitochondrial valine catabolism
   description: 'Loss of ACAD8 function creates a metabolic block in valine degradation, leading to accumulation of isobutyryl-CoA and diversion into alternate conjugation products including isobutyrylcarnitine (C4) and isobutyrylglycine.
 


### PR DESCRIPTION
## Summary
- Connect the IBDD low-penetrance/asymptomatic branch to the ACAD8 molecular defect without modeling compensatory enzyme redundancy as caused by ACAD8 deficiency.
- Add a conservative ACAD8 molecular function deficiency -> Largely asymptomatic course edge using PMID:41606743.
- Improves IBDD pathophysiology graph from 2 components to 1.

## Validation
- `just validate kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `just check-enum-cache`
- `git diff --check`
- direct exact snippet audit for PMID:41606743

Unrelated clinical-trials cache normalization produced by validation was restored before commit.