### PR TITLE
Connect CTX peripheral nerve branch

### DIFF
--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-09T05:02:20Z'
+updated_date: '2026-05-09T05:50:50Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -334,6 +334,9 @@ pathophysiology:
       Accumulated cholestanol in neuronal membranes is modeled as an upstream
       metabolic driver of the peripheral neuropathy branch observed in CTX.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cholestanol deposition in neuronal membranes perturbs peripheral neural structures.
+    - Axonal injury and demyelinating or axonal neuropathy bridge the metabolic lesion to peripheral nerve manifestations.
     evidence:
     - reference: DOI:10.1186/s13023-025-03889-9
       reference_title: "Cholic acid as a treatment for cerebrotendinous xanthomatosis: a comprehensive review of safety and efficacy"

--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-05T09:47:58Z'
+updated_date: '2026-05-09T05:02:20Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -329,6 +329,36 @@ pathophysiology:
   - target: CNS sterol deposition and white-matter injury
     description: Cholestanol and sterol precursor accumulation injures brain white matter and neural structures.
     causal_link_type: DIRECT
+  - target: Peripheral nerve involvement
+    description: >
+      Accumulated cholestanol in neuronal membranes is modeled as an upstream
+      metabolic driver of the peripheral neuropathy branch observed in CTX.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1186/s13023-025-03889-9
+      reference_title: "Cholic acid as a treatment for cerebrotendinous xanthomatosis: a comprehensive review of safety and efficacy"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >
+        Deficiencies in CYP27A1 limit the production of both CA and CDCA,
+        leading to multisystemic cholestanol deposition in membranes, including
+        those of neurons, smooth muscle cells, tendons, and the eye.
+      explanation: >
+        Review-level CTX pathophysiology links CYP27A1 deficiency and
+        accumulated cholestanol to neuronal membrane deposition.
+    - reference: PMID:33313117
+      reference_title: "Cerebrotendinous xanthomatosis with peripheral neuropathy: a clinical and neurophysiological study in Chinese population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Pooling our patients and literature review together, peripheral
+        neuropathy was predominant sensorimotor demyelinating type in Chinese
+        population, with an evident length dependent pattern and increased
+        vulnerability in motor nerves.
+      explanation: >
+        Clinical-neurophysiology data confirm that peripheral neuropathy is a
+        recurring CTX neurologic manifestation downstream of the metabolic
+        disorder.
   - target: Ocular cholestanol deposition and cataractogenesis
     description: Multisystemic cholestanol deposition includes the eye and contributes to early cataract disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES


### PR DESCRIPTION
## Summary
- Added an evidence-backed downstream edge from Cholestanol and bile alcohol accumulation to Peripheral nerve involvement in CTX.
- This connects the isolated peripheral neuropathy branch to the core CYP27A1/cholestanol mechanism while keeping the causal link indirect.
- Used an existing cached CTX review snippet for neuronal cholestanol deposition and an existing cached human clinical-neurophysiology snippet for sensorimotor neuropathy.

## Validation
- just validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- just validate-references kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- uv run python -m dismech.graph --validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- uv run python -m dismech.graph --show kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- git diff --check
- Manual normalized snippet audit for DOI:10.1186/s13023-025-03889-9 and PMID:33313117: OK

Restored validator-induced ClinicalTrials cache churn before commit; this PR is scoped to kb/disorders/Cerebrotendinous_Xanthomatosis.yaml.