### PR TITLE
Improve Adenosine Kinase Deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Adenosine_Kinase_Deficiency.yaml
+++ b/kb/disorders/Adenosine_Kinase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Adenosine Kinase Deficiency
 creation_date: "2026-04-16T00:00:00Z"
-updated_date: "2026-04-16T22:40:00Z"
+updated_date: "2026-05-10T06:39:28Z"
 category: Mendelian
 description: >-
   Adenosine kinase deficiency is a rare autosomal recessive inborn error of
@@ -88,21 +88,22 @@ pathophysiology:
     explanation: >-
       The abstract directly identifies the core biochemical lesion and the
       major organ systems affected by ADK loss of function.
-  - reference: PMID:27903722
-    supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
-    snippet: >-
-      ADK deficiency in human patients (OMIM:614300) disrupts the methionine
-      cycle and triggers hypermethioninemia, hepatic encephalopathy,
-      cognitive impairment, and seizures.
-    explanation: >-
-      The mouse-model paper states the human disease mechanism and links it
-      to the brain and liver phenotypes.
   downstream:
   - target: Adenosine Accumulation and AMP Depletion
     description: >-
       Loss of ADK activity shifts adenosine away from AMP generation and
       raises intracellular and extracellular adenosine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        This defect disrupts the adenosine/AMP futile cycle and interferes
+        with the upstream methionine cycle.
+      explanation: >-
+        The human case-series abstract directly links ADK deficiency to
+        disruption of the adenosine/AMP cycle.
 - name: Adenosine Accumulation and AMP Depletion
   description: >-
     Excess adenosine and reduced AMP availability alter purine homeostasis,
@@ -139,6 +140,48 @@ pathophysiology:
     description: >-
       Adenosine accumulation drives the S-adenosylhomocysteine hydrolase
       reaction backward and impairs methylation flux.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        This defect disrupts the adenosine/AMP futile cycle and interferes
+        with the upstream methionine cycle.
+      explanation: >-
+        The same clinical report connects disrupted adenosine/AMP cycling to
+        upstream methionine-cycle interference.
+  - target: Neurodevelopmental Impairment and Seizures
+    description: >-
+      Elevated brain adenosine alters adenosine receptor signaling and synaptic
+      plasticity, contributing to cognitive impairment and seizure risk.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - adenosine receptor signaling
+    - dysregulated synaptic plasticity
+    evidence:
+    - reference: PMID:27903722
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        Pharmacological, biochemical, and electrophysiological studies
+        suggest enhanced adenosine levels around synapses resulting in an
+        enhanced adenosine A1 receptor (A1R)-dependent protective tone
+        despite lower expression levels of the receptor.
+      explanation: >-
+        Brain-specific ADK deficiency raises synaptic adenosine, and the same
+        model links altered adenosine receptor signaling to neurologic
+        phenotypes.
+    - reference: PMID:27903722
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        We conclude that ADK deficiency in the brain triggers neuronal
+        adaptation processes that lead to dysregulated synaptic plasticity,
+        cognitive deficits, and increased seizure risk.
+      explanation: >-
+        The same mouse model links brain ADK deficiency and downstream synaptic
+        adaptation to cognitive deficits and seizure risk.
 - name: Transmethylation Cycle Disruption and Hypermethioninemia
   description: >-
     Accumulation of adenosine and S-adenosylhomocysteine perturbs one-carbon
@@ -196,10 +239,50 @@ pathophysiology:
     description: >-
       The biochemical block is most evident in the liver and can present as
       neonatal or early infantile liver disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        ADK deficiency is a cause of neonatal or early infantile liver disease
+        that may mimic primary mitochondrial disorders.
+      explanation: >-
+        The clinical series directly supports ADK-related metabolic disruption
+        as a cause of early liver disease.
   - target: Neurodevelopmental Impairment and Seizures
     description: >-
       Methionine cycle disruption and excess adenosine also affect the
       central nervous system.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Adenosine kinase (ADK) deficiency is characterized by liver disease,
+        dysmorphic features, epilepsy and developmental delay. This defect
+        disrupts the adenosine/AMP futile cycle and interferes with the
+        upstream methionine cycle.
+      explanation: >-
+        The human case series links ADK metabolic disruption with epilepsy and
+        developmental delay, while the exact biochemical-to-neurologic
+        intermediates remain incompletely resolved.
+  - target: Hypermethioninemia
+    description: >-
+      Disrupted methionine-cycle flux produces the characteristic elevated
+      plasma methionine phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        methionine level in patients with ADK deficiency was strongly
+        increased compared with patients with other liver diseases.
+      explanation: >-
+        The patient cohort directly supports hypermethioninemia downstream of
+        ADK-related methionine-cycle disruption.
 - name: Hepatic Dysfunction and Cholestasis
   description: >-
     Patients may present with neonatal jaundice, cholestasis, transaminase
@@ -243,10 +326,20 @@ pathophysiology:
     explanation: >-
       Demonstrates cholestatic liver disease in a long-followed patient.
   downstream:
-  - target: Neurodevelopmental Impairment and Seizures
+  - target: Cholestasis
     description: >-
-      Liver dysfunction does not fully explain the neurologic phenotype,
-      which persists even after transplantation in some patients.
+      Hepatic involvement in ADK deficiency commonly presents as transient
+      liver dysfunction with cholestasis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34765398
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        transient liver dysfunction with cholestasis
+      explanation: >-
+        The clinical summary directly links the hepatic disease component to
+        cholestasis.
 - name: Neurodevelopmental Impairment and Seizures
   description: >-
     ADK deficiency causes hypotonia, global developmental delay, epilepsy,
@@ -298,9 +391,67 @@ pathophysiology:
     explanation: >-
       Confirms the common developmental and tone abnormalities.
   downstream:
-  - target: Cerebrovascular Abnormalities
+  - target: Global Developmental Delay
     description: >-
-      A subset of patients develops vascular tortuosity and stroke.
+      Neurodevelopmental impairment manifests clinically as global
+      developmental delay.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30477030
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Subsequently, patients demonstrate hypotonia and global developmental
+        delay.
+      explanation: >-
+        The clinical review directly supports developmental delay as a
+        manifestation of ADK deficiency.
+  - target: Hypotonia
+    description: >-
+      The neurologic disease includes generalized hypotonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34765398
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is characterized by developmental delay, hypotonia, epilepsy,
+        facial dysmorphism, failure to thrive, transient liver dysfunction
+        with cholestasis, recurrent hypoglycemia, and cardiac defects.
+      explanation: >-
+        The human clinical summary lists hypotonia among the core neurologic
+        manifestations.
+  - target: Seizure
+    description: >-
+      Brain ADK deficiency increases seizure susceptibility and epilepsy risk.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27903722
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        We conclude that ADK deficiency in the brain triggers neuronal
+        adaptation processes that lead to dysregulated synaptic plasticity,
+        cognitive deficits, and increased seizure risk.
+      explanation: >-
+        The brain-specific mouse model directly links ADK deficiency to
+        increased seizure risk.
+  - target: Delayed brain myelination
+    description: >-
+      Delayed myelination is a reported neuroimaging manifestation in affected
+      patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36589157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Six-month-old patient presented with cholestatic liver disease,
+        macrocytic anemia, developmental delay, generalized hypotonia,
+        delayed brain myelination, and elevated levels of serum methionine.
+      explanation: >-
+        The case report directly documents delayed brain myelination as part of
+        the neurologic phenotype, though intermediates are not resolved.
 - name: Cerebrovascular Abnormalities
   description: >-
     Vascular tortuosity of the cervical arteries and recurrent stroke have
@@ -328,6 +479,24 @@ pathophysiology:
       abnormalities and stroke.
     explanation: >-
       Supports vascular involvement as part of the broader phenotype.
+  downstream:
+  - target: Stroke
+    description: >-
+      Cervical artery tortuosity and related cerebrovascular abnormalities can
+      lead to stroke in a subset of patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - vascular tortuosity
+    evidence:
+    - reference: PMID:34765398
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Here, we describe two patients with ADK deficiency and vascular
+        tortuosity leading to stroke in one of them.
+      explanation: >-
+        The report explicitly links vascular tortuosity to stroke in ADK
+        deficiency.
 phenotypes:
 - category: Clinical
   name: Hypermethioninemia
@@ -353,7 +522,9 @@ phenotypes:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Biochemically, methionine is elevated with normal homocysteine levels.
+      Biochemically, methionine is elevated with normal homocysteine levels
+      and the diagnosis is confirmed through molecular analysis of the ADK
+      gene.
     explanation: >-
       Confirms the biochemical phenotype.
 - category: Clinical
@@ -544,6 +715,25 @@ phenotypes:
       Directly supports cardiac defects as part of the ADK deficiency
       phenotype.
 - category: Clinical
+  name: Stroke
+  description: >-
+    Stroke has been reported in ADK deficiency in association with tortuous
+    cervical arteries.
+  phenotype_term:
+    preferred_term: Stroke
+    term:
+      id: HP:0001297
+      label: Stroke
+  evidence:
+  - reference: PMID:34765398
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      vascular tortuosity leading to stroke in one of them.
+    explanation: >-
+      The case report documents stroke in a patient with ADK deficiency and
+      vascular tortuosity.
+- category: Clinical
   name: Macrocytic anemia
   description: >-
     Persistent macrocytic anemia has been documented in long-term follow-up.
@@ -702,8 +892,8 @@ differential_diagnoses:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      This review covers briefly the major conditions, genetic and non-
-      genetic, sometimes leading to abnormally elevated methionine, with
+      This review covers briefly the major conditions, genetic and
+      non-genetic, sometimes leading to abnormally elevated methionine, with
       emphasis on recent developments. A major aim is to assist in the
       differential diagnosis of hypermethioninemia.
     explanation: >-
@@ -721,6 +911,23 @@ treatments:
     term:
       id: MAXO:0010092
       label: dietary methionine intake avoidance
+  target_mechanisms:
+  - target: Transmethylation Cycle Disruption and Hypermethioninemia
+    treatment_effect: MODULATES
+    description: >-
+      Methionine restriction is intended to reduce the hypermethioninemia
+      component of the disturbed methionine cycle, though outcomes are variable.
+    evidence:
+    - reference: PMID:30477030
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        There is no curative treatment; however, a methionine-restricted diet
+        has been tried with variable outcomes.
+      explanation: >-
+        The clinical review supports methionine restriction as a management
+        approach but notes variable outcomes, so the target effect is modeled
+        as modulation rather than correction.
   evidence:
   - reference: PMID:30477030
     supports: SUPPORT
@@ -740,6 +947,24 @@ treatments:
     term:
       id: MAXO:0010039
       label: organ transplantation
+  target_mechanisms:
+  - target: Hepatic Dysfunction and Cholestasis
+    treatment_effect: INHIBITS
+    description: >-
+      Liver transplantation can correct the hepatic dysfunction component while
+      neurologic disease may persist.
+    evidence:
+    - reference: PMID:36589157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Ten-year follow-up after LTx revealed a preserved good liver function,
+        persistent regenerative macrocytic anemia, progressive neurological
+        disease but disappearance of brain MR changes, short stature, and
+        cortisol deficiency.
+      explanation: >-
+        Long-term follow-up supports improvement of liver function after
+        transplantation while distinguishing persistent non-hepatic disease.
   evidence:
   - reference: PMID:36589157
     supports: SUPPORT
@@ -748,8 +973,8 @@ treatments:
       The patient underwent living-donor liver transplantation (LTx) at 14
       months of age. Ten-year follow-up after LTx revealed a preserved good
       liver function, persistent regenerative macrocytic anemia,
-      progressive neurological disease but disappearance of brain MR
-      changes.
+      progressive neurological disease but disappearance of brain MR changes,
+      short stature, and cortisol deficiency.
     explanation: >-
       Supports liver transplantation as a major intervention that improves
       liver disease while not fully correcting the neurologic phenotype.


### PR DESCRIPTION
## Summary
- Added causal-link types, edge descriptions, and edge-level evidence across the ADK deficiency mechanism graph.
- Rewired weak parallel-manifestation edges into supported mechanism-to-phenotype links, including hypermethioninemia, cholestasis, developmental delay, hypotonia, seizures, delayed myelination, and stroke.
- Added Stroke (HP:0001297) with cached human clinical evidence for vascular tortuosity leading to stroke.
- Added evidence-backed treatment target mechanisms for methionine restriction and liver transplantation.
- Fixed several pre-existing non-exact snippets in this file while keeping scope to kb/disorders/Adenosine_Kinase_Deficiency.yaml.
- Restored unrelated validator cache churn before staging.

## Validation
- just validate kb/disorders/Adenosine_Kinase_Deficiency.yaml
- just validate-references kb/disorders/Adenosine_Kinase_Deficiency.yaml (built-in validator reported 0 checks)
- uv run python -m dismech.graph --validate kb/disorders/Adenosine_Kinase_Deficiency.yaml
- git diff --check
- local normalized snippet audit: 54 snippets across 7 cached references, all matched