### PR TITLE
Connect CACT SLC25A20 variants

### DIFF
--- a/kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
+++ b/kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Carnitine-acylcarnitine Translocase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-08T01:03:42Z'
+updated_date: '2026-05-09T11:28:10Z'
 synonyms:
 - CACT deficiency
 - CACTD
@@ -898,6 +898,11 @@ histopathology:
     explanation: Autopsy case report directly documents the multi-organ microvesicular steatosis pattern.
 genetic:
 - name: SLC25A20 pathogenic variants
+  gene_term:
+    preferred_term: SLC25A20
+    term:
+      id: hgnc:1421
+      label: SLC25A20
   features: 'CACT deficiency is caused by biallelic pathogenic variants in SLC25A20, encoding the mitochondrial inner membrane carnitine-acylcarnitine translocase. The protein functions via an alternating-access mechanism with asymmetric conformational changes. Over 30 pathogenic variants have been described. The acylcarnitine profile overlaps with CPT II deficiency, requiring SLC25A20 sequencing or functional assays for definitive diagnosis.
 
     '


### PR DESCRIPTION
## Summary
- add `gene_term` for `SLC25A20 pathogenic variants` in Carnitine-acylcarnitine Translocase Deficiency
- connects SLC25A20 variants to the existing `SLC25A20 transporter molecular function deficiency` pathophysiology node via shared HGNC term

## Validation
- `just validate kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml | rg "SLC25A20_pathogenic_variants --> SLC25A20_transporter_molecular_function_deficiency|SLC25A20_pathogenic_variants|SLC25A20_transporter_molecular_function_deficiency"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:1421 -O obo`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed `hgnc:1421` resolves to canonical HGNC `SLC25A20`, the scoped diff only changes the YAML timestamp plus `gene_term`, and the graph emits `SLC25A20_pathogenic_variants --> SLC25A20_transporter_molecular_function_deficiency`.
