### PR TITLE
Connect catecholamine BH4 gene variants

### DIFF
--- a/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
+++ b/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
@@ -1,6 +1,6 @@
 name: Disorder of Catecholamine Synthesis
 creation_date: "2026-05-08T13:18:01Z"
-updated_date: "2026-05-08T14:21:02Z"
+updated_date: "2026-05-09T13:27:18Z"
 category: Genetic
 parents:
 - Inborn Disorder of Neurotransmitter Metabolism and Transport
@@ -604,13 +604,37 @@ genetic:
       broad phenotypic expression caused by bi-allelic mutations in the TH gene,
       which encode for tyrosine hydroxylase (TH) protein.
     explanation: Supports biallelic TH variants in TH deficiency.
-- name: BH4 metabolism gene variants
-  association: Causative variants in BH4 biosynthesis or regeneration genes
+- name: GCH1 pathogenic variants
+  gene_term:
+    preferred_term: GCH1
+    term:
+      id: hgnc:4193
+      label: GCH1
+  association: Causative variants affecting GTP cyclohydrolase I and BH4 synthesis
   relationship_type: CAUSATIVE
   variant_origin: GERMLINE
-  features: >-
-    Includes GCH1, PTS, QDPR, SPR, and PCBD1 variants, with gene-specific
-    phenotypes and biochemical patterns.
+  subtype: Autosomal recessive GTP cyclohydrolase I deficiency
+  evidence:
+  - reference: DOI:10.1002/mdc3.14157
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The GCH1 gene encodes the enzyme guanosine triphosphate cyclohydrolase I
+      (GTPCH), which catalyzes the rate‐limiting step in the biosynthesis of
+      tetrahydrobiopterin (BH4), a critical cofactor in the production of
+      monoamine neurotransmitters.
+    explanation: >-
+      Supports GCH1 as the BH4 biosynthesis gene underlying GTP cyclohydrolase I
+      deficiency.
+- name: PTS pathogenic variants
+  gene_term:
+    preferred_term: PTS
+    term:
+      id: hgnc:9689
+      label: PTS
+  association: Causative variants affecting 6-pyruvoyltetrahydropterin synthase
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
   evidence:
   - reference: DOI:10.1002/mgg3.2294
     supports: SUPPORT
@@ -619,7 +643,69 @@ genetic:
       We successfully identified six mutant alleles in BH4‐deficiency‐associated
       genes, including three novel mutations: one in QDPR, one in PTS, and one
       in the PCBD1 gene, thus giving a definite diagnosis to these patients.
-    explanation: Supports pathogenic variation across BH4 deficiency genes.
+    explanation: Supports PTS mutant alleles in human BH4 deficiency.
+- name: QDPR pathogenic variants
+  gene_term:
+    preferred_term: QDPR
+    term:
+      id: hgnc:9752
+      label: QDPR
+  association: Causative variants affecting dihydropteridine reductase
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  evidence:
+  - reference: DOI:10.1002/mgg3.2294
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We successfully identified six mutant alleles in BH4‐deficiency‐associated
+      genes, including three novel mutations: one in QDPR, one in PTS, and one
+      in the PCBD1 gene, thus giving a definite diagnosis to these patients.
+    explanation: Supports QDPR mutant alleles in human BH4 deficiency.
+- name: SPR pathogenic variants
+  gene_term:
+    preferred_term: SPR
+    term:
+      id: hgnc:11257
+      label: SPR
+  association: Causative variants affecting sepiapterin reductase
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  subtype: Sepiapterin reductase deficiency
+  evidence:
+  - reference: DOI:10.1002/mgg3.2294
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The latter is produced by mutations in genes involved in the
+      tetrahydrobiopterin (BH4) biosynthesis pathway and DNAJC12 pathogenetic
+      variants. The BH4 metabolism, including de novo biosynthesis involved
+      genes (i.e., guanosine 5′‐triphosphate cyclohydrolase I (GTPCH/GCH1),
+      sepiapterin reductase (SR/SPR), 6‐pyruvoyl‐tetrahydropterin synthase
+      (PTPS/PTS)), and two genes that play roles in cofactor regeneration
+      pathway (i.e., dihydropteridine reductase (DHPR/QDPR) and
+      pterin‐4α‐carbinolamine dehydratase (PCD/PCBD1)).
+    explanation: >-
+      Supports SPR as a BH4 biosynthesis gene whose mutation can produce the
+      non-PAH hyperphenylalaninemia/BH4-deficiency group.
+- name: PCBD1 pathogenic variants
+  gene_term:
+    preferred_term: PCBD1
+    term:
+      id: hgnc:8646
+      label: PCBD1
+  association: Causative variants affecting pterin-4 alpha-carbinolamine dehydratase
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  evidence:
+  - reference: DOI:10.1002/mgg3.2294
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We successfully identified six mutant alleles in BH4‐deficiency‐associated
+      genes, including three novel mutations: one in QDPR, one in PTS, and one
+      in the PCBD1 gene, thus giving a definite diagnosis to these patients.
+    explanation: Supports PCBD1 mutant alleles in human BH4 deficiency.
 - name: DNAJC12 pathogenic variants
   gene_term:
     preferred_term: DNAJC12

--- a/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
+++ b/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
@@ -1,6 +1,6 @@
 name: Disorder of Catecholamine Synthesis
 creation_date: "2026-05-08T13:18:01Z"
-updated_date: "2026-05-09T13:27:18Z"
+updated_date: "2026-05-09T14:29:12Z"
 category: Genetic
 parents:
 - Inborn Disorder of Neurotransmitter Metabolism and Transport
@@ -610,7 +610,7 @@ genetic:
     term:
       id: hgnc:4193
       label: GCH1
-  association: Causative variants affecting GTP cyclohydrolase I and BH4 synthesis
+  association: Causative biallelic/recessive variants affecting GTP cyclohydrolase I and BH4 synthesis
   relationship_type: CAUSATIVE
   variant_origin: GERMLINE
   subtype: Autosomal recessive GTP cyclohydrolase I deficiency


### PR DESCRIPTION
## Summary
- split the broad `BH4 metabolism gene variants` genetic item into gene-specific GCH1, PTS, QDPR, SPR, and PCBD1 entries
- added HGNC `gene_term` annotations so each BH4 genetic node connects to `BH4 Cofactor Deficiency` through the graph builder
- kept the PR scoped to `kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml`

## Validation
- `just validate kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml | rg "(GCH1|PTS|QDPR|SPR|PCBD1)_pathogenic_variants --> BH4_Cofactor_Deficiency"`
- manual snippet audit confirmed all five new evidence snippets are exact substrings of cached DOI references
- `git diff --check`

Validation touched the usual clinical trial cache files locally; those were restored before commit.