### PR TITLE
feat: connect Sialidosis type 1 pathograph

### DIFF
--- a/kb/disorders/Sialidosis_Type_1.yaml
+++ b/kb/disorders/Sialidosis_Type_1.yaml
@@ -1,7 +1,7 @@
 name: Sialidosis type 1
 category: Mendelian
 creation_date: "2026-05-04T18:28:00Z"
-updated_date: "2026-05-04T20:14:13Z"
+updated_date: "2026-05-10T09:33:04Z"
 synonyms:
 - Cherry-red spot-myoclonus syndrome
 - Lipomucopolysaccharidosis
@@ -225,6 +225,8 @@ pathophysiology:
     explanation: Patient enzyme testing directly supports neuraminidase deficiency in Sialidosis type 1.
   downstream:
   - target: Sialylated metabolite lysosomal storage
+    description: Deficient lysosomal NEU1 blocks processing of sialylated glycoproteins and oligosaccharides, producing sialylated storage metabolites.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:32143456
       reference_title: Conventional and Unconventional Therapeutic Strategies for Sialidosis Type I.
@@ -265,6 +267,8 @@ pathophysiology:
     explanation: Functional studies of patient variants support residual activity and abnormal trafficking as determinants of type I disease.
   downstream:
   - target: NEU1 lysosomal neuraminidase deficiency
+    description: Mild but catalytically impaired NEU1 variants produce the residual neuraminidase deficiency underlying the type 1 phenotype.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:10944856
       reference_title: Molecular and structural studies of Japanese patients with sialidosis type 1.
@@ -308,7 +312,20 @@ pathophysiology:
     explanation: Orphanet records urinary sialylated oligosaccharide excretion as very frequent.
   downstream:
   - target: Neuronal lysosomal storage and gliosis
+    description: Nervous-system lysosomal storage is associated with glial LAMP1 accumulation, astrogliosis, and the progressive neurologic syndrome.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Lysosomal LAMP1 accumulation and glial activation disrupt neural circuitry and motor function.
     evidence:
+    - reference: PMID:38321198
+      reference_title: Gene therapy corrects the neurological deficits of mice with sialidosis.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: >-
+        Untreated Neu1-/- mice showed astrogliosis and microglial LAMP1
+        accumulation in the nervous system, including brain, spinal cord, and
+        dorsal root ganglion, together with impaired motor function.
+      explanation: The Neu1-deficient mouse model links nervous-system lysosomal pathology and gliosis to motor dysfunction.
     - reference: PMID:41665440
       reference_title: "Sialidosis type I: How to alleviate disabling myoclonic seizures?-A multicenter analysis of eight cases and review of the literature."
       supports: SUPPORT
@@ -316,6 +333,8 @@ pathophysiology:
       snippet: "clinically characterized by progressive ataxia, myoclonic seizures (MS),"
       explanation: The clinical review links storage disease to progressive neurologic manifestations.
   - target: Retinal ganglion cell layer storage
+    description: Sialyloligosaccharide accumulation in perifoveal ganglion-cell and retinal nerve-fiber layers produces the characteristic retinal pathology.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:32453490
       reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
@@ -323,6 +342,50 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "The appearance of macular cherry red spots is caused by the accumulation of sialyloligosaccharides in the perifoveal ganglion cell layer and RNFL."
       explanation: The Type 1 ophthalmic cohort links sialyloligosaccharide storage to retinal ganglion-cell and nerve-fiber-layer pathology.
+  - target: Urinary excretion of sialylated oligosaccharides
+    description: Systemic sialylated metabolite storage is reflected by increased urinary sialylated oligosaccharide excretion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "urinary excretion of sialylated oligosaccharides"
+      explanation: The type 1 cohort review links NEU1 deficiency to urinary sialylated oligosaccharide excretion.
+  - target: Increased urinary O-linked sialopeptides
+    description: Impaired lysosomal sialylated substrate catabolism produces urinary O-linked sialopeptide accumulation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:812
+      reference_title: "Sialidosis type 1 (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003461 | Increased urinary O-linked sialopeptides | Very frequent (99-80%)"
+      explanation: Orphanet records increased urinary O-linked sialopeptides as a very frequent type 1 storage phenotype.
+  - target: Cataract
+    description: Accumulated abnormal metabolic products in ocular tissues contribute to punctate cataracts.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic-product accumulation in the lens alters lens transparency.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Punctate cataracts were found in all patients"
+      explanation: The type 1 cohort documents punctate cataracts in all four patients.
+  - target: Corneal opacity
+    description: Ocular metabolic-product accumulation can manifest as corneal clouding.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Storage-related abnormal metabolic products affect transparent ocular tissues.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "punctate cataract and corneal clouding are considered to be characteristic ophthalmic signs"
+      explanation: The cohort review identifies corneal clouding as a characteristic ophthalmic sign in sialidosis.
 - name: Neuronal lysosomal storage and gliosis
   description: >
     Sialylated storage in the nervous system is associated with glial lysosomal
@@ -366,6 +429,137 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "is clinically characterized by progressive ataxia, myoclonic seizures (MS),"
     explanation: The review identifies progressive ataxia and myoclonic seizures as core clinical features.
+  downstream:
+  - target: Seizure
+    description: Progressive neuronal storage and glial pathology cause network dysfunction that manifests as seizures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Lysosomal neuronal dysfunction and gliosis lower seizure threshold in cortical networks.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A total of 75% (3/4) of patients developed seizures and cerebellar ataxia."
+      explanation: The type 1 cohort supports seizures as a frequent neurologic manifestation.
+  - target: Generalized myoclonic seizure
+    description: Neural storage-related cortical hyperexcitability manifests as progressive myoclonic seizures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Storage-related cortical circuit dysfunction produces progressive myoclonic epilepsy.
+    evidence:
+    - reference: PMID:41665440
+      reference_title: "Sialidosis type I: How to alleviate disabling myoclonic seizures?-A multicenter analysis of eight cases and review of the literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "is clinically characterized by progressive ataxia, myoclonic seizures (MS),"
+      explanation: The 2026 review identifies myoclonic seizures as a core type 1 neurologic manifestation.
+  - target: Ataxia
+    description: Nervous-system storage and gliosis disrupt cerebellar and motor circuitry, causing ataxia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cerebellar and motor circuit dysfunction impairs coordination.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A total of 75% (3/4) of patients developed seizures and cerebellar ataxia."
+      explanation: The type 1 cohort supports cerebellar ataxia as a frequent neurologic manifestation.
+  - target: Gait disturbance
+    description: Progressive ataxia and motor dysfunction produce gait impairment.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cerebellar and motor pathway dysfunction impair gait coordination.
+    evidence:
+    - reference: ORPHA:812
+      reference_title: "Sialidosis type 1 (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001288 | Gait disturbance | Very frequent (99-80%)"
+      explanation: Orphanet records gait disturbance as a very frequent type 1 phenotype.
+  - target: Decreased nerve conduction velocity
+    description: Peripheral nervous system involvement in type 1 can include decreased nerve conduction velocity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:812
+      reference_title: "Sialidosis type 1 (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000762 | Decreased nerve conduction velocity | Frequent (79-30%)"
+      explanation: Orphanet records decreased nerve conduction velocity as a frequent type 1 phenotype.
+  - target: Myoclonus
+    description: Progressive cortical and motor network dysfunction produces myoclonus.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Storage-related cortical hyperexcitability drives progressive myoclonus.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "On neurological assessment, 75% (3/4) of patients had a history of progressive myoclonus"
+      explanation: The type 1 cohort documents progressive myoclonus in three of four patients.
+  - target: Tremor
+    description: Motor circuit involvement can manifest as intentional tremor.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cerebellar and motor pathway dysfunction produce action tremor.
+    evidence:
+    - reference: PMID:23291686
+      reference_title: Clinical and serial MRI findings of a sialidosis type I patient with a novel missense mutation in the NEU1 gene.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "myoclonus, intentional tremors, limb and gait ataxia, hyperreflexia and macular"
+      explanation: The type 1 case report documents intentional tremor with other neurologic manifestations.
+  - target: Dysarthria
+    description: Progressive motor and cerebellar pathway involvement can impair speech articulation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cerebellar and bulbar motor pathway dysfunction disrupt speech motor control.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "evolving to slurred speech and dysphagia in the late stage."
+      explanation: The type 1 cohort supports progressive speech involvement in late-stage disease.
+  - target: Hyperreflexia
+    description: Central motor pathway involvement can manifest as hyperreflexia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Upper motor pathway dysfunction increases reflex responses.
+    evidence:
+    - reference: PMID:23291686
+      reference_title: Clinical and serial MRI findings of a sialidosis type I patient with a novel missense mutation in the NEU1 gene.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "myoclonus, intentional tremors, limb and gait ataxia, hyperreflexia and macular"
+      explanation: The type 1 case report documents hyperreflexia with ataxia and myoclonus.
+  - target: EEG abnormality
+    description: Epileptic network dysfunction can produce diffuse spike-wave EEG abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Cortical hyperexcitability produces epileptiform spike-wave discharges.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "EEG showed different extents of diffuse paroxysmal features as spike‐wave complexes in two patients."
+      explanation: The type 1 cohort documents diffuse paroxysmal EEG abnormalities.
+  - target: Cerebellar atrophy
+    description: Progressive neural storage disease can be accompanied by cerebellar and brain atrophy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic storage-related neurodegeneration causes structural brain volume loss in some patients.
+    evidence:
+    - reference: PMID:23291686
+      reference_title: Clinical and serial MRI findings of a sialidosis type I patient with a novel missense mutation in the NEU1 gene.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Serial brain MRI showed diffuse brain atrophy progressing rapidly"
+      explanation: Serial MRI in a type 1 patient supports progressive neurodegeneration with brain atrophy.
 - name: Retinal ganglion cell layer storage
   description: >
     In Type 1 disease, sialyloligosaccharide and related metabolic-product
@@ -400,6 +594,61 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Accumulation of metabolic products in the lens, ganglion cell, and RNFL are characteristic ocular findings"
     explanation: The cohort identifies lens, ganglion-cell, and RNFL metabolic-product accumulation as characteristic ocular pathology.
+  downstream:
+  - target: Retinopathy
+    description: Ganglion-cell and retinal nerve fiber layer storage produces retinal OCT abnormalities.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "OCT showed increased reflectivity in the retinal nerve fiber layer (RNFL) and ganglion cell layer in all patients."
+      explanation: OCT abnormalities in RNFL and ganglion-cell layers support retinopathy downstream of retinal storage.
+  - target: Visual impairment
+    description: Retinal and visual-pathway storage abnormalities impair visual function.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Retinal nerve fiber layer and ganglion-cell pathology disrupt visual pathway signaling.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "On ophthalmological assessment, all patients presented with visual impairment."
+      explanation: The type 1 cohort documents visual impairment in all four patients.
+  - target: Progressive visual loss
+    description: Progressive retinal and visual-pathway involvement causes worsening vision.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Ongoing storage pathology in retinal ganglion-cell and nerve-fiber layers disrupts visual function.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with sialidosis type 1 typically present progressive myoclonus epilepsy (PME) in their second or third decade of life, as well as progressive impaired vision and macular cherry red spots."
+      explanation: The cohort review identifies progressive impaired vision as a typical type 1 manifestation.
+  - target: Nystagmus
+    description: Visual pathway impairment can manifest with nystagmus.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Severe nystagmus was found in two patients."
+      explanation: The type 1 cohort documents nystagmus in two of four patients.
+  - target: Cherry red spot of the macula
+    description: Perifoveal ganglion-cell and RNFL storage creates the macular cherry-red spot.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The appearance of macular cherry red spots is caused by the accumulation of sialyloligosaccharides in the perifoveal ganglion cell layer and RNFL."
+      explanation: The ophthalmic cohort directly explains the storage basis of macular cherry-red spots.
 genetic:
 - name: Biallelic NEU1 pathogenic variants
   gene_term:


### PR DESCRIPTION
## Summary
- add causal link types and descriptions for the NEU1 deficiency -> sialylated storage -> neural/retinal pathology cascade
- connect neurologic, retinal, urinary, and ocular phenotype endpoints to the pathograph with cached evidence
- preserve existing treatment target mechanisms while improving graph endpoint coverage

## Validation
- `just validate kb/disorders/Sialidosis_Type_1.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Sialidosis_Type_1.yaml`
- custom normalized snippet audit: 102/102 snippets found in cache
- subagent review: one graph-completeness blocker found and fixed (`Decreased nerve conduction velocity` endpoint)

## Scope
- only `kb/disorders/Sialidosis_Type_1.yaml` changed
- validator-generated clinicaltrials cache churn restored before commit