### PR TITLE
Connect Bartter type 4 pathograph

### DIFF
--- a/kb/disorders/Bartter_Syndrome.yaml
+++ b/kb/disorders/Bartter_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Bartter syndrome
 creation_date: "2026-04-22T00:00:00Z"
-updated_date: "2026-05-06T00:21:04Z"
+updated_date: "2026-05-09T04:31:36Z"
 category: Mendelian
 synonyms:
 - Bartter syndrome
@@ -342,6 +342,83 @@ genetic:
       Review describes the molecular function of MAGED2 in cotransporter
       trafficking and consequence of loss-of-function.
 pathophysiology:
+- name: ClC-K/Barttin Chloride Channel Dysfunction (Type 4)
+  description: >-
+    In type 4 Bartter syndrome, BSND loss-of-function or digenic
+    CLCNKA/CLCNKB disruption impairs the ClC-K/barttin chloride-channel system
+    shared by renal epithelia and the inner ear. This links the renal
+    salt-wasting branch to the sensorineural-hearing branch without implying
+    that all Bartter subtypes cause deafness.
+  biological_processes:
+  - preferred_term: Chloride transmembrane transport
+    term:
+      id: GO:1902476
+      label: chloride transmembrane transport
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:30519073
+    reference_title: "Bartter syndrome: causes, diagnosis, and treatment."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Mutations in the BSND gene cause type IVa BS and result in impairment
+      of barttin insertion in the plasma membrane of CLC-Kb and CLC-Ka
+      channels in the Henle’s loop as well as in the inner ear, which
+      interfere with epithelial salt transport.
+    explanation: >-
+      Review links BSND-associated type 4A Bartter syndrome to defective
+      ClC-K/barttin channel handling in both renal epithelia and inner ear.
+  - reference: PMID:30519073
+    reference_title: "Bartter syndrome: causes, diagnosis, and treatment."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      type IVb is a digenic disorder with mutations in both CLCNKA and
+      CLCNKB genes, which can lead to impairment in the functioning of two
+      chloride channels and as a result, severe salt wasting and deafness.
+    explanation: >-
+      Review supports the analogous type 4B mechanism in which dual ClC-K
+      channel disruption produces both renal salt wasting and deafness.
+  downstream:
+  - target: Impaired NaCl Reabsorption in Thick Ascending Limb
+    description: >-
+      Defective ClC-K/barttin channel function in Henle-loop epithelia impairs
+      epithelial salt transport, feeding into the renal NaCl reabsorption
+      defect.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30519073
+      reference_title: "Bartter syndrome: causes, diagnosis, and treatment."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Mutations in the BSND gene cause type IVa BS and result in impairment
+        of barttin insertion in the plasma membrane of CLC-Kb and CLC-Ka
+        channels in the Henle’s loop as well as in the inner ear, which
+        interfere with epithelial salt transport.
+      explanation: >-
+        The review explicitly places the ClC-K/barttin defect in Henle-loop
+        epithelial salt transport, supporting the renal downstream edge.
+  - target: Inner Ear Chloride Transport Defect (Type 4)
+    description: >-
+      The same type 4 chloride-channel system is required in the inner ear,
+      where disrupted barttin or ClC-K channel function impairs potassium
+      secretion and channel activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30519073
+      reference_title: "Bartter syndrome: causes, diagnosis, and treatment."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        The sensory function of the inner ear becomes impaired in type IVa and
+        IVb BS. In type IVa, barttin mutations impair potassium secretion in
+        the stria vascularis and the vestibular labyrinth, whereas in type IVb
+        mutations they occur in both chloride channels impairing their normal
+        function in the inner ear.
+      explanation: >-
+        The review directly links type 4A and 4B chloride-channel defects to
+        impaired inner-ear sensory function.
 - name: Impaired NaCl Reabsorption in Thick Ascending Limb
   description: >-
     The primary defect in Bartter syndrome is impaired sodium chloride

--- a/kb/disorders/Bartter_Syndrome.yaml
+++ b/kb/disorders/Bartter_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Bartter syndrome
 creation_date: "2026-04-22T00:00:00Z"
-updated_date: "2026-05-09T04:31:36Z"
+updated_date: "2026-05-09T04:45:11Z"
 category: Mendelian
 synonyms:
 - Bartter syndrome
@@ -401,9 +401,10 @@ pathophysiology:
         epithelial salt transport, supporting the renal downstream edge.
   - target: Inner Ear Chloride Transport Defect (Type 4)
     description: >-
-      The same type 4 chloride-channel system is required in the inner ear,
-      where disrupted barttin or ClC-K channel function impairs potassium
-      secretion and channel activity.
+      The same type 4 ClC-K/barttin channel system is required in the inner
+      ear; barttin mutations impair potassium secretion in the stria vascularis
+      and vestibular labyrinth, while dual ClC-K channel mutations impair
+      inner-ear channel function.
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:30519073


### PR DESCRIPTION
## Summary\n- Added a type 4 ClC-K/barttin chloride-channel dysfunction pathophysiology node for Bartter syndrome.\n- Connected that subtype-specific root to both the renal TAL NaCl reabsorption branch and the inner-ear chloride transport branch.\n- Kept the description explicit that this links type 4 biology and does not imply deafness for all Bartter subtypes.\n\n## Validation\n- just validate kb/disorders/Bartter_Syndrome.yaml\n- just validate-references kb/disorders/Bartter_Syndrome.yaml\n- uv run python -m dismech.graph --validate kb/disorders/Bartter_Syndrome.yaml\n- uv run python -m dismech.graph --show kb/disorders/Bartter_Syndrome.yaml\n- just check-enum-cache\n- git diff --check\n- Manual normalized snippet audit for all four new PMID:30519073 snippets: OK\n\nRestored validator-induced ClinicalTrials cache churn before commit; this PR is scoped to kb/disorders/Bartter_Syndrome.yaml.