### PR TITLE
Connect Pompe disease pathograph

### DIFF
--- a/kb/disorders/Pompe_Disease.yaml
+++ b/kb/disorders/Pompe_Disease.yaml
@@ -1,6 +1,6 @@
 name: Pompe Disease
 creation_date: '2026-03-08T00:00:00Z'
-updated_date: '2026-05-09T06:13:15Z'
+updated_date: '2026-05-10T02:59:37Z'
 category: Mendelian
 description: >
   Pompe disease (glycogen storage disease type II, acid maltase deficiency) is an
@@ -254,6 +254,27 @@ pathophysiology:
     term:
       id: CL:0008002
       label: skeletal muscle fiber
+  downstream:
+  - target: Progressive proximal myopathy
+    description: Skeletal muscle fiber injury clinically manifests as progressive proximal and limb-girdle weakness.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32745073
+      reference_title: "Pompe disease: pathogenesis, molecular genetics and diagnosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PD is a chronic and progressive pathology usually characterized by limb-girdle muscle weakness and respiratory failure."
+      explanation: Human clinical review links Pompe disease to limb-girdle weakness, supporting the muscle-injury-to-myopathy edge.
+  - target: Respiratory insufficiency
+    description: Respiratory myofiber injury weakens ventilatory muscles and causes respiratory insufficiency.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20393176
+      reference_title: "A randomized study of alglucosidase alfa in late-onset Pompe's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Late-onset Pompe's disease is characterized by progressive muscle weakness and loss of respiratory function, leading to early death."
+      explanation: Randomized trial background directly links progressive muscle weakness with loss of respiratory function in LOPD.
 - name: Cardiomyocyte glycogen storage and hypertrophic remodeling
   description: >
     In infantile-onset Pompe disease, cardiomyocyte glycogen storage produces
@@ -283,6 +304,17 @@ pathophysiology:
     term:
       id: GO:0003300
       label: cardiac muscle hypertrophy
+  downstream:
+  - target: Hypertrophic cardiomyopathy
+    description: Cardiomyocyte glycogen storage and hypertrophic remodeling produce the infantile-onset hypertrophic cardiomyopathy phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18929906
+      reference_title: "Pompe's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cardiac hypertrophy is a key feature of classic infantile Pompe's disease."
+      explanation: Human clinical review supports cardiac hypertrophy as the key cardiac manifestation of classic infantile Pompe disease.
 phenotypes:
 - name: Hypertrophic cardiomyopathy
   description: >
@@ -697,10 +729,34 @@ treatments:
     and cardiac outcomes in IOPD and stabilizes or improves respiratory and
     motor function in LOPD.
   treatment_term:
-    preferred_term: Enzyme replacement therapy
+    preferred_term: enzyme replacement or supplementation therapy
     term:
-      id: MAXO:0000058
-      label: pharmacotherapy
+      id: MAXO:0000933
+      label: enzyme replacement or supplementation therapy
+  target_phenotypes:
+  - preferred_term: Hypertrophic cardiomyopathy
+    term:
+      id: HP:0001639
+      label: Hypertrophic cardiomyopathy
+  - preferred_term: Proximal muscle weakness
+    term:
+      id: HP:0003701
+      label: Proximal muscle weakness
+  - preferred_term: Respiratory insufficiency due to muscle weakness
+    term:
+      id: HP:0002747
+      label: Respiratory insufficiency due to muscle weakness
+  target_mechanisms:
+  - target: Lysosomal glycogen accumulation
+    treatment_effect: MODULATES
+    description: Recombinant human GAA supplies the deficient lysosomal enzyme upstream of glycogen storage.
+    evidence:
+    - reference: PMID:17151339
+      reference_title: "Recombinant human acid [alpha]-glucosidase: major clinical benefits in infantile-onset Pompe disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Recombinant human acid alpha-glucosidase is safe and effective for treatment of infantile-onset Pompe disease."
+      explanation: Clinical trial evidence supports rhGAA as enzyme replacement therapy for the upstream GAA deficiency.
   evidence:
   - reference: PMID:17151339
     reference_title: "Recombinant human acid [alpha]-glucosidase: major clinical benefits in infantile-onset Pompe disease."
@@ -743,6 +799,15 @@ treatments:
       term:
         id: CHEBI:50381
         label: miglustat
+  target_phenotypes:
+  - preferred_term: Proximal muscle weakness
+    term:
+      id: HP:0003701
+      label: Proximal muscle weakness
+  - preferred_term: Respiratory insufficiency due to muscle weakness
+    term:
+      id: HP:0002747
+      label: Respiratory insufficiency due to muscle weakness
   evidence:
   - reference: PMID:34800400
     reference_title: "Safety and efficacy of cipaglucosidase alfa plus miglustat versus alglucosidase alfa plus placebo in late-onset Pompe disease (PROPEL): an international, randomised, double-blind, parallel-group, phase 3 trial."
@@ -756,10 +821,15 @@ treatments:
     required for respiratory insufficiency. Many LOPD patients require nocturnal
     ventilatory support, and some progress to continuous ventilator dependence.
   treatment_term:
-    preferred_term: Respiratory support
+    preferred_term: artificial respiration
     term:
-      id: MAXO:0000950
-      label: supportive care
+      id: MAXO:0000503
+      label: artificial respiration
+  target_phenotypes:
+  - preferred_term: Respiratory insufficiency due to muscle weakness
+    term:
+      id: HP:0002747
+      label: Respiratory insufficiency due to muscle weakness
   evidence:
   - reference: PMID:22173792
     reference_title: "Consensus treatment recommendations for late-onset Pompe disease."
@@ -783,6 +853,15 @@ treatments:
     term:
       id: MAXO:0000011
       label: physical therapy
+  target_phenotypes:
+  - preferred_term: Proximal muscle weakness
+    term:
+      id: HP:0003701
+      label: Proximal muscle weakness
+  - preferred_term: Exercise intolerance
+    term:
+      id: HP:0003546
+      label: Exercise intolerance
   evidence:
   - reference: PMID:31811531
     reference_title: "Adapted physical activity and therapeutic exercise in late-onset Pompe disease (LOPD): a two-step rehabilitative approach."


### PR DESCRIPTION
## Summary

- Adds downstream pathograph edges from skeletal/respiratory myofiber injury to proximal myopathy and respiratory insufficiency.
- Adds a downstream edge from cardiomyocyte glycogen storage/remodeling to hypertrophic cardiomyopathy.
- Connects Pompe therapies to supported target phenotypes, and connects enzyme replacement therapy to the upstream lysosomal glycogen accumulation mechanism.
- Uses the more specific MAXO `artificial respiration` term for respiratory support.

## Review

A subagent reviewed the first draft and flagged weak mechanism claims. I removed the weak myofiber-injury treatment target mechanisms and the weak exercise-intolerance causal edge; the re-review found no remaining blockers.

## Validation

- `just validate kb/disorders/Pompe_Disease.yaml`
- `just validate-references kb/disorders/Pompe_Disease.yaml`
- `just validate-terms kb/disorders/Pompe_Disease.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Pompe_Disease.yaml`
- `git diff --check`

Validator-produced ClinicalTrials cache churn was restored before commit.
