### PR TITLE
Improve OAT deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/ornithine_aminotransferase_deficiency.yaml
+++ b/kb/disorders/ornithine_aminotransferase_deficiency.yaml
@@ -1,6 +1,6 @@
 name: ornithine aminotransferase deficiency
 creation_date: "2026-04-15T17:35:00Z"
-updated_date: "2026-05-02T00:00:00Z"
+updated_date: "2026-05-10T05:06:34Z"
 description: >-
   Ornithine aminotransferase deficiency is a rare autosomal recessive amino acid
   metabolism disorder caused by OAT dysfunction and classically presenting as
@@ -82,6 +82,18 @@ pathophysiology:
   downstream:
   - target: Hyperornithinemia
     description: Loss of OAT activity causes elevated plasma ornithine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33068755
+      reference_title: "Deficit of human ornithine aminotransferase in gyrate atrophy: Molecular, cellular, and clinical aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        OAT is mainly involved in ornithine catabolism in adults, thus
+        explaining the hyperornithinemia as hallmark of the disease.
+      explanation: >-
+        Human review directly links loss of OAT-mediated ornithine catabolism
+        to hyperornithinemia.
 - name: Hyperornithinemia
   description: >-
     Loss of ornithine aminotransferase activity causes marked plasma ornithine
@@ -113,10 +125,62 @@ pathophysiology:
   downstream:
   - target: Progressive chorioretinal degeneration
     description: Sustained hyperornithinemia drives the retinal degenerative process.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:10655512
+      reference_title: "Correction of ornithine accumulation prevents retinal degeneration in a mouse model of gyrate atrophy of the choroid and retina."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        This result indicates that ornithine accumulation is a necessary factor
+        in the pathophysiology of the retinal degeneration in GA
+      explanation: >-
+        Oat-deficient mouse data support ornithine accumulation as necessary for
+        retinal degeneration.
+    - reference: PMID:34894815
+      reference_title: "Gyrate Atrophy of the Choroid and Retina: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Accumulation of ornithine occurs in various body tissues but leads
+        primarily to characteristic ophthalmic manifestations including myopia,
+        cataract, progressive chorioretinal atrophy, and macular changes.
+      explanation: >-
+        Human clinical review connects ornithine accumulation to the
+        characteristic ophthalmic manifestations.
+  - target: Plasma ornithine
+    description: Hyperornithinemia is measured as elevated plasma ornithine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1186/s13023-026-04265-x
+      reference_title: "Gyrate atrophy of the choroid and retina: a tertiary center experience"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        All patients had high plasma ornithine levels at the time of diagnosis,
+        and they were all started on an arginine-restricted diet.
+      explanation: >-
+        Cohort evidence directly supports elevated plasma ornithine as the
+        measured biochemical expression of hyperornithinemia.
+  - target: Cataract
+    description: Ornithine accumulation contributes to cataract as part of the ocular disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34894815
+      reference_title: "Gyrate Atrophy of the Choroid and Retina: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Accumulation of ornithine occurs in various body tissues but leads
+        primarily to characteristic ophthalmic manifestations including myopia,
+        cataract, progressive chorioretinal atrophy, and macular changes.
+      explanation: >-
+        Review lists cataract among the characteristic ophthalmic manifestations
+        associated with ornithine accumulation.
 - name: Progressive chorioretinal degeneration
   description: >-
     The downstream ophthalmologic disease causes progressive retinal and choroidal
-    damage that drives nyctalopia, cataract, and visual decline.
+    damage that drives nyctalopia, visual field constriction, and visual decline.
   evidence:
   - reference: DOI:10.1186/s13023-026-04265-x
     reference_title: "Gyrate atrophy of the choroid and retina: a tertiary center experience"
@@ -140,10 +204,64 @@ pathophysiology:
   downstream:
   - target: Nyctalopia
     description: Chorioretinal degeneration leads to early night blindness.
-  - target: Cataract
-    description: Progressive ocular disease contributes to cataract formation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34894815
+      reference_title: "Gyrate Atrophy of the Choroid and Retina: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Patients usually present with night blindness that starts in the first
+        decade of life followed by visual field constriction and eventually
+        diminution of the central visual acuity and blindness.
+      explanation: >-
+        Review describes night blindness as the first manifestation in the
+        progressive ophthalmologic sequence.
+  - target: Chorioretinal atrophy
+    description: Progressive retinal and choroidal degeneration manifests as chorioretinal atrophy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34894815
+      reference_title: "Gyrate Atrophy of the Choroid and Retina: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Accumulation of ornithine occurs in various body tissues but leads
+        primarily to characteristic ophthalmic manifestations including myopia,
+        cataract, progressive chorioretinal atrophy, and macular changes.
+      explanation: >-
+        Review identifies progressive chorioretinal atrophy as a characteristic
+        ophthalmic manifestation of gyrate atrophy.
+  - target: Constriction of peripheral visual field
+    description: Peripheral retinal degeneration causes progressive visual field constriction.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34894815
+      reference_title: "Gyrate Atrophy of the Choroid and Retina: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Patients usually present with night blindness that starts in the first
+        decade of life followed by visual field constriction and eventually
+        diminution of the central visual acuity and blindness.
+      explanation: >-
+        Review places visual field constriction after night blindness in the
+        progressive ophthalmologic course.
   - target: Visual loss
     description: Ongoing retinal degeneration causes progressive visual loss.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34894815
+      reference_title: "Gyrate Atrophy of the Choroid and Retina: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Patients usually present with night blindness that starts in the first
+        decade of life followed by visual field constriction and eventually
+        diminution of the central visual acuity and blindness.
+      explanation: >-
+        Review supports progressive loss of central visual acuity and blindness
+        as downstream outcomes of ocular degeneration.
 phenotypes:
 - name: Nyctalopia
   category: Ophthalmologic
@@ -487,6 +605,36 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_phenotypes:
+  - preferred_term: Hyperornithinemia
+    term:
+      id: HP:0012026
+      label: Hyperornithinemia
+  target_mechanisms:
+  - target: Hyperornithinemia
+    treatment_effect: INHIBITS
+    description: >-
+      Arginine or protein restriction lowers ornithine burden, targeting the
+      central hyperornithinemia node upstream of retinal degeneration.
+    evidence:
+    - reference: PMID:34340878
+      reference_title: "A review of treatment modalities in gyrate atrophy of the choroid and retina (GACR)."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Protein-restricted diets lowered ornithine levels ranging from 16.0-91.2%."
+      explanation: >-
+        Systematic review directly supports dietary protein or arginine
+        restriction reducing the hyperornithinemia treatment target.
+    - reference: PMID:10655512
+      reference_title: "Correction of ornithine accumulation prevents retinal degeneration in a mouse model of gyrate atrophy of the choroid and retina."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        an arginine-restricted diet substantially reduces plasma ornithine
+        levels and completely prevents retinal degeneration in Oat(-/-)
+      explanation: >-
+        Oat-deficient mouse data support arginine restriction lowering plasma
+        ornithine and preventing retinal degeneration.
   evidence:
   - reference: DOI:10.1186/s13023-026-04265-x
     reference_title: "Gyrate atrophy of the choroid and retina: a tertiary center experience"
@@ -531,6 +679,29 @@ treatments:
       term:
         id: CHEBI:16709
         label: pyridoxine
+  target_phenotypes:
+  - preferred_term: Hyperornithinemia
+    term:
+      id: HP:0012026
+      label: Hyperornithinemia
+  target_mechanisms:
+  - target: Hyperornithinemia
+    treatment_effect: MODULATES
+    description: >-
+      Pyridoxine can reduce ornithine levels in responsive OAT variants, so it
+      is modeled as variant-dependent modulation of the hyperornithinemia node.
+    evidence:
+    - reference: PMID:34340878
+      reference_title: "A review of treatment modalities in gyrate atrophy of the choroid and retina (GACR)."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Based primarily on case reports ornithine levels can be reduced by
+        using a protein restricted diet, pyridoxine supplementation
+        (variation-dependent) and/or lysine supplementation.
+      explanation: >-
+        Systematic review supports variant-dependent ornithine reduction with
+        pyridoxine supplementation.
   evidence:
   - reference: DOI:10.1186/s13023-026-04265-x
     reference_title: "Gyrate atrophy of the choroid and retina: a tertiary center experience"


### PR DESCRIPTION
## Summary
- Add evidence-backed causal edges from OAT deficiency to hyperornithinemia and from hyperornithinemia to retinal/biochemical/ocular outcomes
- Add downstream retinal disease edges for chorioretinal atrophy, visual field constriction, and visual loss progression
- Add mechanism targets for arginine-restricted diet and pyridoxine supplementation against hyperornithinemia

## Validation
- `just validate kb/disorders/ornithine_aminotransferase_deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/ornithine_aminotransferase_deficiency.yaml`
- `git diff --check`
- Local normalized snippet audit: 47 snippets checked across 9 refs, 0 missing caches, 0 failures

## Notes
- Restored validator-generated ClinicalTrials cache churn before committing; only the OAT disorder YAML is in scope.