### PR TITLE
Connect COG7-CDG pathograph

### DIFF
--- a/kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml
+++ b/kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml
@@ -1,6 +1,6 @@
 name: COG7-congenital disorder of glycosylation
 creation_date: "2026-05-09T12:45:18Z"
-updated_date: "2026-05-09T22:34:54Z"
+updated_date: "2026-05-10T04:20:48Z"
 description: >-
   COG7-congenital disorder of glycosylation is a rare autosomal recessive
   congenital disorder of glycosylation caused by biallelic COG7 variants.
@@ -66,7 +66,7 @@ pathophysiology:
   - reference: PMID:15107842
     reference_title: Mutation of the COG complex subunit gene COG7 causes a lethal congenital disorder.
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: IN_VITRO
     snippet: >-
       The mutation impairs integrity of the COG complex and alters Golgi
       trafficking, resulting in disruption of multiple glycosylation pathways.
@@ -79,6 +79,30 @@ pathophysiology:
       Loss of COG-complex integrity disrupts Golgi trafficking and enzyme
       compartmentalization, mislocalizing glycosylation machinery.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:15107842
+      reference_title: Mutation of the COG complex subunit gene COG7 causes a lethal congenital disorder.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        The mutation impairs integrity of the COG complex and alters Golgi
+        trafficking, resulting in disruption of multiple glycosylation
+        pathways.
+      explanation: >-
+        The causal COG7 mutation directly links impaired COG-complex integrity
+        with altered Golgi trafficking and downstream glycosylation disruption.
+    - reference: PMID:17904886
+      reference_title: Deficiencies in subunits of the Conserved Oligomeric Golgi (COG) complex define a novel group of Congenital Disorders of Glycosylation.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        If the balance is disturbed, the glycosylation machinery is
+        mislocalized, which can cause Congenital Disorders of Glycosylation type
+        II (CDG-II), as illustrated by the identification of congenital defects
+        in the Conserved Oligomeric Golgi (COG) complex in humans.
+      explanation: >-
+        The review explicitly connects COG-complex defects with mislocalized
+        glycosylation machinery.
 - name: Mislocalized Golgi Glycosylation Machinery
   description: >-
     Disturbed anterograde and retrograde Golgi trafficking mislocalizes
@@ -126,6 +150,29 @@ pathophysiology:
       Mislocalized Golgi enzymes impair maturation of both N-linked and
       O-linked glycoproteins.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17904886
+      reference_title: Deficiencies in subunits of the Conserved Oligomeric Golgi (COG) complex define a novel group of Congenital Disorders of Glycosylation.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        If the balance is disturbed, the glycosylation machinery is
+        mislocalized, which can cause Congenital Disorders of Glycosylation type
+        II (CDG-II), as illustrated by the identification of congenital defects
+        in the Conserved Oligomeric Golgi (COG) complex in humans.
+      explanation: >-
+        The review connects disturbed Golgi trafficking balance and
+        mislocalized glycosylation machinery to COG-related CDG-II.
+    - reference: PMID:17904886
+      reference_title: Deficiencies in subunits of the Conserved Oligomeric Golgi (COG) complex define a novel group of Congenital Disorders of Glycosylation.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        COG defects are a novel group of CDG-II with deficient N- as well as
+        O-glycosylation.
+      explanation: >-
+        The same review specifically supports combined N- and O-glycosylation
+        deficiency in COG defects.
 - name: Combined N- and O-glycosylation Defect
   description: >-
     COG7-CDG produces a type II CDG biochemical pattern with defective
@@ -158,11 +205,82 @@ pathophysiology:
       Deficient N- and O-glycosylation produces abnormal glycoprotein
       glycosylation profiles.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:17904886
+      reference_title: Deficiencies in subunits of the Conserved Oligomeric Golgi (COG) complex define a novel group of Congenital Disorders of Glycosylation.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        COG defects are a novel group of CDG-II with deficient N- as well as
+        O-glycosylation.
+      explanation: >-
+        The review directly supports abnormal glycosylation as the biochemical
+        manifestation of deficient N- and O-glycosylation in COG defects.
+  - target: Type II-like serum transferrin isoelectric focusing pattern
+    description: >-
+      Defective N-glycan processing is reflected by a type II-like
+      sialotransferrin isoelectric focusing pattern.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16151902
+      reference_title: Clinical and biochemical presentation of siblings with COG-7 deficiency, a lethal multiple O- and N-glycosylation disorder.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Isoelectric focusing of serum sialotransferrins showed a type 2-like
+        CDG pattern.
+      explanation: >-
+        Serum sialotransferrin IEF is a direct biochemical readout of the
+        N-glycosylation component of the combined glycosylation defect.
+  - target: Hyposialylated apolipoprotein C-III isoforms
+    description: >-
+      Defective O-glycosylation is reflected by increased hyposialylated
+      apolipoprotein C-III isoforms.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16151902
+      reference_title: Clinical and biochemical presentation of siblings with COG-7 deficiency, a lethal multiple O- and N-glycosylation disorder.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        O-Glycosylation was investigated by isoelectric focusing of
+        apolipoprotein C-III, which showed increased fractions of hyposialylated
+        isoforms.
+      explanation: >-
+        Apolipoprotein C-III IEF directly reports the O-glycosylation arm of
+        the combined biochemical defect.
+  - target: Decreased total plasma sialic acid
+    description: >-
+      Global Golgi glycosylation disruption is reflected by markedly decreased
+      total plasma sialic acid.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:16151902
+      reference_title: Clinical and biochemical presentation of siblings with COG-7 deficiency, a lethal multiple O- and N-glycosylation disorder.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "total sialic acid in plasma was strongly decreased"
+      explanation: >-
+        Decreased total plasma sialic acid is a directly reported biochemical
+        consequence in affected siblings with the multiple Golgi glycosylation
+        defect.
   - target: Severe Liver Disease
     description: >-
       Multisystem glycoprotein biosynthesis defects contribute to severe
       infantile liver disease.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:16151902
+      reference_title: Clinical and biochemical presentation of siblings with COG-7 deficiency, a lethal multiple O- and N-glycosylation disorder.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We report on two dysmorphic siblings with severe liver disease who died
+        at the age of a few weeks.
+      explanation: >-
+        Human sibling cases with COG7-related combined glycosylation defects
+        directly support severe infantile liver disease as a clinical
+        consequence.
 phenotypes:
 - name: Abnormal Glycosylation
   category: Biochemical
@@ -214,12 +332,27 @@ phenotypes:
     explanation: >-
       This directly supports severe liver disease and early lethality in
       affected siblings.
+  sequelae:
+  - target: Fatal Infantile Course
+    description: >-
+      Severe liver disease in the reported affected siblings was associated
+      with death within the first weeks of life.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:16151902
+      reference_title: Clinical and biochemical presentation of siblings with COG-7 deficiency, a lethal multiple O- and N-glycosylation disorder.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We report on two dysmorphic siblings with severe liver disease who died
+        at the age of a few weeks.
+      explanation: >-
+        The same sibling report links severe liver disease with death during
+        early infancy.
 - name: Fatal Infantile Course
   category: Clinical
   description: >-
     The earliest reported affected siblings died within the first weeks of life.
-  phenotype_term:
-    preferred_term: Death in infancy
   evidence:
   - reference: PMID:16151902
     reference_title: Clinical and biochemical presentation of siblings with COG-7 deficiency, a lethal multiple O- and N-glycosylation disorder.


### PR DESCRIPTION
## Summary
- Added exact-evidence support to the existing COG7 pathophysiology edges from COG-complex destabilization through Golgi machinery mislocalization to combined N- and O-glycosylation defects.
- Connected the combined glycosylation defect to biochemical readouts: abnormal glycosylation, type II-like transferrin IEF, hyposialylated apolipoprotein C-III, and decreased total plasma sialic acid.
- Added a phenotype sequela from severe liver disease to fatal infantile course, supported by the original affected-sibling report.
- Kept broader clinical findings out because the cached abstracts do not support them specifically.

## Review
- Focused subagent review initially flagged one blocker: the mislocalized-machinery to combined N/O-glycosylation edge needed evidence explicitly supporting both N- and O-glycosylation.
- Addressed by adding the PMID:17904886 exact snippet: `COG defects are a novel group of CDG-II with deficient N- as well as O-glycosylation.`
- Re-review found no remaining important blockers.

## Validation
- `just validate kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml`
- `just validate-references kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml`
- `just validate-terms kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml`
- `git diff --check`
- local normalized snippet audit: 28 checked, 0 failures

Note: `just validate-references` currently reports zero checks for this file locally, so I also ran the normalized snippet audit over the cached references.
