### PR TITLE
Connect BSCL insulin resistance mechanism

### DIFF
--- a/kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml
+++ b/kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml
@@ -1,7 +1,7 @@
 name: Berardinelli-Seip Congenital Lipodystrophy
 category: Mendelian
 creation_date: '2026-05-04T00:00:00Z'
-updated_date: '2026-05-04T00:00:00Z'
+updated_date: '2026-05-09T06:21:15Z'
 synonyms:
 - Congenital generalized lipodystrophy
 - Berardinelli-Seip syndrome
@@ -429,6 +429,22 @@ pathophysiology:
     description: Impaired adipose storage and altered lipid handling contribute to circulating hypertriglyceridemia.
   - target: Insulin resistance
     description: Ectopic lipid accumulation is a major driver of severe insulin resistance.
+  - target: Severe insulin resistance
+    description: >
+      Hepatic steatosis and intramyocellular lipid accumulation contribute to
+      the severe insulin-resistance mechanism, although the intervening
+      molecular steps remain incompletely defined.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26239609
+      reference_title: Congenital generalized lipodystrophies--new insights into metabolic dysfunction.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "However, how hepatic steatosis and increased intramyocellular lipids induce insulin resistance has not been elucidated."
+      explanation: >
+        The review supports a causal connection from ectopic lipid deposition to
+        insulin resistance while explicitly noting that the precise intermediates
+        are unresolved.
 - name: Hypoleptinemia-driven metabolic dysregulation
   description: >
     Near-total adipose tissue loss markedly lowers leptin levels. Severe leptin


### PR DESCRIPTION
## Summary
- Connects `Ectopic triglyceride accumulation` to the existing `Severe insulin resistance` mechanism in Berardinelli-Seip congenital lipodystrophy.
- Uses cached PMID:26239609 review evidence and keeps the edge as `INDIRECT_UNKNOWN_INTERMEDIATES` because the source explicitly says the molecular intermediates are not elucidated.
- Leaves the existing direct phenotype edge to `Insulin resistance` in place; subagent review noted it creates a parallel path but not a blocker.

## Validation
- `just validate kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml`
- `just validate-references kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml` (passes; validator reports 0 checks)
- `uv run python -m dismech.graph --validate kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml` confirms the severe insulin resistance mechanism is now connected
- normalized manual snippet audit against `references_cache/PMID_26239609.md`
- `git diff --check`

## Review
- Independent subagent review found no blockers.
- Restored unrelated ClinicalTrials cache churn before commit.