### PR TITLE
Connect pycnodysostosis matrix degradation

### DIFF
--- a/kb/disorders/Pycnodysostosis.yaml
+++ b/kb/disorders/Pycnodysostosis.yaml
@@ -1,6 +1,6 @@
 name: Pycnodysostosis
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-04-19T06:44:39Z'
+updated_date: '2026-05-09T03:42:28Z'
 category: Mendelian
 description: >
   Pycnodysostosis is an autosomal recessive osteochondrodysplasia caused by
@@ -78,6 +78,25 @@ pathophysiology:
     supports: SUPPORT
     snippet: "The hot mutation spots are found in exons 6 and 7"
     explanation: "Identifies mutational hotspots in the CTSK gene."
+  downstream:
+  - target: Impaired Organic Bone Matrix Degradation
+    description: >
+      Loss or inactivity of CTSK/cathepsin K in osteoclasts impairs degradation
+      of type I collagen and other organic bone matrix proteins during bone
+      resorption.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21569238
+      reference_title: "Clinical and animal research findings in pycnodysostosis and gene mutations of cathepsin K from 1996 to 2011."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        CTSK mutations result in total loss or inactivity of the CTSK protein,
+        which causes abnormal degradation of bone matrix proteins such as type I
+        collagen.
+      explanation: >
+        This review links CTSK loss or inactivity directly to abnormal
+        degradation of type I collagen and other bone matrix proteins.
 - name: Impaired Organic Bone Matrix Degradation
   description: >
     Cathepsin K is the major protease responsible for degradation of type I


### PR DESCRIPTION
## Summary
- add a direct downstream edge from cathepsin K deficiency in osteoclasts to impaired organic bone matrix degradation
- use cached PMID:21569238 evidence linking CTSK loss/inactivity to abnormal degradation of type I collagen bone matrix
- collapse the pycnodysostosis pathograph from two components to one

## Validation
- just validate kb/disorders/Pycnodysostosis.yaml
- just validate-references kb/disorders/Pycnodysostosis.yaml (validator reports 0 checks; exact snippet manually audited against references_cache/PMID_21569238.md)
- uv run python -m dismech.graph --validate kb/disorders/Pycnodysostosis.yaml
- just check-enum-cache
- git diff --check