### PR TITLE
feat: connect Hurler syndrome pathograph

### DIFF
--- a/kb/disorders/Hurler_syndrome.yaml
+++ b/kb/disorders/Hurler_syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hurler syndrome
 creation_date: '2026-04-11T17:12:00Z'
-updated_date: '2026-04-11T18:24:00Z'
+updated_date: '2026-05-10T07:51:54Z'
 category: Mendelian
 description: >-
   Hurler syndrome, also called mucopolysaccharidosis type I-Hurler (MPS-IH), is
@@ -67,6 +67,12 @@ pathophysiology:
     term:
       id: hgnc:5391
       label: IDUA
+  molecular_functions:
+  - preferred_term: alpha-L-iduronidase activity
+    modifier: DECREASED
+    term:
+      id: GO:0003940
+      label: L-iduronidase activity
   biological_processes:
   - preferred_term: glycosaminoglycan catabolic process
     modifier: DECREASED
@@ -86,6 +92,17 @@ pathophysiology:
   downstream:
   - target: Dermatan sulfate and heparan sulfate accumulation
     description: Loss of alpha-L-iduronidase blocks lysosomal clearance of dermatan sulfate and heparan sulfate
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32780955
+      reference_title: "Dysostosis Multiplex in Human Mucopolysaccharidosis Type 1 H and in Animal Models of the Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Mucopolysaccharidosis type I (MPS I) is a rare autosomal recessive disorder, caused by deficiency of α-L-iduronidase, and consequent accumulation of dermatan and heparan sulfates.
+      explanation: >-
+        This directly links alpha-L-iduronidase deficiency to dermatan sulfate
+        and heparan sulfate accumulation.
 - name: Dermatan sulfate and heparan sulfate accumulation
   description: >-
     Loss of IDUA blocks lysosomal degradation of dermatan sulfate and heparan
@@ -118,6 +135,17 @@ pathophysiology:
   downstream:
   - target: Progressive skeletal and multisystem organ injury
     description: Glycosaminoglycan storage drives progressive skeletal, visceral, cardiac, and CNS injury
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        MPS I with either severe or attenuated form has limited activity of the enzyme α-L-iduronidase (IDUA) that breaks down DS and HS. These GAGs remain stored in cells causing progressive damage of various tissues including bone and, in severe cases, brain.
+      explanation: >-
+        The review explicitly links DS and HS storage to progressive tissue
+        damage in bone and brain.
 - name: Progressive skeletal and multisystem organ injury
   description: >-
     Glycosaminoglycan storage in connective tissues drives progressive
@@ -149,6 +177,126 @@ pathophysiology:
     explanation: >-
       This infant cohort directly supports the rapid early multisystem
       progression characteristic of Hurler syndrome.
+  downstream:
+  - target: Dysostosis multiplex
+    causal_link_type: DIRECT
+    description: Skeletal glycosaminoglycan storage manifests as dysostosis multiplex in severe MPS I.
+    evidence:
+    - reference: PMID:32780955
+      reference_title: "Dysostosis Multiplex in Human Mucopolysaccharidosis Type 1 H and in Animal Models of the Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        A prominent clinical manifestation of MPS-IH is dysostosis multiplex, a constellation of skeletal abnormalities.
+      explanation: >-
+        This directly connects the skeletal injury branch to dysostosis
+        multiplex.
+  - target: Coarse facial features
+    causal_link_type: DIRECT
+    description: Multisystem storage disease includes progressive coarse facial morphology.
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Typical manifestations include coarse face, corneal clouding, developmental delay, mental retardation, growth retardation, contractures of the joints, kyphoscoliosis, dysostosis multiplex, hearing loss, thickening of the heart valves, hepatosplenomegaly, and umbilical and inguinal hernias.
+      explanation: >-
+        This lists coarse face among the typical manifestations downstream of
+        severe MPS I storage disease.
+  - target: Corneal opacity
+    causal_link_type: DIRECT
+    description: Ocular storage involvement manifests clinically as corneal clouding.
+    evidence:
+    - reference: PMID:28193245
+      reference_title: "Early disease progression of Hurler syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Other symptoms such as kyphosis, corneal clouding, cardiac disease, joint restrictions, and enlarged head circumference typically appeared slightly later (median age, 8-10 months).
+      explanation: >-
+        The Hurler natural-history cohort documents corneal clouding as an
+        early storage-related manifestation.
+  - target: Hearing impairment
+    causal_link_type: DIRECT
+    description: Otolaryngologic involvement in Hurler syndrome includes hearing loss.
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Typical manifestations include coarse face, corneal clouding, developmental delay, mental retardation, growth retardation, contractures of the joints, kyphoscoliosis, dysostosis multiplex, hearing loss, thickening of the heart valves, hepatosplenomegaly, and umbilical and inguinal hernias.
+      explanation: >-
+        This identifies hearing loss as part of the clinical manifestation set
+        for severe MPS I.
+  - target: Hepatosplenomegaly
+    causal_link_type: DIRECT
+    description: Visceral storage involvement causes liver and spleen enlargement.
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Typical manifestations include coarse face, corneal clouding, developmental delay, mental retardation, growth retardation, contractures of the joints, kyphoscoliosis, dysostosis multiplex, hearing loss, thickening of the heart valves, hepatosplenomegaly, and umbilical and inguinal hernias.
+      explanation: >-
+        This lists hepatosplenomegaly among the typical severe MPS I
+        manifestations.
+  - target: Global developmental delay
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Brain glycosaminoglycan storage and severe CNS involvement disrupt early neurodevelopment.
+    description: Severe CNS involvement in Hurler syndrome contributes to early developmental delay.
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Patients with Hurler syndrome develop initial symptoms like hernias, hepatomegaly, kyphosis and developmental delay within a year and die within a decade if untreated
+      explanation: >-
+        This disease-specific summary connects early severe Hurler disease to
+        developmental delay.
+  - target: Joint stiffness
+    causal_link_type: DIRECT
+    description: Connective-tissue storage manifests as early joint restriction and stiffness.
+    evidence:
+    - reference: PMID:28193245
+      reference_title: "Early disease progression of Hurler syndrome."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Other symptoms such as kyphosis, corneal clouding, cardiac disease, joint restrictions, and enlarged head circumference typically appeared slightly later (median age, 8-10 months).
+      explanation: >-
+        Joint restrictions are close clinical support for the joint stiffness
+        endpoint term.
+  - target: Abnormal heart valve morphology
+    causal_link_type: DIRECT
+    description: Cardiac storage involvement includes thickening of the heart valves.
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Typical manifestations include coarse face, corneal clouding, developmental delay, mental retardation, growth retardation, contractures of the joints, kyphoscoliosis, dysostosis multiplex, hearing loss, thickening of the heart valves, hepatosplenomegaly, and umbilical and inguinal hernias.
+      explanation: >-
+        This directly supports heart-valve thickening as a downstream cardiac
+        manifestation.
+  - target: Growth delay
+    causal_link_type: DIRECT
+    description: Severe somatic storage disease includes impaired growth.
+    evidence:
+    - reference: PMID:28595941
+      reference_title: "Epidemiology of mucopolysaccharidoses."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Typical manifestations include coarse face, corneal clouding, developmental delay, mental retardation, growth retardation, contractures of the joints, kyphoscoliosis, dysostosis multiplex, hearing loss, thickening of the heart valves, hepatosplenomegaly, and umbilical and inguinal hernias.
+      explanation: >-
+        This identifies growth retardation as a typical severe MPS I
+        manifestation.
 phenotypes:
 - name: Dysostosis multiplex
   category: Skeletal
@@ -218,8 +366,8 @@ phenotypes:
   phenotype_term:
     preferred_term: Hearing impairment
     term:
-      id: HP:0000364
-      label: Hearing abnormality
+      id: HP:0000365
+      label: Hearing impairment
   evidence:
   - reference: PMID:28193245
     reference_title: "Early disease progression of Hurler syndrome."
@@ -365,6 +513,22 @@ treatments:
     term:
       id: MAXO:0000747
       label: hematopoietic stem cell transplantation
+  target_mechanisms:
+  - target: IDUA enzyme deficiency
+    treatment_effect: RESTORES
+    description: >-
+      Donor-derived hematopoiesis can restore alpha-L-iduronidase enzyme levels;
+      normal post-HCT enzyme levels predict better long-term organ outcomes.
+    evidence:
+    - reference: PMID:25624320
+      reference_title: "Long-term outcome of Hurler syndrome patients after hematopoietic cell transplantation: an international multicenter study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        A normal α-l-iduronidase enzyme level obtained post-HCT was another highly significant predictor for superior long-term outcome in most organ systems.
+      explanation: >-
+        This supports restored enzyme level as the proximal disease-modifying
+        mechanism of HCT in Hurler syndrome.
   evidence:
   - reference: PMID:30442189
     reference_title: "Enzyme replacement therapy: efficacy and limitations."
@@ -393,6 +557,23 @@ treatments:
     term:
       id: MAXO:0000933
       label: enzyme replacement or supplementation therapy
+  target_mechanisms:
+  - target: Dermatan sulfate and heparan sulfate accumulation
+    treatment_effect: INHIBITS
+    description: >-
+      Enzyme replacement reduces systemic glycosaminoglycan storage biomarkers
+      and liver/spleen volume, while having limited penetration into cartilage,
+      bone, eyes, and the CNS.
+    evidence:
+    - reference: PMID:30442189
+      reference_title: "Enzyme replacement therapy: efficacy and limitations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        While ERT is effective in reducing urinary glycosaminoglycans (GAGs) and liver and spleen volume, cartilaginous organs such as the trachea and bronchi, bones and eyes are poorly impacted by ERT probably due to limited penetration in the specific tissue.
+      explanation: >-
+        Reduced urinary GAGs support inhibition of the glycosaminoglycan storage
+        branch, with tissue-penetration limits noted by the review.
   evidence:
   - reference: PMID:30442189
     reference_title: "Enzyme replacement therapy: efficacy and limitations."


### PR DESCRIPTION
## Summary
- add alpha-L-iduronidase molecular function metadata for the proximal IDUA defect
- add evidence-backed causal edges from IDUA deficiency to GAG storage, multisystem injury, and existing Hurler phenotypes
- add treatment target mechanisms for HSCT and ERT, and tighten hearing impairment to HP:0000365

## Validation
- `just validate kb/disorders/Hurler_syndrome.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Hurler_syndrome.yaml`
- custom normalized PMID snippet audit: 35/35 snippets found in cache
- subagent review: no PR-blocking findings

## Scope
- only `kb/disorders/Hurler_syndrome.yaml` changed
- validator-generated cache/reference churn restored before commit