### PR TITLE
Connect Wilson ceruloplasmin branch

### DIFF
--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-05-07T06:25:47Z'
+updated_date: '2026-05-09T02:54:43Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -208,6 +208,82 @@ mechanistic_hypotheses:
     snippet: "In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles"
     explanation: Supports ferroptosis as an inferred downstream consequence of secondary hepatic iron deposition rather than a fully established mechanism in Wilson disease.
 pathophysiology:
+- name: ATP7B Copper-Trafficking Defect
+  description: >
+    Loss of hepatocyte ATP7B copper-trafficking function is the shared upstream
+    defect that impairs both copper excretion into bile and copper incorporation
+    into apoceruloplasmin in the secretory pathway.
+  gene:
+    preferred_term: ATP7B
+    term:
+      id: hgnc:870
+      label: ATP7B
+  molecular_functions:
+  - preferred_term: P-type monovalent copper transporter activity
+    term:
+      id: GO:0140581
+      label: P-type monovalent copper transporter activity
+  biological_processes:
+  - preferred_term: copper ion transport
+    term:
+      id: GO:0006825
+      label: copper ion transport
+  cellular_components:
+  - preferred_term: Golgi apparatus
+    term:
+      id: GO:0005794
+      label: Golgi apparatus
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  evidence:
+  - reference: PMID:16382340
+    reference_title: "Wilson disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The basic defect is an impaired trafficking of copper in hepatocytes."
+    explanation: >
+      This clinical review identifies impaired hepatocyte copper trafficking as
+      the core upstream Wilson disease defect.
+  downstream:
+  - target: Impaired Biliary Copper Excretion
+    description: >
+      ATP7B copper trafficking normally supports hepatocyte copper movement into
+      the bile excretion pathway.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16382340
+      reference_title: "Wilson disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        ATP7B is the gene product of the WD gene located on chromosome 13 and
+        resides in hepatocytes in the trans-Golgi network, transporting copper
+        into the secretory pathway for incorporation into apoceruloplasmin and
+        excretion into the bile.
+      explanation: >
+        The review directly states that hepatocyte ATP7B transports copper
+        through the secretory pathway for biliary excretion.
+  - target: Impaired Ceruloplasmin Loading
+    description: >
+      The same ATP7B secretory-pathway trafficking defect prevents copper
+      incorporation into apoceruloplasmin.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16382340
+      reference_title: "Wilson disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        ATP7B is the gene product of the WD gene located on chromosome 13 and
+        resides in hepatocytes in the trans-Golgi network, transporting copper
+        into the secretory pathway for incorporation into apoceruloplasmin and
+        excretion into the bile.
+      explanation: >
+        The same review explicitly links hepatocyte ATP7B copper transport to
+        apoceruloplasmin copper incorporation.
 - name: Impaired Biliary Copper Excretion
   description: >
     ATP7B mutations impair copper excretion into bile. ATP7B normally resides in


### PR DESCRIPTION
## Summary
- add a shared upstream ATP7B copper-trafficking defect node in Wilson disease
- connect it directly to both impaired biliary copper excretion and impaired ceruloplasmin loading
- avoid implying that copper accumulation causes the ceruloplasmin-loading defect; both branches are modeled as parallel ATP7B consequences

## Validation
- just validate kb/disorders/Wilsons_Disease.yaml
- just validate-references kb/disorders/Wilsons_Disease.yaml (validator reports 0 checks; exact snippets manually audited against references_cache/PMID_16382340.md)
- uv run python -m dismech.graph --validate kb/disorders/Wilsons_Disease.yaml
- just check-enum-cache
- git diff --check