### PR TITLE
feat(qc): require PMID caches to carry authors or journal (#1737)

### DIFF
--- a/src/dismech/reference_cache_frontmatter.py
+++ b/src/dismech/reference_cache_frontmatter.py
@@ -13,6 +13,9 @@ It validates only structural facts:
 - required cache fields are present and have the expected types
 - optional fields match the shapes written by the upstream cache writer
 - the filename matches the normalized ``reference_id``
+- ``PMID:`` caches carry at least one of ``authors`` / ``journal`` (issue
+  #1737 defense-in-depth — the documented fabrication fingerprint had
+  neither field populated)
 
 The heavier last line of defence remains the existing
 ``linkml-reference-validator`` run inside ``just qc``.
@@ -133,6 +136,22 @@ def _validate_contract(path: Path, data: dict[str, Any]) -> list[str]:
         matches_filename = path.name.casefold() == expected_name.casefold()
     if not matches_filename:
         reasons.append(f"filename must match reference_id ({expected_name})")
+
+    # Defense-in-depth check for the fabrication fingerprint documented in
+    # issue #1737: hand-crafted PMID cache files lacking real bibliographic
+    # metadata (no authors, no journal) where the body content was just the
+    # YAML snippet copy-pasted back, defeating the snippet-substring check
+    # in linkml-reference-validator. All legitimate PMID caches in the
+    # current corpus carry at least one of authors / journal — including
+    # pre-abstract-era papers, foreign-language abstracts, and minimal
+    # PubMed records.
+    if frontmatter.reference_id.startswith("PMID:") and not (
+        frontmatter.authors or frontmatter.journal
+    ):
+        reasons.append(
+            "PMID cache files must carry at least one of `authors:` or "
+            "`journal:` (fabrication fingerprint per #1737)"
+        )
 
     return reasons
 

--- a/tests/test_reference_cache_frontmatter.py
+++ b/tests/test_reference_cache_frontmatter.py
@@ -119,6 +119,80 @@ def test_check_cache_file_accepts_database_field(tmp_path: Path):
     assert check_cache_file(good) is None
 
 
+def test_pmid_cache_missing_both_authors_and_journal_is_rejected(tmp_path: Path):
+    """Fabrication-fingerprint defense (#1737): a hand-crafted PMID cache
+    with neither ``authors`` nor ``journal`` and a paraphrastic title was
+    how prior fabrications evaded ``validate-references``. The deterministic
+    check must reject the shape regardless of whether the body is real."""
+    fabricated = tmp_path / "PMID_36606642.md"
+    fabricated.write_text(
+        "---\n"
+        'reference_id: "PMID:36606642"\n'
+        'title: "Some plausible-sounding review"\n'
+        "content_type: abstract_only\n"
+        "---\n\n"
+        "Body content unverified.\n",
+        encoding="utf-8",
+    )
+    finding = check_cache_file(fabricated)
+    assert isinstance(finding, Finding)
+    assert any(
+        "authors" in reason and "journal" in reason for reason in finding.reasons
+    )
+
+
+def test_pmid_cache_with_only_journal_is_accepted(tmp_path: Path):
+    """Pre-abstract-era and brief PubMed records often carry ``journal`` and
+    ``year`` but no ``authors``. They are legitimate and must pass."""
+    good = tmp_path / "PMID_2897563.md"
+    good.write_text(
+        "---\n"
+        'reference_id: "PMID:2897563"\n'
+        'title: "Klinefelter\'s syndrome."\n'
+        "journal: Lancet\n"
+        "year: '1988'\n"
+        "content_type: abstract_only\n"
+        "---\n\n"
+        "# Klinefelter's syndrome.\n",
+        encoding="utf-8",
+    )
+    assert check_cache_file(good) is None
+
+
+def test_pmid_cache_with_only_authors_is_accepted(tmp_path: Path):
+    """Mirror coverage: ``authors`` alone is also sufficient."""
+    good = tmp_path / "PMID_99999999.md"
+    good.write_text(
+        "---\n"
+        'reference_id: "PMID:99999999"\n'
+        'title: "Some paper"\n'
+        "authors:\n"
+        "- Doe J\n"
+        "content_type: abstract_only\n"
+        "---\n\n"
+        "# Some paper\n",
+        encoding="utf-8",
+    )
+    assert check_cache_file(good) is None
+
+
+def test_non_pmid_cache_is_not_subject_to_metadata_check(tmp_path: Path):
+    """Non-PMID prefixes (CGGV, ORPHA, clinicaltrials, GEO, …) follow
+    different cache shapes and must not be flagged for missing
+    journal/authors."""
+    cggv = tmp_path / "CGGV_assertion_abc.md"
+    cggv.write_text(
+        "---\n"
+        'reference_id: "CGGV:assertion_abc"\n'
+        'title: "Gene-disease validity assertion"\n'
+        "content_type: structured_record\n"
+        "---\n\n"
+        "# CGGV:assertion_abc\n",
+        encoding="utf-8",
+    )
+    assert check_cache_file(cggv) is None
+
+
 @pytest.mark.skipif(not CACHE_DIR.is_dir(), reason="references_cache/ not present")
 def test_existing_repo_caches_match_frontmatter_contract():
     findings = scan_cache_dir(CACHE_DIR)


### PR DESCRIPTION
## Summary

Closes the long-standing defense-in-depth gap explicitly flagged by the four prior scanner audits on #1737. Adds a deterministic check to `dismech.reference_cache_frontmatter`: every `PMID:`-prefix cache file must carry at least one of `authors:` or `journal:`. PRs #1740, #1773, #1793, and #1868 each retrofixed individual fabricated caches; this change catches the same fingerprint at frontmatter-check time so future fabrications can't slip past `validate-references` the same way.

## The fingerprint, restated

A handful of `references_cache/PMID_*.md` files were hand-crafted with:

- no `authors:` field
- no `journal:` field
- a short paraphrastic title (e.g. *"CADASIL prevalence and penetrance review"*)
- body content that was just the YAML snippet copy-pasted back

`linkml-reference-validator`'s substring check then compared the snippet against a body containing the snippet, so validation passed trivially. The pattern was first surfaced in #1740 (PMID:36606642 / CADASIL Type 1) and successively swept by #1773, #1793, and #1868.

## Why this specific rule

I scanned all 16,182 `PMID_*.md` cache files currently in `references_cache/` and confirmed:

- **Zero** files lack both `authors:` and `journal:` (all prior fabrications have already been remediated)
- Legitimate small entries — pre-abstract-era papers, foreign-language abstracts, minimal PubMed records, GeneReviews chapters, recent bioRxiv preprints — all carry at least one of the two fields
- The 17 legitimate sub-500B caches the prior scanner pass on this issue listed all carry at least `journal:`

So the rule fires zero false positives on the existing corpus and only blocks future fabrications matching the documented fingerprint.

## What this PR does NOT do

- **No content-length floor.** The original suggestion in #1737 also mentioned a minimum cache-content length floor. That heuristic has more false-positive risk (legitimate `content_type: title_only` and pre-abstract-era entries are intentionally short) and warrants its own design discussion.
- **No mandatory `year:` or `doi:`.** Some real PubMed records lack these in the cache; this PR doesn't tighten beyond the documented fabrication shape.
- **No retroactive sweep of single-field-missing files.** The prior scanner classified those (~207, mostly GeneReviews `PMID:20301*` and bioRxiv preprints) as legitimate format quirks rather than fabrications.
- **No change to non-PMID prefixes.** `CGGV:`, `ORPHA:`, `clinicaltrials:`, `GEO:`, etc. have different cache shapes that don't carry `journal:` by design.

## Validation

- ✅ All 12 tests in `tests/test_reference_cache_frontmatter.py` pass (4 new + 1 fingerprint-rejection + 8 existing)
- ✅ `uv run python -m dismech.reference_cache_frontmatter references_cache` returns clean over the full 21k-file corpus
- ✅ Synthetic fingerprint case (no authors + no journal + paraphrastic title) is rejected with the documented reason

## Test coverage added

- `test_pmid_cache_missing_both_authors_and_journal_is_rejected` — the fingerprint
- `test_pmid_cache_with_only_journal_is_accepted` — pre-abstract-era / Lancet-style brief records
- `test_pmid_cache_with_only_authors_is_accepted` — mirror coverage
- `test_non_pmid_cache_is_not_subject_to_metadata_check` — CGGV/ORPHA pass-through

Refs #1737.

— automated curation scanner run (claude[bot])