### PR TITLE
Backfill CN DEE Falcon evidence

### DIFF
--- a/kb/disorders/CN_Related_DEE.yaml
+++ b/kb/disorders/CN_Related_DEE.yaml
@@ -1,6 +1,6 @@
 name: CN-Related Developmental and Epileptic Encephalopathy
 creation_date: "2026-03-08T00:00:00Z"
-updated_date: "2026-05-08T18:54:20Z"
+updated_date: "2026-05-09T04:33:26Z"
 category: Mendelian
 description: >
   Calcineurin (CN)-related developmental and epileptic encephalopathy (DEE) is a
@@ -694,3 +694,109 @@ treatments:
       id: MAXO:0000079
       label: genetic counseling
 datasets:
+references:
+- reference: DOI:10.1002/humu.24182
+  title: The phenotypic and genetic spectrum of patients with heterozygous mutations in cyclin M2 (CNNM2)
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: The phenotypic and genetic spectrum of patients with heterozygous mutations in cyclin M2 (CNNM2)
+    supporting_text: The phenotypic and genetic spectrum of patients with heterozygous mutations in cyclin M2 (CNNM2)
+- reference: DOI:10.1016/j.ejmg.2018.07.014
+  title: CNNM2 homozygous mutations cause severe refractory hypomagnesemia, epileptic encephalopathy and brain malformations
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: CNNM2 homozygous mutations cause severe refractory hypomagnesemia, epileptic encephalopathy and brain malformations
+    supporting_text: CNNM2 homozygous mutations cause severe refractory hypomagnesemia, epileptic encephalopathy and brain malformations
+- reference: DOI:10.1038/s41598-024-57061-7
+  title: Hypomagnesaemia with varying degrees of extrarenal symptoms as a consequence of heterozygous CNNM2 variants
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: Variants in the CNNM2 gene are causative for hypomagnesaemia, seizures and intellectual disability, although the phenotypes can be variable.
+    supporting_text: Variants in the CNNM2 gene are causative for hypomagnesaemia, seizures and intellectual disability, although the phenotypes can be variable.
+    evidence:
+    - reference: DOI:10.1038/s41598-024-57061-7
+      reference_title: Hypomagnesaemia with varying degrees of extrarenal symptoms as a consequence of heterozygous CNNM2 variants
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Variants in the CNNM2 gene are causative for hypomagnesaemia, seizures and intellectual disability, although the phenotypes can be variable.
+      explanation: Deep research cited this publication as relevant literature for CN Related DEE.
+- reference: DOI:10.1371/journal.pgen.1004267
+  title: CNNM2 Mutations Cause Impaired Brain Development and Seizures in Patients with Hypomagnesemia
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: CNNM2 Mutations Cause Impaired Brain Development and Seizures in Patients with Hypomagnesemia
+    supporting_text: CNNM2 Mutations Cause Impaired Brain Development and Seizures in Patients with Hypomagnesemia
+- reference: DOI:10.3389/fgene.2021.705734
+  title: 'Case Report: CNNM2 Mutations Cause Damaged Brain Development and Intractable Epilepsy in a Patient Without Hypomagnesemia'
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: A series of neurological manifestations such as intellectual disability and epilepsy are closely related to hypomagnesemia.
+    supporting_text: A series of neurological manifestations such as intellectual disability and epilepsy are closely related to hypomagnesemia.
+    evidence:
+    - reference: DOI:10.3389/fgene.2021.705734
+      reference_title: 'Case Report: CNNM2 Mutations Cause Damaged Brain Development and Intractable Epilepsy in a Patient Without Hypomagnesemia'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: A series of neurological manifestations such as intellectual disability and epilepsy are closely related to hypomagnesemia.
+      explanation: Deep research cited this publication as relevant literature for CN Related DEE.
+- reference: DOI:10.3389/fgene.2022.875013
+  title: Novel CNNM2 Mutation Responsible for Autosomal-Dominant Hypomagnesemia With Seizure
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: CNNM2 is primarily expressed in the brain and distal convoluted tubule (DCT) of the kidney.
+    supporting_text: CNNM2 is primarily expressed in the brain and distal convoluted tubule (DCT) of the kidney.
+    evidence:
+    - reference: DOI:10.3389/fgene.2022.875013
+      reference_title: Novel CNNM2 Mutation Responsible for Autosomal-Dominant Hypomagnesemia With Seizure
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: CNNM2 is primarily expressed in the brain and distal convoluted tubule (DCT) of the kidney.
+      explanation: Deep research cited this publication as relevant literature for CN Related DEE.
+- reference: DOI:10.3389/fgene.2025.1600877
+  title: Two novel variants in CNNM2 disrupts magnesium efflux leading to neurodevelopmental disorders
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: Hypomagnesemia, seizures, and impaired intellectual development 1 (HOMGSMR1) is a rare neurodevelopmental disorder associated with magnesium homeostasis disruption, caused by mutations in the CNNM2 gene.
+    supporting_text: Hypomagnesemia, seizures, and impaired intellectual development 1 (HOMGSMR1) is a rare neurodevelopmental disorder associated with magnesium homeostasis disruption, caused by mutations in the CNNM2 gene.
+    evidence:
+    - reference: DOI:10.3389/fgene.2025.1600877
+      reference_title: Two novel variants in CNNM2 disrupts magnesium efflux leading to neurodevelopmental disorders
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Hypomagnesemia, seizures, and impaired intellectual development 1 (HOMGSMR1) is a rare neurodevelopmental disorder associated with magnesium homeostasis disruption, caused by mutations in the CNNM2 gene.
+      explanation: Deep research cited this publication as relevant literature for CN Related DEE.
+- reference: DOI:10.3389/fped.2021.699568
+  title: 'CNNM2-Related Disorders: Phenotype and Its Severity Were Associated With the Mode of Inheritance'
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: CNNM2 (Cystathionine-β-synthase-pair Domain Divalent Metal Cation Transport Mediator 2) pathogenic variants have been reported to cause hypomagnesemia, epilepsy, and intellectual disability/developmental delay (ID/DD).
+    supporting_text: CNNM2 (Cystathionine-β-synthase-pair Domain Divalent Metal Cation Transport Mediator 2) pathogenic variants have been reported to cause hypomagnesemia, epilepsy, and intellectual disability/developmental delay (ID/DD).
+    evidence:
+    - reference: DOI:10.3389/fped.2021.699568
+      reference_title: 'CNNM2-Related Disorders: Phenotype and Its Severity Were Associated With the Mode of Inheritance'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: CNNM2 (Cystathionine-β-synthase-pair Domain Divalent Metal Cation Transport Mediator 2) pathogenic variants have been reported to cause hypomagnesemia, epilepsy, and intellectual disability/developmental delay (ID/DD).
+      explanation: Deep research cited this publication as relevant literature for CN Related DEE.
+- reference: DOI:10.3390/ijms23137284
+  title: The p.Pro482Ala Variant in the CNNM2 Gene Causes Severe Hypomagnesemia Amenable to Treatment with Spironolactone
+  found_in:
+  - CN_Related_DEE-deep-research-falcon.md
+  findings:
+  - statement: Renal hypomagnesemia syndromes involving CNNM2 protein pathogenic variants are associated with variable degrees of neurocognitive dysfunction and hypomagnesemia.
+    supporting_text: Renal hypomagnesemia syndromes involving CNNM2 protein pathogenic variants are associated with variable degrees of neurocognitive dysfunction and hypomagnesemia.
+    evidence:
+    - reference: DOI:10.3390/ijms23137284
+      reference_title: The p.Pro482Ala Variant in the CNNM2 Gene Causes Severe Hypomagnesemia Amenable to Treatment with Spironolactone
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Renal hypomagnesemia syndromes involving CNNM2 protein pathogenic variants are associated with variable degrees of neurocognitive dysfunction and hypomagnesemia.
+      explanation: Deep research cited this publication as relevant literature for CN Related DEE.

--- a/references_cache/DOI_10.1002_humu.24182.md
+++ b/references_cache/DOI_10.1002_humu.24182.md
@@ -1,0 +1,38 @@
+---
+reference_id: "DOI:10.1002/humu.24182"
+title: The phenotypic and genetic spectrum of patients with heterozygous mutations in cyclin M2 (CNNM2)
+authors:
+- Gijs A. C. Franken
+- Dominik Müller
+- Cyril Mignot
+- Boris Keren
+- Jonathan Lévy
+- Anne‐Claude Tabet
+- David Germanaud
+- María‐Isabel Tejada
+- Hester Y. Kroes
+- Rutger A. J. Nievelstein
+- Elise Brimble
+- Maria Ruzhnikov
+- Felix Claverie‐Martin
+- Maria Szczepańska
+- Martin Ćuk
+- Femke Latta
+- Martin Konrad
+- Luis A. Martínez‐Cruz
+- René J. M. Bindels
+- Joost G. J. Hoenderop
+- Karl‐Peter Schlingmann
+- Jeroen H. F. Baaij
+journal: Human Mutation
+year: '2021'
+doi: 10.1002/humu.24182
+content_type: unavailable
+---
+
+# The phenotypic and genetic spectrum of patients with heterozygous mutations in cyclin M2 (CNNM2)
+**Authors:** Gijs A. C. Franken, Dominik Müller, Cyril Mignot, Boris Keren, Jonathan Lévy, Anne‐Claude Tabet, David Germanaud, María‐Isabel Tejada, Hester Y. Kroes, Rutger A. J. Nievelstein, Elise Brimble, Maria Ruzhnikov, Felix Claverie‐Martin, Maria Szczepańska, Martin Ćuk, Femke Latta, Martin Konrad, Luis A. Martínez‐Cruz, René J. M. Bindels, Joost G. J. Hoenderop, Karl‐Peter Schlingmann, Jeroen H. F. Baaij
+**Journal:** Human Mutation (2021)
+**DOI:** [10.1002/humu.24182](https://doi.org/10.1002/humu.24182)
+
+## Content

--- a/references_cache/DOI_10.1016_j.ejmg.2018.07.014.md
+++ b/references_cache/DOI_10.1016_j.ejmg.2018.07.014.md
@@ -1,0 +1,28 @@
+---
+reference_id: "DOI:10.1016/j.ejmg.2018.07.014"
+title: "CNNM2 homozygous mutations cause severe refractory hypomagnesemia, epileptic encephalopathy and brain malformations"
+authors:
+- Andrea Accogli
+- Marcello Scala
+- Annalisa Calcagno
+- Flavia Napoli
+- Natascia Di Iorgi
+- Serena Arrigo
+- Maria Margherita Mancardi
+- Giulia Prato
+- Livia Pisciotta
+- Mato Nagel
+- Mariasavina Severino
+- Valeria Capra
+journal: European Journal of Medical Genetics
+year: '2019'
+doi: 10.1016/j.ejmg.2018.07.014
+content_type: unavailable
+---
+
+# CNNM2 homozygous mutations cause severe refractory hypomagnesemia, epileptic encephalopathy and brain malformations
+**Authors:** Andrea Accogli, Marcello Scala, Annalisa Calcagno, Flavia Napoli, Natascia Di Iorgi, Serena Arrigo, Maria Margherita Mancardi, Giulia Prato, Livia Pisciotta, Mato Nagel, Mariasavina Severino, Valeria Capra
+**Journal:** European Journal of Medical Genetics (2019)
+**DOI:** [10.1016/j.ejmg.2018.07.014](https://doi.org/10.1016/j.ejmg.2018.07.014)
+
+## Content

--- a/references_cache/DOI_10.1038_s41598-024-57061-7.md
+++ b/references_cache/DOI_10.1038_s41598-024-57061-7.md
@@ -1,0 +1,34 @@
+---
+reference_id: "DOI:10.1038/s41598-024-57061-7"
+title: Hypomagnesaemia with varying degrees of extrarenal symptoms as a consequence of heterozygous CNNM2 variants
+authors:
+- Willem Bosman
+- Gijs A. C. Franken
+- Javier de las Heras
+- Leire Madariaga
+- Tahsin Stefan Barakat
+- Rianne Oostenbrink
+- Marjon van Slegtenhorst
+- Ana Perdomo-Ramírez
+- Félix Claverie-Martín
+- Albertien M. van Eerde
+- Rosa Vargas-Poussou
+- Laurence Derain Dubourg
+- Irene González-Recio
+- Luis Alfonso Martínez-Cruz
+- Jeroen H. F. de Baaij
+- Joost G. J. Hoenderop
+journal: Scientific Reports
+year: '2024'
+doi: 10.1038/s41598-024-57061-7
+content_type: abstract_only
+---
+
+# Hypomagnesaemia with varying degrees of extrarenal symptoms as a consequence of heterozygous CNNM2 variants
+**Authors:** Willem Bosman, Gijs A. C. Franken, Javier de las Heras, Leire Madariaga, Tahsin Stefan Barakat, Rianne Oostenbrink, Marjon van Slegtenhorst, Ana Perdomo-Ramírez, Félix Claverie-Martín, Albertien M. van Eerde, Rosa Vargas-Poussou, Laurence Derain Dubourg, Irene González-Recio, Luis Alfonso Martínez-Cruz, Jeroen H. F. de Baaij, Joost G. J. Hoenderop
+**Journal:** Scientific Reports (2024)
+**DOI:** [10.1038/s41598-024-57061-7](https://doi.org/10.1038/s41598-024-57061-7)
+
+## Content
+
+AbstractVariants in the CNNM2 gene are causative for hypomagnesaemia, seizures and intellectual disability, although the phenotypes can be variable. This study aims to understand the genotype–phenotype relationship in affected individuals with CNNM2 variants by phenotypic, functional and structural analysis of new as well as previously reported variants. This results in the identification of seven variants that significantly affect CNNM2-mediated Mg2+ transport. Pathogenicity of these variants is further supported by structural modelling, which predicts CNNM2 structure to be affected by all of them. Strikingly, seizures and intellectual disability are absent in 4 out of 7 cases, indicating these phenotypes are caused either by specific CNNM2 variant only or by additional risk factors. Moreover, in line with sporadic observations from previous reports, CNNM2 variants might be associated with disturbances in parathyroid hormone and Ca2+ homeostasis.

--- a/references_cache/DOI_10.1371_journal.pgen.1004267.md
+++ b/references_cache/DOI_10.1371_journal.pgen.1004267.md
@@ -1,0 +1,30 @@
+---
+reference_id: "DOI:10.1371/journal.pgen.1004267"
+title: CNNM2 Mutations Cause Impaired Brain Development and Seizures in Patients with Hypomagnesemia
+authors:
+- Francisco J. Arjona
+- Jeroen H. F. de Baaij
+- Karl P. Schlingmann
+- Anke L. L. Lameris
+- Erwin van Wijk
+- Gert Flik
+- Sabrina Regele
+- G. Christoph Korenke
+- Birgit Neophytou
+- Stephan Rust
+- Nadine Reintjes
+- Martin Konrad
+- René J. M. Bindels
+- Joost G. J. Hoenderop
+journal: PLoS Genetics
+year: '2014'
+doi: 10.1371/journal.pgen.1004267
+content_type: unavailable
+---
+
+# CNNM2 Mutations Cause Impaired Brain Development and Seizures in Patients with Hypomagnesemia
+**Authors:** Francisco J. Arjona, Jeroen H. F. de Baaij, Karl P. Schlingmann, Anke L. L. Lameris, Erwin van Wijk, Gert Flik, Sabrina Regele, G. Christoph Korenke, Birgit Neophytou, Stephan Rust, Nadine Reintjes, Martin Konrad, René J. M. Bindels, Joost G. J. Hoenderop
+**Journal:** PLoS Genetics (2014)
+**DOI:** [10.1371/journal.pgen.1004267](https://doi.org/10.1371/journal.pgen.1004267)
+
+## Content

--- a/references_cache/DOI_10.3389_fgene.2021.705734.md
+++ b/references_cache/DOI_10.3389_fgene.2021.705734.md
@@ -1,0 +1,27 @@
+---
+reference_id: "DOI:10.3389/fgene.2021.705734"
+title: "Case Report: CNNM2 Mutations Cause Damaged Brain Development and Intractable Epilepsy in a Patient Without Hypomagnesemia"
+authors:
+- Xiucui Li
+- Shijia Bao
+- Wei Wang
+- Xulai Shi
+- Ying Hu
+- Feng Li
+- Qianlei Zhao
+- Feixia Zheng
+- Zhongdong Lin
+journal: Frontiers in Genetics
+year: '2021'
+doi: 10.3389/fgene.2021.705734
+content_type: abstract_only
+---
+
+# Case Report: CNNM2 Mutations Cause Damaged Brain Development and Intractable Epilepsy in a Patient Without Hypomagnesemia
+**Authors:** Xiucui Li, Shijia Bao, Wei Wang, Xulai Shi, Ying Hu, Feng Li, Qianlei Zhao, Feixia Zheng, Zhongdong Lin
+**Journal:** Frontiers in Genetics (2021)
+**DOI:** [10.3389/fgene.2021.705734](https://doi.org/10.3389/fgene.2021.705734)
+
+## Content
+
+A series of neurological manifestations such as intellectual disability and epilepsy are closely related to hypomagnesemia. Cyclin M2 (CNNM2) proteins, as a member of magnesium (Mg2+) transporters, were found along the basolateral membrane of distal renal tubules and involved in the reabsorption of Mg2+. Homozygous and heterozygous variants in CNNM2 reported so far were responsible for a variable degree of hypomagnesemia, several of which also showed varying degrees of neurological phenotypes such as intellectual disability and epilepsy. Here, we report a de novo heterozygous CNNM2 variant (c.2228C &gt; T, p.Ser743Phe) in a Chinese patient, which is the variant located in the cyclic nucleotide monophosphate-binding homology (CNBH) domain of CNNM2 proteins. The patient presented with mild intellectual disability and refractory epilepsy but without hypomagnesemia. Thus, we reviewed the literature and analyzed the phenotypes related to CNNM2 variants, and then concluded that the number of variant alleles and the changed protein domains correlates with the severity of the disease, and speculated that the CNBH domain of CNNM2 possibly plays a limited role in Mg2+ transport but a significant role in brain development. Furthermore, it can be speculated that neurological phenotypes such as intellectual disability and seizures can be purely caused by CNNM2 variants.

--- a/references_cache/DOI_10.3389_fgene.2022.875013.md
+++ b/references_cache/DOI_10.3389_fgene.2022.875013.md
@@ -1,0 +1,25 @@
+---
+reference_id: "DOI:10.3389/fgene.2022.875013"
+title: Novel CNNM2 Mutation Responsible for Autosomal-Dominant Hypomagnesemia With Seizure
+authors:
+- Min-Hua Tseng
+- Sung-Sen Yang
+- Chih-Chien Sung
+- Jhao-Jhuang Ding
+- Yu-Juei Hsu
+- Shih-Ming Chu
+- Shih-Hua Lin
+journal: Frontiers in Genetics
+year: '2022'
+doi: 10.3389/fgene.2022.875013
+content_type: abstract_only
+---
+
+# Novel CNNM2 Mutation Responsible for Autosomal-Dominant Hypomagnesemia With Seizure
+**Authors:** Min-Hua Tseng, Sung-Sen Yang, Chih-Chien Sung, Jhao-Jhuang Ding, Yu-Juei Hsu, Shih-Ming Chu, Shih-Hua Lin
+**Journal:** Frontiers in Genetics (2022)
+**DOI:** [10.3389/fgene.2022.875013](https://doi.org/10.3389/fgene.2022.875013)
+
+## Content
+
+CNNM2 is primarily expressed in the brain and distal convoluted tubule (DCT) of the kidney. Mutations in CNNM2 have been reported to cause hypomagnesemia, seizure, and intellectual disability (HSMR) syndrome. However, the clinical and functional effect of CNNM2 mutations remains incompletely understood. We report our clinical encounter with a 1-year-old infant with HSMR features. Mutation screening for this trio family was performed using next-generation sequencing (NGS)-based whole exome sequencing (WES) with the identified mutation verified by Sanger sequencing. We identified a de novo heterozygous mutation c.G1439T (R480L) in the essential cystathionine β-synthase (CBS) domain of CNNM2 encoding CNNM2 (cyclin M2) without any other gene mutations related to hypomagnesemia. The amino acid involved in this missense mutation was conserved in different species. It was also found to be pathogenic based on the different software prediction models and ACGME criteria. In vitro studies revealed a higher expression of the CNNM2-R480L mutant protein compared to that of the wild-type CNNM2. Like the CNNM2-wild type, proper localization of CNNM2-R480L was shown on immunocytochemistry images. The Mg2+ efflux assay in murine DCT (mDCT) cells revealed a significant increase in intracellular Mg2+ green in CNNM2-R480L compared to that in CNNM2-WT. By using a simulation model, we illustrate that the R480L mutation impaired the interaction between CNNM2 and ATP-Mg2+. We propose that this novel R480L mutation in the CNNM2 gene led to impaired binding between Mg2+-ATP and CNNM2 and diminished Mg2+ efflux, manifesting clinically as refractory hypomagnesemia.

--- a/references_cache/DOI_10.3389_fgene.2025.1600877.md
+++ b/references_cache/DOI_10.3389_fgene.2025.1600877.md
@@ -1,0 +1,28 @@
+---
+reference_id: "DOI:10.3389/fgene.2025.1600877"
+title: Two novel variants in CNNM2 disrupts magnesium efflux leading to neurodevelopmental disorders
+authors:
+- Huijuan Li
+- Jing Liu
+- Yingdi Liu
+- Yaning Liu
+- Kehui Lu
+- Juan Wen
+- Huimin Zhu
+- Desheng Liang
+- Zhuo Li
+- Lingqian Wu
+journal: Frontiers in Genetics
+year: '2025'
+doi: 10.3389/fgene.2025.1600877
+content_type: abstract_only
+---
+
+# Two novel variants in CNNM2 disrupts magnesium efflux leading to neurodevelopmental disorders
+**Authors:** Huijuan Li, Jing Liu, Yingdi Liu, Yaning Liu, Kehui Lu, Juan Wen, Huimin Zhu, Desheng Liang, Zhuo Li, Lingqian Wu
+**Journal:** Frontiers in Genetics (2025)
+**DOI:** [10.3389/fgene.2025.1600877](https://doi.org/10.3389/fgene.2025.1600877)
+
+## Content
+
+BackgroundHypomagnesemia, seizures, and impaired intellectual development 1 (HOMGSMR1) is a rare neurodevelopmental disorder associated with magnesium homeostasis disruption, caused by mutations in the CNNM2 gene. HOMGSMR1 demonstrates considerable clinical heterogeneity, but the genotype-phenotype relationship remains insufficient.MethodsWe recruited two unrelated families with NDDs, and potential variants were identified through whole exome sequencing and confirmed by Sanger sequencing. Quantitative PCR, Western blotting, immunofluorescent staining, and flow cytometry were used to assess functional changes in candidate CNNM2 variants.ResultsTwo novel variants, p.E298del and p.P360R, in CNNM2 gene were identified. The unique facial features of proband 1 may broaden the known phenotypic spectrum of HOMGSMR1. Functional studies confirmed that the p.E298del and p.P360R variants increased CNNM2 transcription and protein levels, impairing the proper localization of the CNNM2 protein to the cell membrane. Two variant proteins accumulated in the cytoplasm and formed clumps. Furthermore, intracellular Mg2+ levels were higher in cells with these variants, disrupting magnesium homeostasis and potentially contributing to hypomagnesemia. Notably, the proteins of these two variants exhibited reduced stability and were prone to degradation, potentially providing new insights into the pathogenic mechanisms of CNNM2.ConclusionOur study expands the mutation and phenotypic spectrum, as well as the functional studies of CNNM2, and contributes to genetic testing and prenatal diagnosis in families with HOMGSMR1.

--- a/references_cache/DOI_10.3389_fped.2021.699568.md
+++ b/references_cache/DOI_10.3389_fped.2021.699568.md
@@ -1,0 +1,21 @@
+---
+reference_id: "DOI:10.3389/fped.2021.699568"
+title: "CNNM2-Related Disorders: Phenotype and Its Severity Were Associated With the Mode of Inheritance"
+authors:
+- Han Zhang
+- Ye Wu
+- Yuwu Jiang
+journal: Frontiers in Pediatrics
+year: '2021'
+doi: 10.3389/fped.2021.699568
+content_type: abstract_only
+---
+
+# CNNM2-Related Disorders: Phenotype and Its Severity Were Associated With the Mode of Inheritance
+**Authors:** Han Zhang, Ye Wu, Yuwu Jiang
+**Journal:** Frontiers in Pediatrics (2021)
+**DOI:** [10.3389/fped.2021.699568](https://doi.org/10.3389/fped.2021.699568)
+
+## Content
+
+CNNM2 (Cystathionine-β-synthase-pair Domain Divalent Metal Cation Transport Mediator 2) pathogenic variants have been reported to cause hypomagnesemia, epilepsy, and intellectual disability/developmental delay (ID/DD). We identified two new cases with CNNM2 novel de novo pathogenic variants, c.814T&gt;C and c.976G&gt;C. They both presented with infantile-onset epilepsy with DD and hypomagnesemia refractory to magnesium supplementation. To date, 21 cases with CNNM2-related disorders have been reported. We combined all 23 cases to analyze the features of CNNM2-related disorders. The phenotypes can be classified into three types: type 1, autosomal dominant (AD) inherited simple hypomagnesemia; type 2, AD inherited hypomagnesemia with epilepsy and ID/DD; and type 3, autosomal recessive (AR) inherited hypomagnesemia with epilepsy and ID/DD. All five type 1 cases had no epilepsy or ID/DD; they all had hypomagnesemia, and three of them presented with symptoms secondary to hypomagnesemia. Fifteen type 2 patients could have ID/DD and seizures, which can be controlled with antiseizure medications (ASMs); their variations clustered in the DUF21 domain of CNNM2. All three type 3 patients had seizures from 1 to 6 days after birth; the seizures were refractory, and 1/3 had status epilepticus; ID/DD in these AR-inherited cases was more severe than that of AD-inherited cases; they all had abnormalities of brain magnetic resonance imaging (MRI). Except for one patient whose serum magnesium was the lower limit of normal, others had definite hypomagnesemia. Hypomagnesemia could be improved after magnesium supplement but could not return to the normal level. Variations in the CBS2 domain may be related to lower serum magnesium. However, there was no significant difference in the level of serum magnesium among the patients with three different types of CNNM2-related disorders. The severity of different phenotypes was therefore not explained by decreased serum magnesium. We expanded the spectrum of CNNM2 variants and classified the phenotypes of CNNM2-related disorders into three types. We found that DUF21 domain variations were most associated with CNNM2-related central nervous system phenotypes, whereas hypomagnesemia was more pronounced in patients with CBS2 domain variations, and AR-inherited CNNM2-related disorders had the most severe phenotype. These results provide important clues for further functional studies of CNNM2 and provide basic foundations for more accurate genetic counseling.

--- a/references_cache/DOI_10.3390_ijms23137284.md
+++ b/references_cache/DOI_10.3390_ijms23137284.md
@@ -1,0 +1,31 @@
+---
+reference_id: "DOI:10.3390/ijms23137284"
+title: The p.Pro482Ala Variant in the CNNM2 Gene Causes Severe Hypomagnesemia Amenable to Treatment with Spironolactone
+authors:
+- Ioannis Petrakis
+- Eleni Drosataki
+- Ioanna Stavrakaki
+- Kleio Dermitzaki
+- Dimitra Lygerou
+- Myrto Konidaki
+- Christos Pleros
+- Nikolaos Kroustalakis
+- Sevasti Maragkou
+- Ariadni Androvitsanea
+- Ioannis Stylianou
+- Ioannis Zaganas
+- Kostas Stylianou
+journal: International Journal of Molecular Sciences
+year: '2022'
+doi: 10.3390/ijms23137284
+content_type: abstract_only
+---
+
+# The p.Pro482Ala Variant in the CNNM2 Gene Causes Severe Hypomagnesemia Amenable to Treatment with Spironolactone
+**Authors:** Ioannis Petrakis, Eleni Drosataki, Ioanna Stavrakaki, Kleio Dermitzaki, Dimitra Lygerou, Myrto Konidaki, Christos Pleros, Nikolaos Kroustalakis, Sevasti Maragkou, Ariadni Androvitsanea, Ioannis Stylianou, Ioannis Zaganas, Kostas Stylianou
+**Journal:** International Journal of Molecular Sciences (2022)
+**DOI:** [10.3390/ijms23137284](https://doi.org/10.3390/ijms23137284)
+
+## Content
+
+Renal hypomagnesemia syndromes involving CNNM2 protein pathogenic variants are associated with variable degrees of neurocognitive dysfunction and hypomagnesemia. Here, we report a family with a novel CNNM2 p.Pro482Ala variant, presenting with overt hypomagnesemia and mild neurological involvement (autosomal dominant renal hypomagnesemia 6, HOMG6, MIM# 613882). Using a bioinformatics approach, we showed that the p.Pro482Ala amino acid substitution causes a 3D conformational change in CNNM2 structure in the cystathionin beta synthase (CBS) domain and the carboxy-terminal protein segment. A novel finding was that aldosterone inhibition with spironolactone helped to alleviate hypomagnesemia and symptoms in the proband.


### PR DESCRIPTION
## Summary
- Backfills the CN_Related_DEE YAML references that were missed in Falcon batch 2.
- Adds the nine DOI reference-cache files cited by the existing Falcon report.
- Fixes the completion-audit gap where the report existed but YAML references lacked CN_Related_DEE-deep-research-falcon.md in found_in.

## Validation
- just validate kb/disorders/CN_Related_DEE.yaml
- uv run python scripts/qc_deep_research.py --only CN_Related_DEE --target-providers falcon --fail-on-missing-reference --fail-on-unresolved-cache --fail-on-holder-bucket --fail-on-missing-found-in
- just check-reference-cache-frontmatter
- just check-enum-cache
- git diff --check
- custom normalized snippet audit: checked=15, problems=0