### PR TITLE
Connect Citrullinemia Type I biochemical nodes

### DIFF
--- a/kb/disorders/Citrullinemia_Type_I.yaml
+++ b/kb/disorders/Citrullinemia_Type_I.yaml
@@ -1,7 +1,7 @@
 name: Citrullinemia Type I
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-06T16:07:45Z'
+updated_date: '2026-05-09T07:26:54Z'
 synonyms:
 - Classic citrullinemia
 - CTLN1
@@ -41,7 +41,7 @@ inheritance:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: CTLN1 is inherited in an autosomal recessive manner.
     explanation: GeneReviews directly states the inheritance pattern for CTLN1.
 pathophysiology:
@@ -132,7 +132,7 @@ pathophysiology:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: elevated plasma ammonia concentration (>150 µmol/L; may range to ≥2000-3000 µmol/L), elevated plasma citrulline concentration (usually >500 µmol/L), and absent argininosuccinate
     explanation: GeneReviews anchors the blocked ASS1 reaction by identifying absent argininosuccinate alongside elevated ammonia and citrulline.
   downstream:
@@ -156,6 +156,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: 'increased citrulline concentrations (936 μmol/L; normal reference: 5-25 μmol/L)'
       explanation: Quantitative CTLN1 case data support citrulline accumulation downstream of the ASS1 block.
+  - target: Argininosuccinate
+    description: Blocked ASS1 activity prevents formation of argininosuccinate from citrulline and aspartate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301631
+      reference_title: "Citrullinemia Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: elevated plasma ammonia concentration (>150 µmol/L; may range to ≥2000-3000 µmol/L), elevated plasma citrulline concentration (usually >500 µmol/L), and absent argininosuccinate
+      explanation: GeneReviews lists absent argininosuccinate as part of the CTLN1 diagnostic biochemical pattern.
   - target: Hyperammonemia
     description: Accumulated ammonia manifests clinically as hyperammonemia.
     causal_link_type: DIRECT
@@ -175,7 +185,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews links hyperammonemia and glutamine accumulation to the neurologic crisis cascade.
 - name: Hyperammonemic neurotoxicity via astrocyte glutamine-osmotic injury
@@ -220,7 +230,7 @@ pathophysiology:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews entry describes the cascade from ammonia and glutamine accumulation to cerebral edema and neurological decline.
   downstream:
@@ -233,9 +243,21 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: Increased ICP is the clinical marker in this GeneReviews statement for the cerebral edema branch.
+  - target: Glutamine
+    description: Astrocytic ammonia detoxification during hyperammonemic crises produces glutamine accumulation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Ammonia is incorporated into glutamine by astrocyte glutamine synthetase.
+    evidence:
+    - reference: PMID:20301631
+      reference_title: "Citrullinemia Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
+      explanation: GeneReviews identifies glutamine as an accumulating toxic metabolite in the hyperammonemic neurologic cascade.
   - target: Encephalopathy
     description: CNS ammonia/glutamine toxicity produces acute hyperammonemic encephalopathy.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -243,7 +265,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
       explanation: GeneReviews describes the clinical encephalopathy sequence after neonatal hyperammonemia develops.
   - target: Seizures
@@ -253,7 +275,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews lists seizures in the hyperammonemic neurologic crisis cascade.
   - target: Coma
@@ -263,7 +285,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: Loss of consciousness supports the coma branch of the crisis cascade.
   - target: Spasticity
@@ -273,7 +295,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews lists increased neuromuscular tone and spasticity in the crisis cascade.
   - target: Intellectual disability
@@ -283,7 +305,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Children with the severe form who are treated promptly may survive for an indeterminate period of time, but usually with significant neurologic deficits.
       explanation: GeneReviews supports persistent neurologic deficits after severe hyperammonemic disease.
   - target: Global developmental delay
@@ -293,7 +315,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Children with the severe form who are treated promptly may survive for an indeterminate period of time, but usually with significant neurologic deficits.
       explanation: GeneReviews supports developmental neurologic sequelae in survivors of severe CTLN1.
 - name: Genotype-to-phenotype correlation through residual ASS1 activity
@@ -350,7 +372,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: emerging evidence suggests that measurement of residual argininosuccinate synthase enzyme activity may help to predict those who are likely to have a severe phenotype and those who are likely to have an attenuated phenotype.
       explanation: GeneReviews links residual ASS1 activity with severity, supporting crisis threshold variation.
 - name: Secondary metabolic derangements during catabolic stress
@@ -366,7 +388,7 @@ pathophysiology:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Agents/circumstances to avoid: Excessive protein intake, prolonged fasting, and obvious exposure to communicable diseases."
     explanation: GeneReviews identifies excess protein, fasting, and infectious exposure as avoidable triggers for metabolic decompensation.
   downstream:
@@ -379,7 +401,7 @@ pathophysiology:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: "Agents/circumstances to avoid: Excessive protein intake, prolonged fasting, and obvious exposure to communicable diseases."
       explanation: These avoided circumstances increase metabolic decompensation risk and support a trigger edge to hyperammonemia.
   - target: Failure to thrive
@@ -424,7 +446,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
       explanation: GeneReviews describes neurologic deterioration after hyperammonemia develops.
   - target: Cerebral edema
@@ -436,7 +458,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews links hyperammonemia and glutamine accumulation to increased ICP.
   - target: Respiratory alkalosis
@@ -465,7 +487,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews describes hyperammonemic encephalopathy progression from lethargy to coma and death.
   sequelae:
@@ -476,7 +498,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
       explanation: GeneReviews directly lists progressive lethargy during neonatal decompensation.
   - target: Poor feeding
@@ -486,7 +508,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
       explanation: GeneReviews directly lists poor feeding during neonatal decompensation.
   - target: Vomiting
@@ -496,7 +518,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
       explanation: GeneReviews directly lists vomiting during neonatal decompensation.
   - target: Seizures
@@ -506,7 +528,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews places seizures in the acute neurologic crisis sequence.
   - target: Spasticity
@@ -516,7 +538,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: GeneReviews places spasticity in the acute neurologic crisis sequence.
   - target: Coma
@@ -526,7 +548,7 @@ phenotypes:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
       explanation: Loss of consciousness supports the coma endpoint in severe crises.
 - name: Seizures
@@ -549,7 +571,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews confirms seizures as a manifestation of hyperammonemic encephalopathy.
 - name: Lethargy
@@ -583,7 +605,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
     explanation: GeneReviews directly describes poor feeding in neonatal CTLN1.
 - name: Vomiting
@@ -600,7 +622,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
     explanation: GeneReviews directly lists vomiting in neonatal CTLN1 decompensation.
 - name: Intellectual disability
@@ -651,7 +673,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews describes increased ICP (intracranial pressure) as a direct consequence of hyperammonemia.
 - name: Spasticity
@@ -668,7 +690,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews lists spasticity among the neurological manifestations of hyperammonemic crises.
 - name: Coma
@@ -685,7 +707,7 @@ phenotypes:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: Loss of consciousness progressing to coma is described as part of the hyperammonemic crisis cascade.
 - name: Failure to thrive
@@ -732,7 +754,7 @@ biochemical:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: elevated plasma citrulline concentration (usually >500 µmol/L)
     explanation: GeneReviews gives elevated plasma citrulline as a diagnostic biochemical feature of CTLN1.
   - reference: PMID:39649700
@@ -774,7 +796,7 @@ biochemical:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: elevated plasma ammonia concentration (>150 µmol/L; may range to ≥2000-3000 µmol/L), elevated plasma citrulline concentration (usually >500 µmol/L), and absent argininosuccinate
     explanation: GeneReviews lists absent argininosuccinate as part of the diagnostic biochemical pattern of CTLN1.
 - name: Orotic acid
@@ -792,7 +814,7 @@ biochemical:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews identifies glutamine as a toxic metabolite that accumulates in CTLN1.
 genetic:
@@ -900,7 +922,7 @@ treatments:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Daily routine treatment in those who have not undergone a liver transplantation includes lifelong protein restriction in conjunction with a metabolic nutritionist; nitrogen scavenger medications; arginine supplementation;
       explanation: GeneReviews identifies lifelong protein restriction as a routine treatment used to prevent metabolic decompensation.
 - name: Nitrogen scavenger therapy
@@ -972,7 +994,7 @@ treatments:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Daily routine treatment in those who have not undergone a liver transplantation includes lifelong protein restriction in conjunction with a metabolic nutritionist; nitrogen scavenger medications; arginine supplementation;
     explanation: GeneReviews directly states arginine supplementation is part of standard CTLN1 management.
   - reference: PMID:10869432
@@ -1005,7 +1027,7 @@ treatments:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Without prompt intervention, hyperammonemia and the accumulation of other toxic metabolites (e.g., glutamine) result in increased ICP, increased neuromuscular tone, spasticity, ankle clonus, seizures, loss of consciousness, and death.
     explanation: GeneReviews emphasizes the need for prompt intervention during hyperammonemic crises.
   - reference: PMID:40218931
@@ -1022,7 +1044,7 @@ treatments:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Acute inpatient treatment of a metabolic crisis includes addressing hyperammonemia through withholding of all protein intake for a maximum of 24 to 28 hours; pharmacologic nitrogen scavenger therapy; and consideration of dialysis
       explanation: GeneReviews directly links acute crisis therapy to rapid hyperammonemia management.
 - name: Liver transplantation
@@ -1055,7 +1077,7 @@ treatments:
     - reference: PMID:20301631
       reference_title: "Citrullinemia Type I."
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: Liver transplantation is the only known curative therapy and eliminates the need for dietary restriction.
       explanation: GeneReviews supports transplantation as the metabolic-level corrective intervention for CTLN1.
 - name: Newborn screening
@@ -1137,7 +1159,7 @@ progression:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: Citrullinemia type I (CTLN1) presents as a spectrum that includes a neonatal acute form (the "classic" form), a milder late-onset form (the "non-classic" form), a form in which women have onset of symptoms at pregnancy or post partum, and a form without symptoms or hyperammonemia.
     explanation: GeneReviews describes the full clinical spectrum of CTLN1 presentations.
   notes: 'Classic neonatal-onset CTLN1 presents within the first days of life with progressive lethargy, poor feeding, vomiting, and hyperammonemic encephalopathy that can rapidly progress to coma and death without treatment. Late-onset forms present with intermittent hyperammonemia, developmental delay, and neurocognitive impairment. A pregnancy/postpartum-triggered form can present in women without prior symptoms. Long-term outcomes are determined by severity and number of hyperammonemic events, with early-onset cases having 35.8% mortality versus 7.1% in late-onset cases. Neurological impairment occurs in 44% of UCD patients overall. Liver transplantation can stabilize metabolism but does not reverse pre-existing brain injury.


### PR DESCRIPTION
## Summary
- Add downstream edges connecting the ASS1 ureagenesis block to decreased argininosuccinate and the hyperammonemic astrocyte injury mechanism to glutamine accumulation.
- Reduce Citrullinemia Type I graph components from 6 to 4 while leaving `Arginine` and `Orotic acid` isolated because the cached snippets do not directly support those edges.
- Reclassify all `PMID:20301631` GeneReviews evidence blocks in this file from `HUMAN_CLINICAL` to `OTHER`, consistent with the repo evidence-source guidance for reviews/expert summaries.

## Validation
- `just validate kb/disorders/Citrullinemia_Type_I.yaml`
- `just validate-references kb/disorders/Citrullinemia_Type_I.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Citrullinemia_Type_I.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Citrullinemia_Type_I.yaml`
- manual normalized snippet audit for both new `PMID:20301631` snippets
- `git diff --check`

Subagent review found no blockers and agreed not to force `Arginine`/`Orotic acid` without direct cached support.