### PR TITLE
Connect MPS subtype genes to GAG storage

### DIFF
--- a/kb/disorders/Mucopolysaccharidosis.yaml
+++ b/kb/disorders/Mucopolysaccharidosis.yaml
@@ -1,6 +1,6 @@
 name: Mucopolysaccharidosis
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-05-06T00:49:29Z'
+updated_date: '2026-05-09T14:04:00Z'
 category: Mendelian
 description: >
   The mucopolysaccharidoses (MPS) are a group of lysosomal storage disorders caused
@@ -68,6 +68,51 @@ pathophysiology:
     cells, causing cellular dysfunction and tissue/organ damage. In
     bone and cartilage, GAG storage disrupts endochondral ossification,
     growth plate organization, and articular cartilage integrity.
+  genes:
+  - preferred_term: IDUA
+    term:
+      id: hgnc:5391
+      label: IDUA
+  - preferred_term: IDS
+    term:
+      id: hgnc:5389
+      label: IDS
+  - preferred_term: SGSH
+    term:
+      id: hgnc:10818
+      label: SGSH
+  - preferred_term: NAGLU
+    term:
+      id: hgnc:7632
+      label: NAGLU
+  - preferred_term: HGSNAT
+    term:
+      id: hgnc:26527
+      label: HGSNAT
+  - preferred_term: GNS
+    term:
+      id: hgnc:4422
+      label: GNS
+  - preferred_term: GALNS
+    term:
+      id: hgnc:4122
+      label: GALNS
+  - preferred_term: GLB1
+    term:
+      id: hgnc:4298
+      label: GLB1
+  - preferred_term: ARSB
+    term:
+      id: hgnc:714
+      label: ARSB
+  - preferred_term: GUSB
+    term:
+      id: hgnc:4696
+      label: GUSB
+  - preferred_term: HYAL1
+    term:
+      id: hgnc:5320
+      label: HYAL1
   biological_processes:
   - preferred_term: Glycosaminoglycan Catabolism
     modifier: DECREASED


### PR DESCRIPTION
## Summary
- added the existing MPS subtype HGNC genes to the `Lysosomal GAG Accumulation` mechanism
- connects all 11 MPS genetic subtype nodes to the upstream GAG storage mechanism in the pathograph
- kept the PR scoped to `kb/disorders/Mucopolysaccharidosis.yaml`

## Validation
- `just validate kb/disorders/Mucopolysaccharidosis.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Mucopolysaccharidosis.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Mucopolysaccharidosis.yaml | rg "(IDUA|IDS|SGSH|NAGLU|HGSNAT|GNS|GALNS|GLB1|ARSB|GUSB|HYAL1).*--> Lysosomal_GAG_Accumulation"`
- `git diff --check`

Validation touched the usual clinical trial cache files locally; those were restored before commit.