### PR TITLE
feat: connect cblC pathograph

### DIFF
--- a/kb/disorders/MMACHC-related_Methylmalonic_Aciduria_and_Homocystinuria_cblC_Type.yaml
+++ b/kb/disorders/MMACHC-related_Methylmalonic_Aciduria_and_Homocystinuria_cblC_Type.yaml
@@ -1,7 +1,7 @@
 name: MMACHC-related Methylmalonic Aciduria and Homocystinuria, cblC Type
 category: Mendelian
 creation_date: '2026-04-13T01:16:34Z'
-updated_date: '2026-04-22T20:53:03Z'
+updated_date: '2026-05-10T10:16:51Z'
 synonyms:
 - Cobalamin C deficiency
 - cblC deficiency
@@ -70,8 +70,24 @@ pathophysiology:
   downstream:
   - target: Reduced methylcobalamin supply
     description: Loss of MMACHC lowers intracellular methylcobalamin available for methionine synthase.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cobalamin C is the most common inborn error of intracellular cobalamin metabolism caused by biallelic pathogenic variants in the MMACHC gene, leading to impaired conversion of dietary vitamin B12 into its two metabolically active forms, methylcobalamin and adenosylcobalamin.
+      explanation: Human cohort abstract directly links biallelic MMACHC variants to impaired generation of methylcobalamin.
   - target: Reduced adenosylcobalamin supply
     description: Loss of MMACHC lowers intracellular adenosylcobalamin available for methylmalonyl-CoA mutase.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cobalamin C is the most common inborn error of intracellular cobalamin metabolism caused by biallelic pathogenic variants in the MMACHC gene, leading to impaired conversion of dietary vitamin B12 into its two metabolically active forms, methylcobalamin and adenosylcobalamin.
+      explanation: Human cohort abstract directly links biallelic MMACHC variants to impaired generation of adenosylcobalamin.
 - name: Reduced methylcobalamin supply
   description: 'Deficient methylcobalamin availability compromises the remethylation arm of cobalamin metabolism.
 
@@ -86,6 +102,14 @@ pathophysiology:
   downstream:
   - target: Impaired methionine synthase-dependent remethylation
     description: Reduced methylcobalamin supply lowers methionine synthase-side remethylation capacity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32071835
+      reference_title: "High-dose hydroxocobalamin achieves biochemical correction and improvement of neuropsychiatric deficits in adults with late onset cobalamin C deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: MeCbl is a cofactor for methionine synthase, which converts homocysteine into methionine in the cytosol.
+      explanation: Human clinical report background identifies methylcobalamin as the methionine synthase cofactor, supporting this branch.
 - name: Impaired methionine synthase-dependent remethylation
   description: 'Disrupted cobalamin delivery to the methionine synthase arm produces remethylation failure with homocysteine accumulation and methionine depletion.
 
@@ -111,6 +135,14 @@ pathophysiology:
   downstream:
   - target: Hyperhomocysteinemia and hypomethioninemia
     description: Remethylation failure produces the defining sulfur-amino-acid abnormalities of cblC disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Biochemical hallmarks are elevated plasma total homocysteine (HCYs) and low methionine accompanied by methylmalonic aciduria.
+      explanation: Human cohort abstract identifies high homocysteine and low methionine as the biochemical output of the remethylation branch.
 - name: Reduced adenosylcobalamin supply
   description: 'Deficient adenosylcobalamin availability compromises the mitochondrial methylmalonyl-CoA mutase arm of cobalamin metabolism.
 
@@ -125,6 +157,14 @@ pathophysiology:
   downstream:
   - target: Impaired methylmalonyl-CoA mutase-dependent metabolism
     description: Reduced adenosylcobalamin supply lowers methylmalonyl-CoA mutase-side flux.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32071835
+      reference_title: "High-dose hydroxocobalamin achieves biochemical correction and improvement of neuropsychiatric deficits in adults with late onset cobalamin C deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: AdoCbl is a cofactor for methylmalonyl‐CoA mutase, which converts methylmalonyl‐CoA into succinyl‐CoA in the mitochondria.
+      explanation: Human clinical report background identifies adenosylcobalamin as the methylmalonyl-CoA mutase cofactor.
 - name: Impaired methylmalonyl-CoA mutase-dependent metabolism
   description: 'Failure to supply adenosylcobalamin impairs the methylmalonyl-CoA mutase pathway and drives methylmalonic acid accumulation.
 
@@ -148,6 +188,26 @@ pathophysiology:
   downstream:
   - target: Methylmalonic acid accumulation
     description: Impaired mutase-side flux produces the MMA branch of the combined disorder.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32186706
+      reference_title: "The vitamin B12 processing enzyme, mmachc, is essential for zebrafish survival, growth and retinal morphology."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: This recessive disorder is characterized by a failure to metabolize cobalamin into adenosyl- and methylcobalamin, which results in the biochemical perturbations of methylmalonic acidemia, hyperhomocysteinemia and hypomethioninemia caused by the impaired activity of the downstream enzymes, methylmalonyl-CoA mutase and methionine synthase.
+      explanation: Model-organism paper explicitly states that impaired methylmalonyl-CoA mutase activity contributes to methylmalonic acidemia in cblC.
+  - target: Propionylcarnitine (C3)
+    description: Impaired mutase-side flux can be detected on newborn screening as abnormal C3 or C3-ratio markers, although mild cases may require second-tier MMA testing.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Propionyl-CoA and related acylcarnitine accumulation upstream of impaired methylmalonyl-CoA mutase flux
+    evidence:
+    - reference: PMID:40981307
+      reference_title: "Milder Form of Cobalamin C Disease May Be Missed by Newborn Screening: The Importance of Methylmalonic Acid Assessment."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: All were recalled due to abnormalities in C3 or related ratios, along with elevated methylmalonic acid (MMA) levels.
+      explanation: Newborn-screening cohort links confirmed cblC cases to abnormal C3-based markers and elevated MMA.
 - name: Hyperhomocysteinemia and hypomethioninemia
   description: 'Remethylation failure elevates total homocysteine while depleting methionine, creating the homocystinuria branch of cblC disease.
 
@@ -164,6 +224,37 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: Cobalamin C (cblC) deficiency is the most common inborn error of intracellular cobalamin metabolism caused by pathogenic variant(s) in MMACHC and manifests with methylmalonic acidemia, hyperhomocysteinemia, and hypomethioninemia with a variable age of presentation.
     explanation: Adult late-onset cohort directly supports hyperhomocysteinemia and hypomethioninemia as core biochemical outputs of cblC disease.
+  downstream:
+  - target: Total homocysteine
+    description: Remethylation failure is measured clinically as increased plasma total homocysteine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Biochemical hallmarks are elevated plasma total homocysteine (HCYs) and low methionine accompanied by methylmalonic aciduria.
+      explanation: Human cohort abstract directly supports increased total homocysteine as the measured biochemical endpoint.
+  - target: Methionine
+    description: Failure to remethylate homocysteine depletes circulating methionine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Biochemical hallmarks are elevated plasma total homocysteine (HCYs) and low methionine accompanied by methylmalonic aciduria.
+      explanation: Human cohort abstract directly supports low methionine as the measured biochemical endpoint.
+  - target: Combined methylmalonic acidemia and homocystinuria injury
+    description: Hyperhomocysteinemia and low methionine are one component of the combined metabolic state that drives neuro-ocular, vascular, and renal morbidity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:32071835
+      reference_title: "High-dose hydroxocobalamin achieves biochemical correction and improvement of neuropsychiatric deficits in adults with late onset cobalamin C deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Individuals with late-onset cblC may be asymptomatic until manifesting neuropsychiatric symptoms, thromboembolic events, and renal disease.
+      explanation: Human late-onset case series links the biochemical cblC disorder to multisystem clinical morbidity.
 - name: Methylmalonic acid accumulation
   description: 'Impaired mutase-side cobalamin handling produces persistent methylmalonic acid elevation as the MMA branch of the combined metabolic phenotype.
 
@@ -180,6 +271,172 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: Biochemical hallmarks are elevated plasma total homocysteine (HCYs) and low methionine accompanied by methylmalonic aciduria.
     explanation: Human cohort data directly support methylmalonic acid accumulation as a defining biochemical feature.
+  downstream:
+  - target: Methylmalonic acid
+    description: The mutase-side branch is measured clinically as elevated methylmalonic acid or methylmalonic aciduria.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Biochemical hallmarks are elevated plasma total homocysteine (HCYs) and low methionine accompanied by methylmalonic aciduria.
+      explanation: Human cohort abstract directly supports methylmalonic aciduria as the measured biochemical endpoint.
+  - target: Combined methylmalonic acidemia and homocystinuria injury
+    description: Methylmalonic acid accumulation is the second component of the combined metabolic state that drives neuro-ocular, vascular, and renal morbidity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39152755
+      reference_title: "Improved biochemical and neurodevelopmental profiles with high-dose hydroxocobalamin therapy in cobalamin C defect."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cobalamin C (Cbl-C) defect causes methylmalonic acidemia, homocystinuria, intellectual disability and visual impairment, despite treatment adherence.
+      explanation: Early-onset treatment cohort links methylmalonic acidemia and homocystinuria to neurodevelopmental and visual morbidity.
+- name: Combined methylmalonic acidemia and homocystinuria injury
+  description: 'Concurrent methylmalonic acidemia and homocystinuria create the multisystem injury state responsible for the neurological, ocular, vascular, and renal complications of cblC disease.
+
+    '
+  biological_processes:
+  - preferred_term: homocysteine metabolic process
+    term:
+      id: GO:0050667
+      label: homocysteine metabolic process
+  - preferred_term: L-methylmalonyl-CoA metabolic process
+    term:
+      id: GO:0046491
+      label: L-methylmalonyl-CoA metabolic process
+  evidence:
+  - reference: PMID:39152755
+    reference_title: "Improved biochemical and neurodevelopmental profiles with high-dose hydroxocobalamin therapy in cobalamin C defect."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Cobalamin C (Cbl-C) defect causes methylmalonic acidemia, homocystinuria, intellectual disability and visual impairment, despite treatment adherence.
+    explanation: Early-onset treatment cohort directly connects the combined biochemical phenotype to neurodevelopmental and visual morbidity.
+  - reference: PMID:32071835
+    reference_title: "High-dose hydroxocobalamin achieves biochemical correction and improvement of neuropsychiatric deficits in adults with late onset cobalamin C deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Individuals with late-onset cblC may be asymptomatic until manifesting neuropsychiatric symptoms, thromboembolic events, and renal disease.
+    explanation: Adult late-onset case series supports multisystem morbidity downstream of the combined cblC biochemical state.
+  downstream:
+  - target: Intellectual disability
+    description: Early-onset combined biochemical disease is associated with persistent neurodevelopmental impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39152755
+      reference_title: "Improved biochemical and neurodevelopmental profiles with high-dose hydroxocobalamin therapy in cobalamin C defect."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cobalamin C (Cbl-C) defect causes methylmalonic acidemia, homocystinuria, intellectual disability and visual impairment, despite treatment adherence.
+      explanation: The treatment cohort explicitly links the combined biochemical disease to intellectual disability.
+  - target: Seizure
+    description: Neurologic injury in cblC includes seizures in pediatric cohorts.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The most common clinical features were cognitive impairment (n = 29), seizures (n = 23), motor developmental delay (n = 20), hypotonia (n = 17), and sparse/hypopigmented scalp hair (n = 16).
+      explanation: Cohort-level clinical data support seizures as a downstream neurological manifestation.
+  - target: Hypotonia
+    description: Neurologic injury in cblC includes hypotonia in pediatric cohorts.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39225018
+      reference_title: "Evaluation of the clinical, biochemical, and molecular spectrum of Cobalamin C (CblC) defect in 33 patients from Pakistan."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The most common clinical features were cognitive impairment (n = 29), seizures (n = 23), motor developmental delay (n = 20), hypotonia (n = 17), and sparse/hypopigmented scalp hair (n = 16).
+      explanation: Cohort-level clinical data support hypotonia as a downstream neurological manifestation.
+  - target: Early retinal degeneration and maculopathy
+    description: The combined methylmalonic acidemia-homocystinuria state can lead to infantile retinal degeneration and maculopathy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:40565527
+      reference_title: "Retinal Changes in Early-Onset cblC Methylmalonic Acidemia Identified Through Expanded Newborn Screening: Highlights from a Case Study and Literature Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Methylmalonic acidemia combined with homocystinuria (cblC) can lead to infantile maculopathy.
+      explanation: Ophthalmic case study and review directly link combined cblC disease to infantile maculopathy.
+  - target: Cardiovascular involvement in MMA-homocysteinemia
+    description: Children with methylmalonic acidemia and homocysteinemia can develop severe cardiovascular involvement, often including pulmonary hypertension.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:40830795
+      reference_title: "Clinical and molecular spectrum of patients with methylmalonic acidemia and homocysteinemia complicated by cardiovascular manifestations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cardiovascular complications were found between the ages of 2 months and 12 years, with 9 patients having pulmonary hypertension, 7 having hypertension, and 5 having non-compaction of ventricular myocardium.
+      explanation: Pediatric cardiovascular cohort supports cardiovascular involvement downstream of MMA-homocysteinemia, mostly in genetically confirmed cblC cases.
+  - target: Renal thrombotic microangiopathy with tubular injury
+    description: Renal cblC disease includes thrombotic microangiopathy and tubular injury in the setting of elevated serum and urine homocysteine.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Homocysteine-associated renal endothelial injury and thrombotic microangiopathy
+    evidence:
+    - reference: PMID:39390411
+      reference_title: "Late-onset renal TMA and tubular injury in cobalamin C disease: a report of three cases and literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: They were diagnosed with renal involvement due to cblC deficiency after laboratory tests revealing elevated serum and urine homocysteine, renal biopsy showing TMA and tubular injury, along with genetic testing showing heterogeneous compound mutations in MMACHC.
+      explanation: Renal case series directly links cblC biochemical abnormalities and MMACHC variants to biopsy-proven TMA and tubular injury.
+  - target: Proteinuria
+    description: Renal cblC injury can present clinically with proteinuria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Renal thrombotic microangiopathy and tubular injury
+    evidence:
+    - reference: PMID:39390411
+      reference_title: "Late-onset renal TMA and tubular injury in cobalamin C disease: a report of three cases and literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Here we described three teenage patients who presented with hematuria, proteinuria, and hypertension in clinical presentation.
+      explanation: Renal case series supports proteinuria as a clinical manifestation downstream of renal cblC involvement.
+- name: Early retinal degeneration and maculopathy
+  description: 'Early-onset cblC can cause retinal degeneration and maculopathy within the first months of life, sometimes despite timely metabolic treatment and biochemical control.
+
+    '
+  evidence:
+  - reference: PMID:40565527
+    reference_title: "Retinal Changes in Early-Onset cblC Methylmalonic Acidemia Identified Through Expanded Newborn Screening: Highlights from a Case Study and Literature Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: In cblC, retinal degeneration occurs in the first months of life despite timely treatment and adequate biochemical control, and it may manifest before any signs of visual deprivation appear.
+    explanation: Ophthalmic case study and review support early retinal degeneration as a cblC organ-injury mechanism.
+  downstream:
+  - target: Visual impairment
+    description: Retinal degeneration and maculopathy provide the ocular mechanism for visual impairment in cblC.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40565527
+      reference_title: "Retinal Changes in Early-Onset cblC Methylmalonic Acidemia Identified Through Expanded Newborn Screening: Highlights from a Case Study and Literature Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: In cblC, retinal degeneration occurs in the first months of life despite timely treatment and adequate biochemical control, and it may manifest before any signs of visual deprivation appear.
+      explanation: Ophthalmic case study and review link early retinal degeneration to the preclinical window before visual deprivation.
+- name: Cardiovascular involvement in MMA-homocysteinemia
+  description: 'A subset of children with methylmalonic acidemia and homocysteinemia develop cardiovascular complications, most notably pulmonary hypertension.
+
+    '
+  evidence:
+  - reference: PMID:40830795
+    reference_title: "Clinical and molecular spectrum of patients with methylmalonic acidemia and homocysteinemia complicated by cardiovascular manifestations."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Cardiovascular complications were found between the ages of 2 months and 12 years, with 9 patients having pulmonary hypertension, 7 having hypertension, and 5 having non-compaction of ventricular myocardium.
+    explanation: Pediatric cohort directly documents cardiovascular manifestations in MMA-homocysteinemia, with most cases confirmed as MMACHC-related cblC.
+  downstream:
+  - target: Pulmonary arterial hypertension
+    description: Pulmonary hypertension is the most common cardiovascular complication reported in the cohort.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40830795
+      reference_title: "Clinical and molecular spectrum of patients with methylmalonic acidemia and homocysteinemia complicated by cardiovascular manifestations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Cardiovascular complications were found between the ages of 2 months and 12 years, with 9 patients having pulmonary hypertension, 7 having hypertension, and 5 having non-compaction of ventricular myocardium.
+      explanation: Cohort-level data directly support pulmonary hypertension as a downstream cardiovascular manifestation.
 phenotypes:
 - category: Neurological
   name: Intellectual disability
@@ -424,6 +681,27 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Reduced methylcobalamin supply
+    treatment_effect: RESTORES
+    description: Hydroxocobalamin improves homocysteine and methionine values, consistent with correcting the methylcobalamin/remethylation branch.
+    evidence:
+    - reference: PMID:39152755
+      reference_title: "Improved biochemical and neurodevelopmental profiles with high-dose hydroxocobalamin therapy in cobalamin C defect."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Biochemical analyses revealed better values of homocysteine, methionine and methylmalonic acid in Group A compared to Group B1 (p < 0.01, p < 0.05 and p < 0.01, respectively) and B2 (p < 0.001, p < 0.01 and p < 0.001, respectively).
+      explanation: High-dose hydroxocobalamin improved remethylation-linked metabolites in treated children.
+  - target: Reduced adenosylcobalamin supply
+    treatment_effect: RESTORES
+    description: Hydroxocobalamin improves methylmalonic acid values, consistent with correcting the adenosylcobalamin/mutase branch.
+    evidence:
+    - reference: PMID:39152755
+      reference_title: "Improved biochemical and neurodevelopmental profiles with high-dose hydroxocobalamin therapy in cobalamin C defect."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Biochemical analyses revealed better values of homocysteine, methionine and methylmalonic acid in Group A compared to Group B1 (p < 0.01, p < 0.05 and p < 0.01, respectively) and B2 (p < 0.001, p < 0.01 and p < 0.001, respectively).
+      explanation: High-dose hydroxocobalamin improved methylmalonic acid in treated children, supporting impact on the adenosylcobalamin-dependent branch.
   evidence:
   - reference: PMID:39152755
     reference_title: "Improved biochemical and neurodevelopmental profiles with high-dose hydroxocobalamin therapy in cobalamin C defect."
@@ -446,6 +724,17 @@ treatments:
     term:
       id: MAXO:0000106
       label: nutritional supplementation
+  target_mechanisms:
+  - target: Hyperhomocysteinemia and hypomethioninemia
+    treatment_effect: BYPASSES
+    description: Betaine supports an alternate remethylation route through betaine-homocysteine methyltransferase, lowering homocysteine and generating methionine.
+    evidence:
+    - reference: PMID:32071835
+      reference_title: "High-dose hydroxocobalamin achieves biochemical correction and improvement of neuropsychiatric deficits in adults with late onset cobalamin C deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Betaine is used to lower homocysteine as a substrate for betaine‐homocysteine methyltransferase, which can convert homocysteine into methionine.
+      explanation: Human clinical report background describes the mechanism by which betaine bypasses impaired cobalamin-dependent remethylation.
   evidence:
   - reference: PMID:32071835
     reference_title: "High-dose hydroxocobalamin achieves biochemical correction and improvement of neuropsychiatric deficits in adults with late onset cobalamin C deficiency."


### PR DESCRIPTION
## Summary
- add typed, evidenced causal edges through the MMACHC methylcobalamin and adenosylcobalamin branches
- connect cblC biochemical endpoints, phenotype endpoints, retinal/cardiovascular/renal injury mechanisms, and treatment target mechanisms
- keep the PR scoped to kb/disorders/MMACHC-related_Methylmalonic_Aciduria_and_Homocystinuria_cblC_Type.yaml

## Validation
- uv run python -m dismech.graph --validate kb/disorders/MMACHC-related_Methylmalonic_Aciduria_and_Homocystinuria_cblC_Type.yaml
- just validate kb/disorders/MMACHC-related_Methylmalonic_Aciduria_and_Homocystinuria_cblC_Type.yaml
- normalized local snippet audit: 62/62 snippets found in cache
- git diff --check

## Review
- subagent blocker review found no blockers; I applied its two easy nonblocking suggestions before commit (RESTORES treatment effects for hydroxocobalamin and tighter retinal edge evidence).