### PR TITLE
Connect ACADSB genetic variants

### DIFF
--- a/kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 2-Methylbutyryl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-09T06:01:35Z'
+updated_date: '2026-05-09T11:45:26Z'
 synonyms:
 - Short/branched-chain acyl-CoA dehydrogenase deficiency
 - SBCADD
@@ -745,6 +745,11 @@ biochemical:
       '
 genetic:
 - name: ACADSB pathogenic variants
+  gene_term:
+    preferred_term: ACADSB
+    term:
+      id: hgnc:91
+      label: ACADSB
   inheritance:
   - name: Autosomal recessive
     evidence:


### PR DESCRIPTION
## Summary
- add `gene_term` for `ACADSB pathogenic variants` in 2-Methylbutyryl-CoA Dehydrogenase Deficiency
- connects ACADSB variants to the existing `ACADSB molecular function deficiency` pathophysiology node via shared HGNC term

## Validation
- `just validate kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --show kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml | rg "ACADSB_pathogenic_variants --> ACADSB_molecular_function_deficiency|ACADSB_pathogenic_variants|ACADSB_molecular_function_deficiency"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:91 -O obo`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed `hgnc:91` resolves to canonical HGNC `ACADSB`, the scoped diff only changes the YAML timestamp plus `gene_term`, and the graph emits `ACADSB_pathogenic_variants --> ACADSB_molecular_function_deficiency`.
