### PR TITLE
Connect Tangier vascular risk branch

### DIFF
--- a/kb/disorders/Tangier_Disease.yaml
+++ b/kb/disorders/Tangier_Disease.yaml
@@ -1,6 +1,6 @@
 name: Tangier_Disease
 creation_date: '2026-05-04T06:39:03Z'
-updated_date: '2026-05-04T06:39:03Z'
+updated_date: '2026-05-09T02:37:24Z'
 category: Mendelian
 description: >
   Tangier disease is an autosomal recessive ABCA1 deficiency disorder of HDL
@@ -240,6 +240,23 @@ pathophysiology:
     description: Tangier disease commonly includes normal to high or elevated plasma triglycerides.
   - target: Cholesteryl Ester Tissue Storage
     description: Loss of HDL-mediated cellular lipid removal promotes cholesterol ester accumulation in tissues.
+  - target: Atherosclerotic Vascular Risk
+    description: >
+      Failure of ABCA1-dependent HDL generation impairs the initial reverse
+      cholesterol transport step, increasing atherosclerotic vascular risk
+      despite often low LDL-C.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33994407
+      reference_title: "Current Diagnosis and Management of Tangier Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        impairment of the initial stage of reverse cholesterol transport should
+        be considered to be a risk for developing atherosclerotic diseases
+      explanation: >
+        The review links the impaired initial reverse-cholesterol-transport step
+        downstream of ABCA1/HDL dysfunction to atherosclerotic disease risk.
 - name: Cholesteryl Ester Tissue Storage
   description: >
     Impaired ABCA1-mediated cholesterol export causes cholesteryl esters to


### PR DESCRIPTION
## Summary
- add a downstream edge from impaired HDL biogenesis to atherosclerotic vascular risk in Tangier disease
- use cached PMID:33994407 evidence for impaired reverse cholesterol transport as atherosclerotic disease risk
- update Tangier graph connectivity from two components to one

## Validation
- just validate kb/disorders/Tangier_Disease.yaml
- just validate-references kb/disorders/Tangier_Disease.yaml (validator reports 0 checks; exact snippet manually audited against references_cache/PMID_33994407.md)
- uv run python -m dismech.graph --validate kb/disorders/Tangier_Disease.yaml
- just check-enum-cache
- git diff --check