### PR TITLE
Connect SBCADD compensatory ACAD branch

### DIFF
--- a/kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 2-Methylbutyryl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-07T23:03:19Z'
+updated_date: '2026-05-09T06:01:35Z'
 synonyms:
 - Short/branched-chain acyl-CoA dehydrogenase deficiency
 - SBCADD
@@ -151,6 +151,33 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Increased flux through the R-pathway may act as a safety valve for overflow of accumulating S-pathway metabolites and thereby mitigate the severity of SBCADD."
       explanation: Patient metabolite study supports diversion through the R-pathway as overflow handling for the S-pathway block.
+  - target: ACAD substrate promiscuity and compensatory enzymology
+    description: >
+      SBCAD loss engages pre-existing alternative and overlapping dehydrogenase
+      activities, connecting the primary isoleucine catabolic block to the
+      broader ACAD compensation branch.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - S-pathway substrate overflow after SBCAD loss
+    - alternative enzyme activity in R-pathway metabolism
+    - engagement of pre-existing overlapping ACAD substrate handling in cell models
+    evidence:
+    - reference: PMID:15615815
+      reference_title: "2-ethylhydracrylic aciduria in short/branched-chain acyl-CoA dehydrogenase deficiency: application to diagnosis and implications for the R-pathway of isoleucine oxidation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Our observation of 2-ethylhydracrylic aciduria in SBCADD implies that a different or alternative enzyme serves this function."
+      explanation: Human urine metabolite data support alternative enzyme activity downstream of the SBCAD block.
+    - reference: PMID:37309295
+      reference_title: "Acyl-CoA dehydrogenase substrate promiscuity: Challenges and opportunities for development of substrate reduction therapy in disorders of valine and isoleucine metabolism."
+      supports: PARTIAL
+      evidence_source: IN_VITRO
+      snippet: "SBCAD was not the sole ACAD responsible for this compensation, which indicates substantial promiscuity of ACADs in HEK-293 cells for the isobutyryl-CoA substrate."
+      explanation: >
+        ACADSB-loss cell data support the broader ACAD compensation concept,
+        while the PARTIAL classification reflects that this compensation is
+        clearer for the related isobutyryl-CoA substrate than for the primary
+        2-methylbutyryl-CoA lesion in HEK-293 cells.
   - target: Stress-sensitive metabolic decompensation
     description: The isoleucine oxidation defect can become clinically relevant during catabolic stress in susceptible patients.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES


### PR DESCRIPTION
## Summary
- Connects the isolated `ACAD substrate promiscuity and compensatory enzymology` node to the main SBCADD isoleucine-catabolism branch.
- Uses existing cached evidence from PMID:15615815 for human SBCADD alternative/R-pathway enzyme activity and PMID:37309295 for in vitro overlapping ACAD substrate handling.
- Keeps the 2023 ACAD evidence as PARTIAL because the abstract says 2-methylbutyryl-CoA promiscuity is less prominent than the related isobutyryl-CoA compensation signal.

## Validation
- `just validate kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `just validate-references kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml` (passes; validator reports 0 checks)
- `uv run python -m dismech.graph --validate kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --show kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml` confirms the compensatory ACAD node is now connected
- normalized manual snippet audit against `references_cache/PMID_15615815.md` and `references_cache/PMID_37309295.md`
- `git diff --check`

## Review
- Independent subagent review found no blockers.
- Incorporated the optional wording suggestion so the edge describes engagement of pre-existing overlapping enzyme activity rather than implying SBCAD loss creates ACAD promiscuity.
- Restored unrelated ClinicalTrials cache churn before commit.