### PR TITLE
feat: connect MEDNIK syndrome pathograph

### DIFF
--- a/kb/disorders/MEDNIK_syndrome.yaml
+++ b/kb/disorders/MEDNIK_syndrome.yaml
@@ -1,6 +1,6 @@
 name: MEDNIK syndrome
 creation_date: "2026-04-13T22:47:36Z"
-updated_date: "2026-04-14T15:05:00Z"
+updated_date: "2026-05-10T10:51:58Z"
 description: >-
   MEDNIK syndrome is a rare AP1S1-related multisystem disorder of intracellular
   trafficking and copper metabolism characterized by intellectual disability,
@@ -62,8 +62,104 @@ pathophysiology:
   downstream:
   - target: Copper pump trafficking defect
     description: AP1S1 dysfunction impairs intracellular trafficking of copper transport machinery.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1111/nyas.12426
+      reference_title: "AP1S1 defect causing MEDNIK syndrome: a new adaptinopathy associated with defective copper metabolism"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "MEDNIK syndrome is caused by mutation of the AP1S1 gene, which codes for the σ1A subunit of adaptor protein complex 1, and directs intracellular trafficking of copper pumps ATP7A and ATP7B."
+      explanation: Review-level evidence directly links AP1S1 mutation to trafficking of the ATP7A and ATP7B copper pumps.
   - target: Intestinal epithelial barrier defect
     description: AP1S1 dysfunction impairs epithelial junctional integrity and barrier function.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1007/s00439-020-02168-w
+      reference_title: AP1S1 missense mutations cause a congenital enteropathy via an epithelial barrier defect
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Our data indicate that loss of AP1S1 function causes an intestinal epithelial barrier defect"
+      explanation: Caco2 AP1S1 knockout and rescue experiments support barrier dysfunction downstream of AP1S1 loss.
+  - target: Intellectual disability
+    description: AP1S1 loss causes the syndromic neurodevelopmental phenotype that includes intellectual disability.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19057675
+      reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "families with a unique syndrome characterized by mental retardation,"
+      explanation: Human family data link AP1S1 loss of function to the syndrome phenotype including intellectual disability.
+  - target: Hearing impairment
+    description: AP1S1 loss causes the syndromic neurocutaneous phenotype that includes deafness.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19057675
+      reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
+      explanation: Human family data link AP1S1 loss of function to the syndrome phenotype including deafness.
+  - target: Peripheral neuropathy
+    description: AP1S1 loss causes the syndromic neurocutaneous phenotype that includes peripheral neuropathy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19057675
+      reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
+      explanation: Human family data link AP1S1 loss of function to the syndrome phenotype including peripheral neuropathy.
+  - target: Ichthyosis
+    description: AP1S1 loss causes the syndromic neurocutaneous phenotype that includes ichthyosis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19057675
+      reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
+      explanation: Human family data link AP1S1 loss of function to the syndrome phenotype including ichthyosis.
+  - target: Palmoplantar keratoderma
+    description: AP1S1 loss causes the syndromic neurocutaneous phenotype that includes palmoplantar keratoderma.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19057675
+      reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
+      explanation: Human family data link AP1S1 loss of function to the syndrome phenotype including keratodermia.
+  - target: Seizures
+    description: Additional AP1S1 pathogenic variants expand the neurological phenotype to include seizures.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1155/ijog/4385128
+      reference_title: "Clinical and Genetic Functional Validation of a Novel AP1S1 Mutation Causing MEDNIK Syndrome"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The proband and his sister exhibited developmental delays, seizures, yellow hair, sparse teeth and a high forehead."
+      explanation: Human sibling-pair report links AP1S1-related MEDNIK syndrome to seizures.
+  - target: Fair hair
+    description: AP1S1-related MEDNIK syndrome can include yellow or pale hair pigmentation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1155/ijog/4385128
+      reference_title: "Clinical and Genetic Functional Validation of a Novel AP1S1 Mutation Causing MEDNIK Syndrome"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The proband and his sister exhibited developmental delays, seizures, yellow hair, sparse teeth and a high forehead."
+      explanation: Human sibling-pair report links AP1S1-related MEDNIK syndrome to yellow hair.
+  - target: Prominent forehead
+    description: AP1S1-related MEDNIK syndrome can include a high or prominent forehead.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1155/ijog/4385128
+      reference_title: "Clinical and Genetic Functional Validation of a Novel AP1S1 Mutation Causing MEDNIK Syndrome"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The proband and his sister exhibited developmental delays, seizures, yellow hair, sparse teeth and a high forehead."
+      explanation: Human sibling-pair report links AP1S1-related MEDNIK syndrome to high forehead.
 - name: Copper pump trafficking defect
   description: >-
     AP1S1 directs intracellular trafficking of ATP7A and ATP7B, linking MEDNIK
@@ -75,6 +171,41 @@ pathophysiology:
     evidence_source: OTHER
     snippet: "MEDNIK syndrome is caused by mutation of the AP1S1 gene, which codes for the σ1A subunit of adaptor protein complex 1, and directs intracellular trafficking of copper pumps ATP7A and ATP7B."
     explanation: This directly supports the copper-trafficking mechanism in MEDNIK syndrome.
+  downstream:
+  - target: Hepatic copper overload
+    description: Defective copper pump trafficking produces the Wilson-like hepatic copper-overload branch of MEDNIK syndrome.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Mislocalization of ATP7A and ATP7B copper pumps
+    evidence:
+    - reference: DOI:10.1111/nyas.12426
+      reference_title: "AP1S1 defect causing MEDNIK syndrome: a new adaptinopathy associated with defective copper metabolism"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "This multisystem disease combines clinical and biochemical signs of both Menkes and Wilson's diseases, in which liver copper overload is treatable using zinc acetate therapy."
+      explanation: Review-level evidence links AP1S1-related MEDNIK syndrome to liver copper overload in the setting of defective copper-pump trafficking.
+- name: Hepatic copper overload
+  description: >-
+    MEDNIK syndrome includes Wilson-like hepatic copper overload downstream of
+    defective AP1S1-dependent copper pump trafficking.
+  evidence:
+  - reference: DOI:10.1111/nyas.12426
+    reference_title: "AP1S1 defect causing MEDNIK syndrome: a new adaptinopathy associated with defective copper metabolism"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "This multisystem disease combines clinical and biochemical signs of both Menkes and Wilson's diseases, in which liver copper overload is treatable using zinc acetate therapy."
+    explanation: Review-level evidence identifies liver copper overload as a treatable biochemical component of MEDNIK syndrome.
+  downstream:
+  - target: Liver copper
+    description: Hepatic copper overload is measured as increased liver copper.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1111/nyas.12426
+      reference_title: "AP1S1 defect causing MEDNIK syndrome: a new adaptinopathy associated with defective copper metabolism"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "This multisystem disease combines clinical and biochemical signs of both Menkes and Wilson's diseases, in which liver copper overload is treatable using zinc acetate therapy."
+      explanation: The review explicitly supports liver copper overload as the biochemical endpoint.
 - name: Intestinal epithelial barrier defect
   description: >-
     AP1S1 loss disrupts tight-junction organization and epithelial barrier
@@ -86,6 +217,25 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: "Our data indicate that loss of AP1S1 function causes an intestinal epithelial barrier defect"
     explanation: This directly supports enteropathy as a downstream consequence of AP1S1 dysfunction.
+  downstream:
+  - target: Chronic diarrhea
+    description: Barrier dysfunction explains the enteropathy and chronic/intractable diarrhea phenotype in MEDNIK syndrome.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Tight-junction protein mislocalization and increased epithelial permeability
+    evidence:
+    - reference: DOI:10.1007/s00439-020-02168-w
+      reference_title: AP1S1 missense mutations cause a congenital enteropathy via an epithelial barrier defect
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Our data indicate that loss of AP1S1 function causes an intestinal epithelial barrier defect"
+      explanation: AP1S1 knockout epithelial model supports the barrier-defect mechanism for enteropathy.
+    - reference: DOI:10.1155/ijog/4385128
+      reference_title: "Clinical and Genetic Functional Validation of a Novel AP1S1 Mutation Causing MEDNIK Syndrome"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Furthermore, the sister initially presented with intractable diarrhoea"
+      explanation: Human sibling-pair report supports the diarrhea endpoint in MEDNIK syndrome.
 phenotypes:
 - name: Intellectual disability
   category: Neurodevelopmental
@@ -101,7 +251,7 @@ phenotypes:
     reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "This founder splice mutation, which leads to a premature stop codon, was found in four families with a unique syndrome characterized by mental retardation, enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia (MEDNIK)."
+    snippet: "families with a unique syndrome characterized by mental retardation,"
     explanation: This directly supports intellectual disability as part of the original clinically defined MEDNIK syndrome phenotype.
 - name: Chronic diarrhea
   category: Gastrointestinal
@@ -131,7 +281,7 @@ phenotypes:
     reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "This founder splice mutation, which leads to a premature stop codon, was found in four families with a unique syndrome characterized by mental retardation, enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia (MEDNIK)."
+    snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
     explanation: This directly supports hearing impairment as part of the original clinically defined MEDNIK syndrome phenotype.
 - name: Peripheral neuropathy
   category: Neurological
@@ -146,7 +296,7 @@ phenotypes:
     reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "This founder splice mutation, which leads to a premature stop codon, was found in four families with a unique syndrome characterized by mental retardation, enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia (MEDNIK)."
+    snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
     explanation: This directly supports peripheral neuropathy as part of the original clinically defined MEDNIK syndrome phenotype.
 - name: Ichthyosis
   category: Dermatologic
@@ -161,7 +311,7 @@ phenotypes:
     reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "This founder splice mutation, which leads to a premature stop codon, was found in four families with a unique syndrome characterized by mental retardation, enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia (MEDNIK)."
+    snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
     explanation: This directly supports ichthyosis as part of the original clinically defined MEDNIK syndrome phenotype.
 - name: Palmoplantar keratoderma
   category: Dermatologic
@@ -176,7 +326,7 @@ phenotypes:
     reference_title: "Disruption of AP1S1, causing a novel neurocutaneous syndrome, perturbs development of the skin and spinal cord."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "This founder splice mutation, which leads to a premature stop codon, was found in four families with a unique syndrome characterized by mental retardation, enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia (MEDNIK)."
+    snippet: "enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia"
     explanation: This directly supports palmoplantar keratoderma as part of the original clinically defined MEDNIK syndrome phenotype.
 - name: Seizures
   category: Neurological
@@ -270,6 +420,17 @@ treatments:
       term:
         id: CHEBI:62984
         label: zinc acetate
+  target_mechanisms:
+  - target: Hepatic copper overload
+    treatment_effect: INHIBITS
+    description: Zinc acetate therapy is proposed for the liver copper-overload component of MEDNIK syndrome.
+    evidence:
+    - reference: DOI:10.1111/nyas.12426
+      reference_title: "AP1S1 defect causing MEDNIK syndrome: a new adaptinopathy associated with defective copper metabolism"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "This multisystem disease combines clinical and biochemical signs of both Menkes and Wilson's diseases, in which liver copper overload is treatable using zinc acetate therapy."
+      explanation: Review-level evidence explicitly states that liver copper overload is treatable using zinc acetate therapy.
   evidence:
   - reference: DOI:10.1111/nyas.12426
     reference_title: "AP1S1 defect causing MEDNIK syndrome: a new adaptinopathy associated with defective copper metabolism"
@@ -302,7 +463,7 @@ diagnosis:
     reference_title: "Clinical and Genetic Functional Validation of a Novel AP1S1 Mutation Causing MEDNIK Syndrome"
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Genetic sequencing revealed a homozygous AP1S1 mutation at the splicing site (NM_001283.3): c.430‐1G>A."
+    snippet: "Genetic sequencing revealed a homozygous\n                    AP1S1\n                    mutation at the splicing site (NM_001283.3): c.430‐1G>A."
     explanation: This directly supports molecular diagnosis through AP1S1 sequencing.
 differential_diagnoses:
 - name: Menkes disease


### PR DESCRIPTION
## Summary
- add typed, evidenced causal edges from AP1S1 loss to copper-pump trafficking, intestinal barrier dysfunction, and phenotype endpoints
- add hepatic copper overload as a pathophysiology node, connect the Liver copper biochemical endpoint, and link zinc acetate to that mechanism
- tighten pre-existing wrapped snippets in MEDNIK to literal cached substrings so raw cache audit passes

## Validation
- uv run python -m dismech.graph --validate kb/disorders/MEDNIK_syndrome.yaml
- just validate kb/disorders/MEDNIK_syndrome.yaml
- local raw snippet audit: 36/36 snippets found exactly in cache
- git diff --check origin/main...HEAD

## Review
- subagent review found one snippet exactness blocker; fixed by replacing wrapped PMID/DOI snippets with raw cache substrings. No remaining graph, schema, or evidence-source blockers.