### PR TITLE
Connect NCL storage pathograph

### DIFF
--- a/kb/disorders/Neuronal_Ceroid_Lipofuscinosis.yaml
+++ b/kb/disorders/Neuronal_Ceroid_Lipofuscinosis.yaml
@@ -1,6 +1,6 @@
 name: Neuronal Ceroid Lipofuscinosis
 creation_date: '2026-03-30T18:20:00Z'
-updated_date: '2026-03-30T23:35:00Z'
+updated_date: '2026-05-09T03:16:10Z'
 description: >
   Neuronal ceroid lipofuscinosis (NCL; Batten disease) is a genetically
   heterogeneous group of lysosomal neurodegenerative disorders that primarily
@@ -52,6 +52,25 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "These are genetic diseases associated with the formation of toxic endo-lysosomal storage."
     explanation: This review identifies toxic endo-lysosomal storage as a core mechanistic feature of childhood NCL.
+  downstream:
+  - target: Progressive Neurodegeneration
+    description: >
+      Toxic endo-lysosomal storage is modeled as part of the inherited
+      lysosomal storage disease process that drives progressive
+      neurodegeneration across NCLs.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:31678162
+      reference_title: "Pathomechanisms in the neuronal ceroid lipofuscinoses."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >
+        The neuronal ceroid lipofuscinoses (NCLs) are a group of inherited
+        neurodegenerative lysosomal storage disorders (LSDs)
+      explanation: >
+        The review defines NCLs as inherited neurodegenerative lysosomal storage
+        disorders, supporting an indirect connection from storage pathology to
+        the shared neurodegenerative process.
 - name: CLN Endomembrane Protein Dysfunction
   description: >
     NCL-causing genes encode proteins distributed across the endomembrane
@@ -79,6 +98,34 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "A growing body of literature supports the networking of CLN genes and proteins within cells, which aligns with the broadly similar cellular and clinical manifestations among the different subtypes of NCL."
     explanation: This supports convergent intracellular CLN protein dysfunction as an explanation for shared manifestations across NCL subtypes.
+  downstream:
+  - target: Toxic Endo-Lysosomal Storage
+    description: >
+      Pathogenic CLN-gene disruption of endomembrane and lysosomal processes is
+      modeled upstream of the shared toxic endo-lysosomal storage phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:37022340
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        In humans, mutations in CLN genes cause a devastating form of
+        neurodegeneration called neuronal ceroid lipofuscinosis (NCL), commonly
+        known as Batten disease.
+      explanation: >
+        This review directly links CLN-gene mutations to the human NCL disease
+        group.
+    - reference: PMID:31678162
+      reference_title: "Pathomechanisms in the neuronal ceroid lipofuscinoses."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >
+        The neuronal ceroid lipofuscinoses (NCLs) are a group of inherited
+        neurodegenerative lysosomal storage disorders (LSDs)
+      explanation: >
+        This review classifies NCLs as lysosomal storage disorders, supporting
+        toxic endo-lysosomal storage as the downstream storage phenotype of
+        CLN-gene disease.
 - name: Autophagy Dysregulation
   description: >
     Impaired autophagic handling is a recurring component of NCL cellular

--- a/references_cache/PMID_31678162.md
+++ b/references_cache/PMID_31678162.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:31678162"
+title: Pathomechanisms in the neuronal ceroid lipofuscinoses.
+authors:
+- Nelvagal HR
+- Lange J
+- Takahashi K
+- Tarczyluk-Wells MA
+- Cooper JD
+journal: Biochim Biophys Acta Mol Basis Dis
+year: '2020'
+doi: 10.1016/j.bbadis.2019.165570
+keywords:
+- Animals
+- "Disease Models, Animal"
+- Humans
+- "Lysosomes/metabolism, pathology"
+- "Membrane Proteins/genetics, metabolism"
+- Mutation
+- "Neuronal Ceroid-Lipofuscinoses/genetics, metabolism, pathology"
+- "Transcription Factors/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Pathomechanisms in the neuronal ceroid lipofuscinoses.
+**Authors:** Nelvagal HR, Lange J, Takahashi K, Tarczyluk-Wells MA, Cooper JD
+**Journal:** Biochim Biophys Acta Mol Basis Dis (2020)
+**DOI:** [10.1016/j.bbadis.2019.165570](https://doi.org/10.1016/j.bbadis.2019.165570)
+
+## Content
+
+1. Biochim Biophys Acta Mol Basis Dis. 2020 Sep 1;1866(9):165570. doi:
+10.1016/j.bbadis.2019.165570. Epub 2019 Oct 31.
+
+Pathomechanisms in the neuronal ceroid lipofuscinoses.
+
+Nelvagal HR(1), Lange J(2), Takahashi K(3), Tarczyluk-Wells MA(4), Cooper JD(3).
+
+Author information:
+(1)Pediatric Storage Disorders Laboratory, Department of Pediatrics, Division of
+Genetics and Genomics, Washington University in St. Louis, School of Medicine,
+St Louis, MO 63110, USA. Electronic address: hemanth.nelvagal@wustl.edu.
+(2)Department of Basic and Clinical Neuroscience, Institute of Psychiatry,
+Psychology & Neuroscience, King's College London, London SE5 9NU, UK; Department
+of Neurodegenerative Disease, Institute of Neurology, University College London,
+London WC1N 3BG, UK.
+(3)Pediatric Storage Disorders Laboratory, Department of Pediatrics, Division of
+Genetics and Genomics, Washington University in St. Louis, School of Medicine,
+St Louis, MO 63110, USA.
+(4)Department of Basic and Clinical Neuroscience, Institute of Psychiatry,
+Psychology & Neuroscience, King's College London, London SE5 9NU, UK; Centre for
+Brain Research, Faculty of Medical and Health Sciences, University of Auckland,
+New Zealand.
+
+The neuronal ceroid lipofuscinoses (NCLs) are a group of inherited
+neurodegenerative lysosomal storage disorders (LSDs), traditionally grouped
+together based on shared clinical symptoms. The recent emergence of new forms of
+NCL along with an improved understanding of endo-lysosomal system function have
+necessitated the reassessment of their classification and pathogenesis. Novel
+clinical findings, as well as observations in various animal models of NCL, have
+revealed significant pathological changes in regions outside the brain, as well
+as progression of disease along connected anatomical pathways. The
+characterization of animal models of NCLs has not only highlighted the
+vulnerability of certain neuron populations but has also revealed glial cells to
+be adversely affected and actively contribute to disease progression. While the
+lysosome has been thought of as being the 'waste-disposal' unit of the cell,
+recent evidence of the endo-lysosomal system playing a crucial role in nutrient
+sensing and cellular homeostasis have shown that NCL mutations have far-ranging
+effects on cellular functions including autophagy and synaptic dysfunction. The
+discovery of the machinery controlling endo-lysosomal function via transcription
+factor EB (TFEB) and mTORC1, have also shed light on potential mechanisms by
+which NCL mutations may exert their effect. While the NCLs share many common
+down-stream pathologies, there is a growing body of evidence for unique
+pathogenic pathways in each form. In light of the rapid advances in therapeutic
+strategies for the NCLs and LSDs, these new lessons learnt about unique NCL
+pathomechanisms will be key for informing the targeting, timing and strategies
+for future treatments.
+
+Copyright © 2019. Published by Elsevier B.V.
+
+DOI: 10.1016/j.bbadis.2019.165570
+PMID: 31678162 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest JDC has been
+in receipt of research support from BioMarin Pharmaceutical Inc., Abeona
+Therapeutics Inc., Regenexbio Inc. and CereSpir Inc., but none of these projects
+relate directly to the subject of this review. The other authors have no
+declarations of interest.


### PR DESCRIPTION
## Summary
- connect CLN endomembrane protein dysfunction to toxic endo-lysosomal storage
- connect toxic endo-lysosomal storage to progressive neurodegeneration, collapsing the NCL pathograph from three components to one
- fetch and cite PMID:31678162 for the inherited neurodegenerative lysosomal storage disorder bridge

## Validation
- just validate kb/disorders/Neuronal_Ceroid_Lipofuscinosis.yaml
- just validate-references kb/disorders/Neuronal_Ceroid_Lipofuscinosis.yaml (validator reports 0 checks; exact snippets manually audited against references_cache/PMID_31678162.md and references_cache/PMID_37022340.md)
- uv run python -m dismech.graph --validate kb/disorders/Neuronal_Ceroid_Lipofuscinosis.yaml
- just check-enum-cache
- git diff --check