### PR TITLE
Connect homocystinuria CBS variants

### DIFF
--- a/kb/disorders/Homocystinuria.yaml
+++ b/kb/disorders/Homocystinuria.yaml
@@ -1,7 +1,7 @@
 name: Homocystinuria
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-05T07:14:54Z'
+updated_date: '2026-05-09T12:17:17Z'
 synonyms:
 - Classical homocystinuria
 - CBS-deficient homocystinuria
@@ -1327,6 +1327,11 @@ biochemical:
     explanation: Directly supports NAD redox-ratio disturbance in CBS-deficient patients.
 genetic:
 - name: CBS (cystathionine beta-synthase) deficiency
+  gene_term:
+    preferred_term: CBS
+    term:
+      id: hgnc:1550
+      label: CBS
   inheritance:
   - name: Autosomal recessive
     evidence:


### PR DESCRIPTION
## Summary
- add `gene_term` for `CBS (cystathionine beta-synthase) deficiency` in Homocystinuria
- connects CBS genetic variants to the existing `CBS molecular function deficiency` pathophysiology node via shared HGNC term
- leave the separate MTHFR heterogeneity note unchanged because there is no matching MTHFR pathophysiology node in this scoped CBS connectivity PR

## Validation
- `just validate kb/disorders/Homocystinuria.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Homocystinuria.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Homocystinuria.yaml | rg "CBS_cystathionine_beta_synthase_deficiency --> CBS_molecular_function_deficiency|CBS_cystathionine_beta_synthase_deficiency|CBS_molecular_function_deficiency|MTHFR"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:1550 -O obo`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed `hgnc:1550` resolves to canonical HGNC `CBS`, the scoped diff only changes the YAML timestamp plus `gene_term`, the graph emits `CBS_cystathionine_beta_synthase_deficiency --> CBS_molecular_function_deficiency`, and leaving MTHFR unchanged is appropriate for this PR.
