### PR TITLE
Connect cystinuria transporter genes

### DIFF
--- a/kb/disorders/Cystinuria.yaml
+++ b/kb/disorders/Cystinuria.yaml
@@ -1,7 +1,7 @@
 name: Cystinuria
 category: Mendelian
 creation_date: '2026-05-05T15:29:06Z'
-updated_date: '2026-05-05T18:15:18Z'
+updated_date: '2026-05-09T18:59:50Z'
 synonyms:
 - Cystinuria-lysinuria syndrome
 description: >
@@ -347,6 +347,15 @@ pathophysiology:
   description: >
     SLC3A1 or SLC7A9 dysfunction impairs b(0,+)-mediated proximal tubular
     reabsorption of filtered cystine and dibasic amino acids.
+  genes:
+  - preferred_term: SLC3A1
+    term:
+      id: hgnc:11025
+      label: SLC3A1
+  - preferred_term: SLC7A9
+    term:
+      id: hgnc:11067
+      label: SLC7A9
   cell_types:
   - preferred_term: Epithelial cell of proximal tubule
     term:


### PR DESCRIPTION
## Summary
- Adds structured `genes` descriptors for SLC3A1 and SLC7A9 to the existing proximal tubule cystine transport defect node
- Lets the graph infer `SLC3A1 --> Proximal_Tubule_Cystine_Transport_Defect` and `SLC7A9 --> Proximal_Tubule_Cystine_Transport_Defect`
- No new references or cache files; restored unrelated ClinicalTrials cache churn before staging

## Validation
- `just validate kb/disorders/Cystinuria.yaml`
- `just validate-references kb/disorders/Cystinuria.yaml` (reported zero checks; no new snippets were added)
- `uv run python -m dismech.graph --validate kb/disorders/Cystinuria.yaml`
- graph show confirmed both SLC3A1/SLC7A9 edges into the transport-defect node
- `git diff --check`
