### PR TITLE
Add acoustic neuroma disorder curation

### DIFF
--- a/kb/disorders/Acoustic_Neuroma.yaml
+++ b/kb/disorders/Acoustic_Neuroma.yaml
@@ -65,7 +65,7 @@ has_subtypes:
   - reference: PMID:38928264
     reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "NF2-related schwannomatosis (NF2) is a genetic syndrome characterized by the growth of benign tumors in the nervous system, particularly bilateral vestibular schwannomas, meningiomas, and ependymomas."
     explanation: The review abstract directly supports bilateral vestibular schwannomas as a key NF2-related disease manifestation.
 prevalence:
@@ -117,13 +117,13 @@ pathophysiology:
   - reference: PMID:38928264
     reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Merlin, a tumor suppressor, integrates multiple signaling pathways that regulate cell contact, proliferation, and motility, thereby influencing tumor growth."
     explanation: This supports merlin as a tumor suppressor coordinating processes relevant to schwannoma growth.
   - reference: PMID:38928264
     reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "The loss of Merlin disrupts these pathways, leading to tumorigenesis."
     explanation: This directly supports the causal edge from merlin loss to tumor formation.
   downstream:
@@ -155,12 +155,57 @@ pathophysiology:
   - reference: PMID:36148553
     reference_title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
     supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "driven by the TAZ protein in human and mouse NF2-null schwannoma cells"
+    explanation: This supports TAZ-driven signaling in NF2-null schwannoma cells.
+  - reference: PMID:36148553
+    reference_title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
+    supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "Using both genetic ablation of the Hippo effectors YAP and TAZ as well as novel TEAD palmitoylation inhibitors, we show that Hippo signalling may be successfully targeted in vitro and in vivo to both block and, remarkably, regress schwannoma tumour growth."
-    explanation: This primary study supports YAP/TAZ-TEAD activity as an experimentally actionable growth mechanism in NF2-null schwannoma.
+    snippet: "successful use of TEAD palmitoylation inhibitors in a preclinical mouse model of schwannoma points to their potential future clinical use."
+    explanation: This supports in vivo mouse-model evidence for TEAD inhibition as a schwannoma growth mechanism.
   downstream:
+  - target: VEGF-Mediated Angiogenesis
+    description: NF2-null schwannoma growth is linked to pro-angiogenic VEGF biology.
+  - target: mTORC1 Signaling
+    description: NF2-related schwannoma biology creates a rationale for mTORC1-directed therapy.
   - target: Vestibulocochlear Nerve Dysfunction
     description: Tumor growth on the eighth cranial nerve disrupts auditory and vestibular function.
+- name: VEGF-Mediated Angiogenesis
+  description: >-
+    VEGF-related angiogenic signaling contributes to NF2-related vestibular
+    schwannoma treatment biology and provides the mechanistic rationale for
+    bevacizumab.
+  biological_processes:
+  - preferred_term: angiogenesis
+    modifier: INCREASED
+    term:
+      id: GO:0001525
+      label: angiogenesis
+  evidence:
+  - reference: PMID:39685944
+    reference_title: "Bevacizumab for Vestibular Schwannomas in Neurofibromatosis Type 2: A Systematic Review of Tumor Control and Hearing Preservation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Bevacizumab, a VEGF-targeting monoclonal antibody, has emerged as a less invasive treatment option, showing potential for tumor volume reduction and hearing preservation."
+    explanation: This supports VEGF as the treatment-linked angiogenic mechanism targeted by bevacizumab in NF2-related VS.
+- name: mTORC1 Signaling
+  description: >-
+    mTORC1 signaling is implicated as a downstream actionable pathway in
+    progressive NF2-related vestibular schwannoma, motivating everolimus therapy.
+  biological_processes:
+  - preferred_term: TOR signaling
+    modifier: INCREASED
+    term:
+      id: GO:0031929
+      label: TOR signaling
+  evidence:
+  - reference: PMID:38372904
+    reference_title: Imaging as an early biomarker to predict sensitivity to everolimus for progressive NF2-related vestibular schwannoma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Pre-clinical studies highlighted the potential of mTORC1 inhibition in delaying schwannoma progression."
+    explanation: This supports mTORC1 signaling as the mechanism targeted by everolimus in progressive NF2-related VS.
 - name: Vestibulocochlear Nerve Dysfunction
   description: >-
     Tumor growth along cranial nerve VIII and in the internal auditory
@@ -225,6 +270,23 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Although VS can cause a variety of symptoms, tinnitus is one of the most distressing symptoms for patients and can greatly impact quality of life."
     explanation: This directly supports tinnitus as a clinically important VS symptom.
+- name: Headache
+  description: >-
+    Headache is a common presenting symptom in clinical acoustic-neuroma cohorts,
+    likely reflecting posterior-fossa mass effect or associated intracranial
+    pressure effects in some patients.
+  phenotype_term:
+    preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+  evidence:
+  - reference: DOI:10.37897/rjn.2024.3.7
+    reference_title: "Current trends in vestibular schwannoma management at a referral center in Indonesia: A cross-sectional study with retrospective data collection"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Common symptoms included hearing loss (63.6%), disequilibrium (50%), and headaches (39.7%)."
+    explanation: This retrospective cohort directly supports headache as a common acoustic-neuroma symptom.
 - name: Vestibular Symptoms
   description: >-
     Disequilibrium and vertigo are common vestibular manifestations and are
@@ -281,7 +343,7 @@ genetic:
   - reference: PMID:38928264
     reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "This review consolidates the current knowledge on NF2 syndrome, emphasizing the molecular pathology associated with the mutations in the gene of the same name, the NF2 gene, and the subsequent dysfunction of its product, the Merlin protein."
     explanation: This supports NF2 mutation and merlin dysfunction as central molecular pathology.
 diagnosis:
@@ -422,8 +484,8 @@ treatments:
       id: HP:0000365
       label: Hearing impairment
   target_mechanisms:
-  - target: NF2 Merlin Tumor-Suppressor Loss
-    treatment_effect: MODULATES
+  - target: VEGF-Mediated Angiogenesis
+    treatment_effect: INHIBITS
     description: Bevacizumab targets VEGF-related tumor biology in NF2-related vestibular schwannoma.
   evidence:
   - reference: PMID:39685944
@@ -438,6 +500,30 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "Following treatment, 40% of the patients experienced hearing improvement, 53%, stable hearing, and 7%, hearing loss."
     explanation: This single-center series supports hearing benefit or stabilization in many bevacizumab-treated NF2-related schwannomatosis patients.
+- name: Lapatinib for NF2-Related Vestibular Schwannoma
+  description: >-
+    Lapatinib has been evaluated as a targeted therapy for vestibular schwannoma
+    in NF2-related schwannomatosis; reported activity is modest compared with
+    bevacizumab.
+  context: NF2-related vestibular schwannoma
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: lapatinib
+  target_mechanisms:
+  - target: YAP TAZ TEAD-Driven Schwannoma Growth
+    treatment_effect: MODULATES
+    description: Lapatinib is represented as a targeted therapy tested in NF2-related vestibular schwannoma; the exact receptor-level ontology binding was left preferred-term-only.
+  evidence:
+  - reference: PMID:37706198
+    reference_title: A systematic review of targeted therapy for vestibular schwannoma in patients with NF2-related schwannomatosis.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "lapatinib had a RR of 6% and a HR of 31%."
+    explanation: This systematic review supports modest lapatinib radiographic and hearing response rates in NF2-related vestibular schwannoma.
 - name: Everolimus for Progressive NF2-Related Vestibular Schwannoma
   description: >-
     Everolimus has been evaluated as mTORC1-directed pharmacotherapy for
@@ -453,8 +539,8 @@ treatments:
     therapeutic_agent:
     - preferred_term: everolimus
   target_mechanisms:
-  - target: NF2 Merlin Tumor-Suppressor Loss
-    treatment_effect: MODULATES
+  - target: mTORC1 Signaling
+    treatment_effect: INHIBITS
     description: Everolimus targets mTORC1 signaling downstream of NF2-related schwannoma biology.
   evidence:
   - reference: PMID:38372904
@@ -463,12 +549,33 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "After 52 weeks of treatment, the median annual VS growth rate decreased from 77.2% at baseline to 29.4%."
     explanation: This supports possible growth-rate reduction but only partial treatment efficacy because the abstract also reports no radiographic response.
-experimental_models:
-- name: NF2-null schwannoma preclinical model
+animal_models:
+- species: mouse
+  genotype: Periostin-Cre NF2fl/fl schwannoma model
+  category: Genetically engineered mouse model
+  genes:
+  - preferred_term: NF2
+    term:
+      id: hgnc:7773
+      label: NF2
   description: >-
-    Human primary schwannoma cells and mouse models were used to test YAP/TAZ
-    ablation and TEAD palmitoylation inhibitors.
-  experimental_model_type: CELL_LINE
+    Mouse schwannoma models were used to test YAP/TAZ ablation and TEAD
+    palmitoylation inhibitors in vivo.
+  associated_phenotypes:
+  - Schwannoma tumor growth
+  evidence:
+  - reference: PMID:36148553
+    reference_title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "successful use of TEAD palmitoylation inhibitors in a preclinical mouse model of schwannoma points to their potential future clinical use."
+    explanation: This directly documents the mouse-model component of the preclinical mechanism study.
+experimental_models:
+- name: NF2-null schwannoma primary-cell model
+  description: >-
+    Human primary schwannoma cells were used to test YAP/TAZ-driven TEAD
+    activity in NF2-null schwannoma growth.
+  experimental_model_type: PRIMARY_CELL_CULTURE
   cell_types:
   - preferred_term: Schwann cell
     term:
@@ -476,23 +583,21 @@ experimental_models:
       label: Schwann cell
   conditions:
   - NF2-null schwannoma cells
-  - mouse schwannoma model
-  cell_source: human primary tumor cells and mouse models
+  cell_source: human primary tumor cells
   modeled_mechanisms:
   - target: NF2 Merlin Tumor-Suppressor Loss
   - target: YAP TAZ TEAD-Driven Schwannoma Growth
   findings:
   - statement: YAP/TAZ-driven TEAD activity supports NF2-null schwannoma tumor growth.
     supporting_text: >-
-      Genetic ablation of YAP/TAZ and TEAD palmitoylation inhibitors blocked
-      and regressed schwannoma tumor growth in preclinical systems.
+      YAP/TAZ-driven signaling was identified in NF2-null schwannoma cells.
   evidence:
   - reference: PMID:36148553
     reference_title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
-    snippet: "Using a combination of human primary tumour cells and mouse models of schwannoma, we have examined the role of the Hippo signalling pathway in driving tumour cell growth."
-    explanation: This directly documents the preclinical systems used to study the pathway.
+    evidence_source: IN_VITRO
+    snippet: "driven by the TAZ protein in human and mouse NF2-null schwannoma cells"
+    explanation: This supports the primary-cell model as an in vitro system for NF2-null schwannoma signaling.
 notes: >-
   Falcon deep research was completed on 2026-05-10 and saved in
   research/Acoustic_Neuroma-deep-research-falcon.md with citations in the

--- a/kb/disorders/Acoustic_Neuroma.yaml
+++ b/kb/disorders/Acoustic_Neuroma.yaml
@@ -1,0 +1,501 @@
+name: Acoustic Neuroma
+creation_date: '2026-05-10T15:02:10Z'
+updated_date: '2026-05-10T15:02:10Z'
+category: Neoplastic
+categories:
+- Benign Neoplasm
+- Peripheral Nerve Sheath Tumor
+- Cranial Nerve Tumor
+parents:
+- schwannoma
+synonyms:
+- vestibular schwannoma
+- acoustic schwannoma
+- acoustic neurinoma
+- acoustic neurilemmoma
+disease_term:
+  preferred_term: acoustic neuroma
+  term:
+    id: MONDO:0001569
+    label: acoustic neuroma
+description: >-
+  Acoustic neuroma, also called vestibular schwannoma, is a benign
+  Schwann-cell tumor of the vestibulocochlear nerve. Most tumors are unilateral
+  and sporadic, while NF2-related schwannomatosis produces bilateral vestibular
+  schwannomas and other nervous-system tumors. The main disease mechanisms are
+  loss of NF2/merlin tumor-suppressor signaling in Schwann-lineage cells,
+  downstream dysregulation of proliferation, motility, Hippo/YAP/TAZ-TEAD
+  activity, and local tumor effects on cranial nerve VIII and adjacent
+  posterior-fossa structures.
+definitions:
+- name: Vestibular schwannoma definition
+  definition_type: CASE_DEFINITION
+  description: >-
+    Vestibular schwannoma is a benign tumor of neoplastic Schwann cells on the
+    eighth cranial nerve.
+  scope: General disease definition for acoustic neuroma / vestibular schwannoma
+  evidence:
+  - reference: PMID:38892775
+    reference_title: "Vestibular Schwannoma and Tinnitus: A Systematic Review of Microsurgery Compared to Gamma Knife Radiosurgery."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Vestibular schwannoma (VS) is a benign tumor of the eighth cranial nerve formed from neoplastic Schwann cells."
+    explanation: This systematic review abstract provides a concise disease-level definition.
+has_subtypes:
+- name: Sporadic Unilateral
+  display_name: Sporadic Unilateral Acoustic Neuroma
+  classification: clinical_context
+  description: >-
+    Most acoustic neuromas are unilateral sporadic tumors managed according to
+    size, hearing status, symptoms, growth, and patient factors.
+  evidence:
+  - reference: PMID:39627752
+    reference_title: "Treatment options for unilateral vestibular schwannoma: a network meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This study aimed to explore the effect of observation, microsurgery, and radiotherapy for patients with vestibular schwannoma (VS)."
+    explanation: This treatment network meta-analysis is explicitly scoped to unilateral VS, supporting a unilateral management context.
+- name: NF2-Related
+  display_name: NF2-Related Vestibular Schwannoma
+  classification: genetic_context
+  description: >-
+    Vestibular schwannomas in NF2-related schwannomatosis are typically
+    bilateral and occur as part of a genetic tumor-predisposition syndrome.
+  evidence:
+  - reference: PMID:38928264
+    reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "NF2-related schwannomatosis (NF2) is a genetic syndrome characterized by the growth of benign tumors in the nervous system, particularly bilateral vestibular schwannomas, meningiomas, and ependymomas."
+    explanation: The review abstract directly supports bilateral vestibular schwannomas as a key NF2-related disease manifestation.
+prevalence:
+- population: Unilateral vestibular schwannoma clinical literature
+  notes: >-
+    The Falcon report identified recent epidemiology summaries reporting annual
+    incidence around 10.4 per 100,000 in a 2024 treatment meta-analysis
+    background and prevalence estimates of 3-5.2 per 100,000 person-years in a
+    tinnitus-focused systematic review background. These exact figures are not
+    quoted here because they were not present in the fetched PubMed abstracts.
+progression:
+- phase: Slow local growth with treatment-dependent functional outcomes
+  notes: >-
+    Acoustic neuroma is generally slow-growing, but tumor growth and active
+    treatments can affect hearing, vestibular symptoms, facial nerve function,
+    and trigeminal nerve function. Long-term hearing outcomes vary by treatment
+    modality and pretreatment selection.
+  evidence:
+  - reference: PMID:39045727
+    reference_title: "Long-Term Hearing Outcome For Vestibular Schwannomas After Microsurgery And Radiotherapy: A Systematic Review and Meta-Analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hearing loss is a common symptom associated with vestibular schwannoma (VS), either because of the tumor's effects on the cochlear nerve or due to active treatments such as surgery or stereotactic radiosurgery (SRS)."
+    explanation: This supports the progressive and treatment-associated auditory outcome framing.
+pathophysiology:
+- name: NF2 Merlin Tumor-Suppressor Loss
+  description: >-
+    Loss or dysfunction of NF2/merlin is the central upstream molecular event in
+    NF2-related vestibular schwannoma and a recurrent driver in schwannoma
+    biology. Merlin normally coordinates contact, proliferation, and motility
+    signals; loss of this restraint promotes tumorigenesis.
+  cell_types:
+  - preferred_term: Schwann cell
+    term:
+      id: CL:0002573
+      label: Schwann cell
+  genes:
+  - preferred_term: NF2
+    term:
+      id: hgnc:7773
+      label: NF2
+  biological_processes:
+  - preferred_term: cell cycle checkpoint signaling
+    modifier: DECREASED
+    term:
+      id: GO:0000075
+      label: cell cycle checkpoint signaling
+  evidence:
+  - reference: PMID:38928264
+    reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Merlin, a tumor suppressor, integrates multiple signaling pathways that regulate cell contact, proliferation, and motility, thereby influencing tumor growth."
+    explanation: This supports merlin as a tumor suppressor coordinating processes relevant to schwannoma growth.
+  - reference: PMID:38928264
+    reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "The loss of Merlin disrupts these pathways, leading to tumorigenesis."
+    explanation: This directly supports the causal edge from merlin loss to tumor formation.
+  downstream:
+  - target: YAP TAZ TEAD-Driven Schwannoma Growth
+    description: Merlin loss releases downstream Hippo/YAP/TAZ-TEAD proliferative programs.
+- name: YAP TAZ TEAD-Driven Schwannoma Growth
+  description: >-
+    NF2-null schwannoma cells depend on Hippo-pathway effector activity,
+    including YAP/TAZ-driven TEAD transcriptional output, to sustain tumor-cell
+    growth. This mechanism is experimentally targetable in human primary tumor
+    cells and mouse models.
+  cell_types:
+  - preferred_term: Schwann cell
+    term:
+      id: CL:0002573
+      label: Schwann cell
+  genes:
+  - preferred_term: NF2
+    term:
+      id: hgnc:7773
+      label: NF2
+  biological_processes:
+  - preferred_term: positive regulation of Schwann cell proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0010625
+      label: positive regulation of Schwann cell proliferation
+  evidence:
+  - reference: PMID:36148553
+    reference_title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Using both genetic ablation of the Hippo effectors YAP and TAZ as well as novel TEAD palmitoylation inhibitors, we show that Hippo signalling may be successfully targeted in vitro and in vivo to both block and, remarkably, regress schwannoma tumour growth."
+    explanation: This primary study supports YAP/TAZ-TEAD activity as an experimentally actionable growth mechanism in NF2-null schwannoma.
+  downstream:
+  - target: Vestibulocochlear Nerve Dysfunction
+    description: Tumor growth on the eighth cranial nerve disrupts auditory and vestibular function.
+- name: Vestibulocochlear Nerve Dysfunction
+  description: >-
+    Tumor growth along cranial nerve VIII and in the internal auditory
+    canal/cerebellopontine-angle region impairs auditory and vestibular
+    signaling; larger tumors can affect adjacent cranial nerves and posterior
+    fossa structures.
+  locations:
+  - preferred_term: vestibulocochlear nerve
+    term:
+      id: UBERON:0001648
+      label: vestibulocochlear nerve
+  - preferred_term: cerebellopontine angle
+    term:
+      id: UBERON:0014908
+      label: cerebellopontine angle
+  evidence:
+  - reference: PMID:38892775
+    reference_title: "Vestibular Schwannoma and Tinnitus: A Systematic Review of Microsurgery Compared to Gamma Knife Radiosurgery."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Although VS can cause a variety of symptoms, tinnitus is one of the most distressing symptoms for patients and can greatly impact quality of life."
+    explanation: This supports symptomatic auditory morbidity from vestibular schwannoma.
+  downstream:
+  - target: Sensorineural Hearing Impairment
+    description: Cochlear nerve involvement produces hearing impairment.
+  - target: Tinnitus
+    description: Eighth-nerve tumor effects can produce persistent tinnitus.
+  - target: Vestibular Symptoms
+    description: Vestibular nerve involvement produces vertigo or disequilibrium.
+phenotypes:
+- name: Sensorineural Hearing Impairment
+  description: >-
+    Hearing impairment is one of the most common and functionally important
+    manifestations of acoustic neuroma and may reflect tumor effects on the
+    cochlear nerve or treatment effects.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+    clinical_course: PROGRESSIVE
+  evidence:
+  - reference: PMID:39045727
+    reference_title: "Long-Term Hearing Outcome For Vestibular Schwannomas After Microsurgery And Radiotherapy: A Systematic Review and Meta-Analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hearing loss is a common symptom associated with vestibular schwannoma (VS), either because of the tumor's effects on the cochlear nerve or due to active treatments such as surgery or stereotactic radiosurgery (SRS)."
+    explanation: This directly supports hearing loss as a common acoustic-neuroma manifestation.
+- name: Tinnitus
+  description: >-
+    Tinnitus can be persistent, distressing, and quality-of-life limiting in
+    patients with vestibular schwannoma.
+  phenotype_term:
+    preferred_term: Tinnitus
+    term:
+      id: HP:0000360
+      label: Tinnitus
+  evidence:
+  - reference: PMID:38892775
+    reference_title: "Vestibular Schwannoma and Tinnitus: A Systematic Review of Microsurgery Compared to Gamma Knife Radiosurgery."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Although VS can cause a variety of symptoms, tinnitus is one of the most distressing symptoms for patients and can greatly impact quality of life."
+    explanation: This directly supports tinnitus as a clinically important VS symptom.
+- name: Vestibular Symptoms
+  description: >-
+    Disequilibrium and vertigo are common vestibular manifestations and are
+    treatment-relevant outcomes in unilateral vestibular schwannoma.
+  phenotype_term:
+    preferred_term: Vertigo or disequilibrium
+    term:
+      id: HP:0002321
+      label: Vertigo
+  evidence:
+  - reference: PMID:39627752
+    reference_title: "Treatment options for unilateral vestibular schwannoma: a network meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In terms of improving the rate of disequilibrium/vertigo, the order from the highest to the lowest was SRS, Observation, FSRT 3 fractions, FSRT 5 fractions, MS, and ConFSRT."
+    explanation: This supports disequilibrium/vertigo as a tracked clinical outcome in unilateral VS treatment studies.
+- name: Facial Nerve Dysfunction
+  description: >-
+    Facial nerve dysfunction can occur from tumor mass effect, treatment
+    morbidity, or both; facial nerve preservation is a major treatment outcome.
+  phenotype_term:
+    preferred_term: Facial nerve dysfunction
+  evidence:
+  - reference: PMID:37402894
+    reference_title: "Proton beam radiation therapy for vestibular schwannomas-tumor control and hearing preservation rates: a systematic review and meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Here, we performed a systematic review and meta-analysis of proton beam for VSs, evaluating tumor control and cranial nerve preservation rates, particularly with regard to facial and hearing preservation."
+    explanation: This supports facial nerve function as a clinically important cranial-nerve outcome in VS.
+- name: Trigeminal Nerve Dysfunction
+  description: >-
+    Trigeminal sensory symptoms are a treatment-relevant cranial-nerve outcome
+    in unilateral vestibular schwannoma.
+  phenotype_term:
+    preferred_term: Trigeminal nerve dysfunction
+  evidence:
+  - reference: PMID:39627752
+    reference_title: "Treatment options for unilateral vestibular schwannoma: a network meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In terms of protection of the trigeminal nerve, the order from the highest to lowest was observation, SRS, ConFSRT, FSRT 3 fractions, FSRT 5 fractions, and MS."
+    explanation: This supports trigeminal nerve dysfunction risk as an outcome considered in treatment comparisons.
+genetic:
+- name: NF2 loss or dysfunction
+  gene_term:
+    preferred_term: NF2
+    term:
+      id: hgnc:7773
+      label: NF2
+  association: Causal tumor suppressor gene in NF2-related disease and a key schwannoma driver.
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE_AND_SOMATIC
+  evidence:
+  - reference: PMID:38928264
+    reference_title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "This review consolidates the current knowledge on NF2 syndrome, emphasizing the molecular pathology associated with the mutations in the gene of the same name, the NF2 gene, and the subsequent dysfunction of its product, the Merlin protein."
+    explanation: This supports NF2 mutation and merlin dysfunction as central molecular pathology.
+diagnosis:
+- name: Contrast-enhanced MRI
+  description: >-
+    MRI, often with contrast, is the key imaging modality for detecting and
+    monitoring acoustic neuroma / vestibular schwannoma.
+  diagnosis_term:
+    preferred_term: magnetic resonance imaging procedure
+    term:
+      id: MAXO:0000424
+      label: magnetic resonance imaging procedure
+  results: MRI identifies the vestibular schwannoma and supports volumetric monitoring during observation or treatment.
+  evidence:
+  - reference: PMID:38372904
+    reference_title: Imaging as an early biomarker to predict sensitivity to everolimus for progressive NF2-related vestibular schwannoma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Brain imaging was obtained quarterly."
+    explanation: This prospective NF2-related VS trial supports serial brain imaging as a monitoring method for progressive VS.
+- name: Audiologic monitoring
+  description: >-
+    Pure-tone audiometry and word-recognition testing are used to track hearing
+    status and treatment response.
+  diagnosis_term:
+    preferred_term: audiologic monitoring
+  results: Hearing outcomes are commonly expressed as serviceable hearing, word recognition score, or pure-tone thresholds.
+  evidence:
+  - reference: PMID:38372904
+    reference_title: Imaging as an early biomarker to predict sensitivity to everolimus for progressive NF2-related vestibular schwannoma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Secondary endpoints included other tumors RR, hearing outcomes, drug safety and quality of life (QOL)."
+    explanation: This supports formal hearing outcomes as part of VS treatment assessment.
+treatments:
+- name: Observation
+  description: >-
+    Observation is a standard management option for selected unilateral tumors,
+    especially when symptoms, size, growth, and patient factors favor
+    surveillance over immediate intervention.
+  treatment_term:
+    preferred_term: observation
+  evidence:
+  - reference: PMID:39627752
+    reference_title: "Treatment options for unilateral vestibular schwannoma: a network meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This study aimed to explore the effect of observation, microsurgery, and radiotherapy for patients with vestibular schwannoma (VS)."
+    explanation: This supports observation as one of the treatment strategies compared for unilateral VS.
+- name: Microsurgical Resection
+  description: >-
+    Microsurgery offers tumor removal and local control but must be balanced
+    against risks to hearing and adjacent cranial nerves.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  target_phenotypes:
+  - preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  target_mechanisms:
+  - target: YAP TAZ TEAD-Driven Schwannoma Growth
+    treatment_effect: INHIBITS
+    description: Microsurgical tumor removal directly reduces tumor burden.
+  evidence:
+  - reference: PMID:39045727
+    reference_title: "Long-Term Hearing Outcome For Vestibular Schwannomas After Microsurgery And Radiotherapy: A Systematic Review and Meta-Analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Microsurgery demonstrated a higher prevalence of maintaining long-term serviceable hearing, with a pooled estimate of 74.5% (95% CI: 63.5%-84.1%)."
+    explanation: This supports microsurgery as an active VS treatment with reported long-term hearing-preservation outcomes in selected cohorts.
+- name: Stereotactic Radiosurgery
+  description: >-
+    Stereotactic radiosurgery is an active tumor-control strategy for selected
+    acoustic neuromas and may preserve nerve function better than microsurgery
+    in some treatment comparisons.
+  treatment_term:
+    preferred_term: stereotactic radiosurgery
+    term:
+      id: MAXO:0009088
+      label: stereotactic radiosurgery
+  target_phenotypes:
+  - preferred_term: Vertigo or disequilibrium
+    term:
+      id: HP:0002321
+      label: Vertigo
+  target_mechanisms:
+  - target: YAP TAZ TEAD-Driven Schwannoma Growth
+    treatment_effect: INHIBITS
+    description: Stereotactic radiosurgery is used to control tumor growth.
+  evidence:
+  - reference: PMID:39627752
+    reference_title: "Treatment options for unilateral vestibular schwannoma: a network meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In patients with VS, MS and radiosurgery showed better local tumor control rates; however, compared with MS, different SRS all provided better protection of nerve function and improved the symptoms of vestibular function and tinnitus, among which the best was SRS."
+    explanation: This network meta-analysis supports radiosurgery as a treatment with tumor-control and nerve-function advantages in selected comparisons.
+- name: Proton Beam Radiation Therapy
+  description: >-
+    Proton beam therapy has high reported tumor-control rates but does not
+    clearly improve hearing or facial-nerve preservation compared with many
+    modern stereotactic radiosurgery series.
+  treatment_term:
+    preferred_term: radiation therapy
+    term:
+      id: MAXO:0000014
+      label: radiation therapy
+  target_mechanisms:
+  - target: YAP TAZ TEAD-Driven Schwannoma Growth
+    treatment_effect: INHIBITS
+    description: Proton beam therapy is used to control tumor growth.
+  evidence:
+  - reference: PMID:37402894
+    reference_title: "Proton beam radiation therapy for vestibular schwannomas-tumor control and hearing preservation rates: a systematic review and meta-analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Proton beam therapy for VSs achieves high tumor control rates, as high as 95.4%."
+    explanation: This supports proton beam therapy as a radiation treatment with high tumor control in pooled studies.
+- name: Bevacizumab for NF2-Related Vestibular Schwannoma
+  description: >-
+    Bevacizumab is an off-label anti-VEGF pharmacotherapy option for selected
+    NF2-related vestibular schwannomas, with reported tumor-volume and hearing
+    benefits in observational literature but frequent adverse events.
+  context: NF2-related vestibular schwannoma
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: bevacizumab
+  target_phenotypes:
+  - preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  target_mechanisms:
+  - target: NF2 Merlin Tumor-Suppressor Loss
+    treatment_effect: MODULATES
+    description: Bevacizumab targets VEGF-related tumor biology in NF2-related vestibular schwannoma.
+  evidence:
+  - reference: PMID:39685944
+    reference_title: "Bevacizumab for Vestibular Schwannomas in Neurofibromatosis Type 2: A Systematic Review of Tumor Control and Hearing Preservation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Bevacizumab showed a partial tumor volume reduction (≥20%) in 40% of cases and disease stabilization in 50%, while 10% experienced tumor progression."
+    explanation: This systematic review supports tumor-volume benefit and stabilization for bevacizumab in NF2-associated VS.
+  - reference: PMID:38672561
+    reference_title: "Bevacizumab Treatment for Patients with NF2-Related Schwannomatosis: A Single Center Experience."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Following treatment, 40% of the patients experienced hearing improvement, 53%, stable hearing, and 7%, hearing loss."
+    explanation: This single-center series supports hearing benefit or stabilization in many bevacizumab-treated NF2-related schwannomatosis patients.
+- name: Everolimus for Progressive NF2-Related Vestibular Schwannoma
+  description: >-
+    Everolimus has been evaluated as mTORC1-directed pharmacotherapy for
+    progressive NF2-related vestibular schwannoma; evidence supports possible
+    growth-rate reduction but not objective radiographic response in the small
+    phase II cohort.
+  context: Progressive NF2-related vestibular schwannoma
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: everolimus
+  target_mechanisms:
+  - target: NF2 Merlin Tumor-Suppressor Loss
+    treatment_effect: MODULATES
+    description: Everolimus targets mTORC1 signaling downstream of NF2-related schwannoma biology.
+  evidence:
+  - reference: PMID:38372904
+    reference_title: Imaging as an early biomarker to predict sensitivity to everolimus for progressive NF2-related vestibular schwannoma.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "After 52 weeks of treatment, the median annual VS growth rate decreased from 77.2% at baseline to 29.4%."
+    explanation: This supports possible growth-rate reduction but only partial treatment efficacy because the abstract also reports no radiographic response.
+experimental_models:
+- name: NF2-null schwannoma preclinical model
+  description: >-
+    Human primary schwannoma cells and mouse models were used to test YAP/TAZ
+    ablation and TEAD palmitoylation inhibitors.
+  experimental_model_type: CELL_LINE
+  cell_types:
+  - preferred_term: Schwann cell
+    term:
+      id: CL:0002573
+      label: Schwann cell
+  conditions:
+  - NF2-null schwannoma cells
+  - mouse schwannoma model
+  cell_source: human primary tumor cells and mouse models
+  modeled_mechanisms:
+  - target: NF2 Merlin Tumor-Suppressor Loss
+  - target: YAP TAZ TEAD-Driven Schwannoma Growth
+  findings:
+  - statement: YAP/TAZ-driven TEAD activity supports NF2-null schwannoma tumor growth.
+    supporting_text: >-
+      Genetic ablation of YAP/TAZ and TEAD palmitoylation inhibitors blocked
+      and regressed schwannoma tumor growth in preclinical systems.
+  evidence:
+  - reference: PMID:36148553
+    reference_title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Using a combination of human primary tumour cells and mouse models of schwannoma, we have examined the role of the Hippo signalling pathway in driving tumour cell growth."
+    explanation: This directly documents the preclinical systems used to study the pathway.
+notes: >-
+  Falcon deep research was completed on 2026-05-10 and saved in
+  research/Acoustic_Neuroma-deep-research-falcon.md with citations in the
+  adjacent .citations.md file. Several additional terms from the report were
+  intentionally left as preferred_term-only because OAK lookups were slow or
+  inconclusive during batch curation.

--- a/kb/disorders/Acoustic_Neuroma.yaml
+++ b/kb/disorders/Acoustic_Neuroma.yaml
@@ -513,10 +513,6 @@ treatments:
       label: pharmacotherapy
     therapeutic_agent:
     - preferred_term: lapatinib
-  target_mechanisms:
-  - target: YAP TAZ TEAD-Driven Schwannoma Growth
-    treatment_effect: MODULATES
-    description: Lapatinib is represented as a targeted therapy tested in NF2-related vestibular schwannoma; the exact receptor-level ontology binding was left preferred-term-only.
   evidence:
   - reference: PMID:37706198
     reference_title: A systematic review of targeted therapy for vestibular schwannoma in patients with NF2-related schwannomatosis.

--- a/references_cache/DOI_10.37897_rjn.2024.3.7.md
+++ b/references_cache/DOI_10.37897_rjn.2024.3.7.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.37897/rjn.2024.3.7"
+title: "Current trends in vestibular schwannoma management at a referral center in Indonesia: A cross-sectional study with retrospective data collection"
+authors:
+- Renindra Ananda Aman
+- Nadya Zaragita
+- Fitrie Desbassarie
+- Bima Andyan Wicaksana
+- Nicholas Calvin
+journal: Romanian Journal of Neurology
+year: '2024'
+doi: 10.37897/rjn.2024.3.7
+content_type: abstract_only
+---
+
+# Current trends in vestibular schwannoma management at a referral center in Indonesia: A cross-sectional study with retrospective data collection
+**Authors:** Renindra Ananda Aman, Nadya Zaragita, Fitrie Desbassarie, Bima Andyan Wicaksana, Nicholas Calvin
+**Journal:** Romanian Journal of Neurology (2024)
+**DOI:** [10.37897/rjn.2024.3.7](https://doi.org/10.37897/rjn.2024.3.7)
+
+## Content
+
+Background. Vestibular schwannoma (VS) is the most common benign brain tumor of the cerebellopontine angle. Due to its location, this pathology can create both focal and general deficits. The registry system for VS in Indonesia is developing, including in the author’s institution, which eventually shows a changing trend in managing VS. Methods. We retrospectively collected data from all patients diagnosed with vestibular schwannoma, based on histological or radiological results. Treatments included craniotomy and/or Gamma Knife Radiosurgery (GKRS) from 2018 to 2023. Results. Data from 88 patients were analyzed. The number of treated patients has increased annually. VS predominantly affects females (64%). The proportion between GKRS and craniotomy procedures also shifted throughout the year. Common symptoms included hearing loss (63.6%), disequilibrium (50%), and headaches (39.7%). The most common tumor size was medium (15-30 mm; n=37; 42%). Tumors that fell into the intrameatal and small (<15 mm) categories were all treated with GKRS, whereas the other groups were divided into GKRS and craniotomy. GKRS demonstrated high efficacy in tumor control and favorable hearing and facial nerve preservation, whereas craniotomy remained crucial for larger tumors. Conclusion. The number of VS diagnosed each year has increased in our center, accompanied by a noticeable shift in preference from GKRS to craniotomy, which is influenced by the integration of intraoperative monitoring. Treatment preference was further determined based on the clinical profile and tumor size. In the future, there is a need to develop a national registry to better reflect the true incidence of VS within the Indonesian population.

--- a/references_cache/PMID_36148553.md
+++ b/references_cache/PMID_36148553.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:36148553"
+title: Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
+authors:
+- Laraba L
+- Hillson L
+- de Guibert JG
+- Hewitt A
+- Jaques MR
+- Tang TT
+- Post L
+- Ercolano E
+- Rai G
+- Yang SM
+- Jagger DJ
+- Woznica W
+- Edwards P
+- Shivane AG
+- Hanemann CO
+- Parkinson DB
+journal: Brain
+year: '2023'
+doi: 10.1093/brain/awac342
+keywords:
+- Animals
+- Humans
+- Mice
+- Cell Proliferation
+- Meningeal Neoplasms
+- Meningioma
+- "Neurilemmoma/genetics, pathology"
+- "Neurofibromin 2/genetics, metabolism"
+- YAP-Signaling Proteins/metabolism
+- Transcriptional Coactivator with PDZ-Binding Motif Proteins/metabolism
+- TEA Domain Transcription Factors/metabolism
+content_type: abstract_only
+---
+
+# Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null schwannoma and meningioma.
+**Authors:** Laraba L, Hillson L, de Guibert JG, Hewitt A, Jaques MR, Tang TT, Post L, Ercolano E, Rai G, Yang SM, Jagger DJ, Woznica W, Edwards P, Shivane AG, Hanemann CO, Parkinson DB
+**Journal:** Brain (2023)
+**DOI:** [10.1093/brain/awac342](https://doi.org/10.1093/brain/awac342)
+
+## Content
+
+1. Brain. 2023 Apr 19;146(4):1697-1713. doi: 10.1093/brain/awac342.
+
+Inhibition of YAP/TAZ-driven TEAD activity prevents growth of NF2-null 
+schwannoma and meningioma.
+
+Laraba L(1), Hillson L(1), de Guibert JG(1), Hewitt A(1), Jaques MR(2), Tang 
+TT(3), Post L(3), Ercolano E(1), Rai G(4), Yang SM(4), Jagger DJ(5), Woznica 
+W(1), Edwards P(6), Shivane AG(6), Hanemann CO(1), Parkinson DB(1).
+
+Author information:
+(1)Faculty of Heath: Medicine, Dentistry and Human Sciences, Derriford Research 
+Facility, University of Plymouth, Plymouth, Devon PL6 8BU, UK.
+(2)Department of Life Sciences, University of Bath, Bath, Somerset BA2 7AY, UK.
+(3)Vivace Therapeutics Inc., San Mateo, CA 94403, USA.
+(4)National Center for Advancing Translational Sciences, National Institutes of 
+Health, 9800 Medical Center Drive, Rockville, MD 20850, USA.
+(5)UCL Ear Institute, University College London, London WC1X 8EE, UK.
+(6)Department of Cellular and Anatomical Pathology, University Hospitals 
+Plymouth NHS Trust, Derriford, Plymouth, Devon PL6 8DH, UK.
+
+Erratum in
+    Brain. 2025 Mar 6;148(3):e16-e20. doi: 10.1093/brain/awae353.
+
+Schwannoma tumours typically arise on the eighth cranial nerve and are mostly 
+caused by loss of the tumour suppressor Merlin (NF2). There are no approved 
+chemotherapies for these tumours and the surgical removal of the tumour carries 
+a high risk of damage to the eighth or other close cranial nerve tissue. New 
+treatments for schwannoma and other NF2-null tumours such as meningioma are 
+urgently required. Using a combination of human primary tumour cells and mouse 
+models of schwannoma, we have examined the role of the Hippo signalling pathway 
+in driving tumour cell growth. Using both genetic ablation of the Hippo 
+effectors YAP and TAZ as well as novel TEAD palmitoylation inhibitors, we show 
+that Hippo signalling may be successfully targeted in vitro and in vivo to both 
+block and, remarkably, regress schwannoma tumour growth. In particular, 
+successful use of TEAD palmitoylation inhibitors in a preclinical mouse model of 
+schwannoma points to their potential future clinical use. We also identify the 
+cancer stem cell marker aldehyde dehydrogenase 1A1 (ALDH1A1) as a Hippo 
+signalling target, driven by the TAZ protein in human and mouse NF2-null 
+schwannoma cells, as well as in NF2-null meningioma cells, and examine the 
+potential future role of this new target in halting schwannoma and meningioma 
+tumour growth.
+
+© The Author(s) 2022. Published by Oxford University Press on behalf of the 
+Guarantors of Brain.
+
+DOI: 10.1093/brain/awac342
+PMCID: PMC10115179
+PMID: 36148553 [Indexed for MEDLINE]
+
+Conflict of interest statement: T.T.T. and L.P. are employees of Vivace 
+Therapeutics and have equity interest in Vivace Therapeutics.

--- a/references_cache/PMID_37402894.md
+++ b/references_cache/PMID_37402894.md
@@ -1,0 +1,115 @@
+---
+reference_id: "PMID:37402894"
+title: "Proton beam radiation therapy for vestibular schwannomas-tumor control and hearing preservation rates: a systematic review and meta-analysis."
+authors:
+- Santacroce A
+- Trandafirescu MF
+- Levivier M
+- Peters D
+- Fürweger C
+- Toma-Dasu I
+- George M
+- Daniel RT
+- Maire R
+- Nakamura M
+- Faouzi M
+- Schiappacasse L
+- Dasu A
+- Tuleasca C
+journal: Neurosurg Rev
+year: '2023'
+doi: 10.1007/s10143-023-02060-x
+keywords:
+- Humans
+- "Neuroma, Acoustic/radiotherapy, surgery, pathology"
+- Proton Therapy
+- Hearing
+- Cranial Nerves
+- Facial Nerve/pathology
+- Radiosurgery/methods
+- Treatment Outcome
+- Follow-Up Studies
+- Retrospective Studies
+content_type: abstract_only
+---
+
+# Proton beam radiation therapy for vestibular schwannomas-tumor control and hearing preservation rates: a systematic review and meta-analysis.
+**Authors:** Santacroce A, Trandafirescu MF, Levivier M, Peters D, Fürweger C, Toma-Dasu I, George M, Daniel RT, Maire R, Nakamura M, Faouzi M, Schiappacasse L, Dasu A, Tuleasca C
+**Journal:** Neurosurg Rev (2023)
+**DOI:** [10.1007/s10143-023-02060-x](https://doi.org/10.1007/s10143-023-02060-x)
+
+## Content
+
+1. Neurosurg Rev. 2023 Jul 4;46(1):163. doi: 10.1007/s10143-023-02060-x.
+
+Proton beam radiation therapy for vestibular schwannomas-tumor control and 
+hearing preservation rates: a systematic review and meta-analysis.
+
+Santacroce A(1)(2)(3), Trandafirescu MF(4), Levivier M(5)(6), Peters D(5)(6), 
+Fürweger C(1), Toma-Dasu I(7)(8), George M(9), Daniel RT(5)(6), Maire R(9), 
+Nakamura M(10)(11), Faouzi M(12), Schiappacasse L(13), Dasu A(14)(15), Tuleasca 
+C(16)(17)(18).
+
+Author information:
+(1)European Radiosurgery Centre Munich, Munich, Germany.
+(2)Department of Medicine, Faculty of Health, Witten/Herdecke University, 
+Witten, Germany.
+(3)Department of Neurosurgery, St. Barbara-Klinik Hamm-Heessen, Hamm, 59073, 
+Germany.
+(4)University of Medicine and Pharmacy "Gr. T. Popa", Iasi, Germany.
+(5)Neurosurgery Service and Gamma Knife Center, Centre Hospitalier Universitaire 
+Vaudois, Lausanne University Hospital (CHUV), Rue du Bugnon 44-46, BH-08, 
+CH-1011, Lausanne, Switzerland.
+(6)Faculty of Biology and Medicine (FBM), University of Lausanne (UNIL), 
+Lausanne, Switzerland.
+(7)Oncology Pathology Department, Karolinska Institutet and Stockholm 
+University, Stockholm, Sweden.
+(8)Medical Radiation Physics, Stockholm University, Stockholm, Sweden.
+(9)ENT Department, Lausanne University Hospital (CHUV), Lausanne, Switzerland.
+(10)Department of Neurosurgery, Academic Hospital Köln-Merheim, Köln, 51058, 
+Germany.
+(11)Department of Medicine, Faculty of Health, Witten/Herdecke University, 
+Witten, 58455, Germany.
+(12)Division of Biostatistics, Center for Primary Care and Public Health 
+(Unisanté), University of Lausanne, Lausanne, Switzerland.
+(13)Radiation Oncology Department, Lausanne University Hospital (CHUV), 
+Lausanne, Switzerland.
+(14)The Skandion Clinic and Uppsala University, Uppsala, Sweden.
+(15)Medical Radiation Sciences, Department of Immunology, Genetics and 
+Pathology, Uppsala University, Uppsala, Sweden.
+(16)Neurosurgery Service and Gamma Knife Center, Centre Hospitalier 
+Universitaire Vaudois, Lausanne University Hospital (CHUV), Rue du Bugnon 44-46, 
+BH-08, CH-1011, Lausanne, Switzerland. constantin.tuleasca@gmail.com.
+(17)Faculty of Biology and Medicine (FBM), University of Lausanne (UNIL), 
+Lausanne, Switzerland. constantin.tuleasca@gmail.com.
+(18)Ecole Polytechnique Fédérale de Lausanne (EPFL, LTS-5), Lausanne, 
+Switzerland. constantin.tuleasca@gmail.com.
+
+OBJECTIVE: Proton beam therapy is considered, by some authors, as having the 
+advantage of delivering dose distributions more conformal to target compared 
+with stereotactic radiosurgery (SRS). Here, we performed a systematic review and 
+meta-analysis of proton beam for VSs, evaluating tumor control and cranial nerve 
+preservation rates, particularly with regard to facial and hearing preservation.
+METHODS: We reviewed, using the Preferred Reporting Items for Systematic Reviews 
+and Meta-Analyses (PRISMA) articles published between 1968 and September 30, 
+2022. We retained 8 studies reporting 587 patients.
+RESULTS: Overall rate of tumor control (both stability and decrease in volume) 
+was 95.4% (range 93.5-97.2%, p heterogeneity= 0.77, p<0.001). Overall rate of 
+tumor progression was 4.6% (range 2.8-6.5%, p heterogeneity < 0.77, p<0.001). 
+Overall rate of trigeminal nerve preservation (absence of numbness) was 95.6% 
+(range 93.5-97.7%, I2 = 11.44%, p heterogeneity= 0.34, p<0.001). Overall rate of 
+facial nerve preservation was 93.7% (range 89.6-97.7%, I2 = 76.27%, p 
+heterogeneity<0.001, p<0.001). Overall rate of hearing preservation was 40.6% 
+(range 29.4-51.8%, I2 = 43.36%, p heterogeneity= 0.1, p<0.001).
+CONCLUSION: Proton beam therapy for VSs achieves high tumor control rates, as 
+high as 95.4%. Facial rate preservation overall rates are 93%, which is lower 
+compared to the most SRS series. Compared with most currently reported SRS 
+techniques, proton beam radiation therapy for VSs does not offer an advantage 
+for facial and hearing preservation compared to most of the currently reported 
+SRS series.
+
+© 2023. The Author(s).
+
+DOI: 10.1007/s10143-023-02060-x
+PMCID: PMC10319703
+PMID: 37402894 [Indexed for MEDLINE]

--- a/references_cache/PMID_37706198.md
+++ b/references_cache/PMID_37706198.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:37706198"
+title: A systematic review of targeted therapy for vestibular schwannoma in patients with NF2-related schwannomatosis.
+authors:
+- Chiranth S
+- Langer SW
+- Poulsen HS
+- Urup T
+journal: Neurooncol Adv
+year: '2023'
+doi: 10.1093/noajnl/vdad099
+content_type: abstract_only
+---
+
+# A systematic review of targeted therapy for vestibular schwannoma in patients with NF2-related schwannomatosis.
+**Authors:** Chiranth S, Langer SW, Poulsen HS, Urup T
+**Journal:** Neurooncol Adv (2023)
+**DOI:** [10.1093/noajnl/vdad099](https://doi.org/10.1093/noajnl/vdad099)
+
+## Content
+
+1. Neurooncol Adv. 2023 Aug 16;5(1):vdad099. doi: 10.1093/noajnl/vdad099. 
+eCollection 2023 Jan-Dec.
+
+A systematic review of targeted therapy for vestibular schwannoma in patients 
+with NF2-related schwannomatosis.
+
+Chiranth S(1)(2), Langer SW(2)(3), Poulsen HS(1), Urup T(1)(3).
+
+Author information:
+(1)The DCCC Brain Tumor Center , Copenhagen, Denmark.
+(2)University of Copenhagen, Copenhagen, Denmark.
+(3)Department of Oncology, Copenhagen University Hospital - Rigshospitalet, 
+Copenhagen, Denmark.
+
+BACKGROUND: One of the hallmarks of NF2-related Schwannomatosis (NF2-related 
+SWN) is bilateral vestibular schwannomas (VS) that can cause progressive hearing 
+impairment in patients. This systematic review was performed to investigate the 
+efficacy and toxicity of tested targeted agents.
+METHODS: The systematic search was conducted on PubMed and EMBASE Ovid databases 
+from inception to October 2022, according to the Preferred Reporting Items for 
+Systematic Reviews and Meta-Analyses (PRISMA) guidelines. The incidence of 
+outcomes in studies involving bevacizumab and other targeted therapies was 
+extracted. The bevacizumab results were pooled, and 95% confidence intervals 
+(95% CI) were calculated.
+RESULTS: Sixteen studies (8 prospective and 8 retrospective) testing 6 drugs 
+were selected out of 721 search results. There were 10 studies concerning 
+bevacizumab, with a total of 200 patients. The pooled radiographic response rate 
+(RR) was 38% (95% CI: 31 - 45%) and the pooled hearing response rate (HR) was 
+45% (95% CI: 36 - 54%). The most frequent bevacizumab-related toxicities were 
+hypertension and menorrhagia. Of other targeted therapies showing activity, 
+lapatinib had a RR of 6% and a HR of 31%. A VEGFR vaccine showed RR in 29% and 
+HR in 40% of patients. Both agents had a manageable safety profile.
+CONCLUSIONS: Bevacizumab, in comparison to other targeted agents, showed the 
+highest efficacy. Lower dosage of bevacizumab shows comparable efficacy and may 
+reduce toxicity. Other targeted agents, administered alone or as combination 
+therapy, have the potential to improve outcomes for VS in patients with 
+NF2-related SWN, but future clinical studies are needed.
+
+© The Author(s) 2023. Published by Oxford University Press, the Society for 
+Neuro-Oncology and the European Association of Neuro-Oncology.
+
+DOI: 10.1093/noajnl/vdad099
+PMCID: PMC10496940
+PMID: 37706198
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_38372904.md
+++ b/references_cache/PMID_38372904.md
@@ -1,0 +1,117 @@
+---
+reference_id: "PMID:38372904"
+title: Imaging as an early biomarker to predict sensitivity to everolimus for progressive NF2-related vestibular schwannoma.
+authors:
+- Nghiemphu PL
+- Vitte J
+- Dombi E
+- Nguyen T
+- Wagle N
+- Ishiyama A
+- Sepahdari AR
+- Cachia D
+- Widemann BC
+- Brackmann DE
+- Doherty JK
+- Kalamarides M
+- Giovannini M
+journal: J Neurooncol
+year: '2024'
+doi: 10.1007/s11060-024-04596-4
+keywords:
+- Humans
+- Biomarkers
+- Everolimus
+- "Neurofibromatosis 2/diagnostic imaging, drug therapy, complications"
+- "Neuroma, Acoustic/diagnostic imaging, drug therapy, etiology"
+- Quality of Life
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Imaging as an early biomarker to predict sensitivity to everolimus for progressive NF2-related vestibular schwannoma.
+**Authors:** Nghiemphu PL, Vitte J, Dombi E, Nguyen T, Wagle N, Ishiyama A, Sepahdari AR, Cachia D, Widemann BC, Brackmann DE, Doherty JK, Kalamarides M, Giovannini M
+**Journal:** J Neurooncol (2024)
+**DOI:** [10.1007/s11060-024-04596-4](https://doi.org/10.1007/s11060-024-04596-4)
+
+## Content
+
+1. J Neurooncol. 2024 Apr;167(2):339-348. doi: 10.1007/s11060-024-04596-4. Epub 
+2024 Feb 19.
+
+Imaging as an early biomarker to predict sensitivity to everolimus for 
+progressive NF2-related vestibular schwannoma.
+
+Nghiemphu PL(1), Vitte J(2), Dombi E(3), Nguyen T(1)(4), Wagle N(5)(6), Ishiyama 
+A(2), Sepahdari AR(7)(8), Cachia D(9)(10), Widemann BC(3), Brackmann DE(11), 
+Doherty JK(12)(13), Kalamarides M(14), Giovannini M(15).
+
+Author information:
+(1)Department of Neurology, UCLA Neuro‑Oncology Program, David Geffen School of 
+Medicine and Jonsson Comprehensive Cancer Center (JCCC), University of 
+California, Los Angeles, Los Angeles, CA, USA.
+(2)Department of Head and Neck Surgery, David Geffen School of Medicine and 
+Jonsson Comprehensive Cancer Center (JCCC), University of California, Los 
+Angeles, 675 Charles E Young Dr. S, MRL 2240, Los Angeles, CA, 90095-7286, USA.
+(3)Pediatric Oncology Branch, National Cancer Institute, Bethesda, MD, USA.
+(4)Department of Pediatrics, Division of Pediatric Hematology, Oncology, Stem 
+Cell Transplant and Regenerative Medicine, Stanford University, Palo Alto, CA, 
+USA.
+(5)Department of Medicine, Division of Medical Oncology, Norris Cancer Center, 
+University of Southern California, Los Angeles, CA, USA.
+(6)Department of Translational Neurosciences, Saint John's Cancer Institute at 
+Providence Saint John's Health Center, Santa Monica, CA, USA.
+(7)Department of Radiology, David Geffen School of Medicine, University of 
+California, Los Angeles, Los Angeles, CA, USA.
+(8)Diagnostic Neuroradiology, Scripps Clinic Medical Group, La Jolla, CA, USA.
+(9)Department of Neurosurgery, Division of Neuro-oncology, Medical University of 
+South Carolina, Charleston, SC, USA.
+(10)Department of Medicine, Division of Hematology/Oncology, University of 
+Massachusetts, Worcester, MA, USA.
+(11)Department of Otolaryngology and Neurotology, House Clinic and Research 
+Institute, Los Angeles, CA, USA.
+(12)Center for Neural Tumor Research, House Research Institute, Los Angeles, CA, 
+USA.
+(13)Department of Otolaryngology - Head and Neck Surgery, University of Southern 
+California, Los Angeles, CA, USA.
+(14)Department of Neurosurgery, Hôpital Pitié-Salpêtrière, APHP, Sorbonne 
+Université, Paris, France.
+(15)Department of Head and Neck Surgery, David Geffen School of Medicine and 
+Jonsson Comprehensive Cancer Center (JCCC), University of California, Los 
+Angeles, 675 Charles E Young Dr. S, MRL 2240, Los Angeles, CA, 90095-7286, USA. 
+mgiovannini@mednet.ucla.edu.
+
+PURPOSE: NF2-related schwannomatosis (NF2) is characterized by bilateral 
+vestibular schwannomas (VS) often causing hearing and neurologic deficits, with 
+currently no FDA-approved drug treatment. Pre-clinical studies highlighted the 
+potential of mTORC1 inhibition in delaying schwannoma progression. We conducted 
+a prospective open-label, phase II study of everolimus for progressive VS in NF2 
+patients and investigated imaging as a potential biomarker predicting effects on 
+growth trajectory.
+METHODS: The trial enrolled 12 NF2 patients with progressive VS. Participants 
+received oral everolimus daily for 52 weeks. Brain imaging was obtained 
+quarterly. As primary endpoint, radiographic response (RR) was defined as ≥ 20% 
+decrease in target VS volume. Secondary endpoints included other tumors RR, 
+hearing outcomes, drug safety and quality of life (QOL).
+RESULTS: Eight participants completed the trial and four discontinued the drug 
+early due to significant volumetric VS progression. After 52 weeks of treatment, 
+the median annual VS growth rate decreased from 77.2% at baseline to 29.4%. 
+There was no VS RR and 3 of 8 (37.5%) participants had stable disease. Decreased 
+or unchanged VS volume after 3 months of treatment was predictive of 
+stabilization at 12 months. Seven of eight participants had stable hearing 
+during treatment except one with a decline in word recognition score. Ten of 
+twelve participants reported only minimal changes to their QOL scores.
+CONCLUSIONS: Volumetric imaging at 3 months can serve as an early biomarker to 
+predict long-term sensitivity to everolimus treatment. Everolimus may represent 
+a safe treatment option to decrease the growth of NF2-related VS in patients who 
+have stable hearing and neurological condition. TRN: NCT01345136 (April 29, 
+2011).
+
+© 2024. The Author(s).
+
+DOI: 10.1007/s11060-024-04596-4
+PMCID: PMC11023969
+PMID: 38372904 [Indexed for MEDLINE]
+
+Conflict of interest statement: M.G., P.L.N. and M.K. report grant support from 
+Novartis. All other authors reported no conflict.

--- a/references_cache/PMID_38672561.md
+++ b/references_cache/PMID_38672561.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:38672561"
+title: "Bevacizumab Treatment for Patients with NF2-Related Schwannomatosis: A Single Center Experience."
+authors:
+- Douwes JPJ
+- Hensen EF
+- Jansen JC
+- Gelderblom H
+- Schopman JE
+journal: Cancers (Basel)
+year: '2024'
+doi: 10.3390/cancers16081479
+content_type: abstract_only
+---
+
+# Bevacizumab Treatment for Patients with NF2-Related Schwannomatosis: A Single Center Experience.
+**Authors:** Douwes JPJ, Hensen EF, Jansen JC, Gelderblom H, Schopman JE
+**Journal:** Cancers (Basel) (2024)
+**DOI:** [10.3390/cancers16081479](https://doi.org/10.3390/cancers16081479)
+
+## Content
+
+1. Cancers (Basel). 2024 Apr 12;16(8):1479. doi: 10.3390/cancers16081479.
+
+Bevacizumab Treatment for Patients with NF2-Related Schwannomatosis: A Single 
+Center Experience.
+
+Douwes JPJ(1), Hensen EF(1), Jansen JC(1), Gelderblom H(2), Schopman JE(2).
+
+Author information:
+(1)Department of Otorhinolaryngology-Head and Neck Surgery, Leiden University 
+Medical Center, 2333 ZA Leiden, The Netherlands.
+(2)Department of Medical Oncology, Leiden University Medical Center, 2333 ZA 
+Leiden, The Netherlands.
+
+(1) Background: NF2-related schwannomatosis, characterized by the development of 
+bilateral vestibular schwannomas, often necessitates varied treatment 
+approaches. Bevacizumab, though widely utilized, demonstrates variable 
+effectiveness on hearing and tumor growth. At the same time, (serious) adverse 
+events have been frequently reported. (2) Methods: A single center retrospective 
+study was conducted, on NF2-related schwannomatosis patients treated with 
+bevacizumab from 2013 to 2023, with the aim to assess treatment-related and 
+clinical outcomes. Outcomes of interest comprised hearing, radiologic response, 
+symptoms, and adverse events. (3) Results: Seventeen patients received 7.5 mg/kg 
+bevacizumab for 7.1 months. Following treatment, 40% of the patients experienced 
+hearing improvement, 53%, stable hearing, and 7%, hearing loss. Vestibular 
+schwannoma regression occurred in 31%, and 69% remained stable. Further 
+symptomatic improvement was reported by 41%, stable symptoms by 47%, and 
+worsened symptoms by 12%. Treatment discontinuation due to adverse events was 
+observed in 29% of cases. Hypertension (82%) and fatigue (29%) were most 
+frequently reported, with no occurrences of grade 4/5 toxicities. (4) 
+Conclusion: Supporting previous studies, bevacizumab demonstrated positive 
+effects on hearing, tumor control, and symptoms in NF2-related schwannomatosis, 
+albeit with common adverse events. Therefore, careful consideration of an 
+appropriate management strategy is warranted.
+
+DOI: 10.3390/cancers16081479
+PMCID: PMC11047890
+PMID: 38672561
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_38892775.md
+++ b/references_cache/PMID_38892775.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:38892775"
+title: "Vestibular Schwannoma and Tinnitus: A Systematic Review of Microsurgery Compared to Gamma Knife Radiosurgery."
+authors:
+- King AM
+- Cooper JN
+- Oganezova K
+- Mittal J
+- McKenna K
+- Godur DA
+- Zalta M
+- Danesh AA
+- Mittal R
+- Eshraghi AA
+journal: J Clin Med
+year: '2024'
+doi: 10.3390/jcm13113065
+content_type: abstract_only
+---
+
+# Vestibular Schwannoma and Tinnitus: A Systematic Review of Microsurgery Compared to Gamma Knife Radiosurgery.
+**Authors:** King AM, Cooper JN, Oganezova K, Mittal J, McKenna K, Godur DA, Zalta M, Danesh AA, Mittal R, Eshraghi AA
+**Journal:** J Clin Med (2024)
+**DOI:** [10.3390/jcm13113065](https://doi.org/10.3390/jcm13113065)
+
+## Content
+
+1. J Clin Med. 2024 May 23;13(11):3065. doi: 10.3390/jcm13113065.
+
+Vestibular Schwannoma and Tinnitus: A Systematic Review of Microsurgery Compared 
+to Gamma Knife Radiosurgery.
+
+King AM(1), Cooper JN(1)(2), Oganezova K(1), Mittal J(1), McKenna K(1), Godur 
+DA(1), Zalta M(1), Danesh AA(1)(3)(4), Mittal R(1), Eshraghi AA(1)(5)(6).
+
+Author information:
+(1)Department of Otolaryngology, Hearing Research and Cochlear Implant 
+Laboratory, University of Miami Miller School of Medicine, Miami, FL 33136, USA.
+(2)School of Medicine, New York Medical College, Valhalla, NY 10595, USA.
+(3)Department of Communication Sciences and Disorders, Florida Atlantic 
+University, Boca Raton, FL 33431, USA.
+(4)Department of Integrated Medical Sciences, Schmidt College of Medicine, 
+Florida Atlantic University, Boca Raton, FL 33431, USA.
+(5)Department of Neurological Surgery, University of Miami Miller School of 
+Medicine, Miami, FL 33136, USA.
+(6)Department of Biomedical Engineering, University of Miami, Coral Gables, FL 
+33143, USA.
+
+Background: Vestibular schwannoma (VS) is a benign tumor of the eighth cranial 
+nerve formed from neoplastic Schwann cells. Although VS can cause a variety of 
+symptoms, tinnitus is one of the most distressing symptoms for patients and can 
+greatly impact quality of life. The objective of this systematic review is to 
+comprehensively examine and compare the outcomes related to tinnitus in patients 
+undergoing treatment for VS. Specifically, it evaluates patient experiences with 
+tinnitus following the removal of VS using the various surgical approaches of 
+traditional surgical resection and gamma knife radiosurgery (GKS). By delving 
+into various aspects such as the severity of tinnitus post-treatment, the 
+duration of symptom relief, patient quality of life, new onset of tinnitus after 
+VS treatment, and any potential complications or side effects, this review aims 
+to provide a detailed analysis of VS treatment on tinnitus outcomes. Methods: 
+Following PRISMA guidelines, articles were included from PubMed, Science Direct, 
+Scopus, and EMBASE. Quality assessment and risk of bias analysis were performed 
+using a ROBINS-I tool. Results: Although VS-associated tinnitus is variable in 
+its intensity and persistence post-resection, there was a trend towards a 
+decreased tinnitus burden in patients. Irrespective of the surgical approach or 
+the treatment with GKS, there were cases of persistent or worsened tinnitus 
+within the studied cohorts. Conclusion: The findings of this systematic review 
+highlight the complex relationship between VS resection and tinnitus outcomes. 
+These findings underscore the need for individualized patient counseling and 
+tailored treatment approaches in managing VS-associated tinnitus. The findings 
+of this systematic review may help in guiding clinicians towards making more 
+informed and personalized healthcare decisions. Further studies must be 
+completed to fill gaps in the current literature.
+
+DOI: 10.3390/jcm13113065
+PMCID: PMC11173275
+PMID: 38892775
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_38928264.md
+++ b/references_cache/PMID_38928264.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:38928264"
+title: "NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues."
+authors:
+- Kim BH
+- Chung YH
+- Woo TG
+- Kang SM
+- Park S
+- Kim M
+- Park BJ
+journal: Int J Mol Sci
+year: '2024'
+doi: 10.3390/ijms25126558
+keywords:
+- Humans
+- "Neurofibromatoses/therapy, genetics, metabolism"
+- "Neurofibromin 2/genetics, metabolism"
+- "Neurilemmoma/genetics, therapy, metabolism, pathology"
+- "Skin Neoplasms/genetics, therapy, metabolism, pathology"
+- Animals
+- "Neurofibromatosis 2/genetics, therapy, metabolism"
+- Mutation
+- Signal Transduction
+- Molecular Targeted Therapy
+content_type: abstract_only
+---
+
+# NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues.
+**Authors:** Kim BH, Chung YH, Woo TG, Kang SM, Park S, Kim M, Park BJ
+**Journal:** Int J Mol Sci (2024)
+**DOI:** [10.3390/ijms25126558](https://doi.org/10.3390/ijms25126558)
+
+## Content
+
+1. Int J Mol Sci. 2024 Jun 14;25(12):6558. doi: 10.3390/ijms25126558.
+
+NF2-Related Schwannomatosis (NF2): Molecular Insights and Therapeutic Avenues.
+
+Kim BH(1), Chung YH(1), Woo TG(1), Kang SM(2), Park S(2), Kim M(1), Park 
+BJ(1)(2).
+
+Author information:
+(1)Rare Disease R&D Center, PRG S&T Co., Ltd., Busan 46274, Republic of Korea.
+(2)Department of Molecular Biology, College of Natural Science, Pusan National 
+University, Busan 46241, Republic of Korea.
+
+NF2-related schwannomatosis (NF2) is a genetic syndrome characterized by the 
+growth of benign tumors in the nervous system, particularly bilateral vestibular 
+schwannomas, meningiomas, and ependymomas. This review consolidates the current 
+knowledge on NF2 syndrome, emphasizing the molecular pathology associated with 
+the mutations in the gene of the same name, the NF2 gene, and the subsequent 
+dysfunction of its product, the Merlin protein. Merlin, a tumor suppressor, 
+integrates multiple signaling pathways that regulate cell contact, 
+proliferation, and motility, thereby influencing tumor growth. The loss of 
+Merlin disrupts these pathways, leading to tumorigenesis. We discuss the roles 
+of another two proteins potentially associated with NF2 deficiency as well as 
+Merlin: Yes-associated protein 1 (YAP), which may promote tumor growth, and Raf 
+kinase inhibitory protein (RKIP), which appears to suppress tumor development. 
+Additionally, this review discusses the efficacy of various treatments, such as 
+molecular therapies that target specific pathways or inhibit neomorphic 
+protein-protein interaction caused by NF2 deficiency. This overview not only 
+expands on the fundamental understanding of NF2 pathophysiology but also 
+explores the potential of novel therapeutic targets that affect the clinical 
+approach to NF2 syndrome.
+
+DOI: 10.3390/ijms25126558
+PMCID: PMC11204266
+PMID: 38928264 [Indexed for MEDLINE]
+
+Conflict of interest statement: Bae-Hoon Kim, Yeon-Ho Chung, Tae-Gyun Woo, Minju 
+Kim and Bum-Joon Park are employees of PRG S&T Co., Ltd.

--- a/references_cache/PMID_38974623.md
+++ b/references_cache/PMID_38974623.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:38974623"
+title: "Hearing Function after CyberKnife for Vestibular Schwannoma: A Systematic Review."
+authors:
+- Tavares MP
+- Bahmad F Jr
+journal: Int Arch Otorhinolaryngol
+year: '2024'
+doi: 10.1055/s-0044-1787736
+content_type: abstract_only
+---
+
+# Hearing Function after CyberKnife for Vestibular Schwannoma: A Systematic Review.
+**Authors:** Tavares MP, Bahmad F Jr
+**Journal:** Int Arch Otorhinolaryngol (2024)
+**DOI:** [10.1055/s-0044-1787736](https://doi.org/10.1055/s-0044-1787736)
+
+## Content
+
+1. Int Arch Otorhinolaryngol. 2024 Jul 5;28(3):e543-e551. doi: 
+10.1055/s-0044-1787736. eCollection 2024 Jul.
+
+Hearing Function after CyberKnife for Vestibular Schwannoma: A Systematic 
+Review.
+
+Tavares MP(1), Bahmad F Jr(1).
+
+Author information:
+(1)Postgraduate Program in Health Sciences, School of Medicine, Universidade de 
+Brasília, Brasília, DF, Brazil.
+
+Introduction  CyberKnife (CK) radiosurgery is a treatment strategy for 
+vestibular schwannoma (VS). Objectives  To evaluate hearing preservation (HP) 
+after CK for VS. Data Synthesis  The study was conducted following the Preferred 
+Reporting Items for Systematic reviews and Meta-Analyses (PRISMA) statement, and 
+it was registered at the International Prospective Register of Systematic 
+Reviews (PROSPERO, under number CRD42021250300). The inclusion criteria were 
+based on the population, intervention, comparison, outcome, timing and study 
+design (PICOTS) strategy: population - patients with VS; intervention - CK; 
+Comparison - none; Outcome - serviceable HP defined by Gardner and Robertson as 
+grades I or II, or by the American Academy of Otolaryngology and Head and Neck 
+Surgery as classes A or B; timing - mean follow-up longer than 1 year; and study 
+design - retrospective or prospective studies. The exclusion criteria were: 
+studies not published in English; studies published before January 2000 and 
+after October 2021; and studies only including patients with neurofibromatosis 
+type 2 or submitted to a previous treatment. The PubMed/MEDLINE, EMBASE, Web of 
+Science, Cochrane Library, LILACS, and IBECS databases were used and last 
+searched on October 27th, 2021. Statistical heterogeneity was assessed using I 2 
+statistics. The appraisal checklist was used to assess the risk of bias in the 
+included studies. A total of 222 studies were analyzed, and 13 were included in 
+the synthesis, which represents 493 participants with serviceable hearing before 
+intervention. The mean HP rate after CK using a random effects model was of 68% 
+(95% confidence interval [95%CI]: 59-76%) at a mean follow-up of 42.96 months. 
+Conclusion  The longer follow-up period was associated with a lower HP rate 
+after CK radiosurgery for VS in the qualitative synthesis.
+
+The Author(s). This is an open access article published by Thieme under the 
+terms of the Creative Commons Attribution 4.0 International License, permitting 
+copying and reproduction so long as the original work is given appropriate 
+credit ( https://creativecommons.org/licenses/by/4.0/ ).
+
+DOI: 10.1055/s-0044-1787736
+PMCID: PMC11226254
+PMID: 38974623
+
+Conflict of interest statement: Conflict of Interests The authors have no 
+conflict of interests to declare.

--- a/references_cache/PMID_39045727.md
+++ b/references_cache/PMID_39045727.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:39045727"
+title: "Long-Term Hearing Outcome For Vestibular Schwannomas After Microsurgery And Radiotherapy: A Systematic Review and Meta-Analysis."
+authors:
+- Daloiso A
+- Cazzador D
+- Concheri S
+- Tealdo G
+- Zanoletti E
+journal: Otolaryngol Head Neck Surg
+year: '2024'
+doi: 10.1002/ohn.910
+keywords:
+- Humans
+- "Neuroma, Acoustic/surgery, radiotherapy"
+- Microsurgery
+- Hearing Loss/etiology
+- "Radiosurgery/adverse effects, methods"
+- Hearing/radiation effects
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Long-Term Hearing Outcome For Vestibular Schwannomas After Microsurgery And Radiotherapy: A Systematic Review and Meta-Analysis.
+**Authors:** Daloiso A, Cazzador D, Concheri S, Tealdo G, Zanoletti E
+**Journal:** Otolaryngol Head Neck Surg (2024)
+**DOI:** [10.1002/ohn.910](https://doi.org/10.1002/ohn.910)
+
+## Content
+
+1. Otolaryngol Head Neck Surg. 2024 Dec;171(6):1670-1681. doi: 10.1002/ohn.910. 
+Epub 2024 Jul 24.
+
+Long-Term Hearing Outcome For Vestibular Schwannomas After Microsurgery And 
+Radiotherapy: A Systematic Review and Meta-Analysis.
+
+Daloiso A(1), Cazzador D(1), Concheri S(1), Tealdo G(1), Zanoletti E(1).
+
+Author information:
+(1)Department of Neuroscience DNS, Otolaryngology Section, University of Padova, 
+Padova, Italy.
+
+OBJECTIVE: Hearing loss is a common symptom associated with vestibular 
+schwannoma (VS), either because of the tumor's effects on the cochlear nerve or 
+due to active treatments such as surgery or stereotactic radiosurgery (SRS). 
+Treatment decisions for VS are based on factors including tumor size, hearing 
+status, patient symptoms, and institutional preference. The study aimed to 
+investigate long-term auditory outcomes in VS patients undergoing active 
+treatments with a hearing preservation intent.
+DATA SOURCES: A systematic literature review was conducted following Preferred 
+Reporting Items for Systematic Reviews and Meta-Analyses guidelines, searching 
+Scopus, Pubmed, and Web of Science databases from inception to January 2024.
+REVIEW METHODS: Studies meeting inclusion criteria, including a minimum 5-year 
+follow-up and assessment of pre- and posttreatment hearing outcomes, were 
+included. Pooled prevalence estimates for serviceable hearing after SRS and 
+microsurgery were calculated using MetaXL software. Risk of bias assessment was 
+performed with the Risk of Bias in Non-randomized Studies of Interventions tool.
+RESULTS: Nine studies met the inclusion criteria, with 356 patients included for 
+analysis. The pooled prevalence of maintaining serviceable hearing after SRS at 
+10 years was 18.1% (95% confidence interval [CI]: 1.7%-43.3%), with wide 
+prediction intervals indicating variability in outcomes. Microsurgery 
+demonstrated a higher prevalence of maintaining long-term serviceable hearing, 
+with a pooled estimate of 74.5% (95% CI: 63.5%-84.1%).
+CONCLUSION: This systematic review underscores the importance of long-term 
+follow-up in evaluating auditory outcomes in VS treatment. Despite the biases 
+inherent to pretreatment patients selection, hearing preservation microsurgery 
+for sporadic VS removal demonstrated favorable and stable long-term serviceable 
+hearing.
+
+© 2024 The Author(s). Otolaryngology–Head and Neck Surgery published by Wiley 
+Periodicals LLC on behalf of American Academy of Otolaryngology–Head and Neck 
+Surgery Foundation.
+
+DOI: 10.1002/ohn.910
+PMCID: PMC11605020
+PMID: 39045727 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no conflict 
+of interest.

--- a/references_cache/PMID_39627752.md
+++ b/references_cache/PMID_39627752.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:39627752"
+title: "Treatment options for unilateral vestibular schwannoma: a network meta-analysis."
+authors:
+- Huo X
+- Zhao X
+- Liu X
+- Zhang Y
+- Tian J
+- Li M
+journal: BMC Cancer
+year: '2024'
+doi: 10.1186/s12885-024-13242-1
+keywords:
+- Humans
+- Microsurgery/methods
+- "Neuroma, Acoustic/complications, therapy"
+- Radiosurgery/methods
+- "Tinnitus/diagnosis, etiology, therapy"
+- Treatment Outcome
+- "Vertigo/diagnosis, etiology, therapy"
+- Watchful Waiting
+content_type: abstract_only
+---
+
+# Treatment options for unilateral vestibular schwannoma: a network meta-analysis.
+**Authors:** Huo X, Zhao X, Liu X, Zhang Y, Tian J, Li M
+**Journal:** BMC Cancer (2024)
+**DOI:** [10.1186/s12885-024-13242-1](https://doi.org/10.1186/s12885-024-13242-1)
+
+## Content
+
+1. BMC Cancer. 2024 Dec 3;24(1):1490. doi: 10.1186/s12885-024-13242-1.
+
+Treatment options for unilateral vestibular schwannoma: a network meta-analysis.
+
+Huo X(1), Zhao X(2), Liu X(2), Zhang Y(1), Tian J(3), Li M(4).
+
+Author information:
+(1)Department of Neurosurgery, General Hospital of Ningxia Medical University, 
+Yinchuan, China.
+(2)Department of Neurosurgery, North China University of Science and Technology 
+Affiliated Hospital, Tangshan, Hebei, China.
+(3)Department of Neurosurgery, General Hospital of Ningxia Medical University, 
+Yinchuan, China. nxtjh1968@163.com.
+(4)Department of Neurosurgery, The First Medical Center of Chinese PLA General 
+Hospital, Beijing, China. 18332758771@163.com.
+
+This study aimed to explore the effect of observation, microsurgery, and 
+radiotherapy for patients with vestibular schwannoma (VS). We searched PubMed, 
+Medline, Embase, Web of Science, and Cochrane library from their establishment 
+to July 31, 2024. 34 non-RCTs and 1 RCT that included 6 interventions were 
+analyzed. We found the MS, and different SRS all had better tumor local control 
+rates. Regarding preserved hearing, the order from the highest to the lowest was 
+FSRT 5 fractions, FSRT 3 fractions, SRS, ConFSRT, Observation, and MS. Regarding 
+improvement in the rate of tinnitus, the order from the highest to the lowest 
+was ConFSRT, FSRT 3 fractions, SRS, Observation, MS, and FSRT 5 fractions. In 
+terms of improving the rate of disequilibrium/vertigo, the order from the 
+highest to the lowest was SRS, Observation, FSRT 3 fractions, FSRT 5 fractions, 
+MS, and ConFSRT. In terms of protection of the trigeminal nerve, the order from 
+the highest to lowest was observation, SRS, ConFSRT, FSRT 3 fractions, FSRT 5 
+fractions, and MS. Lastly, in terms of protection of the facial nerve, the order 
+from the highest to lowest was SRS, ConFSRT, Observation, FSRT 3 fractions, FSRT 
+5 fractions, and MS. In patients with VS, MS and radiosurgery showed better 
+local tumor control rates; however, compared with MS, different SRS all provided 
+better protection of nerve function and improved the symptoms of vestibular 
+function and tinnitus, among which the best was SRS. Therefore, in these 
+patients, SRS may be a promising alternative treatment.
+
+© 2024. The Author(s).
+
+DOI: 10.1186/s12885-024-13242-1
+PMCID: PMC11613487
+PMID: 39627752 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Ethics approval and consent to 
+participate: Not Applicable. Consent for publication: Not applicable. Competing 
+interests: The authors declare no competing interests.

--- a/references_cache/PMID_39685944.md
+++ b/references_cache/PMID_39685944.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:39685944"
+title: "Bevacizumab for Vestibular Schwannomas in Neurofibromatosis Type 2: A Systematic Review of Tumor Control and Hearing Preservation."
+authors:
+- Screnci M
+- Puechmaille M
+- Berton Q
+- Khalil T
+- Mom T
+- Coll G
+journal: J Clin Med
+year: '2024'
+doi: 10.3390/jcm13237488
+content_type: abstract_only
+---
+
+# Bevacizumab for Vestibular Schwannomas in Neurofibromatosis Type 2: A Systematic Review of Tumor Control and Hearing Preservation.
+**Authors:** Screnci M, Puechmaille M, Berton Q, Khalil T, Mom T, Coll G
+**Journal:** J Clin Med (2024)
+**DOI:** [10.3390/jcm13237488](https://doi.org/10.3390/jcm13237488)
+
+## Content
+
+1. J Clin Med. 2024 Dec 9;13(23):7488. doi: 10.3390/jcm13237488.
+
+Bevacizumab for Vestibular Schwannomas in Neurofibromatosis Type 2: A Systematic 
+Review of Tumor Control and Hearing Preservation.
+
+Screnci M(1)(2), Puechmaille M(3)(4), Berton Q(1)(3), Khalil T(1), Mom T(2)(4), 
+Coll G(1)(3).
+
+Author information:
+(1)Département de Neurochirurgie, CHU Clermont-Ferrand, 63000 Clermont-Ferrand, 
+France.
+(2)Unité CRECHE, CIC 1405, INSERM, CHU Clermont-Ferrand, 63000 Clermont-Ferrand, 
+France.
+(3)Département d'Otorhinolaryngologie et de Chirurgie Cervico-Faciale, CHU 
+Clermont-Ferrand, 63000 Clermont-Ferrand, France.
+(4)Mixt Unit of Research (UMR) 1107, National Institute of Health and Medical 
+Research (INSERM), University of Clermont Auvergne (UCA), 63000 
+Clermont-Ferrand, France.
+
+Background/Objectives: Vestibular schwannomas (VSs), also called acoustic 
+neuromas, are benign tumors affecting the vestibulocochlear nerve, often leading 
+to hearing loss and balance issues. This condition is particularly challenging 
+in patients with neurofibromatosis type 2 (NF2), where VSs tend to develop 
+bilaterally. Conventional treatments, such as surgery and radiotherapy, although 
+effective, carry risks like hearing loss and nerve damage. Bevacizumab, a 
+VEGF-targeting monoclonal antibody, has emerged as a less invasive treatment 
+option, showing potential for tumor volume reduction and hearing preservation. 
+This systematic review aims to assess the efficacy of bevacizumab in controlling 
+tumor volume, preserving hearing, and identifying associated adverse events. 
+Methods: A comprehensive systematic review was performed using PRISMA 
+guidelines. PubMed and Cochrane Library databases were searched for studies 
+evaluating the effects of bevacizumab on VS, focusing on key outcomes like tumor 
+volume reduction, hearing preservation, and adverse events. Data extraction and 
+quality assessment were independently conducted by two reviewers using the 
+Newcastle-Ottawa Scale. Results: Nine studies involving 176 patients were 
+included. Bevacizumab showed a partial tumor volume reduction (≥20%) in 40% of 
+cases and disease stabilization in 50%, while 10% experienced tumor progression. 
+Hearing outcomes revealed improvement in 36% of patients, stabilization in 46%, 
+and deterioration in 18%. Severe adverse effects, including hypertension and 
+thromboembolic events, occurred in 13% of patients, while 18% reported no side 
+effects. Tumor regrowth was observed in some patients after treatment 
+discontinuation, emphasizing the need for long-term monitoring. Conclusions: 
+Bevacizumab demonstrates effectiveness in managing VS, particularly in NF2 
+patients, by reducing tumor size and preserving hearing in a substantial 
+proportion of cases. However, the variability in patient response and the risk 
+of adverse events underscore the need for individualized treatment approaches 
+and further research, including randomized controlled trials, to optimize its 
+clinical application.
+
+DOI: 10.3390/jcm13237488
+PMCID: PMC11642482
+PMID: 39685944
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/research/Acoustic_Neuroma-deep-research-falcon.md
+++ b/research/Acoustic_Neuroma-deep-research-falcon.md
@@ -1,0 +1,1275 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T11:05:59.407450'
+end_time: '2026-05-10T11:17:15.413079'
+duration_seconds: 676.01
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Acoustic Neuroma
+  mondo_id: ''
+  category: Neoplastic
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 47
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Acoustic Neuroma
+- **MONDO ID:**  (if available)
+- **Category:** Neoplastic
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Acoustic Neuroma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Acoustic Neuroma
+- **MONDO ID:**  (if available)
+- **Category:** Neoplastic
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Acoustic Neuroma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Acoustic Neuroma (Vestibular Schwannoma) — Disease Characteristics Research Report (Neoplastic)
+
+**Scope note:** This report synthesizes only the evidence retrieved with the provided tools in this run. Some standard ontology identifiers (e.g., MONDO, MeSH, ICD-10/ICD-11, OMIM, Orphanet) are not present in the retrieved sources, so they are flagged as *not available from the current evidence corpus*.
+
+## 1. Disease Information
+
+### 1.1 Overview (current understanding)
+**Acoustic neuroma** is the common clinical name for **vestibular schwannoma (VS)**, a **benign Schwann-cell tumor** that arises on the **vestibulocochlear nerve (cranial nerve VIII)**, typically in the cerebellopontine angle/internal auditory canal region, and can cause hearing loss, tinnitus, and balance symptoms. (screnci2024bevacizumabforvestibular pages 1-2, huo2024treatmentoptionsfor pages 1-2)
+
+**Synonyms / alternative names (from retrieved sources):**
+- Vestibular schwannoma (VS) (huo2024treatmentoptionsfor pages 1-2, screnci2024bevacizumabforvestibular pages 1-2)
+- Acoustic neuroma (huo2024treatmentoptionsfor pages 1-2, screnci2024bevacizumabforvestibular pages 1-2)
+
+### 1.2 Key identifiers
+- **MONDO ID:** not available from retrieved sources.
+- **MeSH / ICD-10 / ICD-11 / OMIM / Orphanet:** not available from retrieved sources.
+
+### 1.3 Evidence source type
+The information below is derived from:
+- **Aggregated disease-level resources**: systematic reviews/meta-analyses and reviews (e.g., BMC Cancer 2024 network meta-analysis; J Clin Med 2024 systematic review; Neurosurg Rev 2023 meta-analysis; IJMS 2024 review). (huo2024treatmentoptionsfor pages 1-2, screnci2024bevacizumabforvestibular pages 1-2, santacroce2023protonbeamradiation pages 1-2, kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+- **Single-center/retrospective clinical cohorts** (e.g., an 88-patient Indonesian series). (aman2024currenttrendsin pages 5-6, aman2024currenttrendsin pages 1-2)
+- **Primary preclinical mechanistic studies** (e.g., Brain 2023 Hippo/TEAD targeting). (laraba2023inhibitionofyaptazdriven pages 1-2)
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+**Genetic/mechanistic (core driver): NF2 loss (merlin deficiency).** Schwannomas are reported to be “mostly caused by loss of the tumour suppressor Merlin (NF2)”. (laraba2023inhibitionofyaptazdriven pages 1-2)
+
+**Syndromic etiology:** NF2-associated vestibular schwannomas are commonly bilateral and are attributed to **autosomal dominant pathogenic variants in NF2** (chromosome 22), encoding **merlin**. (screnci2024bevacizumabforvestibular pages 1-2, kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+### 2.2 Risk factors
+**NF2-related schwannomatosis (genetic) risk:**
+- NF2-related schwannomatosis prevalence and inheritance features are summarized in the 2024 review: autosomal dominant; approximately half inherited; among de novo cases, **25–50% mosaicism**. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+**Sporadic VS epidemiology context:** Up to **95%** of VS are reported as unilateral/sporadic in a 2024 systematic review background. (king2024vestibularschwannomaand pages 1-2)
+
+**Environmental/lifestyle risk factors:** high-quality causal environmental risk factor evidence is not established in the retrieved texts. One Mendelian-randomization analysis was retrieved (as background evidence of genetically predicted exposures), but it does not provide established clinical risk-factor guidance in the excerpts available. ( is not available; MR paper presence noted in retrieval but not in citeable evidence set beyond initial search list)
+
+### 2.3 Protective factors
+No clinically established protective factors with quantitative effects were available in the retrieved excerpts for VS specifically.
+
+### 2.4 Gene–environment interaction
+No gene–environment interaction results were available in the retrieved excerpts.
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotypes (with characteristics and frequencies)
+**Typical symptom domains** include hearing loss, tinnitus, and vestibular symptoms; larger tumors can produce hydrocephalus/brainstem compression and cranial neuropathies. (huo2024treatmentoptionsfor pages 1-2)
+
+**Quantitative phenotype frequencies (recent real-world cohort, 2018–2023; n=88):**
+- Hearing loss: **63.6%** (aman2024currenttrendsin pages 1-2)
+- Disequilibrium: **50%** (aman2024currenttrendsin pages 1-2)
+- Headache: **39.7%** (aman2024currenttrendsin pages 1-2)
+
+**Quantitative phenotype frequencies (same center; additional cohort summary with broader symptom listing):**
+- Hearing loss: **71.5%**
+- Disequilibrium: **50%**
+- Headache: **39.7%**
+- Tinnitus: **25%**
+- Facial nerve palsy: **25%**
+- Trigeminal deficits: **20.4%**
+(Short mean follow-up for treated subgroup noted in the paper; interpret as baseline presentation frequencies in a tertiary-care cohort.) (aman2024currenttrendsin pages 5-6)
+
+**Systematic review background symptom statement:** “More than 60%” of patients have progressive hearing loss and tinnitus. (huo2024treatmentoptionsfor pages 1-2)
+
+### 3.2 Quality of life impact
+Tinnitus is repeatedly emphasized as distressing and QoL-limiting. In a 2024 systematic review on tinnitus outcomes, **36.6%** had at least one episode of tinnitus distress (THI>18), and mean THI decreased from **15.8 preoperatively** to **10.1 postoperatively** at mean follow-up ~**34.7 months**. (king2024vestibularschwannomaand pages 4-5)
+
+### 3.3 HPO term suggestions (phenotype normalization)
+Suggested HPO terms (as a starting mapping set; confirm exact term IDs in HPO browser during curation):
+- Hearing loss: **HP:0000365** (aman2024currenttrendsin pages 5-6)
+- Tinnitus: **HP:0000360** (aman2024currenttrendsin pages 5-6)
+- Vertigo/disequilibrium/dizziness: **HP:0002321 / HP:0002329** (aman2024currenttrendsin pages 5-6)
+- Headache: **HP:0002315** (aman2024currenttrendsin pages 5-6)
+- Facial palsy/weakness: **HP:0000490** (aman2024currenttrendsin pages 5-6)
+- Trigeminal sensory deficit/facial numbness: **HP:0003407** (aman2024currenttrendsin pages 5-6)
+
+## 4. Genetic/Molecular Information
+
+### 4.1 Causal genes
+**NF2 (merlin)** is the core tumor suppressor gene implicated in NF2-related disease and in schwannoma biology; the 2024 NF2 review places NF2 at **22q12.2**. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+### 4.2 Molecular pathways and cellular processes (current understanding)
+**Merlin function and loss-of-function consequences:** merlin is described as a FERM-domain membrane–cytoskeleton scaffolding tumor suppressor (enriched in Schwann cells/adherens junctions) integrating signals controlling proliferation and motility; its loss promotes tumorigenesis. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+**Hippo/YAP/TAZ signaling as a central downstream axis:**
+- Preclinical evidence (2023): “Using both genetic ablation of the Hippo effectors YAP and TAZ as well as novel TEAD palmitoylation inhibitors, we show that Hippo signalling may be successfully targeted in vitro and in vivo to both block and…regress schwannoma tumour growth.” (direct abstract quote) (laraba2023inhibitionofyaptazdriven pages 1-2)
+- The study also identifies **ALDH1A1** as a TAZ-driven Hippo target in NF2-null schwannoma cells. (laraba2023inhibitionofyaptazdriven pages 1-2)
+
+**Angiogenesis (VEGF) and signaling cross-talk:** a 2024 immune-microenvironment review describes a causal chain in which VEGF/VEGFR2 activates PI3K–AKT and MEK–ERK, suppresses Hippo kinases (Mst1/2; Lats1/2), and promotes YAP/TAZ-driven programs; merlin loss contributes to constitutive YAP/TAZ-mediated VEGF angiogenesis. (jones2024deconvolvingtheimmunea pages 35-39)
+
+**mTOR pathway and targeted inhibition rationale:**
+- A phase II everolimus trial is motivated by preclinical findings that “mTORC1 inhibition” may delay schwannoma progression (summarized within the clinical paper). (nghiemphu2024imagingasan pages 1-2)
+
+### 4.3 Epigenetics / multi-omics
+No quantitative epigenetic methylation signatures or multi-omics datasets for VS were extractable from the retrieved excerpts, although mechanistic reviews discuss pathway-level regulation and emerging molecular therapies. (kim2024nf2relatedschwannomatosis(nf2) pages 6-7, kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+### 4.4 GO and CL term suggestions (mechanism annotation)
+Proposed GO biological process terms for curation (validate with GO browser):
+- Hippo signaling: **GO:0035329** (Hippo signaling)
+- Regulation of cell proliferation: **GO:0042127**
+- Angiogenesis: **GO:0001525**
+- PI3K signaling: **GO:0014065** (phosphatidylinositol 3-kinase signaling)
+- mTOR signaling: **GO:0031929** (TOR signaling)
+
+Proposed CL cell types:
+- Schwann cell: **CL:0000218** (primary tumor lineage)
+
+## 5. Environmental Information
+
+No specific toxins, infectious triggers, or validated lifestyle risk/protective factors for VS were established in the retrieved excerpts. General audiovestibular symptom epidemiology in non-VS populations was retrieved but is not disease-specific evidence for VS etiologic inference. ( not citeable; not in evidence set)
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Causal chain (integrated model)
+1) **Initiating event:** NF2/merlin loss (germline/mosaic in NF2-related schwannomatosis; somatic in sporadic schwannoma) in Schwann lineage. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2, laraba2023inhibitionofyaptazdriven pages 1-2)
+2) **Pathway dysregulation:** derepression of Hippo effector activity (YAP/TAZ → TEAD transcriptional programs) and coupling to proliferative and angiogenic signaling (VEGF/VEGFR2 → PI3K/AKT, MEK/ERK; suppression of Hippo core kinases). (laraba2023inhibitionofyaptazdriven pages 1-2, jones2024deconvolvingtheimmunea pages 35-39)
+3) **Tissue/organ-level effects:** tumor growth along CN VIII and adjacent cranial nerves in the cerebellopontine angle/internal auditory canal causes cochlear nerve dysfunction (hearing loss), aberrant auditory perception (tinnitus), vestibular dysfunction (disequilibrium/vertigo), and—if larger—mass effect with hydrocephalus/brainstem compression and cranial neuropathies (CN V/VII). (huo2024treatmentoptionsfor pages 1-2, aman2024currenttrendsin pages 5-6)
+
+### 6.2 Upstream vs downstream
+- **Upstream:** merlin loss (NF2), VEGF/VEGFR2 activation, TGFβ axis changes (TGFβR2 loss/TGFβR1 upregulation described in review). (jones2024deconvolvingtheimmunea pages 35-39)
+- **Downstream:** YAP/TAZ–TEAD transcriptional output; tumor proliferation/survival; angiogenesis; cranial nerve dysfunction from local compression/invasion. (laraba2023inhibitionofyaptazdriven pages 1-2, huo2024treatmentoptionsfor pages 1-2)
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/tissue level
+- **Primary site:** vestibulocochlear nerve (CN VIII) / cerebellopontine angle region. (screnci2024bevacizumabforvestibular pages 1-2, huo2024treatmentoptionsfor pages 1-2)
+- **Secondary/adjacent structures:** facial nerve (CN VII), trigeminal nerve (CN V), brainstem, ventricular system (hydrocephalus). (huo2024treatmentoptionsfor pages 1-2, aman2024currenttrendsin pages 5-6)
+
+### 7.2 UBERON suggestions
+- Vestibulocochlear nerve (UBERON term to be confirmed in ontology browser)
+- Cerebellopontine angle (UBERON term to be confirmed)
+
+### 7.3 Lateralization
+Most cases are unilateral/sporadic, while NF2-associated disease is commonly bilateral. (king2024vestibularschwannomaand pages 1-2, screnci2024bevacizumabforvestibular pages 1-2)
+
+## 8. Temporal Development
+
+### 8.1 Onset and progression
+VS is described as a slowly growing benign tumor with clinical impact evolving as auditory/vestibular symptoms and, for larger tumors, mass effect. (screnci2024bevacizumabforvestibular pages 1-2, huo2024treatmentoptionsfor pages 1-2)
+
+NF2-related schwannomatosis: adults often present with hearing loss and balance disturbance; pediatric cases may show other early signs. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+### 8.2 Staging / grading
+A management review excerpt references use of Koos grading (I–IV) for tumor-size-based decision making (not fully detailed in the excerpt). (jones2024deconvolvingtheimmunea pages 35-39)
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology (VS)
+- VS reported as ~**8% of intracranial tumors** and most common cerebellopontine angle tumor. (huo2024treatmentoptionsfor pages 1-2)
+- Reported annual incidence **10.4 per 100,000** (in background of 2024 network meta-analysis). (huo2024treatmentoptionsfor pages 1-2)
+- A 2024 tinnitus-focused systematic review background states VS prevalence **3–5.2 per 100,000 person-years**, and **up to 95%** are unilateral/sporadic. (king2024vestibularschwannomaand pages 1-2)
+
+### 9.2 NF2-related schwannomatosis (inheritance)
+- **Autosomal dominant**, caused by germline or mosaic NF2 variants (22q12.2). (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+- **Prevalence** ~**1:50,000**; **birth incidence** ~**1:28,000**. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+- ~50% inherited; among de novo, **25–50%** mosaicism. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+## 10. Diagnostics
+
+### 10.1 Imaging
+- A 2024 AI-in-AN systematic review states **CT and MRI are preferred imaging modalities**; gadolinium contrast improves visualization; typical MRI signal characteristics are described (T1 iso/hypointense; heterogeneous hyperintense T2). (alsaleh2024theimpactof pages 1-3)
+- NF2-related disease diagnosis and monitoring: MRI emphasized as key neuroimaging tool. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+### 10.2 Audiology and electrophysiology
+- Hearing outcomes and monitoring often use **pure-tone audiometry (PTA)** and **word recognition score (WRS)**; one NF2 bevacizumab series pre-specified hearing change as ≥10% WRS or ≥10 dB PTA thresholds. (douwes2024bevacizumabtreatmentfor pages 2-4)
+- Intraoperative monitoring: **brainstem auditory evoked potentials (BAEPs)** are commonly used; a 2024 cohort (n=127) introduced standardized BAEP indices using the contralateral healthy side reference to improve prediction of postoperative hearing preservation. ( not citeable; not in current evidence set)
+
+### 10.3 Emerging/real-world implementations (2023–2024)
+- AI applications: models for segmentation, volume estimation, radiomics, decision support, QoL evaluation, and treatment planning are being developed, but standardization and external validation remain key needs. (alsaleh2024theimpactof pages 1-3)
+
+### 10.4 Differential diagnosis
+Not systematically extractable from the current evidence excerpts.
+
+## 11. Outcome / Prognosis
+
+### 11.1 Treatment-associated functional outcomes (hearing)
+- **Long-term serviceable hearing after SRS**: pooled **18.1% at 10 years** (wide CI). (daloiso2024long‐termhearingoutcome pages 1-2)
+- **Long-term serviceable hearing after microsurgery** in selected hearing-preservation cohorts: pooled **74.5% at 10 years**. (daloiso2024long‐termhearingoutcome pages 1-2)
+
+### 11.2 Morbidity/QoL
+Tinnitus distress burden and its improvement after interventions have been quantified by THI changes in recent systematic review data. (king2024vestibularschwannomaand pages 4-5)
+
+## 12. Treatment
+
+### 12.1 Treatment strategy (current practice)
+A 2024 network meta-analysis frames VS management options as:
+- **Observation**
+- **Microsurgery (MS)**
+- **Radiotherapy**, including **SRS** and fractionated stereotactic radiotherapy (FSRT/ConFSRT)
+(PQ evidence indicates decision-making depends on tumor size, symptoms, and preference.) (huo2024treatmentoptionsfor pages 1-2)
+
+### 12.2 Radiotherapy/radiosurgery outcomes
+- **CyberKnife radiosurgery hearing preservation:** pooled **68%** (95% CI 59–76%) at mean follow-up **~43 months** among patients with serviceable hearing pre-treatment (systematic review of 13 studies/493 participants). (tavares2024hearingfunctionafter pages 1-2)
+- **Proton beam therapy (meta-analysis, 587 patients):** tumor control **95.4%**, progression **4.6%**, facial nerve preservation **93.7%**, hearing preservation **40.6%**, shunt for hydrocephalus **1.4%**. (santacroce2023protonbeamradiation pages 1-2)
+- **SRS tumor control** reported as **90–98% at 10 years** in a 2024 review/meta-analysis summary. (pontillo2024hearingpreservationsurgery pages 1-2)
+
+### 12.3 Surgery outcomes
+- Reported broadly as <25% hearing preservation overall in a 2024 hearing-preservation surgery meta-analysis summary (noting heterogeneity and limitations), while SRT ~50% (long-term SRT data limited). (pontillo2024hearingpreservationsurgery pages 1-2)
+- A tinnitus-focused systematic review background reports surgical mortality **0.38%** and overall complication rate **5.3%** (contextual figures rather than modality-stratified modern series outcomes). (king2024vestibularschwannomaand pages 1-2)
+
+### 12.4 Pharmacotherapy / targeted therapy (NF2-related VS)
+**Bevacizumab (anti-VEGF; off-label use in NF2-related VS):**
+- Systematic review (9 studies; n=176): tumor volume reduction ≥20% **40%**, stabilization **50%**, progression **10%**; hearing improvement **36%**, stabilization **46%**, deterioration **18%**; severe adverse events **13%**. (screnci2024bevacizumabforvestibular pages 1-2)
+- Single-center experience (n=17): hearing improvement **40%**, stable **53%**, hearing loss **7%**; tumor regression **31%**, stable **69%**; discontinuation for adverse events **29%**; hypertension **82%**, fatigue **29%**. (douwes2024bevacizumabtreatmentfor pages 13-14)
+
+**Everolimus (mTORC1 inhibitor):**
+- 2024 prospective open-label phase II report (NCT01345136; n=12): “After 52 weeks of treatment, the median annual VS growth rate decreased from **77.2%** at baseline to **29.4%**.” (direct abstract quote) There was **no radiographic response**, and **3/8 (37.5%)** had stable disease; 3-month volumetric imaging predicted 12-month stabilization. (nghiemphu2024imagingasan pages 1-2)
+- ClinicalTrials.gov record NCT01345136: phase II monotherapy trial was terminated for slow accrual; planned primary endpoint was MRI volumetric change at 1 year. (NCT01345136 chunk 1)
+
+**Other targeted agents (systematic review through Oct 2022):**
+- Lapatinib: hearing response **31% (4/13)**; radiographic response **6% (1/17)**; median TTP ~**14 months**. (chiranth2023asystematicreview pages 5-7, chiranth2023asystematicreview pages 4-5)
+- Axitinib: hearing response **25%**; radiographic response **17%** (small studies; toxicity frequent). (chiranth2023asystematicreview pages 4-5)
+
+### 12.5 Experimental / translational directions (2023–2024)
+- **Hippo/TEAD inhibition as a candidate strategy:** TEAD palmitoylation inhibitors and YAP/TAZ genetic ablation regressed NF2-null schwannoma growth in preclinical models (positioned as a route toward future clinical translation). (laraba2023inhibitionofyaptazdriven pages 1-2)
+- **AI-based tools** for segmentation and monitoring may support clinical workflow and decision-making, but require standardization and reproducibility. (alsaleh2024theimpactof pages 1-3)
+
+### 12.6 MAXO term suggestions (treatment normalization)
+Suggested MAXO mappings (confirm in MAXO browser):
+- Microsurgical resection of tumor
+- Stereotactic radiosurgery
+- Fractionated stereotactic radiotherapy
+- Proton beam therapy
+- Anti-VEGF monoclonal antibody therapy (bevacizumab)
+- mTOR inhibitor therapy (everolimus)
+- Cochlear implantation (as rehabilitative hearing restoration; referenced as improving QoL outcomes in VS management literature, though quantitative CI outcomes were not extractable in the excerpts here) ( not citeable)
+
+## 13. Prevention
+
+### 13.1 Primary prevention
+No primary prevention measures (e.g., vaccination, exposure modification) are established for sporadic VS in the retrieved evidence.
+
+### 13.2 Secondary prevention / early detection
+- For NF2-associated disease, proactive MRI screening is recommended/used in registry contexts (mentioned in systematic review). (screnci2024bevacizumabforvestibular pages 1-2)
+
+### 13.3 Genetic counseling
+NF2-related schwannomatosis is autosomal dominant with mosaicism common in de novo cases, supporting family counseling and tailored genetic testing strategies (details beyond this were not extractable from retrieved excerpts). (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+
+## 14. Other Species / Natural Disease
+Not available from the retrieved evidence.
+
+## 15. Model Organisms
+- A 2023 primary study used mouse models (Periostin-Cre NF2fl/fl) and human primary schwannoma cells to test Hippo/TEAD targeting. (laraba2023inhibitionofyaptazdriven pages 1-2)
+- A 2024 review describes multiple preclinical candidate therapies tested in mouse/xenograft contexts for NF2-related schwannomas. (kim2024nf2relatedschwannomatosis(nf2) pages 6-7)
+
+## Structured summary artifact
+The following table consolidates key identifiers, symptom frequencies, molecular mechanisms, diagnostics, treatments, outcomes statistics, and trial IDs from the retrieved evidence.
+
+| Domain | Key facts | Evidence |
+|---|---|---|
+| Disease / synonyms | Acoustic neuroma is the historical/common name for **vestibular schwannoma (VS)**, a benign Schwann-cell tumor arising on the vestibulocochlear nerve (CN VIII); NF2-associated tumors are often bilateral. | (huo2024treatmentoptionsfor pages 1-2, screnci2024bevacizumabforvestibular pages 1-2, kim2024nf2relatedschwannomatosis(nf2) pages 1-2) |
+| Epidemiology | VS is reported as the **most common cerebellopontine angle tumor** and about **8% of intracranial tumors**; one 2024 meta-analysis background states annual incidence **10.4/100,000**. Another 2024 review notes VS prevalence **3–5.2 per 100,000 person-years** and that **up to 95%** are unilateral/sporadic. | (huo2024treatmentoptionsfor pages 1-2, king2024vestibularschwannomaand pages 1-2) |
+| NF2-related epidemiology | NF2-related schwannomatosis prevalence estimated **1:50,000** and birth incidence **1:28,000**; another review cites birth incidence **1 in 25,000–33,000**. NF2 accounts for about **~7% of VS cases**. About **half** of NF2 cases are inherited; among de novo cases **25–50%** show somatic mosaicism. | (screnci2024bevacizumabforvestibular pages 1-2, kim2024nf2relatedschwannomatosis(nf2) pages 1-2) |
+| Core phenotypes / frequencies | Recent cohort data: hearing loss **63.6%** (or **71.5%** in another cohort summary), disequilibrium **50%**, headache **39.7%**, tinnitus **25%**, facial palsy **25%**, trigeminal deficits **20.4%**. Another meta-analysis background states **>60%** of patients have progressive hearing loss and tinnitus. | (aman2024currenttrendsin pages 5-6, aman2024currenttrendsin pages 1-2, huo2024treatmentoptionsfor pages 1-2) |
+| Symptom domains / HPO suggestions | Suggested HPO mappings: hearing loss **HP:0000365**, tinnitus **HP:0000360**, vertigo/disequilibrium **HP:0002321 / HP:0002329**, headache **HP:0002315**, facial weakness/palsy **HP:0000490**, facial numbness/sensory disturbance **HP:0003407**. | (aman2024currenttrendsin pages 1-2, king2024vestibularschwannomaand pages 13-14, king2024vestibularschwannomaand pages 4-5) |
+| Quality-of-life related findings | Tinnitus is emphasized as highly distressing and QoL-limiting. In one 2024 tinnitus review, **63%** did not require tinnitus treatment while **36.6%** had at least one episode of tinnitus distress; mean THI fell from **15.8 pre-op** to **10.1 post-op** at mean follow-up **~34.7 months**. | (king2024vestibularschwannomaand pages 1-2, king2024vestibularschwannomaand pages 4-5) |
+| Primary causal gene | **NF2** on chromosome **22q12.2** encodes **merlin**, a FERM-domain membrane–cytoskeleton scaffolding tumor suppressor highly expressed in Schwann cells/adherens junctions. Loss of merlin alters cell adhesion, increases migration, reduces apoptosis, and promotes tumorigenesis. | (kim2024nf2relatedschwannomatosis(nf2) pages 1-2) |
+| Key molecular pathways | Recurrently implicated pathways: **Hippo/YAP/TAZ**, **VEGF/VEGFR2 angiogenic signaling**, **PI3K–AKT–mTOR**, **MEK–ERK**, **PAK**, and **TGFβ** dysregulation. Merlin loss dysregulates Hippo signaling; VEGF-VEGFR2 can activate PI3K-Akt and MEK-ERK, suppressing Hippo kinases and promoting YAP/TAZ activity. | (laraba2023inhibitionofyaptazdriven pages 1-2, benton2024identifyingnewtargets pages 16-20, jones2024deconvolvingtheimmunea pages 35-39, benton2024identifyingnewtargets pages 98-101) |
+| Mechanistic 2023–2024 advances | 2023 primary data showed **YAP/TAZ-driven TEAD activity** is functionally required in NF2-null schwannoma; genetic ablation or TEAD palmitoylation inhibitors blocked/regressed tumor growth in vitro and in mouse models. Preclinical candidates in 2024 review include TEW7197, MLN4924 + GDC-0980, brigatinib, CUDC907, FASN inhibitors, and agents targeting merlin-related neo-PPIs. | (laraba2023inhibitionofyaptazdriven pages 1-2, kim2024nf2relatedschwannomatosis(nf2) pages 6-7) |
+| Diagnostics: imaging | **MRI and CT** are preferred imaging modalities; **gadolinium-enhanced MRI** improves visualization. Typical MRI appearance described as an oval/round mass with **T1 iso-/hypointense** signal and **heterogeneous hyperintense T2** signal. MRI is the key detection and treatment-assessment tool in NF2-related disease. | (alsaleh2024theimpactof pages 1-3, kim2024nf2relatedschwannomatosis(nf2) pages 1-2) |
+| Diagnostics: audiology / functional testing | Hearing assessment commonly uses **pure-tone audiometry (PTA)** and **word recognition score (WRS)**; one NF2 bevacizumab study defined hearing improvement/worsening as **≥10% WRS change** (or **≥10 dB PTA** if WRS = 100% at both times). **BAEP/brainstem auditory evoked potentials** are used intraoperatively; a 2024 study of **127 patients** reported standardized BAEP V-wave latency/amplitude metrics improved prediction of hearing preservation. | (douwes2024bevacizumabtreatmentfor pages 2-4, chiranth2023asystematicreview pages 2-4, nghiemphu2024imagingasan pages 1-2) |
+| Differential / anatomy-related manifestations | Large tumors may cause **brainstem compression**, **hydrocephalus**, facial paresis/paresthesia, vertigo, and headache; VS is anatomically related to the trigeminal, facial, and cochlear nerves, explaining cranial neuropathies. | (huo2024treatmentoptionsfor pages 1-2) |
+| Observation / conservative management | Observation remains a standard option, especially for selected patients; in the 2024 network meta-analysis, microsurgery and radiosurgery had better local tumor control than observation, while observation ranked relatively well for trigeminal nerve protection compared with microsurgery. | (huo2024treatmentoptionsfor pages 1-2) |
+| Microsurgery outcomes | 2024 long-term hearing meta-analysis reported pooled **10-year serviceable hearing preservation 74.5%** (95% CI 63.5–84.1%) for microsurgery in hearing-preservation cohorts. Another 2024 review states hearing preservation after surgery is **<25%** overall in broader literature. Surgical mortality was reported **0.38%** and overall complication rate **5.3%** in one review. | (daloiso2024long‐termhearingoutcome pages 1-2, pontillo2024hearingpreservationsurgery pages 1-2, king2024vestibularschwannomaand pages 1-2) |
+| SRS / FSRT / ConFSRT comparative outcomes | 2024 network meta-analysis found **MS and radiosurgery** had better local control than observation. For preserved hearing, ranking was **FSRT 5 fractions > FSRT 3 fractions > SRS > ConFSRT > Observation > MS**. For facial nerve protection, ranking was **SRS > ConFSRT > Observation > FSRT 3 fractions > FSRT 5 fractions > MS**. For disequilibrium/vertigo improvement, **SRS** ranked best. | (huo2024treatmentoptionsfor pages 1-2) |
+| SRS long-term hearing | In the 2024 long-term meta-analysis (≥5-year audiologic follow-up), pooled maintenance of serviceable hearing after **SRS at 10 years was 18.1%** (95% CI 1.7–43.3%), with wide variability. | (daloiso2024long‐termhearingoutcome pages 1-2) |
+| CyberKnife outcomes | 2024 systematic review of **13 studies / 493 participants** found pooled **hearing preservation 68%** (95% CI 59–76%) after **CyberKnife** at mean follow-up **42.96 months**; longer follow-up was associated with lower preservation rates. | (tavares2024hearingfunctionafter pages 1-2) |
+| Proton beam outcomes | 2023 systematic review/meta-analysis of **8 studies / 587 patients**: tumor control **95.4%**, progression **4.6%**, trigeminal nerve preservation **95.6%**, facial nerve preservation **93.7%**, hearing preservation **40.6%**, hydrocephalus requiring shunt **1.4%**. Authors concluded proton therapy does **not** offer clear hearing/facial nerve advantage over most current SRS series. | (santacroce2023protonbeamradiation pages 1-2) |
+| Bevacizumab (systematic review) | 2024 systematic review in NF2-associated VS (**9 studies, 176 patients**): partial tumor volume reduction **≥20% in 40%**, stabilization **50%**, progression **10%**; hearing improvement **36%**, stabilization **46%**, deterioration **18%**; severe adverse events **13%**; **18%** had no side effects; regrowth after discontinuation can occur. | (screnci2024bevacizumabforvestibular pages 1-2) |
+| Bevacizumab (single-center 2024) | Single-center 2024 series (**17 patients**, 7.5 mg/kg, median/mean treatment about **7.1 months**): hearing improvement **40%**, stable hearing **53%**, hearing loss **7%**; tumor regression **31%**, stable **69%**; symptomatic improvement **41%**; treatment discontinuation for adverse events **29%**; hypertension **82%**, fatigue **29%**. | (douwes2024bevacizumabtreatmentfor pages 13-14) |
+| Everolimus | 2024 phase II report in **12 NF2 patients** (NCT01345136): after **52 weeks**, median annual VS growth rate decreased from **77.2%** to **29.4%**; **no radiographic responses** (≥20% decrease), **3/8 (37.5%)** had stable disease, **7/8** had stable hearing; early volumetric MRI at **3 months** predicted stabilization at 12 months. | (nghiemphu2024imagingasan pages 1-2, NCT01345136 chunk 1) |
+| Other targeted therapies | 2023 systematic review: **lapatinib** phase II yielded hearing response **31% (4/13)** and radiographic response **6% (1/17)**, median TTP **~14 months**; **axitinib** showed hearing response **25%** and radiographic response **17%**; **everolimus** and **erlotinib** showed minimal/no hearing or radiographic responses in small cohorts. | (chiranth2023asystematicreview pages 5-7, chiranth2023asystematicreview pages 4-5, chiranth2023asystematicreview pages 2-4) |
+| Clinical trials / IDs | Relevant trial IDs identified in gathered evidence: **NCT01345136** (everolimus/RAD001 phase II), **NCT01207687** (bevacizumab phase II), **NCT02129647** (axitinib phase II), **NCT04374305** (INTUITT-NF2 ongoing platform/phase II), **NCT01767792** (bevacizumab in children/young adults), **NCT00973739** (lapatinib), **NCT00863122** (lapatinib concentration/activity), **NCT01490476** and **NCT01419639** (everolimus), **NCT05685836** (89Zr-bevacizumab PET/CT imaging). | (nghiemphu2024imagingasan pages 1-2, NCT01345136 chunk 1) |
+| Real-world implementation / AI | 2024 systematic review of AI in acoustic neuroma reported successful models for **volume estimation, segmentation, tumor differentiation, radiomics, QoL evaluation, monitoring, robotic-assisted surgery, and decision support**, reflecting growing translational use of routine MRI datasets. | (alsaleh2024theimpactof pages 1-3) |
+
+
+*Table: This table compiles high-yield disease facts for acoustic neuroma/vestibular schwannoma, including epidemiology, phenotypes, molecular mechanisms, diagnostics, treatment outcomes, and relevant trial identifiers. It is designed as a rapid reference for knowledge-base population using only gathered evidence.*
+
+## URLs and publication dates (from retrieved sources)
+- Huo et al., *BMC Cancer*, **Dec 2024**. https://doi.org/10.1186/s12885-024-13242-1 (huo2024treatmentoptionsfor pages 1-2)
+- Screnci et al., *Journal of Clinical Medicine*, **Dec 2024**. https://doi.org/10.3390/jcm13237488 (screnci2024bevacizumabforvestibular pages 1-2)
+- Kim et al., *International Journal of Molecular Sciences*, **Jun 2024**. https://doi.org/10.3390/ijms25126558 (kim2024nf2relatedschwannomatosis(nf2) pages 1-2)
+- Nghiemphu et al., *Journal of Neuro-Oncology*, **Feb 2024**. https://doi.org/10.1007/s11060-024-04596-4 (nghiemphu2024imagingasan pages 1-2)
+- Douwes et al., *Cancers*, **Apr 2024**. https://doi.org/10.3390/cancers16081479 (douwes2024bevacizumabtreatmentfor pages 13-14)
+- Tavares & Bahmad, *Int Arch Otorhinolaryngol*, **Jul 2024**. https://doi.org/10.1055/s-0044-1787736 (tavares2024hearingfunctionafter pages 1-2)
+- Santacroce et al., *Neurosurgical Review*, **Jul 2023**. https://doi.org/10.1007/s10143-023-02060-x (santacroce2023protonbeamradiation pages 1-2)
+- Laraba et al., *Brain*, **Sep 2023**. https://doi.org/10.1093/brain/awac342 (laraba2023inhibitionofyaptazdriven pages 1-2)
+- Alsaleh, *Technology and Health Care*, **Nov 2024**. https://doi.org/10.3233/thc-232043 (alsaleh2024theimpactof pages 1-3)
+- Aman et al., *Romanian Journal of Neurology*, **Sep 2024**. https://doi.org/10.37897/rjn.2024.3.7 (aman2024currenttrendsin pages 1-2)
+- ClinicalTrials.gov NCT01345136, posted record (year in record excerpt: **2015**). https://clinicaltrials.gov/study/NCT01345136 (NCT01345136 chunk 1)
+
+
+References
+
+1. (screnci2024bevacizumabforvestibular pages 1-2): Melina Screnci, Mathilde Puechmaille, Quentin Berton, Toufic Khalil, Thierry Mom, and Guillaume Coll. Bevacizumab for vestibular schwannomas in neurofibromatosis type 2: a systematic review of tumor control and hearing preservation. Journal of Clinical Medicine, 13:7488, Dec 2024. URL: https://doi.org/10.3390/jcm13237488, doi:10.3390/jcm13237488. This article has 5 citations.
+
+2. (huo2024treatmentoptionsfor pages 1-2): Xianhao Huo, Xu Zhao, Xiaozhuo Liu, Yifan Zhang, Jihui Tian, and Mei Li. Treatment options for unilateral vestibular schwannoma: a network meta-analysis. BMC Cancer, Dec 2024. URL: https://doi.org/10.1186/s12885-024-13242-1, doi:10.1186/s12885-024-13242-1. This article has 6 citations and is from a peer-reviewed journal.
+
+3. (santacroce2023protonbeamradiation pages 1-2): Antonio Santacroce, Mioara- Florentina Trandafirescu, Marc Levivier, David Peters, Christoph Fürweger, Iuliana Toma-Dasu, Mercy George, Roy Thomas Daniel, Raphael Maire, Makoto Nakamura, Mohamed Faouzi, Luis Schiappacasse, Alexandru Dasu, and Constantin Tuleasca. Proton beam radiation therapy for vestibular schwannomas-tumor control and hearing preservation rates: a systematic review and meta-analysis. Neurosurgical Review, Jul 2023. URL: https://doi.org/10.1007/s10143-023-02060-x, doi:10.1007/s10143-023-02060-x. This article has 7 citations and is from a peer-reviewed journal.
+
+4. (kim2024nf2relatedschwannomatosis(nf2) pages 1-2): Bae-Hoon Kim, Yeon-Ho Chung, Tae-Gyun Woo, So-mi Kang, Soyoung Park, Minju Kim, and Bum-Joon Park. Nf2-related schwannomatosis (nf2): molecular insights and therapeutic avenues. International Journal of Molecular Sciences, 25:6558, Jun 2024. URL: https://doi.org/10.3390/ijms25126558, doi:10.3390/ijms25126558. This article has 11 citations.
+
+5. (aman2024currenttrendsin pages 5-6): Renindra Ananda Aman, Nadya Zaragita, Fitrie Desbassarie, Bima Andyan Wicaksana, and Nicholas Calvin. Current trends in vestibular schwannoma management at a referral center in indonesia: a cross-sectional study with retrospective data collection. Romanian Journal of Neurology, 23:272-280, Sep 2024. URL: https://doi.org/10.37897/rjn.2024.3.7, doi:10.37897/rjn.2024.3.7. This article has 0 citations.
+
+6. (aman2024currenttrendsin pages 1-2): Renindra Ananda Aman, Nadya Zaragita, Fitrie Desbassarie, Bima Andyan Wicaksana, and Nicholas Calvin. Current trends in vestibular schwannoma management at a referral center in indonesia: a cross-sectional study with retrospective data collection. Romanian Journal of Neurology, 23:272-280, Sep 2024. URL: https://doi.org/10.37897/rjn.2024.3.7, doi:10.37897/rjn.2024.3.7. This article has 0 citations.
+
+7. (laraba2023inhibitionofyaptazdriven pages 1-2): Liyam Laraba, Lily Hillson, Julio Grimm de Guibert, Amy Hewitt, Maisie R Jaques, Tracy T Tang, Leonard Post, Emanuela Ercolano, Ganesha Rai, Shyh-Ming Yang, Daniel J Jagger, Waldemar Woznica, Philip Edwards, Aditya G Shivane, C Oliver Hanemann, and David B Parkinson. Inhibition of yap/taz-driven tead activity prevents growth of nf2-null schwannoma and meningioma. Brain, 146:1697-1713, Sep 2023. URL: https://doi.org/10.1093/brain/awac342, doi:10.1093/brain/awac342. This article has 62 citations and is from a highest quality peer-reviewed journal.
+
+8. (king2024vestibularschwannomaand pages 1-2): Ava M. King, Jaimee N. Cooper, Karina Oganezova, Jeenu Mittal, Keelin McKenna, Dimitri A. Godur, Max Zalta, Ali A. Danesh, Rahul Mittal, and Adrien A. Eshraghi. Vestibular schwannoma and tinnitus: a systematic review of microsurgery compared to gamma knife radiosurgery. Journal of Clinical Medicine, 13:3065, May 2024. URL: https://doi.org/10.3390/jcm13113065, doi:10.3390/jcm13113065. This article has 6 citations.
+
+9. (king2024vestibularschwannomaand pages 4-5): Ava M. King, Jaimee N. Cooper, Karina Oganezova, Jeenu Mittal, Keelin McKenna, Dimitri A. Godur, Max Zalta, Ali A. Danesh, Rahul Mittal, and Adrien A. Eshraghi. Vestibular schwannoma and tinnitus: a systematic review of microsurgery compared to gamma knife radiosurgery. Journal of Clinical Medicine, 13:3065, May 2024. URL: https://doi.org/10.3390/jcm13113065, doi:10.3390/jcm13113065. This article has 6 citations.
+
+10. (jones2024deconvolvingtheimmunea pages 35-39): AP Jones. Deconvolving the immune microenvironment of vestibular schwannoma and the implications for t-cell immunotherapy in nf2-related schwannomatosis. Unknown journal, 2024.
+
+11. (nghiemphu2024imagingasan pages 1-2): Phioanh Leia Nghiemphu, Jeremie Vitte, Eva Dombi, Thien Nguyen, Naveed Wagle, Akira Ishiyama, Ali R. Sepahdari, David Cachia, Brigitte C. Widemann, Derald E. Brackmann, Joni K. Doherty, Michel Kalamarides, and Marco Giovannini. Imaging as an early biomarker to predict sensitivity to everolimus for progressive nf2-related vestibular schwannoma. Journal of Neuro-Oncology, 167:339-348, Feb 2024. URL: https://doi.org/10.1007/s11060-024-04596-4, doi:10.1007/s11060-024-04596-4. This article has 7 citations and is from a peer-reviewed journal.
+
+12. (kim2024nf2relatedschwannomatosis(nf2) pages 6-7): Bae-Hoon Kim, Yeon-Ho Chung, Tae-Gyun Woo, So-mi Kang, Soyoung Park, Minju Kim, and Bum-Joon Park. Nf2-related schwannomatosis (nf2): molecular insights and therapeutic avenues. International Journal of Molecular Sciences, 25:6558, Jun 2024. URL: https://doi.org/10.3390/ijms25126558, doi:10.3390/ijms25126558. This article has 11 citations.
+
+13. (alsaleh2024theimpactof pages 1-3): Hadeel Alsaleh. The impact of artificial intelligence in the diagnosis and management of acoustic neuroma: a systematic review. Technology and Health Care, 32:3801-3813, Nov 2024. URL: https://doi.org/10.3233/thc-232043, doi:10.3233/thc-232043. This article has 5 citations and is from a peer-reviewed journal.
+
+14. (douwes2024bevacizumabtreatmentfor pages 2-4): Jules P. J. Douwes, Erik F. Hensen, Jeroen C. Jansen, Hans Gelderblom, and Josefine E. Schopman. Bevacizumab treatment for patients with nf2-related schwannomatosis: a single center experience. Cancers, 16:1479, Apr 2024. URL: https://doi.org/10.3390/cancers16081479, doi:10.3390/cancers16081479. This article has 13 citations.
+
+15. (daloiso2024long‐termhearingoutcome pages 1-2): Antonio Daloiso, Diego Cazzador, Stefano Concheri, Giulia Tealdo, and Elisabetta Zanoletti. Long‐term hearing outcome for vestibular schwannomas after microsurgery and radiotherapy: a systematic review and meta‐analysis. Otolaryngology–Head and Neck Surgery, 171:1670-1681, Jul 2024. URL: https://doi.org/10.1002/ohn.910, doi:10.1002/ohn.910. This article has 8 citations.
+
+16. (tavares2024hearingfunctionafter pages 1-2): Matheus Pedrosa Tavares and Fayez Bahmad Jr. Hearing function after cyberknife for vestibular schwannoma: a systematic review. International Archives of Otorhinolaryngology, 28:e543-e551, Jul 2024. URL: https://doi.org/10.1055/s-0044-1787736, doi:10.1055/s-0044-1787736. This article has 2 citations.
+
+17. (pontillo2024hearingpreservationsurgery pages 1-2): Vito Pontillo, Valentina Foscolo, Francesco Salonna, Francesco Barbara, Maria Teresa Bozzi, Raffaella Messina, Francesco Signorelli, and Nicola Antonio Adolfo Quaranta. Hearing preservation surgery for vestibular schwannoma: a systematic review and meta-analysis. Acta Otorhinolaryngologica Italica, 44:S86-S93, May 2024. URL: https://doi.org/10.14639/0392-100x-suppl.1-44-2024-n2900, doi:10.14639/0392-100x-suppl.1-44-2024-n2900. This article has 8 citations and is from a peer-reviewed journal.
+
+18. (douwes2024bevacizumabtreatmentfor pages 13-14): Jules P. J. Douwes, Erik F. Hensen, Jeroen C. Jansen, Hans Gelderblom, and Josefine E. Schopman. Bevacizumab treatment for patients with nf2-related schwannomatosis: a single center experience. Cancers, 16:1479, Apr 2024. URL: https://doi.org/10.3390/cancers16081479, doi:10.3390/cancers16081479. This article has 13 citations.
+
+19. (NCT01345136 chunk 1):  Study of RAD001 for Treatment of NF2-related Vestibular Schwannoma. Jonsson Comprehensive Cancer Center. 2015. ClinicalTrials.gov Identifier: NCT01345136
+
+20. (chiranth2023asystematicreview pages 5-7): Shivani Chiranth, Seppo W Langer, Hans Skovgaard Poulsen, and Thomas Urup. A systematic review of targeted therapy for vestibular schwannoma in patients with nf2-related schwannomatosis. Neuro-Oncology Advances, Aug 2023. URL: https://doi.org/10.1093/noajnl/vdad099, doi:10.1093/noajnl/vdad099. This article has 23 citations and is from a peer-reviewed journal.
+
+21. (chiranth2023asystematicreview pages 4-5): Shivani Chiranth, Seppo W Langer, Hans Skovgaard Poulsen, and Thomas Urup. A systematic review of targeted therapy for vestibular schwannoma in patients with nf2-related schwannomatosis. Neuro-Oncology Advances, Aug 2023. URL: https://doi.org/10.1093/noajnl/vdad099, doi:10.1093/noajnl/vdad099. This article has 23 citations and is from a peer-reviewed journal.
+
+22. (king2024vestibularschwannomaand pages 13-14): Ava M. King, Jaimee N. Cooper, Karina Oganezova, Jeenu Mittal, Keelin McKenna, Dimitri A. Godur, Max Zalta, Ali A. Danesh, Rahul Mittal, and Adrien A. Eshraghi. Vestibular schwannoma and tinnitus: a systematic review of microsurgery compared to gamma knife radiosurgery. Journal of Clinical Medicine, 13:3065, May 2024. URL: https://doi.org/10.3390/jcm13113065, doi:10.3390/jcm13113065. This article has 6 citations.
+
+23. (benton2024identifyingnewtargets pages 16-20): Dorothy Benton. Identifying new targets and drug combinations in neurofibromatosis type 2. ArXiv, 2024. URL: https://doi.org/10.17918/00010718, doi:10.17918/00010718. This article has 1 citations.
+
+24. (benton2024identifyingnewtargets pages 98-101): Dorothy Benton. Identifying new targets and drug combinations in neurofibromatosis type 2. ArXiv, 2024. URL: https://doi.org/10.17918/00010718, doi:10.17918/00010718. This article has 1 citations.
+
+25. (chiranth2023asystematicreview pages 2-4): Shivani Chiranth, Seppo W Langer, Hans Skovgaard Poulsen, and Thomas Urup. A systematic review of targeted therapy for vestibular schwannoma in patients with nf2-related schwannomatosis. Neuro-Oncology Advances, Aug 2023. URL: https://doi.org/10.1093/noajnl/vdad099, doi:10.1093/noajnl/vdad099. This article has 23 citations and is from a peer-reviewed journal.

--- a/research/Acoustic_Neuroma-deep-research-falcon.md.citations.md
+++ b/research/Acoustic_Neuroma-deep-research-falcon.md.citations.md
@@ -1,0 +1,498 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Acoustic Neuroma
+- **MONDO ID:**  (if available)
+- **Category:** Neoplastic
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Acoustic Neuroma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-10T11:17:15.413079
+
+1. laraba2023inhibitionofyaptazdriven pages 1-2
+2. king2024vestibularschwannomaand pages 1-2
+3. huo2024treatmentoptionsfor pages 1-2
+4. aman2024currenttrendsin pages 1-2
+5. aman2024currenttrendsin pages 5-6
+6. king2024vestibularschwannomaand pages 4-5
+7. jones2024deconvolvingtheimmunea pages 35-39
+8. nghiemphu2024imagingasan pages 1-2
+9. alsaleh2024theimpactof pages 1-3
+10. douwes2024bevacizumabtreatmentfor pages 2-4
+11. tavares2024hearingfunctionafter pages 1-2
+12. santacroce2023protonbeamradiation pages 1-2
+13. pontillo2024hearingpreservationsurgery pages 1-2
+14. screnci2024bevacizumabforvestibular pages 1-2
+15. douwes2024bevacizumabtreatmentfor pages 13-14
+16. chiranth2023asystematicreview pages 4-5
+17. chiranth2023asystematicreview pages 5-7
+18. king2024vestibularschwannomaand pages 13-14
+19. benton2024identifyingnewtargets pages 16-20
+20. benton2024identifyingnewtargets pages 98-101
+21. chiranth2023asystematicreview pages 2-4
+22. https://doi.org/10.1186/s12885-024-13242-1
+23. https://doi.org/10.3390/jcm13237488
+24. https://doi.org/10.3390/ijms25126558
+25. https://doi.org/10.1007/s11060-024-04596-4
+26. https://doi.org/10.3390/cancers16081479
+27. https://doi.org/10.1055/s-0044-1787736
+28. https://doi.org/10.1007/s10143-023-02060-x
+29. https://doi.org/10.1093/brain/awac342
+30. https://doi.org/10.3233/thc-232043
+31. https://doi.org/10.37897/rjn.2024.3.7
+32. https://clinicaltrials.gov/study/NCT01345136
+33. https://doi.org/10.3390/jcm13237488,
+34. https://doi.org/10.1186/s12885-024-13242-1,
+35. https://doi.org/10.1007/s10143-023-02060-x,
+36. https://doi.org/10.3390/ijms25126558,
+37. https://doi.org/10.37897/rjn.2024.3.7,
+38. https://doi.org/10.1093/brain/awac342,
+39. https://doi.org/10.3390/jcm13113065,
+40. https://doi.org/10.1007/s11060-024-04596-4,
+41. https://doi.org/10.3233/thc-232043,
+42. https://doi.org/10.3390/cancers16081479,
+43. https://doi.org/10.1002/ohn.910,
+44. https://doi.org/10.1055/s-0044-1787736,
+45. https://doi.org/10.14639/0392-100x-suppl.1-44-2024-n2900,
+46. https://doi.org/10.1093/noajnl/vdad099,
+47. https://doi.org/10.17918/00010718,


### PR DESCRIPTION
## Summary
- Adds a new `kb/disorders/Acoustic_Neuroma.yaml` page for acoustic neuroma / vestibular schwannoma (`MONDO:0001569`).
- Incorporates Falcon deep research plus evidence-backed mechanisms, phenotypes, diagnosis, genetics, treatments, and experimental models.
- Adds generated PMID reference-cache files via `just fetch-reference`; no reference cache files were hand-created or hand-edited.

## Validation
- `just validate kb/disorders/Acoustic_Neuroma.yaml`
- `just validate-references kb/disorders/Acoustic_Neuroma.yaml` (passes, but reports zero checks in this repo invocation)
- `just check-reference-cache-frontmatter`
- `git diff --cached --check -- kb/disorders/Acoustic_Neuroma.yaml research/Acoustic_Neuroma-deep-research-falcon.md research/Acoustic_Neuroma-deep-research-falcon.md.citations.md`

## Notes
- Some nonessential descriptors are left as preferred-term-only where OAK lookup was slow or uncertain during batch curation.
- Generated PMID cache files contain upstream trailing whitespace from `just fetch-reference`; they were not hand-edited per repo instructions.