### PR TITLE
Improve Wolman disease pathograph connectivity

### DIFF
--- a/kb/disorders/Wolman_Disease.yaml
+++ b/kb/disorders/Wolman_Disease.yaml
@@ -233,16 +233,13 @@ pathophysiology:
       explanation: The same tissue-distribution statement directly supports gastrointestinal tract lipid storage.
   - target: Adrenal Cortical Lipid Storage
     description: Adrenal cortical tissues accumulate stored lipids and become structurally abnormal.
-    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
-    intermediate_mechanisms:
-    - multisystem neutral-lipid storage with adrenal enlargement
-    - adrenal tissue injury and calcification
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
-      explanation: The review supports adrenal structural disease in rapidly progressive LAL-D; the edge is marked indirect because adrenal lipid storage is represented as the inferred tissue mechanism between systemic neutral-lipid storage and adrenal calcification.
+      explanation: The review supports adrenal structural disease in rapidly progressive LAL-D, consistent with adrenal cortical lipid storage as a direct tissue-specific extension of multisystem neutral-lipid storage.
   evidence:
   - reference: PMID:41599846
     supports: SUPPORT

--- a/kb/disorders/Wolman_Disease.yaml
+++ b/kb/disorders/Wolman_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wolman Disease
 creation_date: '2026-04-14T19:53:03Z'
-updated_date: '2026-04-14T19:53:03Z'
+updated_date: '2026-05-10T12:07:15Z'
 category: Mendelian
 description: >
   Wolman disease is the rapidly progressive infantile phenotype of lysosomal acid
@@ -74,6 +74,12 @@ pathophysiology:
   - target: Lysosomal Acid Lipase Deficiency
     description: Loss of LIPA function reduces or abolishes lysosomal acid lipase activity.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28786388
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Lysosomal acid lipase deficiency is a rare, autosomal recessive condition caused by mutations in the gene encoding lysosomal acid lipase (LIPA) that result in reduced or absent activity of this essential enzyme."
+      explanation: This review directly connects LIPA mutations to reduced or absent lysosomal acid lipase activity.
   evidence:
   - reference: PMID:28786388
     supports: SUPPORT
@@ -109,6 +115,12 @@ pathophysiology:
   - target: Impaired Lysosomal Cholesteryl Ester and Triglyceride Hydrolysis
     description: Deficient lysosomal acid lipase prevents normal lysosomal hydrolysis of cholesteryl esters and triglycerides.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36204319
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Lysosomal acid lipase (LAL), encoded by the gene LIPA, is the sole neutral lipid hydrolase in lysosomes, responsible for cleavage of cholesteryl esters and triglycerides into their component parts."
+      explanation: This review defines LAL as the lysosomal hydrolase responsible for cleaving cholesteryl esters and triglycerides, supporting the hydrolysis block caused by deficiency.
   evidence:
   - reference: PMID:30866656
     supports: SUPPORT
@@ -148,6 +160,12 @@ pathophysiology:
   - target: Lysosomal Cholesteryl Ester and Triglyceride Storage
     description: Undegraded cholesteryl esters and triglycerides accumulate in lysosomes.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23624251
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Lysosomal Acid Lipase (LAL) deficiency is a rare metabolic storage disease, caused by a marked reduction in activity of LAL, which leads to accumulation of cholesteryl esters (CE) and triglycerides (TG) in lysosomes in many tissues."
+      explanation: Human LAL deficiency data directly support lysosomal cholesteryl ester and triglyceride storage downstream of reduced LAL activity.
   evidence:
   - reference: PMID:30866656
     supports: SUPPORT
@@ -198,12 +216,33 @@ pathophysiology:
   - target: Hepatic and Reticuloendothelial Lipid Storage
     description: Lipid-laden macrophages and parenchymal cells accumulate in liver and spleen.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41599846
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "LAL deficiency leads to the accumulation of cholesteryl esters and triglycerides within the lysosomes, macrophages, and parenchymal cells in most tissue types, including those in the liver, gastrointestinal tract, and lymph nodes but excluding the central nervous system."
+      explanation: The review directly identifies lipid storage in macrophages and parenchymal cells, including liver and lymphoid tissues.
   - target: Intestinal Lipid Storage
     description: Lipid storage in the gastrointestinal tract drives enteric dysfunction.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41599846
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "LAL deficiency leads to the accumulation of cholesteryl esters and triglycerides within the lysosomes, macrophages, and parenchymal cells in most tissue types, including those in the liver, gastrointestinal tract, and lymph nodes but excluding the central nervous system."
+      explanation: The same tissue-distribution statement directly supports gastrointestinal tract lipid storage.
   - target: Adrenal Cortical Lipid Storage
     description: Adrenal cortical tissues accumulate stored lipids and become structurally abnormal.
-    causal_link_type: DIRECT
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - multisystem neutral-lipid storage with adrenal enlargement
+    - adrenal tissue injury and calcification
+    evidence:
+    - reference: PMID:41599846
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
+      explanation: The review supports adrenal structural disease in rapidly progressive LAL-D; the edge is marked indirect because adrenal lipid storage is represented as the inferred tissue mechanism between systemic neutral-lipid storage and adrenal calcification.
   evidence:
   - reference: PMID:41599846
     supports: SUPPORT
@@ -241,6 +280,21 @@ pathophysiology:
   - target: Progressive Liver Dysfunction
     description: Progressive hepatic storage contributes to liver dysfunction and eventual hepatic failure.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28179030
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
+      explanation: The infant treatment study links hepatosplenomegaly and rapidly progressive liver disease in the severe LAL-D phenotype.
+  - target: Hepatosplenomegaly
+    description: Hepatic and reticuloendothelial lipid storage clinically manifests as marked hepatosplenomegaly.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28179030
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
+      explanation: The study identifies massive hepatosplenomegaly as a hallmark manifestation of infantile LAL-D.
   evidence:
   - reference: PMID:28179030
     supports: SUPPORT
@@ -267,6 +321,19 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Wolman's disease is a severe disorder that presents during infancy, resulting in failure to thrive, hepatomegaly, and hepatic failure, and an average life expectancy of less than 4 months."
     explanation: This review directly connects the severe infantile phenotype to progressive hepatic failure.
+  downstream:
+  - target: Failure to thrive
+    description: Severe hepatic failure contributes to the infantile failure-to-thrive phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - severe infantile multisystem disease
+    - impaired growth and nutritional status
+    evidence:
+    - reference: PMID:28786388
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Wolman's disease is a severe disorder that presents during infancy, resulting in failure to thrive, hepatomegaly, and hepatic failure, and an average life expectancy of less than 4 months."
+      explanation: The review links the severe infantile hepatic phenotype with failure to thrive.
 - name: Intestinal Lipid Storage
   description: >
     Storage in the gastrointestinal tract injures intestinal tissue and contributes
@@ -289,6 +356,12 @@ pathophysiology:
   - target: Malabsorption and Severe Gastrointestinal Dysfunction
     description: Intestinal storage produces gastrointestinal disturbance and impaired nutrient absorption.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41599846
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
+      explanation: The review links infantile LAL-D gastrointestinal disturbance with malabsorption-driven growth failure.
   evidence:
   - reference: PMID:41599846
     supports: SUPPORT
@@ -320,6 +393,43 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "The gastrointestinal symptoms are particularly improved after HCT, with reduced diarrhoea and vomiting. This allows gradual structured normalisation of diet with improved tolerance of dietary fat. Histologically there are reduced cholesterol clefts, fewer foamy macrophages and an improved villous structure."
     explanation: Improvement in diarrhea, vomiting, fat tolerance, and villous structure after therapy supports intestinal pathology as a key disease mechanism.
+  downstream:
+  - target: Malabsorption
+    description: Severe gastrointestinal dysfunction includes malabsorption.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41599846
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
+      explanation: The review explicitly states that malabsorption drives growth failure in rapidly progressive infantile LAL-D.
+  - target: Diarrhea
+    description: Gastrointestinal dysfunction commonly manifests as diarrhea.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28179030
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
+      explanation: The infant LAL-D study directly lists diarrhea among the severe gastrointestinal manifestations.
+  - target: Vomiting
+    description: Severe gastrointestinal dysfunction begins early with persistent vomiting.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24832708
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In early onset LAL deficiency, clinical manifestations start in the first few weeks of life with persistent vomiting, failure to thrive, hepatosplenomegaly, liver dysfunction and hepatic failure."
+      explanation: This case-based review directly supports persistent vomiting as an early gastrointestinal manifestation.
+  - target: Failure to thrive
+    description: Malabsorption and gastrointestinal dysfunction drive severe infantile growth failure.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41599846
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
+      explanation: The review directly connects malabsorption to growth failure in infantile-onset LAL-D.
 - name: Adrenal Cortical Lipid Storage
   description: >
     Lipid storage in the adrenal cortex produces adrenal enlargement and underlies
@@ -335,6 +445,16 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
     explanation: This review directly supports adrenal involvement with enlargement and calcification in rapidly progressive infantile disease.
+  downstream:
+  - target: Adrenal calcification
+    description: Adrenal cortical disease produces the characteristic adrenal calcification phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24832708
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Adrenal calcification is a striking feature but is present in only about 50% of cases."
+      explanation: This case-based review directly supports adrenal calcification as a characteristic adrenal manifestation of Wolman disease.
 phenotypes:
 - name: Failure to thrive
   category: Growth
@@ -436,6 +556,21 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
     explanation: This study directly identifies anemia as part of the severe infantile presentation.
+genetic:
+- name: LIPA
+  gene_term:
+    preferred_term: LIPA
+    term:
+      id: hgnc:6617
+      label: LIPA
+  association: Pathogenic Variants
+  evidence:
+  - reference: CGGV:assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z
+    reference_title: "LIPA / lysosomal acid lipase deficiency (Definitive)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "LIPA | HGNC:6617 | lysosomal acid lipase deficiency | MONDO:0800449 | AR | Definitive"
+    explanation: ClinGen classifies the LIPA-lysosomal acid lipase deficiency gene-disease relationship as definitive with autosomal recessive inheritance.
 treatments:
 - name: Sebelipase alfa enzyme replacement therapy
   description: >
@@ -462,6 +597,15 @@ treatments:
       evidence_source: HUMAN_CLINICAL
       snippet: "Sebelipase alfa markedly improved survival with substantial clinically meaningful improvements in growth and other key disease manifestations in infants with rapidly progressive lysosomal acid lipase deficiency"
       explanation: This phase 2/3 study supports enzyme replacement as proximal therapy for the underlying lysosomal acid lipase deficiency.
+  - target: Lysosomal Cholesteryl Ester and Triglyceride Storage
+    treatment_effect: INHIBITS
+    description: Enzyme replacement lowers the stored neutral-lipid burden downstream of the LAL deficiency.
+    evidence:
+    - reference: PMID:23624251
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "A significant decrease in hepatic CE was observed in LAL-deficient rats following treatment with sebelipase alfa."
+      explanation: In a LAL-deficient animal model, sebelipase alfa reduced hepatic cholesteryl ester accumulation, supporting direct inhibition of the storage mechanism.
   target_phenotypes:
   - preferred_term: Failure to thrive
     term:

--- a/references_cache/CGGV_assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z.md
+++ b/references_cache/CGGV_assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z.md
@@ -1,0 +1,26 @@
+---
+reference_id: "CGGV:assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z"
+title: "LIPA / lysosomal acid lipase deficiency (Definitive)"
+database: "ClinGen"
+content_type: "structured_record"
+---
+
+# CGGV:assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z  LIPA / lysosomal acid lipase deficiency
+
+**CGGV:assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z** - LIPA / lysosomal acid lipase deficiency (Definitive)
+
+## Gene-disease validity
+
+| Gene | HGNC | Disease | MONDO | MOI | Classification | SOP | GCEP | Classification date |
+|---|---|---|---|---|---|---|---|---|
+| LIPA | HGNC:6617 | lysosomal acid lipase deficiency | MONDO:0800449 | AR | Definitive | SOP9 | Lysosomal Diseases Gene Curation Expert Panel | 2023-04-28T04:00:00.000Z |
+
+## Online report
+
+- Report URL: https://search.clinicalgenome.org/kb/gene-validity/CGGV:assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z
+
+## Source
+
+ClinGen Gene-Disease Validity Curations CSV snapshot **2026-01-24** (`gene_validity.csv`).
+
+[ClinGen gene validity search](https://search.clinicalgenome.org/kb/gene-validity)


### PR DESCRIPTION
## Summary
- add evidence to Wolman disease causal edges from LIPA loss through LAL deficiency, CE/TG hydrolysis block, lysosomal storage, and tissue-specific mechanisms
- connect hepatic, intestinal, and adrenal mechanisms to phenotype endpoints including hepatosplenomegaly, failure to thrive, malabsorption, diarrhea, vomiting, and adrenal calcification
- add ClinGen definitive LIPA gene-disease evidence and a generated structured reference cache
- add storage-reduction target-mechanism evidence for sebelipase alfa

## Validation
- uv run python -m dismech.graph --validate kb/disorders/Wolman_Disease.yaml
- just validate kb/disorders/Wolman_Disease.yaml
- custom cached-snippet audit: 45 normalized snippets found in cache
- git diff --check
- subagent blocker review: no blockers

## Scope
- intentional files: kb/disorders/Wolman_Disease.yaml and references_cache/CGGV_assertion_1691be18-3aa2-46e7-b6a6-e7acafb9f998-2023-04-28T040000.000Z.md
- restored unrelated ClinicalTrials cache normalization churn