### PR TITLE
Connect BTD genetic variants

### DIFF
--- a/kb/disorders/Biotinidase_Deficiency.yaml
+++ b/kb/disorders/Biotinidase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Biotinidase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-06T17:16:40Z'
+updated_date: '2026-05-09T12:01:33Z'
 synonyms:
 - BTD deficiency
 - Biotinidase deficiency, profound
@@ -1060,6 +1060,11 @@ biochemical:
     explanation: Large cohort quantifies the distribution of enzyme deficiency severity categories.
 genetic:
 - name: BTD gene variants causing biotinidase deficiency
+  gene_term:
+    preferred_term: BTD
+    term:
+      id: hgnc:1122
+      label: BTD
   inheritance:
   - name: Autosomal recessive
     evidence:


### PR DESCRIPTION
## Summary
- add `gene_term` for `BTD gene variants causing biotinidase deficiency` in Biotinidase Deficiency
- connects BTD variants to the existing `Impaired biotin recycling and secondary multiple carboxylase deficiency` pathophysiology node via shared HGNC term

## Validation
- `just validate kb/disorders/Biotinidase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Biotinidase_Deficiency.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Biotinidase_Deficiency.yaml | rg "BTD_gene_variants_causing_biotinidase_deficiency --> Impaired_biotin_recycling_and_secondary_multiple_carboxylase_deficiency|BTD_gene_variants_causing_biotinidase_deficiency|Impaired_biotin_recycling_and_secondary_multiple_carboxylase_deficiency"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:1122 -O obo`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed `hgnc:1122` resolves to canonical HGNC `BTD`, the scoped diff only changes the YAML timestamp plus `gene_term`, and the graph emits `BTD_gene_variants_causing_biotinidase_deficiency --> Impaired_biotin_recycling_and_secondary_multiple_carboxylase_deficiency`.
