### PR TITLE
Connect OTCD genetic node to OTC mechanism

### DIFF
--- a/kb/disorders/Ornithine_Carbamoyltransferase_Deficiency.yaml
+++ b/kb/disorders/Ornithine_Carbamoyltransferase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Ornithine Carbamoyltransferase Deficiency
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-08T05:38:44Z'
+updated_date: '2026-05-09T09:43:18Z'
 category: Mendelian
 synonyms:
 - OTC deficiency
@@ -686,6 +686,11 @@ phenotypes:
   notes: Behavioral disorders reported in 35% of adult-onset UCD presentations in systematic reviews.
 genetic:
 - name: OTC variants
+  gene_term:
+    preferred_term: OTC
+    term:
+      id: hgnc:8512
+      label: OTC
   inheritance:
   - name: X-linked inheritance
     evidence:


### PR DESCRIPTION
## Summary
- Added the structured OTC gene_term to the OTCD genetic node.
- This lets graph generation connect OTC variants to the ornithine carbamoyltransferase molecular-function deficiency node.

## Validation
- just validate kb/disorders/Ornithine_Carbamoyltransferase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/Ornithine_Carbamoyltransferase_Deficiency.yaml
- uv run python -m dismech.graph --show kb/disorders/Ornithine_Carbamoyltransferase_Deficiency.yaml (confirmed OTC variants connect to the molecular-function mechanism)
- git diff --check
- OAK/HGNC check: hgnc:8512 = OTC