### PR TITLE
Add punctate palmoplantar keratoderma

### DIFF
--- a/kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml
+++ b/kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml
@@ -1,0 +1,526 @@
+name: Punctate Palmoplantar Keratoderma
+category: Mendelian
+creation_date: "2026-05-10T15:03:46Z"
+updated_date: "2026-05-10T15:03:46Z"
+synonyms:
+- punctate PPK
+- punctate keratosis palmoplantaris
+- punctate palmoplantar hyperkeratosis
+- punctate palmoplantar keratoderma type 1
+- Buschke-Fischer-Brauer disease
+description: >
+  Punctate palmoplantar keratoderma is a rare hereditary palmoplantar
+  keratoderma characterized by multiple discrete hyperkeratotic papules or
+  plaques on the palms and soles. Type 1 disease is usually autosomal dominant
+  and is most strongly associated with heterozygous loss-of-function variants in
+  AAGAB, with resulting p34 haploinsufficiency, impaired vesicle trafficking,
+  increased growth-factor receptor signaling, keratinocyte hyperproliferation,
+  and focal palmoplantar hyperkeratosis. Severity is variable; lesions can
+  increase with age, coalesce at pressure-bearing plantar sites, and cause pain
+  or functional limitation.
+disease_term:
+  preferred_term: punctate palmoplantar keratoderma
+  term:
+    id: MONDO:0017675
+    label: punctate palmoplantar keratoderma
+parents:
+- Hereditary palmoplantar keratoderma
+has_subtypes:
+- name: Type 1A
+  display_name: Punctate palmoplantar keratoderma type 1A
+  description: >
+    AAGAB-associated punctate palmoplantar keratoderma type 1 with autosomal
+    dominant inheritance and multiple punctate palmoplantar hyperkeratotic
+    lesions.
+- name: Type 1B
+  display_name: Punctate palmoplantar keratoderma type 1B
+  description: >
+    COL14A1-associated punctate palmoplantar keratoderma type 1B has been
+    described in the subtype framework used by current guidelines, but the
+    evidence base is smaller than for AAGAB-associated type 1A.
+definitions:
+- name: Punctate palmoplantar keratoderma clinical definition
+  definition_type: OTHER
+  description: >
+    A papular or punctate palmoplantar keratoderma in which affected individuals
+    develop multiple discrete hyperkeratotic lesions on palms and soles.
+  evidence:
+  - reference: PMID:23000146
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Punctate palmoplantar keratodermas (PPKPs) are rare autosomal-dominant inherited skin diseases that are characterized by multiple hyperkeratotic plaques distributed on the palms and soles."
+    explanation: This abstract sentence defines the inherited punctate PPK phenotype and inheritance pattern.
+  - reference: PMID:36793812
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Palmoplantar keratoderma (PPK) is an umbrella term for a group of heterogeneous disorders, acquired or inherited, that are characterized by hyperkeratosis of palmar and/or plantar surfaces."
+    explanation: This case-report abstract supports the broader PPK classification and palmoplantar hyperkeratosis definition.
+inheritance:
+- name: Autosomal dominant inheritance
+  description: >
+    Type 1 punctate palmoplantar keratoderma usually segregates as an autosomal
+    dominant trait in families with heterozygous AAGAB loss-of-function variants.
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  evidence:
+  - reference: PMID:31526046
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PPPK1 is an autosomal dominant skin disease caused by AAGAB mutations."
+    explanation: This directly supports autosomal dominant inheritance for AAGAB-associated PPPK1.
+prevalence:
+- population: General population
+  percentage: Rare
+  notes: >
+    Exact population prevalence is uncertain. The systematic review evidence
+    base is dominated by family reports and case series rather than
+    population-based prevalence studies.
+  evidence:
+  - reference: PMID:37705065
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Of 773 studies identified, 45 were included. Most studies were reports on single families (24 of 45 studies) or multiple families (10 of 45 studies)."
+    explanation: This supports that available epidemiologic evidence is largely case- and family-report based.
+progression:
+- phase: Onset
+  age_range: Late childhood to adulthood
+  notes: >
+    Onset is variable and may occur from late childhood through adulthood,
+    depending on family and variant background.
+  evidence:
+  - reference: PMID:31526046
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PPPK1 presents in late childhood to adulthood with multiple small discrete hyperkeratotic papules on palms and soles."
+    explanation: This directly supports the typical onset range and initial clinical morphology.
+- phase: Chronic progression
+  age_range: Adolescence through adulthood
+  notes: >
+    Lesions can increase in number and size with advancing age and coalesce at
+    pressure points, especially on plantar surfaces.
+  evidence:
+  - reference: PMID:23743648
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PPKP1 (OMIM ♯148600, Buschke–Fischer–Brauer type) is characterized by the progressive development of discrete areas of hyperkeratosis on the palms and soles, followed by more extensive diffuse hyperkeratosis on the pressure-bearing areas of plantar skin."
+    explanation: This supports progressive lesion development and plantar pressure-site coalescence.
+pathophysiology:
+- name: AAGAB Haploinsufficiency
+  description: >
+    Heterozygous nonsense, frameshift, splice, or other loss-of-function
+    variants in AAGAB reduce functional p34 dosage in type 1A disease. The p34
+    protein binds clathrin adaptor complexes, so haploinsufficiency links the
+    inherited variant to abnormal membrane-trafficking biology in keratinocytes.
+  gene:
+    preferred_term: AAGAB
+    term:
+      id: hgnc:25662
+      label: AAGAB
+  cell_types:
+  - preferred_term: Keratinocyte
+    term:
+      id: CL:0000312
+      label: keratinocyte
+  biological_processes:
+  - preferred_term: Endocytosis
+    term:
+      id: GO:0006897
+      label: endocytosis
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In 18 families with autosomal dominant punctate PPK, we report heterozygous loss-of-function mutations in AAGAB, encoding α- and γ-adaptin-binding protein p34, located at a previously linked locus at 15q22."
+    explanation: This establishes heterozygous AAGAB loss-of-function variants as a cause of autosomal dominant punctate PPK.
+  - reference: PMID:23000146
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "AAGAB encodes the alpha-and gamma-adaptin-binding protein p34 and might play a role in membrane traffic as a chaperone."
+    explanation: This connects the causal gene product with membrane-trafficking biology.
+  downstream:
+  - target: Growth Factor Receptor Signaling Increase
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: >
+      p34 deficiency is proposed to impair endocytic recycling and turnover of
+      receptor tyrosine kinases, increasing EGFR protein abundance and
+      phosphorylation.
+    evidence:
+    - reference: PMID:23064416
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Knockdown of AAGAB in keratinocytes led to increased cell division, which was linked to greatly elevated epidermal growth factor receptor (EGFR) protein expression and tyrosine phosphorylation."
+      explanation: Keratinocyte knockdown experiments support the link from AAGAB deficiency to increased EGFR abundance and activation.
+- name: Growth Factor Receptor Signaling Increase
+  description: >
+    Impaired receptor endocytosis and turnover increases growth-factor receptor
+    signaling in keratinocytes. This mechanism is best supported for EGFR in
+    AAGAB-knockdown keratinocyte models and provides a plausible route from
+    vesicle-traffic dysfunction to epidermal hyperproliferation.
+  cell_types:
+  - preferred_term: Keratinocyte
+    term:
+      id: CL:0000312
+      label: keratinocyte
+  biological_processes:
+  - preferred_term: Epidermal growth factor receptor signaling pathway
+    term:
+      id: GO:0007173
+      label: epidermal growth factor receptor signaling pathway
+    modifier: INCREASED
+  - preferred_term: Endocytosis
+    term:
+      id: GO:0006897
+      label: endocytosis
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "We hypothesize that p34 deficiency may impair endocytic recycling of growth factor receptors such as EGFR, leading to increased signaling and cellular proliferation."
+    explanation: This abstract sentence states the proposed mechanism linking AAGAB/p34 deficiency to growth-factor signaling and proliferation.
+  downstream:
+  - target: Keratinocyte Hyperproliferation
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: >
+      Increased receptor signaling drives increased cell division in
+      keratinocytes and focal lesional epidermal hyperproliferation.
+    evidence:
+    - reference: PMID:23064416
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Knockdown of AAGAB in keratinocytes led to increased cell division, which was linked to greatly elevated epidermal growth factor receptor (EGFR) protein expression and tyrosine phosphorylation."
+      explanation: This supports the growth-factor signaling to keratinocyte-proliferation step in the causal chain.
+- name: Keratinocyte Hyperproliferation
+  description: >
+    Increased keratinocyte proliferation in palmoplantar epidermis produces
+    focal hyperkeratotic papules and plaques. The anatomic restriction to palms
+    and soles is not fully explained, but pressure-bearing and frictional sites
+    are clinically important for lesion coalescence and symptoms.
+  cell_types:
+  - preferred_term: Keratinocyte
+    term:
+      id: CL:0000312
+      label: keratinocyte
+  locations:
+  - preferred_term: Skin of palm and sole
+    term:
+      id: UBERON:0013776
+      label: skin of palmar/plantar part of autopod
+  biological_processes:
+  - preferred_term: Positive regulation of keratinocyte proliferation
+    term:
+      id: GO:0008284
+      label: positive regulation of cell population proliferation
+    modifier: INCREASED
+  - preferred_term: Keratinization
+    term:
+      id: GO:0031424
+      label: keratinization
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Immunohistochemistry showed hyperproliferation within the punctate lesions."
+    explanation: Lesional tissue evidence supports hyperproliferation within punctate lesions.
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Knockdown of AAGAB in keratinocytes led to increased cell division, which was linked to greatly elevated epidermal growth factor receptor (EGFR) protein expression and tyrosine phosphorylation."
+    explanation: Cell-based knockdown experiments support increased keratinocyte proliferation as a downstream effect of AAGAB deficiency.
+phenotypes:
+- name: Punctate palmoplantar hyperkeratosis
+  category: Clinical
+  frequency: Frequent
+  description: >
+    Multiple small, discrete hyperkeratotic papules or plaques affect the palms
+    and soles.
+  phenotype_term:
+    preferred_term: Punctate palmoplantar hyperkeratosis
+    term:
+      id: HP:0007530
+      label: Punctate palmoplantar hyperkeratosis
+  evidence:
+  - reference: PMID:31526046
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PPPK1 presents in late childhood to adulthood with multiple small discrete hyperkeratotic papules on palms and soles."
+    explanation: This directly supports the core punctate palmoplantar hyperkeratosis phenotype.
+- name: Palmoplantar keratoderma
+  category: Clinical
+  frequency: Frequent
+  description: >
+    Hyperkeratosis is localized to palmar and plantar surfaces, consistent with
+    the broader palmoplantar keratoderma phenotype.
+  phenotype_term:
+    preferred_term: Palmoplantar keratoderma
+    term:
+      id: HP:0000982
+      label: Palmoplantar keratoderma
+  evidence:
+  - reference: PMID:34121213
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Palmoplantar keratoderma (PPK) is a collective term for keratinizing disorders in which the main clinical symptom is hyperkeratosis on the palms and soles."
+    explanation: This guideline abstract supports palmoplantar hyperkeratosis as the defining clinical symptom of PPK.
+- name: Foot pain from plantar keratoses
+  category: Clinical
+  frequency: Variable
+  description: >
+    Plantar pressure-site lesions can be painful and may impair standing or
+    walking in more severe cases.
+  phenotype_term:
+    preferred_term: Foot pain
+    term:
+      id: HP:0025238
+      label: Foot pain
+  evidence:
+  - reference: PMID:24588319
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In family 5, PPPK1 developed around the age of 20 years and progressed thereafter in the 68-year-old Danish proband. She presented with severe, very painful punctate palmoplantar keratoderma on the pressure points of her soles."
+    explanation: This case-series text supports painful plantar involvement in severe disease.
+histopathology:
+- name: Orthokeratotic hyperkeratosis with central epidermal depression
+  description: >
+    Lesional palmar or plantar skin may show orthokeratosis or compact
+    orthokeratosis, hypergranulosis, and a defined central epidermal or dermal
+    depression, consistent with a focal hyperproliferative hyperkeratosis.
+  diagnostic: true
+  evidence:
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Histology of lesional palmar epidermis from 3 unrelated kindreds – Families 1, 11 and 15 – all showed very similar findings of a well-defined central epidermal depression associated with hypergranulosis and a prominent layer of overlying orthokeratosis"
+    explanation: This supports the characteristic histopathologic pattern in AAGAB-associated punctate PPK lesions.
+genetic:
+- name: AAGAB loss-of-function variants
+  association: Causative germline variant
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  subtype: Type 1A
+  gene_term:
+    preferred_term: AAGAB
+    term:
+      id: hgnc:25662
+      label: AAGAB
+  evidence:
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In 18 families with autosomal dominant punctate PPK, we report heterozygous loss-of-function mutations in AAGAB, encoding α- and γ-adaptin-binding protein p34, located at a previously linked locus at 15q22."
+    explanation: This establishes AAGAB loss-of-function variants as causative in autosomal dominant punctate PPK.
+  - reference: PMID:31526046
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We have identified 5 heterozygous AAGAB loss of function mutations in 11 families."
+    explanation: This independent Canadian family series supports recurrent heterozygous AAGAB loss-of-function variants.
+- name: AAGAB c.370C>T p.Arg124Ter founder variant
+  association: Population founder variant
+  relationship_type: RISK_FACTOR
+  variant_origin: GERMLINE
+  subtype: Type 1A
+  gene_term:
+    preferred_term: AAGAB
+    term:
+      id: hgnc:25662
+      label: AAGAB
+  evidence:
+  - reference: PMID:38311882
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This study confirms that the frequently observed variant AAGAB c.370C>T, p.Arg124Ter in punctate PPK among patients in the Region of Southern Denmark is caused by a founder variant."
+    explanation: This supports founder effect status for the recurrent Southern Denmark AAGAB variant.
+- name: COL14A1-associated type 1B
+  association: Reported genetic association
+  relationship_type: UNKNOWN
+  variant_origin: GERMLINE
+  subtype: Type 1B
+  gene_term:
+    preferred_term: COL14A1
+    term:
+      id: hgnc:2191
+      label: COL14A1
+  evidence:
+  - reference: PMID:36793812
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In type 1 PPPK, also known as Buschke-Fischer-Brauer disease, loss-of-function mutations in either the AAGAB or the COL14A1 genes have been associated with the disorder."
+    explanation: This supports COL14A1 as a reported association, but this entry treats AAGAB as the stronger established mechanism because the report and primary mechanistic studies center on AAGAB.
+environmental:
+- name: Mechanical pressure and friction
+  presence: Exacerbating factor
+  description: >
+    Mechanical pressure and friction are not primary causes of hereditary
+    punctate PPK, but pressure-bearing plantar sites are where lesions commonly
+    become confluent and symptomatic.
+  evidence:
+  - reference: PMID:23743648
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PPKP1 (OMIM ♯148600, Buschke–Fischer–Brauer type) is characterized by the progressive development of discrete areas of hyperkeratosis on the palms and soles, followed by more extensive diffuse hyperkeratosis on the pressure-bearing areas of plantar skin."
+    explanation: This supports pressure-bearing plantar skin as a site of more extensive disease.
+diagnosis:
+- name: Clinical morphology and differential diagnosis
+  description: >
+    Diagnosis is based on punctate palmoplantar hyperkeratotic lesions, family
+    history, and exclusion of acquired or infectious mimics when appropriate.
+  evidence:
+  - reference: PMID:32147745
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Palmoplantar keratodermas are grouped depending on the morphology of the keratoderma into diffuse, focal/striate or papular/punctate."
+    explanation: This supports morphology-based clinical classification, including papular/punctate forms.
+  - reference: PMID:23064416
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In severely affected cases, where keratoderma resembled plantar warts, presence of human papilloma virus was excluded in the clinical work-up."
+    explanation: This supports excluding wart-like mimics in severe plantar disease.
+- name: Genetic testing
+  description: >
+    Molecular testing can confirm AAGAB-associated punctate PPK and helps
+    distinguish punctate PPK from other inherited palmoplantar keratoderma
+    subtypes with overlapping clinical morphology.
+  evidence:
+  - reference: PMID:39630431
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It demonstrates the value of genetic testing for accurate diagnoses and to distinguish between different subtypes."
+    explanation: This supports genetic testing as diagnostically useful in palmoplantar keratoderma cohorts.
+  - reference: PMID:38311882
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We recommend testing for the variant as initial screening in our region and potentially for all Danish patients presenting with punctate PPK."
+    explanation: This supports targeted founder-variant testing in the Southern Denmark context.
+treatments:
+- name: Topical keratolytics and physical debridement
+  description: >
+    Symptomatic treatment may include topical keratolytics such as urea,
+    salicylic acid, or lactic acid and repeated physical debridement, especially
+    when no reversible underlying acquired etiology is present.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: Punctate palmoplantar hyperkeratosis
+    term:
+      id: HP:0007530
+      label: Punctate palmoplantar hyperkeratosis
+  evidence:
+  - reference: PMID:17298101
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "If no such etiology is evident, then conservative treatment options include topical keratolytics (urea, salicylic acid, lactic acid), repeated physical debridement, topical retinoids, topical psoralen plus UVA, and topical corticosteroids."
+    explanation: This review concerns acquired PPK broadly, so it partially supports conservative symptomatic management options for palmoplantar hyperkeratosis rather than disease-specific efficacy in inherited punctate PPK.
+  - reference: PMID:33765759
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "After treatment with 30% urea plus 10% salicylic acid, the patient experienced an improvement in her condition."
+    explanation: This single AAGAB-associated BFB case supports potential symptomatic improvement with keratolytics but is case-level evidence.
+- name: Genetic counseling
+  description: >
+    Genetic counseling is appropriate for autosomal dominant families, especially
+    when molecular testing identifies an AAGAB pathogenic variant.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: PMID:39630431
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "It demonstrates the value of genetic testing for accurate diagnoses and to distinguish between different subtypes."
+    explanation: Confirmed molecular diagnosis provides the basis for subtype-specific counseling in affected families.
+- name: KM-001 topical TRPV3 antagonist trial
+  description: >
+    KM-001 topical 1% cream is an investigational therapy studied in open-label
+    phase I/phase Ib trials for type I punctate palmoplantar keratoderma or
+    pachyonychia congenita; no efficacy result is asserted here from the trial
+    registry summaries.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: Punctate palmoplantar hyperkeratosis
+    term:
+      id: HP:0007530
+      label: Punctate palmoplantar hyperkeratosis
+  - preferred_term: Foot pain
+    term:
+      id: HP:0025238
+      label: Foot pain
+  evidence:
+  - reference: clinicaltrials:NCT05435638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In this phase 1 open label study for patients with type I punctate palmoplantar keratoderma or pachyonychia congenital, 2 arms will be recruited to be treated twice daily, with 1% topical KM-001."
+    explanation: The trial record supports KM-001 as an investigational topical therapy evaluated in type I punctate PPK.
+  - reference: clinicaltrials:NCT05956314
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This Phase 1b, open-label, single-center, prospective trial will be assessing the safety, tolerability, and efficacy of topical KM-001 1% in patients with PPPK1 or PC diseases."
+    explanation: The trial record supports a second open-label KM-001 study in PPPK1 or pachyonychia congenita.
+clinical_trials:
+- name: NCT05435638
+  phase: PHASE_I
+  status: COMPLETED
+  description: >
+    Phase I open-label study of topical KM-001 1% in type I punctate
+    palmoplantar keratoderma or pachyonychia congenita, with lesion clearance
+    and pain assessments.
+  target_phenotypes:
+  - preferred_term: Punctate palmoplantar hyperkeratosis
+    term:
+      id: HP:0007530
+      label: Punctate palmoplantar hyperkeratosis
+  - preferred_term: Foot pain
+    term:
+      id: HP:0025238
+      label: Foot pain
+  evidence:
+  - reference: clinicaltrials:NCT05435638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "At the in-clinic visits, treatment efficacy (lesion clearance - IGA, CGI-S, PGI-C, PGI-S and VAS pain) will also be assessed."
+    explanation: The registry summary supports the trial endpoints relevant to lesion clearance and pain.
+- name: NCT05956314
+  phase: PHASE_I
+  status: COMPLETED
+  description: >
+    Phase Ib open-label study of topical KM-001 1% in PPPK1 or pachyonychia
+    congenita, with safety, tolerability, efficacy, pharmacokinetic, and
+    patient-reported diary assessments.
+  target_phenotypes:
+  - preferred_term: Punctate palmoplantar hyperkeratosis
+    term:
+      id: HP:0007530
+      label: Punctate palmoplantar hyperkeratosis
+  - preferred_term: Foot pain
+    term:
+      id: HP:0025238
+      label: Foot pain
+  evidence:
+  - reference: clinicaltrials:NCT05956314
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patient will complete a patient-reported diary, consisting of treatment compliance and self-assessments for efficacy."
+    explanation: The registry summary supports patient-reported efficacy assessment during the KM-001 trial.
+review_notes: >
+  Falcon research completed on 2026-05-10 using
+  research/Punctate_Palmoplantar_Keratoderma-deep-research-falcon.md and its
+  citations file. ORPHA:307967 was not cited in evidence because
+  `just fetch-reference ORPHA:307967` did not find a supported structured
+  reference source.
+
+  COL14A1 is included conservatively as a reported type 1B association with
+  PARTIAL support; the strongest primary and mechanistic evidence in the
+  Falcon report supports AAGAB-associated type 1A disease.

--- a/kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml
+++ b/kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml
@@ -28,6 +28,11 @@ parents:
 has_subtypes:
 - name: Type 1A
   display_name: Punctate palmoplantar keratoderma type 1A
+  subtype_term:
+    preferred_term: punctate palmoplantar keratoderma type 1
+    term:
+      id: MONDO:0019332
+      label: punctate palmoplantar keratoderma type 1
   description: >
     AAGAB-associated punctate palmoplantar keratoderma type 1 with autosomal
     dominant inheritance and multiple punctate palmoplantar hyperkeratotic
@@ -125,10 +130,10 @@ pathophysiology:
       id: CL:0000312
       label: keratinocyte
   biological_processes:
-  - preferred_term: Endocytosis
+  - preferred_term: Clathrin-mediated endocytosis
     term:
-      id: GO:0006897
-      label: endocytosis
+      id: GO:0072583
+      label: clathrin-dependent endocytosis
     modifier: DECREASED
   evidence:
   - reference: PMID:23064416
@@ -171,10 +176,10 @@ pathophysiology:
       id: GO:0007173
       label: epidermal growth factor receptor signaling pathway
     modifier: INCREASED
-  - preferred_term: Endocytosis
+  - preferred_term: Clathrin-mediated endocytosis
     term:
-      id: GO:0006897
-      label: endocytosis
+      id: GO:0072583
+      label: clathrin-dependent endocytosis
     modifier: DECREASED
   evidence:
   - reference: PMID:23064416
@@ -213,8 +218,8 @@ pathophysiology:
   biological_processes:
   - preferred_term: Positive regulation of keratinocyte proliferation
     term:
-      id: GO:0008284
-      label: positive regulation of cell population proliferation
+      id: GO:0010838
+      label: positive regulation of keratinocyte proliferation
     modifier: INCREASED
   - preferred_term: Keratinization
     term:
@@ -364,6 +369,18 @@ environmental:
     evidence_source: HUMAN_CLINICAL
     snippet: "PPKP1 (OMIM ♯148600, Buschke–Fischer–Brauer type) is characterized by the progressive development of discrete areas of hyperkeratosis on the palms and soles, followed by more extensive diffuse hyperkeratosis on the pressure-bearing areas of plantar skin."
     explanation: This supports pressure-bearing plantar skin as a site of more extensive disease.
+- name: Water exposure and skin care context
+  presence: Exacerbating factor
+  description: >
+    Water exposure and personal skin-care practices may modulate plantar
+    hyperkeratosis severity in affected individuals, but they are modeled as
+    modifiers rather than primary causes.
+  evidence:
+  - reference: PMID:23743648
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "There is no apparent genotype–phenotype correlation within this small group of patients, but our clinical observation is that environmental factors and personal skin care regimes affect the degree of plantar hyperkeratosis."
+    explanation: This supports environmental and skin-care context as a modifier of plantar hyperkeratosis severity.
 diagnosis:
 - name: Clinical morphology and differential diagnosis
   description: >
@@ -438,6 +455,33 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "It demonstrates the value of genetic testing for accurate diagnoses and to distinguish between different subtypes."
     explanation: Confirmed molecular diagnosis provides the basis for subtype-specific counseling in affected families.
+- name: Systemic retinoids
+  description: >
+    Oral retinoids such as acitretin have been used as symptomatic therapy for
+    recalcitrant palmoplantar keratoderma, including hereditary punctate forms.
+    The support is partial because the abstract-backed evidence is broader PPK
+    management literature rather than controlled punctate PPK-specific efficacy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: acitretin
+      term:
+        id: CHEBI:50172
+        label: acitretin
+  target_phenotypes:
+  - preferred_term: Punctate palmoplantar hyperkeratosis
+    term:
+      id: HP:0007530
+      label: Punctate palmoplantar hyperkeratosis
+  evidence:
+  - reference: PMID:17298101
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Etretinate and acitretin have also shown some success as alternative treatments in recalcitrant cases."
+    explanation: This acquired PPK review supports systemic retinoid use in recalcitrant PPK; it is partial support for hereditary punctate PPK.
 - name: KM-001 topical TRPV3 antagonist trial
   description: >
     KM-001 topical 1% cream is an investigational therapy studied in open-label

--- a/references_cache/PMID_17298101.md
+++ b/references_cache/PMID_17298101.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:17298101"
+title: Acquired palmoplantar keratoderma.
+authors:
+- Patel S
+- Zirwas M
+- English JC 3rd
+journal: Am J Clin Dermatol
+year: '2007'
+doi: 10.2165/00128071-200708010-00001
+keywords:
+- Climacteric/physiology
+- "Communicable Diseases/complications, diagnosis"
+- Drug-Related Side Effects and Adverse Reactions
+- Humans
+- "Keratoderma, Palmoplantar/chemically induced, diagnosis, etiology"
+- "Malnutrition/complications, diagnosis"
+- "Neoplasms/complications, diagnosis"
+- "Skin Diseases/complications, diagnosis"
+content_type: abstract_only
+---
+
+# Acquired palmoplantar keratoderma.
+**Authors:** Patel S, Zirwas M, English JC 3rd
+**Journal:** Am J Clin Dermatol (2007)
+**DOI:** [10.2165/00128071-200708010-00001](https://doi.org/10.2165/00128071-200708010-00001)
+
+## Content
+
+1. Am J Clin Dermatol. 2007;8(1):1-11. doi: 10.2165/00128071-200708010-00001.
+
+Acquired palmoplantar keratoderma.
+
+Patel S(1), Zirwas M, English JC 3rd.
+
+Author information:
+(1)Department of Dermatology, University of Pittsburgh, Pittsburgh, PA 15213, 
+USA.
+
+Palmoplantar keratodermas (PPKs) are a diverse entity of disorders that are 
+characterized by abnormal thickening of the skin on the palms and soles. 
+Traditionally they have been classified as either hereditary or acquired and are 
+distinguished from each other on the basis of mode of inheritance, presence of 
+transgrediens (defined as contiguous extension of hyperkeratosis beyond the 
+palmar and/or plantar skin), co-morbidities with other symptoms, and extent of 
+epidermal involvement, namely diffuse, focal, and punctate. As the terms 
+hyperkeratosis and keratoderma have been used interchangeably throughout the 
+literature, we define acquired keratoderma as a non-hereditary, non-frictional 
+hyperkeratosis of the palms and/or soles that involves >/=50% of the surface of 
+involved acral areas and that may or may not be associated with clinical and 
+histologic inflammation. Given the numerous possible underlying causes for 
+acquired PPKs, evaluation of patients presenting with acquired PPK can be a 
+perplexing task. To facilitate such evaluations, this review categorizes the 
+acquired PPKs as: keratoderma climactericum, drug related, malnutrition 
+associated, chemically induced, systemic disease related, malignancy associated, 
+dermatoses related, infectious, and idiopathic. In order to avoid the 
+possibility of overlooking an underlying etiology and to eliminate excessive 
+testing, we present an algorithm for assessing patients presenting with acquired 
+PPK. The first step should include a comprehensive history and a physical 
+examination, including a complete skin examination. If findings are consistent 
+with a hereditary keratoderma, then a genetics consultation should be 
+considered. Any findings suggestive of underlying conditions should be 
+aggressively evaluated and treated. If no pertinent findings are identified 
+after a history and a physical examination, laboratory and radiology studies 
+should be undertaken in a systematic, logical fashion. In terms of treatment, 
+the most successful results occur when the underlying etiology is diagnosed and 
+treated. If no such etiology is evident, then conservative treatment options 
+include topical keratolytics (urea, salicylic acid, lactic acid), repeated 
+physical debridement, topical retinoids, topical psoralen plus UVA, and topical 
+corticosteroids. Etretinate and acitretin have also shown some success as 
+alternative treatments in recalcitrant cases.
+
+DOI: 10.2165/00128071-200708010-00001
+PMID: 17298101 [Indexed for MEDLINE]

--- a/references_cache/PMID_23000146.md
+++ b/references_cache/PMID_23000146.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:23000146"
+title: Nonsense mutations in AAGAB cause punctate palmoplantar keratoderma type Buschke-Fischer-Brauer.
+authors:
+- Giehl KA
+- Eckstein GN
+- Pasternack SM
+- Praetzel-Wunder S
+- Ruzicka T
+- Lichtner P
+- Seidl K
+- Rogers M
+- Graf E
+- Langbein L
+- Braun-Falco M
+- Betz RC
+- Strom TM
+journal: Am J Hum Genet
+year: '2012'
+doi: 10.1016/j.ajhg.2012.08.024
+keywords:
+- "Adaptor Proteins, Vesicular Transport"
+- Alleles
+- Carrier Proteins/genetics
+- "Chromosomes, Human, Pair 15/genetics"
+- "Codon, Nonsense"
+- Exome
+- Female
+- Genetic Predisposition to Disease
+- Heterozygote
+- Humans
+- Keratinocytes/metabolism
+- "Keratoderma, Palmoplantar/genetics, metabolism"
+- Male
+- Pedigree
+- Protein Biosynthesis
+- "RNA, Messenger/genetics"
+- "Sequence Analysis, DNA/methods"
+- "Skin Diseases/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Nonsense mutations in AAGAB cause punctate palmoplantar keratoderma type Buschke-Fischer-Brauer.
+**Authors:** Giehl KA, Eckstein GN, Pasternack SM, Praetzel-Wunder S, Ruzicka T, Lichtner P, Seidl K, Rogers M, Graf E, Langbein L, Braun-Falco M, Betz RC, Strom TM
+**Journal:** Am J Hum Genet (2012)
+**DOI:** [10.1016/j.ajhg.2012.08.024](https://doi.org/10.1016/j.ajhg.2012.08.024)
+
+## Content
+
+1. Am J Hum Genet. 2012 Oct 5;91(4):754-9. doi: 10.1016/j.ajhg.2012.08.024. Epub 
+2012 Sep 20.
+
+Nonsense mutations in AAGAB cause punctate palmoplantar keratoderma type 
+Buschke-Fischer-Brauer.
+
+Giehl KA(1), Eckstein GN, Pasternack SM, Praetzel-Wunder S, Ruzicka T, Lichtner 
+P, Seidl K, Rogers M, Graf E, Langbein L, Braun-Falco M, Betz RC, Strom TM.
+
+Author information:
+(1)Center for Rare and Genetic Skin Diseases, Department of Dermatology, Ludwig 
+Maximilians University, 80337 Munich, Germany. kathrin.giehl@med.uni-muenchen.de
+
+Punctate palmoplantar keratodermas (PPKPs) are rare autosomal-dominant inherited 
+skin diseases that are characterized by multiple hyperkeratotic plaques 
+distributed on the palms and soles. To date, two different loci in chromosomal 
+regions 15q22-15q24 and 8q24.13-8q24.21 have been reported. Pathogenic 
+mutations, however, have yet to be identified. In order to elucidate the genetic 
+cause of PPKP type Buschke-Fischer-Brauer (PPKP1), we performed exome sequencing 
+in five affected individuals from three families, and we identified in 
+chromosomal region 15q22.33-q23 two heterozygous nonsense mutations-c.370C>T 
+(p.Arg124(∗)) and c.481C>T (p.Arg161(∗))-in AAGAB in all affected individuals. 
+Using immunoblot analysis, we showed that both mutations result in premature 
+termination of translation and truncated protein products. Analyses of mRNA of 
+affected individuals revealed that the disease allele is either not detectable 
+or only detectable at low levels. To assess the consequences of the mutations in 
+skin, we performed immunofluorescence analyses. Notably, the amount of granular 
+staining in the keratinocytes of affected individuals was lower in the cytoplasm 
+but higher around the nucleus than it was in the keratinocytes of control 
+individuals. AAGAB encodes the alpha-and gamma-adaptin-binding protein p34 and 
+might play a role in membrane traffic as a chaperone. The identification of 
+mutations, along with the results from additional studies, defines the genetic 
+basis of PPKP1 and provides evidence that AAGAB plays an important role in skin 
+integrity.
+
+Copyright © 2012 The American Society of Human Genetics. Published by Elsevier 
+Inc. All rights reserved.
+
+DOI: 10.1016/j.ajhg.2012.08.024
+PMCID: PMC3484507
+PMID: 23000146 [Indexed for MEDLINE]

--- a/references_cache/PMID_23064416.md
+++ b/references_cache/PMID_23064416.md
@@ -1,0 +1,153 @@
+---
+reference_id: "PMID:23064416"
+title: Haploinsufficiency for AAGAB causes clinically heterogeneous forms of punctate palmoplantar keratoderma.
+authors:
+- Pohler E
+- Mamai O
+- Hirst J
+- Zamiri M
+- Horn H
+- Nomura T
+- Irvine AD
+- Moran B
+- Wilson NJ
+- Smith FJ
+- Goh CS
+- Sandilands A
+- Cole C
+- Barton GJ
+- Evans AT
+- Shimizu H
+- Akiyama M
+- Suehiro M
+- Konohana I
+- Shboul M
+- Teissier S
+- Boussofara L
+- Denguezli M
+- Saad A
+- Gribaa M
+- Dopping-Hepenstal PJ
+- McGrath JA
+- Brown SJ
+- Goudie DR
+- Reversade B
+- Munro CS
+- McLean WH
+journal: Nat Genet
+year: '2012'
+doi: 10.1038/ng.2444
+keywords:
+- "Adaptor Proteins, Vesicular Transport/genetics, metabolism"
+- Carrier Proteins/genetics
+- Chromosome Mapping
+- Cytosol/ultrastructure
+- "ErbB Receptors/genetics, metabolism"
+- Gene Expression Regulation
+- Haploinsufficiency
+- HeLa Cells
+- Humans
+- "Keratinocytes/metabolism, pathology"
+- Pedigree
+- "Porokeratosis/genetics, metabolism"
+- Protein Binding
+- "Proteins/genetics, metabolism"
+content_type: full_text_xml
+---
+
+# Haploinsufficiency for AAGAB causes clinically heterogeneous forms of punctate palmoplantar keratoderma.
+**Authors:** Pohler E, Mamai O, Hirst J, Zamiri M, Horn H, Nomura T, Irvine AD, Moran B, Wilson NJ, Smith FJ, Goh CS, Sandilands A, Cole C, Barton GJ, Evans AT, Shimizu H, Akiyama M, Suehiro M, Konohana I, Shboul M, Teissier S, Boussofara L, Denguezli M, Saad A, Gribaa M, Dopping-Hepenstal PJ, McGrath JA, Brown SJ, Goudie DR, Reversade B, Munro CS, McLean WH
+**Journal:** Nat Genet (2012)
+**DOI:** [10.1038/ng.2444](https://doi.org/10.1038/ng.2444)
+
+## Content
+
+1. Nat Genet. 2012 Nov;44(11):1272-6. doi: 10.1038/ng.2444. Epub 2012 Oct 14.
+
+Haploinsufficiency for AAGAB causes clinically heterogeneous forms of punctate 
+palmoplantar keratoderma.
+
+Pohler E(1), Mamai O, Hirst J, Zamiri M, Horn H, Nomura T, Irvine AD, Moran B, 
+Wilson NJ, Smith FJ, Goh CS, Sandilands A, Cole C, Barton GJ, Evans AT, Shimizu 
+H, Akiyama M, Suehiro M, Konohana I, Shboul M, Teissier S, Boussofara L, 
+Denguezli M, Saad A, Gribaa M, Dopping-Hepenstal PJ, McGrath JA, Brown SJ, 
+Goudie DR, Reversade B, Munro CS, McLean WH.
+
+Author information:
+(1)Centre for Dermatology and Genetic Medicine, College of Life Sciences and 
+College of Medicine, Dentistry & Nursing, University of Dundee, UK.
+
+Palmoplantar keratodermas (PPKs) are a group of disorders that are 
+diagnostically and therapeutically problematic in dermatogenetics. Punctate PPKs 
+are characterized by circumscribed hyperkeratotic lesions on the palms and soles 
+with considerable heterogeneity. In 18 families with autosomal dominant punctate 
+PPK, we report heterozygous loss-of-function mutations in AAGAB, encoding α- and 
+γ-adaptin-binding protein p34, located at a previously linked locus at 15q22. α- 
+and γ-adaptin-binding protein p34, a cytosolic protein with a Rab-like GTPase 
+domain, was shown to bind both clathrin adaptor protein complexes, indicating a 
+role in membrane trafficking. Ultrastructurally, lesional epidermis showed 
+abnormalities in intracellular vesicle biology. Immunohistochemistry showed 
+hyperproliferation within the punctate lesions. Knockdown of AAGAB in 
+keratinocytes led to increased cell division, which was linked to greatly 
+elevated epidermal growth factor receptor (EGFR) protein expression and tyrosine 
+phosphorylation. We hypothesize that p34 deficiency may impair endocytic 
+recycling of growth factor receptors such as EGFR, leading to increased 
+signaling and cellular proliferation.
+
+DOI: 10.1038/ng.2444
+PMCID: PMC3836166
+PMID: 23064416 [Indexed for MEDLINE]
+
+Palmoplantar keratoderma (PPK) describes a group of hereditary skin disorders characterized by thickening (hyperkeratosis) of the palm and sole epidermis1. Historically, PPKs have been classified according to the pattern of lesions (diffuse, focal, punctate, striate), as well as histopathologic changes (epidermolytic, non-epidermolytic, porokeratotic). Molecular genetics now allows for improved classification, diagnosis and personalized medicine approaches to treatment. Three distinct types of inherited punctate PPK are recognized by OMIM2. These are: PPKP1 (also known as the Buschke-Fischer-Brauer type, OMIM #148600), mapped to 15q22 Ref.4-6; PPKP2 (porokeratotic type, OMIM #175860), not yet mapped; and PPKP3 (also known as acrokeratoelastoidosis, OMIM #101850), where preliminary linkage suggests a possible locus on 2p25-p12 Ref.7. An additional locus was identified at 8q24.13-8q24.21 in two Chinese families whose phenotype resembles PPKP1 clinically and histologically8. Here we studied a collection of 18 kindreds with PPKP1 from Scotland, Ireland, Japan and Tunisia, 11 of which had a family history consistent with autosomal dominant inheritance (Supplementary Fig. 1). In our PPKP1 case collection, there was considerable phenotypic variation (Figure 1). In all families, onset was typically during the first to second decades of life, with the appearance of small circumscribed lesions on palms and soles. These consistently increase in number with advancing age and later coalesce to form larger lesions. In some families, lesions remained subtle (Figure 1a&b), whereas in other kindreds, the phenotype, resembling HPV-induced papilloma-like lesions, was much more severe, painful and debilitating (Figure 1c&d). Histology of lesional palmar epidermis from 3 unrelated kindreds – Families 1, 11 and 15 – all showed very similar findings of a well-defined central epidermal depression associated with hypergranulosis and a prominent layer of overlying orthokeratosis (Figure 1e). Immunohistochemical staining for cell proliferation marker Ki67 showed continuous staining of the basal cell (proliferative) compartment of the epidermis beneath the hyperkeratotic lesions (Figure 1f), indicative of a hyperproliferative form of hyperkeratosis rather than a retention hyperkeratosis due to defective desquamation.
+
+Microsatellite linkage to the previously reported 15q22 locus was observed in a large Tunisian kindred originating from Saudi Arabia (Supplementary Fig. 2), with a maximum 2-point lod score of 8.18 at θ=0 obtained with D15S983 (Supplementary Table 1). The family was reported previously9. A 6.24 Mb critical interval was defined by visible recombination with markers D15S993 (proximal) and D15S977 (distal) containing 80 RefSeq genes. This locus overlaps the previously reported intervals for PPKP1 (Supplementary Table 2). In parallel, the proband in Family 1 (of Scottish ancestry) was subjected to whole exome sequencing. Of 28,513 SNPs identified, we elected to concentrate on loss-of-function variants located within the critical interval defined by our linkage data and that previously reported. Of 106 unique “stop-gained” SNPs in the exome dataset, only 3 SNPs, all heterozygous in the proband, were located on chromosome 15 (Supplementary Table 3). Two were located well outside the interval: a known SNP rs57809907 predicting p.E417X in DYX1C1; and a second previously unreported variant of unknown consequence predicting p.L439X in GABRG3. The remaining variant, c.481C>T, predicting p.R161X in AAGAB fell within our linkage interval and that initially reported5, but was just outside the interval reported in a Chinese kindred6. This variant was absent from current dbSNP and 1000Genomes datasets. The mutation was confirmed by conventional sequencing and co-segregated with the PPKP1 phenotype in Family 1 (Supplementary Fig. 3a&b). By conventional sequencing, a second loss-of-function mutation, c.348_349del, was identified and found to fully co-segregate in the linked kindred and two additional Tunisian families (Supplementary Fig. 3c&d). Sequencing of the remaining 16 families revealed a total of 8 mutations in AAGAB (2 nonsense; 5 frameshift and 1 splice site mutation), as detailed in Supplementary Table 4. AAGAB, consisting of 10 exons spanning 53,708 bp of genomic DNA, encodes alpha- and gamma-adaptin binding protein p34, identified from a yeast 2-hybrid screen using a subunit of the AP-1 adaptor protein complex as bait10. The positions of the mutations in relation to the p34 protein organization are shown in Figure 2.
+
+By quantitative RT-PCR, we confirmed that p34 is expressed at broadly comparable levels in skin, HeLa cells, primary epidermal keratinocytes and the commonly used keratinocyte cell line HaCaT11 (Figure 3a). By QRT-PCR, we also showed that p34 message is very widely expressed across tissues, including skin (Supplementary Fig. 4). Two independent siRNAs were developed that showed near-complete knockdown of p34 protein in HaCaT cells (Figure 3b). Treatment of HaCaT cells with either of these potent siRNAs resulted in an approximately 2-fold increase in cell counts over time (Figure 3c), thus mirroring the increased epidermal proliferation observed in lesional epidermis (Figure 1f).
+
+The coating of clathrin-coated vesicles consists of clathrin and adaptor complexes, both of which have to be recruited to the appropriate membrane from the cytoplasm12,13. The two most abundant types of adaptor protein complexes are AP-1, which is responsible for sorting proteins between the trans-Golgi network (TGN) and endosomes, and AP-2, which is responsible for sorting proteins at the plasma membrane. Both are heterotypic complexes with AP-1 containing a γ-adaptin subunit and AP-2 containing an α-adaptin subunit. Although cDNAs encoding p34 were the predominant species of clone from the original yeast 2-hybrid screen10, difficulties in obtaining specific antibodies meant that further biochemical confirmation of these protein-protein interactions were not presented. Here, using two independent antibodies to p34 made in-house, we confirm by immunoprecipitation followed by western blotting that this protein indeed interacts with both AP-1 and AP-2 complexes in the cytosol (Figure 4a). Cytosolic localization was confirmed by immunocytochemistry and using both N- and C-terminal GFP-tagged p34 constructs (Figure 4b), although C-terminal tagging also led to some nuclear accumulation of the fusion protein. Cell fractionation studies showed that p34 is found in the cytosol but not in membrane or clathrin-coated vesicle fractions in HeLa cells (Figure 4c). Near-complete siRNA knockdown of p34 (Figure 4d) did not lead to an overt change in the plasma membrane or TGN localization of AP-2 or AP-1, respectively (Figure 4e). Neither AP-1 nor AP-2 co-localized with N- or C-terminal GFP fusions of p34 (Supplementary Fig. 5). Essentially identical diffuse cytoplasmic localization data were obtained in the keratinocyte cell line HaCaT (not shown). Overall, these data confirm that p34 is a cytosolic protein that binds to AP-1 and AP-2, however, p34 does not follow these protein complexes into their membrane-associated vesicle populations on intracellular membranes or at the plasma membrane, respectively. This is consistent with a possible chaperone role, as previously suggested10. For example, p34 might either prevent soluble clathrin from assembling with soluble adaptor complexes in the cytosol; p34 might be involved in vesicle uncoating; or this protein might aid recruitment of soluble adaptors to membranes10. Bioinformatics analysis revealed the presence of a GTPase domain, which is most closely related to the Rab superfamily of vesicular trafficking proteins (Figure 2a; Supplementary Fig. 6). It is not known if this GTPase domain is functional. If so, this may be indicative of a role in active transport of cytosolic adaptor complexes rather than a more passive-acting chaperone function14.
+
+Ultrastructural analysis of lesional plantar skin revealed mild acanthosis, a reduction in the granular cell layer and compact orthokeratosis (Supplementary Fig. 7). In basal keratinocytes (Figure 5), there was a large increase in the number of small vesicles close to the cell membrane and prominent dilatation of the Golgi apparatus (Supplementary Fig. 7). These ultrastructural features are consistent with a vesicle transport defect.
+
+We hypothesized that a possible mechanism whereby perturbation of vesicle trafficking could lead to increased epidermal proliferation might involve recycling of the epidermal growth factor receptor (EGFR). EGFR is known to undergo a process of rapid turnover – a process that requires a number of sorting steps including clathrin- and AP-2-dependent endocytosis15,16. Internalized ligand-bound EGFR is either shuttled to late endosomes/lysosomes for degradation or into recycling endosomes, where, following removal of the bound ligand and dephosphorylation, the receptor is returned to the plasma membrane via vesicle fusion. Knockdown of p34 in HaCaT cells led to a modest ~2.5-fold increase in EGFR mRNA levels as determined by QRT-PCR (data not shown), however, a >10-fold increase in EGFR total protein expression was seen by western blot (Figure 6a), consistent with decreased EGFR turnover. Importantly, phosphorylation of EGFR at tyrosine-992, indicating active EGFR signaling17, was increased >20-fold (Figure 6b). The regulation of EGFR signaling via clathrin-mediated endocytosis is a complex process involving Rab proteins15, dynamin18, AP-2, the Grb2 adaptor protein, and multiple mechanisms relating to post-translational modification of the receptor itself19. Disruption of EGFR endocytosis by knockdown of the motor protein dynamin has been shown to produce decreased protein turnover with increased EGFR signaling18, very similar to what we observed here by knockdown of p34.
+
+Here, using a combination of genetic linkage and whole exome sequencing, we have identified a gene for the autosomal dominant form of punctate palmoplantar keratoderma previously linked to 15q22 Ref.5,6,9, known as PPKP1 (OMIM #148600). The causative gene, AAGAB, encodes alpha- and gamma-adaptin binding protein p34 Ref.10. AP-2 is known to be involved in EGFR endocytosis19 and we confirm here that p34 binds cytosolic AP-2 (Figure 4) and show that p34 deficiency increases epidermal cell proliferation (Figure 1f & Figure 3). Overall, p34 appears to play a hitherto unrecognized role in the control of cell division, possibly by contributing to normal endocytotic recycling of receptor tyrosine kinases such as EGFR15,16,18,19. Other genes involved in intracellular vesicle trafficking have been linked to inherited skin disease where hyperkeratosis and/or keratoderma form part of the phenotypic constellation. This includes SNAP29 in cerebral dysgenesis, neuropathy, ichthyosis, and keratoderma (CEDNIK syndrome)20 and VPS33B in arthrogryposis, renal dysfunction, and cholestasis (ARC syndrome)21, both of which encode proteins required for vesicle membrane fusion in the epidermis and other tissues. Moreover, loss-of-function mutations in AP1S1, which encodes the small σ1A subunit of the AP-1 complex, have been shown to cause the recessive neurocutaneous disorder MEDNIK (mental retardation, enteropathy, deafness, peripheral neuropathy, ichthyosis, and keratodermia)22. Similarly, defects in multiple proteins involved in melanosome transport and fusion lead to the pigmentation disorder Griscelli syndrome23 and mutations in the AP-3 subunit protein β3A have been linked to Hermansky-Pudlak syndrome type 2, which consists of oculocutaneous albinism and other features24. Thus, a growing number of genes involved in vesicle transport have been linked to genetic skin disease, plus or minus extra-cutaneous phenotypes.
+
+Disruption of EGFR signaling is a feature of neoplasia. There are anecdotal reports of cancer occurring in association with punctate PPK families25, however, without genetic testing we cannot say that the p34 gene was involved in those cases. Although a few cases of cancer were reported in the larger families studied here, we did not observe co-segregation with the p34 mutations and so any causal link remains unproven.
+
+It remains unclear why haploinsufficiency for this widely expressed protein leads to a phenotype limited to palm and sole epidermis, although this is not unusual in hereditary skin disease, e.g. haploinsufficiency for the desmosomal proteins desmoplakin and desmoglein-1 Ref.26,27, or keratin 1 Ref.28, all of which are structural proteins expressed throughout the epidermis, lead to striate palmoplantar keratoderma29. Another unanswered question relates to why the hyperkeratotic lesions are focal. These lesions are late-onset, appearing in the first or second decades of life, and increase in number with increasing age. This might be explained by a “second hit” mutation in AAGAB and so we examined this by sequencing the gene using genomic DNA derived from microdissected lesional tissue from more than one patient. This revealed neither loss-of-heterozygosity nor a second compound heterozygous p34 mutation (data not shown). Immunohistochemistry was also attempted, however, neither the in-house nor commercial p34 antibodies available gave a signal on fixed tissue. A further possibility is the occurrence of a second somatic mutation in a gene other than AAGAB.
+
+In conclusion, this study expands the molecular diagnostic repertoire for keratodermas and reveals that the AP-1 and AP-2 associated protein p34 is involved in control of epidermal cell division.
+
+Individuals from 18 apparently unrelated families presented with PPK at dermatology clinics in Scotland, Ireland, Japan and Tunisia. Clinical examination and histological analysis of affected persons was consistent with a diagnosis of the Buschke-Fischer-Brauer type of punctate PPK (PPKP1; OMIM reference number 148600)2. In severely affected cases, where keratoderma resembled plantar warts, presence of human papilloma virus was excluded in the clinical work-up. EDTA blood samples were obtained from the patients with written informed consent and Institutional Ethics Committee approval that complied with the Declaration of Helsinki Principles. DNA was extracted following standard procedures.
+
+Microsatellite genotypes were generated for members of Family 15 using standard protocols. Lod scores were calculated using FASTLINK, assuming a mutant allele frequency of 1 in 50,000 30,31. The lod scores were re-calculated using a 10% chance of non-penetrance because of difficulties obtaining a definitive clinical ascertainment in some individuals in Family 15 (the family reside in a remote mountainous area of Tunisia).
+
+Exome enrichment was performed using the Agilent SureSelect 50 Mb exome enrichment system (Agilent UK, Wokingham, UK), using the protocol for Applied Biosystems SOLiD (Protocol version 1.0, May 2010), followed by sequencing on the ABI SOLiD platform (Applied Biosystems, Foster City CA), giving an average sequencing depth of >30x across the exome. Next generation sequencing and SNP calling was performed by The East Anglian Sequencing and Informatics Hub (EASIH; http://www.easih.ac.uk).
+
+Routine hematoxylin and eosin staining of paraffin-embedded tissue was performed using standard protocols. Immunohistochemical staining Ki67 for the cell proliferation marker Ki67 was performed using polyclonal antibody HPA000451 (Sigma-Aldrich, Poole, UK).
+
+The individual exons of AAGAB were amplified by PCR using the genomic primers listed in Supplementary Table 5 and the following cycling conditions: One cycle of 94°C for 5 min; 35 cycles of 94°C for 30 s, 55°C for 30 s and 72°C for 1 min; and 1 final extension at 72°C for 5 min.
+
+HaCaT keratinocytes were maintained in a monolayer in 5% CO2 in Dulbecco’s modified Eagle’s medium (DMEM, Invitrogen, Paisley, UK) containing 10% fetal calf serum (FCS). Normal human keratinocytes were obtained from CELLnTECH and cultured in the defined growth medium CnT57 (TCS Cellworks Ltd, Buckingham, UK). HeLa cells were cultured in DMEM supplemented with 10% FCS, 2mM L-glutamine, 50 units/ml penicillin and 50μg/ml streptomycin (Sigma-Aldrich).
+
+Total RNA was extracted from cultured HaCaT cells and primary keratinocytes using an RNeasy Mini kit (Qiagen, Crawley, UK). 1 μg of RNA was reverse transcribed using AMV Reverse Transcriptase (Promega, Southampton, UK) and oligo(dT)15 (Roche Diagnostics, Welwyn Garden City, UK). 1 μl of reaction mix was used in subsequent PCR using Expand High Fidelity PCR buffer containing 1.5mM MgCl2 and 0.5 units of High Fidelity DNA Polymerase (Roche Diagnostics). Primers AAGAB5intFor and AAGAB8intRev (see Supplementary Table 5) were used to amplify a 292 bp fragment using the following program: one cycle of 94°C for 5 min; 35 cycles of 94°C for 30 s, 52°C for 30 s and 72°C for 30 s; 72°C for 5 min.
+
+RNA was isolated from abdominal skin, primary keratinocytes, HaCaT and HeLa cells using an RNeasy mini kit (Qiagen) and the RNA was treated with RNase-Free DNase to remove any contaminating genomic DNA. 1μg of each was reversed transcribed using a High Capacity cDNA Reverse Transcription Kit (Applied Biosystems). 1μl of reaction were used in quantitative PCR using Perfecta qPCR ToughMix™, ROX™ (Quanta Biosciences) on a 7900HT Fast Real-Time PCR system (Applied Biosystems). Taqman® Gene Expression Assays (Life Technologies) for AAGAB (part number Hs01027607_m1) and GAPDH (part number 4310884E) were used as per manufacturer’s recommendations.
+
+A cDNA clone was generated to act as a standard, as follows: cDNA generated following reverse transcription of HaCaT RNA was used as template for amplification of a 940 bp AAGAB cDNA fragment using the primers P34clone1 and P34clone2 (see Supplementary Table 5). The cDNA was cloned as an EcoR I–Hind III fragment into pcDNA™3.1(−)/myc-HisA (Life Technologies). A normalized cDNA panel from 48 different human tissues (Origene Technologies, Inc., Maryland, USA) was quantified using Taqman® Gene Expression Assay Hs01027607_m1 (Life Technologies). The standard used in this assay was plasmid DNA encoding wild type AAGAB. The standard curve was calculated using the formulae described by Applied Biosystems.
+
+siRNA oligonucleotides targeting AAGAB and a scrambled negative control were obtained from Eurofins MWG Operon. The sequences of the siRNAs used were AAGAB1239 UGU AAG AGA GUG AGG AAU A and AAGAB2164 GGA AAG UAC UGC AAA UAA A. Non-specific control siRNA (NSC4) sequence (a scrambled bacterial lacZ sequence) was UAG CGA CUA AAC ACA UCA AUU’. 1.2 × 105 HaCaT cells were added to wells of a 6 well dish containing DMEM supplemented with 10% FCS and transfected with siRNAs at a final concentration of 5 nM using Lipofectamine RNAiMAX Reagent (Invitrogen). Cells were incubated for 72 hours or 96 hours before harvesting for RNA extraction and protein isolation or for the cell proliferation analysis.
+
+HaCaT cells were treated with siRNAs as above and incubated for 96 hours. Cells were washed with PBS then detached from the dishes using 0.05% Trypsin-EDTA. Counts of viable cells (trypan-blue staining) were obtained using a hemocytometer.
+
+Two affinity purified rabbit polyclonal antibodies were made in-house (J.H. group), designated p34-1 and p34-2, using GST-fusion protein consisting of residues 142-315 (C-terminus) of rat p34 (85% identical and 91% similar to human p34). These antibodies were used for the HeLa cell experiments (western and immunofluorescence). For the HaCaT cell experiments (W.H.I.M. group), rabbit anti-AAGAB polyclonal antibody was used (Sigma-Aldrich). Immunofluorescence and western blotting of HeLa cells was repeated using the Sigma-Aldrich antibody with very similar results (W.H.I.M. group, data not shown). Similarly, western blotting and immunofluorescence of HaCaT cells was repeated using p34-2 with similar results (W.H.I.M. group, data not shown).
+
+Cells were rinsed in ice-cold PBS then lyzed in SDS lysis buffer (1% SDS, 20 mM Tris-HCl pH 8.0, 137 mM NaCl, 10% glycerol, 2 mM EDTA) plus protease inhibitor cocktail (Sigma-Aldrich), phosphatase inhibitor cocktail (Sigma-Aldrich) and 25 U/ml Benzonase (Merck, Darmstadt, Germany), incubating at room temperature for 10 min with agitation. Lysates were cleared by centrifugation at 10,000 g for 10min at 4°C then protein concentrations determined using Bio-Rad Protein Assay (Bio-Rad Laboratories, Hemel Hempsted, UK). For each sample, 10 μg of total protein were separated on NuPAGE 4-12% Bis-Tris polyacrylamide gels (Invitrogen) in MOPS buffer then blotted onto HyBond-C Extra (GE Healthcare, Amersham, UK). Membranes were probed with 1:1000 dilution of the appropriate primary antibody (rabbit anti-AAGAB; Sigma-Aldrich), rabbit anti-EGFR (Cell Signaling Technologies, Beverly MA), or 1:10000 dilution mouse anti-beta-actin (Sigma-Aldrich), then 1:1000 dilution of goat anti-rabbit-HRP or rabbit anti-mouse-HRP (Dako, Glostrup, Denmark) as the secondary antibody. Immobilon Western Chemiluminescent HRP substrate (Millipore, Watford, UK) was used for visualization. For detection of phospho-EGFR, blots were blocked in 3% BSA in PBS containing 0.1% Tween 20 (PBST) and 10mM beta-glycerophosphate for 1h at room temperature then incubated overnight in 1/1000 dilution of phospho-EGF receptor (Tyr-992) antibody (Cell Signalling Technology) in PBST containing 10 mM beta-glycerophosphate at 4°C. Blots were washed in 3 changes of PBST containing 10mM beta-glycerophosphate then incubated in 1/1000 dilution of goat anti-rabbit HRP (DAKO) in PBST plus 10 mM beta-glycerophosphate for 1 h at room temperature. Following washing as before, blots were developed using ECL. For detection of beta-actin, blots were blocked and antibodies were diluted in 5% non-fat milk in PBST under the same conditions as above. A dilution of 1/10,000 was used for the anti-actin antibody (Sigma-Aldrich) and 1/1000 for the secondary rabbit anti-mouse HRP antibody (DAKO). Quantification of protein bands on blots was done using a LI-COR Odyssey infra-red imaging system.
+
+Transfection of HeLa cells with siRNAs was achieved with Oligofectamine (Invitrogen) following the manufacturer’s instructions, using 25 mM siRNA and incubating for 72 h. Knockdown of p34 was achieved using an siGENOME SMARTpool (#M-0159891) and control knockdowns were performed with a non-targeting siRNA (#D-001810-10), both (Thermo-Fisher, Epsom, UK). Transient transfections with GFP-tagged plasmid DNA was achieved using HeLa Monster transfection reagent (Cambridge Bioscience, Cambridge, UK) following the manufacturer’s instructions and transfecting 48 h prior to imaging. For immunofluorescence, cells were grown on glass bottom coverslips (Mat Tek, Ashland MA), fixed in 3% formaldehyde in PBS at room temperature and permeabilized with 0.1% Triton X-100. The cells were imaged with a Zeiss Axiovert 200 inverted microscope using a Zeiss Plan Achromat 63x oil immersion objective, a Hamamatsu ORCA-ER2 camera and Improvision Openlab software (Perkin-Elmer, Cambridge, UK).
+
+These were performed with antibodies raised in-house including p34 (p34-1, p34-2), AP-2α, AP-1γ, clathrin heavy chain 10. Antibody P34-2 was used to detect p34 unless otherwise specified. N- and C- terminally tagged p34 were constructed from rat cDNA 10 (note that human and rat AP-1γ, share 99% amino acid identity) by PCR amplification and cloned in-frame into pEGFP-N3 (p34GFP) or pEGFP-C1 (GFPp34; Takara Bio Europe/Clontech, Saint-Germain-en-Laye, France) using Hind III and Kpn I restriction sites. The sequence of both constructs was verified by Sanger sequence analysis.
+
+For immunoprecipitation, cells were lyzed in PBS containing 1% IGEPAL (Sigma-Aldrich), cleared of debris by centrifugation and antibody-protein complexes captured using protein-A Sepharose (Pharmacia, Milton Keynes, UK). The samples were then analyzed by PAGE electrophoresis and Western blotting. Blots were probed with various antibodies followed by ECL Plus Western Blotting Detection System (GE Healthcare). Control CCV-enriched fractions were prepared as described previously 32, except the final pelleting step was performed at 86,900 × g RCFmax (40,000 rpm, TLA-110) for 30 min to improve yield.
+
+Skin biopsy specimens were cut into small pieces (of <1 mm3) and fixed in half-strength Karnovsky fixative for 4 hours at room temperature. After washing in 0.1 M phosphate buffer (pH 7.4), the samples were immersed in 1.3% aqueous osmium tetroxide (TAAB Laboratories, Berkshire, UK) for 2 hours, followed by incubation in 2% uranyl acetate (Bio-Rad), and dehydrated in a graded ethanol series, and then embedded in epoxy resin via propylene oxide (TAAB Laboratories). Ultra-thin sections were stained with uranyl acetate and lead citrate and examined in a Philips CM10 transmission electron microscope (Philips, Eindhoven, The Netherlands).

--- a/references_cache/PMID_23743648.md
+++ b/references_cache/PMID_23743648.md
@@ -1,0 +1,100 @@
+---
+reference_id: "PMID:23743648"
+title: Heterozygous mutations in AAGAB cause type 1 punctate palmoplantar keratoderma with evidence for increased growth factor signaling.
+authors:
+- Pöhler E
+- Zamiri M
+- Harkins CP
+- Salas-Alanis JC
+- Perkins W
+- Smith FJD
+- Irwin McLean WH
+- Brown SJ
+journal: J Invest Dermatol
+year: '2013'
+doi: 10.1038/jid.2013.243
+keywords:
+- "Adaptor Proteins, Vesicular Transport"
+- Adult
+- Aged
+- Carrier Proteins/genetics
+- Family Health
+- Female
+- Genotype
+- Heterozygote
+- Humans
+- Intercellular Signaling Peptides and Proteins/metabolism
+- "Keratoderma, Palmoplantar/genetics"
+- Male
+- Microsatellite Repeats/genetics
+- Middle Aged
+- Mutation
+- Pedigree
+- Signal Transduction
+content_type: full_text_xml
+---
+
+# Heterozygous mutations in AAGAB cause type 1 punctate palmoplantar keratoderma with evidence for increased growth factor signaling.
+**Authors:** Pöhler E, Zamiri M, Harkins CP, Salas-Alanis JC, Perkins W, Smith FJD, Irwin McLean WH, Brown SJ
+**Journal:** J Invest Dermatol (2013)
+**DOI:** [10.1038/jid.2013.243](https://doi.org/10.1038/jid.2013.243)
+
+## Content
+
+1. J Invest Dermatol. 2013 Dec;133(12):2805-2808. doi: 10.1038/jid.2013.243. Epub
+ 2013 Jun 6.
+
+Heterozygous mutations in AAGAB cause type 1 punctate palmoplantar keratoderma 
+with evidence for increased growth factor signaling.
+
+Pöhler E(1), Zamiri M(2), Harkins CP(3), Salas-Alanis JC(4), Perkins W(5), Smith 
+FJD(1), Irwin McLean WH(1), Brown SJ(6).
+
+Author information:
+(1)Dermatology and Genetic Medicine, College of Life Sciences and College of 
+Medicine, Dentistry and Nursing, University of Dundee, Dundee, UK.
+(2)Department of Dermatology, University Hospital Crosshouse, Kilmarnock, UK.
+(3)Dermatology and Genetic Medicine, College of Life Sciences and College of 
+Medicine, Dentistry and Nursing, University of Dundee, Dundee, UK; Department of 
+Dermatology, Ninewells Hospital and Medical School, Dundee, UK.
+(4)Basic Science Department, Universidad de Monterrey, Nuevo León, México.
+(5)Department of Dermatology, Nottingham University Hospitals NHS Trust, 
+Nottingham, UK.
+(6)Dermatology and Genetic Medicine, College of Life Sciences and College of 
+Medicine, Dentistry and Nursing, University of Dundee, Dundee, UK; Department of 
+Dermatology, Ninewells Hospital and Medical School, Dundee, UK. Electronic 
+address: s.j.brown@dundee.ac.uk.
+
+DOI: 10.1038/jid.2013.243
+PMCID: PMC3826975
+PMID: 23743648 [Indexed for MEDLINE]
+
+TO THE EDITOR
+
+Punctate palmoplantar keratoderma (punctate PPK or PPKP) is a rare autosomal dominant disorder of keratinization. Three variants of this disease have been described; PPKP1 (OMIM ♯148600, Buschke–Fischer–Brauer type) is characterized by the progressive development of discrete areas of hyperkeratosis on the palms and soles, followed by more extensive diffuse hyperkeratosis on the pressure-bearing areas of plantar skin.
+
+Linkage analyses of families affected by PPKP1 have previously identified a locus within 15q22–q24 (Martinez-Mir et al., 2003; Gao et al., 2005), but two Chinese pedigrees with a PPKP1 phenotype demonstrated linkage on chromosome 8q24.13–q24.21 (Zhang et al., 2004). Recently, nonsense mutations in AAGAB, the gene encoding alpha- and gamma-adaptin-binding protein p34, were reported in three PPKP1 families (Giehl et al., 2012). Simultaneously, we applied whole-exome sequencing and reported heterozygous loss-of-function mutations in AAGAB in 18 PPKP1 kindreds (Pohler et al., 2012). AAGAB is located on chromosome 15q22, within one of the previously reported linkage regions (Martinez-Mir et al., 2003; Pohler et al., 2012). We now report the AAGAB genotype in a further 12 PPKP1 patients from 6 independent kindreds of Scottish, English, and Mexican ancestry. This study was carried out in accordance with the Declaration of Helsinki Principles, and all subjects gave written informed consent.
+
+A 56-year-old Scottish woman reported a 15-year history of the progressive development of tender callosities on her soles and palms. Examination revealed multiple hyperkeratotic foci on the palmar skin of hands and fingers (Figure 1a) and diffuse hyperkeratosis on weight-bearing areas of plantar skin (Figure 1b). The proband's parents were unaffected, but one of her three offspring demonstrated a PPKP1 phenotype. Sequencing of AAGAB using reported methodology (Pohler et al., 2012) identified a heterozygous 1-bp deletion, mutation c.344del resulting in a premature termination codon (p.Asp115Valfs*7; Supplementary Figure S1 online). This mutation has previously been observed in two apparently unrelated Scottish families (Pohler et al., 2012).
+
+A 74-year-old Scottish woman presented with a 25-year history of progressive hyperkeratosis of her plantar skin (Figure 1d), with lesser involvement of the palmar skin (Figure 1c). The proband's parents were unaffected, but one of her three adult children had keratoderma. DNA sequencing identified a previously unreported heterozygous nonsense mutation, c.390G>A, predicting the protein change p.Trp130*0, within AAGAB (Supplementary Figures S1 and S2b online). This mutation was not detected in ∼11,000 European and African American individuals' exome sequencing data (NHLBI Exome Sequencing Project http://evs.gs.washington.edu/EVS/ accessed 27 March 2013), nor is it reported in the 1000 Genomes Catalogue of Human Genetic Variation (http://www.1000genomes.org/ensembl-browser accessed 27 March 2013).
+
+A 79-year-old Scottish man presented with a 30-year history of hyperkeratosis of the soles and palms (Supplementary Figure S3a and b online). His medical history included a cutaneous squamous cell carcinoma on the hand and a basal cell carcinoma on the nose, but these were not at sites affected by keratoderma. The patient's parents, eight siblings, and two children were unaffected. DNA sequencing revealed a heterozygous c.870+1G>A splice-site mutation within AAGAB (Supplementary Figure S1 online), previously reported in an unrelated Scottish family (Pohler et al., 2012). The protein consequences of this mutation are unknown but is likely to represent a frameshift mutation.
+
+A 55-year-old female patient of English ancestry presented at the age of 30 years with typical features of PPKP1. She had multiple keratotic papules on palmar and plantar surfaces, which had gradually increased in number, becoming confluent and tender (Supplementary Figure S4a and b online). The patient has one affected and four unaffected siblings; her two daughters are similarly affected and her one grandson shows early signs of punctate keratoderma. DNA sequencing revealed a heterozygous frameshift mutation c.472del, leading to a premature termination codon (p.Gly158Glufs*0; Supplementary Figure S1 online), previously reported in five apparently unrelated Scottish families (Pohler et al., 2012).
+
+Thirty-one members of this Mexican family over four generations demonstrate a PPK1P phenotype with an autosomal dominant pattern of inheritance. The affected living relatives showed multiple hyperkeratotic papules on the palms and soles with no associated nail disease (representative clinical images are shown in Figure 1e and f). Linkage analysis in this family has identified the AAGAB locus at chromosome 15q22 (Martinez-Mir et al., 2003). AAGAB sequencing of DNA from five affected family members has now identified a previously unreported heterozygous 1-bp deletion in exon 3, c.275del predicting the protein change p.Leu92Leufs*18, in each affected individual (Supplementary Figures S1 and S2d online). This mutation was not detected in ∼11,000 European and African American individuals' exome sequencing data (NHLBI Exome Sequencing Project http://evs.gs.washington.edu/EVS/ accessed 27 March 2013), nor is it reported in the 1000 Genomes Catalogue of Human Genetic Variation (http://www.1000genomes.org/ensembl-browser accessed 27 March 2013).
+
+A 42-year-old Scottish woman presented with punctate callosities affecting her palms and soles, which were present since early adulthood (Figure 1g and h). The proband's mother was affected to a milder degree, and her 15-year-old son showed early signs of punctate keratoderma on the plantar surfaces. Sequencing of all exons of AAGAB in these three cases failed to identify any mutations. However, microsatellite linkage analysis in the pedigree was consistent with involvement of the AAGAB locus (Figure 2). Hemizygous inheritance of a microsatellite marker within intron 1 of AAGAB indicated a genomic deletion. A reduction in the gene dosage for AAGAB exon 1 in the proband compared with her unaffected father was confirmed using semiquantitative fluorescent PCR (Supplementary Figure S5a and b online), whereas exons 2 and 3 were amplified in equal quantities in the proband and control (Supplementary Figure S5c and d online). The precise size of this genomic deletion involving exon 1/intron 1 of AAGAB has not been defined, but it is consistent with the resultant haploinsufficiency of AAGAB.
+
+It has previously been shown that knockdown of p34 in HaCaT cells in vitro leads to increased stabilization of the EGFR protein, a receptor tyrosine kinase (Pohler et al., 2012). In addition to EGFR, keratinocytes express several other receptor tyrosine kinases (RTKs). To further investigate the functional effects of AAGAB mutations, we tested the effect of gene knockdown on the transmembrane protein Axl, an RTK that is highly expressed in skin and is involved in signaling pathways to cellular proliferation (Postel-Vinay and Ashworth, 2012). We investigated the effect of p34 knockdown on Axl in HaCaT keratinocytes and found a significant increase in the amount of Axl protein in cells treated with AAGAB-specific small interfering RNA (Supplementary Figure S6 online; methods are fully described in online Supplementary Tables S1 and S2 online).
+
+These six kindreds demonstrate replication of a newly reported genetic cause for punctate PPK1, further confirming AAGAB as a causative gene. AAGAB mutations result in hereditary deficiency of p34, leading to hyperproliferative hyperkeratosis through increased growth factor signaling, which is thought to result from impairment in the endocytosis and recycling of EGFR proteins (Pohler et al., 2012).
+
+A total of 13 predicted loss-of-function mutations have now been reported; these are listed in Supplementary Table S3 online. We have identified recurrent mutations resulting in frameshift and deleterious splice site changes, as well as previously unreported variants. There is no apparent genotype–phenotype correlation within this small group of patients, but our clinical observation is that environmental factors and personal skin care regimes affect the degree of plantar hyperkeratosis. The PPKP1 families reported here demonstrate some diversity in the clinical appearance of plantar hyperkeratosis, whereas the punctate palmar keratoses have a more similar appearance in each kindred (Figure 1).
+
+An association with the development of malignancy in PPKP1 patients has been reported, including breast and colonic adenocarcinoma (Bennion and Patterson, 1984; Stevens et al., 1996). It is not clear whether there is truly an over-representation of malignancy in PPKP1 cases, and malignant neoplasms were not prevalent in the six kindreds reported here.
+
+Hyperkeratosis of the plantar skin localized to the weight-bearing areas may be explained by mechanical trauma, but the extremely focal distribution of hyperkeratosis on the palmar skin in the disorder is striking. The mechanism(s) responsible for producing this very focal disease on the background of a mutation expressed throughout the palmar skin are likely to be of clinical relevance, but they remain to be defined. It is possible that a second mutation has occurred within each focal area of hyperkeratosis. This was not identified by microdissection and sequence analysis (Pohler et al., 2012), but further investigation is warranted. A clearer understanding of the genetic and/or environmental mechanisms by which focal keratoses arise may give further insight into the role of p34 in controlling cell division. Because of the role of EGFR and Axl in various malignancies, Axl-specific inhibitors are under development (Postel-Vinay and Ashworth, 2012) and are potentially of relevance to this rare but distressing keratoderma.
+
+The p34 protein encoded by AAGAB has been functionally implicated in the biology of intracellular transport of membrane-bound, clathrin-coated vesicles. We hypothesized that a possible link between an inherited defect in vesicle transport and epidermal hyperproliferation might involve RTKs, which are turned over by endocytosis via clathrin- and AP2-dependent processes (Ceresa, 2006; Rappoport and Simon, 2009). The upregulation of Axl protein expression after small interfering RNA knockdown of AAGAB demonstrates the involvement of p34 in RTK turnover in addition to EGFR. The identification of molecular mechanisms in palmoplantar keratoderma serves to improve our understanding of the pathogenesis of cutaneous hyperkeratosis. It may also offer insight into the control of keratinization in physiological conditions, as well as more prevalent inflammatory skin diseases characterized by hyperproliferation and hyperkeratosis.

--- a/references_cache/PMID_24588319.md
+++ b/references_cache/PMID_24588319.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:24588319"
+title: New and recurrent AAGAB mutations in punctate palmoplantar keratoderma.
+authors:
+- Pohler E
+- Huber M
+- Boonen SE
+- Zamiri M
+- Gregersen PA
+- Sommerlund M
+- Ramsing M
+- Hohl D
+- McLean WH
+- Smith FJ
+journal: Br J Dermatol
+year: '2014'
+doi: 10.1111/bjd.12927
+keywords:
+- "Adaptor Proteins, Vesicular Transport/genetics"
+- Adult
+- Aged
+- Female
+- Humans
+- "Keratoderma, Palmoplantar/genetics"
+- Mutation/genetics
+- Pedigree
+- Recurrence
+content_type: full_text_xml
+---
+
+# New and recurrent AAGAB mutations in punctate palmoplantar keratoderma.
+**Authors:** Pohler E, Huber M, Boonen SE, Zamiri M, Gregersen PA, Sommerlund M, Ramsing M, Hohl D, McLean WH, Smith FJ
+**Journal:** Br J Dermatol (2014)
+**DOI:** [10.1111/bjd.12927](https://doi.org/10.1111/bjd.12927)
+
+## Content
+
+1. Br J Dermatol. 2014 Aug;171(2):433-6. doi: 10.1111/bjd.12927. Epub 2014 Aug 7.
+
+New and recurrent AAGAB mutations in punctate palmoplantar keratoderma.
+
+Pohler E(1), Huber M, Boonen SE, Zamiri M, Gregersen PA, Sommerlund M, Ramsing 
+M, Hohl D, McLean WH, Smith FJ.
+
+Author information:
+(1)Centre for Dermatology and Genetic Medicine, Colleges of Life Sciences and 
+Medicine, Dentistry and Nursing, University of Dundee, Dundee, U.K.
+
+DOI: 10.1111/bjd.12927
+PMCID: PMC4282079
+PMID: 24588319 [Indexed for MEDLINE]
+
+Dear Editor, Punctate palmoplantar keratoderma type I (PPPK1; also known as Buschke-Fischer-Brauer type; OMIM 148600) is an autosomal dominant disorder of keratinization, characterized by multiple hyperkeratotic lesions on the palms and soles that usually start in early adolescence but may also start later in life.1 Lesions increase in size and number with advancing age and may coalesce over pressure points to form larger plaques. Recently, two consecutive studies identified the causative gene for PPPK1 as AAGAB,2,3 located on chromosome 15q23, a locus to which the causal gene for PPPK1 was previously mapped.4 Subsequently, further mutations in AAGAB were described in families from several countries worldwide.5–11 In this study, we investigated five European families with a clinical diagnosis of PPPK1. This work was conducted in accordance with the principles of the Declaration of Helsinki. Blood was obtained following written informed consent and DNA extracted using standard protocols. Polymerase chain reaction amplification and Sanger sequencing to screen all exons and exon/intron boundaries of AAGAB was done as described previously.3
+
+The 31-year-old proband from family 1, a four-generation family of Swiss origin (Fig.1a), presented with small, horny nails and hyperkeratosis of the palms and soles. Age of onset was 7 years. Discrete punctate lesions were observed along the lateral edge of the plantar surface, with more extensive hyperkeratosis over the heels (Fig.1b). Peeling skin was observed in the interdigital webspaces of the feet. The proband's father displayed extensive hyperkeratotic lesions on his palms (Fig.1c). We identified a previously unreported heterozygous nonsense mutation p.Gln88*; c.262C>T (Fig.1d,e) within the GTPase domain of the p34 protein (Fig.2e). This mutation is neither present in the Database of Single Nucleotide Polymorphisms (http://www.ncbi.nlm.nih.gov/SNP/) nor in the Exome Variant Server (http://evs.gs.washington.edu/EVS/). The resulting haploinsufficiency in this family is consistent with the increase in cell proliferation seen in PPPK lesions, as reported previously.3
+
+Pedigree, clinical images and mutation analysis of family 1. (a) Pedigree showing a four-generation history of punctate palmoplantar keratoderma. The arrowhead indicates the proband. (b) Punctate hyperkeratotic lesions (arrows) around the lateral edge of the foot and heel on the proband. (c) Palms of the father of the proband showing multiple hyperkeratotic lesions. (d) DNA sequence of codons 86–88 of AAGAB in an unaffected control sample. (e) The same region as in (d) from the proband of family 1. The arrow indicates the heterozygous C>T mutation at c.262 resulting in nonsense mutation p.Gln88*.
+
+Pedigrees, clinical images and histology of punctate palmoplantar keratoderma type 1 families 2–5. (a) Pedigrees of the families with the relevant mutations indicated. Arrows denote the proband, and asterisks show individuals in whom AAGAB was sequenced. (b) The palm of the proband of family 3 showing the presence of multiple hyperkeratotic lesions. (c) Haematoxylin and eosin staining of a punch biopsy from palmar skin from the proband in family 3. This shows compact orthokeratosis with a defined central depression within the lesion. (d) The plantar surface of the index case in family 4. Hyperkeratotic lesions coalesce at pressure points. (e) Organization of the protein domains in p34 encoded by AAGAB, illustrating the location of all mutations reported to date. The p.Gln88* mutation highlighted in red is the novel mutation reported in this study.
+
+In family 2, a 72-year-old Scottish woman was one of four family members over three generations with palmoplantar keratoderma (Fig.2a). She presented with a 1-year history of worsening hyperkeratosis affecting primarily her soles. Small hyperkeratotic lesions were seen on her fingers but not on her palms. Both her children were affected, with hyperkeratosis developing at a much younger age than in herself. Her two brothers were similarly affected, and her deceased father was reported to have been affected. A recurrent heterozygous nonsense mutation, p.Trp47*; c.140G>A,3,5 within the N-terminal domain of p34 (Fig.2e), was identified in the proband.
+
+The other three families studied were apparently unrelated Danish kindreds. The 44-year-old proband of family 3 (Fig.2a) developed dry palmar skin in her childhood progressing to punctate keratosis on the palms (Fig.2b) and subsequently the soles. Haematoxylin and eosin staining of a biopsy from palmar skin (Fig.2c) showed compact orthokeratosis with pronounced hyperkeratosis. A central dermal depression characteristic for punctate palmoplantar keratoderma was observed. A recurrent heterozygous nonsense mutation Arg124*; c.370C>T2 was identified in the proband and four other affected members of this four-generation kindred (Fig.2a). PPPK1 was reported in four generations of family 4 (Fig.2a). The proband, a 53-year-old Danish female developed PPPK1 at 18–20 years of age. It gradually became worse, especially at pressure points on the feet (Fig.2d) where punctate lesions coalesced. The palms and volar sides of the fingers were affected to a lesser degree. The same p.Arg124* mutation as in family 3 was identified in the proband, her affected daughter, son and aunt but not in an unaffected sister (Fig.2a). In family 5, PPPK1 developed around the age of 20 years and progressed thereafter in the 68-year-old Danish proband. She presented with severe, very painful punctate palmoplantar keratoderma on the pressure points of her soles. Palms were also affected with multiple 3–5-mm punctate keratosis. Heterozygous nonsense mutation p.Arg124* was also identified in this individual. Three unaffected members did not carry the mutation (Fig.2a).
+
+PPPK1, an autosomal dominant disorder characterized by multiple hyperkeratotic lesions on the palms and soles, can vary in severity from mild to severe, and can be painful and socially debilitating. Recently, mutations have been described in the AAGAB gene, which encodes the α- and γ-adaptin binding protein p34, and has been proposed to have a role in skin integrity.2 p34 has been functionally implicated in the intracellular transport of clathrin-coated vesicles,3 and may affect cell signalling via regulation of the expression of receptor tyrosine kinases, which are turned over by clathrin- and AP2-dependant mechanisms.3,5,12,13 Recently a mutation was reported in AAGAB in a Jewish family of Dutch origin with PPPK1 co-segregating with congenital dislocation of the hip.10 Whether this is a coincidence or if AAGAB has an as yet unknown role in skeletal development is unclear.
+
+This study has revealed one novel, p.Gln88*, and two recurrent, p.Trp47* and p.Arg124*, mutations. This brings the total to 27 distinct loss-of-function mutations reported in AAGAB (Fig.2e), providing further evidence for this being the causative gene for PPPK1.

--- a/references_cache/PMID_31526046.md
+++ b/references_cache/PMID_31526046.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:31526046"
+title: AAGAB Mutations in 18 Canadian Families With Punctate Palmoplantar Keratoderma and a Possible Link to Cancer.
+authors:
+- Elhaji Y
+- Hedlin C
+- Nath A
+- Price EL
+- Gallant C
+- Northgrave S
+- Hull PR
+journal: J Cutan Med Surg
+year: '2020'
+doi: 10.1177/1203475419878161
+keywords:
+- "Adaptor Proteins, Vesicular Transport/genetics, metabolism"
+- Adult
+- Canada/epidemiology
+- DNA/genetics
+- DNA Mutational Analysis
+- Female
+- Humans
+- Incidence
+- "Keratoderma, Palmoplantar/complications, genetics, metabolism"
+- Male
+- Middle Aged
+- Mutation
+- "Neoplasms/etiology, genetics, metabolism"
+- Pedigree
+- Young Adult
+content_type: abstract_only
+---
+
+# AAGAB Mutations in 18 Canadian Families With Punctate Palmoplantar Keratoderma and a Possible Link to Cancer.
+**Authors:** Elhaji Y, Hedlin C, Nath A, Price EL, Gallant C, Northgrave S, Hull PR
+**Journal:** J Cutan Med Surg (2020)
+**DOI:** [10.1177/1203475419878161](https://doi.org/10.1177/1203475419878161)
+
+## Content
+
+1. J Cutan Med Surg. 2020 Jan/Feb;24(1):28-32. doi: 10.1177/1203475419878161.
+Epub  2019 Sep 16.
+
+AAGAB Mutations in 18 Canadian Families With Punctate Palmoplantar Keratoderma 
+and a Possible Link to Cancer.
+
+Elhaji Y(1), Hedlin C(2), Nath A(1), Price EL(1), Gallant C(1), Northgrave S(1), 
+Hull PR(1).
+
+Author information:
+(1)3688 Division of Clinical Dermatology and Cutaneous Science, Department of 
+Medicine, Dalhousie University, Halifax, NS, Canada.
+(2)7235 Division of Dermatology, Department of Medicine, University of 
+Saskatchewan, Saskatoon, SK, Canada.
+
+BACKGROUND: Punctate palmoplantar keratoderma type 1 (PPPK1) presents in late 
+childhood to adulthood with multiple small discrete hyperkeratotic papules on 
+palms and soles. PPPK1 is an autosomal dominant skin disease caused by AAGAB 
+mutations. It has been suggested that PPPK1 may be associated with an increased 
+predisposition to systemic malignancies.
+OBJECTIVES: To evaluate the presence of AAGAB mutations in Canadian families 
+with PPPK1 and the possible increased predisposition to systemic malignancies.
+METHODS: Eighteen unrelated Canadian families with PPPK1 were recruited for this 
+study. Genomic DNA was extracted from saliva and PCR amplification was performed 
+for all AAGAB exons and exon/intron junctions. PCR products were sequenced and 
+analyzed for mutations. A family history of malignancy was obtained from the 
+index case and, when possible, from other family members.
+RESULTS: We have identified 5 heterozygous AAGAB loss of function mutations in 
+11 families. The mutation c.370 C>T, p.Arg124* was the most prevalent and was 
+identified in 6 families. A splice site mutation, c.451+3delAAGT, was identified 
+in 2 families. The other mutations c.473delG, p.Gly158Glufs*0; c.550-551insAAT, 
+p.Gly183*; and c.505-506 dupAA, p.Asn169Lysfs*6 were each identified in 1 
+family. Different cancers were reported in 11 families (Table 1 and Supplemental 
+Figure S1).
+CONCLUSIONS: AAGAB mutations were found in 11 of 18 families with PPPK1. In some 
+families there appears to be an association with cancer.
+
+DOI: 10.1177/1203475419878161
+PMID: 31526046 [Indexed for MEDLINE]

--- a/references_cache/PMID_32147745.md
+++ b/references_cache/PMID_32147745.md
@@ -1,0 +1,45 @@
+---
+reference_id: "PMID:32147745"
+title: Diagnosis and Management of Inherited Palmoplantar Keratodermas.
+authors:
+- Thomas BR
+- "O'Toole EA"
+journal: Acta Derm Venereol
+year: '2020'
+doi: 10.2340/00015555-3430
+keywords:
+- Humans
+- "Keratoderma, Palmoplantar/diagnosis, genetics, therapy"
+- "Keratoderma, Palmoplantar, Epidermolytic/diagnosis, genetics, therapy"
+- Mutation
+- Phenotype
+content_type: abstract_only
+---
+
+# Diagnosis and Management of Inherited Palmoplantar Keratodermas.
+**Authors:** Thomas BR, O'Toole EA
+**Journal:** Acta Derm Venereol (2020)
+**DOI:** [10.2340/00015555-3430](https://doi.org/10.2340/00015555-3430)
+
+## Content
+
+1. Acta Derm Venereol. 2020 Mar 25;100(7):adv00094. doi: 10.2340/00015555-3430.
+
+Diagnosis and Management of Inherited Palmoplantar Keratodermas.
+
+Thomas BR, O'Toole EA.
+
+Inherited monogenic palmoplantar keratodermas are a heterogeneous group of 
+conditions characterised by persistent epidermal thickening of the palmoplantar 
+skin. Palmoplantar keratodermas are grouped depending on the morphology of the 
+keratoderma into diffuse, focal/striate or papular/punctate. Some palmoplantar 
+keratodermas just affect the skin of the palms and soles and others have 
+associated syndromic features which include changes in hair, teeth, nails, 
+hearing loss or cardiomyopathy. Next generation sequencing has helped discover 
+genes involved in many of these conditions and has led to reclassification of 
+some palmoplantar keratodermas. In this review, we discuss the diagnostic 
+features of palmoplantar keratodermas and management options.
+
+DOI: 10.2340/00015555-3430
+PMCID: PMC9128927
+PMID: 32147745 [Indexed for MEDLINE]

--- a/references_cache/PMID_33765759.md
+++ b/references_cache/PMID_33765759.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:33765759"
+title: A novel AAGAB mutation in a Peruvian family with punctate palmoplantar keratoderma.
+authors:
+- Gómez-García AC
+- Salas-Alanís JC
+- Bar-Fernandez N
+- Mendoza-Meza R
+- Díaz-Montes SM
+- Fajardo-Ramírez OR
+journal: Acta Dermatovenerol Alp Pannonica Adriat
+year: '2021'
+keywords:
+- "Adaptor Proteins, Vesicular Transport/genetics"
+- Aged
+- Female
+- Humans
+- "Keratoderma, Palmoplantar/genetics"
+- Mutation
+- Peru
+content_type: abstract_only
+---
+
+# A novel AAGAB mutation in a Peruvian family with punctate palmoplantar keratoderma.
+**Authors:** Gómez-García AC, Salas-Alanís JC, Bar-Fernandez N, Mendoza-Meza R, Díaz-Montes SM, Fajardo-Ramírez OR
+**Journal:** Acta Dermatovenerol Alp Pannonica Adriat (2021)
+
+## Content
+
+1. Acta Dermatovenerol Alp Pannonica Adriat. 2021 Mar;30(1):47-48.
+
+A novel AAGAB mutation in a Peruvian family with punctate palmoplantar 
+keratoderma.
+
+Gómez-García AC(1), Salas-Alanís JC(2)(3), Bar-Fernandez N(1), Mendoza-Meza 
+R(1), Díaz-Montes SM(4), Fajardo-Ramírez OR(5).
+
+Author information:
+(1)Department of Dermatology, Peru National Police Hospital, Lima, Peru.
+(2)Jalisco Dermatological Institute, Guadalajara, Mexico.
+(3)Secretary of Health of the State of Nuevo León, Monterrey, Mexico.
+(4)National Institute of Neoplastic Diseases, Lima, Peru.
+(5)Instituto Tecnológico de Monterrey, Escuela de Medicina y Ciencias de la 
+Salud, Monterrey, Mexico.
+
+Buschke-Fischer-Brauer (BFB) disease is a rare keratoderma characterized by 
+multiple hyperkeratotic lesions on the palms and soles, with an autosomal 
+dominant pattern. In several countries, some genetic alterations have been 
+associated with this clinical entity. A 68-year-old Peruvian woman presenting 
+with hyperkeratotic lesions on both her palms and soles was diagnosed with BFB 
+keratoderma. After sequencing of the genes that had previously been related to 
+this disease, a mutation (c.249C>G) that was predicted to generate a termination 
+codon (Tyr83*) was found in the alpha and gamma adaptin binding protein P34 gene 
+(AAGAB). After treatment with 30% urea plus 10% salicylic acid, the patient 
+experienced an improvement in her condition. Here we report a novel mutation in 
+the AAGAB gene of a patient diagnosed with BFB keratoderma and a treatment that 
+improved her symptoms.
+
+PMID: 33765759 [Indexed for MEDLINE]

--- a/references_cache/PMID_34121213.md
+++ b/references_cache/PMID_34121213.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:34121213"
+title: Japanese guidelines for the management of palmoplantar keratoderma.
+authors:
+- Yoneda K
+- Kubo A
+- Nomura T
+- Ishida-Yamamoto A
+- Suga Y
+- Akiyama M
+- Kanazawa N
+- Hashimoto T
+- Committee on Guidelines for the Management of PPKs
+journal: J Dermatol
+year: '2021'
+doi: 10.1111/1346-8138.15850
+keywords:
+- Humans
+- Japan
+- "Keratoderma, Palmoplantar/diagnosis, therapy"
+content_type: abstract_only
+---
+
+# Japanese guidelines for the management of palmoplantar keratoderma.
+**Authors:** Yoneda K, Kubo A, Nomura T, Ishida-Yamamoto A, Suga Y, Akiyama M, Kanazawa N, Hashimoto T, Committee on Guidelines for the Management of PPKs
+**Journal:** J Dermatol (2021)
+**DOI:** [10.1111/1346-8138.15850](https://doi.org/10.1111/1346-8138.15850)
+
+## Content
+
+1. J Dermatol. 2021 Aug;48(8):e353-e367. doi: 10.1111/1346-8138.15850. Epub 2021 
+Jun 13.
+
+Japanese guidelines for the management of palmoplantar keratoderma.
+
+Yoneda K(1), Kubo A(2), Nomura T(3), Ishida-Yamamoto A(4), Suga Y(5), Akiyama 
+M(6), Kanazawa N(7), Hashimoto T(8); Committee on Guidelines for the Management 
+of PPKs.
+
+Author information:
+(1)Department of Clinical Pharmacology, Faculty of Pharmacy, Osaka Ohtani 
+University, Tondabayashi, Japan.
+(2)Department of Dermatology, Keio University Graduate School of Medicine, 
+Tokyo, Japan.
+(3)Department of Dermatology, Tsukuba University, Tsukuba, Japan.
+(4)Department of Dermatology, Asahikawa Medical University, Asahikawa, Japan.
+(5)Department of Dermatology, Juntendo University Urayasu Hospital, Urayasu, 
+Japan.
+(6)Department of Dermatology, Nagoya University Graduate School of Medicine, 
+Nagoya, Japan.
+(7)Department of Dermatology, Hyogo College of Medicine, Nishinomiya, Japan.
+(8)Department of Dermatology, Osaka City University Graduate School of Medicine, 
+Osaka, Japan.
+
+Palmoplantar keratoderma (PPK) is a collective term for keratinizing disorders 
+in which the main clinical symptom is hyperkeratosis on the palms and soles. To 
+establish the first Japanese guidelines approved by the Japanese Dermatological 
+Association for the management of PPKs, the Committee for the Management of PPKs 
+was founded as part of the Study Group for Rare Intractable Diseases. These 
+guidelines aim to provide current information for the management of PPKs in 
+Japan. Based on evidence, they summarize the clinical manifestations, 
+pathophysiologies, diagnostic criteria, disease severity determination criteria, 
+treatment, and treatment recommendations. Because of the rarity of PPKs, there 
+are only few clinical studies with a high degree of evidence. Therefore, several 
+parts of these guidelines were established based on the opinions of the 
+committee. To further optimize the guidelines, periodic revision in line with 
+new evidence is necessary.
+
+© 2021 Japanese Dermatological Association.
+
+DOI: 10.1111/1346-8138.15850
+PMID: 34121213 [Indexed for MEDLINE]

--- a/references_cache/PMID_36793812.md
+++ b/references_cache/PMID_36793812.md
@@ -1,0 +1,51 @@
+---
+reference_id: "PMID:36793812"
+title: "Punctate Palmoplantar Keratoderma: A Case Report."
+authors:
+- Knowles A
+- Adams M
+- Glass DA 2nd
+journal: Cureus
+year: '2023'
+doi: 10.7759/cureus.33769
+content_type: abstract_only
+---
+
+# Punctate Palmoplantar Keratoderma: A Case Report.
+**Authors:** Knowles A, Adams M, Glass DA 2nd
+**Journal:** Cureus (2023)
+**DOI:** [10.7759/cureus.33769](https://doi.org/10.7759/cureus.33769)
+
+## Content
+
+1. Cureus. 2023 Jan 14;15(1):e33769. doi: 10.7759/cureus.33769. eCollection 2023 
+Jan.
+
+Punctate Palmoplantar Keratoderma: A Case Report.
+
+Knowles A(1), Adams M(1), Glass DA 2nd(1)(2).
+
+Author information:
+(1)Department of Dermatology, University of Texas Southwestern Medical Center, 
+Dallas, USA.
+(2)Eugene McDermott Center for Human Growth and Development, University of Texas 
+Southwestern Medical Center, Dallas, USA.
+
+Palmoplantar keratoderma (PPK) is an umbrella term for a group of heterogeneous 
+disorders, acquired or inherited, that are characterized by hyperkeratosis of 
+palmar and/or plantar surfaces. Punctate PPK (PPPK) has been shown to have an 
+autosomal dominant pattern of inheritance. It is linked with two loci on 
+chromosomes 8q24.13-8q24.21 and 15q22-15q24. In type 1 PPPK, also known as 
+Buschke-Fischer-Brauer disease, loss-of-function mutations in either the AAGAB 
+or the COL14A1 genes have been associated with the disorder. We report here the 
+clinical and genetic features of a patient with findings most consistent with 
+type 1 PPPK.
+
+Copyright © 2023, Knowles et al.
+
+DOI: 10.7759/cureus.33769
+PMCID: PMC9924831
+PMID: 36793812
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.

--- a/references_cache/PMID_37705065.md
+++ b/references_cache/PMID_37705065.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:37705065"
+title: "Is punctate palmoplantar keratoderma type 1 associated with malignancy? A systematic review of the literature."
+authors:
+- Gram SB
+- Bjerrelund J
+- Jelsig AM
+- Bygum A
+- Leboeuf-Yde C
+- Ousager LB
+journal: Orphanet J Rare Dis
+year: '2023'
+doi: 10.1186/s13023-023-02862-8
+keywords:
+- Humans
+- Neoplasms/genetics
+- "Keratoderma, Palmoplantar/genetics"
+- "Databases, Factual"
+- Family
+content_type: abstract_only
+---
+
+# Is punctate palmoplantar keratoderma type 1 associated with malignancy? A systematic review of the literature.
+**Authors:** Gram SB, Bjerrelund J, Jelsig AM, Bygum A, Leboeuf-Yde C, Ousager LB
+**Journal:** Orphanet J Rare Dis (2023)
+**DOI:** [10.1186/s13023-023-02862-8](https://doi.org/10.1186/s13023-023-02862-8)
+
+## Content
+
+1. Orphanet J Rare Dis. 2023 Sep 13;18(1):290. doi: 10.1186/s13023-023-02862-8.
+
+Is punctate palmoplantar keratoderma type 1 associated with malignancy? A 
+systematic review of the literature.
+
+Gram SB(1)(2), Bjerrelund J(3)(4), Jelsig AM(5), Bygum A(3)(4)(6), Leboeuf-Yde 
+C(7), Ousager LB(3)(4).
+
+Author information:
+(1)Department of Clinical Genetics, Odense University Hospital, J.B. Winsløws 
+Vej 4, Indgang 24, 5000, Odense C, Denmark. stine.bjorn.gram@rsyd.dk.
+(2)Department of Clinical Research, University of Southern Denmark, Odense, 
+Denmark. stine.bjorn.gram@rsyd.dk.
+(3)Department of Clinical Genetics, Odense University Hospital, J.B. Winsløws 
+Vej 4, Indgang 24, 5000, Odense C, Denmark.
+(4)Department of Clinical Research, University of Southern Denmark, Odense, 
+Denmark.
+(5)Department of Clinical Genetics, Copenhagen University Hospital, Copenhagen, 
+Denmark.
+(6)Hudklinikken Kolding, Kolding, Denmark.
+(7)Institute for Regional Health Research, University of Southern Denmark, 
+Odense, Denmark.
+
+BACKGROUND: An association between punctate palmoplantar keratoderma type 1 
+(PPPK1) and malignancy has been proposed for decades. Some authors suggest that 
+individuals with PPPK1 should undergo screening for various types of 
+malignancies while others caution that an association is not well-established. 
+In this systematic review, we summarized and evaluated the current evidence for 
+a possible association between PPPK1 and malignancy.
+METHODS: The review was conducted along PRISMA guidelines. The search used 
+Embase, MEDLINE, Scopus, and the Human Gene Mutation Database up to March 2022. 
+All studies reporting on individuals with the diagnosis of PPPK1 with or 
+without history of malignancy were included. Two authors screened for eligible 
+studies, extracted predefined data, and performed a quality assessment.
+RESULTS: Of 773 studies identified, 45 were included. Most studies were reports 
+on single families (24 of 45 studies) or multiple families (10 of 45 studies). 
+The number of index cases with PPPK1 across all included studies was 280, and 
+when family members reported with PPPK1 were added, a total of 817 individuals 
+were identified. Overall, 23 studies reported on individuals with PPPK1 with a 
+history of malignancy, whereas 22 studies reported on individuals with PPPK1 
+without a history of malignancy. Although the extracted data were not considered 
+to be of sufficient quality to synthesize and answer our research question, the 
+review did not confirm an association between PPPK1 and malignancy.
+CONCLUSION: This review shows that there is a lack of well-designed studies on 
+this topic to conclude whether individuals with PPPK1 have an increased risk of 
+malignancy. Based on the present literature, however, we could not confirm an 
+association between PPPK1 and malignancy and find it highly questionable if 
+patients with PPPK1 should be offered surveillance for malignancies.
+
+© 2023. Institut National de la Santé et de la Recherche Médicale (INSERM).
+
+DOI: 10.1186/s13023-023-02862-8
+PMCID: PMC10500882
+PMID: 37705065 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_38311882.md
+++ b/references_cache/PMID_38311882.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:38311882"
+title: "Identification of a founder variant AAGAB c.370C>T, p.Arg124Ter in patients with punctate palmoplantar keratoderma in Southern Denmark."
+authors:
+- Gram SB
+- Jørgensen ASF
+- Bygum A
+- Brusgaard K
+- Ousager LB
+journal: Clin Genet
+year: '2024'
+doi: 10.1111/cge.14486
+keywords:
+- Humans
+- "Keratoderma, Palmoplantar/genetics"
+- Skin
+- Heterozygote
+- Haplotypes
+- Denmark
+- "Adaptor Proteins, Vesicular Transport"
+content_type: abstract_only
+---
+
+# Identification of a founder variant AAGAB c.370C>T, p.Arg124Ter in patients with punctate palmoplantar keratoderma in Southern Denmark.
+**Authors:** Gram SB, Jørgensen ASF, Bygum A, Brusgaard K, Ousager LB
+**Journal:** Clin Genet (2024)
+**DOI:** [10.1111/cge.14486](https://doi.org/10.1111/cge.14486)
+
+## Content
+
+1. Clin Genet. 2024 May;105(5):561-566. doi: 10.1111/cge.14486. Epub 2024 Feb 4.
+
+Identification of a founder variant AAGAB c.370C>T, p.Arg124Ter in patients with 
+punctate palmoplantar keratoderma in Southern Denmark.
+
+Gram SB(1)(2)(3), Jørgensen ASF(1), Bygum A(1)(2)(4), Brusgaard K(1)(2), Ousager 
+LB(1)(2).
+
+Author information:
+(1)Department of Clinical Genetics, Odense University Hospital, Odense, Denmark.
+(2)Department of Clinical Research, University of Southern Denmark, Odense, 
+Denmark.
+(3)European Reference Network for Rare Skin Diseases (ERN-Skin), Odense, 
+Denmark.
+(4)Hudklinikken Kolding, Kolding, Denmark.
+
+Palmoplantar keratoderma (PPK) is a heterogeneous group of rare skin diseases 
+characterized by hyperkeratosis on the palms or soles. The subtype isolated 
+punctate PPK is caused by heterozygous variants in AAGAB. We investigated if the 
+variant AAGAB c.370C>T, p.Arg124Ter in patients with punctate PPK in the Region 
+of Southern Denmark represented a founder variant and estimated the age to the 
+most recent common ancestor. We performed haplotype analysis on samples from 20 
+patients diagnosed with punctate PPK and the AAGAB c.370C>T, p.Arg124Ter 
+variant. Using the Gamma Method, we calculated the years to the most recent 
+common ancestor. We also explored the presence of the variant in other 
+populations through literature and databases (HGMD, ClinVar, and gnomAD). Our 
+analysis revealed a shared haplotype of 3.0 Mb, suggesting shared ancestry. The 
+ancestral haplogroup was estimated to an age of 12.1 generations (CI: 4.9-20.3) 
+equivalent to approximately 339 years (CI: 137-568). This study confirms that 
+the frequently observed variant AAGAB c.370C>T, p.Arg124Ter in punctate PPK 
+among patients in the Region of Southern Denmark is caused by a founder variant. 
+We recommend testing for the variant as initial screening in our region and 
+potentially for all Danish patients presenting with punctate PPK.
+
+© 2024 The Authors. Clinical Genetics published by John Wiley & Sons Ltd.
+
+DOI: 10.1111/cge.14486
+PMID: 38311882 [Indexed for MEDLINE]

--- a/references_cache/clinicaltrials_NCT05435638.md
+++ b/references_cache/clinicaltrials_NCT05435638.md
@@ -1,0 +1,19 @@
+---
+reference_id: clinicaltrials:NCT05435638
+title: "Phase I, Open Label Study Designed to Evaluate the Safety and Efficacy of a 1% Topical Formulation of KM-001 in the Treatment of Type I Punctate Palmoplantar Keratoderma or Pachyonychia Congenital Diseases"
+content_type: summary
+---
+
+# Phase I, Open Label Study Designed to Evaluate the Safety and Efficacy of a 1% Topical Formulation of KM-001 in the Treatment of Type I Punctate Palmoplantar Keratoderma or Pachyonychia Congenital Diseases
+
+## Content
+
+In this phase 1 open label study for patients with type I punctate palmoplantar keratoderma or pachyonychia congenital, 2 arms will be recruited to be treated twice daily, with 1% topical KM-001.
+
+Arm 1: up to 10 eligible patients will be treated for 12 weeks. Arm 2: up to 8 eligible patients will be treated for 16 weeks.
+
+Treatment safety and efficacy will be assessed in the clinic visits (for arm 1 up to day 91, for arm 2 up to day 126). In between safety will also be assessed by phone visits.
+
+At the in-clinic visits, treatment efficacy (lesion clearance - IGA, CGI-S, PGI-C, PGI-S and VAS pain) will also be assessed.
+
+PK blood samples will be collected for arm 1: on Days 0, 7, 84 (EoT visit). One week after the end of treatment (EoT) visit, patients will return to the clinic for final safety, efficacy and PK evaluations. For arm 2, PK blood samples will be collected on days 0, 7, 84, 112 (EoT visit). Two weeks after the end of treatment (EoT) visit, patients will return to the clinic for final safety, efficacy and PK evaluations.

--- a/references_cache/clinicaltrials_NCT05956314.md
+++ b/references_cache/clinicaltrials_NCT05956314.md
@@ -1,0 +1,27 @@
+---
+reference_id: clinicaltrials:NCT05956314
+title: "Phase 1b, Open Label Study to Evaluate the Safety, Tolerability, and Efficacy of a 1% Topical Formulation of KM-001 for the Treatment of Type I Punctate Palmoplantar Keratoderma or Pachyonychia Congenita"
+content_type: summary
+---
+
+# Phase 1b, Open Label Study to Evaluate the Safety, Tolerability, and Efficacy of a 1% Topical Formulation of KM-001 for the Treatment of Type I Punctate Palmoplantar Keratoderma or Pachyonychia Congenita
+
+## Content
+
+This Phase 1b, open-label, single-center, prospective trial will be assessing the safety, tolerability, and efficacy of topical KM-001 1% in patients with PPPK1 or PC diseases. In this study 2 cohorts will be recruited:
+
+1. Cohort 1: up to 11 eligible patients, will be enrolled to be treated twice daily, for 12 weeks, with 1% topical KM-001, on the plantar surfaces (2 feet).
+2. Cohort 2: up to 8 eligible patients, will be enrolled to be treated twice daily, for 16 weeks, with 1% topical KM-001, on the plantar surfaces (2 feet).
+
+Safety (AEs, blood work \[at specific visits\], vital signs), tolerability, and efficacy parameters (overall lesion improvement) will be assessed during in-clinic visits (Cohort 1: during Screening, Enrolment, and on Days 7, 28, 42, 63, 84 \[end of treatment, EoT\], 112 \[End of Study, EoS\] post first investigational medicinal product (IMP) administration; Cohort 2: during Screening, Enrolment, and on Days 7, 28, 42, 63, 84, 112 \[EoT\], 140 \[EoS\] post first investigational medicinal product (IMP) administration).
+
+PK samples will be collected to assess plasma levels of KM-001 on
+
+* Screening (Day -14 to -0): any time during the visit. (or on Day 1 up to 30 minutes pre-dose if missed during Screening)
+* Day 7 and at EoT (Cohort 1: Day 84; Cohort 2: Day 112) up to 30 minutes pre-dose, and at 1 h, 2 h, 3 h, 6 h (+15 min) post-dose
+* Days 28, 42 for both Cohorts, and Day 84 for Cohort 2: 1 sample after the first dose, before the second dose, as late as possible in the visit.
+* End of Study (EoS, Day 112 (Cohort 1) or Day 140 (cohort 2)), or at Early Termination (ET): at any time during the visit.
+
+The patient will complete a patient-reported diary, consisting of treatment compliance and self-assessments for efficacy.
+
+Follow up- 2 weeks after EoT by phone call, and 4 weeks after EoT in clinic visit.

--- a/research/Punctate_Palmoplantar_Keratoderma-deep-research-falcon.md
+++ b/research/Punctate_Palmoplantar_Keratoderma-deep-research-falcon.md
@@ -1,0 +1,1266 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T11:05:45.843858'
+end_time: '2026-05-10T11:26:46.388556'
+duration_seconds: 1260.54
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Punctate Palmoplantar Keratoderma
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 35
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Punctate Palmoplantar Keratoderma
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Punctate Palmoplantar Keratoderma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Punctate Palmoplantar Keratoderma
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Punctate Palmoplantar Keratoderma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Research Report: Punctate Palmoplantar Keratoderma (PPPK)
+
+### Target disease
+- **Disease name:** Punctate palmoplantar keratoderma (PPPK)
+- **Category:** Mendelian (primarily **PPPK type 1 / PPKP1 / Buschke–Fischer–Brauer**, autosomal dominant)
+- **MONDO ID:** Not identified in the retrieved full-text sources in this run (reporting limitation).
+
+---
+
+## 1. Disease Information
+
+### 1.1 Overview and definition (current understanding)
+Punctate palmoplantar keratoderma (punctate PPK; PPPK/PPKP) is a rare disorder of keratinization characterized by multiple discrete hyperkeratotic papules/lesions on the palms and soles, often progressive with age and prone to coalescence at pressure-bearing sites. A classic description for type 1 notes “progressive development of discrete areas of hyperkeratosis on the palms and soles, followed by more extensive diffuse hyperkeratosis on the pressure-bearing areas of plantar skin.” (matsuzawa2013heterozygousmutationsin pages 1-2)
+
+### 1.2 Key identifiers and subtype taxonomy
+In the landmark genetics literature, OMIM recognizes three inherited punctate PPK types: 
+- **PPKP1 (Buschke–Fischer–Brauer)**: **OMIM #148600**
+- **PPKP2 (porokeratotic type / porokeratosis punctata palmaris et plantaris)**: **OMIM #175860**
+- **PPKP3 (acrokeratoelastoidosis)**: **OMIM #101850** (pohler2012haploinsufficiencyforaagab pages 1-2)
+
+The 2021 Japanese Dermatological Association guidelines further subdivide punctate type 1 into:
+- **Punctate PPK type 1A:** **AAGAB**
+- **Punctate PPK type 1B:** **COL14A1** (yoneda2021japaneseguidelinesfor pages 4-5)
+
+**Orphanet / ICD-10 / ICD-11 / MeSH / MONDO:** these identifiers were not explicitly provided in the retrieved excerpts; therefore, they cannot be reliably populated from this evidence set.
+
+### 1.3 Common synonyms and alternative names
+- Punctate palmoplantar keratoderma (PPPK)
+- Punctate PPK / PPKP
+- **Buschke–Fischer–Brauer disease** (type 1) (gram2023ispunctatepalmoplantar pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5)
+- Porokeratosis punctata palmaris et plantaris (type 2) (gram2023ispunctatepalmoplantar pages 1-2)
+- Acrokeratoelastoidosis (type 3) (gram2023ispunctatepalmoplantar pages 1-2)
+
+### 1.4 Evidence sources (individual vs aggregated)
+The evidence base is dominated by families and case reports/series rather than large epidemiologic cohorts. A 2023 systematic review identified **45 included studies**, where most were **single-family** or **multi-family** reports; it counted **280 index cases** and **817 total affected individuals** across the literature. The review emphasized limitations of study quality and concluded it could not confirm a malignancy association. (gram2023ispunctatepalmoplantar pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (genetic and mechanistic)
+**PPPK type 1 (PPKP1/Buschke–Fischer–Brauer)** is most strongly associated with **heterozygous loss-of-function variants in AAGAB**, consistent with **haploinsufficiency**. (pohler2012haploinsufficiencyforaagab pages 1-2, pohler2014newandrecurrent pages 1-2)
+
+A less frequent genetic association reported for punctate PPK type 1 includes **COL14A1**, emphasized in guidelines as punctate type 1B and referenced as occurring in Chinese pedigrees. (yoneda2021japaneseguidelinesfor pages 4-5, thomas2020diagnosisandmanagement pages 5-6)
+
+### 2.2 Risk factors
+**Genetic risk:**
+- **AAGAB** heterozygous truncating/splice variants (nonsense/frameshift/splice) are repeatedly observed in pedigrees and case series. Recurrent variants include **AAGAB c.370C>T (p.Arg124Ter)**. (pohler2014newandrecurrent pages 2-3, pohler2014newandrecurrent pages 1-2)
+
+**Environmental/occupational modifiers:**
+- Lesions may worsen with **water exposure** and at **pressure/friction** sites (knowles2023punctatepalmoplantarkeratoderma pages 4-5, elhaji2020aagabmutationsin pages 1-2).
+- Lesions can be worse in **manual labourers** (trauma/friction exposure). (thomas2020diagnosisandmanagement pages 5-6)
+
+**Acquired punctate PPK phenocopies:**
+- The 2023 systematic review notes PPK can be hereditary or acquired due to exposures/conditions such as “**arsenic exposure, menopause, and paraneoplastic syndromes**.” (gram2023ispunctatepalmoplantar pages 1-2)
+
+### 2.3 Protective factors
+No genetic or environmental protective factors were identified in the retrieved sources.
+
+### 2.4 Gene–environment interaction
+Direct GxE interaction studies were not identified in this evidence set; however, multiple sources consistently indicate that mechanical stress/pressure and water exposure can modulate severity in genetically affected individuals (suggesting an interaction between inherited predisposition and local environmental triggers). (thomas2020diagnosisandmanagement pages 5-6, elhaji2020aagabmutationsin pages 1-2)
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core clinical phenotypes
+**Morphology:** multiple punctate hyperkeratotic papules/lesions on palms and soles, which may coalesce into plaques at pressure-bearing areas. (matsuzawa2013heterozygousmutationsin pages 1-2, pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5)
+
+**Pain and functional impact:** plantar pain can be prominent; a case series highlights plantar pain with functional impact on walking/standing and notes that manual paring and analgesia can help. (zamiri2019painfulpunctatepalmoplantar pages 5-6)
+
+**Progression:** a large Danish cohort reported progression in **31/42 punctate probands (74%)**, stability in **8/42 (19%)**, and improvement in **1/42 (2%)**. (gram2025clinicalandgenetic pages 3-4)
+
+**Distribution:** in the Danish cohort, punctate probands had **palms and soles involvement in 40/42 (95%)**. (gram2025clinicalandgenetic pages 3-4)
+
+### 3.2 Age of onset
+- Often begins in adolescence/early adulthood, but range is broad. Median onset for punctate PPK in the Danish cohort was **19.0 years (range 5–47)**. (gram2025clinicalandgenetic pages 3-4)
+- A pain-focused series reports onsets spanning childhood through later adulthood (e.g., ~8 to 50s). (zamiri2019painfulpunctatepalmoplantar pages 5-6)
+
+### 3.3 Histopathology
+A characteristic lesion histology described in genetic studies includes a **central epidermal depression** with **hypergranulosis** and an overlying **orthokeratotic layer**; immunostaining suggests a **hyperproliferative** basal compartment. (pohler2012haploinsufficiencyforaagab pages 1-2)
+
+### 3.4 Suggested HPO terms (examples)
+(IDs not provided in evidence; listed as term labels for mapping)
+- Punctate palmoplantar keratoderma
+- Palmoplantar hyperkeratosis
+- Hyperkeratosis
+- Plantar pain
+- Progressive skin disease
+- Verrucous skin lesion / Hyperkeratotic papule
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes
+- **AAGAB** (major gene for PPKP1/PPPK1 type 1A) (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5)
+- **COL14A1** (reported; emphasized as type 1B in guidelines; rare compared to AAGAB) (yoneda2021japaneseguidelinesfor pages 4-5, thomas2020diagnosisandmanagement pages 5-6)
+
+### 4.2 Pathogenic variant classes and functional consequences
+**AAGAB** variants reported across studies are predominantly truncating/splice variants consistent with **loss of function** and **haploinsufficiency** (pohler2012haploinsufficiencyforaagab pages 1-2, pohler2014newandrecurrent pages 1-2). A 2014 multi-family report noted “**27 distinct loss-of-function mutations** reported in AAGAB,” illustrating substantial allelic heterogeneity. (pohler2014newandrecurrent pages 2-3)
+
+A large 2019 series lists many AAGAB truncating/splice variants across families and includes both familial and sporadic cases, supporting dominant inheritance and recurrent mutational spectra. (zamiri2019painfulpunctatepalmoplantar pages 5-6)
+
+**Founder variant example (recent development):** A 2024 Clinical Genetics study demonstrates **AAGAB c.370C>T (p.Arg124Ter)** is a **founder variant** in Southern Denmark: shared haplotype **3.0 Mb** and an estimated most recent common ancestor **12.1 generations (~339 years; CI 137–568)**; it recommends initial screening for this variant in the region and potentially all Danish punctate PPK patients. (gram2024identificationofa pages 1-2)
+
+### 4.3 Modifier genes / epigenetics / chromosomal abnormalities
+No validated modifier genes, epigenetic drivers, or chromosomal abnormalities specific to PPPK were identified in the retrieved sources.
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Environmental and lifestyle contributors
+- **Mechanical stress/friction:** worse in manual labourers; pressure points are common sites of coalescence. (thomas2020diagnosisandmanagement pages 5-6, pohler2012haploinsufficiencyforaagab pages 1-2)
+- **Water exposure:** reported to worsen papules in several reports. (knowles2023punctatepalmoplantarkeratoderma pages 4-5, elhaji2020aagabmutationsin pages 1-2)
+
+### 5.2 Infectious agents
+No infectious triggers were identified as causal in the retrieved evidence.
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Mechanistic causal chain (AAGAB/PPKP1)
+AAGAB encodes p34 (α- and γ-adaptin–binding protein), linked to clathrin adaptor complexes and membrane trafficking. Functional work supports the causal chain:
+1) **AAGAB loss-of-function → p34 deficiency** (haploinsufficiency) (pohler2012haploinsufficiencyforaagab pages 1-2, giehl2012nonsensemutationsin pages 1-2)
+2) **Disrupted vesicle trafficking/endocytic recycling**, with ultrastructural abnormalities in intracellular vesicle biology in lesional epidermis (pohler2012haploinsufficiencyforaagab pages 1-2, pohler2012haploinsufficiencyforaagab pages 4-5)
+3) **Increased EGFR protein and activation**: keratinocyte knockdown leads to markedly increased EGFR protein and phosphorylation, consistent with impaired receptor turnover (pohler2012haploinsufficiencyforaagab pages 4-5)
+4) **Keratinocyte hyperproliferation**: increased cell division in vitro and hyperproliferative lesions in vivo (pohler2012haploinsufficiencyforaagab pages 1-2)
+5) Clinical manifestation as **focal hyperproliferative hyperkeratosis** (punctate lesions) (pohler2012haploinsufficiencyforaagab pages 1-2)
+
+A complementary mechanistic discussion highlights that impaired RTK endocytosis (EGFR/Axl) could sustain growth-factor signaling and drive hyperkeratosis. (matsuzawa2013heterozygousmutationsin pages 4-4)
+
+### 6.2 Suggested GO biological process / cellular component terms (labels)
+- Endocytosis; clathrin-mediated endocytosis (pohler2012haploinsufficiencyforaagab pages 4-5)
+- Vesicle-mediated transport; endosomal recycling (pohler2012haploinsufficiencyforaagab pages 1-2)
+- EGFR signaling pathway / receptor tyrosine kinase signaling (pohler2012haploinsufficiencyforaagab pages 4-5)
+- Regulation of keratinocyte proliferation (pohler2012haploinsufficiencyforaagab pages 1-2)
+
+### 6.3 Suggested CL (cell types)
+- Keratinocyte; basal keratinocyte (pohler2012haploinsufficiencyforaagab pages 4-5)
+
+### 6.4 Molecular profiling (transcriptomics/proteomics/metabolomics)
+No disease-specific omics profiling studies were identified in the retrieved sources.
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/tissue level
+- **Primary sites:** palmar and plantar skin (thick glabrous epidermis), frequently both. (gram2025clinicalandgenetic pages 3-4)
+
+### 7.2 Suggested UBERON terms (labels)
+- Skin of palm; skin of sole; epidermis
+
+### 7.3 Subcellular/cellular compartments
+Mechanistic evidence implicates vesicular/endocytic compartments (clathrin adaptor-related trafficking and receptor turnover). (pohler2012haploinsufficiencyforaagab pages 4-5)
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset
+Typically after childhood/adolescence, with broad variability by family and cohort; Danish cohort median 19 years. (gram2025clinicalandgenetic pages 3-4)
+
+### 8.2 Course
+Often chronic and progressive; lesions increase in number and can coalesce over time. (pohler2012haploinsufficiencyforaagab pages 1-2, gram2025clinicalandgenetic pages 3-4)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Inheritance
+Type 1 punctate PPK is classically **autosomal dominant** with variable expressivity; AAGAB variants segregate in pedigrees with multiple affected generations. (pohler2012haploinsufficiencyforaagab pages 1-2, pohler2014newandrecurrent pages 1-2)
+
+### 9.2 Epidemiology and statistics
+- Prevalence estimates in a review of inherited PPK: **“1 in 100,000”** with AD inheritance. (thomas2020diagnosisandmanagement pages 5-6)
+- A case report cites an estimated prevalence of **1.17 per 100,000**. (knowles2023punctatepalmoplantarkeratoderma pages 4-5)
+
+### 9.3 Founder effects and population distribution (recent)
+A 2024 founder study in Southern Denmark supports a founder origin for **AAGAB c.370C>T (p.Arg124Ter)** with a **3.0 Mb shared haplotype** and estimated origin ~**339 years**; it recommends first-tier screening for this variant in Denmark. (gram2024identificationofa pages 1-2)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical diagnosis
+Key features include punctate hyperkeratotic lesions on palms/soles; guidelines emphasize excluding look-alikes such as callus/clavus and viral warts when diagnosing PPK. (yoneda2021japaneseguidelinesfor pages 9-10)
+
+### 10.2 Histopathology
+Characteristic lesions may show central epidermal depression with orthokeratosis and hypergranulosis, consistent with hyperproliferation. (pohler2012haploinsufficiencyforaagab pages 1-2)
+
+### 10.3 Genetic testing strategy (expert consensus / implementation)
+- Guidelines recommend genetic counseling and consent in hereditary PPK (yoneda2021japaneseguidelinesfor pages 10-12).
+- In Denmark, initial testing for founder **AAGAB c.370C>T (p.Arg124Ter)** is recommended for regional patients and potentially all Danish punctate PPK patients. (gram2024identificationofa pages 1-2)
+
+### 10.4 Differential diagnosis
+The punctate phenotype should prompt consideration of punctate PPK types 1A/1B/2/3 and related entities (including Cole disease), and recognition that PPK can be acquired (e.g., arsenic exposure or paraneoplastic syndromes). (yoneda2021japaneseguidelinesfor pages 10-12, gram2023ispunctatepalmoplantar pages 1-2)
+
+---
+
+## 11. Outcome / Prognosis
+
+PPPK is primarily a chronic morbidity condition with variable severity; pain can be significant and impair ambulation in some patients (zamiri2019painfulpunctatepalmoplantar pages 5-6). No survival/mortality impact was identified in the retrieved sources.
+
+### Malignancy association (expert analysis; 2023 systematic review)
+A 2023 Orphanet Journal of Rare Diseases systematic review states: “**we could not confirm an association between PPPK1 and malignancy**” and highlights “**a lack of well-designed studies**” to conclude cancer risk; it questions whether surveillance should be offered on the basis of existing literature. (gram2023ispunctatepalmoplantar pages 1-2)
+
+---
+
+## 12. Treatment
+
+### 12.1 Standard management (real-world implementation)
+Evidence and guidelines emphasize symptomatic management:
+- **Topical keratolytics/emollients**: urea and salicylic acid preparations are repeatedly listed. (yoneda2021japaneseguidelinesfor pages 8-9, knowles2023punctatepalmoplantarkeratoderma pages 4-5)
+- **Mechanical debridement/paring/dermabrasion**: cone cutters/razors/punches/scissors, and patient self-care. (yoneda2021japaneseguidelinesfor pages 8-9, yoneda2021japaneseguidelinesfor pages 9-10)
+- **Systemic retinoids**: guideline synthesis reports acitretin use with reported benefit in case-based evidence (see below). (yoneda2021japaneseguidelinesfor pages 10-12)
+- Practical measures: **comfortable footwear** and reducing trauma/friction. (thomas2020diagnosisandmanagement pages 5-6)
+
+### 12.2 Retinoids (evidence and statistics)
+The Japanese guidelines summarize case-based evidence and state that oral retinoids are useful for PPK; they report **acitretin** was used in **12 cases**, with **10/12 showing therapeutic effect**, and **isotretinoin** in 6 cases with variable outcomes and discontinuation for side effects in some cases. (yoneda2021japaneseguidelinesfor pages 10-12)
+
+### 12.3 Emerging/experimental therapies (2022–2024 developments)
+Two completed interventional trials evaluate **KM-001 topical 1% cream**, described as “**a potent and selective TRPV3 antagonist**,” in PPPK1 or pachyonychia congenita:
+- **NCT05435638** (ClinicalTrials.gov record dated 2022; Phase 1; **COMPLETED**; enrollment 14): topical KM-001 1% twice daily for 12 or 16 weeks. (NCT05435638 chunk 1)
+- **NCT05956314** (ClinicalTrials.gov record dated 2023; Phase 1b; **COMPLETED**; enrollment 18; primary completion Nov 2024; last update Jan 15, 2025): topical KM-001 1% twice daily for 12 or 16 weeks, with pain and clinician/patient global outcomes. (NCT05956314 chunk 1, NCT05956314 chunk 2)
+
+No efficacy results were available in the retrieved trial record excerpts (status only).
+
+### 12.4 Suggested MAXO terms (labels)
+- Topical keratolytic therapy (salicylic acid; urea)
+- Mechanical debridement/paring
+- Systemic retinoid therapy (acitretin; isotretinoin)
+- Genetic counseling
+- Genetic testing
+- Topical TRPV3 antagonist therapy (KM-001; investigational)
+
+---
+
+## 13. Prevention
+
+No disease-specific primary prevention is established for hereditary PPPK. Secondary/tertiary prevention focuses on symptom control and prevention of fissures/pain via keratolytics, debridement, and minimizing mechanical stress. (yoneda2021japaneseguidelinesfor pages 8-9, thomas2020diagnosisandmanagement pages 5-6)
+
+Genetic counseling and cascade testing can be considered for at-risk relatives in hereditary families. (yoneda2021japaneseguidelinesfor pages 10-12)
+
+---
+
+## 14. Other Species / Natural Disease
+
+No naturally occurring animal disease analogs were identified in the retrieved sources.
+
+---
+
+## 15. Model Organisms
+
+No whole-animal model systems were identified in the retrieved sources. However, mechanistic evidence includes **in vitro keratinocyte knockdown** experiments (e.g., HaCaT keratinocytes) showing increased proliferation and altered EGFR protein/phosphorylation, supporting cell-based modeling of AAGAB haploinsufficiency. (pohler2012haploinsufficiencyforaagab pages 1-2, pohler2012haploinsufficiencyforaagab pages 4-5)
+
+---
+
+## Subtype summary table
+
+| Subtype | Synonyms / nomenclature | OMIM ID | Typical clinical features / onset | Known genes | Inheritance | Key citations (year / URL) |
+|---|---|---:|---|---|---|---|
+| PPKP1 / PPPK1 | Punctate palmoplantar keratoderma type 1; Buschke-Fischer-Brauer disease; punctate PPK type 1A and 1B in Japanese guidelines | 148600 | Progressive discrete hyperkeratotic lesions/papules on palms and soles; often begin in the 1st-2nd decades or after adolescence; lesions increase with age and may coalesce on pressure-bearing plantar skin; type 1A: numerous tiny punctate keratotic papules from childhood-adolescence that can fuse into larger plaques (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5) | **Type 1A:** AAGAB (major established cause); **Type 1B:** COL14A1 (reported in Chinese family/families; much rarer) (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5, gram2023ispunctatepalmoplantar pages 1-2) | Autosomal dominant (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5) | Pohler et al. 2012, https://doi.org/10.1038/ng.2444; Matsuzawa et al. 2013, https://doi.org/10.1038/jid.2013.243; Yoneda et al. 2021, https://doi.org/10.1111/1346-8138.15850; Gram et al. 2023, https://doi.org/10.1186/s13023-023-02862-8 (pohler2012haploinsufficiencyforaagab pages 1-2, matsuzawa2013heterozygousmutationsin pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5, gram2023ispunctatepalmoplantar pages 1-2) |
+| PPKP1A | Punctate PPK type 1A; Buschke-Fischer-Brauer type | 148600 | Numerous tiny punctate keratotic papules on palmoplantar skin from childhood to adolescence; lesions gradually increase and may fuse into larger hyperkeratotic lesions (yoneda2021japaneseguidelinesfor pages 4-5) | AAGAB (yoneda2021japaneseguidelinesfor pages 4-5, pohler2012haploinsufficiencyforaagab pages 1-2) | Autosomal dominant (yoneda2021japaneseguidelinesfor pages 4-5) | Yoneda et al. 2021, https://doi.org/10.1111/1346-8138.15850; Pohler et al. 2012, https://doi.org/10.1038/ng.2444 (yoneda2021japaneseguidelinesfor pages 4-5, pohler2012haploinsufficiencyforaagab pages 1-2) |
+| PPKP1B | Punctate PPK type 1B | Not specified in provided sources | Included by Japanese guidelines as a punctate PPK subtype; detailed phenotype not expanded in retrieved excerpts beyond punctate palmoplantar hyperkeratosis classification (yoneda2021japaneseguidelinesfor pages 4-5) | COL14A1 (yoneda2021japaneseguidelinesfor pages 4-5, gram2023ispunctatepalmoplantar pages 1-2) | Autosomal dominant (yoneda2021japaneseguidelinesfor pages 4-5) | Yoneda et al. 2021, https://doi.org/10.1111/1346-8138.15850; Gram et al. 2023, https://doi.org/10.1186/s13023-023-02862-8 (yoneda2021japaneseguidelinesfor pages 4-5, gram2023ispunctatepalmoplantar pages 1-2) |
+| PPKP2 | Porokeratotic type; porokeratosis punctata palmaris et plantaris; punctate PPK type 2 | 175860 | Tiny punctate keratotic lesions appearing around puberty; histopathology characterized by a coronoid lamella-like column of parakeratotic cells (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5) | Unknown in provided sources (yoneda2021japaneseguidelinesfor pages 4-5) | Autosomal dominant (yoneda2021japaneseguidelinesfor pages 4-5) | Pohler et al. 2012, https://doi.org/10.1038/ng.2444; Yoneda et al. 2021, https://doi.org/10.1111/1346-8138.15850; Gram et al. 2023, https://doi.org/10.1186/s13023-023-02862-8 (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5, gram2023ispunctatepalmoplantar pages 1-2) |
+| PPKP3 | Acrokeratoelastoidosis; punctate PPK type 3 | 101850 | Small keratotic papules appearing after adolescence on the marginal edges of palmar and plantar surfaces (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5) | Unknown in provided sources (yoneda2021japaneseguidelinesfor pages 4-5) | Autosomal dominant (yoneda2021japaneseguidelinesfor pages 4-5) | Pohler et al. 2012, https://doi.org/10.1038/ng.2444; Yoneda et al. 2021, https://doi.org/10.1111/1346-8138.15850; Gram et al. 2023, https://doi.org/10.1186/s13023-023-02862-8 (pohler2012haploinsufficiencyforaagab pages 1-2, yoneda2021japaneseguidelinesfor pages 4-5, gram2023ispunctatepalmoplantar pages 1-2) |
+
+
+*Table: This table summarizes the punctate palmoplantar keratoderma subtype framework used in the retrieved sources, including OMIM identifiers, clinical patterns, inheritance, and the distinction between type 1A (AAGAB) and type 1B (COL14A1). It is useful for quickly aligning historical subtype names with current gene-based understanding.*
+
+---
+
+## Visual evidence (figures)
+- Pedigrees/clinical images/histology and an AAGAB mutation schematic (including the panel describing mutation locations relative to functional domains) were retrieved from a multi-family PPPK1 mutation report. (pohler2014newandrecurrent media e8a4666c, pohler2014newandrecurrent media f62067ed, pohler2014newandrecurrent media 7e640702)
+
+---
+
+## Notes on gaps and limitations
+1) This run’s retrieved excerpts did not explicitly contain Orphanet/ICD/MeSH/MONDO identifiers; these should be added by querying OMIM/Orphanet/MONDO directly if required for KB completeness.
+2) Some gene claims (e.g., COL14A1 as type 1B) are supported here through guideline and review-level evidence but not by direct full-text extraction of the original COL14A1 pedigree paper in this run.
+3) ClinicalTrials.gov entries show completed studies of KM-001, but trial results were not present in the retrieved record chunks.
+
+
+References
+
+1. (matsuzawa2013heterozygousmutationsin pages 1-2): Takamitsu Matsuzawa, T. Kawamura, Y. Ogawa, Masaaki Takahashi, R. Aoki, Kohji Moriishi, Yoshio Koyanagi, Hiroyuki Gatanaga, A. Blauvelt, and Shinji Shimada. Heterozygous mutations in aagab cause type 1 punctate palmoplantar keratoderma with evidence for increased growth factor signaling. Journal of Investigative Dermatology, 133:2805-2808, Dec 2013. URL: https://doi.org/10.1038/jid.2013.243, doi:10.1038/jid.2013.243. This article has 23 citations and is from a highest quality peer-reviewed journal.
+
+2. (pohler2012haploinsufficiencyforaagab pages 1-2): Elizabeth Pohler, Ons Mamai, Jennifer Hirst, Mozheh Zamiri, Helen Horn, Toshifumi Nomura, Alan D Irvine, Benvon Moran, Neil J Wilson, Frances J D Smith, Christabelle S M Goh, Aileen Sandilands, Christian Cole, Geoffrey J Barton, Alan T Evans, Hiroshi Shimizu, Masashi Akiyama, Mitsuhiro Suehiro, Izumi Konohana, Mohammad Shboul, Sebastien Teissier, Lobna Boussofara, Mohamed Denguezli, Ali Saad, Moez Gribaa, Patricia J Dopping-Hepenstal, John A McGrath, Sara J Brown, David R Goudie, Bruno Reversade, Colin S Munro, and W H Irwin McLean. Haploinsufficiency for aagab causes clinically heterogeneous forms of punctate palmoplantar keratoderma. Nature Genetics, 44:1272-1276, Oct 2012. URL: https://doi.org/10.1038/ng.2444, doi:10.1038/ng.2444. This article has 114 citations and is from a highest quality peer-reviewed journal.
+
+3. (yoneda2021japaneseguidelinesfor pages 4-5): Kozo Yoneda, Akiharu Kubo, Toshifumi Nomura, Akemi Ishida‐Yamamoto, Yasushi Suga, Masashi Akiyama, Nobuo Kanazawa, and Takashi Hashimoto. Japanese guidelines for the management of palmoplantar keratoderma. The Journal of Dermatology, Jun 2021. URL: https://doi.org/10.1111/1346-8138.15850, doi:10.1111/1346-8138.15850. This article has 10 citations.
+
+4. (gram2023ispunctatepalmoplantar pages 1-2): S. B. Gram, J. Bjerrelund, A. M. Jelsig, A. Bygum, C. Leboeuf-Yde, and L. B. Ousager. Is punctate palmoplantar keratoderma type 1 associated with malignancy? a systematic review of the literature. Orphanet Journal of Rare Diseases, Sep 2023. URL: https://doi.org/10.1186/s13023-023-02862-8, doi:10.1186/s13023-023-02862-8. This article has 4 citations and is from a peer-reviewed journal.
+
+5. (pohler2014newandrecurrent pages 1-2): Elizabeth Pohler, M. Huber, S. E. Boonen, M. Zamiri, M. Zamiri, P. A. Gregersen, Mette Sommerlund, Mette Ramsing, Daniel Hohl, W. McLean, and F. Smith. New and recurrent aagab mutations in punctate palmoplantar keratoderma. The British Journal of Dermatology, 171:433-436, Aug 2014. URL: https://doi.org/10.1111/bjd.12927, doi:10.1111/bjd.12927. This article has 10 citations.
+
+6. (thomas2020diagnosisandmanagement pages 5-6): BR Thomas and EA O'TOOLE. Diagnosis and management of inherited palmoplantar keratodermas. Acta Dermato-Venereologica, 100:adv00094-176, Mar 2020. URL: https://doi.org/10.2340/00015555-3430, doi:10.2340/00015555-3430. This article has 50 citations and is from a domain leading peer-reviewed journal.
+
+7. (pohler2014newandrecurrent pages 2-3): Elizabeth Pohler, M. Huber, S. E. Boonen, M. Zamiri, M. Zamiri, P. A. Gregersen, Mette Sommerlund, Mette Ramsing, Daniel Hohl, W. McLean, and F. Smith. New and recurrent aagab mutations in punctate palmoplantar keratoderma. The British Journal of Dermatology, 171:433-436, Aug 2014. URL: https://doi.org/10.1111/bjd.12927, doi:10.1111/bjd.12927. This article has 10 citations.
+
+8. (knowles2023punctatepalmoplantarkeratoderma pages 4-5): A Knowles, M Adams, DA Glass II, MJ Adams, and D Glass. Punctate palmoplantar keratoderma: a case report. Cureus, Jan 2023. URL: https://doi.org/10.7759/cureus.33769, doi:10.7759/cureus.33769. This article has 3 citations.
+
+9. (elhaji2020aagabmutationsin pages 1-2): Youssef Elhaji, Cherise Hedlin, Anu Nath, Emma L. Price, Christopher Gallant, Stacey Northgrave, and Peter R. Hull. Aagab mutations in 18 canadian families with punctate palmoplantar keratoderma and a possible link to cancer. Journal of Cutaneous Medicine and Surgery, 24:28-32, Jan 2020. URL: https://doi.org/10.1177/1203475419878161, doi:10.1177/1203475419878161. This article has 15 citations and is from a peer-reviewed journal.
+
+10. (zamiri2019painfulpunctatepalmoplantar pages 5-6): M. Zamiri, Neil J. Wilson, A. Mackenzie, G. Sobey, C. Leitch, and F.J.D. Smith. Painful punctate palmoplantar keratoderma due to heterozygous mutations in aagab. British Journal of Dermatology, 180:1250-1251, Feb 2019. URL: https://doi.org/10.1111/bjd.17442, doi:10.1111/bjd.17442. This article has 7 citations and is from a highest quality peer-reviewed journal.
+
+11. (gram2025clinicalandgenetic pages 3-4): Stine Bjørn Gram, Klaus Brusgaard, Ulrikke Lei, Mette Sommerlund, Gabrielle Randskov Vinding, Sondre Olai Kjellevold Sleire, Alex Hørby Christensen, Sanne Pedersen Fast, Rasmus Bach, Anette Bygum, and Lilian Bomme Ousager. Clinical and genetic findings in patients with palmoplantar keratoderma. JAMA Dermatology, 161:157, Feb 2025. URL: https://doi.org/10.1001/jamadermatol.2024.4824, doi:10.1001/jamadermatol.2024.4824. This article has 6 citations and is from a domain leading peer-reviewed journal.
+
+12. (gram2024identificationofa pages 1-2): Stine Bjørn Gram, Anne Sofie Fredberg Jørgensen, Anette Bygum, Klaus Brusgaard, and Lilian Bomme Ousager. Identification of a founder variant aagab c.370c>t, p.arg124ter in patients with punctate palmoplantar keratoderma in southern denmark. Clinical Genetics, 105:561-566, Feb 2024. URL: https://doi.org/10.1111/cge.14486, doi:10.1111/cge.14486. This article has 1 citations and is from a peer-reviewed journal.
+
+13. (giehl2012nonsensemutationsin pages 1-2): Kathrin A. Giehl, Gertrud N. Eckstein, Sandra M. Pasternack, Silke Praetzel-Wunder, Thomas Ruzicka, Peter Lichtner, Kerstin Seidl, Mike Rogers, Elisabeth Graf, Lutz Langbein, Markus Braun-Falco, Regina C. Betz, and Tim M. Strom. Nonsense mutations in aagab cause punctate palmoplantar keratoderma type buschke-fischer-brauer. American journal of human genetics, 91 4:754-9, Oct 2012. URL: https://doi.org/10.1016/j.ajhg.2012.08.024, doi:10.1016/j.ajhg.2012.08.024. This article has 98 citations and is from a highest quality peer-reviewed journal.
+
+14. (pohler2012haploinsufficiencyforaagab pages 4-5): Elizabeth Pohler, Ons Mamai, Jennifer Hirst, Mozheh Zamiri, Helen Horn, Toshifumi Nomura, Alan D Irvine, Benvon Moran, Neil J Wilson, Frances J D Smith, Christabelle S M Goh, Aileen Sandilands, Christian Cole, Geoffrey J Barton, Alan T Evans, Hiroshi Shimizu, Masashi Akiyama, Mitsuhiro Suehiro, Izumi Konohana, Mohammad Shboul, Sebastien Teissier, Lobna Boussofara, Mohamed Denguezli, Ali Saad, Moez Gribaa, Patricia J Dopping-Hepenstal, John A McGrath, Sara J Brown, David R Goudie, Bruno Reversade, Colin S Munro, and W H Irwin McLean. Haploinsufficiency for aagab causes clinically heterogeneous forms of punctate palmoplantar keratoderma. Nature Genetics, 44:1272-1276, Oct 2012. URL: https://doi.org/10.1038/ng.2444, doi:10.1038/ng.2444. This article has 114 citations and is from a highest quality peer-reviewed journal.
+
+15. (matsuzawa2013heterozygousmutationsin pages 4-4): Takamitsu Matsuzawa, T. Kawamura, Y. Ogawa, Masaaki Takahashi, R. Aoki, Kohji Moriishi, Yoshio Koyanagi, Hiroyuki Gatanaga, A. Blauvelt, and Shinji Shimada. Heterozygous mutations in aagab cause type 1 punctate palmoplantar keratoderma with evidence for increased growth factor signaling. Journal of Investigative Dermatology, 133:2805-2808, Dec 2013. URL: https://doi.org/10.1038/jid.2013.243, doi:10.1038/jid.2013.243. This article has 23 citations and is from a highest quality peer-reviewed journal.
+
+16. (yoneda2021japaneseguidelinesfor pages 9-10): Kozo Yoneda, Akiharu Kubo, Toshifumi Nomura, Akemi Ishida‐Yamamoto, Yasushi Suga, Masashi Akiyama, Nobuo Kanazawa, and Takashi Hashimoto. Japanese guidelines for the management of palmoplantar keratoderma. The Journal of Dermatology, Jun 2021. URL: https://doi.org/10.1111/1346-8138.15850, doi:10.1111/1346-8138.15850. This article has 10 citations.
+
+17. (yoneda2021japaneseguidelinesfor pages 10-12): Kozo Yoneda, Akiharu Kubo, Toshifumi Nomura, Akemi Ishida‐Yamamoto, Yasushi Suga, Masashi Akiyama, Nobuo Kanazawa, and Takashi Hashimoto. Japanese guidelines for the management of palmoplantar keratoderma. The Journal of Dermatology, Jun 2021. URL: https://doi.org/10.1111/1346-8138.15850, doi:10.1111/1346-8138.15850. This article has 10 citations.
+
+18. (yoneda2021japaneseguidelinesfor pages 8-9): Kozo Yoneda, Akiharu Kubo, Toshifumi Nomura, Akemi Ishida‐Yamamoto, Yasushi Suga, Masashi Akiyama, Nobuo Kanazawa, and Takashi Hashimoto. Japanese guidelines for the management of palmoplantar keratoderma. The Journal of Dermatology, Jun 2021. URL: https://doi.org/10.1111/1346-8138.15850, doi:10.1111/1346-8138.15850. This article has 10 citations.
+
+19. (NCT05435638 chunk 1):  Study Designed to Evaluate Safety and Efficacy of 1% Topical Formulation of KM-001 on Type 1 Punctate Palmoplantar Keratoderma or Pachyonychia Congenita Diseases. Kamari Pharma Ltd. 2022. ClinicalTrials.gov Identifier: NCT05435638
+
+20. (NCT05956314 chunk 1):  Assessment of KM-001 - Safety, Tolerability, and Efficacy in Patients With PPPK1 or PC. Kamari Pharma Ltd. 2023. ClinicalTrials.gov Identifier: NCT05956314
+
+21. (NCT05956314 chunk 2):  Assessment of KM-001 - Safety, Tolerability, and Efficacy in Patients With PPPK1 or PC. Kamari Pharma Ltd. 2023. ClinicalTrials.gov Identifier: NCT05956314
+
+22. (pohler2014newandrecurrent media e8a4666c): Elizabeth Pohler, M. Huber, S. E. Boonen, M. Zamiri, M. Zamiri, P. A. Gregersen, Mette Sommerlund, Mette Ramsing, Daniel Hohl, W. McLean, and F. Smith. New and recurrent aagab mutations in punctate palmoplantar keratoderma. The British Journal of Dermatology, 171:433-436, Aug 2014. URL: https://doi.org/10.1111/bjd.12927, doi:10.1111/bjd.12927. This article has 10 citations.
+
+23. (pohler2014newandrecurrent media f62067ed): Elizabeth Pohler, M. Huber, S. E. Boonen, M. Zamiri, M. Zamiri, P. A. Gregersen, Mette Sommerlund, Mette Ramsing, Daniel Hohl, W. McLean, and F. Smith. New and recurrent aagab mutations in punctate palmoplantar keratoderma. The British Journal of Dermatology, 171:433-436, Aug 2014. URL: https://doi.org/10.1111/bjd.12927, doi:10.1111/bjd.12927. This article has 10 citations.
+
+24. (pohler2014newandrecurrent media 7e640702): Elizabeth Pohler, M. Huber, S. E. Boonen, M. Zamiri, M. Zamiri, P. A. Gregersen, Mette Sommerlund, Mette Ramsing, Daniel Hohl, W. McLean, and F. Smith. New and recurrent aagab mutations in punctate palmoplantar keratoderma. The British Journal of Dermatology, 171:433-436, Aug 2014. URL: https://doi.org/10.1111/bjd.12927, doi:10.1111/bjd.12927. This article has 10 citations.

--- a/research/Punctate_Palmoplantar_Keratoderma-deep-research-falcon.md.citations.md
+++ b/research/Punctate_Palmoplantar_Keratoderma-deep-research-falcon.md.citations.md
@@ -1,0 +1,486 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Punctate Palmoplantar Keratoderma
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Punctate Palmoplantar Keratoderma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-10T11:26:46.388556
+
+1. matsuzawa2013heterozygousmutationsin pages 1-2
+2. pohler2012haploinsufficiencyforaagab pages 1-2
+3. yoneda2021japaneseguidelinesfor pages 4-5
+4. gram2023ispunctatepalmoplantar pages 1-2
+5. thomas2020diagnosisandmanagement pages 5-6
+6. zamiri2019painfulpunctatepalmoplantar pages 5-6
+7. gram2025clinicalandgenetic pages 3-4
+8. pohler2014newandrecurrent pages 2-3
+9. gram2024identificationofa pages 1-2
+10. pohler2012haploinsufficiencyforaagab pages 4-5
+11. matsuzawa2013heterozygousmutationsin pages 4-4
+12. knowles2023punctatepalmoplantarkeratoderma pages 4-5
+13. yoneda2021japaneseguidelinesfor pages 9-10
+14. yoneda2021japaneseguidelinesfor pages 10-12
+15. pohler2014newandrecurrent pages 1-2
+16. elhaji2020aagabmutationsin pages 1-2
+17. giehl2012nonsensemutationsin pages 1-2
+18. yoneda2021japaneseguidelinesfor pages 8-9
+19. https://doi.org/10.1038/ng.2444;
+20. https://doi.org/10.1038/jid.2013.243;
+21. https://doi.org/10.1111/1346-8138.15850;
+22. https://doi.org/10.1186/s13023-023-02862-8
+23. https://doi.org/10.1038/ng.2444
+24. https://doi.org/10.1038/jid.2013.243,
+25. https://doi.org/10.1038/ng.2444,
+26. https://doi.org/10.1111/1346-8138.15850,
+27. https://doi.org/10.1186/s13023-023-02862-8,
+28. https://doi.org/10.1111/bjd.12927,
+29. https://doi.org/10.2340/00015555-3430,
+30. https://doi.org/10.7759/cureus.33769,
+31. https://doi.org/10.1177/1203475419878161,
+32. https://doi.org/10.1111/bjd.17442,
+33. https://doi.org/10.1001/jamadermatol.2024.4824,
+34. https://doi.org/10.1111/cge.14486,
+35. https://doi.org/10.1016/j.ajhg.2012.08.024,


### PR DESCRIPTION
## Summary

- Added `kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml` for MONDO:0017675.
- Ran required Falcon research and committed the report plus citations artifact.
- Cached cited PubMed and ClinicalTrials.gov references using `just fetch-reference`; did not hand-edit `references_cache/*.md`.
- Curated AAGAB-centered pathophysiology, phenotypes, histopathology, genetics, diagnostics, conservative treatment support, and KM-001 trial records.

## Key evidence

- AAGAB haploinsufficiency and p34/membrane-trafficking mechanism: PMID:23064416, PMID:23000146
- Growth-factor signaling and keratinocyte hyperproliferation: PMID:23064416
- Type 1 PPPK clinical genetics and onset: PMID:31526046, PMID:23743648
- PPK guideline/review context: PMID:34121213, PMID:32147745
- Malignancy association uncertainty: PMID:37705065
- Founder variant in Southern Denmark: PMID:38311882
- Symptomatic keratolytic evidence: PMID:17298101, PMID:33765759
- KM-001 trial records: clinicaltrials:NCT05435638, clinicaltrials:NCT05956314

## Validation

- `just validate kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml` passed.
- `just validate-references kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml` passed with the current repo validator output.
- `just compliance kb/disorders/Punctate_Palmoplantar_Keratoderma.yaml` reported global compliance 60.4%; remaining gaps are primarily `reference_title`, datasets, and subtype evidence.

## Notes

- `just fetch-reference ORPHA:307967` did not find a supported structured reference source, so ORPHA:307967 is noted in review notes but not used as evidence.
- COL14A1 is included conservatively as a reported type 1B association with `PARTIAL` evidence support; the stronger mechanism is AAGAB-associated type 1A.
