### PR TITLE
Improve D-2-HGA pathograph connectivity

### DIFF
--- a/kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
+++ b/kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
@@ -1,7 +1,7 @@
 name: D-2-Hydroxyglutaric Aciduria
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-09T14:39:31Z'
+updated_date: '2026-05-10T07:13:21Z'
 synonyms:
 - D-2-HGA
 - D2HGA
@@ -98,6 +98,14 @@ pathophysiology:
   downstream:
   - target: Impaired D-2-hydroxyglutarate clearance (type I)
     description: Reduced D2HGDH activity decreases oxidation of D-2-HG to alpha-ketoglutarate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15609246
+      reference_title: "Mutations in the D-2-hydroxyglutarate dehydrogenase gene cause D-2-hydroxyglutaric aciduria."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Overexpression studies in HEK-293 cells of proteins containing the missense mutations showed a marked reduction of d-2-hydroxyglutarate dehydrogenase activity, proving that mutations in the d-2-hydroxyglutarate dehydrogenase gene cause d-2-hydroxyglutaric aciduria.
+      explanation: Functional overexpression studies directly link D2HGDH mutations to reduced D-2-HG dehydrogenase activity.
 - name: Impaired D-2-hydroxyglutarate clearance (type I)
   description: 'Reduced D2HGDH activity impairs oxidation of D-2-HG back to alpha-ketoglutarate, causing progressive accumulation of D-2-HG in urine, plasma, and CSF.
 
@@ -116,7 +124,52 @@ pathophysiology:
     explanation: Confirms D-2-HG accumulation as the downstream biochemical hallmark.
   downstream:
   - target: Mitochondrial bioenergetic dysfunction and oxidative stress
+    description: D-2-HGDH impairment causes D-2-HG accumulation, which is linked to downstream cellular and organ pathology.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - D-2-HG accumulation
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Both gene defects lead to supraphysiological accumulation of D-2-HG in urine, plasma and CSF, representing the biochemical hallmarks of the diseases.
+      explanation: Review of D-2-HGA types I and II supports D-2-HG accumulation as the shared biochemical intermediate.
+    - reference: PMID:27469509
+      reference_title: "A small molecule inhibitor of mutant IDH2 rescues cardiomyopathy in a D-2-hydroxyglutaric aciduria type II mouse model."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Idh2R140Q mice displayed significantly elevated 2HG levels and recapitulated multiple defects seen in patients.
+      explanation: Mouse-model data support elevated 2HG as sufficient to reproduce disease-relevant defects.
   - target: Epigenetic dysregulation via alpha-KG-dependent dioxygenase inhibition
+    description: Accumulated D-2-HG can act as an alpha-KG antagonist and inhibit alpha-KG-dependent dioxygenases.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - D-2-HG accumulation
+    - alpha-KG antagonism
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Both gene defects lead to supraphysiological accumulation of D-2-HG in urine, plasma and CSF, representing the biochemical hallmarks of the diseases.
+      explanation: The D-2-HGA review supports D-2-HG accumulation as the upstream metabolic intermediate.
+    - reference: PMID:21251613
+      reference_title: Oncometabolite 2-hydroxyglutarate is a competitive inhibitor of alpha-ketoglutarate-dependent dioxygenases.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Here we demonstrate that 2-HG is a competitive inhibitor of multiple α-KG-dependent dioxygenases, including histone demethylases and the TET family of 5-methlycytosine (5mC) hydroxylases.
+      explanation: Mechanistic cancer-cell and biochemical data support the D-2-HG alpha-KG-dependent dioxygenase inhibition mechanism.
+  - target: D-2-Hydroxyglutarate
+    description: Impaired D-2-HG clearance produces the diagnostic increase in D-2-hydroxyglutarate in body fluids.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Both gene defects lead to supraphysiological accumulation of D-2-HG in urine, plasma and CSF, representing the biochemical hallmarks of the diseases.
+      explanation: The review directly supports increased D-2-HG as the biochemical endpoint of impaired clearance.
 - name: IDH2 neomorphic molecular function gain (type II)
   description: 'In D-2-HGA type II, heterozygous IDH2 gain-of-function variants (typically at Arg140) confer neomorphic catalytic activity.
 
@@ -148,6 +201,14 @@ pathophysiology:
   downstream:
   - target: Neomorphic IDH2-driven D-2-HG overproduction (type II)
     description: Mutant IDH2 directly generates D-2-HG from 2-ketoglutarate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20847235
+      reference_title: "IDH2 mutations in patients with D-2-hydroxyglutaric aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: 'These mutations disable the enzymes'' normal ability to convert isocitrate to 2-ketoglutarate (2-KG) and confer on the enzymes a new function: the ability to convert 2-KG to d-2-hydroxyglutarate (D-2-HG).'
+      explanation: The IDH2 patient report directly states the neomorphic conversion of 2-KG to D-2-HG.
 - name: Neomorphic IDH2-driven D-2-HG overproduction (type II)
   description: 'IDH2 neomorphic activity converts alpha-ketoglutarate to D-2-HG using NADPH, producing substantially higher D-2-HG levels than type I.
 
@@ -166,7 +227,47 @@ pathophysiology:
     explanation: Confirms pathogenic IDH2 Arg140 variants driving type II D-2-HGA.
   downstream:
   - target: Mitochondrial bioenergetic dysfunction and oxidative stress
+    description: IDH2-driven 2HG overproduction causes multisystem pathology that is reversible with mutant IDH2 inhibition in a type II model.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27469509
+      reference_title: "A small molecule inhibitor of mutant IDH2 rescues cardiomyopathy in a D-2-hydroxyglutaric aciduria type II mouse model."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Idh2R140Q mice displayed significantly elevated 2HG levels and recapitulated multiple defects seen in patients.
+      explanation: The type II mouse model links IDH2-driven 2HG elevation to disease-relevant defects.
+    - reference: PMID:27469509
+      reference_title: "A small molecule inhibitor of mutant IDH2 rescues cardiomyopathy in a D-2-hydroxyglutaric aciduria type II mouse model."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: AGI-026, a potent, selective inhibitor of the human IDH2R140Q-mutant enzyme, suppressed 2HG production, rescued cardiomyopathy, and provided a survival benefit in Idh2R140Q mice; treatment withdrawal resulted in deterioration of cardiac function.
+      explanation: Rescue by mutant IDH2 inhibition supports overproduced 2HG as a causal driver of downstream pathology.
   - target: Epigenetic dysregulation via alpha-KG-dependent dioxygenase inhibition
+    description: IDH2 neomorphic production of D-2-HG provides the alpha-KG antagonist that can inhibit dioxygenases.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20847235
+      reference_title: "IDH2 mutations in patients with D-2-hydroxyglutaric aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: 'These mutations disable the enzymes'' normal ability to convert isocitrate to 2-ketoglutarate (2-KG) and confer on the enzymes a new function: the ability to convert 2-KG to d-2-hydroxyglutarate (D-2-HG).'
+      explanation: The IDH2 patient report supports D-2-HG production from mutant IDH2 as the upstream event.
+    - reference: PMID:21251613
+      reference_title: Oncometabolite 2-hydroxyglutarate is a competitive inhibitor of alpha-ketoglutarate-dependent dioxygenases.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Here we demonstrate that 2-HG is a competitive inhibitor of multiple α-KG-dependent dioxygenases, including histone demethylases and the TET family of 5-methlycytosine (5mC) hydroxylases.
+      explanation: Mechanistic data show that 2-HG inhibits the alpha-KG-dependent dioxygenases named in this mechanism.
+  - target: D-2-Hydroxyglutarate
+    description: Neomorphic IDH2 activity produces the diagnostic D-2-HG excess in D-2-HGA type II.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20847235
+      reference_title: "IDH2 mutations in patients with D-2-hydroxyglutaric aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We have detected heterozygous germline mutations in IDH2 that alter enzyme residue Arg(140) in 15 unrelated patients with d-2-hydroxyglutaric aciduria (D-2-HGA), a rare neurometabolic disorder characterized by supraphysiological levels of D-2-HG.
+      explanation: The IDH2 cohort directly links IDH2 Arg140 mutations with supraphysiological D-2-HG levels.
 - name: Mitochondrial bioenergetic dysfunction and oxidative stress
   description: 'Elevated D-2-HG perturbs mitochondrial energy metabolism and redox homeostasis in both subtypes. The structural similarity of D-2-HG to alpha-ketoglutarate allows it to interfere with TCA cycle enzymes and mitochondrial respiratory chain function, leading to impaired energy production and increased oxidative stress, particularly affecting neurons and cardiomyocytes.
 
@@ -207,6 +308,66 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: The current review describes the knowledge gathered on 2-hydroxyglutaric acidurias (2-HGA), since the description of the first patients in 1980.
     explanation: Foundational review supporting mitochondrial dysfunction as a core mechanism.
+  downstream:
+  - target: Dilated cardiomyopathy
+    description: Elevated 2HG-driven cellular pathology affects cardiomyocytes and can produce cardiomyopathy, especially in type II disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - elevated 2HG
+    - cardiomyocyte dysfunction
+    evidence:
+    - reference: PMID:27469509
+      reference_title: "A small molecule inhibitor of mutant IDH2 rescues cardiomyopathy in a D-2-hydroxyglutaric aciduria type II mouse model."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: AGI-026, a potent, selective inhibitor of the human IDH2R140Q-mutant enzyme, suppressed 2HG production, rescued cardiomyopathy, and provided a survival benefit in Idh2R140Q mice; treatment withdrawal resulted in deterioration of cardiac function.
+      explanation: Reversal of cardiomyopathy by lowering 2HG supports this downstream phenotype link.
+    - reference: PMID:37248298
+      reference_title: "Enasidenib treatment in two individuals with D-2-hydroxyglutaric aciduria carrying a germline IDH2 mutation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: For the child with cardiomyopathy, chronic D-2-HG inhibition was associated with improved cardiac function, and for both children, therapy was associated with improved daily functioning, global motility and social interactions.
+      explanation: Human enasidenib treatment supports cardiomyopathy as a D-2-HG-responsive downstream phenotype.
+  - target: Epilepsy
+    description: D-2-HGA-associated neurometabolic dysfunction manifests with seizures.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cardinal clinical manifestations for both disorders include developmental delay, hypotonia and seizures, although seizures occur with higher frequency in type II patients
+      explanation: Clinical questionnaire data support seizures downstream of the shared D-2-HGA disease process.
+  - target: Global developmental delay
+    description: D-2-HGA-associated neurometabolic dysfunction commonly causes developmental delay.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cardinal clinical manifestations for both disorders include developmental delay, hypotonia and seizures, although seizures occur with higher frequency in type II patients
+      explanation: Clinical questionnaire data support developmental delay downstream of the shared D-2-HGA disease process.
+  - target: Muscular hypotonia
+    description: D-2-HGA-associated neurometabolic dysfunction commonly manifests as hypotonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cardinal clinical manifestations for both disorders include developmental delay, hypotonia and seizures, although seizures occur with higher frequency in type II patients
+      explanation: Clinical questionnaire data support hypotonia downstream of the shared D-2-HGA disease process.
+  - target: Cerebral white matter abnormalities
+    description: D-2-HGA-associated neurometabolic pathology includes multifocal cerebral white matter abnormalities.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:22391998
+      reference_title: "Progress in understanding 2-hydroxyglutaric acidurias."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Neuroimaging performed in D-2-HGA patients was predominantly instituted prior to knowledge of the underlying molecular defects. The clinical features in these undifferentiated patients included enlargement of the lateral ventricles, enlarged frontal subarachnoid spaces, subdural effusions, subependymal pseudocysts, signs of delayed cerebral maturation and multifocal cerebral white-matter abnormalities
+      explanation: The review directly documents white matter abnormalities in D-2-HGA patients, although the exact cellular-to-imaging intermediates remain unresolved.
 - name: Epigenetic dysregulation via alpha-KG-dependent dioxygenase inhibition
   description: 'D-2-HG competitively inhibits alpha-ketoglutarate/Fe(II)-dependent dioxygenases, including histone and DNA demethylases (TET family enzymes and Jumonji-domain histone demethylases). This creates aberrant epigenetic modifications including DNA and histone hypermethylation, which may contribute to transcriptional dysregulation and the neurodevelopmental phenotype. This mechanism is shared with IDH-mutant cancers.
 
@@ -233,6 +394,12 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: These findings provide additional impetus for investigating the role of D-2-HG in the pathophysiology of metabolic disease and cancer.
     explanation: Motivates investigation of D-2-HG role in epigenetic dysregulation; the mechanism is well-established in cancer but the snippet is aspirational rather than demonstrative.
+  - reference: PMID:21251613
+    reference_title: Oncometabolite 2-hydroxyglutarate is a competitive inhibitor of alpha-ketoglutarate-dependent dioxygenases.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Here we demonstrate that 2-HG is a competitive inhibitor of multiple α-KG-dependent dioxygenases, including histone demethylases and the TET family of 5-methlycytosine (5mC) hydroxylases.
+    explanation: Provides direct mechanistic evidence that 2-HG inhibits the alpha-KG-dependent dioxygenases represented by this node.
 phenotypes:
 - name: Epilepsy
   frequency: VERY_FREQUENT
@@ -584,6 +751,23 @@ treatments:
     term:
       id: NCIT:C93352
       label: Targeted Therapy
+  target_mechanisms:
+  - target: Neomorphic IDH2-driven D-2-HG overproduction (type II)
+    treatment_effect: INHIBITS
+    description: Enasidenib inhibits mutant IDH2-driven D-2-HG production in type II disease.
+    evidence:
+    - reference: PMID:37248298
+      reference_title: "Enasidenib treatment in two individuals with D-2-hydroxyglutaric aciduria carrying a germline IDH2 mutation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: In both children, enasidenib treatment led to normalization of D-2-hydroxyglutarate (D-2-HG) concentrations in body fluids.
+      explanation: Human treatment data support enasidenib inhibition of the D-2-HG overproduction mechanism.
+    - reference: PMID:27469509
+      reference_title: "A small molecule inhibitor of mutant IDH2 rescues cardiomyopathy in a D-2-hydroxyglutaric aciduria type II mouse model."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: AGI-026, a potent, selective inhibitor of the human IDH2R140Q-mutant enzyme, suppressed 2HG production, rescued cardiomyopathy, and provided a survival benefit in Idh2R140Q mice; treatment withdrawal resulted in deterioration of cardiac function.
+      explanation: The type II mouse model supports mutant IDH2 inhibition as the mechanism for lowering 2HG.
   evidence:
   - reference: PMID:37248298
     reference_title: "Enasidenib treatment in two individuals with D-2-hydroxyglutaric aciduria carrying a germline IDH2 mutation."

--- a/references_cache/PMID_21251613.md
+++ b/references_cache/PMID_21251613.md
@@ -1,0 +1,103 @@
+---
+reference_id: "PMID:21251613"
+title: Oncometabolite 2-hydroxyglutarate is a competitive inhibitor of α-ketoglutarate-dependent dioxygenases.
+authors:
+- Xu W
+- Yang H
+- Liu Y
+- Yang Y
+- Wang P
+- Kim SH
+- Ito S
+- Yang C
+- Wang P
+- Xiao MT
+- Liu LX
+- Jiang WQ
+- Liu J
+- Zhang JY
+- Wang B
+- Frye S
+- Zhang Y
+- Xu YH
+- Lei QY
+- Guan KL
+- Zhao SM
+- Xiong Y
+journal: Cancer Cell
+year: '2011'
+doi: 10.1016/j.ccr.2010.12.014
+keywords:
+- "5-Methylcytosine/metabolism, analogs & derivatives"
+- Amino Acid Substitution/physiology
+- Animals
+- "Binding, Competitive"
+- Biocatalysis/drug effects
+- Caenorhabditis elegans/enzymology
+- "Caenorhabditis elegans Proteins/antagonists & inhibitors, chemistry, metabolism"
+- Catalytic Domain
+- "Cell Line, Tumor"
+- "Cytosine/analogs & derivatives, metabolism"
+- "DNA-Binding Proteins/antagonists & inhibitors, genetics, metabolism"
+- "Dioxygenases/antagonists & inhibitors, metabolism"
+- Endostatins/metabolism
+- F-Box Proteins
+- "Gene Expression/drug effects, genetics"
+- "Glioma/enzymology, genetics, metabolism"
+- "Glutarates/chemistry, metabolism, pharmacology"
+- "Histone Demethylases/antagonists & inhibitors, metabolism"
+- Histones/metabolism
+- Homeodomain Proteins/genetics
+- Humans
+- "Hypoxia-Inducible Factor 1, alpha Subunit/metabolism"
+- Hypoxia-Inducible Factor-Proline Dioxygenases
+- "Isocitrate Dehydrogenase/antagonists & inhibitors, genetics, metabolism"
+- "Jumonji Domain-Containing Histone Demethylases/antagonists & inhibitors, chemistry, metabolism"
+- "Ketoglutaric Acids/chemistry, metabolism, pharmacology"
+- Mixed Function Oxygenases
+- "Models, Molecular"
+- Oxalates/pharmacology
+- "Oxidoreductases, N-Demethylating/antagonists & inhibitors, metabolism"
+- "Procollagen-Proline Dioxygenase/antagonists & inhibitors, genetics, metabolism"
+- "Proto-Oncogene Proteins/antagonists & inhibitors, genetics, metabolism"
+content_type: abstract_only
+---
+
+# Oncometabolite 2-hydroxyglutarate is a competitive inhibitor of α-ketoglutarate-dependent dioxygenases.
+**Authors:** Xu W, Yang H, Liu Y, Yang Y, Wang P, Kim SH, Ito S, Yang C, Wang P, Xiao MT, Liu LX, Jiang WQ, Liu J, Zhang JY, Wang B, Frye S, Zhang Y, Xu YH, Lei QY, Guan KL, Zhao SM, Xiong Y
+**Journal:** Cancer Cell (2011)
+**DOI:** [10.1016/j.ccr.2010.12.014](https://doi.org/10.1016/j.ccr.2010.12.014)
+
+## Content
+
+1. Cancer Cell. 2011 Jan 18;19(1):17-30. doi: 10.1016/j.ccr.2010.12.014.
+
+Oncometabolite 2-hydroxyglutarate is a competitive inhibitor of
+α-ketoglutarate-dependent dioxygenases.
+
+Xu W(1), Yang H, Liu Y, Yang Y, Wang P, Kim SH, Ito S, Yang C, Wang P, Xiao MT,
+Liu LX, Jiang WQ, Liu J, Zhang JY, Wang B, Frye S, Zhang Y, Xu YH, Lei QY, Guan
+KL, Zhao SM, Xiong Y.
+
+Author information:
+(1)State Key Laboratory of Genetic Engineering, School of Life Sciences,
+Shanghai Medical School, Fudan University, Shanghai 20032, China.
+
+IDH1 and IDH2 mutations occur frequently in gliomas and acute myeloid leukemia,
+leading to simultaneous loss and gain of activities in the production of
+α-ketoglutarate (α-KG) and 2-hydroxyglutarate (2-HG), respectively. Here we
+demonstrate that 2-HG is a competitive inhibitor of multiple α-KG-dependent
+dioxygenases, including histone demethylases and the TET family of
+5-methlycytosine (5mC) hydroxylases. 2-HG occupies the same space as α-KG does
+in the active site of histone demethylases. Ectopic expression of tumor-derived
+IDH1 and IDH2 mutants inhibits histone demethylation and 5mC hydroxylation. In
+glioma, IDH1 mutations are associated with increased histone methylation and
+decreased 5-hydroxylmethylcytosine (5hmC). Hence, tumor-derived IDH1 and IDH2
+mutations reduce α-KG and accumulate an α-KG antagonist, 2-HG, leading to
+genome-wide histone and DNA methylation alterations.
+
+Copyright Â© 2011 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ccr.2010.12.014
+PMCID: PMC3229304
+PMID: 21251613 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Added causal-link types, descriptions, and edge-level evidence to D-2-HGA type I and type II mechanism paths.
- Connected upstream clearance/overproduction mechanisms to increased D-2-HG biochemical output.
- Added supported downstream phenotype links for cardiomyopathy, seizures, developmental delay, hypotonia, and cerebral white matter abnormalities.
- Added an enasidenib target-mechanism link for mutant IDH2-driven D-2-HG overproduction.
- Fetched and included PMID:21251613 for the 2-HG alpha-KG-dependent dioxygenase inhibition mechanism; restored unrelated ClinicalTrials cache churn.

## Validation
- just validate kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
- uv run python -m dismech.graph --validate kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
- git diff --check
- local normalized snippet audit: 65 snippets across 10 cached references, all matched