### PR TITLE
Connect LONP1 to PDH deficiency mechanism

### DIFF
--- a/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Pyruvate Dehydrogenase Deficiency
 creation_date: "2026-05-05T20:20:53Z"
-updated_date: "2026-05-06T22:31:47Z"
+updated_date: "2026-05-09T18:46:08Z"
 category: Mendelian
 parents:
 - mitochondrial disease
@@ -428,6 +428,48 @@ pathophysiology:
   downstream:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: DIRECT
+- name: LONP1 impaired phospho-E1-alpha proteolysis
+  description: >-
+    Biallelic pathogenic LONP1 variants can impair mitochondrial LonP1 protease
+    degradation of phosphorylated PDH E1-alpha. Accumulation of inhibitory
+    phospho-E1-alpha reduces PDH activity and produces a PDH deficiency
+    biochemical phenotype.
+  genes:
+  - preferred_term: LONP1
+    term:
+      id: hgnc:9479
+      label: LONP1
+  biological_processes:
+  - preferred_term: mitochondrial phospho-E1-alpha proteolysis
+    term:
+      id: GO:0006508
+      label: proteolysis
+    modifier: DECREASED
+  cellular_components:
+  - preferred_term: mitochondrial matrix
+    term:
+      id: GO:0005759
+      label: mitochondrial matrix
+  evidence:
+  - reference: PMID:30304514
+    reference_title: "Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "We demonstrated that in the siblings' fibroblasts, PDH dysfunction was caused by increased levels of the phosphorylated E1α subunit of PDH, which inhibits enzyme activity."
+    explanation: Patient-derived fibroblast experiments connect LONP1 variant cells to inhibitory phospho-E1-alpha accumulation and PDH dysfunction.
+  - reference: PMID:30304514
+    reference_title: "Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Furthermore, in vitro studies demonstrated that purified LonP1-P761L failed to degrade phosphorylated E1α, in contrast to wild-type LonP1."
+    explanation: Biochemical evidence supports the specific loss of LonP1-mediated phospho-E1-alpha proteolysis.
+  downstream:
+  - target: Reduced pyruvate decarboxylation to acetyl-CoA
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Failed LonP1 degradation of phosphorylated E1-alpha increases the inhibitory phosphorylated E1-alpha pool, lowering PDH activity and pyruvate oxidation.
+  - target: Decreased PDH complex activity
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Patient fibroblasts with biallelic LONP1 variants showed reduced PDH activity through inhibitory E1-alpha phosphorylation.
 - name: Thiamine-responsive PDHA1 residual activity
   description: >-
     Selected PDHA1 variants can retain thiamine-responsive residual activity,
@@ -1751,7 +1793,10 @@ genetic:
     term:
       id: hgnc:9479
       label: LONP1
-  notes: Orphanet lists LONP1 alongside PDHA1 in the E1-alpha deficiency subtype record.
+  notes: >-
+    Orphanet lists LONP1 alongside PDHA1 in the E1-alpha deficiency subtype
+    record, and a sibling report links biallelic LONP1 variants to reduced PDH
+    activity through defective LonP1 proteolysis of phosphorylated E1-alpha.
   evidence:
   - reference: ORPHA:79243
     reference_title: "Pyruvate dehydrogenase E1-alpha deficiency (Orphanet structured-database record)"
@@ -1759,6 +1804,12 @@ genetic:
     evidence_source: OTHER
     snippet: "LONP1 | lon peptidase 1, mitochondrial | hgnc:9479 | Disease-causing germline mutation(s) in"
     explanation: Orphanet identifies LONP1 as disease-causing in the E1-alpha deficiency subtype record.
+  - reference: PMID:30304514
+    reference_title: "Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We identified a novel homozygous missense LONP1 variant, c.2282 C > T, (p.Pro761Leu), by whole-exome and Sanger sequencing in two siblings born to healthy consanguineous parents."
+    explanation: Human sibling sequencing evidence supports LONP1 as a causal germline gene for this PDH deficiency presentation.
 - name: PDHB
   association: Causal biallelic pathogenic variant
   gene_term:

--- a/references_cache/PMID_30304514.md
+++ b/references_cache/PMID_30304514.md
@@ -1,0 +1,108 @@
+---
+reference_id: "PMID:30304514"
+title: Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy.
+authors:
+- Nimmo GAM
+- Venkatesh S
+- Pandey AK
+- Marshall CR
+- Hazrati LN
+- Blaser S
+- Ahmed S
+- Cameron J
+- Singh K
+- Ray PN
+- Suzuki CK
+- Yoon G
+journal: Hum Mol Genet
+year: '2019'
+doi: 10.1093/hmg/ddy351
+keywords:
+- ATP-Dependent Proteases/genetics
+- Alleles
+- "Cerebellar Diseases/enzymology, genetics"
+- "DNA, Mitochondrial/metabolism"
+- Homozygote
+- Humans
+- "Infant, Newborn"
+- Lactates/metabolism
+- Male
+- Mitochondrial Proteins/genetics
+- Mutation
+- "Neurodegenerative Diseases/enzymology, genetics"
+- Pedigree
+- Phosphorylation
+- Protein Subunits/metabolism
+- Proteolysis
+- "Pyruvate Dehydrogenase Complex Deficiency Disease/genetics, pathology"
+content_type: abstract_only
+---
+
+# Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy.
+**Authors:** Nimmo GAM, Venkatesh S, Pandey AK, Marshall CR, Hazrati LN, Blaser S, Ahmed S, Cameron J, Singh K, Ray PN, Suzuki CK, Yoon G
+**Journal:** Hum Mol Genet (2019)
+**DOI:** [10.1093/hmg/ddy351](https://doi.org/10.1093/hmg/ddy351)
+
+## Content
+
+1. Hum Mol Genet. 2019 Jan 15;28(2):290-306. doi: 10.1093/hmg/ddy351.
+
+Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause
+pyruvate dehydrogenase deficiency and profound neurodegeneration with
+progressive cerebellar atrophy.
+
+Nimmo GAM(1), Venkatesh S(2), Pandey AK(2), Marshall CR(3)(4), Hazrati LN(5),
+Blaser S(6), Ahmed S(1), Cameron J(3), Singh K(7)(8), Ray PN(3)(4)(9), Suzuki
+CK(2), Yoon G(1)(10).
+
+Author information:
+(1)Division of Clinical and Metabolic Genetics, Department of Paediatrics, The
+Hospital for Sick Children, University of Toronto, Toronto, Ontario, Canada.
+(2)Department of Microbiology, Biochemistry, and Molecular Genetics, New Jersey
+Medical School, Rutgers, The State University of New Jersey, Newark, NJ, USA.
+(3)Department of Paediatric Laboratory Medicine, The Hospital for Sick Children,
+University of Toronto, Toronto, Ontario, Canada.
+(4)The Centre for Applied Genomics, The Hospital for Sick Children, Toronto,
+Ontario, Canada.
+(5)Division of Neuropathology, The Hospital for Sick Children, The University of
+Toronto, Toronto, Ontario, Canada.
+(6)Division of Paediatric Neuroradiology, The Hospital for Sick Children,
+University of Toronto, Toronto, Ontario, Canada.
+(7)Molecular Microbiology and Immunology, Christopher Bond Life Sciences Center,
+University of Missouri School of Medicine, Columbia, Missouri, USA.
+(8)Department of Laboratory Medicine, Division of Clinical Microbiology,
+Karolinska Institutet, Stockholm, SE Sweden.
+(9)Department of Molecular Genetics, The University of Toronto, Toronto,
+Ontario, Canada.
+(10)Division of Neurology, Department of Paediatrics, The Hospital for Sick
+Children, The University of Toronto, Toronto, Ontario, Canada.
+
+LonP1 is crucial for maintaining mitochondrial proteostasis and mitigating cell
+stress. We identified a novel homozygous missense LONP1 variant, c.2282 C > T,
+(p.Pro761Leu), by whole-exome and Sanger sequencing in two siblings born to
+healthy consanguineous parents. Both siblings presented with stepwise regression
+during infancy, profound hypotonia and muscle weakness, severe intellectual
+disability and progressive cerebellar atrophy on brain imaging. Muscle biopsy
+revealed the absence of ragged-red fibers, however, scattered cytochrome c
+oxidase-negative staining and electron dense mitochondrial inclusions were
+observed. Primary cultured fibroblasts from the siblings showed normal levels of
+mtDNA and mitochondrial transcripts, and normal activities of oxidative
+phosphorylation complexes I through V. Interestingly, fibroblasts of both
+siblings showed glucose-repressed oxygen consumption compared to their mother,
+whereas galactose and palmitic acid utilization were similar. Notably, the
+siblings' fibroblasts had reduced pyruvate dehydrogenase (PDH) activity and
+elevated intracellular lactate:pyruvate ratios, whereas plasma ratios were
+normal. We demonstrated that in the siblings' fibroblasts, PDH dysfunction was
+caused by increased levels of the phosphorylated E1α subunit of PDH, which
+inhibits enzyme activity. Blocking E1α phosphorylation activated PDH and reduced
+intracellular lactate concentrations. In addition, overexpressing wild-type
+LonP1 in the siblings' fibroblasts down-regulated phosphoE1α. Furthermore, in
+vitro studies demonstrated that purified LonP1-P761L failed to degrade
+phosphorylated E1α, in contrast to wild-type LonP1. We propose a novel mechanism
+whereby homozygous expression of the LonP1-P761L variant leads to PDH deficiency
+and energy metabolism dysfunction, which promotes severe neurologic impairment
+and neurodegeneration.
+
+DOI: 10.1093/hmg/ddy351
+PMCID: PMC6322071
+PMID: 30304514 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Adds a LONP1-specific pathophysiology node for impaired LonP1 degradation of phosphorylated PDH E1-alpha
- Connects the LONP1 genetic node into the existing reduced pyruvate decarboxylation and decreased PDH activity branch
- Adds PMID:30304514 via `just fetch-reference` and uses separate HUMAN_CLINICAL and IN_VITRO evidence items
- Restored unrelated ClinicalTrials cache churn before staging

## Validation
- `just validate kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml`
- `just validate-references kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml` (reported zero checks, so I also ran a manual normalized snippet audit for all new PMID:30304514 quotes)
- `uv run python -m dismech.graph --validate kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml`
- graph show confirmed `LONP1 --> LONP1_impaired_phospho_E1_alpha_proteolysis`, then downstream to `Reduced_pyruvate_decarboxylation_to_acetyl_CoA` and `Decreased_PDH_complex_activity`
- `git diff --check`
