### PR TITLE
Connect CPS1 genetic variants

### DIFF
--- a/kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml
+++ b/kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Carbamoyl Phosphate Synthetase I Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-05T01:28:48Z'
+updated_date: '2026-05-09T11:14:31Z'
 synonyms:
 - CPS1 deficiency
 - CPS1D
@@ -579,6 +579,11 @@ biochemical:
     explanation: Quantitative documentation of elevated alanine in a late-onset CPS1D case.
 genetic:
 - name: CPS1 pathogenic variants
+  gene_term:
+    preferred_term: CPS1
+    term:
+      id: hgnc:2323
+      label: CPS1
   features: 'CPS1D is caused by biallelic pathogenic variants in the CPS1 gene encoding carbamoyl phosphate synthetase 1, a mitochondrial urea-cycle enzyme. Extensive allelic heterogeneity exists, with many novel variants reported in 2023-2024 cohorts. Variant types include missense, frameshift, in-frame deletion, and splicing mutations. Compound heterozygosity is common. No hotspot variants have been observed. Complete loss of function typically causes severe neonatal-onset disease, while hypomorphic variants with residual enzyme activity are associated with late-onset presentations.
 
     '


### PR DESCRIPTION
## Summary
- add `gene_term` for `CPS1 pathogenic variants` in Carbamoyl Phosphate Synthetase I Deficiency
- connects CPS1 variants to the existing `CPS1 molecular function deficiency` pathophysiology node via shared HGNC term

## Validation
- `just validate kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml | rg "CPS1_pathogenic_variants --> CPS1_molecular_function_deficiency|CPS1_pathogenic_variants|CPS1_molecular_function_deficiency"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:2323 -O obo`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed `hgnc:2323` resolves to canonical HGNC `CPS1`, the scoped diff only changes the YAML timestamp plus `gene_term`, and the graph emits `CPS1_pathogenic_variants --> CPS1_molecular_function_deficiency`.
