### PR TITLE
Connect Lesch-Nyhan pathograph

### DIFF
--- a/kb/disorders/Lesch-Nyhan_Syndrome.yaml
+++ b/kb/disorders/Lesch-Nyhan_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Lesch-Nyhan Syndrome
 creation_date: "2026-03-22T07:38:41Z"
-updated_date: "2026-05-01T12:00:00Z"
+updated_date: "2026-05-10T03:39:10Z"
 category: Mendelian
 description: >-
   Lesch-Nyhan syndrome is an X-linked recessive disorder of purine metabolism caused by
@@ -234,6 +234,34 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Uric acid overproduction is present inall HPRT-deficient patients and is associated with lithiasis and gout."
     explanation: Confirms universal uric acid overproduction across all HPRT deficiency phenotypes.
+  downstream:
+  - target: Hyperuricemia
+    description: HPRT-deficiency-driven uric acid overproduction causes hyperuricemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22198833
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All of these phenotypes are associated with marked overproduction of uric acid and related problems such as hyperuricemia, urate nephrolithiasis, tophi, and gout."
+      explanation: Directly lists hyperuricemia among the uric-acid overproduction complications of HPRT deficiency.
+  - target: Gout
+    description: Uric acid overproduction leads to monosodium urate crystal arthropathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:19259384
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "LND is characterized by overproduction of uric acid, leading to gouty arthritis and nephrolithiasis."
+      explanation: Directly links uric acid overproduction to gouty arthritis.
+  - target: Nephrolithiasis
+    description: Urate excess causes uric acid nephrolithiasis in the urinary tract.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:19259384
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "LND is characterized by overproduction of uric acid, leading to gouty arthritis and nephrolithiasis."
+      explanation: Directly links uric acid overproduction to nephrolithiasis.
 - name: Basal Ganglia Dopaminergic Dysfunction
   description: >-
     HPRT deficiency leads to profound dopaminergic dysfunction in the basal ganglia,
@@ -284,6 +312,54 @@ pathophysiology:
     evidence_source: MODEL_ORGANISM
     snippet: "One of the hallmarks of LNS is maximal expression of HPRT in the central nervous system with the highest activity of this enzyme in the midbrain and basal ganglia."
     explanation: Demonstrates that HPRT is maximally expressed in the midbrain and basal ganglia, explaining why these regions are most affected in LNS.
+  downstream:
+  - target: Dystonia
+    description: Basal ganglia dopaminergic dysfunction contributes to the severe movement disorder dominated by generalized dystonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:10760551
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These findings support the proposal that many of the neurobehavioral features of LND might be related to dysfunction of the basal ganglia."
+      explanation: Human neurochemical evidence supports a basal-ganglia contribution to LND neurobehavioral manifestations.
+    - reference: PMID:24891139
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "a characteristic neurobehavioral phenotype that includes a movement disorder dominated by generalized dystonia, intellectual disability, and recurrent self-injurious behavior."
+      explanation: Human neuropathology study connects the LND neurobehavioral phenotype with generalized dystonia, intellectual disability, and self-injury.
+    - reference: PMID:24891139
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "the major motor problem is dystonia, a movement disorder that has been linked with early developmental dysfunction of dopamine pathways and the motor circuit of the basal ganglia involving the putamen and motor cortex."
+      explanation: Review text in a human neuropathology study specifically links dystonia to developmental dysfunction of basal-ganglia dopamine pathways.
+  - target: Choreoathetosis
+    description: Basal ganglia dysfunction contributes to the hyperkinetic movement disorder that includes choreoathetosis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:10760551
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Affected individuals have severe motor disability described by prominent extrapyramidal features that are characteristic of dysfunction of the motor circuits of the basal ganglia."
+      explanation: Human review links the extrapyramidal motor disability of LND to dysfunction of basal-ganglia motor circuits.
+    - reference: PMID:18067674
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Neurological manifestations include severe action dystonia, choreoathetosis, ballismus, cognitive and attention deficit, and self-injurious behaviour."
+      explanation: Clinical review lists choreoathetosis within the neurological manifestations of HPRT deficiency.
+  - target: Self-injurious behavior
+    description: Basal ganglia dysfunction is implicated in the hallmark compulsive self-injury phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:10760551
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These findings support the proposal that many of the neurobehavioral features of LND might be related to dysfunction of the basal ganglia."
+      explanation: Human neurochemical evidence supports a basal-ganglia contribution to LND neurobehavioral features including self-injury.
+    - reference: PMID:24891139
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The behavioral phenotype, in particular self-injurious behavior, has been linked with early brain dopamine loss in the limbic circuit involving the ventral striatum and orbitofrontal cortex."
+      explanation: Review text in a human neuropathology study specifically links self-injurious behavior to early dopamine loss in a basal-ganglia limbic circuit.
 - name: Mitochondrial Energy Metabolism Disruption
   description: >-
     HPRT1 deficiency inhibits complex I-dependent mitochondrial respiration,
@@ -389,7 +465,7 @@ phenotypes:
   - reference: PMID:24891139
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Lesch-Nyhan disease (LND) is an inherited disorder with a characteristic neurobehavioral phenotype that includes a movement disorder dominated by generalized dystonia, intellectual disability, and recurrent self-injurious behavior."
+    snippet: "a characteristic neurobehavioral phenotype that includes a movement disorder dominated by generalized dystonia, intellectual disability, and recurrent self-injurious behavior."
     explanation: Characterizes the movement disorder as dominated by generalized dystonia.
 - category: Neurological
   name: Choreoathetosis
@@ -707,6 +783,29 @@ treatments:
       term:
         id: CHEBI:40279
         label: allopurinol
+  target_phenotypes:
+  - preferred_term: Hyperuricemia
+    term:
+      id: HP:0002149
+      label: Hyperuricemia
+  - preferred_term: Gout
+    term:
+      id: HP:0001997
+      label: Gout
+  - preferred_term: Uric acid nephrolithiasis
+    term:
+      id: HP:0000791
+      label: Uric acid nephrolithiasis
+  target_mechanisms:
+  - target: Hyperuricemia and Gout
+    treatment_effect: INHIBITS
+    description: Allopurinol reduces uric acid overproduction and thereby treats the urate-complication branch of the pathograph.
+    evidence:
+    - reference: PMID:18067674
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Uric acid overproduction can be managed by allopurinol treatment."
+      explanation: Clinical review supports allopurinol treatment for the uric-acid overproduction mechanism.
   evidence:
   - reference: PMID:18067674
     supports: SUPPORT
@@ -723,6 +822,11 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_phenotypes:
+  - preferred_term: Self-injurious behavior
+    term:
+      id: HP:0100716
+      label: Self-injurious behavior
   evidence:
   - reference: PMID:18067674
     supports: SUPPORT
@@ -738,6 +842,15 @@ treatments:
     term:
       id: MAXO:0000011
       label: physical therapy
+  target_phenotypes:
+  - preferred_term: Dysarthria
+    term:
+      id: HP:0001260
+      label: Dysarthria
+  - preferred_term: Dysphagia
+    term:
+      id: HP:0002015
+      label: Dysphagia
   evidence:
   - reference: PMID:18067674
     supports: SUPPORT
@@ -756,6 +869,15 @@ treatments:
     term:
       id: MAXO:0000943
       label: deep brain stimulation
+  target_phenotypes:
+  - preferred_term: Dystonia
+    term:
+      id: HP:0001332
+      label: Dystonia
+  - preferred_term: Self-injurious behavior
+    term:
+      id: HP:0100716
+      label: Self-injurious behavior
   evidence:
   - reference: PMID:36694014
     supports: SUPPORT


### PR DESCRIPTION
## Summary
- Added downstream causal links from the urate-complication mechanism to hyperuricemia, gout, and nephrolithiasis.
- Added basal-ganglia downstream links to dystonia, choreoathetosis, and self-injurious behavior with human evidence.
- Added treatment target phenotypes for allopurinol, behavioral/supportive care, physical rehabilitation, and DBS; added an allopurinol target-mechanism link to the urate branch.
- Fixed an existing PMID:24891139 snippet to avoid an ASCII/en-dash mismatch against the cached source.

## Review
- Focused subagent review initially flagged two important blockers: non-exact PMID:24891139 snippets and an over-specific basal-ganglia to intellectual-disability edge.
- Addressed both by using exact cached substrings and removing the intellectual-disability downstream edge.
- Re-review found no remaining important blockers.

## Validation
- `just validate kb/disorders/Lesch-Nyhan_Syndrome.yaml`
- `just validate-references kb/disorders/Lesch-Nyhan_Syndrome.yaml`
- `just validate-terms kb/disorders/Lesch-Nyhan_Syndrome.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Lesch-Nyhan_Syndrome.yaml`
- `git diff --check`
- local normalized snippet audit: 72 checked, 0 failures

Note: `just validate-references` currently reports zero checks for this file locally, so I also ran the normalized snippet audit over the cached references.
