### PR TITLE
Connect Gilbert UGT1A1 mechanism

### DIFF
--- a/kb/disorders/Gilberts_Syndrome.yaml
+++ b/kb/disorders/Gilberts_Syndrome.yaml
@@ -46,6 +46,11 @@ pathophysiology:
     (e.g., Gly71Arg / UGT1A1*6) are more prevalent. Gilbert's syndrome is the
     most prevalent (2-19% in population studies) and mildest of the hereditary
     unconjugated hyperbilirubinaemia syndromes.
+  genes:
+  - preferred_term: UGT1A1
+    term:
+      id: hgnc:12530
+      label: UGT1A1
   cell_types:
   - preferred_term: Hepatocyte
     term:


### PR DESCRIPTION
## Summary
- add the canonical UGT1A1 HGNC descriptor to the reduced UGT1A1 activity mechanism
- connect both existing UGT1A1 variant genetic nodes into the Gilbert syndrome pathograph
- keep the PR scoped to the Gilbert disorder YAML only; no evidence or cache files changed

## Validation
- just validate kb/disorders/Gilberts_Syndrome.yaml
- uv run python -m dismech.graph --validate kb/disorders/Gilberts_Syndrome.yaml
- uv run python -m dismech.graph --show kb/disorders/Gilberts_Syndrome.yaml | rg "UGT1A1.*--> Reduced_UGT1A1"
- uv run runoak -i sqlite:obo:hgnc info hgnc:12530 -O obo
- git diff --check