### PR TITLE
Improve COQ8A ataxia pathograph connectivity

### DIFF
--- a/kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml
+++ b/kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Recessive Ataxia Due to Ubiquinone Deficiency
 creation_date: "2026-04-23T00:00:00Z"
-updated_date: "2026-05-05T16:40:30Z"
+updated_date: "2026-05-10T05:37:16Z"
 category: Neurological Disorder
 parents:
 - Mendelian Disorder
@@ -56,6 +56,18 @@ pathophysiology:
   downstream:
   - target: Impaired Oxidative Phosphorylation
     description: Reduced CoQ10 availability compromises mitochondrial energy transfer.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.3390/metabo12100955
+      reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        COQ8A-ataxia is a mitochondrial disease in which a defect in coenzyme
+        Q10 synthesis leads to dysfunction of the respiratory chain.
+      explanation: >-
+        Human clinical review directly links the CoQ10 synthesis defect to
+        respiratory-chain dysfunction.
 - name: Impaired Oxidative Phosphorylation
   description: >-
     Reduced coenzyme Q10 availability impairs respiratory-chain function and
@@ -85,6 +97,18 @@ pathophysiology:
   downstream:
   - target: Progressive Cerebellar Neurodegeneration
     description: Energy failure drives selective cerebellar vulnerability and progressive ataxia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.3390/metabo12100955
+      reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The disease is usually present as childhood-onset progressive ataxia
+        with developmental regression and cerebellar atrophy.
+      explanation: >-
+        Review supports progressive cerebellar ataxia and cerebellar atrophy as
+        downstream manifestations of COQ8A-related respiratory-chain disease.
 - name: Progressive Cerebellar Neurodegeneration
   description: >-
     COQ8A-related ubiquinone deficiency preferentially injures cerebellar
@@ -114,8 +138,30 @@ pathophysiology:
   downstream:
   - target: Ataxia
     description: Cerebellar system degeneration produces the core ataxic phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        COQ8A‐ataxia presented as variable multisystemic, early‐onset
+        cerebellar ataxia,
+      explanation: >-
+        Cohort evidence identifies early-onset cerebellar ataxia as the central
+        manifestation of cerebellar involvement.
   - target: Cerebellar Atrophy
     description: Structural cerebellar volume loss is the imaging hallmark of disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cerebellar atrophy was universal on MRI (100%),
+      explanation: >-
+        Cohort evidence supports cerebellar atrophy as the universal structural
+        consequence of cerebellar disease.
 phenotypes:
 - name: Ataxia
   description: >-
@@ -200,6 +246,28 @@ phenotypes:
     explanation: >-
       This directly supports cognitive impairment as a common multisystem
       manifestation.
+- name: Developmental Regression
+  description: >-
+    Developmental regression can occur in childhood-onset COQ8A ataxia as part
+    of the broader neurodevelopmental presentation.
+  phenotype_term:
+    preferred_term: developmental regression
+    term:
+      id: HP:0002376
+      label: Developmental regression
+    onset:
+      onset_category: CHILDHOOD
+  evidence:
+  - reference: DOI:10.3390/metabo12100955
+    reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The disease is usually present as childhood-onset progressive ataxia with
+      developmental regression and cerebellar atrophy.
+    explanation: >-
+      Review directly names developmental regression as part of the usual
+      childhood-onset presentation.
 - name: Exercise Intolerance
   description: >-
     Exercise intolerance reflects broader mitochondrial energy failure beyond
@@ -405,6 +473,28 @@ treatments:
   - target: COQ8A-Dependent Coenzyme Q10 Deficiency
     treatment_effect: RESTORES
     description: Replacement therapy addresses the primary ubiquinone deficiency state.
+    evidence:
+    - reference: DOI:10.3390/metabo12100955
+      reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        COQ8A-ataxia is a potentially treatable condition with the
+        supplementation of coenzyme Q10 as a main therapy;
+      explanation: >-
+        Review supports CoQ10 supplementation as replacement therapy for the
+        primary coenzyme Q deficiency state.
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        CoQ10 treatment led to improvement by clinical report in 14 of 30
+        patients, and by quantitative longitudinal assessments in 8 of 11
+        patients
+      explanation: >-
+        Cohort treatment-response data support CoQ10 as a disease-targeted
+        mechanism intervention.
   evidence:
   - reference: DOI:10.3390/metabo12100955
     reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency


### PR DESCRIPTION
## Summary
- Add evidence and causal-link types to the existing COQ8A deficiency -> impaired oxidative phosphorylation -> cerebellar neurodegeneration -> ataxia/cerebellar atrophy path
- Add developmental regression as a supported phenotype from the cached Metabolites review
- Add evidence to the existing CoQ10 supplementation mechanism target

## Validation
- `just validate kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml`
- `git diff --check`
- Local normalized snippet audit: 26 snippets checked across 2 DOI refs, 0 missing caches, 0 failures

## Notes
- A broader multisystemic mechanism node was considered during local review but removed because the available snippets support clinical spectrum rather than a distinct mechanistic intermediate.
- Restored validator-generated ClinicalTrials cache churn before committing; only the COQ8A disorder YAML is in scope.