### PR TITLE
Connect IBDD ACAD8 variants

### DIFF
--- a/kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Isobutyryl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-09T02:08:31Z'
+updated_date: '2026-05-09T10:39:39Z'
 synonyms:
 - IBDD
 - IBD deficiency
@@ -722,6 +722,11 @@ biochemical:
     explanation: Identifies seven novel ratio biomarkers for distinguishing IBDD from false positives and SCADD.
 genetic:
 - name: ACAD8 pathogenic variants
+  gene_term:
+    preferred_term: ACAD8
+    term:
+      id: hgnc:87
+      label: ACAD8
   inheritance:
   - name: Autosomal recessive
     evidence:


### PR DESCRIPTION
## Summary
- add `gene_term` for `ACAD8 pathogenic variants` in Isobutyryl-CoA Dehydrogenase Deficiency
- connects ACAD8 variants to the existing `ACAD8 molecular function deficiency` pathophysiology node via shared HGNC term

## Validation
- `just validate kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Isobutyryl-CoA_Dehydrogenase_Deficiency.yaml | rg "ACAD8_pathogenic_variants|ACAD8_molecular_function_deficiency"`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed `hgnc:87` resolves to canonical HGNC `ACAD8`, the scoped diff only changes the YAML timestamp plus `gene_term`, and the graph emits `ACAD8_pathogenic_variants --> ACAD8_molecular_function_deficiency`.
