### PR TITLE
Connect NKH glycine cleavage genes

### DIFF
--- a/kb/disorders/Nonketotic_Hyperglycinemia.yaml
+++ b/kb/disorders/Nonketotic_Hyperglycinemia.yaml
@@ -1,7 +1,7 @@
 name: Nonketotic Hyperglycinemia
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-08T00:00:00Z'
+updated_date: '2026-05-09T12:36:35Z'
 synonyms:
 - Glycine encephalopathy
 - NKH
@@ -630,7 +630,12 @@ biochemical:
     snippet: "markedly decreased in nonketotic hyperglycinemia."
     explanation: Documents d-serine deficiency in NKH challenging the NMDA overactivation model.
 genetic:
-- name: Glycine cleavage system gene variants
+- name: GLDC pathogenic variants
+  gene_term:
+    preferred_term: GLDC
+    term:
+      id: hgnc:4313
+      label: GLDC
   inheritance:
   - name: Autosomal recessive
     evidence:
@@ -646,35 +651,44 @@ genetic:
       evidence_source: HUMAN_CLINICAL
       snippet: "rare inherited disease caused by an inborn error of glycine metabolism,"
       explanation: Confirms NKH as an inherited disease with biallelic variants.
-  variants:
-  - name: GLDC pathogenic variants
-    description: 'GLDC encodes glycine decarboxylase (P-protein) of the glycine cleavage system. GLDC variants account for approximately 65-80% of classical NKH cases. In a Chinese cohort, GLDC variants were found in 65% (13/20) of patients. Novel compound heterozygous variants continue to expand the mutational spectrum.
-
-      '
-  - name: AMT pathogenic variants
-    description: 'AMT encodes aminomethyltransferase (T-protein) of the glycine cleavage system. AMT variants account for approximately 20-35% of NKH cases. In a Chinese cohort, AMT variants were found in 35% (7/20) of patients.
-
-      '
-  - name: GCSH pathogenic variants (variant NKH)
-    description: 'GCSH encodes the H-protein, a multifunctional lipoyl carrier protein with dual roles in glycine cleavage and mitochondrial lipoylation. Pathogenic GCSH variants cause combined NKH and lipoate deficiency (variant NKH) with a broad clinical spectrum from neonatal fatal glycine encephalopathy to attenuated phenotypes with developmental delay. Most variants produce a hypomorphic effect on both protein lipoylation and glycine metabolism.
-
-      '
-    evidence:
-    - reference: PMID:36190515
-      reference_title: "Pathogenic variants in GCSH encoding the moonlighting H-protein cause combined nonketotic hyperglycinemia and lipoate deficiency."
-      supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
-      snippet: "spectrum ranging from neonatal fatal glycine encephalopathy to an attenuated"
-      explanation: Documents pathogenic GCSH variants with broad clinical spectrum.
-    - reference: PMID:36190515
-      reference_title: "Pathogenic variants in GCSH encoding the moonlighting H-protein cause combined nonketotic hyperglycinemia and lipoate deficiency."
-      supports: SUPPORT
-      evidence_source: IN_VITRO
-      snippet: "lipoylation and glycine metabolism, causing combined deficiency, whereas some"
-      explanation: Demonstrates functional consequences of GCSH variants.
-  features: 'NKH is caused by biallelic pathogenic variants in genes encoding components of the mitochondrial glycine cleavage system. GLDC (glycine decarboxylase, P-protein) mutations are most common (65-80%), followed by AMT (aminomethyltransferase, T-protein) at 20-35%. Rare GCSH (H-protein) variants cause combined NKH and lipoate deficiency. DLD (dihydrolipoamide dehydrogenase, L-protein) variants are shared with other mitochondrial dehydrogenase deficiencies. Genotype-phenotype correlations are complex; residual enzyme activity generally determines severity.
+  features: 'GLDC encodes glycine decarboxylase (P-protein) of the glycine cleavage system. GLDC variants account for approximately 65-80% of classical NKH cases. In a Chinese cohort, GLDC variants were found in 65% (13/20) of patients. Novel compound heterozygous variants continue to expand the mutational spectrum.
 
     '
+- name: AMT pathogenic variants
+  gene_term:
+    preferred_term: AMT
+    term:
+      id: hgnc:473
+      label: AMT
+  inheritance:
+  - name: Autosomal recessive
+  features: 'AMT encodes aminomethyltransferase (T-protein) of the glycine cleavage system. AMT variants account for approximately 20-35% of NKH cases. In a Chinese cohort, AMT variants were found in 35% (7/20) of patients.
+
+    '
+- name: GCSH pathogenic variants (variant NKH)
+  gene_term:
+    preferred_term: GCSH
+    term:
+      id: hgnc:4208
+      label: GCSH
+  inheritance:
+  - name: Autosomal recessive
+  features: 'GCSH encodes the H-protein, a multifunctional lipoyl carrier protein with dual roles in glycine cleavage and mitochondrial lipoylation. Pathogenic GCSH variants cause combined NKH and lipoate deficiency (variant NKH) with a broad clinical spectrum from neonatal fatal glycine encephalopathy to attenuated phenotypes with developmental delay. Most variants produce a hypomorphic effect on both protein lipoylation and glycine metabolism.
+
+    '
+  evidence:
+  - reference: PMID:36190515
+    reference_title: "Pathogenic variants in GCSH encoding the moonlighting H-protein cause combined nonketotic hyperglycinemia and lipoate deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "spectrum ranging from neonatal fatal glycine encephalopathy to an attenuated"
+    explanation: Documents pathogenic GCSH variants with broad clinical spectrum.
+  - reference: PMID:36190515
+    reference_title: "Pathogenic variants in GCSH encoding the moonlighting H-protein cause combined nonketotic hyperglycinemia and lipoate deficiency."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "lipoylation and glycine metabolism, causing combined deficiency, whereas some"
+    explanation: Demonstrates functional consequences of GCSH variants.
 treatments:
 - name: Sodium benzoate therapy
   description: 'Sodium benzoate is the mainstay of glycine reduction therapy in NKH. Benzoate conjugates with glycine and is excreted in urine as hippurate, thereby lowering plasma glycine. Clinical targets commonly aim for plasma glycine approximately 120-300 umol/L.


### PR DESCRIPTION
## Summary
- split the broad `Glycine cleavage system gene variants` genetic parent into gene-specific GLDC, AMT, and GCSH genetic nodes
- add HGNC `gene_term` annotations for GLDC, AMT, and GCSH so each node connects to `Glycine cleavage system dysfunction`
- preserve existing GLDC/AMT/GCSH feature text and GCSH evidence while avoiding a misleading singular gene_term on the old broad parent

## Validation
- `just validate kb/disorders/Nonketotic_Hyperglycinemia.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Nonketotic_Hyperglycinemia.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Nonketotic_Hyperglycinemia.yaml | rg "GLDC_pathogenic_variants --> Glycine_cleavage_system_dysfunction|AMT_pathogenic_variants --> Glycine_cleavage_system_dysfunction|GCSH_pathogenic_variants_variant_NKH --> Glycine_cleavage_system_dysfunction|Glycine_cleavage_system_gene_variants"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:4313 hgnc:473 hgnc:4208 -O obo`
- `git diff --check`

## Review
- Subagent review found no blockers; confirmed the split is schema-valid and semantically preferable to a singular `gene_term`, all three HGNC terms match the pathophysiology genes, and graph emission includes GLDC/AMT/GCSH contributes_to edges into `Glycine cleavage system dysfunction`.
