### PR TITLE
Curate pulmonary hemosiderosis

### DIFF
--- a/kb/disorders/Pulmonary_Hemosiderosis.yaml
+++ b/kb/disorders/Pulmonary_Hemosiderosis.yaml
@@ -1,0 +1,998 @@
+name: Pulmonary Hemosiderosis
+category: Respiratory Disease
+creation_date: "2026-05-09T18:28:00Z"
+updated_date: "2026-05-09T18:28:00Z"
+synonyms:
+- Idiopathic pulmonary hemosiderosis
+- IPH
+- Idiopathic pulmonary haemosiderosis
+- Pulmonary haemosiderosis
+description: >
+  Pulmonary hemosiderosis is a rare respiratory disorder, usually represented
+  clinically by idiopathic pulmonary hemosiderosis, in which recurrent diffuse
+  alveolar hemorrhage causes blood to enter alveolar spaces. Alveolar
+  macrophages ingest erythrocytes and accumulate hemosiderin, producing
+  hemosiderin-laden macrophages in sputum, gastric aspirate, bronchoalveolar
+  lavage, or lung tissue. Patients commonly present in childhood with iron
+  deficiency anemia, cough, hemoptysis, pulmonary infiltrates or ground-glass
+  opacities, dyspnea, and relapsing pulmonary hemorrhage. The initiating cause is
+  idiopathic after exclusion of infections, cardiac disease, coagulation
+  disorders, connective-tissue disease, vasculitis, celiac disease/Lane-Hamilton
+  syndrome, and other secondary causes of diffuse alveolar hemorrhage.
+disease_term:
+  preferred_term: pulmonary hemosiderosis
+  term:
+    id: MONDO:0008346
+    label: pulmonary hemosiderosis
+parents:
+- Respiratory disease
+- Hemosiderosis
+external_assertions:
+- name: Orphanet idiopathic pulmonary hemosiderosis record
+  source: Orphanet
+  assertion_type: structured_disease_record
+  external_id: ORPHA:99931
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=99931
+  description: >
+    Orphanet's ORPHA:99931 structured record provides the disease definition,
+    childhood age of onset, epidemiology, cross-references, and HPO phenotype
+    rows used in this entry.
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "OMIM:178550 | Exact"
+    explanation: Orphanet records an exact OMIM cross-reference for idiopathic pulmonary hemosiderosis.
+definitions:
+- name: Orphanet idiopathic pulmonary hemosiderosis definition
+  definition_type: OTHER
+  description: >
+    A respiratory disease, most often beginning in childhood, caused by repeated
+    episodes of otherwise unexplained diffuse alveolar hemorrhage with anemia,
+    cough, and chest-imaging infiltrates.
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Idiopathic pulmonary hemosiderosis is a respiratory disease due to repeated episodes of diffuse alveolar hemorrhage without any underlying apparent cause"
+    explanation: Orphanet defines IPH by unexplained repeated diffuse alveolar hemorrhage.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Idiopathic pulmonary hemosiderosis (IPH) is a rare disorder that is responsible for recurrent episodes of diffuse alveolar hemorrhage"
+    explanation: The 107-patient pediatric cohort supports recurrent diffuse alveolar hemorrhage as the central clinical definition.
+prevalence:
+- population: Europe
+  percentage: "<1 / 1,000,000 annual incidence"
+  notes: Orphanet records annual incidence below 1 per million in Europe.
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "<1 / 1 000 000 | Europe | Annual incidence | EXPERT"
+    explanation: Orphanet records the expert-estimated European annual incidence band.
+- population: Europe
+  percentage: Unknown point prevalence
+  notes: Orphanet records European point prevalence as unknown.
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Unknown | Europe | Point prevalence | ORPHANET"
+    explanation: Orphanet records unknown European point prevalence.
+progression:
+- phase: Childhood onset
+  age_range: Childhood
+  notes: Orphanet lists childhood as the age-of-onset category.
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Age of onset: Childhood"
+    explanation: Orphanet records childhood onset.
+- phase: Relapsing hemorrhage and diagnostic delay
+  age_range: Childhood through adolescence
+  notes: >
+    Pediatric IPH often presents variably rather than with the complete classic
+    triad, leading to high misdiagnosis rates and recurrence during treatment
+    taper or withdrawal.
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The classic triad of pediatric IPH is not always present. The rates of misdiagnosis and recurrence of IPH are high."
+    explanation: The cohort directly supports variable presentation, misdiagnosis, and recurrence.
+- phase: Chronic pulmonary morbidity
+  notes: >
+    Repeated hemorrhage can cause recurrent respiratory insufficiency and, in a
+    minority of patients, pulmonary fibrosis.
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Death may quickly occur with acute, massive, pulmonary hemorrhage or may occur over longer periods as the result of continued respiratory insufficiency and heart failure."
+    explanation: The pediatric cohort review of prognosis links acute massive hemorrhage and chronic respiratory insufficiency to severe outcomes.
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One patient developed severe pulmonary fibrosis, and another with Down syndrome died as a result of severe pulmonary hemorrhage."
+    explanation: The French pediatric cohort documents severe fibrosis and fatal hemorrhage as uncommon but important complications.
+pathophysiology:
+- name: Recurrent idiopathic diffuse alveolar hemorrhage
+  description: >
+    The initiating lesion is recurrent bleeding into alveolar spaces without an
+    identified secondary cause. Proposed environmental, allergic, autoimmune,
+    and genetic contributors remain hypotheses rather than established causes.
+  role: trigger
+  cell_types:
+  - preferred_term: alveolar capillary endothelial cell
+    term:
+      id: CL:0002144
+      label: capillary endothelial cell
+  locations:
+  - preferred_term: alveolus of lung
+    term:
+      id: UBERON:0002299
+      label: alveolus of lung
+  biological_processes:
+  - preferred_term: hemostasis
+    term:
+      id: GO:0007599
+      label: hemostasis
+    modifier: DYSREGULATED
+  - preferred_term: vascular permeability regulation
+    term:
+      id: GO:0043114
+      label: regulation of vascular permeability
+    modifier: DYSREGULATED
+  evidence:
+  - reference: PMID:15293620
+    reference_title: "Idiopathic pulmonary haemosiderosis revisited."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Idiopathic pulmonary haemosiderosis is a rare cause of diffuse alveolar haemorrhage of unknown aetiology."
+    explanation: The clinical review supports unexplained diffuse alveolar hemorrhage as the initiating lesion.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "There are four main etiological hypotheses of IPH described in the literature, including environmental, allergic, autoimmune, and genetic hypotheses."
+    explanation: The cohort review supports keeping the upstream cause as unresolved rather than assigning a single causal trigger.
+  downstream:
+  - target: Hemosiderin-laden alveolar macrophage accumulation
+    causal_link_type: DIRECT
+  - target: Diffuse alveolar hemorrhage
+    causal_link_type: DIRECT
+  - target: Hemoptysis
+    causal_link_type: DIRECT
+  - target: Pulmonary infiltrates
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+- name: Hemosiderin-laden alveolar macrophage accumulation
+  description: >
+    Alveolar macrophages phagocytose extravasated erythrocytes after repeated
+    hemorrhage and accumulate hemosiderin iron. Detection of these siderophages
+    in sputum, gastric lavage fluid, bronchoalveolar lavage fluid, or lung
+    tissue is a diagnostic hallmark and links pulmonary blood loss to systemic
+    iron deficiency.
+  role: effector
+  cell_types:
+  - preferred_term: alveolar macrophage
+    term:
+      id: CL:0000583
+      label: alveolar macrophage
+  locations:
+  - preferred_term: alveolus of lung
+    term:
+      id: UBERON:0002299
+      label: alveolus of lung
+  biological_processes:
+  - preferred_term: phagocytosis
+    term:
+      id: GO:0006909
+      label: phagocytosis
+    modifier: INCREASED
+  - preferred_term: heme catabolic process
+    term:
+      id: GO:0042167
+      label: heme catabolic process
+    modifier: INCREASED
+  - preferred_term: intracellular iron ion homeostasis
+    term:
+      id: GO:0006879
+      label: intracellular iron ion homeostasis
+    modifier: DYSREGULATED
+  evidence:
+  - reference: PMID:15293620
+    reference_title: "Idiopathic pulmonary haemosiderosis revisited."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Many patients develop iron deficiency anaemia secondary to deposition of haemosiderin iron in the alveoli."
+    explanation: The clinical review connects alveolar hemosiderin deposition with iron deficiency anemia.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hemosiderin-laden macrophages were found in all of the patients."
+    explanation: The 107-patient cohort supports hemosiderin-laden macrophages as a consistent diagnostic finding.
+  downstream:
+  - target: Iron deficiency anemia
+    causal_link_type: DIRECT
+  - target: Pallor
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+  - target: Fatigue
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+- name: Recurrent hemorrhage-driven lung injury and remodeling
+  description: >
+    Recurrent alveolar bleeding, iron/heme deposition, and inflammatory repair
+    injure alveolar units and can progress to restrictive physiology, respiratory
+    failure, and pulmonary fibrosis in severe or relapsing disease.
+  role: downstream_pathology
+  cell_types:
+  - preferred_term: pulmonary alveolar type 2 cell
+    term:
+      id: CL:0002063
+      label: pulmonary alveolar type 2 cell
+  - preferred_term: fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
+  locations:
+  - preferred_term: lung
+    term:
+      id: UBERON:0002048
+      label: lung
+  biological_processes:
+  - preferred_term: wound healing
+    term:
+      id: GO:0042060
+      label: wound healing
+    modifier: DYSREGULATED
+  - preferred_term: response to oxidative stress
+    term:
+      id: GO:0006979
+      label: response to oxidative stress
+    modifier: INCREASED
+  - preferred_term: extracellular matrix organization
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Death may quickly occur with acute, massive, pulmonary hemorrhage or may occur over longer periods as the result of continued respiratory insufficiency and heart failure."
+    explanation: The cohort review supports chronic respiratory insufficiency as a consequence of persistent or recurrent pulmonary hemorrhage.
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One patient developed severe pulmonary fibrosis, and another with Down syndrome died as a result of severe pulmonary hemorrhage."
+    explanation: The French cohort supports pulmonary fibrosis as a severe downstream complication.
+  downstream:
+  - target: Restrictive ventilatory defect
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+  - target: Pulmonary fibrosis
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+  - target: Respiratory failure
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+histopathology:
+- name: Hemosiderin-laden alveolar macrophages without vasculitis
+  description: >
+    Sputum, bronchoalveolar lavage fluid, gastric lavage fluid, or lung biopsy
+    can show siderophages reflecting prior alveolar hemorrhage; classic IPH
+    lacks pulmonary vasculitis or immune-complex deposition on biopsy.
+  diagnostic: true
+  evidence:
+  - reference: PMID:15293620
+    reference_title: "Idiopathic pulmonary haemosiderosis revisited."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Examination of sputum and bronchoalveolar lavage fluid can disclose haemosiderin-laden alveolar macrophages (siderophages)"
+    explanation: The review supports siderophages in respiratory samples as a characteristic finding.
+  - reference: PMID:15293620
+    reference_title: "Idiopathic pulmonary haemosiderosis revisited."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "the lung biopsy shows numerous siderophages in the alveoli, without any evidence of pulmonary vasculitis"
+    explanation: The review supports numerous alveolar siderophages without vasculitis as a histopathologic pattern.
+phenotypes:
+- category: Hematologic
+  name: Iron deficiency anemia
+  frequency: VERY_FREQUENT
+  description: Iron deficiency anemia is a cardinal manifestation of chronic pulmonary blood loss.
+  phenotype_term:
+    preferred_term: iron deficiency anemia
+    term:
+      id: HP:0001891
+      label: Iron deficiency anemia
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001891 | Iron deficiency anemia | Very frequent (99-80%)"
+    explanation: Orphanet records iron deficiency anemia as very frequent.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "anemia (n = 100, 93.45%)"
+    explanation: The pediatric cohort found anemia in 100 of 107 patients.
+- category: Constitutional
+  name: Pallor
+  frequency: FREQUENT
+  description: Pallor accompanies anemia from recurrent pulmonary blood loss.
+  phenotype_term:
+    preferred_term: pallor
+    term:
+      id: HP:0000980
+      label: Pallor
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000980 | Pallor | Frequent (79-30%)"
+    explanation: Orphanet records pallor as frequent.
+- category: Abdominal
+  name: Hepatosplenomegaly
+  frequency: FREQUENT
+  description: Hepatosplenomegaly is a reported systemic finding.
+  phenotype_term:
+    preferred_term: hepatosplenomegaly
+    term:
+      id: HP:0001433
+      label: Hepatosplenomegaly
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001433 | Hepatosplenomegaly | Frequent (79-30%)"
+    explanation: Orphanet records hepatosplenomegaly as frequent.
+- category: Pulmonary
+  name: Hemoptysis
+  frequency: FREQUENT
+  description: Hemoptysis reflects alveolar hemorrhage but may be absent in children who cannot expectorate.
+  phenotype_term:
+    preferred_term: hemoptysis
+    term:
+      id: HP:0002105
+      label: Hemoptysis
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002105 | Hemoptysis | Frequent (79-30%)"
+    explanation: Orphanet records hemoptysis as frequent.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "hemoptysis (n = 61, 57%)"
+    explanation: The pediatric cohort found hemoptysis in 61 of 107 patients at diagnosis.
+- category: Pulmonary
+  name: Pulmonary infiltrates
+  frequency: FREQUENT
+  description: Chest imaging commonly shows pulmonary infiltrates during hemorrhagic episodes.
+  phenotype_term:
+    preferred_term: pulmonary infiltrates
+    term:
+      id: HP:0002113
+      label: Pulmonary infiltrates
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002113 | Pulmonary infiltrates | Frequent (79-30%)"
+    explanation: Orphanet records pulmonary infiltrates as frequent.
+- category: Constitutional
+  name: Fatigue
+  frequency: FREQUENT
+  description: Fatigue is consistent with anemia and chronic respiratory disease.
+  phenotype_term:
+    preferred_term: fatigue
+    term:
+      id: HP:0012378
+      label: Fatigue
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012378 | Fatigue | Frequent (79-30%)"
+    explanation: Orphanet records fatigue as frequent.
+- category: Pulmonary
+  name: Cough
+  frequency: FREQUENT
+  description: Cough is one of the common respiratory manifestations.
+  phenotype_term:
+    preferred_term: cough
+    term:
+      id: HP:0012735
+      label: Cough
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012735 | Cough | Frequent (79-30%)"
+    explanation: Orphanet records cough as frequent.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "cough (n = 68, 63.55%)"
+    explanation: The pediatric cohort found cough in 68 of 107 patients at diagnosis.
+- category: Imaging
+  name: Ground-glass opacification on pulmonary HRCT
+  frequency: FREQUENT
+  description: Ground-glass opacification on HRCT reflects alveolar filling during hemorrhage.
+  phenotype_term:
+    preferred_term: ground-glass opacification on pulmonary HRCT
+    term:
+      id: HP:0025179
+      label: Ground-glass opacification
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0025179 | Ground-glass opacification on pulmonary HRCT | Frequent (79-30%)"
+    explanation: Orphanet records ground-glass opacification on pulmonary HRCT as frequent.
+- category: Renal
+  name: Glomerulonephritis
+  frequency: VERY_RARE
+  description: Glomerulonephritis suggests renal involvement or a pulmonary-renal differential diagnosis.
+  phenotype_term:
+    preferred_term: glomerulonephritis
+    term:
+      id: HP:0000099
+      label: Glomerulonephritis
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000099 | Glomerulonephritis | Very rare (<4-1%)"
+    explanation: Orphanet records glomerulonephritis as very rare.
+- category: Growth
+  name: Failure to thrive
+  frequency: OCCASIONAL
+  description: Chronic illness and recurrent anemia can impair growth.
+  phenotype_term:
+    preferred_term: failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001508 | Failure to thrive | Occasional (29-5%)"
+    explanation: Orphanet records failure to thrive as occasional.
+- category: Cardiac
+  name: Cardiomegaly
+  frequency: OCCASIONAL
+  description: Cardiomegaly can accompany severe chronic cardiopulmonary burden.
+  phenotype_term:
+    preferred_term: cardiomegaly
+    term:
+      id: HP:0001640
+      label: Cardiomegaly
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001640 | Cardiomegaly | Occasional (29-5%)"
+    explanation: Orphanet records cardiomegaly as occasional.
+- category: Constitutional
+  name: Fever
+  frequency: OCCASIONAL
+  description: Fever can occur during acute presentations and may contribute to misdiagnosis as infection.
+  phenotype_term:
+    preferred_term: fever
+    term:
+      id: HP:0001945
+      label: Fever
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0001945 | Fever | Occasional (29-5%)"
+    explanation: Orphanet records fever as occasional.
+- category: Pulmonary
+  name: Restrictive ventilatory defect
+  frequency: OCCASIONAL
+  description: Restrictive physiology may emerge with chronic parenchymal injury or fibrosis.
+  phenotype_term:
+    preferred_term: restrictive ventilatory defect
+    term:
+      id: HP:0002091
+      label: Restrictive ventilatory defect
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002091 | Restrictive ventilatory defect | Occasional (29-5%)"
+    explanation: Orphanet records restrictive ventilatory defect as occasional.
+- category: Pulmonary
+  name: Dyspnea
+  frequency: OCCASIONAL
+  description: Dyspnea reflects impaired gas exchange during alveolar hemorrhage or chronic lung disease.
+  phenotype_term:
+    preferred_term: dyspnea
+    term:
+      id: HP:0002094
+      label: Dyspnea
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002094 | Dyspnea | Occasional (29-5%)"
+    explanation: Orphanet records dyspnea as occasional.
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "dyspnea (n = 17, 68%)"
+    explanation: The French cohort recorded dyspnea at diagnosis in 17 of 25 children.
+- category: Pulmonary
+  name: Pulmonary fibrosis
+  frequency: OCCASIONAL
+  description: Severe or relapsing disease can progress to pulmonary fibrosis.
+  phenotype_term:
+    preferred_term: pulmonary fibrosis
+    term:
+      id: HP:0002206
+      label: Pulmonary fibrosis
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002206 | Pulmonary fibrosis | Occasional (29-5%)"
+    explanation: Orphanet records pulmonary fibrosis as occasional.
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "One patient developed severe pulmonary fibrosis"
+    explanation: The French cohort documents pulmonary fibrosis as a severe complication.
+- category: Abdominal
+  name: Hepatomegaly
+  frequency: OCCASIONAL
+  description: Hepatomegaly is reported as an occasional systemic finding.
+  phenotype_term:
+    preferred_term: hepatomegaly
+    term:
+      id: HP:0002240
+      label: Hepatomegaly
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002240 | Hepatomegaly | Occasional (29-5%)"
+    explanation: Orphanet records hepatomegaly as occasional.
+- category: Pulmonary
+  name: Respiratory failure
+  frequency: OCCASIONAL
+  description: Acute massive hemorrhage or chronic respiratory insufficiency can cause respiratory failure.
+  phenotype_term:
+    preferred_term: respiratory failure
+    term:
+      id: HP:0002878
+      label: Respiratory failure
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002878 | Respiratory failure | Occasional (29-5%)"
+    explanation: Orphanet records respiratory failure as occasional.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "three died from massive pulmonary hemorrhage and respiratory failure"
+    explanation: The pediatric cohort documents respiratory failure in fatal severe presentations.
+- category: Laboratory
+  name: Rheumatoid factor positive
+  frequency: OCCASIONAL
+  description: Rheumatoid factor positivity is one of the reported autoimmune serologic abnormalities.
+  phenotype_term:
+    preferred_term: rheumatoid factor positive
+    term:
+      id: HP:0002923
+      label: Rheumatoid factor positive
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0002923 | Rheumatoid factor positive | Occasional (29-5%)"
+    explanation: Orphanet records rheumatoid factor positivity as occasional.
+- category: Laboratory
+  name: Smooth muscle antibody positivity
+  frequency: OCCASIONAL
+  description: Smooth muscle antibody positivity is one of the reported autoimmune serologic abnormalities.
+  phenotype_term:
+    preferred_term: smooth muscle antibody positivity
+    term:
+      id: HP:0003262
+      label: Anti-smooth muscle antibody positivity
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0003262 | Smooth muscle antibody positivity | Occasional (29-5%)"
+    explanation: Orphanet records smooth muscle antibody positivity as occasional.
+- category: Laboratory
+  name: Antineutrophil antibody positivity
+  frequency: OCCASIONAL
+  description: Antineutrophil antibody positivity is one of the reported autoimmune serologic abnormalities.
+  phenotype_term:
+    preferred_term: antineutrophil antibody positivity
+    term:
+      id: HP:0003453
+      label: Antineutrophil antibody positivity
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0003453 | Antineutrophil antibody positivity | Occasional (29-5%)"
+    explanation: Orphanet records antineutrophil antibody positivity as occasional.
+- category: Laboratory
+  name: Antinuclear antibody positivity
+  frequency: OCCASIONAL
+  description: Antinuclear antibody positivity is one of the reported autoimmune serologic abnormalities.
+  phenotype_term:
+    preferred_term: antinuclear antibody positivity
+    term:
+      id: HP:0003493
+      label: Antinuclear antibody positivity
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0003493 | Antinuclear antibody positivity | Occasional (29-5%)"
+    explanation: Orphanet records antinuclear antibody positivity as occasional.
+- category: Immune
+  name: Allergy
+  frequency: OCCASIONAL
+  description: Allergy is reported in a subset and is one hypothesized contributor rather than a proven cause.
+  phenotype_term:
+    preferred_term: allergy
+    term:
+      id: HP:0012393
+      label: Allergy
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0012393 | Allergy | Occasional (29-5%)"
+    explanation: Orphanet records allergy as occasional.
+- category: Imaging
+  name: Reticular pattern on pulmonary HRCT
+  frequency: OCCASIONAL
+  description: Reticular pulmonary HRCT changes may reflect chronic interstitial injury.
+  phenotype_term:
+    preferred_term: reticular pattern on pulmonary HRCT
+    term:
+      id: HP:0025390
+      label: Reticular pattern on pulmonary HRCT
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0025390 | Reticular pattern on pulmonary HRCT | Occasional (29-5%)"
+    explanation: Orphanet records reticular pattern on pulmonary HRCT as occasional.
+- category: Imaging
+  name: Nodular pattern on pulmonary HRCT
+  frequency: OCCASIONAL
+  description: Nodular pulmonary HRCT changes are reported in a subset.
+  phenotype_term:
+    preferred_term: nodular pattern on pulmonary HRCT
+    term:
+      id: HP:0025392
+      label: Nodular pattern on pulmonary HRCT
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0025392 | Nodular pattern on pulmonary HRCT | Occasional (29-5%)"
+    explanation: Orphanet records nodular pattern on pulmonary HRCT as occasional.
+- category: Pulmonary
+  name: Diffuse alveolar hemorrhage
+  frequency: OCCASIONAL
+  description: Diffuse alveolar hemorrhage is the core lesion of IPH and can be recurrent.
+  phenotype_term:
+    preferred_term: diffuse alveolar hemorrhage
+    term:
+      id: HP:0025420
+      label: Diffuse alveolar hemorrhage
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0025420 | Diffuse alveolar hemorrhage | Occasional (29-5%)"
+    explanation: Orphanet records diffuse alveolar hemorrhage as occasional.
+  - reference: PMID:15293620
+    reference_title: "Idiopathic pulmonary haemosiderosis revisited."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "repetitive episodes of diffuse alveolar haemorrhage"
+    explanation: The clinical review supports recurrent diffuse alveolar hemorrhage as central to IPH.
+- category: Laboratory
+  name: Autoimmune antibody positivity
+  frequency: OCCASIONAL
+  description: Autoimmune serologic abnormalities support immune involvement in a subset.
+  phenotype_term:
+    preferred_term: autoimmune antibody positivity
+    term:
+      id: HP:0030057
+      label: Autoimmune antibody positivity
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0030057 | Autoimmune antibody positivity | Occasional (29-5%)"
+    explanation: Orphanet records autoimmune antibody positivity as occasional.
+- category: Cardiac
+  name: Heart murmur
+  frequency: OCCASIONAL
+  description: Heart murmur is an occasional clinical finding.
+  phenotype_term:
+    preferred_term: heart murmur
+    term:
+      id: HP:0030148
+      label: Heart murmur
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0030148 | Heart murmur | Occasional (29-5%)"
+    explanation: Orphanet records heart murmur as occasional.
+- category: Pulmonary
+  name: Crackles
+  frequency: OCCASIONAL
+  description: Crackles can occur with alveolar filling and parenchymal involvement.
+  phenotype_term:
+    preferred_term: crackles
+    term:
+      id: HP:0030830
+      label: Crackles
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0030830 | Crackles | Occasional (29-5%)"
+    explanation: Orphanet records crackles as occasional.
+- category: Immune
+  name: Cow milk allergy
+  frequency: VERY_RARE
+  description: Cow milk allergy is a rare reported associated finding and should not be treated as the primary IPH mechanism.
+  phenotype_term:
+    preferred_term: cow milk allergy
+    term:
+      id: HP:0100327
+      label: Cow milk allergy
+  evidence:
+  - reference: ORPHA:99931
+    reference_title: Idiopathic pulmonary hemosiderosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0100327 | Cow milk allergy | Very rare (<4-1%)"
+    explanation: Orphanet records cow milk allergy as very rare.
+diagnosis:
+- name: Chest radiography and computed tomography
+  description: >
+    Chest radiographs or CT are used to identify infiltrates, ground-glass
+    opacity, nodular changes, cardiomegaly, or reticular interstitial changes
+    compatible with alveolar hemorrhage and chronic injury.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All of the patients showed abnormal chest X-rays or computed tomography scans."
+    explanation: The pediatric cohort supports chest imaging as a routine diagnostic component.
+- name: Hemosiderin-laden macrophage testing
+  description: >
+    Sputum, gastric lavage fluid, or bronchoalveolar lavage fluid can be tested
+    for hemosiderin-laden macrophages; repeated gastric lavage or BAL can improve
+    detection in children who cannot expectorate.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The positive rates of hemosiderin-laden macrophages in sputum, gastric lavage fluid, and bronchoalveolar lavage fluid were 91.66%, 98.21%, and 100%, respectively."
+    explanation: The cohort supports cytologic testing for hemosiderin-laden macrophages across respiratory and gastric samples.
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Chest imaging combined with repeated examinations for hemosiderin-laden macrophages in sputum, gastric lavage fluid, or bronchoalveolar lavage fluid are helpful for diagnosing IPH."
+    explanation: The cohort conclusion supports combined imaging and repeated siderophage testing.
+- name: Exclusion of secondary diffuse alveolar hemorrhage causes
+  description: >
+    IPH is diagnosed only after excluding secondary causes such as infection,
+    bronchiectasis, interstitial pneumonia, neoplasm, cardiovascular disease,
+    coagulation disorders, connective-tissue disease, celiac disease, and
+    systemic vasculitis.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "exclusion of other diseases, which are associated with diffuse alveolar hemorrhage, such as bronchiectasis, interstitial pneumonia, neoplasms, cardiovascular disease, coagulation disorders, infections, connective tissue diseases, celiac disease, and systemic vasculitis."
+    explanation: The cohort's case definition supports exclusion of secondary DAH causes.
+treatments:
+- name: Systemic corticosteroid therapy
+  description: >
+    Systemic corticosteroids are first-line therapy for acute episodes and are
+    commonly used for initial control and maintenance, though recurrence during
+    tapering is frequent.
+  treatment_term:
+    preferred_term: corticosteroid agent therapy
+    term:
+      id: MAXO:0000640
+      label: corticosteroid agent therapy
+    therapeutic_agent:
+    - preferred_term: corticosteroid
+      term:
+        id: CHEBI:50858
+        label: corticosteroid
+    - preferred_term: prednisone
+      term:
+        id: CHEBI:8382
+        label: prednisone
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Glucocorticoids and immunosuppressive agents are the first choice for treating IPH."
+    explanation: The pediatric cohort review supports glucocorticoids as first-choice treatment.
+  - reference: PMID:26289251
+    reference_title: "A physician survey reveals differences in management of idiopathic pulmonary hemosiderosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Common medications respondents used for treatment at initial presentation and chronic maintenance therapy were corticosteroids (98.7 and 84.0 %, initial and chronic therapy respectively)"
+    explanation: The international physician survey supports common corticosteroid use for initial and chronic therapy.
+  - reference: PMID:33184706
+    reference_title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Corticosteroid therapy represents the first line of treatment"
+    explanation: The treatment review supports corticosteroids as first-line therapy.
+- name: Steroid-sparing immunosuppressive therapy
+  description: >
+    Hydroxychloroquine, azathioprine, cyclophosphamide, mycophenolate mofetil,
+    and other immunomodulatory agents have been used when disease is severe,
+    recurrent, steroid-refractory, or steroid-toxic.
+  treatment_term:
+    preferred_term: immune suppressant agent therapy
+    term:
+      id: MAXO:0000297
+      label: immune suppressant agent therapy
+    therapeutic_agent:
+    - preferred_term: hydroxychloroquine
+      term:
+        id: CHEBI:5801
+        label: hydroxychloroquine
+    - preferred_term: azathioprine
+      term:
+        id: CHEBI:2948
+        label: azathioprine
+  evidence:
+  - reference: PMID:33184706
+    reference_title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Additional immunomodulatory/immunosuppressive medications have been used with varying success, especially in the setting of steroid-refractory disease."
+    explanation: The treatment review supports steroid-sparing immunosuppression for steroid-refractory IPH.
+  - reference: PMID:30806370
+    reference_title: "Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We initiated hydroxy-chloroquine and azathioprine early in treatment along with steroids in seven children with idiopathic pulmonary hemosiderosis"
+    explanation: The pediatric series supports hydroxychloroquine and azathioprine as steroid-sparing options used with corticosteroids.
+  - reference: PMID:30806370
+    reference_title: "Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "early introduction of second line immunosuppressants helped in reducing disease flare and steroid toxicity without serious adverse effects."
+    explanation: The series supports benefit of early steroid-sparing immunosuppression in seven children.
+- name: Supportive care for acute anemia and respiratory compromise
+  description: >
+    Supportive management includes acute stabilization, oxygen or respiratory
+    support when needed, and transfusion for severe anemia while disease-directed
+    immunosuppression is initiated.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: PMID:30278795
+    reference_title: "Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All of the 107 patients were provided symptomatic treatments before diagnosis, and 29 received blood transfusions."
+    explanation: The pediatric cohort documents symptomatic care and transfusion in a subset before definitive diagnosis.
+notes: >
+  Pulmonary hemosiderosis in this entry follows the idiopathic pulmonary
+  hemosiderosis concept mapped by ORPHA:99931 and MONDO:0008346. Celiac disease
+  with pulmonary hemosiderosis is represented separately as Lane-Hamilton
+  syndrome; IPH should be evaluated for that association but is not itself
+  defined by gluten sensitivity. Etiologic hypotheses include environmental,
+  allergic, autoimmune, and genetic contributors, but none is established enough
+  to curate as a single upstream causal node.
+references:
+- reference: ORPHA:99931
+  title: Idiopathic pulmonary hemosiderosis
+  findings: []
+- reference: PMID:15293620
+  title: Idiopathic pulmonary haemosiderosis revisited.
+  findings: []
+- reference: PMID:24125570
+  title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+  findings: []
+- reference: PMID:26289251
+  title: A physician survey reveals differences in management of idiopathic pulmonary hemosiderosis.
+  findings: []
+- reference: PMID:30278795
+  title: Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients.
+  findings: []
+- reference: PMID:30806370
+  title: Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis.
+  findings: []
+- reference: PMID:33184706
+  title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
+  findings: []

--- a/kb/disorders/Pulmonary_Hemosiderosis.yaml
+++ b/kb/disorders/Pulmonary_Hemosiderosis.yaml
@@ -1,7 +1,7 @@
 name: Pulmonary Hemosiderosis
 category: Respiratory Disease
 creation_date: "2026-05-09T18:28:00Z"
-updated_date: "2026-05-09T18:28:00Z"
+updated_date: "2026-05-09T20:47:29Z"
 synonyms:
 - Idiopathic pulmonary hemosiderosis
 - IPH
@@ -170,11 +170,41 @@ pathophysiology:
   downstream:
   - target: Hemosiderin-laden alveolar macrophage accumulation
     causal_link_type: DIRECT
+  - target: Recurrent hemorrhage-driven lung injury and remodeling
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
   - target: Diffuse alveolar hemorrhage
     causal_link_type: DIRECT
   - target: Hemoptysis
     causal_link_type: DIRECT
   - target: Pulmonary infiltrates
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+- name: Autoimmune serologic contribution to hemorrhage susceptibility
+  description: >
+    A subset of pediatric idiopathic pulmonary hemosiderosis cases show ANCA,
+    ANA, or coeliac antibody positivity, supporting autoimmunity as a modifier
+    or contributor rather than a universal primary cause.
+  role: modifier
+  biological_processes:
+  - preferred_term: immune response
+    term:
+      id: GO:0006955
+      label: immune response
+    modifier: DYSREGULATED
+  evidence:
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In screened patients, initial auto-immune screening revealed positive antineutrophilic cytoplasmic antibodies (ANCA) (n = 6, 40%), antinuclear antibodies (ANA) (n = 5, 45%) and specific coeliac disease antibodies (n = 4, 28%)."
+    explanation: The cohort documents autoimmune serology in screened children with IPH, supporting an immune contribution in a subset.
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Analysis of potential contributors supports a role of auto-immunity in disease development and highlights the importance of genetic factors."
+    explanation: The authors explicitly interpret potential contributors as supporting an autoimmune role in disease development.
+  downstream:
+  - target: Recurrent idiopathic diffuse alveolar hemorrhage
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
 - name: Hemosiderin-laden alveolar macrophage accumulation
   description: >
@@ -615,6 +645,24 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "three died from massive pulmonary hemorrhage and respiratory failure"
     explanation: The pediatric cohort documents respiratory failure in fatal severe presentations.
+- category: Comorbidity
+  name: Down syndrome
+  frequency: OCCASIONAL
+  description: >
+    Down syndrome is an associated comorbidity reported in pediatric idiopathic
+    pulmonary hemosiderosis cohorts, not a defining feature of all cases.
+  phenotype_term:
+    preferred_term: Down syndrome
+    term:
+      id: MONDO:0008608
+      label: Down syndrome
+  evidence:
+  - reference: PMID:24125570
+    reference_title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We identified 25 reported cases of IPH in children from the database (20 females and 5 males). Among them, 5 presented with Down syndrome."
+    explanation: The French pediatric cohort documents Down syndrome in 5 of 25 IPH cases, supporting an occasional comorbidity association.
 - category: Laboratory
   name: Rheumatoid factor positive
   frequency: OCCASIONAL
@@ -930,6 +978,14 @@ treatments:
       term:
         id: CHEBI:2948
         label: azathioprine
+    - preferred_term: cyclophosphamide
+      term:
+        id: CHEBI:4027
+        label: cyclophosphamide
+    - preferred_term: mycophenolate mofetil
+      term:
+        id: CHEBI:8764
+        label: mycophenolate mofetil
   evidence:
   - reference: PMID:33184706
     reference_title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
@@ -949,6 +1005,12 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "early introduction of second line immunosuppressants helped in reducing disease flare and steroid toxicity without serious adverse effects."
     explanation: The series supports benefit of early steroid-sparing immunosuppression in seven children.
+  - reference: PMID:33184706
+    reference_title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Cyclophosphamide, azathioprine, hydroxychloroquine, mycophenolate mofetil, and mesenchymal cell transplantation have been attempted to improve outcome and reduce side effects."
+    explanation: The treatment review specifically names cyclophosphamide and mycophenolate mofetil among attempted steroid-sparing options.
 - name: Supportive care for acute anemia and respiratory compromise
   description: >
     Supportive management includes acute stabilization, oxygen or respiratory
@@ -977,22 +1039,36 @@ notes: >
 references:
 - reference: ORPHA:99931
   title: Idiopathic pulmonary hemosiderosis
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []
 - reference: PMID:15293620
   title: Idiopathic pulmonary haemosiderosis revisited.
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []
 - reference: PMID:24125570
   title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort."
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []
 - reference: PMID:26289251
   title: A physician survey reveals differences in management of idiopathic pulmonary hemosiderosis.
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []
 - reference: PMID:30278795
   title: Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients.
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []
 - reference: PMID:30806370
   title: Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis.
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []
 - reference: PMID:33184706
   title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
+  found_in:
+  - Pulmonary_Hemosiderosis-deep-research-fallback.md
   findings: []

--- a/references_cache/ORPHA_99931.md
+++ b/references_cache/ORPHA_99931.md
@@ -1,0 +1,78 @@
+---
+reference_id: "ORPHA:99931"
+title: "Idiopathic pulmonary hemosiderosis"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:99931  Idiopathic pulmonary hemosiderosis
+
+**ORPHA:99931** — Idiopathic pulmonary hemosiderosis (Disease, Disorder)
+
+## Definition
+
+Idiopathic pulmonary hemosiderosis is a respiratory disease due to repeated episodes of diffuse alveolar hemorrhage without any underlying apparent cause, most often in children. Anemia, cough, and pulmonary infiltrates on chest radiographs are found in majority of the patients.
+
+## Natural history
+
+- Age of onset: Childhood
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| <1 / 1 000 000 | Europe | Annual incidence | EXPERT |
+| Unknown | Europe | Point prevalence | ORPHANET |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000099 | Glomerulonephritis | Very rare (<4-1%) |
+| HP:0000980 | Pallor | Frequent (79-30%) |
+| HP:0001433 | Hepatosplenomegaly | Frequent (79-30%) |
+| HP:0001508 | Failure to thrive | Occasional (29-5%) |
+| HP:0001640 | Cardiomegaly | Occasional (29-5%) |
+| HP:0001891 | Iron deficiency anemia | Very frequent (99-80%) |
+| HP:0001945 | Fever | Occasional (29-5%) |
+| HP:0002091 | Restrictive ventilatory defect | Occasional (29-5%) |
+| HP:0002094 | Dyspnea | Occasional (29-5%) |
+| HP:0002105 | Hemoptysis | Frequent (79-30%) |
+| HP:0002113 | Pulmonary infiltrates | Frequent (79-30%) |
+| HP:0002206 | Pulmonary fibrosis | Occasional (29-5%) |
+| HP:0002240 | Hepatomegaly | Occasional (29-5%) |
+| HP:0002878 | Respiratory failure | Occasional (29-5%) |
+| HP:0002923 | Rheumatoid factor positive | Occasional (29-5%) |
+| HP:0003262 | Smooth muscle antibody positivity | Occasional (29-5%) |
+| HP:0003453 | Antineutrophil antibody positivity | Occasional (29-5%) |
+| HP:0003493 | Antinuclear antibody positivity | Occasional (29-5%) |
+| HP:0012378 | Fatigue | Frequent (79-30%) |
+| HP:0012393 | Allergy | Occasional (29-5%) |
+| HP:0012735 | Cough | Frequent (79-30%) |
+| HP:0025179 | Ground-glass opacification on pulmonary HRCT | Frequent (79-30%) |
+| HP:0025390 | Reticular pattern on pulmonary HRCT | Occasional (29-5%) |
+| HP:0025392 | Nodular pattern on pulmonary HRCT | Occasional (29-5%) |
+| HP:0025420 | Diffuse alveolar hemorrhage | Occasional (29-5%) |
+| HP:0030057 | Autoimmune antibody positivity | Occasional (29-5%) |
+| HP:0030148 | Heart murmur | Occasional (29-5%) |
+| HP:0030830 | Crackles | Occasional (29-5%) |
+| HP:0100327 | Cow milk allergy | Very rare (<4-1%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:6763 | Exact |
+| ICD-10:E83.1+ | Narrower |
+| ICD-10:J99.8* | Narrower |
+| ICD-11:CB04.30 | Exact |
+| MeSH:C536281 | Exact |
+| OMIM:178550 | Exact |
+| OMIM:235500 | Broader |
+| UMLS:C0020807 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=99931)

--- a/references_cache/PMID_15293620.md
+++ b/references_cache/PMID_15293620.md
@@ -1,0 +1,66 @@
+---
+reference_id: "PMID:15293620"
+title: Idiopathic pulmonary haemosiderosis revisited.
+authors:
+- Ioachimescu OC
+- Sieber S
+- Kotch A
+journal: Eur Respir J
+year: '2004'
+doi: 10.1183/09031936.04.00116302
+keywords:
+- Adult
+- "Biopsy, Needle"
+- Blood Chemical Analysis
+- Female
+- "Hemosiderosis/diagnosis, drug therapy, epidemiology"
+- Humans
+- Immunohistochemistry
+- Immunosuppressive Agents/therapeutic use
+- Incidence
+- Lung/pathology
+- "Lung Diseases/diagnosis, drug therapy, epidemiology"
+- Male
+- Prognosis
+- "Radiography, Thoracic"
+- Respiratory Function Tests
+- Risk Assessment
+- Severity of Illness Index
+- Survival Rate
+- "Tomography, X-Ray Computed"
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Idiopathic pulmonary haemosiderosis revisited.
+**Authors:** Ioachimescu OC, Sieber S, Kotch A
+**Journal:** Eur Respir J (2004)
+**DOI:** [10.1183/09031936.04.00116302](https://doi.org/10.1183/09031936.04.00116302)
+
+## Content
+
+1. Eur Respir J. 2004 Jul;24(1):162-70. doi: 10.1183/09031936.04.00116302.
+
+Idiopathic pulmonary haemosiderosis revisited.
+
+Ioachimescu OC(1), Sieber S, Kotch A.
+
+Author information:
+(1)Dept of Pulmonary Allergy and Critical Care Medicine, Cleveland Clinic
+Foundation, Cleveland, OH, USA. oioac@yahoo.com
+
+Idiopathic pulmonary haemosiderosis is a rare cause of diffuse alveolar
+haemorrhage of unknown aetiology. It occurs most frequently in children, has a
+variable natural history with repetitive episodes of diffuse alveolar
+haemorrhage, and has been reported to have a high mortality. Many patients
+develop iron deficiency anaemia secondary to deposition of haemosiderin iron in
+the alveoli. Examination of sputum and bronchoalveolar lavage fluid can disclose
+haemosiderin-laden alveolar macrophages (siderophages), and the lung biopsy
+shows numerous siderophages in the alveoli, without any evidence of pulmonary
+vasculitis, nonspecific/granulomatous inflammation, or deposition of
+immunoglobulins. Contrary to earlier reports, corticosteroids alone or in
+combination with other immunosuppressive agents may be effective for either
+exacerbations or maintenance therapy of idiopathic pulmonary haemosiderosis.
+
+DOI: 10.1183/09031936.04.00116302
+PMID: 15293620 [Indexed for MEDLINE]

--- a/references_cache/PMID_24125570.md
+++ b/references_cache/PMID_24125570.md
@@ -1,0 +1,93 @@
+---
+reference_id: "PMID:24125570"
+title: "New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare(®) cohort."
+authors:
+- Taytard J
+- Nathan N
+- de Blic J
+- Fayon M
+- Epaud R
+- Deschildre A
+- Troussier F
+- Lubrano M
+- Chiron R
+- Reix P
+- Cros P
+- Mahloul M
+- Michon D
+- Clement A
+- Corvol H
+- French RespiRare® group
+journal: Orphanet J Rare Dis
+year: '2013'
+doi: 10.1186/1750-1172-8-161
+keywords:
+- Adolescent
+- Child
+- "Child, Preschool"
+- Female
+- "Hemosiderosis/diagnosis, drug therapy"
+- Humans
+- Immunosuppressive Agents/therapeutic use
+- Infant
+- "Lung Diseases/diagnosis, drug therapy"
+- Male
+- "Hemosiderosis, Pulmonary"
+content_type: abstract_only
+---
+
+# New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare(®) cohort.
+**Authors:** Taytard J, Nathan N, de Blic J, Fayon M, Epaud R, Deschildre A, Troussier F, Lubrano M, Chiron R, Reix P, Cros P, Mahloul M, Michon D, Clement A, Corvol H, French RespiRare® group
+**Journal:** Orphanet J Rare Dis (2013)
+**DOI:** [10.1186/1750-1172-8-161](https://doi.org/10.1186/1750-1172-8-161)
+
+## Content
+
+1. Orphanet J Rare Dis. 2013 Oct 14;8:161. doi: 10.1186/1750-1172-8-161.
+
+New insights into pediatric idiopathic pulmonary hemosiderosis: the French
+RespiRare(®) cohort.
+
+Taytard J(1), Nathan N, de Blic J, Fayon M, Epaud R, Deschildre A, Troussier F,
+Lubrano M, Chiron R, Reix P, Cros P, Mahloul M, Michon D, Clement A, Corvol H;
+French RespiRare® group.
+
+Author information:
+(1)Pediatric Pulmonary Department, AP-HP, Hôpital Trousseau, Université Pierre
+et Marie Curie-Paris6, Inserm U938, 26, avenue du Docteur Arnold-Netter, 75012
+Paris, France. harriet.corvol@trs.aphp.fr.
+
+BACKGROUND: Idiopathic pulmonary hemosiderosis (IPH) is a rare cause of alveolar
+hemorrhage in children and its pathophysiology remains obscure. Classically,
+diagnosis is based on a triad including hemoptysis, diffuse parenchymal
+infiltrates on chest X-rays, and iron-deficiency anemia. We present the French
+pediatric cohort of IPH collected through the French Reference Center for Rare
+Lung Diseases (RespiRare®, http://www.respirare.fr).
+METHODS: Since 2008, a national network/web-linked RespiRare® database has been
+set up in 12 French pediatric respiratory centres. It is structured as a medical
+recording tool with extended disease-specific datasets containing clinical
+information relevant to all forms of rare lung diseases including IPH.
+RESULTS: We identified 25 reported cases of IPH in children from the database
+(20 females and 5 males). Among them, 5 presented with Down syndrome. Upon
+diagnosis, median age was 4.3 [0.8-14.0] yrs, and the main manifestations were:
+dyspnea (n = 17, 68%), anemia (n = 16, 64%), cough (n = 12, 48%), febrile
+pneumonia (n = 11, 44%) and hemoptysis (n = 11, 44%). Half of the patients
+demonstrated diffuse parenchymal infiltrates on chest imaging, and diagnosis was
+ascertained either by broncho-alveolar lavage indicating the presence of
+hemosiderin-laden macrophages (19/25 cases), or lung biopsy (6/25). In screened
+patients, initial auto-immune screening revealed positive antineutrophilic
+cytoplasmic antibodies (ANCA) (n = 6, 40%), antinuclear antibodies (ANA) (n = 5,
+45%) and specific coeliac disease antibodies (n = 4, 28%). All the patients were
+initially treated by corticosteroids. In 13 cases, immunosuppressants were
+introduced due to corticoresistance and/or major side effects. Median length of
+follow-up was 5.5 yrs, with a satisfactory respiratory outcome in 23/25
+patients. One patient developed severe pulmonary fibrosis, and another with Down
+syndrome died as a result of severe pulmonary hemorrhage.
+CONCLUSION: The present cohort provides substantial information on clinical
+expression and outcomes of pediatric IPH. Analysis of potential contributors
+supports a role of auto-immunity in disease development and highlights the
+importance of genetic factors.
+
+DOI: 10.1186/1750-1172-8-161
+PMCID: PMC3852822
+PMID: 24125570 [Indexed for MEDLINE]

--- a/references_cache/PMID_26289251.md
+++ b/references_cache/PMID_26289251.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:26289251"
+title: A physician survey reveals differences in management of idiopathic pulmonary hemosiderosis.
+authors:
+- Chin CI
+- Kohn SL
+- Keens TG
+- Margetis MF
+- Kato RM
+journal: Orphanet J Rare Dis
+year: '2015'
+doi: 10.1186/s13023-015-0319-5
+keywords:
+- Hemosiderosis/therapy
+- Humans
+- Lung Diseases/therapy
+- Physicians
+- "Practice Patterns, Physicians'"
+- Surveys and Questionnaires
+- "Hemosiderosis, Pulmonary"
+content_type: abstract_only
+---
+
+# A physician survey reveals differences in management of idiopathic pulmonary hemosiderosis.
+**Authors:** Chin CI, Kohn SL, Keens TG, Margetis MF, Kato RM
+**Journal:** Orphanet J Rare Dis (2015)
+**DOI:** [10.1186/s13023-015-0319-5](https://doi.org/10.1186/s13023-015-0319-5)
+
+## Content
+
+1. Orphanet J Rare Dis. 2015 Aug 20;10:98. doi: 10.1186/s13023-015-0319-5.
+
+A physician survey reveals differences in management of idiopathic pulmonary
+hemosiderosis.
+
+Chin CI(1), Kohn SL(2), Keens TG(3)(4), Margetis MF(3)(4), Kato RM(5)(6).
+
+Author information:
+(1)Division of Pulmonology, Children's Hospital Los Angeles, Los Angeles,
+California. chana.chantaw@gmail.com.
+(2)Division of Pulmonology, Children's Hospital Los Angeles, Los Angeles,
+California. sloloyan@chla.usc.edu.
+(3)Division of Pulmonology, Children's Hospital Los Angeles, Los Angeles,
+California.
+(4)Department of Pediatrics, Keck School of Medicine, University of Southern
+California, Los Angeles, California.
+(5)Division of Pulmonology, Children's Hospital Los Angeles, Los Angeles,
+California. rkato@chla.usc.edu.
+(6)Department of Pediatrics, Keck School of Medicine, University of Southern
+California, Los Angeles, California. rkato@chla.usc.edu.
+
+BACKGROUND: Idiopathic pulmonary hemosiderosis (IPH) is a rare disorder of
+unknown etiology characterized by chronic pulmonary hemorrhage and presents with
+a triad of anemia, hemoptysis and pulmonary infiltrates. IPH is a diagnosis of
+exclusion with a variable and disparate clinical course. Despite existing
+therapies, few children achieve full remission while others have recurrent
+hemorrhage, progressive lung damage, and premature death.
+METHODS: We surveyed physicians who care for patients with IPH via a web-based
+survey to assess the most common practices. 88 providers responded, caring for
+274 IPH patients from five continents.
+RESULTS: 63.3 % of respondents had patients that were initially misdiagnosed
+with anemia (60.0 %) or gastrointestinal bleed (18.2 %). Respondents varied in
+diagnostic tools used for evaluation. The key difference was in the use of lung
+biopsy (51.9 %) for diagnosis. Common medications respondents used for treatment
+at initial presentation and chronic maintenance therapy were corticosteroids
+(98.7 and 84.0 %, initial and chronic therapy respectively), hydroxychloroquine
+(33.3 and 64.0 %), azathioprine (8.0 and 37.3 %), and cyclophosphamide (4.0 and
+16.0 %). There was agreement on the use of corticosteroids for exacerbation
+amongst all respondents. Reported deaths before adulthood occurred in 7.3 % of
+patients. We conclude that there were common features and specific variations in
+physician management of IPH. Respondents were divided on whether to perform lung
+biopsy for diagnosis.
+CONCLUSION: Despite the availability of various immunomodulators,
+corticosteroids remained the primary therapy. We speculate that the
+standardization of care for diffuse alveolar hemorrhage will improve patient
+outcomes.
+
+DOI: 10.1186/s13023-015-0319-5
+PMCID: PMC4545926
+PMID: 26289251 [Indexed for MEDLINE]

--- a/references_cache/PMID_30278795.md
+++ b/references_cache/PMID_30278795.md
@@ -1,0 +1,146 @@
+---
+reference_id: "PMID:30278795"
+title: Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients.
+authors:
+- Zhang Y
+- Luo F
+- Wang N
+- Song Y
+- Tao Y
+journal: J Int Med Res
+year: '2019'
+doi: 10.1177/0300060518800652
+keywords:
+- Adolescent
+- "Anemia/diagnostic imaging, drug therapy, mortality, physiopathology"
+- Anti-Inflammatory Agents/therapeutic use
+- Bronchoalveolar Lavage Fluid/chemistry
+- Child
+- "Child, Preschool"
+- "Cough/diagnostic imaging, drug therapy, mortality, physiopathology"
+- "Diagnostic Errors/statistics & numerical data"
+- "Dyspnea/diagnostic imaging, drug therapy, mortality, physiopathology"
+- Female
+- "Fever/diagnostic imaging, drug therapy, mortality, physiopathology"
+- Gastric Lavage/methods
+- Glucocorticoids/therapeutic use
+- "Hemoptysis/diagnostic imaging, drug therapy, mortality, physiopathology"
+- "Hemosiderosis/diagnostic imaging, drug therapy, mortality, physiopathology"
+- Humans
+- Infant
+- Lung/physiopathology
+- "Lung Diseases/diagnostic imaging, drug therapy, mortality, physiopathology"
+- Macrophages/chemistry
+- Male
+- Retrospective Studies
+- Sputum/chemistry
+- Survival Analysis
+- "Tomography, X-Ray Computed"
+- "Hemosiderosis, Pulmonary"
+content_type: full_text_xml
+---
+
+# Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients.
+**Authors:** Zhang Y, Luo F, Wang N, Song Y, Tao Y
+**Journal:** J Int Med Res (2019)
+**DOI:** [10.1177/0300060518800652](https://doi.org/10.1177/0300060518800652)
+
+## Content
+
+1. J Int Med Res. 2019 Jan;47(1):293-302. doi: 10.1177/0300060518800652. Epub
+2018  Oct 2.
+
+Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in
+pediatric patients.
+
+Zhang Y(1)(2), Luo F(1), Wang N(1), Song Y(1), Tao Y(1).
+
+Author information:
+(1)1 Department of Pediatrics, West China Second University Hospital, Sichuan
+University, Sichuan Province, China.
+(2)2 Key Laboratory of Birth Defects and Related Diseases of Women and Children
+(Sichuan University), Ministry of Education, China.
+
+OBJECTIVE: This study aimed to analyze the clinical characteristics and
+prognosis of pediatric idiopathic pulmonary hemosiderosis (IPH).
+METHODS: Pediatric IPH cases that were diagnosed at West China Second University
+Hospital, Sichuan University between 1996 and 2017 were reviewed. Follow-up data
+from 34 patients were collected.
+RESULTS: A total of 107 patients were included (42 boys and 65 girls). The
+median age was 6 years at diagnosis. The main manifestations of the patients
+were as follows: anemia (n = 100, 93.45%), cough (n = 68, 63.55%), hemoptysis
+(n = 61, 57%), fever (n = 23, 21.5%), and dyspnea (n = 23, 21.5%). There were
+relatively few pulmonary signs. The positive rates of hemosiderin-laden
+macrophages in sputum, gastric lavage fluid, and bronchoalveolar lavage fluid
+were 91.66%, 98.21%, and 100%, respectively. Seventy-nine patients were
+misdiagnosed. A total of 105 patients were initially treated with
+glucocorticoids, among whom 102 survived and three died. Among the followed up
+patients, two died and 32 survived, among whom 10 presented with recurrent
+episodes.
+CONCLUSIONS: The classic triad of pediatric IPH is not always present. The rates
+of misdiagnosis and recurrence of IPH are high. Early recognition and adequate
+immunosuppressive therapy are imperative for improving prognosis of IPH.
+
+DOI: 10.1177/0300060518800652
+PMCID: PMC6384493
+PMID: 30278795 [Indexed for MEDLINE]
+
+Idiopathic pulmonary hemosiderosis (IPH) is a rare disorder that is responsible for recurrent episodes of diffuse alveolar hemorrhage in children.1,2 IPH is characterized by the triad of hemoptysis, iron deficiency anemia, and pulmonary infiltrates on chest imaging. This condition was first described by Rudolf Virchow in 1864 in patients after their death.3 The exact incidence and prevalence of IPH are largely unknown. In select pediatric populations, the incidence of IPH varies between 0.24 and 1.26 patients per million, with a mortality rate of up to 50%.4,5
+
+Children with IPH appear to more frequently experience a rapid course and have a worse prognosis than adults. Death may quickly occur with acute, massive, pulmonary hemorrhage or may occur over longer periods as the result of continued respiratory insufficiency and heart failure.5,6 Historically, patients with IPH had an average survival of 2.5 years after diagnosis. Currently, 86% of patients with IPH may survive beyond 5 years.3 At present, several pediatric IPH cases have been reported in the literature,7,8 but few cohorts have been described. There is limited knowledge on the physiopathology, and there is a lack of consensus regarding care for IPH.9 Therefore, we conducted a retrospective review to investigate the clinical characteristics and prognosis of IPH in children.
+
+Complete data from children with confirmed IPH who were hospitalized at West China Second University Hospital, Sichuan University between January 1996 and January 2017 were reviewed. Patients with IPH were defined as follows: (1) the triad of iron deficiency anemia, respiratory symptoms (including dyspnea, cough and hemoptysis), and pulmonary infiltrates on chest imaging; (2) the presence of hemosiderin-laden macrophages in sputum, gastric lavage fluid, or bronchoalveolar lavage fluid; and (3) exclusion of other diseases, which are associated with diffuse alveolar hemorrhage, such as bronchiectasis, interstitial pneumonia, neoplasms, cardiovascular disease, coagulation disorders, infections, connective tissue diseases, celiac disease, and systemic vasculitis.1 Laboratory investigations for antinuclear antibodies (ANA), anti-double-stranded DNA, antineutrophil cytoplasmic antibodies, antiglomerular basement membrane antibodies, antiphospholipid antibodies, and rheumatoid factor were negative in all patients. Because this was a retrospective study, ethical approval and consent were not required.
+
+“Idiopathic pulmonary hemosiderosis” and “children” were used as the keywords to collect data from hospital medical records and from the Department of Pathology. Cases with complete data were included in this study. A database was established using Microsoft Excel 2007 software, with double entry of demographic data, clinical manifestations, laboratory findings, treatments, and clinical outcomes. Long-term prognosis was assessed in March 2018 by contacting the families by telephone.
+
+All of the data were analyzed using IBM SPSS Statistics for Windows, version 20.0 (IBM Corp, Armonk, NY, USA). Normally distributed data are presented as the mean ± standard deviation. Continuous variables were analyzed using the Student’s t-test, and categorical variables were analyzed using the chi-square test or Fisher’s exact test, if any expected value was below five. Data that were not normally distributed were reported as the median. The results were considered significant when P < 0.05.
+
+A total of 107 hospitalized children were diagnosed with IPH during the 21-year study period. There was no clustering of patients in time or site during the 21-year period. The main clinical data at diagnosis are shown in Table 1. All of the patients were sporadic patients, comprising 42 boys and 65 girls. The median age of onset of IPH was 5 years (1 month to 14.3 years). The median age of diagnosis was 6 years (4 months to 14.6 years old). The average time from onset to diagnosis was 10.46 months, with the longest time of 6 years. Seventy-six (71.03%) patients were from rural areas, while 31 (28.97%) patients were from urban areas. Nine patients had a history of allergies before the diagnosis of IPH. Among these patients, four were allergic to milk, two were allergic to penicillin, and the other three patients were allergic to shrimp, eggs, and azithromycin in one each. Among the 107 patients, one patient had concomitant Down syndrome and one had congenital esophageal atresia, and no comorbidity was found in any of the other patients.
+
+Baseline clinical profiles of 107 pediatric patients with idiopathic pulmonary hemosiderosis.
+
+Values are mean ± standard deviation or number.
+
+The main initial manifestations of the patients included cough (n = 62, 57.94%), hemoptysis (n = 53, 49.53%), fever (n = 20, 18.69%), and dyspnea (n = 17, 15.89%). Among the patients, 15 (14.02%) manifested with cough, hemoptysis, and anemia simultaneously. A total of 28 (26.17%) patients had anemia as the only initial symptom and six (5.61%) patients had hemoptysis as the only initial symptom.
+
+The main manifestations at diagnosis included cough (n = 68, 63.55%), hemoptysis (n = 61, 57%), fever (n = 23, 21.5%), dyspnea (n = 23, 21.5%), hepatomegaly (n = 13, 12.15%), and heart murmurs (n = 11, 10.28%). There were relatively few pulmonary signs. Only 17 (15.89%) patients had wet rales in pulmonary auscultation.
+
+Hemoglobin levels ranged from 26 to 130 g/L, with an average level of 74.86 g/L. Anemia was defined by a hemoglobin level below the range considered normal for age and sex.10 One hundred (93.45%) patients had anemia, among whom 28 were classified as mild (90 g/L to normal levels), 40 were moderate (60–90 g/L), 30 were severe (30–60 g/L), and two were critical (<30 g/L). A red blood cell morphology test was performed in 97 of the anemic patients, of whom 57 (58.8%) showed microcytic hypochromic anemia. Reticulocyte counts were recorded in 54 patients, of whom 53 (98.15%) had high reticulocyte counts.
+
+All of the patients showed normal liver function. ANA and antinuclear cytoplasmic antibody studies were negative in all of the patients. Allergen-specific immunoglobulin E was screened in 12 patients, among whom three were allergic to milk, one to dust mite allergies, and one to animal fur. In addition to ANA, antineutrophil cytoplasmic antibodies, allergen-specific immunoglobulin E, anti-double-stranded DNA, antiglomerular basement membrane antibodies, antigliadin antibodies, antireticulin, antiphospholipid antibodies, rheumatoid factor, and cow-milk precipitins were tested. However, all of these tests were negative.
+
+A total of 72 patients underwent an iron metabolism test, and 64 (88.9%) showed iron deficiency anemia. Serum iron tests were performed in 72 patients, and a decrease in iron levels was detected in 64 patients. Transferrin saturation was decreased in 62 (91.2%) of 68 patients. Serum ferritin tests were normal in 60 of 62 tested patients. The total iron binding capacity was increased in 32 (45.07%) of 71 tested patients.
+
+Bone marrow examinations were performed in 52 patients, among whom 46 (88.5%) showed proliferative bone marrow, two (3.8%) showed a decreased myeloid/erythroid ratio, and four (7.7%) were normal.
+
+All of the patients showed abnormal chest X-rays or computed tomography scans. Among them, 71 patients were examined by chest radiograph, 48 were examined by chest computed tomography, and 12 were examined by both tests. Patchy or cloud-like density was observed in 57 patients, ground-glass opacity in 36, small nodular changes in 20, miliary changes in 13, an enlarged heart shadow in 10, and reticular interstitial changes in 21.
+
+Hemosiderin-laden macrophages were found in all of the patients. Sputum from 48 patients was examined for hemosiderin-laden macrophages and 44 (91.66%) patients were positive, with an average of 1.69 tests. Gastric juice from 56 patients was examined for hemosiderin-laden macrophages and 55 (98.21%) patients were positive, with an average of 1.95 tests. Thirty-five patients who had hemosiderin-laden macrophages in sputum also had positivity in gastric juice. Bronchoalveolar lavage fluid from eight patients was examined for hemosiderin-laden macrophages, and it had a positive rate of 100%. Bronchoalveolar lavage fluid was sent for culture to exclude infectious etiologies and cytological analysis, but the results were negative.
+
+A total of 79 (73.83%) patients were misdiagnosed. Misdiagnoses included the following: nutritional iron deficiency anemia (n = 24), bronchial pneumonia (n = 21), pulmonary tuberculosis (n = 6), hemolytic anemia (n = 4), upper respiratory tract infection (n = 4), bronchiectasis (n = 3), myocarditis (n = 1), intestinal diseases (n=1), and favism (n = 1).
+
+The main clinical features of IPH (except for cough and wet rales; P = 0.002 and P = 0.012, respectively) were not significantly different among the different age groups at diagnosis and among the different symptom durations (Table 1).
+
+All of the 107 patients were provided symptomatic treatments before diagnosis, and 29 received blood transfusions. Two patients prematurely discontinued therapy after diagnosis. Of the 105 patients who received treatment, nine were administered 10 to 30 mg/kg/d of methylprednisolone for 3 days in the acute phase and then switched to 2 mg/kg/d of prednisone. The remaining 96 patients were administered oral prednisone at a dosage of 2 mg/kg/d for 2 weeks, one of whom received cyclosporine A in combination with prednisone. No patients received azathioprine. Of the 105 treated patients, three died from massive pulmonary hemorrhage and respiratory failure; 102 patients showed remission after the initial treatment. The patients were then followed up in outpatient clinics. Treatment was tapered and discontinued after 18 to 24 months if the patient had been free of recurrent events.
+
+A total of 34 patients were successfully followed up, with a median follow-up time of 3.71 years (1.08–6.23 years). No children subsequently developed any form of autoimmune disease. Two patients died of severe hemoptysis and 32 patients survived. Twenty-two patients remained asymptomatic over 3 months after withdrawal of treatment. Ten patients experienced recurrent episodes of symptoms upon reduction or withdrawal of prednisone. Children who had recurrence of symptoms were administered oral prednisone for 1 to 2 weeks. Those who developed symptoms during tapering of steroids had their dosages increased to 2 mg/kg/d for 2 to 4 weeks, followed by an attempt to taper. The rate of elevated bilirubin levels was significantly higher in children who had recurrent IPH than in those who were healed or improved (P = 0.049). However, there were no significant differences in the age of onset, age at diagnosis, history of hemoptysis, dyspnea, and hemoglobin levels between the two groups (Table 2).
+
+Risk factors for recurrent idiopathic pulmonary hemosiderosis.
+
+There are four main etiological hypotheses of IPH described in the literature, including environmental, allergic, autoimmune, and genetic hypotheses.6,9,11,12 In the present study, 71.03% of patients were from rural areas, which indicated that environmental factors might contribute to the pathogenesis of IPH. Previous studies have also indicated that exposure to second-hand smoke and indoor mold are causative factors in infants with IPH.13,14 In addition to mold, IPH has also been associated with exposure to insecticides or mycotoxigenic pathogens, such as Aspergillus, Penicillium, and Trichoderma. The association between environmental factors and IPH still needs further study.
+
+IPH is a rare clinical condition in children and generally occurs in children aged younger than 10 years,15 especially between the ages of 1 to 7 years.5 Some studies have also described family clustering of IPH.16,17 In the present study, all of our patients were sporadic, with the highest incidence among 3- to 6-year-olds, similar to patients reported in previous studies.1 Delayed diagnosis of IPH is frequently reported, with a delay period of 4 months to 10 years.18 In the present study, the average time from onset to diagnosis was 10.46 months and the misdiagnosis rate was as high as 73.83%. The high misdiagnosis rate may have been due to an insidious onset, a variable clinical presentation, and a lack of awareness about the condition.19
+
+Although the classic triad of hemoptysis, iron-deﬁciency anemia, and pulmonary inﬁltrates on chest imaging is characteristic of IPH, the clinical presentation is greatly variable and is not always present in children with IPH.7,20 In the present study, only 14.02% of patients simultaneously manifested cough, hemoptysis, and anemia. This group of patients also had the following characteristics. First, only 15.89% (initial manifestation) and 21.5% (at diagnosis) of the patients had dyspnea. Taytard et al.9 reported that the most frequent clinical features in pediatric patients at diagnosis were anemia and dyspnea (64% and 68%, respectively). This discrepancy between studies may be associated with a longer course of disease in the present group. Second, only 49.53% (initial manifestation) and 61.57% (at diagnosis) of the patients had hemoptysis in the present study. Hemoptysis is rare in children because most of them are unable to expectorate.9,21 For this reason, the absence of hemoptysis still does not exclude the diagnosis of IPH in children. Third, 57 (53.27%) patients had iron deficiency anemia as the primary manifestation, and 28 (49.12%) of these patients lacked any pulmonary signs in the present study. Iron deficiency anemia often occurs in malnourished children.22 However, iron deficiency anemia is also a common manifestation of IPH, and this condition may precede other symptoms and signs by several months.23,24 Bhatia S et al.25 performed an etiological analysis of 108 patients with microcytic hypochromic anemia, among whom 15 (13.9%) patients were diagnosed with IPH. Although IPH and nutritional iron deficiency anemia are characterized by microcytic hypochromic anemia, patients with IPH have normal serum ferritin levels.26 In the present study, 70 (65.42%) patients had moderate to severe anemia, and this was accompanied by chest imaging abnormalities. Therefore, IPH should be suspected in children with iron deficiency anemia who show no signs of improvement with iron supplementation and with bilateral lung infiltration.
+
+Searching for hemosiderin-laden macrophages contributes to the diagnosis of IPH. Lung biopsy is the gold standard for diagnosis of IPH,27 but this method is invasive and is not practiced in children.21,28 In the present study, no patients received a lung biopsy. Bronchoalveolar lavage fluid analysis is a safe and confirmatory method for pulmonary hemorrhage.29 Studies have shown that the sensitivity of finding hemosiderin-laden macrophages is 30% in gastric juice and 92% in bronchoalveolar lavage fluid.1 In the present study, the positive rates of hemosiderin-laden macrophages in bronchoalveolar lavage and gastric lavage fluid were 100% and 98.21%, respectively. Repeated examination of gastric lavage fluid is also a reliable and simple method that can increase the positive rate.
+
+Glucocorticoids and immunosuppressive agents are the first choice for treating IPH.11,18,21,30 Despite the fact that three patients died of severe hemoptysis in our study, most patients responded favorably to glucocorticoids. This finding indicates that systematic glucocorticoids are the first-line therapy for treatment of acute episodes of IPH.11,31 Immunosuppressive agents (e.g., hydroxychloroquine, azathioprine, and cyclophosphamide) may only be added to oral glucocorticoid therapy for those who have a severe initial condition.32–37 Rare treatments, such as intravenous immunoglobulin, plasmapheresis, liposteroids, and diet modification, have also been prescribed in some case reports.38–41
+
+The prognosis of IPH is influenced by several factors, including the time of diagnosis, early initiation of treatment, and the presence of comorbidities.20 Historically, patients had an average survival of 2.5 years after diagnosis of IPH, but Saeed et al.3 found that 86% of patients may survive beyond 5 years. Le et al.42 followed up 15 children with IPH for an average of 17.2 years, and found that 14 patients received long-term glucocorticoid therapy and 80% of patients led a normal life. In the present study, glucocorticoid therapy could control symptoms, but the recurrence rate was high. Many of the children continued to have recurrent pulmonary hemorrhage during the reduction or withdrawal process. In a series of 23 children with IPH,18 low-dose oral prednisone was associated with prolonged survival and a decreased recurrence rate compared with historical controls. In patients who have recurrent episodes of pulmonary hemorrhage that limit the tapering of glucocorticoids, a combination of glucocorticoids with other immunosuppressants may be considered.
+
+Because IPH is a rare disease, performing a randomized, controlled trial is difficult. Our study has some limitations that should be noted, namely its retrospective nature and its lack of a control group.
+
+In conclusion, our study shows that IPH has diverse clinical manifestations. The classic triad of IPH is not always present in children. The misdiagnosis ratio is high in IPH. Chest imaging combined with repeated examinations for hemosiderin-laden macrophages in sputum, gastric lavage fluid, or bronchoalveolar lavage fluid are helpful for diagnosing IPH. Systemic glucocorticoids are the main treatment for IPH, but recurrence is frequent during the reduction or withdrawal process. Long-term, low-dose glucocorticoid therapy, or a combination with other immunosuppressive agents, may help to reduce recurrence. Early recognition of IPH and adequate immunosuppressive treatment play a crucial role in prolonging survival and improving prognosis.
+
+The authors declare that there is no conflict of interest.

--- a/references_cache/PMID_30806370.md
+++ b/references_cache/PMID_30806370.md
@@ -1,0 +1,50 @@
+---
+reference_id: "PMID:30806370"
+title: Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis.
+authors:
+- Pal P
+- De H
+- Giri PP
+- Ganguly N
+- Mandal A
+journal: Indian Pediatr
+year: '2019'
+keywords:
+- Azathioprine/therapeutic use
+- Child
+- Hemosiderosis/drug therapy
+- Humans
+- Hydroxychloroquine/therapeutic use
+- Immunosuppressive Agents/therapeutic use
+- Lung Diseases/drug therapy
+- Time-to-Treatment
+- "Hemosiderosis, Pulmonary"
+content_type: abstract_only
+---
+
+# Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis.
+**Authors:** Pal P, De H, Giri PP, Ganguly N, Mandal A
+**Journal:** Indian Pediatr (2019)
+
+## Content
+
+1. Indian Pediatr. 2019 Jan 15;56(1):73-74.
+
+Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis.
+
+Pal P(1), De H(2), Giri PP(2), Ganguly N(2), Mandal A(2).
+
+Author information:
+(1)Department of Pediatrics, Institute of Child Health, Kolkata, West Bengal,
+India. mailme.priyankar@gmail.com.
+(2)Department of Pediatrics, Institute of Child Health, Kolkata, West Bengal,
+India.
+
+Idiopathic pulmonary hemosiderosis is conventionally treated with steroids,
+prolonged usage of which maybe deleterious and disease often recurs on tapering.
+We initiated hydroxy-chloroquine and azathioprine early in treatment along with
+steroids in seven children with idiopathic pulmonary hemosiderosis, and observed
+that early introduction of second line immunosuppressants helped in reducing
+disease flare and steroid toxicity without serious adverse effects.
+
+PMID: 30806370 [Indexed for MEDLINE]

--- a/references_cache/PMID_33184706.md
+++ b/references_cache/PMID_33184706.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:33184706"
+title: "Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions."
+authors:
+- Saha BK
+- Milman NT
+journal: Clin Rheumatol
+year: '2021'
+doi: 10.1007/s10067-020-05507-4
+keywords:
+- Adult
+- Azathioprine/therapeutic use
+- Hemoptysis
+- Hemosiderosis/drug therapy
+- Humans
+- Lung Diseases/drug therapy
+- "Hemosiderosis, Pulmonary"
+content_type: abstract_only
+---
+
+# Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions.
+**Authors:** Saha BK, Milman NT
+**Journal:** Clin Rheumatol (2021)
+**DOI:** [10.1007/s10067-020-05507-4](https://doi.org/10.1007/s10067-020-05507-4)
+
+## Content
+
+1. Clin Rheumatol. 2021 Jul;40(7):2547-2557. doi: 10.1007/s10067-020-05507-4.
+Epub  2020 Nov 12.
+
+Idiopathic pulmonary hemosiderosis: a review of the treatments used during the
+past 30 years and future directions.
+
+Saha BK(1), Milman NT(2).
+
+Author information:
+(1)Division of Pulmonary and Critical Care Medicine, Ozarks Medical Center, 1100
+Kentucky Avenue, West Plains, MO, 65775, USA. spanophiliac@yahoo.com.
+(2)Department of Clinical Biochemistry, Næstved Hospital, University College
+Zealand, DK-4700, Næstved, Denmark.
+
+This paper reviews the literature on the treatment modalities for idiopathic
+pulmonary hemosiderosis (IPH) used over the past 30 years, attempting to define
+treatment options that appear to be efficacious and safe, and in addition
+presents a treatment algorithm. IPH is an uncommon etiology of diffuse alveolar
+hemorrhage. IPH is a rare disease in adults and often associated with a
+significant temporal delay in diagnosis. Patients present with hemoptysis,
+radiographic chest abnormalities, and iron deficiency anemia. Although several
+pathogenetic hypotheses have been proposed, IPH appears to be an immunologic
+disease, possibly with a genetic component. Corticosteroid therapy represents
+the first line of treatment, including liposome-incorporated dexamethasone
+palmitate (liposteroid). Additional immunomodulatory/immunosuppressive
+medications have been used with varying success, especially in the setting of
+steroid-refractory disease. Cyclophosphamide, azathioprine, hydroxychloroquine,
+mycophenolate mofetil, and mesenchymal cell transplantation have been attempted
+to improve outcome and reduce side effects. Controlled studies are needed to
+assess the optimal combination of medications, which are effective to control
+the disease.
+
+DOI: 10.1007/s10067-020-05507-4
+PMID: 33184706 [Indexed for MEDLINE]

--- a/research/Pulmonary_Hemosiderosis-deep-research-fallback.md
+++ b/research/Pulmonary_Hemosiderosis-deep-research-fallback.md
@@ -1,0 +1,18 @@
+# Pulmonary Hemosiderosis Deep-Research Fallback
+
+Date: 2026-05-09
+
+Automated deep-research providers were attempted after local evidence-backed
+curation, but both stayed silent and were stopped by bounded timeouts:
+
+- `timeout 120s just research-disorder falcon Pulmonary_Hemosiderosis` returned 124 / signal 15.
+- `timeout 60s just research-disorder openai Pulmonary_Hemosiderosis` returned 124 / signal 15.
+
+The curation therefore used generated local caches only:
+
+- ORPHA:99931 for definition, age of onset, epidemiology, cross-references, and HPO phenotype coverage.
+- PMID:30278795 for the 107-patient pediatric cohort, clinical frequencies, diagnosis, prognosis, and glucocorticoid treatment.
+- PMID:24125570 for the French RespiRare pediatric cohort, autoimmunity signals, diagnosis, fibrosis, and severe hemorrhage outcomes.
+- PMID:15293620 for recurrent diffuse alveolar hemorrhage, siderophages, alveolar hemosiderin deposition, and biopsy exclusion of vasculitis.
+- PMID:26289251 for physician-practice treatment patterns.
+- PMID:33184706 and PMID:30806370 for corticosteroid and steroid-sparing immunosuppressive treatment scope.

--- a/research/Pulmonary_Hemosiderosis-deep-research-fallback.md
+++ b/research/Pulmonary_Hemosiderosis-deep-research-fallback.md
@@ -1,6 +1,14 @@
-# Pulmonary Hemosiderosis Deep-Research Fallback
+---
+title: Pulmonary Hemosiderosis Deep-Research Fallback
+disorder: Pulmonary_Hemosiderosis
+date: 2026-05-09
+status: provider_timeout_fallback
+attempted_providers:
+  - falcon
+  - openai
+---
 
-Date: 2026-05-09
+# Pulmonary Hemosiderosis Deep-Research Fallback
 
 Automated deep-research providers were attempted after local evidence-backed
 curation, but both stayed silent and were stopped by bounded timeouts:
@@ -8,11 +16,40 @@ curation, but both stayed silent and were stopped by bounded timeouts:
 - `timeout 120s just research-disorder falcon Pulmonary_Hemosiderosis` returned 124 / signal 15.
 - `timeout 60s just research-disorder openai Pulmonary_Hemosiderosis` returned 124 / signal 15.
 
-The curation therefore used generated local caches only:
+Because provider runs were unavailable, the curation used generated local caches
+and the disease-specific literature already fetched into `references_cache/`.
+The reviewed scope is idiopathic pulmonary hemosiderosis as represented by
+ORPHA:99931 and MONDO:0008346, with secondary diffuse alveolar hemorrhage causes
+and Lane-Hamilton syndrome kept outside the core disease definition.
 
-- ORPHA:99931 for definition, age of onset, epidemiology, cross-references, and HPO phenotype coverage.
-- PMID:30278795 for the 107-patient pediatric cohort, clinical frequencies, diagnosis, prognosis, and glucocorticoid treatment.
-- PMID:24125570 for the French RespiRare pediatric cohort, autoimmunity signals, diagnosis, fibrosis, and severe hemorrhage outcomes.
-- PMID:15293620 for recurrent diffuse alveolar hemorrhage, siderophages, alveolar hemosiderin deposition, and biopsy exclusion of vasculitis.
-- PMID:26289251 for physician-practice treatment patterns.
-- PMID:33184706 and PMID:30806370 for corticosteroid and steroid-sparing immunosuppressive treatment scope.
+## Scope Confirmation
+
+- ORPHA:99931 supplied the disease definition, childhood onset, epidemiology,
+  cross-references, and HPO phenotype rows.
+- PMID:30278795 supplied the large 107-patient pediatric cohort, clinical
+  frequencies, diagnosis, prognosis, and glucocorticoid treatment evidence.
+- PMID:24125570 supplied the French RespiRare pediatric cohort, autoimmunity
+  signals, Down syndrome comorbidity signal, diagnosis, fibrosis, and severe
+  hemorrhage outcomes.
+- PMID:15293620 supplied recurrent diffuse alveolar hemorrhage, siderophages,
+  alveolar hemosiderin deposition, and biopsy exclusion of vasculitis.
+- PMID:26289251 supplied physician-practice treatment patterns.
+- PMID:33184706 and PMID:30806370 supplied corticosteroid and steroid-sparing
+  immunosuppressive treatment scope.
+
+## Review Follow-Up
+
+The provider fallback was explicitly cross-checked for obvious curation gaps.
+PMID:24125570 supports autoimmune contribution in a subset through ANCA, ANA,
+and coeliac antibody positivity and through the authors' conclusion that
+autoimmunity contributes to disease development. The YAML now models this as an
+atomic modifier node rather than replacing the idiopathic upstream trigger.
+
+The same cohort reported Down syndrome in 5 of 25 pediatric IPH cases. Because
+the current disease schema has no top-level `comorbidities` slot, the YAML
+represents this as a `Comorbidity` phenotype entry with a MONDO term binding and
+an exact cohort snippet.
+
+PMID:33184706 names cyclophosphamide and mycophenolate mofetil among attempted
+steroid-sparing therapies. The YAML treatment entry now includes those
+therapeutic-agent bindings alongside hydroxychloroquine and azathioprine.

--- a/research/Pulmonary_Hemosiderosis-deep-research-fallback.md.citations.md
+++ b/research/Pulmonary_Hemosiderosis-deep-research-fallback.md.citations.md
@@ -1,0 +1,9 @@
+# Pulmonary Hemosiderosis Fallback Citations
+
+- ORPHA:99931 - Idiopathic pulmonary hemosiderosis structured record.
+- PMID:15293620 - Idiopathic pulmonary haemosiderosis revisited.
+- PMID:24125570 - New insights into pediatric idiopathic pulmonary hemosiderosis: the French RespiRare cohort.
+- PMID:26289251 - A physician survey reveals differences in management of idiopathic pulmonary hemosiderosis.
+- PMID:30278795 - Clinical characteristics and prognosis of idiopathic pulmonary hemosiderosis in pediatric patients.
+- PMID:30806370 - Early Initiation of Steroid-sparing Drugs in Idiopathic Pulmonary Hemosiderosis.
+- PMID:33184706 - Idiopathic pulmonary hemosiderosis: a review of the treatments used during the past 30 years and future directions.


### PR DESCRIPTION
Adds `Pulmonary_Hemosiderosis.yaml` for MONDO:0008346 / ORPHA:99931.\n\nSummary:\n- Captures idiopathic recurrent diffuse alveolar hemorrhage, siderophage/hemosiderin accumulation, iron-deficiency anemia, and chronic lung remodeling/fibrosis risk.\n- Adds all 29 cached ORPHA phenotype rows with frequency support.\n- Adds chest imaging, hemosiderin-laden macrophage testing, exclusion of secondary DAH causes, histopathology, corticosteroid treatment, steroid-sparing immunosuppression, and supportive care.\n- Deep-research providers were attempted with bounded timeouts; fallback artifact documents Falcon and OpenAI timeout failures and local evidence scope.\n\nValidation:\n- `just validate kb/disorders/Pulmonary_Hemosiderosis.yaml`\n- snippet audit: 64/64 snippets found with whitespace normalization\n- graph audit: 3 pathophysiology nodes / 10 downstream edges, no orphan targets\n- ORPHA phenotype coverage: 29/29 rows included\n- `just check-reference-cache-frontmatter`\n- `just qc-deep-research --only Pulmonary_Hemosiderosis`