### PR TITLE
Connect HFE hepcidin mechanism

### DIFF
--- a/kb/disorders/Hemochromatosis.yaml
+++ b/kb/disorders/Hemochromatosis.yaml
@@ -1,6 +1,6 @@
 name: Hemochromatosis
 creation_date: '2026-01-09T07:07:01Z'
-updated_date: '2026-04-30T20:00:00Z'
+updated_date: '2026-05-09T15:42:00Z'
 category: Mendelian
 disease_term:
   preferred_term: hereditary hemochromatosis
@@ -84,6 +84,11 @@ pathophysiology:
   description: >
     Pathogenic HFE variants (most commonly C282Y homozygosity) blunt hepcidin induction,
     leaving circulating hepcidin inappropriately low relative to body iron stores.
+  genes:
+  - preferred_term: HFE
+    term:
+      id: hgnc:4886
+      label: HFE
   evidence:
   - reference: PMID:23985001
     reference_title: "Diagnosis and treatment of hereditary hemochromatosis: an update."


### PR DESCRIPTION
## Summary
- Adds the existing HGNC HFE descriptor to the `HFE Loss Lowers Hepcidin` mechanism.
- This lets the pathograph derive the genetic edge from `HFE Mutations` to the hepcidin mechanism.
- Leaves `BMP6 Mutations` unconnected for now because adding a BMP6-specific mechanism should be evidence-backed separately.
- Restored generated ClinicalTrials cache churn; this PR is YAML-only.

## Validation
- `just validate kb/disorders/Hemochromatosis.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Hemochromatosis.yaml`
- `uv run python -m dismech.graph --show kb/disorders/Hemochromatosis.yaml | rg "HFE_Mutations --> HFE_Loss_Lowers_Hepcidin"`
- `uv run runoak -i sqlite:obo:hgnc info hgnc:4886 -O obo`
- `git diff --check`
