### PR TITLE
Curate diffuse nonepidermolytic palmoplantar keratoderma

### DIFF
--- a/kb/disorders/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma.yaml
+++ b/kb/disorders/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma.yaml
@@ -312,10 +312,10 @@ pathophysiology:
       id: CL:0000312
       label: keratinocyte
   biological_processes:
-  - preferred_term: epidermis development
+  - preferred_term: cornification
     term:
-      id: GO:0008544
-      label: epidermis development
+      id: GO:0070268
+      label: cornification
     modifier: ABNORMAL
   evidence:
   - reference: ORPHA:530838

--- a/kb/disorders/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma.yaml
+++ b/kb/disorders/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma.yaml
@@ -1,0 +1,718 @@
+name: Diffuse Nonepidermolytic Palmoplantar Keratoderma
+category: Mendelian
+creation_date: "2026-05-09T17:03:34Z"
+updated_date: "2026-05-09T17:03:34Z"
+synonyms:
+- KRT1-related diffuse nonepidermolytic keratoderma
+- KRT1-related diffuse NEPPK
+- Diffuse nonepidermolytic palmoplantar keratoderma
+- Non-epidermolytic palmoplantar keratoderma
+- NEPPK
+- Diffuse palmoplantar keratoderma, Bothnian type
+- Thost-Unna palmoplantar keratoderma
+- Unna-Thost palmoplantar keratoderma
+description: >
+  Diffuse nonepidermolytic palmoplantar keratoderma is a rare autosomal
+  dominant isolated palmoplantar keratoderma caused by germline KRT1 variants.
+  Affected individuals develop diffuse, sharply demarcated hyperkeratosis of
+  the palms and soles without the epidermolysis that characterizes epidermolytic
+  keratinopathies. Associated findings include dry skin, umbilical or areolar
+  hyperkeratosis, knuckle pad-like lesions, hyperhidrosis, nail changes, and
+  recurrent fungal infection or onychomycosis. Histology shows orthokeratotic
+  hyperkeratosis, acanthosis, hypergranulosis, and mild superficial dermal
+  lymphocytic inflammation without epidermolysis.
+disease_term:
+  preferred_term: diffuse nonepidermolytic palmoplantar keratoderma
+  term:
+    id: MONDO:0010962
+    label: diffuse nonepidermolytic palmoplantar keratoderma
+parents:
+- Diffuse palmoplantar keratoderma
+- Autosomal dominant disease
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0010962
+      label: diffuse nonepidermolytic palmoplantar keratoderma
+    mapping_predicate: skos:exactMatch
+    mapping_source: Orphanet ORPHA:530838
+    mapping_justification: >
+      Orphanet ORPHA:530838 lists MONDO:0010962 as an exact cross-reference
+      for KRT1-related diffuse nonepidermolytic keratoderma.
+external_assertions:
+- name: Orphanet KRT1-related diffuse nonepidermolytic keratoderma record
+  source: Orphanet
+  assertion_type: structured_disease_record
+  external_id: ORPHA:530838
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=530838
+  description: >
+    Orphanet's ORPHA:530838 structured record provides the disease definition,
+    autosomal dominant inheritance, KRT1 disease-gene assertion, worldwide
+    prevalence class, HPO phenotype rows, and exact MONDO and OMIM cross-
+    references used in this entry.
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "MONDO:0010962 | Exact"
+    explanation: Orphanet maps ORPHA:530838 exactly to the MONDO identifier used by this entry.
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "OMIM:600962 | Exact"
+    explanation: Orphanet lists OMIM:600962 as an exact external cross-reference.
+- name: Orphanet Thost-Unna palmoplantar keratoderma historical record
+  source: Orphanet
+  assertion_type: sparse_historical_disease_record
+  external_id: ORPHA:496
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=496
+  description: >
+    ORPHA:496 is a sparse Orphanet historical record for Thost-Unna
+    palmoplantar keratoderma. It is retained here only as a synonym/history
+    signal and is not used as the phenotype or gene-evidence source.
+  evidence:
+  - reference: ORPHA:496
+    reference_title: Thost-Unna palmoplantar keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Thost-Unna palmoplantar keratoderma"
+    explanation: The sparse Orphanet record supports Thost-Unna palmoplantar keratoderma as a historical label.
+definitions:
+- name: Orphanet KRT1-related diffuse nonepidermolytic keratoderma definition
+  definition_type: OTHER
+  description: >
+    A rare genetic isolated diffuse palmoplantar keratoderma with diffuse,
+    well-demarcated hyperkeratosis of the palms and soles, additional
+    cutaneous/nail findings, and nonepidermolytic histology.
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "A rare, genetic, isolated diffuse palmoplantar keratoderma characterized by diffuse, mild to thick, finely demarcated hyperkeratosis of palms and soles."
+    explanation: Orphanet defines the disorder as a rare isolated diffuse palmoplantar keratoderma.
+  - reference: PMID:30452289
+    reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "pedigree with diffuse nonepidermolytic palmoplantar keratoderma (NEPPK)."
+    explanation: The clinical pedigree report uses the same diffuse NEPPK disease label.
+inheritance:
+- name: Autosomal dominant inheritance
+  description: Diffuse nonepidermolytic palmoplantar keratoderma is inherited in an autosomal dominant pattern.
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Autosomal dominant"
+    explanation: Orphanet records autosomal dominant inheritance.
+  - reference: PMID:7531539
+    reference_title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "An autosomal dominant form of diffuse non-epidermolytic palmoplantar keratoderma"
+    explanation: The northern Sweden linkage study describes the disease as autosomal dominant.
+prevalence:
+- population: Worldwide
+  percentage: Unknown
+  notes: >
+    Orphanet lists worldwide point prevalence as unknown. The northern Sweden
+    linkage cohort represents a regional founder context and is not used as a
+    global prevalence estimate.
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Unknown | Worldwide | Point prevalence | PMID:30452289"
+    explanation: Orphanet records unknown worldwide point prevalence.
+  - reference: PMID:7531539
+    reference_title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "encountered in northern Sweden with a prevalence of 0.3-0.55%."
+    explanation: The linkage paper documents a high regional prevalence in northern Sweden, consistent with founder enrichment rather than worldwide prevalence.
+progression:
+- phase: Onset
+  age_range: Infancy to childhood
+  notes: Orphanet lists both infancy and childhood onset.
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Infancy"
+    explanation: Orphanet lists infancy as an onset category.
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Childhood"
+    explanation: Orphanet lists childhood as an onset category.
+- phase: Chronic palmoplantar keratoderma
+  age_range: Childhood through adulthood
+  notes: >
+    The disorder is modeled as a chronic inherited keratinization disorder with
+    persistent palmoplantar hyperkeratosis and variable associated cutaneous
+    complications.
+  evidence:
+  - reference: PMID:7531539
+    reference_title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hereditary palmoplantar keratoderma is characterized by hyperkeratosis of the skin of palms and soles."
+    explanation: The linkage study supports chronic palmoplantar hyperkeratosis as the core inherited disease manifestation.
+genetic:
+- name: KRT1 germline pathogenic variants
+  association: Causative germline variant
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  gene_term:
+    preferred_term: KRT1
+    term:
+      id: hgnc:6412
+      label: KRT1
+  features: >
+    Germline pathogenic KRT1 variants, including splice-site variants, cause
+    diffuse NEPPK in affected pedigrees. ORPHA:530838 records KRT1 as the
+    disease-causing germline gene.
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "KRT1 | keratin 1 | hgnc:6412 | Disease-causing germline mutation(s) in"
+    explanation: Orphanet identifies KRT1 germline mutations as disease-causing for this disorder.
+  - reference: PMID:30452289
+    reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We identified a novel splice-site mutation"
+    explanation: The affected pedigree report identifies a KRT1 splice-site mutation segregating with NEPPK.
+  - reference: PMID:30452289
+    reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "in all individuals with NEPPK in the pedigree."
+    explanation: The variant was found in affected individuals in the clinical pedigree.
+pathophysiology:
+- name: KRT1 germline keratin 1 defect
+  description: >
+    Disease-causing germline KRT1 variants alter keratin 1, a type II keratin
+    expressed in suprabasal epidermal keratinocytes. In diffuse NEPPK pedigrees,
+    KRT1 variation segregates with diffuse palmoplantar keratoderma and points
+    to a keratin filament defect distinct from KRT9-related epidermolytic PPK.
+  gene:
+    preferred_term: KRT1
+    term:
+      id: hgnc:6412
+      label: KRT1
+  cell_types:
+  - preferred_term: suprabasal keratinocyte
+    term:
+      id: CL:0000312
+      label: keratinocyte
+  biological_processes:
+  - preferred_term: intermediate filament organization
+    term:
+      id: GO:0045109
+      label: intermediate filament organization
+    modifier: ABNORMAL
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "KRT1 | keratin 1 | hgnc:6412 | Disease-causing germline mutation(s) in"
+    explanation: Orphanet's gene row anchors the upstream disease mechanism to KRT1.
+  - reference: PMID:30452289
+    reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "sequencing of relevant potential causative genes, including KRT1, KRT6C, KRT10, KRT16, AQP5, and SERPINB7, was performed."
+    explanation: The clinical genetic study evaluated keratinization genes and identified KRT1 variation in the affected pedigree.
+  downstream:
+  - target: Nonepidermolytic palmoplantar keratinization disturbance
+    causal_link_type: DIRECT
+    description: >
+      KRT1 variation disrupts the keratinocyte cytoskeletal program that
+      supports palmoplantar epidermal differentiation.
+    evidence:
+    - reference: PMID:30452289
+      reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Diffuse NEPPK is a relatively rare subtype of palmoplantar keratoderma."
+      explanation: The KRT1 pedigree paper connects KRT1 variation to diffuse NEPPK as a palmoplantar keratoderma subtype.
+- name: Nonepidermolytic palmoplantar keratinization disturbance
+  description: >
+    The KRT1-related keratinocyte defect produces abnormal palmoplantar
+    keratinization and diffuse hyperkeratosis while preserving nonepidermolytic
+    histology. This separates the entity from epidermolytic palmoplantar
+    keratoderma and supports the diffuse palmoplantar hyperkeratosis phenotype.
+  cell_types:
+  - preferred_term: palmoplantar keratinocyte
+    term:
+      id: CL:0000312
+      label: keratinocyte
+  biological_processes:
+  - preferred_term: keratinization
+    term:
+      id: GO:0031424
+      label: keratinization
+    modifier: ABNORMAL
+  - preferred_term: keratinocyte differentiation
+    term:
+      id: GO:0030216
+      label: keratinocyte differentiation
+    modifier: ABNORMAL
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "diffuse, mild to thick, finely demarcated hyperkeratosis of palms and soles"
+    explanation: Orphanet defines the disease by diffuse palmoplantar hyperkeratosis.
+  - reference: PMID:7531539
+    reference_title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "frequently complicated by fungal infections"
+    explanation: The historical linkage cohort supports fungal infection as a recurring complication of the diffuse nonepidermolytic PPK phenotype.
+  downstream:
+  - target: Diffuse palmoplantar hyperkeratosis
+    causal_link_type: DIRECT
+    description: >
+      Abnormal palmoplantar keratinization directly produces diffuse thickening
+      of the palms and soles.
+  - target: Nonepidermolytic palmoplantar hyperkeratosis
+    causal_link_type: DIRECT
+    description: >
+      The hyperkeratosis occurs without epidermolysis on histology.
+  - target: Palmoplantar scaling skin
+    causal_link_type: DIRECT
+    description: >
+      Disordered cornification contributes to palmoplantar scaling.
+- name: Orthokeratotic hyperkeratosis without epidermolysis
+  description: >
+    Lesional skin biopsy shows orthokeratotic hyperkeratosis, acanthosis,
+    hypergranulosis, and mild upper-dermal lymphocytic infiltrates without
+    epidermolysis, matching the nonepidermolytic clinical designation.
+  cell_types:
+  - preferred_term: keratinocyte
+    term:
+      id: CL:0000312
+      label: keratinocyte
+  biological_processes:
+  - preferred_term: epidermis development
+    term:
+      id: GO:0008544
+      label: epidermis development
+    modifier: ABNORMAL
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Histological examination of lesions reveals orthokeratotic hyperkeratosis, acanthosis, hypergranulosis, and mild lymphocyte infiltrations in the upper dermis with no evidence of epidermolysis."
+    explanation: Orphanet's histology statement supports a nonepidermolytic microscopic pattern.
+  downstream:
+  - target: Nonepidermolytic palmoplantar hyperkeratosis
+    causal_link_type: DIRECT
+    description: >
+      Nonepidermolytic histology distinguishes the hyperkeratosis from
+      epidermolytic keratinopathies.
+histopathology:
+- name: Orthokeratotic hyperkeratosis without epidermolysis
+  description: >
+    Microscopic lesions show orthokeratotic hyperkeratosis with acanthosis,
+    hypergranulosis, mild superficial dermal lymphocytic infiltrates, and no
+    evidence of epidermolysis.
+  diagnostic: true
+  finding_term:
+    preferred_term: orthokeratotic hyperkeratosis
+    term:
+      id: NCIT:C35541
+      label: Hyperkeratosis
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "orthokeratotic hyperkeratosis, acanthosis, hypergranulosis, and mild lymphocyte infiltrations in the upper dermis with no evidence of epidermolysis."
+    explanation: Orphanet lists the characteristic histopathologic findings.
+phenotypes:
+- name: Nonepidermolytic palmoplantar hyperkeratosis
+  frequency: OBLIGATE
+  diagnostic: true
+  description: Diffuse palmoplantar hyperkeratosis lacks histologic epidermolysis.
+  phenotype_term:
+    preferred_term: Nonepidermolytic palmoplantar hyperkeratosis
+    term:
+      id: HP:0007404
+      label: Nonepidermolytic palmoplantar hyperkeratosis
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0007404 | Nonepidermolytic palmoplantar keratoderma | Obligate (100%)"
+    explanation: Orphanet lists nonepidermolytic palmoplantar keratoderma as obligate.
+- name: Diffuse palmoplantar hyperkeratosis
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: Diffuse mild to thick, finely demarcated hyperkeratosis affects the palms and soles.
+  phenotype_term:
+    preferred_term: Diffuse palmoplantar hyperkeratosis
+    term:
+      id: HP:0007447
+      label: Diffuse palmoplantar hyperkeratosis
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0007447 | Diffuse palmoplantar kyperkeratosis | Very frequent (99-80%)"
+    explanation: Orphanet lists diffuse palmoplantar hyperkeratosis as very frequent.
+  - reference: PMID:30452289
+    reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Histological findings, clinical features, and medical history were in accordance with the diagnosis of diffuse NEPPK."
+    explanation: The clinical pedigree report supports the diffuse NEPPK diagnosis in affected individuals.
+- name: Dry skin
+  frequency: FREQUENT
+  description: Diffuse dry skin is a frequent associated cutaneous feature.
+  phenotype_term:
+    preferred_term: Dry skin
+    term:
+      id: HP:0000958
+      label: Dry skin
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000958 | Dry skin | Frequent (79-30%)"
+    explanation: Orphanet lists dry skin as frequent.
+- name: Atopic dermatitis
+  frequency: OCCASIONAL
+  description: Atopic dermatitis is an occasional associated feature.
+  phenotype_term:
+    preferred_term: Atopic dermatitis
+    term:
+      id: HP:0001047
+      label: Atopic dermatitis
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001047 | Atopic dermatitis | Occasional (29-5%)"
+    explanation: Orphanet lists atopic dermatitis as occasional.
+- name: Abnormal umbilicus morphology
+  frequency: FREQUENT
+  description: Umbilical hyperkeratosis or abnormal umbilical morphology is frequent.
+  phenotype_term:
+    preferred_term: Abnormal umbilicus morphology
+    term:
+      id: HP:0001551
+      label: Abnormal umbilicus morphology
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001551 | Abnormal umbilicus morphology | Frequent (79-30%)"
+    explanation: Orphanet lists abnormal umbilicus morphology as frequent.
+- name: Concave nail
+  frequency: OCCASIONAL
+  description: Concave nails are occasional.
+  phenotype_term:
+    preferred_term: Concave nail
+    term:
+      id: HP:0001598
+      label: Concave nail
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001598 | Concave nail | Occasional (29-5%)"
+    explanation: Orphanet lists concave nail as occasional.
+- name: Thickened Achilles tendon
+  frequency: OCCASIONAL
+  description: Thickening of the Achilles tendon is occasional.
+  phenotype_term:
+    preferred_term: Thickened Achilles tendon
+    term:
+      id: HP:0004690
+      label: Thickened Achilles tendon
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0004690 | Thickened Achilles tendon | Occasional (29-5%)"
+    explanation: Orphanet lists thickened Achilles tendon as occasional.
+- name: Decreased movement range in interphalangeal joints
+  frequency: OCCASIONAL
+  description: Restricted interphalangeal joint motion is occasional.
+  phenotype_term:
+    preferred_term: Decreased movement range in interphalangeal joints
+    term:
+      id: HP:0006203
+      label: Decreased movement range in interphalangeal joints
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0006203 | Decreased movement range in interphalangeal joints | Occasional (29-5%)"
+    explanation: Orphanet lists decreased movement range in interphalangeal joints as occasional.
+- name: Palmoplantar blistering
+  frequency: OCCASIONAL
+  description: Blistering of palms and soles can occur occasionally.
+  phenotype_term:
+    preferred_term: Palmoplantar blistering
+    term:
+      id: HP:0007446
+      label: Palmoplantar blistering
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0007446 | Palmoplantar blistering | Occasional (29-5%)"
+    explanation: Orphanet lists palmoplantar blistering as occasional.
+- name: Erythema
+  frequency: FREQUENT
+  description: Erythema is frequent.
+  phenotype_term:
+    preferred_term: Erythema
+    term:
+      id: HP:0010783
+      label: Erythema
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0010783 | Erythema | Frequent (79-30%)"
+    explanation: Orphanet lists erythema as frequent.
+- name: Onychomycosis
+  frequency: FREQUENT
+  description: Fungal nail infection is a frequent complication.
+  phenotype_term:
+    preferred_term: Onychomycosis
+    term:
+      id: HP:0012203
+      label: Onychomycosis
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012203 | Onychomycosis | Frequent (79-30%)"
+    explanation: Orphanet lists onychomycosis as frequent.
+  - reference: PMID:7531539
+    reference_title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "frequently complicated by fungal infections"
+    explanation: The northern Sweden cohort describes fungal infections as frequent complications of diffuse non-epidermolytic PPK.
+- name: Palmoplantar scaling skin
+  frequency: OCCASIONAL
+  description: Scaling of palmar and plantar skin can occur occasionally.
+  phenotype_term:
+    preferred_term: Palmoplantar scaling skin
+    term:
+      id: HP:0025524
+      label: Palmoplantar scaling skin
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0025524 | Palmoplantar scaling skin | Occasional (29-5%)"
+    explanation: Orphanet lists palmoplantar scaling skin as occasional.
+- name: Tendon thickening
+  frequency: OCCASIONAL
+  description: Tendon thickening is occasional.
+  phenotype_term:
+    preferred_term: Tendon thickening
+    term:
+      id: HP:0032523
+      label: Tendon thickening
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0032523 | Tendon thickening | Occasional (29-5%)"
+    explanation: Orphanet lists tendon thickening as occasional.
+- name: Knuckle pad
+  frequency: OCCASIONAL
+  description: Knuckle pad-like keratoses on the fingers are occasional.
+  phenotype_term:
+    preferred_term: Knuckle pad
+    term:
+      id: HP:0032541
+      label: Knuckle pad
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0032541 | Knuckle pad | Occasional (29-5%)"
+    explanation: Orphanet lists knuckle pad as occasional.
+- name: Scaling skin
+  frequency: OCCASIONAL
+  description: Scaling outside the palmoplantar distribution can occur occasionally.
+  phenotype_term:
+    preferred_term: Scaling skin
+    term:
+      id: HP:0040189
+      label: Scaling skin
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0040189 | Scaling skin | Occasional (29-5%)"
+    explanation: Orphanet lists scaling skin as occasional.
+diagnosis:
+- name: Clinical dermatologic and histologic diagnosis
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  description: >
+    Diagnosis is supported by the characteristic diffuse palmoplantar
+    hyperkeratosis phenotype and lesional histology showing nonepidermolytic
+    orthokeratotic hyperkeratosis.
+  results: Diffuse palmoplantar hyperkeratosis without epidermolysis supports the diagnosis.
+  evidence:
+  - reference: ORPHA:530838
+    reference_title: KRT1-related diffuse nonepidermolytic keratoderma (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Histological examination of lesions reveals orthokeratotic hyperkeratosis, acanthosis, hypergranulosis, and mild lymphocyte infiltrations in the upper dermis with no evidence of epidermolysis."
+    explanation: Orphanet describes the diagnostic histologic pattern.
+- name: KRT1 molecular genetic testing
+  diagnosis_term:
+    preferred_term: genetic testing
+    term:
+      id: MAXO:0000127
+      label: genetic testing
+  description: >
+    Sequencing of KRT1 and other palmoplantar keratoderma genes can identify a
+    causative germline KRT1 variant in a compatible clinical pedigree.
+  results: A pathogenic germline KRT1 variant supports molecular diagnosis.
+  evidence:
+  - reference: PMID:30452289
+    reference_title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Mutation detection via polymerase chain reaction and Sanger sequencing of relevant potential causative genes"
+    explanation: The pedigree study used molecular sequencing to identify the causative variant.
+treatments:
+- name: Topical emollient and keratolytic symptom therapy
+  description: >
+    Topical emollients, keratolytics, topical retinoids, and topical steroids
+    are used symptomatically to soften hyperkeratosis, reduce scale, and relieve
+    pain or functional impairment. These treatments are not curative.
+  treatment_term:
+    preferred_term: application of emollient to skin
+    term:
+      id: MAXO:0000996
+      label: application of emollient to skin
+  target_mechanisms:
+  - target: Nonepidermolytic palmoplantar keratinization disturbance
+    treatment_effect: MODULATES
+    description: Topical therapy acts downstream by reducing the symptomatic cornified burden.
+  target_phenotypes:
+  - preferred_term: Diffuse palmoplantar hyperkeratosis
+    term:
+      id: HP:0007447
+      label: Diffuse palmoplantar hyperkeratosis
+  - preferred_term: Palmoplantar scaling skin
+    term:
+      id: HP:0025524
+      label: Palmoplantar scaling skin
+  evidence:
+  - reference: PMID:32307694
+    reference_title: "Treatment of hereditary palmoplantar keratoderma: a review by analysis of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Topical (emollients, keratolytics, retinoids, steroids) and systemic treatments (mostly different retinoids), often combined, are used to relieve symptoms."
+    explanation: The hereditary PPK treatment review supports topical symptom-directed therapy.
+- name: Oral retinoid therapy
+  description: >
+    Oral retinoids are a systemic option for severe hereditary palmoplantar
+    keratoderma, but benefit varies by PPK subtype and tolerability can limit
+    use.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: retinoid
+      term:
+        id: CHEBI:26537
+        label: retinoid
+  target_mechanisms:
+  - target: Nonepidermolytic palmoplantar keratinization disturbance
+    treatment_effect: MODULATES
+    description: Retinoids modulate keratinocyte differentiation and cornification.
+  target_phenotypes:
+  - preferred_term: Diffuse palmoplantar hyperkeratosis
+    term:
+      id: HP:0007447
+      label: Diffuse palmoplantar hyperkeratosis
+  evidence:
+  - reference: PMID:32307694
+    reference_title: "Treatment of hereditary palmoplantar keratoderma: a review by analysis of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Oral retinoids appear to be the most efficient treatment, but not in all PPK forms, and with variable tolerance."
+    explanation: The hereditary PPK treatment review supports oral retinoids as a systemic treatment option with variable efficacy and tolerance.
+references:
+- reference: ORPHA:530838
+  title: KRT1-related diffuse nonepidermolytic keratoderma
+  found_in:
+  - Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
+- reference: ORPHA:496
+  title: Thost-Unna palmoplantar keratoderma
+  found_in:
+  - Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
+- reference: PMID:30452289
+  title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+  found_in:
+  - Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
+- reference: PMID:7531539
+  title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+  found_in:
+  - Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
+- reference: PMID:32307694
+  title: "Treatment of hereditary palmoplantar keratoderma: a review by analysis of the literature."
+  found_in:
+  - Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
+clinical_trials: []
+datasets: []
+notes: >-
+  ORPHA:530838 is the primary structured record for KRT1-related diffuse
+  nonepidermolytic keratoderma. ORPHA:496 is sparse and is used only to retain
+  the historical Thost-Unna palmoplantar keratoderma naming context. This entry
+  is separate from the broader KRT1 keratinopathy entry, which focuses on
+  epidermolytic ichthyosis and epidermolytic PPK spectrum disease.

--- a/references_cache/ORPHA_496.md
+++ b/references_cache/ORPHA_496.md
@@ -1,0 +1,16 @@
+---
+reference_id: "ORPHA:496"
+title: "Thost-Unna palmoplantar keratoderma"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:496  Thost-Unna palmoplantar keratoderma
+
+**ORPHA:496** — Thost-Unna palmoplantar keratoderma (Disease, Disorder)
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=496)

--- a/references_cache/ORPHA_530838.md
+++ b/references_cache/ORPHA_530838.md
@@ -1,0 +1,76 @@
+---
+reference_id: "ORPHA:530838"
+title: "KRT1-related diffuse nonepidermolytic keratoderma"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:530838  KRT1-related diffuse nonepidermolytic keratoderma
+
+**ORPHA:530838** — KRT1-related diffuse nonepidermolytic keratoderma (Disease, Disorder)
+
+## Synonyms
+
+- KRT1-related diffuse NEPPK
+
+## Definition
+
+A rare, genetic, isolated diffuse palmoplantar keratoderma characterized by diffuse, mild to thick, finely demarcated hyperkeratosis of palms and soles. Additional clinical findings include knuckle pad-like keratoses on fingers, hyperkeratosis of umbilicus and areolae, diffuse dry skin, hyperhidrosis, hangnails and frequent fungal infections. Histological examination of lesions reveals orthokeratotic hyperkeratosis, acanthosis, hypergranulosis, and mild lymphocyte infiltrations in the upper dermis with no evidence of epidermolysis.
+
+## Inheritance
+
+- Autosomal dominant
+
+## Natural history
+
+- Age of onset: Childhood
+- Age of onset: Infancy
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| Unknown | Worldwide | Point prevalence | PMID:30452289 |
+
+## Genes
+
+| Symbol | Name | HGNC | Association |
+|---|---|---|---|
+| KRT1 | keratin 1 | hgnc:6412 | Disease-causing germline mutation(s) in |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000958 | Dry skin | Frequent (79-30%) |
+| HP:0001047 | Atopic dermatitis | Occasional (29-5%) |
+| HP:0001551 | Abnormal umbilicus morphology | Frequent (79-30%) |
+| HP:0001598 | Concave nail | Occasional (29-5%) |
+| HP:0004690 | Thickened Achilles tendon | Occasional (29-5%) |
+| HP:0006203 | Decreased movement range in interphalangeal joints | Occasional (29-5%) |
+| HP:0007404 | Nonepidermolytic palmoplantar keratoderma | Obligate (100%) |
+| HP:0007446 | Palmoplantar blistering | Occasional (29-5%) |
+| HP:0007447 | Diffuse palmoplantar kyperkeratosis | Very frequent (99-80%) |
+| HP:0010783 | Erythema | Frequent (79-30%) |
+| HP:0012203 | Onychomycosis | Frequent (79-30%) |
+| HP:0025524 | Palmoplantar scaling skin | Occasional (29-5%) |
+| HP:0032523 | Tendon thickening | Occasional (29-5%) |
+| HP:0032541 | Knuckle pad | Occasional (29-5%) |
+| HP:0040189 | Scaling skin | Occasional (29-5%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:5186 | Exact |
+| ICD-10:Q82.8 | Narrower |
+| MONDO:0010962 | Exact |
+| MONDO:10962 | Exact |
+| OMIM:600962 | Exact |
+| UMLS:C5680142 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=530838)

--- a/references_cache/PMID_30452289.md
+++ b/references_cache/PMID_30452289.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:30452289"
+title: Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+authors:
+- Tang ZL
+- Wang T
+- Xiao T
+- Wang YQ
+- Ma CW
+- Niu XW
+- Xiao SX
+- Wang XP
+journal: Genet Test Mol Biomarkers
+year: '2018'
+doi: 10.1089/gtmb.2018.0154
+content_type: abstract_only
+---
+
+# Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in a Large Chinese Pedigree.
+**Authors:** Tang ZL, Wang T, Xiao T, Wang YQ, Ma CW, Niu XW, Xiao SX, Wang XP
+**Journal:** Genet Test Mol Biomarkers (2018)
+**DOI:** [10.1089/gtmb.2018.0154](https://doi.org/10.1089/gtmb.2018.0154)
+
+## Content
+
+1. Genet Test Mol Biomarkers. 2018 Nov 21. doi: 10.1089/gtmb.2018.0154. Online
+ahead of print.
+
+Novel Splice-Site Mutation of KRT1 Underlies Diffuse Palmoplantar Keratoderma in
+a Large Chinese Pedigree.
+
+Tang ZL(1), Wang T(1), Xiao T(1), Wang YQ(1), Ma CW(2), Niu XW(1), Xiao SX(1),
+Wang XP(1).
+
+Author information:
+(1)1 Department of Dermatology and The Second Affiliated Hospital of Xi'an
+Jiaotong University , Xi'an, People's Republic of China .
+(2)2 Department of Neurosurgery, The Second Affiliated Hospital of Xi'an
+Jiaotong University , Xi'an, People's Republic of China .
+
+AIMS: To identify potential causative gene mutations in a large Han Chinese
+pedigree with diffuse nonepidermolytic palmoplantar keratoderma (NEPPK).
+METHODS: We enrolled 11 patients and 8 healthy individuals from a pedigree with
+NEPPK and 100 randomly selected healthy controls. Biopsy samples were obtained
+from the proband. Genomic DNA was extracted from a peripheral blood sample from
+each participant. Mutation detection via polymerase chain reaction and Sanger
+sequencing of relevant potential causative genes, including KRT1, KRT6C, KRT10,
+KRT16, AQP5, and SERPINB7, was performed. Comparisons were made between
+sequencing outcomes and currently available reference genome databases,
+including HGMD Pro, Pubmed, 1000 Genomics, and dbSNP.
+RESULTS: Histological findings, clinical features, and medical history were in
+accordance with the diagnosis of diffuse NEPPK. We identified a novel
+splice-site mutation c.1255-1G > C in intron 6 of KRT1 in all individuals with
+NEPPK in the pedigree.
+CONCLUSIONS: Diffuse NEPPK is a relatively rare subtype of palmoplantar
+keratoderma. The results of this study expand the spectrum of KRT1 mutations in
+diffuse NEPPK and provide insights into the understanding of its underlying
+pathological mechanisms and phenotype-genotype correlations.
+
+DOI: 10.1089/gtmb.2018.0154
+PMID: 30452289

--- a/references_cache/PMID_32307694.md
+++ b/references_cache/PMID_32307694.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:32307694"
+title: "Treatment of hereditary palmoplantar keratoderma: a review by analysis of the literature."
+authors:
+- Bodemer C
+- Steijlen P
+- Mazereeuw-Hautier J
+- "O'Toole EA"
+journal: Br J Dermatol
+year: '2021'
+doi: 10.1111/bjd.19144
+keywords:
+- Humans
+- "Keratoderma, Palmoplantar/drug therapy, genetics"
+- Keratolytic Agents
+- Quality of Life
+- Retinoids
+- Skin
+content_type: abstract_only
+---
+
+# Treatment of hereditary palmoplantar keratoderma: a review by analysis of the literature.
+**Authors:** Bodemer C, Steijlen P, Mazereeuw-Hautier J, O'Toole EA
+**Journal:** Br J Dermatol (2021)
+**DOI:** [10.1111/bjd.19144](https://doi.org/10.1111/bjd.19144)
+
+## Content
+
+1. Br J Dermatol. 2021 Mar;184(3):393-400. doi: 10.1111/bjd.19144. Epub 2020 Jun
+17.
+
+Treatment of hereditary palmoplantar keratoderma: a review by analysis of the
+literature.
+
+Bodemer C(1), Steijlen P(2), Mazereeuw-Hautier J(3), O'Toole EA(4).
+
+Author information:
+(1)Department of Dermatology, Reference Centre for Genodermatoses, MAGEC Necker
+Enfants Malades, Paris-centre University, APHP5, ERN-Skin, France.
+(2)Department of Dermatology, Maastricht University Medical Centre and the GROW
+School for Oncology and Developmental Biology, Maastricht, ERN-Skin, the
+Netherlands.
+(3)Department of Dermatology, Centre de référence des maladies rares de la peau,
+Larrey Hospital, Paul Sabatier University, Toulouse, ERN-Skin, France.
+(4)Department of Dermatology, Royal London Hospital, Barts Health NHS Trust,
+London, ERN-Skin, UK.
+
+BACKGROUND: No specific or curative therapy exists for hereditary palmoplantar
+keratoderma (hPPK), which can profoundly alter patient quality of life, leading
+sometimes to severe functional impairment and pain. The rarity and the
+aetiological diversity of this group of disorders can explain the difficulty in
+comparing the efficacy of available treatments.
+OBJECTIVES: To review the different treatments tried in patients with hPPK since
+2008, their efficacy and safety, with an evaluation of the various therapeutic
+modalities that can be used to treat hPPK.
+METHODS: We undertook a comprehensive review of the literature data published
+since 2008.
+RESULTS: Only a few case series and individual case reports were identified.
+Topical (emollients, keratolytics, retinoids, steroids) and systemic treatments
+(mostly different retinoids), often combined, are used to relieve symptoms. Oral
+retinoids appear to be the most efficient treatment, but not in all PPK forms,
+and with variable tolerance. New targeted treatments, according to the specific
+mechanisms of hPPK, appear promising for the future.
+CONCLUSIONS: More studies using robust methodology and involving larger cohorts
+of well-characterized patients (phenotype-genotype) are necessary and should be
+prioritized by structured networks, such as the European Network for Rare Skin
+Diseases (ERN-Skin), with the aim of better management of patients with rare
+skin diseases.
+
+© 2020 British Association of Dermatologists.
+
+DOI: 10.1111/bjd.19144
+PMID: 32307694 [Indexed for MEDLINE]

--- a/references_cache/PMID_7531539.md
+++ b/references_cache/PMID_7531539.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:7531539"
+title: The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+authors:
+- Lind L
+- Lundström A
+- Hofer PA
+- Holmgren G
+journal: Hum Mol Genet
+year: '1994'
+doi: 10.1093/hmg/3.10.1789
+keywords:
+- Chromosome Mapping
+- "Chromosomes, Human, Pair 12"
+- DNA/blood
+- Family
+- Female
+- "Genes, Dominant"
+- Genetic Linkage
+- Genetic Markers
+- Humans
+- Keratins/genetics
+- "Keratoderma, Palmoplantar, Diffuse/genetics"
+- Male
+- Multigene Family
+- Pedigree
+- "Receptors, Retinoic Acid/genetics"
+- Sweden
+- Retinoic Acid Receptor gamma
+content_type: abstract_only
+---
+
+# The gene for diffuse palmoplantar keratoderma of the type found in northern Sweden is localized to chromosome 12q11-q13.
+**Authors:** Lind L, Lundström A, Hofer PA, Holmgren G
+**Journal:** Hum Mol Genet (1994)
+**DOI:** [10.1093/hmg/3.10.1789](https://doi.org/10.1093/hmg/3.10.1789)
+
+## Content
+
+1. Hum Mol Genet. 1994 Oct;3(10):1789-93. doi: 10.1093/hmg/3.10.1789.
+
+The gene for diffuse palmoplantar keratoderma of the type found in northern
+Sweden is localized to chromosome 12q11-q13.
+
+Lind L(1), Lundström A, Hofer PA, Holmgren G.
+
+Author information:
+(1)Department of Clinical Genetics/Applied Cell and Molecular Biology,
+University Hospital, Umeå, Sweden.
+
+Hereditary palmoplantar keratoderma is characterized by hyperkeratosis of the
+skin of palms and soles. An autosomal dominant form of diffuse non-epidermolytic
+palmoplantar keratoderma, frequently complicated by fungal infections, is
+encountered in northern Sweden with a prevalence of 0.3-0.55%. We have examined
+two families with this type of palmoplantar keratoderma and localized the
+causative genetic defect to a 14 cM interval on chromosome 12q11-q13, a region
+known to contain the keratin type II gene cluster as well as the retinoic acid
+receptor gamma gene. The palmoplantar keratoderma variant investigated in this
+study is thus genetically different from epidermolytic palmoplantar keratoderma,
+which recently has been shown to result from mutations in the gene for the type
+I keratin 9.
+
+DOI: 10.1093/hmg/3.10.1789
+PMID: 7531539 [Indexed for MEDLINE]

--- a/research/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
+++ b/research/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md
@@ -1,0 +1,16 @@
+# Diffuse Nonepidermolytic Palmoplantar Keratoderma Research Fallback
+
+Deep-research provider attempts were bounded and did not produce usable output:
+
+- `just research-disorder falcon Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma` was stopped after extended silence; the wrapper returned exit code 124 after the provider process was terminated.
+- `just research-disorder openai Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma` was stopped after extended silence; the wrapper returned exit code 124 after the provider process was terminated.
+
+Local curation proceeded from generated Orphanet and PubMed caches:
+
+- ORPHA:530838: primary structured record for KRT1-related diffuse nonepidermolytic keratoderma, including definition, autosomal dominant inheritance, KRT1 gene association, epidemiology, exact MONDO/OMIM mappings, and 15 HPO phenotype rows.
+- ORPHA:496: sparse historical Thost-Unna palmoplantar keratoderma record, used only as a naming-history signal.
+- PMID:30452289: KRT1 splice-site mutation in a large Han Chinese diffuse NEPPK pedigree.
+- PMID:7531539: autosomal dominant diffuse non-epidermolytic palmoplantar keratoderma in northern Sweden, regional prevalence, fungal infections, and chromosome 12q11-q13 linkage.
+- PMID:32307694: hereditary palmoplantar keratoderma treatment review supporting topical symptom therapy and oral retinoids.
+
+Scope note: no provider-generated synthesis was used. The YAML claims are limited to snippets available in the cached Orphanet/PubMed references listed above.


### PR DESCRIPTION
## Summary
- Adds `kb/disorders/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma.yaml` for MONDO:0010962 / ORPHA:530838.
- Uses generated ORPHA caches for the definition, inheritance, KRT1 gene row, prevalence, exact mappings, and all 15 Orphanet HPO phenotype rows.
- Adds PubMed-backed KRT1 pedigree, historical northern Sweden diffuse non-epidermolytic PPK, and hereditary PPK treatment evidence.
- Includes `research/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma-deep-research-fallback.md` documenting bounded Falcon/OpenAI provider hangs and the local evidence scope.

## Validation
- `just validate kb/disorders/Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma.yaml`
- snippet audit: 43/43 snippets/findings found with whitespace normalization against generated caches
- graph audit: 21 nodes / 11 edges, no orphan targets
- ORPHA phenotype coverage: 15/15 ORPHA:530838 HPO rows included
- `just qc-deep-research --only Diffuse_Nonepidermolytic_Palmoplantar_Keratoderma`
- `just check-reference-cache-frontmatter`

## Notes
- ORPHA:496 is sparse and is used only as a historical Thost-Unna naming signal, not as a phenotype/gene source.
- The built-in reference validator reported zero checks for this new file, so I ran the explicit snippet audit above against the local caches.
