### PR TITLE
Connect type 2 diabetes gene mechanisms

### DIFF
--- a/kb/disorders/Type_2_Diabetes_Mellitus.yaml
+++ b/kb/disorders/Type_2_Diabetes_Mellitus.yaml
@@ -56,7 +56,7 @@ pathophysiology:
     snippet: "Insulin resistance impairs glucose disposal, resulting in a compensatory increase in beta-cell insulin production and hyperinsulinemia."
     explanation: This confirms that insulin resistance leads to compensatory hyperinsulinemia as beta cells attempt to overcome impaired glucose disposal in peripheral tissues.
   - reference: PMID:28507210
-    reference_title: "Gene variants associated with susceptibility to pancreatic ductal adenocarcinoma and related diseases."
+    reference_title: "Diabetes, Pancreatogenic Diabetes, and Pancreatic Cancer."
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "Thiazolidinediones reduce insulin resistance by activating peroxisome proliferator–activated receptor γ, a nuclear receptor regulating glucose and lipid metabolism."
@@ -79,7 +79,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:32872570
-      reference_title: "Type 2 Diabetes Mellitus: A Pathophysiologic Perspective."
+      reference_title: "Pathophysiology of Type 2 Diabetes Mellitus."
       supports: SUPPORT
       evidence_source: OTHER
       snippet: "IR contributes to increased glucose production in the liver and decreased glucose uptake both in the muscle, liver and adipose tissue."
@@ -130,7 +130,7 @@ pathophysiology:
     snippet: "This vicious cycle continues until pancreatic beta-cell activity can no longer adequately meet the insulin demand created by insulin resistance, resulting in hyperglycemia."
     explanation: This describes the progression from compensatory beta cell hyperfunction to beta cell exhaustion and failure, leading to hyperglycemia.
   - reference: PMID:29931562
-    reference_title: "Approach to the Patient with MODY-Monogenic Diabetes."
+    reference_title: "Monogenic Diabetes in Children and Adolescents: Recognition and Treatment Options."
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "The ABCC8 and KCNJ11 genes encode the sulfonylurea receptor 1 (SUR1) and inward rectifier potassium channel Kir6 (Kir6.2) subunits of the ATP-sensitive potassium (KATP) channel in the pancreatic beta cell, regulating insulin secretion."
@@ -147,7 +147,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:32872570
-      reference_title: "Type 2 Diabetes Mellitus: A Pathophysiologic Perspective."
+      reference_title: "Pathophysiology of Type 2 Diabetes Mellitus."
       supports: SUPPORT
       evidence_source: OTHER
       snippet: "In the case of β-cell dysfunction, insulin secretion is reduced, limiting the body’s capacity to maintain physiological glucose levels."

--- a/kb/disorders/Type_2_Diabetes_Mellitus.yaml
+++ b/kb/disorders/Type_2_Diabetes_Mellitus.yaml
@@ -1,6 +1,6 @@
 name: Type 2 Diabetes Mellitus
 creation_date: '2025-12-18T17:01:35Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-09T17:11:56Z'
 category: Complex
 parents:
 - Metabolic Disease
@@ -16,6 +16,11 @@ pathophysiology:
     Peripheral tissues (muscle, liver, adipose) become resistant to insulin action,
     requiring higher insulin levels to maintain glucose homeostasis. This leads to
     compensatory hyperinsulinemia and eventually beta cell exhaustion.
+  genes:
+  - preferred_term: PPARG
+    term:
+      id: hgnc:9236
+      label: PPARG
   cell_types:
   - preferred_term: Hepatocyte
     term:
@@ -50,11 +55,49 @@ pathophysiology:
     supports: SUPPORT
     snippet: "Insulin resistance impairs glucose disposal, resulting in a compensatory increase in beta-cell insulin production and hyperinsulinemia."
     explanation: This confirms that insulin resistance leads to compensatory hyperinsulinemia as beta cells attempt to overcome impaired glucose disposal in peripheral tissues.
+  - reference: PMID:28507210
+    reference_title: "Gene variants associated with susceptibility to pancreatic ductal adenocarcinoma and related diseases."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Thiazolidinediones reduce insulin resistance by activating peroxisome proliferator–activated receptor γ, a nuclear receptor regulating glucose and lipid metabolism."
+    explanation: Supports PPARG as an insulin-sensitizing nuclear receptor pathway relevant to insulin resistance biology.
+  downstream:
+  - target: Beta Cell Dysfunction
+    description: Sustained insulin resistance increases compensatory beta-cell insulin demand, contributing to eventual beta-cell failure.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Compensatory hyperinsulinemia and beta-cell secretory stress
+    evidence:
+    - reference: PMID:29939616
+      reference_title: "Insulin Resistance."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "This vicious cycle continues until pancreatic beta-cell activity can no longer adequately meet the insulin demand created by insulin resistance, resulting in hyperglycemia."
+      explanation: Directly supports progression from insulin-resistance-driven insulin demand to beta-cell failure.
+  - target: Hepatic Glucose Overproduction
+    description: Hepatic insulin resistance reduces insulin-mediated suppression of liver glucose production.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32872570
+      reference_title: "Type 2 Diabetes Mellitus: A Pathophysiologic Perspective."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "IR contributes to increased glucose production in the liver and decreased glucose uptake both in the muscle, liver and adipose tissue."
+      explanation: Supports insulin resistance as a cause of increased hepatic glucose production.
 - name: Beta Cell Dysfunction
   description: >
     Progressive loss of pancreatic beta cell function and mass leads to inadequate
     insulin secretion relative to insulin demand. Beta cell failure is the key
     determinant of disease progression.
+  genes:
+  - preferred_term: KCNJ11
+    term:
+      id: hgnc:6257
+      label: KCNJ11
+  - preferred_term: SLC30A8
+    term:
+      id: hgnc:20303
+      label: SLC30A8
   cell_types:
   - preferred_term: Pancreatic Beta Cell
     term:
@@ -86,6 +129,29 @@ pathophysiology:
     supports: SUPPORT
     snippet: "This vicious cycle continues until pancreatic beta-cell activity can no longer adequately meet the insulin demand created by insulin resistance, resulting in hyperglycemia."
     explanation: This describes the progression from compensatory beta cell hyperfunction to beta cell exhaustion and failure, leading to hyperglycemia.
+  - reference: PMID:29931562
+    reference_title: "Approach to the Patient with MODY-Monogenic Diabetes."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "The ABCC8 and KCNJ11 genes encode the sulfonylurea receptor 1 (SUR1) and inward rectifier potassium channel Kir6 (Kir6.2) subunits of the ATP-sensitive potassium (KATP) channel in the pancreatic beta cell, regulating insulin secretion."
+    explanation: Supports KCNJ11 as a pancreatic beta-cell KATP-channel gene that regulates insulin secretion.
+  - reference: PMID:17463248
+    reference_title: "A genome-wide association study of type 2 diabetes in Finns detects multiple susceptibility variants."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "SLC30A8 transports zinc from the cytoplasm into insulin secretory vesicles (20, 21), where insulin is stored as a hexamer bound with two Zn2+ ions before secretion (22). Variation in SLC30A8 may affect zinc accumulation in insulin granules, affecting insulin stability, storage, or secretion."
+    explanation: Links SLC30A8 to beta-cell insulin granule biology and T2D-associated variation affecting insulin storage or secretion.
+  downstream:
+  - target: Hyperglycemia
+    description: Insufficient beta-cell insulin secretion limits glucose control and drives hyperglycemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32872570
+      reference_title: "Type 2 Diabetes Mellitus: A Pathophysiologic Perspective."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "In the case of β-cell dysfunction, insulin secretion is reduced, limiting the body’s capacity to maintain physiological glucose levels."
+      explanation: Supports beta-cell dysfunction as a direct cause of impaired glucose homeostasis.
 - name: Hepatic Glucose Overproduction
   description: >
     Impaired suppression of hepatic gluconeogenesis leads to elevated fasting
@@ -116,6 +182,17 @@ pathophysiology:
     supports: SUPPORT
     snippet: "FBP1 catalyzes the irreversible hydrolysis of fructose-1,6-bisphosphate (F-1,6-P2) to fructose-6-phosphate (F6P) and inorganic phosphate (Pi) in the presence of divalent cations. FBP1 is a key rate-controlling enzyme in the gluconeogenic pathway."
     explanation: This identifies fructose-1,6-bisphosphatase (FBP1) as a key rate-controlling enzyme in hepatic gluconeogenesis, the pathway responsible for glucose overproduction in diabetes.
+  downstream:
+  - target: Hyperglycemia
+    description: Excess hepatic glucose production contributes directly to impaired glucose homeostasis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30150719
+      reference_title: "Metformin reduces liver glucose production by inhibition of fructose-1-6-bisphosphatase."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Diabetes is characterized by impaired glucose homeostasis partly due to abnormally elevated hepatic glucose production (HGP)."
+      explanation: Supports hepatic glucose overproduction as a contributor to diabetes-associated hyperglycemia.
 - name: Mitochondrial Dysfunction and Oxidative Stress
   description: >
     Early-onset mitochondrial dysfunction and pathological reactive oxygen species
@@ -163,6 +240,11 @@ pathophysiology:
     insulinotropic peptide (GIP) action in beta cells. GLP-1 action is relatively
     preserved. The incretin effect amplifies insulin secretion in response to
     oral glucose via cAMP-PKA signaling pathways.
+  genes:
+  - preferred_term: TCF7L2
+    term:
+      id: hgnc:11641
+      label: TCF7L2
   cell_types:
   - preferred_term: Pancreatic Beta Cell
     term:
@@ -192,6 +274,23 @@ pathophysiology:
     supports: PARTIAL
     snippet: "Tirzepatide, characterized by its ability to selectively bind and activate receptors for the intestinal hormones GIP and GLP-1, has been tested in numerous clinical studies and is already currently authorized in several countries for the treatment of type 2 diabetes and obesity."
     explanation: This demonstrates the clinical relevance of incretin axis dysfunction by showing dual GLP-1/GIP agonism is effective for T2D treatment.
+  - reference: PMID:19934000
+    reference_title: "TCF7L2 variant rs7903146 affects the risk of type 2 diabetes by modulating incretin action."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The TCF7L2 variant rs7903146 appears to affect risk of type 2 diabetes, at least in part, by modifying the effect of incretins on insulin secretion."
+    explanation: Supports TCF7L2 as a genetic contributor to incretin-axis effects on insulin secretion in humans.
+  downstream:
+  - target: Beta Cell Dysfunction
+    description: Reduced beta-cell sensitivity to incretins impairs oral-glucose-stimulated insulin secretion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:19934000
+      reference_title: "TCF7L2 variant rs7903146 affects the risk of type 2 diabetes by modulating incretin action."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "This is not due to reduced secretion of GLP-1 and GIP but rather due to the effect of TCF7L2 on the sensitivity of the beta-cell to incretins."
+      explanation: Directly supports a TCF7L2-associated incretin-sensitivity defect at the beta cell.
 phenotypes:
 - name: Hyperglycemia
   category: Metabolic
@@ -315,12 +414,32 @@ phenotypes:
       label: Peripheral neuropathy
 genetic:
 - name: TCF7L2
+  gene_term:
+    preferred_term: TCF7L2
+    term:
+      id: hgnc:11641
+      label: TCF7L2
   association: Risk Factor
 - name: PPARG
+  gene_term:
+    preferred_term: PPARG
+    term:
+      id: hgnc:9236
+      label: PPARG
   association: Risk Factor
 - name: KCNJ11
+  gene_term:
+    preferred_term: KCNJ11
+    term:
+      id: hgnc:6257
+      label: KCNJ11
   association: Risk Factor
 - name: SLC30A8
+  gene_term:
+    preferred_term: SLC30A8
+    term:
+      id: hgnc:20303
+      label: SLC30A8
   association: Risk Factor
 environmental:
 - name: Sedentary Lifestyle

--- a/references_cache/PMID_19934000.md
+++ b/references_cache/PMID_19934000.md
@@ -1,0 +1,168 @@
+---
+reference_id: "PMID:19934000"
+title: TCF7L2 variant rs7903146 affects the risk of type 2 diabetes by modulating incretin action.
+authors:
+- Villareal DT
+- Robertson H
+- Bell GI
+- Patterson BW
+- Tran H
+- Wice B
+- Polonsky KS
+journal: Diabetes
+year: '2010'
+doi: 10.2337/db09-1169
+keywords:
+- Blood Glucose/metabolism
+- Body Composition
+- C-Peptide/blood
+- "Diabetes Mellitus, Type 2/epidemiology, genetics"
+- Female
+- Genetic Variation
+- Genotype
+- Glucose Tolerance Test
+- Humans
+- Incretins/physiology
+- Insulin/metabolism
+- Insulin Secretion
+- "Insulin-Secreting Cells/drug effects, metabolism, physiology"
+- Male
+- Reference Values
+- Risk Assessment
+- Risk Factors
+- TCF Transcription Factors/genetics
+- Transcription Factor 7-Like 2 Protein
+content_type: full_text_xml
+---
+
+# TCF7L2 variant rs7903146 affects the risk of type 2 diabetes by modulating incretin action.
+**Authors:** Villareal DT, Robertson H, Bell GI, Patterson BW, Tran H, Wice B, Polonsky KS
+**Journal:** Diabetes (2010)
+**DOI:** [10.2337/db09-1169](https://doi.org/10.2337/db09-1169)
+
+## Content
+
+1. Diabetes. 2010 Feb;59(2):479-85. doi: 10.2337/db09-1169. Epub 2009 Nov 23.
+
+TCF7L2 variant rs7903146 affects the risk of type 2 diabetes by modulating
+incretin action.
+
+Villareal DT(1), Robertson H, Bell GI, Patterson BW, Tran H, Wice B, Polonsky
+KS.
+
+Author information:
+(1)Department of Medicine, Washington University School of Medicine, St. Louis,
+Missouri, USA.
+
+Comment in
+    Diabetes. 2010 Jun;59(6):e4; author reply e5-6. doi: 10.2337/db10-0236.
+
+OBJECTIVE: Common variants in the gene TCF7L2 confer the largest effect on the
+risk of type 2 diabetes. The present study was undertaken to increase our
+understanding of the mechanisms by which this gene affects type 2 diabetes risk.
+RESEARCH DESIGN AND METHODS: Eight subjects with risk-conferring TCF7L2
+genotypes (TT or TC at rs7903146) and 10 matched subjects with wild-type
+genotype (CC) underwent 5-h oral glucose tolerance test (OGTT), isoglycemic
+intravenous glucose infusion, and graded glucose infusion (GGI). Mathematical
+modeling was used to quantify insulin-secretory profiles during OGTT and glucose
+infusion protocols. The incretin effect was assessed from ratios of the insulin
+secretory rates (ISR) during oral and isoglycemic glucose infusions.
+Dose-response curves relating insulin secretion to glucose concentrations were
+derived from the GGI.
+RESULTS: beta-cell responsivity to oral glucose was 50% lower (47 +/- 4 vs. 95
++/- 15 x 10(9) min(-1); P = 0.01) in the group of subjects with risk-conferring
+TCF7L2 genotypes compared with control subjects. The incretin effect was also
+reduced by 30% (32 +/- 4 vs. 46 +/- 4%; P = 0.02) in the at-risk group. The
+lower incretin effect occurred despite similar glucose-dependent insulinotropic
+polypeptide (GIP) and glucagon-like peptide 1 (GLP-1) responses to oral glucose.
+The ISR response to intravenous glucose over a physiologic glucose concentration
+range (5-9 mmol/l) was similar between groups.
+CONCLUSIONS: The TCF7L2 variant rs7903146 appears to affect risk of type 2
+diabetes, at least in part, by modifying the effect of incretins on insulin
+secretion. This is not due to reduced secretion of GLP-1 and GIP but rather due
+to the effect of TCF7L2 on the sensitivity of the beta-cell to incretins.
+Treatments that increase incretin sensitivity may decrease the risk of type 2
+diabetes.
+
+DOI: 10.2337/db09-1169
+PMCID: PMC2809956
+PMID: 19934000 [Indexed for MEDLINE]
+
+Recently, polymorphisms in the transcription factor 7-like 2 gene (TCF7L2) have been associated with type 2 diabetes (1), increasing risk ∼1.46-fold (2). Current evidence suggests that TCF7L2 increases the risk for type 2 diabetes by reducing glucose-induced insulin secretion. In the Diabetes Prevention Program, carriers of the T allele (rs79012146 or rs12255372) had significantly lower values for insulin/glucose ratio and insulin response than CC homozygotes (3). The mechanisms for reduced insulin secretion are uncertain. TCF7L2 is a transcription factor involved in the Wnt signaling pathway and is ubiquitously expressed (4). Thus, one possibility is it has direct effects on the pancreatic β-cell. Another possibility is that there is an effect on proglucagon gene expression in intestinal endocrine cells, thereby reducing the incretin response to oral nutrients (5). In turn, this would be expected to lead to reduced insulin secretion.
+
+Indeed, several studies have reported reduced insulin secretion after an oral glucose tolerance test (OGTT) in subjects with TCF7L2 variants using ratios between insulin and glucose levels such as insulinogenic index (3,6,7). Reduced insulin secretion in response to oral compared with intravenous glucose has also been reported (8,9), consistent with alterations in the incretin system. Studies that have used intravenous glucose to assess the direct effects on the pancreatic β-cell have yielded mixed results. Some studies have shown diminished insulin responses to standard intravenous glucose tolerance tests (10–13), whereas others have shown no effect of TCF7L2 variants on the response to hyperglycemic clamp or Arg (9,14,15). The effect of TCF7L2 polymorphisms on insulin action is also unclear. Several studies have shown no change in insulin sensitivity (6,8), whereas other studies have shown increased (3,14) or decreased (9,11) insulin sensitivity.
+
+The present study was undertaken in an attempt to clarify the effect of TCF7L2 on insulin secretion. Certain features of the study design set this study apart from previous studies. All subjects had normal or only mildly impaired glucose tolerance, thus avoiding confounding effects of hyperglycemia on insulin secretion. Insulin secretory responses to oral glucose derived by mathematical modeling of peripheral C-peptide were compared at the same plasma glucose concentrations achieved by intravenous infusion of glucose. Insulin sensitivity was also quantified during the OGTT. Finally, the effects of the at-risk variant in TCF7L2 on the dose-response relationships between intravenous glucose and insulin secretion were assessed across a physiologic range of glucose concentrations.
+
+Eight subjects with the risk-conferring genotype (TT [seven subjects] or TC [one subject] at rs7903146) and ten age-, sex-, and BMI-matched subjects with the wild-type genotype (CC at rs7903146) participated. All subjects were nondiabetic, younger than 65 years, in good general health and with stable weight for 6 months, and were recruited using advertisements. They were unrelated and had no family history of type 2 diabetes. The studies were approved by the Human Research Protective Office Committee at Washington University School of Medicine and written informed consent was obtained from each participant.
+
+The subjects underwent three separate protocols designed to test pancreatic β-cell secretion and the incretin effect. Insulin secretion was assessed during the 5-h OGTT and in response to graded glucose infusion (GGI). The incretin effect was assessed by comparing insulin secretion in response to oral glucose with the response to an isoglycemic intravenous glucose infusion designed to match the plasma glucose concentrations achieved after oral glucose.
+
+The subjects were instructed to adhere to their regular diet and to refrain from exercise for 3 days before the studies. All studies were performed in the Intensive Research Unit of the Washington University Institute for Clinical and Translational Sciences after an overnight fast with the subjects in the recumbent position. Intravenous cannulae were placed in a forearm vein for blood withdrawal, and the forearm was warmed to arterialize the venous sample. When necessary, a second catheter was placed for administration of glucose or insulin as described below.
+
+At time 0, participants ingested a 75-g glucose load. Blood samples were collected at −10, 0, 10, 20, 30, 60, 90, 120, 150, 180, 240, and 300 min after glucose ingestion to determine plasma glucose, insulin, and C-peptide concentrations.
+
+Intravenous infusions of glucose (20% dextrose) were designed to reproduce the plasma glucose profile after oral glucose ingestion. Accuracy was assured by repeatedly measuring plasma glucose concentrations, which allowed frequent adjustments of the infusion rate according to deviations from the profile that was to be mimicked. Blood samples were drawn and treated as described for OGTT.
+
+GGI involves the intravenous administration of glucose at progressively increasing rates (1, 2, 3, 4, 6, and 8 mg/kg per min) for 40 min each, as we have previously described (16,17). This protocol raises the plasma glucose concentration from basal to mildly hyperglycemic levels and is used to define the dose-response relationships between glucose and insulin secretion. To compare each subject's plasma insulin response at the same plasma glucose level, the best-fit quadratic curve (using SigmaPlot Version 11; SigmaPlot, San Jose, CA) was drawn through the data. The insulin concentration at molar increments of plasma glucose beginning at 5 mmol/l was then obtained by interpolation. The same technique applied to the insulin secretion rate (ISR) provides a plot of the ISR at molar increments of plasma glucose (18).
+
+Fat mass was measured using dual energy X-ray absorptiometry (Delphi 4500-W; Hologic, Waltham, MA).
+
+The areas under the curve (AUCs) were calculated using the trapezoid method (19).
+
+Indexes of β-cell function were estimated from plasma glucose and C-peptide concentrations using the oral minimal model of C-peptide secretion and kinetics (20,21) and incorporating parameters for C-peptide kinetics and volume of distribution as measured by Van Cauter et al. (22). This model calculates the ISR (pmol/min) as a function of time and several indexes of β-cell responsivity: 1) dynamic responsivity index (Φd [109]), which is an index of insulin secretion in response to the rate of change in glucose concentration; 2) static responsivity index (Φs [109 min−1]), which is an index of insulin secretion in response to a given glucose concentration; and 3) overall responsivity index (Φo [109 min−1]), which is a global sensitivity-to-glucose index of postprandial insulin secretion.
+
+The calculation of incretin effects from estimates of β-cell secretory responses is based on the assumption that after glucose ingestion, the pancreas is stimulated by the increase in plasma glucose and the added effect of incretin factors secreted by the intestine. Thus, intravenous glucose infusion (IGI) provides a measure of the β-cell secretory response to the glucose stimulus in the absence of superimposed incretin effects. The incretin effect is calculated from the insulin secretion response (SR) to oral and intravenous glucose according to the following formula (23):
+
+
+The dose-response relationship between ISR and glucose over the physiological range was determined from the GGI. ISRs and glucose concentrations used in the analysis represented the average of the values between 10 and 40 min at each glucose infusion rate. Mean ISR for each glucose infusion rate was then plotted against the corresponding mean glucose concentration to define the dose-response relationship. The slope of the line relating these two variables provided a measure of the sensitivity of the β-cell to glucose.
+
+Whole-body insulin sensitivity was estimated using the oral glucose minimal model (24,25), which has been shown previously to be well correlated with the M value from the euglycemic hyperinsulinemic clamp (26).
+
+Insulin clearance rate was calculated by dividing the ISR AUC by the insulin AUC (16).
+
+Plasma glucose was measured immediately using an automated glucose analyzer (Yellow Springs Instruments, Yellow Springs, OH). Plasma insulin, C-peptide, and glucagon were measured by double-antibody radioimmunoassays (Linco Research, St. Louis, MO). Human glucose-dependent insulinotropic polypeptide (GIP; total) ELISA kit was used for the quantification of human GIP in plasma samples (Linco Research). This kit has 100% cross-reactivity to human GIP (1–42) and GIP (3–42). Human (total) electrochemiluminescent GLP-1 assay kit was used for the quantification of human glucagon-like peptide 1 (GLP-1; Meso Scale Discovery, Gaithersburg, MD). This kit has 100% cross-reactivity to human GLP-1 (7–36) amide, human GLP-1 (9–36) amide, GLP-1 (1–36) amide, GLP-1 (7–37), and GLP-1 (1–37).
+
+DNA was prepared from peripheral blood lymphocytes and the TCF7L2 polymorphisms (dbSNP rs7903146) typed using a TaqMan SNP Genotyping Assay (Applied Biosystems, Foster City, CA).
+
+Group differences in demographics and parameters of glucose homeostasis were compared using the two-tailed unpaired Student t tests for continuous variables and the Fisher exact test for categorical variables. The AUCs for glucose, insulin, ISR, and incretin effects were compared using two-tailed unpaired Student t tests. SPSS Version 15.0 (SPSS, Chicago, IL) was used for all statistical analyses. A P value < 0.05 was considered statistically significant. Results are reported as mean ± SE.
+
+The group with the at-risk genotype (TT and TC) at rs7903146 and the control group (CC genotype) were well matched for age, sex, and body weight and composition (Table 1). Both groups had normal fasting glucose concentrations and hemoglobin A1C. Two-h glucose and glucose AUC tended to be greater in the at-risk group (Table 1, Fig. 1) but the differences did not reach statistical significance.
+
+Anthropometrics and metabolic data of study participants
+
+Data are means ± SE. Statistically significant P values are shown in bold.
+
+Plasma glucose, insulin, and C-peptide concentrations during the 5-h OGTT (●) and isoglycemic intravenous glucose infusion (△) in control subjects and carriers of the at-risk TCF7L2 variant. Shaded areas indicate the incretin effects. P values indicate the significance of the differences in incretin effects between groups. Values are means ± SE.
+
+The static β-cell responsivity (Φs) and dynamic β-cell responsivity (Φd) to oral glucose tended to be lower in the at-risk group than in the control group, with the difference in the former reaching significance (P = 0.02). Consistent with these findings, the overall β-cell responsivity (Φo) was significantly lower (P = 0.01), by ∼50% in the at-risk group (Table 1). Insulin sensitivity and insulin clearance rates were similar between the groups (P > 0.05).
+
+The plasma glucose profile in the OGTT and IGI were well matched in both groups (Table 2, Fig. 1). Consistent with incretin effects in both groups, the AUCs for insulin and C-peptide (Table 2, Fig. 1) and the AUCs for static, dynamic, and overall ISRs (Table 2, Fig. 2) were lower in the IGI than in the OGTT. However, subjects with the at-risk TCF7L2 genotypes had significantly reduced incretin responses for insulin AUC (41 vs. 59%; P = 0.004), C-peptide AUC (32 vs. 45%; P = 0.03), and overall insulin secretory response to glucose AUC (32 vs. 46%; P = 0.02).
+
+AUCs for glucose, hormones, and the incretin effect
+
+Data are means ± SE. IGI, isoglycemic intravenous glucose infusion. Statistically significant P values are shown in bold.
+
+Insulin secretory indexes during the 5-h OGTT (●) and isoglycemic intravenous glucose infusion (△) in control subjects and carriers of the at-risk TCF7L2 variant. Shaded areas indicate the incretin effects. P values indicate the significance of the differences in incretin effects between groups. Values are means ± SE.
+
+By contrast, both the GLP-1 (AUC: 3.2 ± 0.6 vs. 2.9 ± 0.4 × 103 pg/ml · min; P = 0.67) and GIP (AUC: 4.4 ± 1.0 vs. 3.3 ± 0.4 × 103; P = 0.31) responses to oral glucose were similar between the two groups (Fig. 3).
+
+Plasma concentrations of GLP-1 and GIP during the 5-h OGTT in control subjects (△) and carriers of the at-risk TCF7L2 variant (●). There were no significant between group differences in AUCs (P < 0.05). Values are means ± SE.
+
+The GGI demonstrated that the ISR-glucose dose-response relationships were not different (AUC: 1.7 ± 0.2 vs. 2.0 ± 0.3 ×103 pmol/min · mmol/l; P = 0.41) between groups (Fig. 4) over a physiologic range of glucose concentrations (5–9 mmol/l).
+
+Insulin secretory rates plotted against glucose infusion rate (A) and plasma glucose (B) during the graded-glucose infusion in control subjects (△) and carriers of the at-risk TCF7L2 variant (●). There were no significant between group differences in AUCs (P < 0.05). Values are means ± SE.
+
+The statistical results remained the same when the one subject with TC genotype was excluded from the analyses (Φs, 43.3 ± 3.4 vs. 67.5 ± 8.8 109 min−1, P = 0.04; Φo, 49.5 ± 3.8 vs. 94.5 ± 15.4, P = 0.03), although they were borderline significant for difference in incretin effect (34.3 ± −4.3 vs. 45.5 ± 4.1%; P = 0.08).
+
+The present study used the isoglycemic intravenous glucose infusion (IGI), the definitive test of the incretin effect, to examine the incretin effect in subjects with a TCF7L2 variant that enhances type 2 diabetes risk. Using measurements of insulin secretion in response to oral and matched intravenous infusions of glucose, the incretin effect was reduced by ∼30% and this was consistent with the ∼50% reduction in overall β-cell responsivity to glucose demonstrated during the OGTT. The reduced incretin effect was accompanied by normal levels of GIP and GLP-1, suggesting a reduced ability of the pancreatic β-cell to respond to incretins. Another new finding is that the defect in insulin secretion appears to be selective for oral glucose and is not present in response to intravenous glucose. Thus, the graded glucose infusion study demonstrated that insulin secretory response to intravenous glucose over a physiologic range of glucose concentrations is well preserved in subjects with type 2 diabetes–associated genotypes. The diminished β-cell response to oral relative to intravenous glucose is consistent with a key abnormality in the enteroinsular axis in subjects with diabetes-associated TCF7L2 genotype.
+
+Although the incretin effect was reduced in subjects with the diabetes-risk genotypes, the concentrations of GLP-1 and GIP after oral glucose ingestion were not different from those in control subjects. We measured total rather than intact levels of GLP-1 and GIP. However, a previous study showed that the pattern of GLP-1 and GIP release appears similar when total or active levels are measured (27). Our results are consistent with the results of previous studies that have reported similar total GLP-1 and GIP levels independent of TCF7L2 genotype (8,9). Our study assessed the entire secretory profile of both GIP and GLP-1 during the course of a 5-h OGTT, something not consistently done in previous studies. Our results expand and strengthen the evidence that the incretin secretory capacity is normal in subjects with at-risk and non–at-risk TCF7L2 genotypes, suggesting an inability of the pancreatic β-cell in subjects with an at-risk genotype to appropriately respond to normal concentrations of GLP-1 and GIP. This conclusion is consistent with data from two previous studies. Schäfer et al. (14) and Pilgaard et al. (9) reported that the GLP-1– and/or GIP-induced insulin secretion during a hyperglycemic clamp is reduced in subjects with the at-risk TCF7L2 genotype. In the latter study, the reduced insulin response occurred at GIP and GLP-1 concentrations administered to closely mimic physiologic concentrations (∼120 and 1,000 pmol/l, respectively) and at glucose concentrations close to physiologic postprandial levels of glucose (∼10 mmol/l), conditions that approximate those in the IGI in the present study. Collectively, these findings point to a reduction in incretin signaling at the level of the pancreatic β-cell in subjects with type 2 diabetes–associated TCF7L2 genotypes.
+
+The molecular mechanisms responsible for the reduced β-cell response to GLP-1 and GIP as a function of TCF7L2 genotype have not been defined and warrant further investigation. TCF7L2 is a Wnt signaling-associated transcription factor that plays an important role in the synthesis of GLP-1 in intestinal L-cells (4). It was thus anticipated that genetic variation in TCF7L2 would lead to reduced secretion of GLP-1 and GIP. Clearly this is not the case. In addition, the diabetes-associated variants in TCF7L2 have been shown to have increased, rather than decreased, islet levels of TCF7L2 mRNA (8). Interestingly, Shu et al. (28) recently reported that increased levels of TCF7L2 mRNA in β-cells are actually associated with decreased TCF7L2 proteins, indicating altered regulation at a posttranscriptional level. The reduction in TCF7L2 protein was found to correlate with downregulation of GIP and GLP receptors, thus resulting in decreased Akt phosphorylation and Akt-mediated Foxo-1 phosphorylation, and, therefore, impaired β-cell function.
+
+Based on the results of a graded intravenous infusion of glucose, our study is the first to demonstrate that the dose-response relationships between glucose and insulin secretion over the physiologic range of glucose concentrations (5–9 mmol/l) are relatively well preserved in subjects with at-risk and non–at-risk TCF7L2 genotypes. These findings may not be surprising, given that the response to intravenous glucose is not influenced by intestinal incretin peptides. Previous studies that have examined the direct effect of intravenous glucose on the pancreatic β-cell using various protocols have yielded inconsistent results. For example, intravenous glucose tolerance tests showed that the acute insulin response (AIR) was unchanged (9,14,15) or reduced (12,13) as a function of TCF7L2 genotype. Moreover, hyperglycemic clamp with Arg showed that the AIR was unchanged (at 10 mmol/l glucose) (14), whereas the same test showed that AIR was reduced (at 14 and 24 mmol/l glucose) in another study (8). Although the latter might suggest that the maximal insulin secretory response is impaired in subjects with a diabetes-associated TCF7L2 genotype, the physiologic significance of this finding has yet to be determined. On the other hand, the results from our GGI protocol show that within the physiologic range of glucose concentrations (5–9 mmol/l), TCF7L2 genotype does not significantly affect the insulin response to intravenous glucose, as evidenced by the normal β-cell dose response.
+
+Finally, we also demonstrated that the TCF7L2 genotype does not significantly affect overall insulin sensitivity. We used the oral glucose minimal model to derive insulin sensitivity index, which has the advantage of being simultaneously assessed with β-cell responsivity during the OGTT. The sensitivity index measures the overall effect of insulin to stimulate glucose disposal and inhibit glucose production, and has been validated against the euglycemic-hyperinsulinemic clamp (26). Indeed, our results are consistent with previous studies using euglycemic-hyperinsulinemic clamp that have also reported normal whole-body insulin sensitivity in subjects with diabetes-associated genotypes (8,14). However, interestingly, two recent studies (9,11) have reported decreased hepatic insulin sensitivity in subjects with diabetes-associated genotypes, possibly attributed to the lower insulin levels and/or a direct or indirect effect of TCF7L2 on endogenous glucose production. The latter findings await confirmation in other studies (29).
+
+In summary, the present study provides evidence that TCF7L2 affects the insulin secretory response to oral glucose with an impaired incretin effect (30% reduction) due to impaired GIP- and GLP-1–induced insulin secretion rather than incretin deficiency in subjects with the at-risk TCF7L2 rs7903146 genotype. In contrast, the β-cell dose response to intravenous glucose over a physiologic range of glucose concentrations is normal. We also found no evidence of impairment in whole-body insulin sensitivity. Further studies are needed to elucidate the mechanisms for the lack of response to incretins as a function of TCF2L7 genotype. Our findings raise the possibility that increasing incretin levels through pharmacotherapy might overcome incretin resistance and thus decrease the risk of type 2 diabetes due to genetic variation in TCF7L2.


### PR DESCRIPTION
## Summary
- add HGNC descriptors for TCF7L2, PPARG, KCNJ11, and SLC30A8 to existing T2D genetic nodes
- connect PPARG to insulin resistance, KCNJ11/SLC30A8 to beta-cell dysfunction, and TCF7L2 to incretin-axis dysfunction
- add a small causal backbone: insulin resistance to beta-cell dysfunction and hepatic glucose overproduction, incretin-axis dysfunction to beta-cell dysfunction, and beta-cell/hepatic glucose mechanisms to hyperglycemia
- add generated cache for PMID:19934000 via `just fetch-reference` to support the TCF7L2-incretin mechanism

## Subagent review
Kuhn reviewed the existing T2D genetics and recommended gene_term additions for all four genes plus PPARG/KCNJ11/SLC30A8 mechanism connections. After fetching PMID:19934000 with the required cache workflow, I also connected TCF7L2 to the existing incretin-axis node using exact human-clinical evidence.

## Validation
- just validate kb/disorders/Type_2_Diabetes_Mellitus.yaml
- just validate-references kb/disorders/Type_2_Diabetes_Mellitus.yaml
- uv run python -m dismech.graph --validate kb/disorders/Type_2_Diabetes_Mellitus.yaml
- uv run python -m dismech.graph --show kb/disorders/Type_2_Diabetes_Mellitus.yaml | rg "TCF7L2|PPARG|KCNJ11|SLC30A8|Insulin_Resistance|Beta_Cell_Dysfunction|Hepatic_Glucose_Overproduction|Incretin_Axis_Dysfunction|Hyperglycemia"
- uv run runoak -i sqlite:obo:hgnc info hgnc:11641 hgnc:9236 hgnc:6257 hgnc:20303 -O obo
- normalized snippet audit passed for every newly added evidence quote
- git diff --check

## Notes
- Restored validator-generated ClinicalTrials cache churn before committing.
- The reference validator currently reports zero checks for this file, so I also ran a normalized exact-snippet audit against the local caches.