### PR TITLE
Add auriculocondylar syndrome curation

### DIFF
--- a/kb/disorders/Auriculocondylar_Syndrome.yaml
+++ b/kb/disorders/Auriculocondylar_Syndrome.yaml
@@ -536,7 +536,7 @@ genetic:
     snippet: "A novel insertional mutation in the guanine nucleotide-binding protein alpha-inhibiting activity polypeptide 3 (GNAI3) was identified in the patient and their brother using whole-exome sequencing."
     explanation: A recent family report supports GNAI3 as a causal gene and illustrates WES diagnosis.
 - name: PLCB4 pathogenic variants
-  subtype: ARCND2
+  subtype: ARCND2A
   gene_term:
     preferred_term: PLCB4
     term:

--- a/kb/disorders/Auriculocondylar_Syndrome.yaml
+++ b/kb/disorders/Auriculocondylar_Syndrome.yaml
@@ -1,0 +1,695 @@
+name: Auriculocondylar Syndrome
+creation_date: "2026-05-10T15:02:55Z"
+updated_date: "2026-05-10T15:45:00Z"
+description: >-
+  Auriculocondylar syndrome is an ultra-rare congenital craniofacial
+  malformation syndrome affecting first and second pharyngeal arch derivatives.
+  It is characterized by question mark ears, mandibular condyle hypoplasia,
+  micrognathia, and variable oral, airway, and developmental complications.
+  Most known causes disrupt the EDN1-EDNRA developmental signaling axis or
+  cranial neural crest regulatory programs.
+category: Mendelian
+parents:
+- ear malformation
+- craniofacial malformation syndrome
+synonyms:
+- auriculo-condylar syndrome
+- question mark ear syndrome
+- dysgnathia complex
+disease_term:
+  preferred_term: auriculocondylar syndrome
+  term:
+    id: MONDO:0000107
+    label: auriculocondylar syndrome
+has_subtypes:
+- name: ARCND1
+  display_name: ARCND1 (GNAI3-related)
+  description: >-
+    Usually autosomal dominant auriculocondylar syndrome caused by heterozygous
+    GNAI3 variants affecting GDP/GTP-binding motifs and EDN1 pathway signaling.
+- name: ARCND2
+  display_name: ARCND2 (PLCB4-related)
+  description: >-
+    PLCB4-related auriculocondylar syndrome includes autosomal dominant
+    heterozygous missense variants and rarer autosomal recessive loss-of-function
+    mechanisms.
+- name: ARCND3
+  display_name: ARCND3 (EDN1-related)
+  description: >-
+    EDN1-related disease includes recessive auriculocondylar syndrome and
+    dominant isolated question mark ear, depending on the variant and residual
+    endothelin 1 activity.
+- name: ARCND4
+  display_name: ARCND4 (TWIST1 regulatory duplication)
+  description: >-
+    A regulatory locus caused by a 430 kb duplication involving HDAC9 and
+    TWIST1 regulatory elements, altering TWIST1 expression during craniofacial
+    development.
+inheritance:
+- name: Autosomal dominant
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  expressivity: VARIABLE
+  description: >-
+    Many reported PLCB4 and GNAI3 families show autosomal dominant inheritance,
+    often with variable expressivity and incomplete penetrance.
+  evidence:
+  - reference: PMID:28328130
+    reference_title: "Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Auriculocondylar syndrome, mainly characterized by micrognathia, small mandibular condyle, and question mark ears, is a rare disease segregating in an autosomal dominant pattern in the majority of the families reported in the literature."
+    explanation: This cohort review directly supports autosomal dominant inheritance as the most common reported pattern.
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "As with other studies examining familial cases of ARCND2, incomplete penetrance and variable expressivity were observed within different families' heterozygous mutations in PLCB4 gene."
+    explanation: The 2024 review supports variable expressivity and incomplete penetrance in PLCB4-related families.
+- name: Autosomal recessive
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  description: >-
+    Recessive auriculocondylar syndrome has been reported for EDN1 variants and
+    for biallelic PLCB4 loss-of-function lesions.
+  evidence:
+  - reference: PMID:24268655
+    reference_title: "Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "By whole-exome sequencing (WES), we identified a homozygous substitution in a furin cleavage site of the EDN1 proprotein in ACS-affected siblings born to consanguineous parents."
+    explanation: This directly supports recessive EDN1-related auriculocondylar syndrome.
+  - reference: PMID:23315542
+    reference_title: "Heterogeneity of mutational mechanisms and modes of inheritance in auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "CONCLUSIONS: These findings indicate that ACS is not only genetically heterogeneous but also an autosomal dominant or recessive condition according to the nature of the PLCB4 gene lesion."
+    explanation: This directly supports recessive inheritance for some PLCB4 lesions.
+pathophysiology:
+- name: EDN1-EDNRA Craniofacial Signaling Disruption
+  description: >-
+    The central mechanism is impaired endothelin 1 signaling during early
+    pharyngeal arch patterning. EDN1 ligand, EDNRA receptor signaling, and
+    downstream GNAI3 and PLCB4 effectors help specify mandibular identity in
+    cranial neural crest-derived tissues; disruption reduces downstream
+    DLX5/DLX6 expression and repatterns mandibular structures toward a more
+    maxillary-like identity.
+  genes:
+  - preferred_term: EDN1
+    term:
+      id: hgnc:3176
+      label: EDN1
+  - preferred_term: GNAI3
+    term:
+      id: hgnc:4387
+      label: GNAI3
+  - preferred_term: PLCB4
+    term:
+      id: hgnc:9059
+      label: PLCB4
+  cell_types:
+  - preferred_term: cranial neural crest cell
+    term:
+      id: CL:0000008
+      label: migratory cranial neural crest cell
+  biological_processes:
+  - preferred_term: signal transduction
+    term:
+      id: GO:0007165
+      label: signal transduction
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:22560091
+    reference_title: "A human homeotic transformation resulting from mutations in PLCB4 and GNAI3 causes auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Functional studies demonstrated a significant reduction in downstream DLX5 and DLX6 expression in ACS cases in assays using cultured osteoblasts from probands and controls."
+    explanation: Patient-derived osteoblast assays directly support reduced DLX5/DLX6 output downstream of PLCB4 and GNAI3 mutations.
+  - reference: PMID:24268655
+    reference_title: "Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "These findings provide further support for the hypothesis that ACS and QMEs are uniquely caused by disruption of the EDN1-EDNRA signaling pathway."
+    explanation: EDN1 mutation discovery supports EDN1-EDNRA pathway disruption as a unifying disease mechanism.
+  downstream:
+  - target: Mandibular condyle hypoplasia
+    description: Impaired mandibular identity specification disrupts condylar development.
+  - target: Micrognathia
+    description: Mandibular hypoplasia results from abnormal first arch-derived jaw patterning.
+  - target: Question mark ear
+    description: External ear malformation accompanies first and second arch patterning defects.
+- name: Cranial Neural Crest Patterning Defect
+  description: >-
+    Cranial neural crest cells populate the pharyngeal arches and generate most
+    craniofacial bone, cartilage, and connective tissue. In auriculocondylar
+    syndrome, disturbed neural crest identity and patterning underlie ear and
+    mandibular malformations.
+  cell_types:
+  - preferred_term: cranial neural crest cell
+    term:
+      id: CL:0000008
+      label: migratory cranial neural crest cell
+  biological_processes:
+  - preferred_term: neural crest cell migration
+    term:
+      id: GO:0001755
+      label: neural crest cell migration
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:24123988
+    reference_title: "Understanding the basis of auriculocondylar syndrome: Insights from human, mouse and zebrafish genetic studies."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Affected structures arise from cranial neural crest cells, a population of cells in the embryo that reside in the pharyngeal arches and give rise to most of the bone, cartilage and connective tissue of the face."
+    explanation: This review links affected auriculocondylar structures to cranial neural crest-derived tissues.
+  - reference: PMID:24123988
+    reference_title: "Understanding the basis of auriculocondylar syndrome: Insights from human, mouse and zebrafish genetic studies."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Disruption of this signaling pathway in both mouse and zebrafish results in loss of identity of neural crest cells of the mandibular portion of the first pharyngeal arch and the subsequent repatterning of these cells, leading to homeosis of lower jaw structures into more maxillary-like structures."
+    explanation: Mouse and zebrafish evidence supports neural crest mandibular identity loss as a mechanism for the craniofacial phenotype.
+  downstream:
+  - target: EDN1-EDNRA Craniofacial Signaling Disruption
+    description: Developmental patterning defects converge on the EDN1-DLX5/6 mandibular identity program.
+- name: Dominant-Negative GNAI3 Dysfunction
+  description: >-
+    GNAI3 variants cluster around GDP/GTP-binding motifs and are proposed to
+    act through a dominant-negative mechanism that interferes with endothelin
+    pathway signal transduction during pharyngeal arch development.
+  genes:
+  - preferred_term: GNAI3
+    term:
+      id: hgnc:4387
+      label: GNAI3
+  biological_processes:
+  - preferred_term: signal transduction
+    term:
+      id: GO:0007165
+      label: signal transduction
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:25026904
+    reference_title: "Novel variants in GNAI3 associated with auriculocondylar syndrome strengthen a common dominant negative effect."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Structural modeling shows that all five altered GNAI3 residues identified to date cluster in a region involved in GDP/GTP binding."
+    explanation: Variant clustering near GDP/GTP binding supports disrupted GNAI3 signaling function.
+  - reference: PMID:25026904
+    reference_title: "Novel variants in GNAI3 associated with auriculocondylar syndrome strengthen a common dominant negative effect."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We hypothesize that all GNAI3 variants lead to dominant negative effects."
+    explanation: The abstract explicitly supports a dominant-negative interpretation for GNAI3 variants.
+- name: PLCB4 Catalytic Domain Dysfunction
+  description: >-
+    PLCB4 variants include heterozygous missense variants clustered in protein
+    domains and biallelic loss-of-function lesions. Heterozygous missense
+    variants are proposed to interfere dominantly rather than act through simple
+    haploinsufficiency.
+  genes:
+  - preferred_term: PLCB4
+    term:
+      id: hgnc:9059
+      label: PLCB4
+  biological_processes:
+  - preferred_term: signal transduction
+    term:
+      id: GO:0007165
+      label: signal transduction
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:23315542
+    reference_title: "Heterogeneity of mutational mechanisms and modes of inheritance in auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The narrow distribution of mutations within protein space suggests that the mutations may result in dominantly interfering proteins, rather than haploinsufficiency."
+    explanation: This supports a dominant-interference mechanism for many heterozygous PLCB4 missense variants.
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Trio-based whole-exome sequencing identified a novel missense variant of NM_001377142.1:c.1928C>T (NP_001364071.1:p.Ser643Phe) in the PLCB4 gene, which was predicted to impair the local structural stability with a result that the protein function might be affected."
+    explanation: A recent neonatal case supports PLCB4 structural and functional disruption in ARCND2.
+- name: TWIST1 Regulatory Dosage Disruption
+  description: >-
+    A 430 kb duplication involving HDAC9 and TWIST1 regulatory elements can
+    deregulate TWIST1 expression in neural crest cells and impair neural crest
+    migration and osteogenic differentiation.
+  genes:
+  - preferred_term: TWIST1
+    term:
+      id: hgnc:12428
+      label: TWIST1
+  cell_types:
+  - preferred_term: neural crest cell
+    term:
+      id: CL:0011012
+      label: neural crest cell
+  - preferred_term: mesenchymal stem cell
+    term:
+      id: CL:0000134
+      label: mesenchymal stem cell
+  biological_processes:
+  - preferred_term: neural crest cell migration
+    term:
+      id: GO:0001755
+      label: neural crest cell migration
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:34750192
+    reference_title: "New locus underlying auriculocondylar syndrome (ARCND): 430 kb duplication involving TWIST1 regulatory elements."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "We also identified decreased migration of iPSC-derived neural crest cells together with dysregulation of osteogenic differentiation in iPSC-affected mesenchymal stem cells."
+    explanation: Patient iPSC-derived cellular models directly support neural crest migration and osteogenic differentiation defects.
+  - reference: PMID:34750192
+    reference_title: "New locus underlying auriculocondylar syndrome (ARCND): 430 kb duplication involving TWIST1 regulatory elements."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Our findings support the hypothesis that the 430 kb duplication is causative of the ARCND phenotype in this family and that deregulation of TWIST1 expression during craniofacial development can contribute to the phenotype."
+    explanation: The study supports regulatory TWIST1 dosage disruption as an ARCND mechanism.
+phenotypes:
+- name: Question mark ear
+  category: Craniofacial
+  frequency: FREQUENT
+  description: >-
+    A characteristic external ear malformation with a defect or cleft near the
+    lobe-helix junction; it may be syndromic or, in some EDN1 families, isolated.
+  phenotype_term:
+    preferred_term: Question mark ear
+    term:
+      id: HP:0030022
+      label: Question mark ear
+  evidence:
+  - reference: PMID:24268655
+    reference_title: "Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Auriculocondylar syndrome (ACS) is a rare craniofacial disorder with mandibular hypoplasia and question-mark ears (QMEs) as major features."
+    explanation: This directly supports question mark ears as a major feature.
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Micrognathia, microstomia, distinctive question mark ears, as well as mandibular condyle hypoplasia were identified."
+    explanation: A recent PLCB4 neonatal case directly documents question mark ears.
+- name: Mandibular condyle hypoplasia
+  category: Craniofacial
+  frequency: FREQUENT
+  description: Underdevelopment of the mandibular condyle is part of the defining clinical triad.
+  phenotype_term:
+    preferred_term: Mandibular condyle hypoplasia
+    term:
+      id: HP:0007628
+      label: Mandibular condyle hypoplasia
+  evidence:
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "BACKGROUND: Auriculocondylar syndrome (ARCND) is an extremely rare autosomal dominant or recessive condition that typically manifests as question mark ears (QMEs), mandibular condyle hypoplasia, and micrognathia."
+    explanation: This recent clinical report directly supports mandibular condyle hypoplasia as a typical manifestation.
+  - reference: PMID:28328130
+    reference_title: "Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Auriculocondylar syndrome, mainly characterized by micrognathia, small mandibular condyle, and question mark ears, is a rare disease segregating in an autosomal dominant pattern in the majority of the families reported in the literature."
+    explanation: This supports small mandibular condyle as a main disease feature.
+- name: Micrognathia
+  category: Craniofacial
+  frequency: FREQUENT
+  description: Developmental mandibular hypoplasia is a core clinical feature.
+  phenotype_term:
+    preferred_term: Micrognathia
+    term:
+      id: HP:0000347
+      label: Micrognathia
+  evidence:
+  - reference: PMID:34789173
+    reference_title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "BACKGROUND: Auriculocondylar syndrome (ACS) is a rare disorder characterized by micrognathia, mandibular condyle hypoplasia, and auricular abnormalities."
+    explanation: Prenatal case report directly identifies micrognathia as a core disease characteristic.
+  - reference: PMID:34789173
+    reference_title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Severe micrognathia and mandibular hypoplasia were identified on ultrasonography."
+    explanation: This supports prenatal detectability of severe micrognathia.
+- name: Microstomia
+  category: Craniofacial
+  description: A small oral aperture can accompany mandibular and maxillofacial malformations.
+  phenotype_term:
+    preferred_term: microstomia
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Micrognathia, microstomia, distinctive question mark ears, as well as mandibular condyle hypoplasia were identified."
+    explanation: The cited neonatal case directly reports microstomia in PLCB4-related ARCND2.
+- name: Cleft palate
+  category: Craniofacial
+  description: Cleft palate is a variable craniofacial feature in auriculocondylar syndrome.
+  phenotype_term:
+    preferred_term: Cleft palate
+    term:
+      id: HP:0000175
+      label: Cleft palate
+  evidence:
+  - reference: PMID:22560091
+    reference_title: "A human homeotic transformation resulting from mutations in PLCB4 and GNAI3 causes auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Auriculocondylar syndrome (ACS) is a rare, autosomal-dominant craniofacial malformation syndrome characterized by variable micrognathia, temporomandibular joint ankylosis, cleft palate, and a characteristic \"question-mark\" ear malformation."
+    explanation: The original PLCB4/GNAI3 discovery paper includes cleft palate among variable clinical features.
+- name: Respiratory distress
+  category: Respiratory
+  description: Severe neonatal mandibular and oral malformations can present with respiratory distress.
+  phenotype_term:
+    preferred_term: Respiratory distress
+    term:
+      id: HP:0002098
+      label: Respiratory distress
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The proband, a 5-day-old male neonate, was referred to our hospital for respiratory distress."
+    explanation: A recent neonatal ARCND2 case directly documents respiratory distress.
+- name: Polyhydramnios
+  category: Prenatal
+  description: Polyhydramnios may accompany severe prenatal mandibular hypoplasia.
+  phenotype_term:
+    preferred_term: polyhydramnios
+  evidence:
+  - reference: PMID:34789173
+    reference_title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Severe micrognathia and mandibular hypoplasia accompanied by polyhydramnios are prenatal indicators of ACS."
+    explanation: This directly supports polyhydramnios as a prenatal indicator when combined with severe mandibular findings.
+- name: Full cheeks
+  category: Craniofacial
+  description: Full cheeks are associated with molecularly characterized auriculocondylar syndrome.
+  phenotype_term:
+    preferred_term: Full cheeks
+    term:
+      id: HP:0000293
+      label: Full cheeks
+  evidence:
+  - reference: PMID:28328130
+    reference_title: "Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We also performed a detailed comparative analysis of the patients presented in this study with those previously published, which showed that the pattern of auricular abnormality and full cheeks were associated with molecularly characterized individuals with Auriculocondylar syndrome."
+    explanation: The molecular cohort analysis directly associates full cheeks with molecularly confirmed disease.
+genetic:
+- name: GNAI3 pathogenic variants
+  subtype: ARCND1
+  gene_term:
+    preferred_term: GNAI3
+    term:
+      id: hgnc:4387
+      label: GNAI3
+  association: Causative
+  notes: >-
+    GNAI3 variants usually affect highly conserved GDP/GTP-binding motifs and
+    are interpreted as dominant-negative in reported families.
+  evidence:
+  - reference: PMID:25026904
+    reference_title: "Novel variants in GNAI3 associated with auriculocondylar syndrome strengthen a common dominant negative effect."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Causative variants have been identified in PLCB4, GNAI3 and EDN1, which are predicted to function within the EDN1-EDNRA pathway during early pharyngeal arch patterning."
+    explanation: This directly includes GNAI3 among causative genes in the pathway.
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A novel insertional mutation in the guanine nucleotide-binding protein alpha-inhibiting activity polypeptide 3 (GNAI3) was identified in the patient and their brother using whole-exome sequencing."
+    explanation: A recent family report supports GNAI3 as a causal gene and illustrates WES diagnosis.
+- name: PLCB4 pathogenic variants
+  subtype: ARCND2
+  gene_term:
+    preferred_term: PLCB4
+    term:
+      id: hgnc:9059
+      label: PLCB4
+  association: Causative
+  notes: >-
+    PLCB4 variants are a common molecular cause in investigated ARCND cohorts
+    and include both heterozygous missense variants and biallelic loss-of-function
+    lesions.
+  evidence:
+  - reference: PMID:28328130
+    reference_title: "Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "So far, pathogenic variants in PLCB4, GNAI3, and EDN1 have been associated with this syndrome."
+    explanation: This cohort paper directly supports PLCB4 as an associated causative gene.
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "METHODS: This study reports a case of ARCND2 resulting from a novel pathogenic variant in the PLCB4 gene, and summarizes PLCB4 gene mutation sites and phenotypes of ARCND2."
+    explanation: Recent case report directly supports PLCB4 variants as causative for ARCND2.
+- name: EDN1 pathogenic variants
+  subtype: ARCND3
+  gene_term:
+    preferred_term: EDN1
+    term:
+      id: hgnc:3176
+      label: EDN1
+  association: Causative
+  notes: >-
+    EDN1 variants can cause recessive syndromic auriculocondylar syndrome or
+    dominant isolated question mark ears, consistent with mutation-dependent
+    residual endothelin 1 activity.
+  evidence:
+  - reference: PMID:24268655
+    reference_title: "Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Targeted sequencing of EDN1 in an ACS individual with related parents identified a fourth, homozygous mutation falling close to the site of cleavage by endothelin-converting enzyme."
+    explanation: This supports EDN1 as a causal gene for recessive auriculocondylar syndrome.
+- name: TWIST1 regulatory duplication
+  subtype: ARCND4
+  gene_term:
+    preferred_term: TWIST1
+    term:
+      id: hgnc:12428
+      label: TWIST1
+  association: Causative
+  notes: >-
+    The ARCND4 locus is a noncoding structural variant affecting regulatory
+    elements that interact with the TWIST1 promoter rather than a coding TWIST1
+    variant.
+  evidence:
+  - reference: PMID:34750192
+    reference_title: "New locus underlying auriculocondylar syndrome (ARCND): 430 kb duplication involving TWIST1 regulatory elements."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This study highlights a fourth locus causative of ARCND, represented by a tandem duplication of 430 kb in a candidate region on chromosome 7 defined by linkage analysis."
+    explanation: This directly supports the structural regulatory duplication as a causative ARCND locus.
+diagnosis:
+- name: Clinical triad recognition
+  description: >-
+    Clinical diagnosis is anchored by the triad of question mark ears,
+    mandibular condyle hypoplasia, and micrognathia, while recognizing that
+    partial presentations occur.
+  evidence:
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "CONCLUSIONS: ARCND is a monogenic and rare condition that can be diagnosed based on its clinical triad of core features."
+    explanation: This directly supports clinical triad-based diagnosis.
+- name: Molecular testing
+  description: >-
+    Whole-exome sequencing or targeted testing of ARCND genes can confirm
+    diagnosis, especially when clinical features are inconspicuous, atypical, or
+    detected prenatally.
+  results: Pathogenic or likely pathogenic variants in GNAI3, PLCB4, EDN1, or ARCND4 regulatory CNV.
+  evidence:
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Molecular diagnosis plays a crucial role in the diagnosis of patients with inconspicuous clinical features."
+    explanation: This supports molecular testing for less obvious clinical presentations.
+  - reference: PMID:34789173
+    reference_title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Whole-exome sequencing identified a novel de novo missense variant of c.140G > A in the GNAI3 gene."
+    explanation: This supports WES utility in prenatal diagnosis.
+prevalence:
+- population: General population
+  notes: >-
+    Ultra-rare; Falcon research and recent reviews cite Orphanet estimates of
+    less than 1 in 1,000,000, but no PMID-backed abstract snippet with a numeric
+    prevalence was available for validation.
+progression:
+- phase: Congenital
+  duration: Lifelong
+  notes: >-
+    Craniofacial anomalies are congenital. Severity varies from isolated ear
+    anomalies to severe mandibular, oral, airway, feeding, and dental
+    complications requiring staged treatment.
+  evidence:
+  - reference: PMID:34789173
+    reference_title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Severe micrognathia and mandibular hypoplasia accompanied by polyhydramnios are prenatal indicators of ACS."
+    explanation: Prenatal ultrasound evidence supports congenital onset.
+treatments:
+- name: Multidisciplinary Craniofacial Surgery
+  description: >-
+    Severe dentofacial deformities may be treated with staged craniofacial
+    surgery, including distraction osteogenesis and orthognathic surgery, often
+    guided by three-dimensional digital planning.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  target_phenotypes:
+  - preferred_term: Micrognathia
+    term:
+      id: HP:0000347
+      label: Micrognathia
+  - preferred_term: Mandibular condyle hypoplasia
+    term:
+      id: HP:0007628
+      label: Mandibular condyle hypoplasia
+  evidence:
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "After a multidisciplinary consultation and examination, sequential orthodontic treatment and craniofacial surgery, including distraction osteogenesis and orthognathic surgery, were performed using three-dimensional (3D) digital technology to treat the patient's dentofacial deformity."
+    explanation: This directly supports multidisciplinary staged craniofacial surgical management.
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sequential therapy with preoperative orthodontic treatment combined with distraction osteogenesis and orthognathic surgery guided by 3D digital technology may be a practical and effective method for treating ARCND."
+    explanation: The conclusion supports this approach as a practical treatment option for severe ARCND dentofacial deformity.
+- name: Distraction Osteogenesis
+  description: >-
+    Mandibular distraction osteogenesis can be part of staged treatment for
+    severe mandibular and airway-related dentofacial deformity.
+  treatment_term:
+    preferred_term: distraction osteogenesis
+    term:
+      id: MAXO:0000486
+      label: distraction osteogenesis
+  target_phenotypes:
+  - preferred_term: Micrognathia
+    term:
+      id: HP:0000347
+      label: Micrognathia
+  evidence:
+  - reference: PMID:39014351
+    reference_title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sequential therapy with preoperative orthodontic treatment combined with distraction osteogenesis and orthognathic surgery guided by 3D digital technology may be a practical and effective method for treating ARCND."
+    explanation: This directly names distraction osteogenesis as part of effective staged treatment.
+- name: Supportive Airway and Feeding Care
+  description: >-
+    Infants with severe mandibular hypoplasia, microstomia, or respiratory
+    distress require individualized supportive airway, feeding, dental, and
+    craniofacial specialty care.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  target_phenotypes:
+  - preferred_term: Respiratory distress
+    term:
+      id: HP:0002098
+      label: Respiratory distress
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The proband, a 5-day-old male neonate, was referred to our hospital for respiratory distress."
+    explanation: This supports the need to monitor and manage airway complications in severe neonatal presentations.
+- name: Genetic Counseling
+  description: >-
+    Genetic counseling should address autosomal dominant and recessive
+    inheritance, incomplete penetrance, variable expressivity, recurrence risk,
+    and options for prenatal or family testing when a pathogenic variant is
+    known.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: PMID:34789173
+    reference_title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A woman with 30 weeks of gestation was referred to genetic counseling for polyhydramnios and fetal craniofacial anomaly."
+    explanation: This prenatal case supports the relevance of genetic counseling when fetal craniofacial anomalies suggest ACS.
+differential_diagnoses:
+- name: Pierre Robin sequence-plus
+  description: >-
+    Pierre Robin sequence and Pierre Robin sequence-plus overlap through
+    micrognathia and clefting, but question mark ears and mandibular condyle
+    hypoplasia point toward auriculocondylar syndrome.
+  distinguishing_features:
+  - Question mark ears
+  - Mandibular condyle hypoplasia
+  evidence:
+  - reference: PMID:28328130
+    reference_title: "Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "In order to address these questions, we searched for alterations in PLCB4, GNAI3, and EDN1 in patients with typical Auriculocondylar syndrome (n = 3), Pierre Robin sequence-plus (n = 3), micrognathia with additional craniofacial malformations (n = 4), or non-specific auricular dysplasia (n = 1), which could represent subtypes of Auriculocondylar syndrome."
+    explanation: This supports Pierre Robin sequence-plus as part of the clinical differential or spectrum considered in testing.
+animal_models:
+- species: Mouse
+  genotype: Edn1/Ednra/Ece1 pathway loss-of-function
+  description: >-
+    Mouse endothelin pathway disruption produces mandibular patterning defects
+    relevant to the auriculocondylar syndrome mechanism.
+  associated_phenotypes:
+  - Mandibular defects
+  - Neural crest identity loss
+  evidence:
+  - reference: PMID:24268655
+    reference_title: "Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Studies in animal models have indicated the essential role of endothelin 1 (EDN1) signaling through the endothelin receptor type A (EDNRA) in patterning the mandibular portion of the first pharyngeal arch."
+    explanation: This supports the relevance of mouse endothelin-pathway models to mandibular patterning defects.
+- species: Zebrafish
+  genotype: Endothelin signaling disruption
+  description: >-
+    Zebrafish endothelin pathway disruption supports the conserved role of
+    endothelin signaling in mandibular neural crest patterning.
+  associated_phenotypes:
+  - Lower jaw homeosis
+  - Neural crest identity loss
+  evidence:
+  - reference: PMID:24123988
+    reference_title: "Understanding the basis of auriculocondylar syndrome: Insights from human, mouse and zebrafish genetic studies."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Disruption of this signaling pathway in both mouse and zebrafish results in loss of identity of neural crest cells of the mandibular portion of the first pharyngeal arch and the subsequent repatterning of these cells, leading to homeosis of lower jaw structures into more maxillary-like structures."
+    explanation: This directly supports zebrafish as a mechanistic model for jaw patterning defects.

--- a/kb/disorders/Auriculocondylar_Syndrome.yaml
+++ b/kb/disorders/Auriculocondylar_Syndrome.yaml
@@ -24,27 +24,76 @@ disease_term:
 has_subtypes:
 - name: ARCND1
   display_name: ARCND1 (GNAI3-related)
+  subtype_term:
+    preferred_term: ARCND1 (OMIM:602483)
   description: >-
     Usually autosomal dominant auriculocondylar syndrome caused by heterozygous
     GNAI3 variants affecting GDP/GTP-binding motifs and EDN1 pathway signaling.
-- name: ARCND2
-  display_name: ARCND2 (PLCB4-related)
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four subtypes of ARCND have been described so far, that is, ARCND1 (OMIM # 602483), ARCND2 (ARCND2A, OMIM # 614669; ARCND2B, OMIM # 620458), ARCND3 (OMIM # 615706), and ARCND4 (OMIM # 620457)."
+    explanation: This identifies ARCND1 and its OMIM identifier.
+- name: ARCND2A
+  display_name: ARCND2A (PLCB4-related, autosomal dominant)
+  subtype_term:
+    preferred_term: ARCND2A (OMIM:614669)
   description: >-
-    PLCB4-related auriculocondylar syndrome includes autosomal dominant
-    heterozygous missense variants and rarer autosomal recessive loss-of-function
-    mechanisms.
+    Autosomal dominant PLCB4-related auriculocondylar syndrome, typically caused
+    by heterozygous missense variants.
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four subtypes of ARCND have been described so far, that is, ARCND1 (OMIM # 602483), ARCND2 (ARCND2A, OMIM # 614669; ARCND2B, OMIM # 620458), ARCND3 (OMIM # 615706), and ARCND4 (OMIM # 620457)."
+    explanation: This identifies ARCND2A and its OMIM identifier.
+- name: ARCND2B
+  display_name: ARCND2B (PLCB4-related, autosomal recessive)
+  subtype_term:
+    preferred_term: ARCND2B (OMIM:620458)
+  description: >-
+    Autosomal recessive PLCB4-related auriculocondylar syndrome caused by
+    biallelic loss-of-function or damaging PLCB4 variants.
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four subtypes of ARCND have been described so far, that is, ARCND1 (OMIM # 602483), ARCND2 (ARCND2A, OMIM # 614669; ARCND2B, OMIM # 620458), ARCND3 (OMIM # 615706), and ARCND4 (OMIM # 620457)."
+    explanation: This identifies ARCND2B and its OMIM identifier.
 - name: ARCND3
   display_name: ARCND3 (EDN1-related)
+  subtype_term:
+    preferred_term: ARCND3 (OMIM:615706)
   description: >-
     EDN1-related disease includes recessive auriculocondylar syndrome and
     dominant isolated question mark ear, depending on the variant and residual
     endothelin 1 activity.
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four subtypes of ARCND have been described so far, that is, ARCND1 (OMIM # 602483), ARCND2 (ARCND2A, OMIM # 614669; ARCND2B, OMIM # 620458), ARCND3 (OMIM # 615706), and ARCND4 (OMIM # 620457)."
+    explanation: This identifies ARCND3 and its OMIM identifier.
 - name: ARCND4
   display_name: ARCND4 (TWIST1 regulatory duplication)
+  subtype_term:
+    preferred_term: ARCND4 (OMIM:620457)
   description: >-
     A regulatory locus caused by a 430 kb duplication involving HDAC9 and
     TWIST1 regulatory elements, altering TWIST1 expression during craniofacial
     development.
+  evidence:
+  - reference: PMID:38618928
+    reference_title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four subtypes of ARCND have been described so far, that is, ARCND1 (OMIM # 602483), ARCND2 (ARCND2A, OMIM # 614669; ARCND2B, OMIM # 620458), ARCND3 (OMIM # 615706), and ARCND4 (OMIM # 620457)."
+    explanation: This identifies ARCND4 and its OMIM identifier.
 inheritance:
 - name: Autosomal dominant
   inheritance_term:
@@ -206,6 +255,9 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "We hypothesize that all GNAI3 variants lead to dominant negative effects."
     explanation: The abstract explicitly supports a dominant-negative interpretation for GNAI3 variants.
+  downstream:
+  - target: EDN1-EDNRA Craniofacial Signaling Disruption
+    description: GNAI3 acts as an intracellular effector in the EDN1-EDNRA developmental signaling pathway.
 - name: PLCB4 Catalytic Domain Dysfunction
   description: >-
     PLCB4 variants include heterozygous missense variants clustered in protein
@@ -236,6 +288,9 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Trio-based whole-exome sequencing identified a novel missense variant of NM_001377142.1:c.1928C>T (NP_001364071.1:p.Ser643Phe) in the PLCB4 gene, which was predicted to impair the local structural stability with a result that the protein function might be affected."
     explanation: A recent neonatal case supports PLCB4 structural and functional disruption in ARCND2.
+  downstream:
+  - target: EDN1-EDNRA Craniofacial Signaling Disruption
+    description: PLCB4 acts as an intracellular effector in the EDN1-EDNRA developmental signaling pathway.
 - name: TWIST1 Regulatory Dosage Disruption
   description: >-
     A 430 kb duplication involving HDAC9 and TWIST1 regulatory elements can
@@ -274,6 +329,9 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: "Our findings support the hypothesis that the 430 kb duplication is causative of the ARCND phenotype in this family and that deregulation of TWIST1 expression during craniofacial development can contribute to the phenotype."
     explanation: The study supports regulatory TWIST1 dosage disruption as an ARCND mechanism.
+  downstream:
+  - target: Cranial Neural Crest Patterning Defect
+    description: TWIST1 regulatory dysregulation impairs neural crest migration and craniofacial differentiation programs.
 phenotypes:
 - name: Question mark ear
   category: Craniofacial
@@ -370,6 +428,23 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Auriculocondylar syndrome (ACS) is a rare, autosomal-dominant craniofacial malformation syndrome characterized by variable micrognathia, temporomandibular joint ankylosis, cleft palate, and a characteristic \"question-mark\" ear malformation."
     explanation: The original PLCB4/GNAI3 discovery paper includes cleft palate among variable clinical features.
+- name: Temporomandibular joint ankylosis
+  category: Craniofacial
+  description: >-
+    Fusion or ankylosis of the temporomandibular joint can restrict jaw opening
+    and is part of the original auriculocondylar syndrome clinical description.
+  phenotype_term:
+    preferred_term: Temporomandibular joint ankylosis
+    term:
+      id: HP:0012478
+      label: Temporomandibular joint ankylosis
+  evidence:
+  - reference: PMID:22560091
+    reference_title: "A human homeotic transformation resulting from mutations in PLCB4 and GNAI3 causes auriculocondylar syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Auriculocondylar syndrome (ACS) is a rare, autosomal-dominant craniofacial malformation syndrome characterized by variable micrognathia, temporomandibular joint ankylosis, cleft palate, and a characteristic \"question-mark\" ear malformation."
+    explanation: This original discovery paper directly lists temporomandibular joint ankylosis as a clinical feature.
 - name: Respiratory distress
   category: Respiratory
   description: Severe neonatal mandibular and oral malformations can present with respiratory distress.
@@ -385,6 +460,29 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "The proband, a 5-day-old male neonate, was referred to our hospital for respiratory distress."
     explanation: A recent neonatal ARCND2 case directly documents respiratory distress.
+- name: Hearing impairment
+  category: Auditory
+  description: >-
+    Hearing impairment can occur in auriculocondylar syndrome, including
+    conductive mechanisms related to middle-ear ossicular malformation.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: PMID:22865651
+    reference_title: "Ossicular fusion and cholesteatoma in auriculo-condylar syndrome: in vivo evidence of arrest of embryogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We describe a 14-year-old male with constricted pinnae, mandibular dysostosis, glossoptosis, a high-arched palate, hearing loss, and cholesteatoma."
+    explanation: This case report directly documents hearing loss in auriculo-condylar syndrome.
+  - reference: PMID:22865651
+    reference_title: "Ossicular fusion and cholesteatoma in auriculo-condylar syndrome: in vivo evidence of arrest of embryogenesis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Computed tomography imaging demonstrated malleoincudal joint ankylosis."
+    explanation: Middle-ear ossicular ankylosis supports a plausible structural basis for conductive hearing impairment.
 - name: Polyhydramnios
   category: Prenatal
   description: Polyhydramnios may accompany severe prenatal mandibular hypoplasia.

--- a/references_cache/PMID_22560091.md
+++ b/references_cache/PMID_22560091.md
@@ -1,0 +1,103 @@
+---
+reference_id: "PMID:22560091"
+title: A human homeotic transformation resulting from mutations in PLCB4 and GNAI3 causes auriculocondylar syndrome.
+authors:
+- Rieder MJ
+- Green GE
+- Park SS
+- Stamper BD
+- Gordon CT
+- Johnson JM
+- Cunniff CM
+- Smith JD
+- Emery SB
+- Lyonnet S
+- Amiel J
+- Holder M
+- Heggie AA
+- Bamshad MJ
+- Nickerson DA
+- Cox TC
+- Hing AV
+- Horst JA
+- Cunningham ML
+journal: Am J Hum Genet
+year: '2012'
+doi: 10.1016/j.ajhg.2012.04.002
+keywords:
+- Amino Acid Sequence
+- Cohort Studies
+- "Ear/abnormalities, physiopathology"
+- "Ear Diseases/genetics, physiopathology"
+- "Endothelin-1/genetics, metabolism"
+- Exome
+- Female
+- "GTP-Binding Protein alpha Subunits, Gi-Go/genetics, metabolism"
+- Gene Expression Regulation
+- "Homeodomain Proteins/genetics, metabolism"
+- Humans
+- Male
+- Molecular Sequence Data
+- Mutation
+- Pedigree
+- Phenotype
+- "Phospholipase C beta/genetics, metabolism"
+- Protein Conformation
+- "Sequence Analysis, RNA"
+content_type: abstract_only
+---
+
+# A human homeotic transformation resulting from mutations in PLCB4 and GNAI3 causes auriculocondylar syndrome.
+**Authors:** Rieder MJ, Green GE, Park SS, Stamper BD, Gordon CT, Johnson JM, Cunniff CM, Smith JD, Emery SB, Lyonnet S, Amiel J, Holder M, Heggie AA, Bamshad MJ, Nickerson DA, Cox TC, Hing AV, Horst JA, Cunningham ML
+**Journal:** Am J Hum Genet (2012)
+**DOI:** [10.1016/j.ajhg.2012.04.002](https://doi.org/10.1016/j.ajhg.2012.04.002)
+
+## Content
+
+1. Am J Hum Genet. 2012 May 4;90(5):907-14. doi: 10.1016/j.ajhg.2012.04.002.
+
+A human homeotic transformation resulting from mutations in PLCB4 and GNAI3 
+causes auriculocondylar syndrome.
+
+Rieder MJ(1), Green GE, Park SS, Stamper BD, Gordon CT, Johnson JM, Cunniff CM, 
+Smith JD, Emery SB, Lyonnet S, Amiel J, Holder M, Heggie AA, Bamshad MJ, 
+Nickerson DA, Cox TC, Hing AV, Horst JA, Cunningham ML.
+
+Author information:
+(1)Department of Genome Sciences, University of Washington, Seattle, WA 98195, 
+USA.
+
+Erratum in
+    Am J Hum Genet. 2012 Aug 10;91(2):397.
+    Am J Hum Genet. 2012 Jun 8;90(6):1116.
+
+Auriculocondylar syndrome (ACS) is a rare, autosomal-dominant craniofacial 
+malformation syndrome characterized by variable micrognathia, temporomandibular 
+joint ankylosis, cleft palate, and a characteristic "question-mark" ear 
+malformation. Careful phenotypic characterization of severely affected probands 
+in our cohort suggested the presence of a mandibular patterning defect resulting 
+in a maxillary phenotype (i.e., homeotic transformation). We used exome 
+sequencing of five probands and identified two novel (exclusive to the patient 
+and/or family studied) missense mutations in PLCB4 and a shared mutation in 
+GNAI3 in two unrelated probands. In confirmatory studies, three additional novel 
+PLCB4 mutations were found in multigenerational ACS pedigrees. All mutations 
+were confirmed by Sanger sequencing, were not present in more than 10,000 
+control chromosomes, and resulted in amino-acid substitutions located in highly 
+conserved protein domains. Additionally, protein-structure modeling demonstrated 
+that all ACS substitutions disrupt the catalytic sites of PLCB4 and GNAI3. We 
+suggest that PLCB4 and GNAI3 are core signaling molecules of the 
+endothelin-1-distal-less homeobox 5 and 6 (EDN1-DLX5/DLX6) pathway. Functional 
+studies demonstrated a significant reduction in downstream DLX5 and DLX6 
+expression in ACS cases in assays using cultured osteoblasts from probands and 
+controls. These results support the role of the previously implicated 
+EDN1-DLX5/6 pathway in regulating mandibular specification in other species, 
+which, when disrupted, results in a maxillary phenotype. This work defines the 
+molecular basis of ACS as a homeotic transformation (mandible to maxilla) in 
+humans.
+
+Copyright © 2012 The American Society of Human Genetics. Published by Elsevier 
+Inc. All rights reserved.
+
+DOI: 10.1016/j.ajhg.2012.04.002
+PMCID: PMC3376493
+PMID: 22560091 [Indexed for MEDLINE]

--- a/references_cache/PMID_22865651.md
+++ b/references_cache/PMID_22865651.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:22865651"
+title: "Ossicular fusion and cholesteatoma in auriculo-condylar syndrome: in vivo evidence of arrest of embryogenesis."
+authors:
+- Propst EJ
+- Ngan BY
+- Mount RJ
+- Martin-Munoz D
+- Blaser S
+- Harrison RV
+- Cushing SL
+- Papsin BC
+journal: Laryngoscope
+year: '2013'
+doi: 10.1002/lary.23492
+keywords:
+- Adolescent
+- "Cholesteatoma, Middle Ear/diagnosis, surgery"
+- "Ear/abnormalities, surgery"
+- "Ear Diseases/diagnosis, surgery"
+- "Ear Ossicles/embryology, pathology, surgery"
+- Humans
+- "Imaging, Three-Dimensional"
+- Male
+- "Tomography, X-Ray Computed"
+- Tympanoplasty
+content_type: abstract_only
+---
+
+# Ossicular fusion and cholesteatoma in auriculo-condylar syndrome: in vivo evidence of arrest of embryogenesis.
+**Authors:** Propst EJ, Ngan BY, Mount RJ, Martin-Munoz D, Blaser S, Harrison RV, Cushing SL, Papsin BC
+**Journal:** Laryngoscope (2013)
+**DOI:** [10.1002/lary.23492](https://doi.org/10.1002/lary.23492)
+
+## Content
+
+1. Laryngoscope. 2013 Feb;123(2):528-32. doi: 10.1002/lary.23492. Epub 2012 Aug
+2.
+
+Ossicular fusion and cholesteatoma in auriculo-condylar syndrome: in vivo 
+evidence of arrest of embryogenesis.
+
+Propst EJ(1), Ngan BY, Mount RJ, Martin-Munoz D, Blaser S, Harrison RV, Cushing 
+SL, Papsin BC.
+
+Author information:
+(1)Department of Otolaryngology-Head and Neck Surgery, The Hospital for Sick 
+Children, Toronto, Canada. evan.propst@utoronto.ca
+
+Auriculo-condylar syndrome (ACS) is a rare condition affecting first branchial 
+arch structures. The types of hearing loss and temporal bone findings in ACS 
+have not been reported. We describe a 14-year-old male with constricted pinnae, 
+mandibular dysostosis, glossoptosis, a high-arched palate, hearing loss, and 
+cholesteatoma. Computed tomography imaging demonstrated malleoincudal joint 
+ankylosis. The fused malleoincudal complex was removed during mastoidectomy for 
+cholesteatoma. Electron microscopy and histopathology of the joint suggested the 
+fusion was congenital. This is the first report of ossicular fusion and 
+cholesteatoma in ACS and the most detailed in vivo evidence of disruption of 
+embryogenesis during malleoincudal joint formation.
+
+Copyright © 2012 The American Laryngological, Rhinological, and Otological 
+Society, Inc.
+
+DOI: 10.1002/lary.23492
+PMID: 22865651 [Indexed for MEDLINE]

--- a/references_cache/PMID_23315542.md
+++ b/references_cache/PMID_23315542.md
@@ -1,0 +1,128 @@
+---
+reference_id: "PMID:23315542"
+title: Heterogeneity of mutational mechanisms and modes of inheritance in auriculocondylar syndrome.
+authors:
+- Gordon CT
+- Vuillot A
+- Marlin S
+- Gerkes E
+- Henderson A
+- AlKindy A
+- Holder-Espinasse M
+- Park SS
+- Omarjee A
+- Sanchis-Borja M
+- Bdira EB
+- Oufadem M
+- Sikkema-Raddatz B
+- Stewart A
+- Palmer R
+- McGowan R
+- Petit F
+- Delobel B
+- Speicher MR
+- Aurora P
+- Kilner D
+- Pellerin P
+- Simon M
+- Bonnefont JP
+- Tobias ES
+- García-Miñaúr S
+- Bitner-Glindzicz M
+- Lindholm P
+- Meijer BA
+- Abadie V
+- Denoyelle F
+- Vazquez MP
+- Rotky-Fast C
+- Couloigner V
+- Pierrot S
+- Manach Y
+- Breton S
+- Hendriks YM
+- Munnich A
+- Jakobsen L
+- Kroisel P
+- Lin A
+- Kaban LB
+- Basel-Vanagaite L
+- Wilson L
+- Cunningham ML
+- Lyonnet S
+- Amiel J
+journal: J Med Genet
+year: '2013'
+doi: 10.1136/jmedgenet-2012-101331
+keywords:
+- Adult
+- Child
+- "Child, Preschool"
+- DNA Mutational Analysis
+- "Ear/abnormalities, pathology"
+- "Ear Diseases/genetics, pathology"
+- Female
+- "GTP-Binding Protein alpha Subunits, Gi-Go/genetics"
+- Genetic Predisposition to Disease
+- Humans
+- Infant
+- Male
+- Mutation
+- Pedigree
+- Phospholipase C beta/genetics
+- Polymerase Chain Reaction
+content_type: abstract_only
+---
+
+# Heterogeneity of mutational mechanisms and modes of inheritance in auriculocondylar syndrome.
+**Authors:** Gordon CT, Vuillot A, Marlin S, Gerkes E, Henderson A, AlKindy A, Holder-Espinasse M, Park SS, Omarjee A, Sanchis-Borja M, Bdira EB, Oufadem M, Sikkema-Raddatz B, Stewart A, Palmer R, McGowan R, Petit F, Delobel B, Speicher MR, Aurora P, Kilner D, Pellerin P, Simon M, Bonnefont JP, Tobias ES, García-Miñaúr S, Bitner-Glindzicz M, Lindholm P, Meijer BA, Abadie V, Denoyelle F, Vazquez MP, Rotky-Fast C, Couloigner V, Pierrot S, Manach Y, Breton S, Hendriks YM, Munnich A, Jakobsen L, Kroisel P, Lin A, Kaban LB, Basel-Vanagaite L, Wilson L, Cunningham ML, Lyonnet S, Amiel J
+**Journal:** J Med Genet (2013)
+**DOI:** [10.1136/jmedgenet-2012-101331](https://doi.org/10.1136/jmedgenet-2012-101331)
+
+## Content
+
+1. J Med Genet. 2013 Mar;50(3):174-86. doi: 10.1136/jmedgenet-2012-101331. Epub 
+2013 Jan 12.
+
+Heterogeneity of mutational mechanisms and modes of inheritance in 
+auriculocondylar syndrome.
+
+Gordon CT(1), Vuillot A, Marlin S, Gerkes E, Henderson A, AlKindy A, 
+Holder-Espinasse M, Park SS, Omarjee A, Sanchis-Borja M, Bdira EB, Oufadem M, 
+Sikkema-Raddatz B, Stewart A, Palmer R, McGowan R, Petit F, Delobel B, Speicher 
+MR, Aurora P, Kilner D, Pellerin P, Simon M, Bonnefont JP, Tobias ES, 
+García-Miñaúr S, Bitner-Glindzicz M, Lindholm P, Meijer BA, Abadie V, Denoyelle 
+F, Vazquez MP, Rotky-Fast C, Couloigner V, Pierrot S, Manach Y, Breton S, 
+Hendriks YM, Munnich A, Jakobsen L, Kroisel P, Lin A, Kaban LB, Basel-Vanagaite 
+L, Wilson L, Cunningham ML, Lyonnet S, Amiel J.
+
+Author information:
+(1)INSERM U781, Tour Lavoisier 2ème étage, Hôpital Necker-Enfants Malades, 149 
+rue de Sèvres, Paris 75015, France. chris.gordon@inserm.fr
+
+BACKGROUND: Auriculocondylar syndrome (ACS) is a rare craniofacial disorder 
+consisting of micrognathia, mandibular condyle hypoplasia and a specific 
+malformation of the ear at the junction between the lobe and helix. Missense 
+heterozygous mutations in the phospholipase C, β 4 (PLCB4) and guanine 
+nucleotide binding protein (G protein), α inhibiting activity polypeptide 3 
+(GNAI3) genes have recently been identified in ACS patients by exome sequencing. 
+These genes are predicted to function within the G protein-coupled endothelin 
+receptor pathway during craniofacial development.
+RESULTS: We report eight additional cases ascribed to PLCB4 or GNAI3 gene 
+lesions, comprising six heterozygous PLCB4 missense mutations, one heterozygous 
+GNAI3 missense mutation and one homozygous PLCB4 intragenic deletion. Certain 
+residues represent mutational hotspots; of the total of 11 ACS PLCB4 missense 
+mutations now described, five disrupt Arg621 and two disrupt Asp360. The narrow 
+distribution of mutations within protein space suggests that the mutations may 
+result in dominantly interfering proteins, rather than haploinsufficiency. The 
+consanguineous parents of the patient with a homozygous PLCB4 deletion each 
+harboured the heterozygous deletion, but did not present the ACS phenotype, 
+further suggesting that ACS is not caused by PLCB4 haploinsufficiency. In 
+addition to ACS, the patient harbouring a homozygous deletion presented with 
+central apnoea, a phenotype that has not been previously reported in ACS 
+patients.
+CONCLUSIONS: These findings indicate that ACS is not only genetically 
+heterogeneous but also an autosomal dominant or recessive condition according to 
+the nature of the PLCB4 gene lesion.
+
+DOI: 10.1136/jmedgenet-2012-101331
+PMID: 23315542 [Indexed for MEDLINE]

--- a/references_cache/PMID_24123988.md
+++ b/references_cache/PMID_24123988.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:24123988"
+title: "Understanding the basis of auriculocondylar syndrome: Insights from human, mouse and zebrafish genetic studies."
+authors:
+- Clouthier DE
+- Passos-Bueno MR
+- Tavares AL
+- Lyonnet S
+- Amiel J
+- Gordon CT
+journal: Am J Med Genet C Semin Med Genet
+year: '2013'
+doi: 10.1002/ajmg.c.31376
+keywords:
+- Animals
+- Body Patterning/genetics
+- "Branchial Region/growth & development, physiopathology"
+- "Disease Models, Animal"
+- "Ear/abnormalities, physiopathology"
+- "Ear Diseases/genetics, physiopathology"
+- Face/pathology
+- "Gene Expression Regulation, Developmental"
+- Humans
+- "Mandible/growth & development, pathology"
+- Maxillofacial Development/genetics
+- Mice
+- "Neural Crest/growth & development, pathology"
+- Signal Transduction
+- Zebrafish
+content_type: abstract_only
+---
+
+# Understanding the basis of auriculocondylar syndrome: Insights from human, mouse and zebrafish genetic studies.
+**Authors:** Clouthier DE, Passos-Bueno MR, Tavares AL, Lyonnet S, Amiel J, Gordon CT
+**Journal:** Am J Med Genet C Semin Med Genet (2013)
+**DOI:** [10.1002/ajmg.c.31376](https://doi.org/10.1002/ajmg.c.31376)
+
+## Content
+
+1. Am J Med Genet C Semin Med Genet. 2013 Nov;163C(4):306-17. doi: 
+10.1002/ajmg.c.31376. Epub 2013 Oct 4.
+
+Understanding the basis of auriculocondylar syndrome: Insights from human, mouse 
+and zebrafish genetic studies.
+
+Clouthier DE, Passos-Bueno MR, Tavares AL, Lyonnet S, Amiel J, Gordon CT.
+
+Among human birth defect syndromes, malformations affecting the face are perhaps 
+the most striking due to cultural and psychological expectations of facial 
+shape. One such syndrome is auriculocondylar syndrome (ACS), in which patients 
+present with defects in ear and mandible development. Affected structures arise 
+from cranial neural crest cells, a population of cells in the embryo that reside 
+in the pharyngeal arches and give rise to most of the bone, cartilage and 
+connective tissue of the face. Recent studies have found that most cases of ACS 
+arise from defects in signaling molecules associated with the endothelin 
+signaling pathway. Disruption of this signaling pathway in both mouse and 
+zebrafish results in loss of identity of neural crest cells of the mandibular 
+portion of the first pharyngeal arch and the subsequent repatterning of these 
+cells, leading to homeosis of lower jaw structures into more maxillary-like 
+structures. These findings illustrate the importance of endothelin signaling in 
+normal human craniofacial development and illustrate how clinical and basic 
+science approaches can coalesce to improve our understanding of the genetic 
+basis of human birth defect syndromes. Further, understanding the genetic basis 
+for ACS that lies outside of known endothelin signaling components may help 
+elucidate unknown aspects critical to the establishment of neural crest cell 
+patterning during facial morphogenesis.
+
+© 2013 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.c.31376
+PMCID: PMC4038158
+PMID: 24123988 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have no conflict of interest to 
+declare.

--- a/references_cache/PMID_24268655.md
+++ b/references_cache/PMID_24268655.md
@@ -1,0 +1,101 @@
+---
+reference_id: "PMID:24268655"
+title: Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears.
+authors:
+- Gordon CT
+- Petit F
+- Kroisel PM
+- Jakobsen L
+- Zechi-Ceide RM
+- Oufadem M
+- Bole-Feysot C
+- Pruvost S
+- Masson C
+- Tores F
+- Hieu T
+- Nitschké P
+- Lindholm P
+- Pellerin P
+- Guion-Almeida ML
+- Kokitsu-Nakata NM
+- Vendramini-Pittoli S
+- Munnich A
+- Lyonnet S
+- Holder-Espinasse M
+- Amiel J
+journal: Am J Hum Genet
+year: '2013'
+doi: 10.1016/j.ajhg.2013.10.023
+keywords:
+- Amino Acid Sequence
+- Amino Acid Substitution
+- DNA Mutational Analysis
+- Ear/abnormalities
+- "Ear Diseases/diagnosis, genetics, metabolism"
+- "Endothelin-1/genetics, metabolism"
+- Female
+- "Genes, Dominant"
+- "Genes, Recessive"
+- Genotype
+- Humans
+- Male
+- Molecular Sequence Data
+- Mutation
+- Pedigree
+- Phenotype
+- Sequence Alignment
+- Signal Transduction
+content_type: abstract_only
+---
+
+# Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears.
+**Authors:** Gordon CT, Petit F, Kroisel PM, Jakobsen L, Zechi-Ceide RM, Oufadem M, Bole-Feysot C, Pruvost S, Masson C, Tores F, Hieu T, Nitschké P, Lindholm P, Pellerin P, Guion-Almeida ML, Kokitsu-Nakata NM, Vendramini-Pittoli S, Munnich A, Lyonnet S, Holder-Espinasse M, Amiel J
+**Journal:** Am J Hum Genet (2013)
+**DOI:** [10.1016/j.ajhg.2013.10.023](https://doi.org/10.1016/j.ajhg.2013.10.023)
+
+## Content
+
+1. Am J Hum Genet. 2013 Dec 5;93(6):1118-25. doi: 10.1016/j.ajhg.2013.10.023.
+Epub  2013 Nov 21.
+
+Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant 
+isolated question-mark ears.
+
+Gordon CT(1), Petit F, Kroisel PM, Jakobsen L, Zechi-Ceide RM, Oufadem M, 
+Bole-Feysot C, Pruvost S, Masson C, Tores F, Hieu T, Nitschké P, Lindholm P, 
+Pellerin P, Guion-Almeida ML, Kokitsu-Nakata NM, Vendramini-Pittoli S, Munnich 
+A, Lyonnet S, Holder-Espinasse M, Amiel J.
+
+Author information:
+(1)Institut National de la Santé et de la Recherche Médicale U781, Hôpital 
+Necker - Enfants Malades, 75015 Paris, France; Université Paris Descartes - 
+Sorbonne Paris Cité, Institut Imagine, 75015 Paris, France. Electronic address: 
+chris.gordon@inserm.fr.
+
+Auriculocondylar syndrome (ACS) is a rare craniofacial disorder with mandibular 
+hypoplasia and question-mark ears (QMEs) as major features. QMEs, consisting of 
+a specific defect at the lobe-helix junction, can also occur as an isolated 
+anomaly. Studies in animal models have indicated the essential role of 
+endothelin 1 (EDN1) signaling through the endothelin receptor type A (EDNRA) in 
+patterning the mandibular portion of the first pharyngeal arch. Mutations in the 
+genes coding for phospholipase C, beta 4 (PLCB4) and guanine nucleotide binding 
+protein (G protein), alpha inhibiting activity polypeptide 3 (GNAI3), predicted 
+to function as signal transducers downstream of EDNRA, have recently been 
+reported in ACS. By whole-exome sequencing (WES), we identified a homozygous 
+substitution in a furin cleavage site of the EDN1 proprotein in ACS-affected 
+siblings born to consanguineous parents. WES of two cases with vertical 
+transmission of isolated QMEs revealed a stop mutation in EDN1 in one family and 
+a missense substitution of a highly conserved residue in the mature EDN1 peptide 
+in the other. Targeted sequencing of EDN1 in an ACS individual with related 
+parents identified a fourth, homozygous mutation falling close to the site of 
+cleavage by endothelin-converting enzyme. The different modes of inheritance 
+suggest that the degree of residual EDN1 activity differs depending on the 
+mutation. These findings provide further support for the hypothesis that ACS and 
+QMEs are uniquely caused by disruption of the EDN1-EDNRA signaling pathway.
+
+Copyright © 2013 The American Society of Human Genetics. Published by Elsevier 
+Inc. All rights reserved.
+
+DOI: 10.1016/j.ajhg.2013.10.023
+PMCID: PMC3853412
+PMID: 24268655 [Indexed for MEDLINE]

--- a/references_cache/PMID_25026904.md
+++ b/references_cache/PMID_25026904.md
@@ -1,0 +1,101 @@
+---
+reference_id: "PMID:25026904"
+title: Novel variants in GNAI3 associated with auriculocondylar syndrome strengthen a common dominant negative effect.
+authors:
+- Romanelli Tavares VL
+- Gordon CT
+- Zechi-Ceide RM
+- Kokitsu-Nakata NM
+- Voisin N
+- Tan TY
+- Heggie AA
+- Vendramini-Pittoli S
+- Propst EJ
+- Papsin BC
+- Torres TT
+- Buermans H
+- Capelo LP
+- den Dunnen JT
+- Guion-Almeida ML
+- Lyonnet S
+- Amiel J
+- Passos-Bueno MR
+journal: Eur J Hum Genet
+year: '2015'
+doi: 10.1038/ejhg.2014.132
+keywords:
+- Branchial Region/metabolism
+- Brazil
+- Ear/abnormalities
+- "Ear Diseases/diagnosis, genetics"
+- Female
+- "GTP-Binding Protein alpha Subunits, Gi-Go/genetics"
+- Genetic Variation
+- Humans
+- Male
+- Pedigree
+- Phenotype
+- Protein Conformation
+content_type: abstract_only
+---
+
+# Novel variants in GNAI3 associated with auriculocondylar syndrome strengthen a common dominant negative effect.
+**Authors:** Romanelli Tavares VL, Gordon CT, Zechi-Ceide RM, Kokitsu-Nakata NM, Voisin N, Tan TY, Heggie AA, Vendramini-Pittoli S, Propst EJ, Papsin BC, Torres TT, Buermans H, Capelo LP, den Dunnen JT, Guion-Almeida ML, Lyonnet S, Amiel J, Passos-Bueno MR
+**Journal:** Eur J Hum Genet (2015)
+**DOI:** [10.1038/ejhg.2014.132](https://doi.org/10.1038/ejhg.2014.132)
+
+## Content
+
+1. Eur J Hum Genet. 2015 Apr;23(4):481-5. doi: 10.1038/ejhg.2014.132. Epub 2014
+Jul  16.
+
+Novel variants in GNAI3 associated with auriculocondylar syndrome strengthen a 
+common dominant negative effect.
+
+Romanelli Tavares VL(1), Gordon CT(2), Zechi-Ceide RM(3), Kokitsu-Nakata NM(3), 
+Voisin N(2), Tan TY(4), Heggie AA(5), Vendramini-Pittoli S(3), Propst EJ(6), 
+Papsin BC(6), Torres TT(7), Buermans H(8), Capelo LP(9), den Dunnen JT(8), 
+Guion-Almeida ML(3), Lyonnet S(10), Amiel J(10), Passos-Bueno MR(1).
+
+Author information:
+(1)Centro de Pesquisas do Genoma Humano e Células Tronco, Departamento de 
+Genetica e Biologia Evolutiva, Instituto de Biociências, Universidade de São 
+Paulo, São Paulo, Brazil.
+(2)INSERM U1163, Université Paris Descartes-Sorbonne Paris Cité, Institut 
+Imagine, Paris, France.
+(3)Department of Clinical Genetics, Hospital of Rehabilitation of Craniofacial 
+Anomalies, University of São Paulo (HRCA-USP), Bauru, Brazil.
+(4)Victorian Clinical Genetics Services, Murdoch Children's Research Institute, 
+Royal Children's Hospital, and Department of Paediatrics, University of 
+Melbourne, Melbourne, Victoria, Australia.
+(5)Department of Plastic and Maxillofacial Surgery, Royal Children's Hospital, 
+Melbourne, Victoria, Australia.
+(6)Department of Otolaryngology - Head & Neck Surgery, The Hospital for Sick 
+Children, Toronto, Ontario, Canada.
+(7)Institute of Biosciences, University of São Paulo, São Paulo, Brazil.
+(8)Leiden Genome Technology Center, Leiden University Medical Center, Leiden, 
+The Netherlands.
+(9)1] Centro de Pesquisas do Genoma Humano e Células Tronco, Departamento de 
+Genetica e Biologia Evolutiva, Instituto de Biociências, Universidade de São 
+Paulo, São Paulo, Brazil [2] Instituto de Ciência e Tecnologia, Universidade 
+Federal de São Paulo, São José dos Campos, Brazil.
+(10)1] INSERM U1163, Université Paris Descartes-Sorbonne Paris Cité, Institut 
+Imagine, Paris, France [2] Département de Génétique, Hôpital Necker-Enfants 
+Malades AP-HP, Paris, France.
+
+Auriculocondylar syndrome is a rare craniofacial disorder comprising core 
+features of micrognathia, condyle dysplasia and question mark ear. Causative 
+variants have been identified in PLCB4, GNAI3 and EDN1, which are predicted to 
+function within the EDN1-EDNRA pathway during early pharyngeal arch patterning. 
+To date, two GNAI3 variants in three families have been reported. Here we report 
+three novel GNAI3 variants, one segregating with affected members in a family 
+previously linked to 1p21.1-q23.3 and two de novo variants in simplex cases. Two 
+variants occur in known functional motifs, the G1 and G4 boxes, and the third 
+variant is one amino acid outside of the G1 box. Structural modeling shows that 
+all five altered GNAI3 residues identified to date cluster in a region involved 
+in GDP/GTP binding. We hypothesize that all GNAI3 variants lead to dominant 
+negative effects.
+
+DOI: 10.1038/ejhg.2014.132
+PMCID: PMC4666574
+PMID: 25026904 [Indexed for MEDLINE]

--- a/references_cache/PMID_28328130.md
+++ b/references_cache/PMID_28328130.md
@@ -1,0 +1,113 @@
+---
+reference_id: "PMID:28328130"
+title: Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome.
+authors:
+- Romanelli Tavares VL
+- Zechi-Ceide RM
+- Bertola DR
+- Gordon CT
+- Ferreira SG
+- Hsia GS
+- Yamamoto GL
+- Ezquina SA
+- Kokitsu-Nakata NM
+- Vendramini-Pittoli S
+- Freitas RS
+- Souza J
+- Raposo-Amaral CA
+- Zatz M
+- Amiel J
+- Guion-Almeida ML
+- Passos-Bueno MR
+journal: Am J Med Genet A
+year: '2017'
+doi: 10.1002/ajmg.a.38101
+keywords:
+- Adult
+- Child
+- "Ear/abnormalities, pathology"
+- "Ear Diseases/classification, diagnosis, genetics, pathology"
+- Endothelin-1/genetics
+- Female
+- "GTP-Binding Protein alpha Subunits, Gi-Go/genetics"
+- Gene Expression
+- "Genes, Dominant"
+- Genetic Predisposition to Disease
+- High-Throughput Nucleotide Sequencing
+- Humans
+- Male
+- "Micrognathism/classification, diagnosis, genetics, pathology"
+- Mutation
+- Pedigree
+- Phenotype
+- Phospholipase C beta/genetics
+- "Pierre Robin Syndrome/classification, diagnosis, genetics, pathology"
+- Terminology as Topic
+content_type: abstract_only
+---
+
+# Targeted molecular investigation in patients within the clinical spectrum of Auriculocondylar syndrome.
+**Authors:** Romanelli Tavares VL, Zechi-Ceide RM, Bertola DR, Gordon CT, Ferreira SG, Hsia GS, Yamamoto GL, Ezquina SA, Kokitsu-Nakata NM, Vendramini-Pittoli S, Freitas RS, Souza J, Raposo-Amaral CA, Zatz M, Amiel J, Guion-Almeida ML, Passos-Bueno MR
+**Journal:** Am J Med Genet A (2017)
+**DOI:** [10.1002/ajmg.a.38101](https://doi.org/10.1002/ajmg.a.38101)
+
+## Content
+
+1. Am J Med Genet A. 2017 Apr;173(4):938-945. doi: 10.1002/ajmg.a.38101.
+
+Targeted molecular investigation in patients within the clinical spectrum of 
+Auriculocondylar syndrome.
+
+Romanelli Tavares VL(1), Zechi-Ceide RM(2), Bertola DR(1)(3), Gordon CT(4)(5), 
+Ferreira SG(1), Hsia GS(1), Yamamoto GL(1)(3), Ezquina SA(1), Kokitsu-Nakata 
+NM(2), Vendramini-Pittoli S(2), Freitas RS(6), Souza J(6), Raposo-Amaral CA(7), 
+Zatz M(1), Amiel J(4)(5)(8), Guion-Almeida ML(2), Passos-Bueno MR(1).
+
+Author information:
+(1)Centro de Pesquisas Sobre o Genoma Humano e Células-Tronco, Departamento de 
+Genética e Biologia Evolutiva, Instituto de Biociências, Universidade de São 
+Paulo, São Paulo, São Paulo, Brazil.
+(2)Departamento de Genética Clínica, Hospital de Reabilitação de Anomalias 
+Craniofaciais, Universidade de São Paulo (HRAC-USP), Bauru, São Paulo, Brazil.
+(3)Instituto da Criança do Hospital das Clínicas da Faculdade de Medicina da 
+USP, São Paulo, São Paulo, Brazil.
+(4)Laboratory of Embryology and Genetics of Congenital Malformations, Institut 
+National de la Santé et de la Recherche Médicale (INSERM) U11163, Institut 
+Imagine, Paris, France.
+(5)Paris Descartes-Sorbonne Paris Cité University, Institut Imagine, Paris, 
+France.
+(6)Centro de Atendimento Integral ao Fissurado Lábio Palatal (CAIF), Curitiba, 
+Paraná, Brazil.
+(7)Hospital de Crânio e Face, Sociedade Brasileira de Pesquisa e Assistência 
+para Reabilitação Craniofacial (SOBRAPAR), Campinas, São Paulo, Brazil.
+(8)Département de Génétique, Hôpital Necker-Enfants Malades, Assistance 
+Publique-Hôpitaux de Paris, Paris, France.
+
+Auriculocondylar syndrome, mainly characterized by micrognathia, small 
+mandibular condyle, and question mark ears, is a rare disease segregating in an 
+autosomal dominant pattern in the majority of the families reported in the 
+literature. So far, pathogenic variants in PLCB4, GNAI3, and EDN1 have been 
+associated with this syndrome. It is caused by a developmental abnormality of 
+the first and second pharyngeal arches and it is associated with great inter- 
+and intra-familial clinical variability, with some patients not presenting the 
+typical phenotype of the syndrome. Moreover, only a few patients of each 
+molecular subtype of Auriculocondylar syndrome have been reported and sequenced. 
+Therefore, the spectrum of clinical and genetic variability is still not 
+defined. In order to address these questions, we searched for alterations in 
+PLCB4, GNAI3, and EDN1 in patients with typical Auriculocondylar syndrome 
+(n = 3), Pierre Robin sequence-plus (n = 3), micrognathia with additional 
+craniofacial malformations (n = 4), or non-specific auricular dysplasia (n = 1), 
+which could represent subtypes of Auriculocondylar syndrome. We found novel 
+pathogenic variants in PLCB4 only in two of three index patients with typical 
+Auriculocondylar syndrome. We also performed a detailed comparative analysis of 
+the patients presented in this study with those previously published, which 
+showed that the pattern of auricular abnormality and full cheeks were associated 
+with molecularly characterized individuals with Auriculocondylar syndrome. 
+Finally, our data contribute to a better definition of a set of parameters for 
+clinical classification that may be used as a guidance for geneticists ordering 
+molecular testing for Auriculocondylar syndrome. © 2017 Wiley Periodicals, Inc.
+
+© 2017 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.a.38101
+PMID: 28328130 [Indexed for MEDLINE]

--- a/references_cache/PMID_34750192.md
+++ b/references_cache/PMID_34750192.md
@@ -1,0 +1,98 @@
+---
+reference_id: "PMID:34750192"
+title: "New locus underlying auriculocondylar syndrome (ARCND): 430 kb duplication involving TWIST1 regulatory elements."
+authors:
+- Romanelli Tavares VL
+- Guimarães-Ramos SL
+- Zhou Y
+- Masotti C
+- Ezquina S
+- Moreira DP
+- Buermans H
+- Freitas RS
+- Den Dunnen JT
+- Twigg SRF
+- Passos-Bueno MR
+journal: J Med Genet
+year: '2022'
+doi: 10.1136/jmedgenet-2021-107825
+keywords:
+- "Ear/abnormalities, pathology"
+- "Ear Diseases/genetics, pathology"
+- Humans
+- Nuclear Proteins/genetics
+- Osteogenesis
+- "Regulatory Sequences, Nucleic Acid"
+- Twist-Related Protein 1/genetics
+content_type: abstract_only
+---
+
+# New locus underlying auriculocondylar syndrome (ARCND): 430 kb duplication involving TWIST1 regulatory elements.
+**Authors:** Romanelli Tavares VL, Guimarães-Ramos SL, Zhou Y, Masotti C, Ezquina S, Moreira DP, Buermans H, Freitas RS, Den Dunnen JT, Twigg SRF, Passos-Bueno MR
+**Journal:** J Med Genet (2022)
+**DOI:** [10.1136/jmedgenet-2021-107825](https://doi.org/10.1136/jmedgenet-2021-107825)
+
+## Content
+
+1. J Med Genet. 2022 Sep;59(9):895-905. doi: 10.1136/jmedgenet-2021-107825. Epub 
+2021 Nov 8.
+
+New locus underlying auriculocondylar syndrome (ARCND): 430 kb duplication 
+involving TWIST1 regulatory elements.
+
+Romanelli Tavares VL(#)(1), Guimarães-Ramos SL(#)(1), Zhou Y(2), Masotti 
+C(1)(3), Ezquina S(1)(4), Moreira DP(1), Buermans H(5), Freitas RS(6), Den 
+Dunnen JT(5), Twigg SRF(7), Passos-Bueno MR(8).
+
+Author information:
+(1)Genética e Biologia Evolutiva, Universidade de São Paulo Instituto de 
+Biociências, Sao Paulo, Brazil.
+(2)Clinical Genetics Group, MRC Weatherall Institute of Molecular Medicine, John 
+Radcliffe Hospital, University of Oxford, Oxford, UK.
+(3)Molecular Oncology Center, Hospital Sírio-Libanês, Sao Paulo, Brazil.
+(4)Centre for Cancer Genetic Epidemiology, University of Cambridge, Cambridge, 
+UK.
+(5)Leiden Genome Technology Center, Leiden University Medical Center, Leiden, 
+The Netherlands.
+(6)Centro de Atendimento Integral ao Fissurado Lábio Palatal, Curitiba, Brazil.
+(7)Clinical Genetics Group, MRC Weatherall Institute of Molecular Medicine, John 
+Radcliffe Hospital, University of Oxford, Oxford, UK passos@ib.usp.br 
+stephen.twigg@imm.ox.ac.uk.
+(8)Genética e Biologia Evolutiva, Universidade de São Paulo Instituto de 
+Biociências, Sao Paulo, Brazil passos@ib.usp.br stephen.twigg@imm.ox.ac.uk.
+(#)Contributed equally
+
+BACKGROUND: Auriculocondylar syndrome (ARCND) is a rare genetic disease that 
+affects structures derived from the first and second pharyngeal arches, mainly 
+resulting in micrognathia and auricular malformations. To date, pathogenic 
+variants have been identified in three genes involved in the EDN1-DLX5/6 pathway 
+(PLCB4, GNAI3 and EDN1) and some cases remain unsolved. Here we studied a large 
+unsolved four-generation family.
+METHODS: We performed linkage analysis, resequencing and Capture-C to 
+investigate the causative variant of this family. To test the pathogenicity of 
+the CNV found, we modelled the disease in patient craniofacial progenitor cells, 
+including induced pluripotent cell (iPSC)-derived neural crest and mesenchymal 
+cells.
+RESULTS: This study highlights a fourth locus causative of ARCND, represented by 
+a tandem duplication of 430 kb in a candidate region on chromosome 7 defined by 
+linkage analysis. This duplication segregates with the disease in the family 
+(LOD score=2.88) and includes HDAC9, which is located over 200 kb telomeric to 
+the top candidate gene TWIST1. Notably, Capture-C analysis revealed multiple cis 
+interactions between the TWIST1 promoter and possible regulatory elements within 
+the duplicated region. Modelling of the disease revealed an increased expression 
+of HDAC9 and its neighbouring gene, TWIST1, in neural crest cells. We also 
+identified decreased migration of iPSC-derived neural crest cells together with 
+dysregulation of osteogenic differentiation in iPSC-affected mesenchymal stem 
+cells.
+CONCLUSION: Our findings support the hypothesis that the 430 kb duplication is 
+causative of the ARCND phenotype in this family and that deregulation of TWIST1 
+expression during craniofacial development can contribute to the phenotype.
+
+© Author(s) (or their employer(s)) 2022. Re-use permitted under CC BY. Published 
+by BMJ.
+
+DOI: 10.1136/jmedgenet-2021-107825
+PMCID: PMC9411924
+PMID: 34750192 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None declared.

--- a/references_cache/PMID_34789173.md
+++ b/references_cache/PMID_34789173.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:34789173"
+title: "Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report."
+authors:
+- Liu X
+- Sun W
+- Wang J
+- Chu G
+- He R
+- Zhang B
+- Zhao Y
+journal: BMC Pregnancy Childbirth
+year: '2021'
+doi: 10.1186/s12884-021-04238-x
+keywords:
+- Adult
+- "Ear/abnormalities, diagnostic imaging"
+- "Ear Diseases/diagnosis, genetics"
+- Female
+- "Fetal Diseases/diagnosis, genetics"
+- "GTP-Binding Protein alpha Subunits, G12-G13/genetics"
+- Humans
+- Micrognathism/diagnostic imaging
+- "Mutation, Missense"
+- Phenotype
+- Polyhydramnios/diagnostic imaging
+- Pregnancy
+- Prenatal Diagnosis
+content_type: abstract_only
+---
+
+# Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of GNAI3: a case report.
+**Authors:** Liu X, Sun W, Wang J, Chu G, He R, Zhang B, Zhao Y
+**Journal:** BMC Pregnancy Childbirth (2021)
+**DOI:** [10.1186/s12884-021-04238-x](https://doi.org/10.1186/s12884-021-04238-x)
+
+## Content
+
+1. BMC Pregnancy Childbirth. 2021 Nov 17;21(1):780. doi: 
+10.1186/s12884-021-04238-x.
+
+Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of 
+GNAI3: a case report.
+
+Liu X(1), Sun W(2), Wang J(3), Chu G(1), He R(1), Zhang B(1), Zhao Y(4).
+
+Author information:
+(1)Department of Clinical Genetics, Shengjing Hospital of China Medical 
+University, Shenyang, China.
+(2)Department of Ultrasonography, Shengjing Hospital of China Medical 
+University, Shenyang, China.
+(3)Department of Obstetrics and Gynecology, Shengjing Hospital of China Medical 
+University, Shenyang, China.
+(4)Department of Clinical Genetics, Shengjing Hospital of China Medical 
+University, Shenyang, China. yyzhao@sj-hospital.org.
+
+BACKGROUND: Auriculocondylar syndrome (ACS) is a rare disorder characterized by 
+micrognathia, mandibular condyle hypoplasia, and auricular abnormalities. Only 6 
+pathogenic variants of GNAI3 have been identified associated with ACS so far. 
+Here, we report a case of prenatal genetic diagnosis of ACS carrying a novel 
+GNAI3 variant.
+CASE PRESENTATION: A woman with 30 weeks of gestation was referred to genetic 
+counseling for polyhydramnios and fetal craniofacial anomaly. Severe 
+micrognathia and mandibular hypoplasia were identified on ultrasonography. The 
+mandibular length was 2.4 cm, which was markedly smaller than the 95th 
+percentile. The ears were low-set with no cleft or notching between the lobe and 
+helix. The face was round with prominent cheeks. Whole-exome sequencing 
+identified a novel de novo missense variant of c.140G > A in the GNAI3 gene. 
+This mutation caused an amino acid substitution of p.Ser47Asn in the highly 
+conserved G1 motif, which was predicted to impair the guanine nucleotide-binding 
+function. All ACS cases with GNAI3 mutations were literature reviewed, revealing 
+female-dominated severe cases and right-side-prone deformities.
+CONCLUSION: Severe micrognathia and mandibular hypoplasia accompanied by 
+polyhydramnios are prenatal indicators of ACS. We expanded the mutation spectrum 
+of GNAI3 and summarized clinical features to promote awareness of ACS.
+
+© 2021. The Author(s).
+
+DOI: 10.1186/s12884-021-04238-x
+PMCID: PMC8597305
+PMID: 34789173 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_35170830.md
+++ b/references_cache/PMID_35170830.md
@@ -1,0 +1,152 @@
+---
+reference_id: "PMID:35170830"
+title: Further delineation of auriculocondylar syndrome based on 14 novel cases and reassessment of 25 published cases.
+authors:
+- Vegas N
+- Demir Z
+- Gordon CT
+- Breton S
+- Romanelli Tavares VL
+- Moisset H
+- Zechi-Ceide R
+- Kokitsu-Nakata NM
+- Kido Y
+- Marlin S
+- Gherbi Halem S
+- Meerschaut I
+- Callewaert B
+- Chung B
+- Revencu N
+- Lehalle D
+- Petit F
+- Propst EJ
+- Papsin BC
+- Phillips JH
+- Jakobsen L
+- Le Tanno P
+- Thévenon J
+- McGaughran J
+- Gerkes EH
+- Leoni C
+- Kroisel P
+- Tan TY
+- Henderson A
+- Terhal P
+- Basel-Salmon L
+- Alkindy A
+- White SM
+- Passos-Bueno MR
+- Pingault V
+- De Pontual L
+- Amiel J
+journal: Hum Mutat
+year: '2022'
+doi: 10.1002/humu.24349
+keywords:
+- Ear/abnormalities
+- Ear Diseases/genetics
+- Humans
+- Pedigree
+- Phenotype
+content_type: abstract_only
+---
+
+# Further delineation of auriculocondylar syndrome based on 14 novel cases and reassessment of 25 published cases.
+**Authors:** Vegas N, Demir Z, Gordon CT, Breton S, Romanelli Tavares VL, Moisset H, Zechi-Ceide R, Kokitsu-Nakata NM, Kido Y, Marlin S, Gherbi Halem S, Meerschaut I, Callewaert B, Chung B, Revencu N, Lehalle D, Petit F, Propst EJ, Papsin BC, Phillips JH, Jakobsen L, Le Tanno P, Thévenon J, McGaughran J, Gerkes EH, Leoni C, Kroisel P, Tan TY, Henderson A, Terhal P, Basel-Salmon L, Alkindy A, White SM, Passos-Bueno MR, Pingault V, De Pontual L, Amiel J
+**Journal:** Hum Mutat (2022)
+**DOI:** [10.1002/humu.24349](https://doi.org/10.1002/humu.24349)
+
+## Content
+
+1. Hum Mutat. 2022 May;43(5):582-594. doi: 10.1002/humu.24349. Epub 2022 Mar 7.
+
+Further delineation of auriculocondylar syndrome based on 14 novel cases and 
+reassessment of 25 published cases.
+
+Vegas N(1), Demir Z(1)(2), Gordon CT(1), Breton S(3), Romanelli Tavares VL(4), 
+Moisset H(1), Zechi-Ceide R(5), Kokitsu-Nakata NM(5), Kido Y(6), Marlin S(1)(7), 
+Gherbi Halem S(7), Meerschaut I(8), Callewaert B(8), Chung B(9), Revencu N(10), 
+Lehalle D(11)(12), Petit F(13), Propst EJ(14), Papsin BC(14), Phillips JH(14), 
+Jakobsen L(15), Le Tanno P(16), Thévenon J(16), McGaughran J(17), Gerkes EH(18), 
+Leoni C(19), Kroisel P(20), Tan TY(21), Henderson A(22), Terhal P(23), 
+Basel-Salmon L(24)(25)(26), Alkindy A(27), White SM(21), Passos-Bueno MR(4), 
+Pingault V(1)(28), De Pontual L(1)(29), Amiel J(1)(28).
+
+Author information:
+(1)Laboratory of Embryology and Genetics of Malformations, Institut National de 
+la Santé et de la Recherche Médicale (INSERM) UMR 1163, Institut Imagine, 
+Université de Paris, Paris, France.
+(2)Unité d'hépatologie Pédiatrie et Transplantation, Hôpital Necker-Enfants 
+Malades, AP-HP, Paris, France.
+(3)Service d'imagerie Pédiatrie, Hôpital Necker-Enfants Malades, AP-HP, Paris, 
+France.
+(4)Departamento de Genetica e Biología Evolutiva, Centro de Pesquisas do Genoma 
+Humano e Celulas Tronco, Instituto de Biociencias, Universidade de Sao Paulo, 
+Sao Paulo, Brazil.
+(5)Department of Clinical Genetics, Hospital for Rehabilitation of Craniofacial 
+Anomalies, University of Sao Paulo, Bauru, Brazil.
+(6)Department of Pediatrics, Dokkyo Medical University Koshigaya Hospital, 
+Saitama, Japan.
+(7)Reference Center for Genetic Hearing Loss, Fédération de Génétique et de 
+Médecine Génomique, Hôpital Necker, APHP.CUP, Paris, France.
+(8)Department of Biomolecular Medicine, Center for Medical Genetics, Ghent 
+University Hospital, Ghent University, Ghent, Belgium.
+(9)Department of Paediatrics and Adolescent Medicine, The University of Hong 
+Kong, Hong Kong, Hong Kong.
+(10)Center for Human Genetics, Cliniques Universitaires Saint Luc, Université 
+Catholique de Louvain, Brussels, Belgium.
+(11)Centre de Génétique-Centre de Référence des Maladies Rares, Anomalies du 
+Développement et Syndrome Malformatifs, Centre Hospitalo-Universitaire de Dijon, 
+Bourgogne, France.
+(12)Département de Génétique, UF de Génétique Médicale, Groupe Hospitalier 
+Pitié-Salpêtrière, APHP Sorbonne Université, Paris, France.
+(13)CHU Lille, Clinique de Génétique Guy Fontaine, Lille, France.
+(14)Department of Otolaryngology-Head and Neck Surgery, The Hospital for Sick 
+Children, University of Toronto, Canada.
+(15)Department of Plastic Surgery, Copenhagen University Hospital, Herlev, 
+Denmark.
+(16)Service de Génétique et Université Grenoble-Alpes, Grenoble, France.
+(17)Genetic Health Queensland, Royal Brisbane and Women's Hospital, Herston and 
+the University of Queensland, St Lucia, Brisbane, Australia.
+(18)Department of Genetics, University Medical Center Groningen, University of 
+Groningen, Groningen, The Netherlands.
+(19)Department of Woman and Child Health and Public Health, Center for Rare 
+Diseases and Birth Defects, Fondazione Policlinico A. Gemelli, IRCCS, Rome, 
+Italy.
+(20)Institute of Human Genetics, Medical University of Graz, Graz, Austria.
+(21)Victorian Clinical Genetics Services, Murdoch Children's Research Institute, 
+Royal Children's Hospital, and Department of Paediatrics, University of 
+Melbourne, Melbourne, Australia.
+(22)Northern Genetics Service, Newcastle upon Tyne Hospitals NHS Foundation 
+Trust, Newcastle Upon Tyne, UK.
+(23)Department of Medical Genetics, University Medical Centre Utrecht, Utrecht, 
+The Netherlands.
+(24)Pediatric Genetics, Schneider Children's Medical Center of Israel and 
+Raphael Recanati Genetics Institute, Rabin Medical Center, Beilinson Campus, 
+Petah Tikva, Israel.
+(25)Sackler Faculty of Medicine, Tel Aviv University, Tel Aviv, Israel.
+(26)Felsenstein Medical Research Center, Rabin Medical Center, Petah Tikva, 
+Israel.
+(27)Department of Genetics, Sultan Qaboos University Hospital, Muscat, Oman.
+(28)Fédération de Génétique et de Médecine Génomique, Hôpital Necker, APHP.CUP, 
+Paris, France.
+(29)Service de Pédiatrie, Hôpital Jean Verdier, Bondy, France.
+
+Auriculocondylar syndrome (ACS) is a rare craniofacial disorder characterized by 
+mandibular hypoplasia and an auricular defect at the junction between the lobe 
+and helix, known as a "Question Mark Ear" (QME). Several additional features, 
+originating from the first and second branchial arches and other tissues, have 
+also been reported. ACS is genetically heterogeneous with autosomal dominant and 
+recessive modes of inheritance. The mutations identified to date are presumed to 
+dysregulate the endothelin 1 signaling pathway. Here we describe 14 novel cases 
+and reassess 25 published cases of ACS through a questionnaire for systematic 
+data collection. All patients harbor mutation(s) in PLCB4, GNAI3, or EDN1. This 
+series of patients contributes to the characterization of additional features 
+occasionally associated with ACS such as respiratory, costal, 
+neurodevelopmental, and genital anomalies, and provides management and 
+monitoring recommendations.
+
+© 2022 Wiley Periodicals LLC.
+
+DOI: 10.1002/humu.24349
+PMID: 35170830 [Indexed for MEDLINE]

--- a/references_cache/PMID_38618928.md
+++ b/references_cache/PMID_38618928.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:38618928"
+title: "Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature."
+authors:
+- Zhang Y
+- Zhao Y
+- Dai L
+- Liu Y
+- Shi Z
+journal: Mol Genet Genomic Med
+year: '2024'
+doi: 10.1002/mgg3.2441
+keywords:
+- Humans
+- "Infant, Newborn"
+- Male
+- China
+- Ear/abnormalities
+- Ear Diseases
+- Micrognathism
+- Phospholipase C beta
+- East Asian People
+content_type: abstract_only
+---
+
+# Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese neonate: A case report and review of the literature.
+**Authors:** Zhang Y, Zhao Y, Dai L, Liu Y, Shi Z
+**Journal:** Mol Genet Genomic Med (2024)
+**DOI:** [10.1002/mgg3.2441](https://doi.org/10.1002/mgg3.2441)
+
+## Content
+
+1. Mol Genet Genomic Med. 2024 Apr;12(4):e2441. doi: 10.1002/mgg3.2441.
+
+Auriculocondylar syndrome 2 caused by a novel PLCB4 variant in a male Chinese 
+neonate: A case report and review of the literature.
+
+Zhang Y(1), Zhao Y(1), Dai L(1), Liu Y(1), Shi Z(2).
+
+Author information:
+(1)Department of Neonatology, Anhui Provincial Children's Hospital/Children's 
+Hospital of Fudan University (Affiliated Anhui Branch), Hefei, Anhui, China.
+(2)Radiology Department, Center of Imaging Diagnosis, Anhui Provincial 
+Children's Hospital/Children's Hospital of Fudan University (Affiliated Anhui 
+Branch), Hefei, Anhui, China.
+
+BACKGROUND: Auriculocondylar syndrome (ARCND) is a rare congenital craniofacial 
+developmental malformation syndrome of the first and second pharyngeal arches 
+with external ear malformation at the junction between the lobe and helix, 
+micromaxillary malformation, and mandibular condylar hypoplasia. Four subtypes 
+of ARCND have been described so far, that is, ARCND1 (OMIM # 602483), ARCND2 
+(ARCND2A, OMIM # 614669; ARCND2B, OMIM # 620458), ARCND3 (OMIM # 615706), and 
+ARCND4 (OMIM # 620457).
+METHODS: This study reports a case of ARCND2 resulting from a novel pathogenic 
+variant in the PLCB4 gene, and summarizes PLCB4 gene mutation sites and 
+phenotypes of ARCND2.
+RESULTS: The proband, a 5-day-old male neonate, was referred to our hospital for 
+respiratory distress. Micrognathia, microstomia, distinctive question mark ears, 
+as well as mandibular condyle hypoplasia were identified. Trio-based whole-exome 
+sequencing identified a novel missense variant of NM_001377142.1:c.1928C>T 
+(NP_001364071.1:p.Ser643Phe) in the PLCB4 gene, which was predicted to impair 
+the local structural stability with a result that the protein function might be 
+affected. From a review of the literature, only 36 patients with PLCB4 gene 
+mutations were retrieved.
+CONCLUSION: As with other studies examining familial cases of ARCND2, incomplete 
+penetrance and variable expressivity were observed within different families' 
+heterozygous mutations in PLCB4 gene. Although, motor and intellectual 
+development are in the normal range in the vast majority of patients with 
+ARCND2, long-term follow-up and assessment are still required.
+
+© 2024 The Authors. Molecular Genetics & Genomic Medicine published by Wiley 
+Periodicals LLC.
+
+DOI: 10.1002/mgg3.2441
+PMCID: PMC11017300
+PMID: 38618928 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that there are no conflicts 
+of interest.

--- a/references_cache/PMID_39014351.md
+++ b/references_cache/PMID_39014351.md
@@ -1,0 +1,106 @@
+---
+reference_id: "PMID:39014351"
+title: "Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report."
+authors:
+- Shi Y
+- Rong L
+- Liu S
+- Liu Y
+- Zong C
+- Lu J
+- Shang H
+- Xue Y
+- Tian L
+journal: BMC Oral Health
+year: '2024'
+doi: 10.1186/s12903-024-04575-1
+keywords:
+- Humans
+- Male
+- "Dentofacial Deformities/genetics, surgery"
+- Follow-Up Studies
+- "Ear Diseases/genetics, surgery"
+- "GTP-Binding Protein alpha Subunits, Gi-Go/genetics"
+- Pedigree
+- Ear/abnormalities
+- "Osteogenesis, Distraction/methods"
+- Mutation
+- Orthognathic Surgical Procedures
+- China
+- East Asian People
+content_type: abstract_only
+---
+
+# Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report.
+**Authors:** Shi Y, Rong L, Liu S, Liu Y, Zong C, Lu J, Shang H, Xue Y, Tian L
+**Journal:** BMC Oral Health (2024)
+**DOI:** [10.1186/s12903-024-04575-1](https://doi.org/10.1186/s12903-024-04575-1)
+
+## Content
+
+1. BMC Oral Health. 2024 Jul 16;24(1):803. doi: 10.1186/s12903-024-04575-1.
+
+Novel GNAI3 mutation in a Chinese family with auriculocondylar syndrome and 
+treatment of severe dentofacial deformities: a 5-year follow-up case report.
+
+Shi Y(#)(1), Rong L(#)(2), Liu S(3), Liu Y(1), Zong C(1), Lu J(1), Shang H(1), 
+Xue Y(4), Tian L(5).
+
+Author information:
+(1)State Key Laboratory of Oral & Maxillofacial Reconstruction and Regeneration, 
+National Clinical Research Center for Oral Diseases, Shaanxi Clinical Research 
+Center for Oral Diseases, Department of Oral and Maxillofacial Surgery, School 
+of Stomatology, The Fourth Military Medical University, 145 West Changle Road, 
+Xi'an, 710032, PR China.
+(2)Department of Stomatology, Air Force Medical Center, The Fourth Military 
+Medical University, 30 Fucheng Road, Beijing, 100089, China.
+(3)State Key Laboratory of Oral & Maxillofacial Reconstruction and Regeneration, 
+National Clinical Research Center for Oral Diseases, Shaanxi Clinical Research 
+Center for Oral Diseases, Department of Orthodontics, School of Stomatology, The 
+Fourth Military Medical University, 145 West Changle Road, Xi'an, 710032, PR 
+China.
+(4)State Key Laboratory of Oral & Maxillofacial Reconstruction and Regeneration, 
+National Clinical Research Center for Oral Diseases, Shaanxi Clinical Research 
+Center for Oral Diseases, Department of Oral Surgery, School of Stomatology, The 
+Fourth Military Medical University, 145 West Changle Road, Xi'an, 710032, PR 
+China. 530170019@qq.com.
+(5)State Key Laboratory of Oral & Maxillofacial Reconstruction and Regeneration, 
+National Clinical Research Center for Oral Diseases, Shaanxi Clinical Research 
+Center for Oral Diseases, Department of Oral and Maxillofacial Surgery, School 
+of Stomatology, The Fourth Military Medical University, 145 West Changle Road, 
+Xi'an, 710032, PR China. tianleison@163.com.
+(#)Contributed equally
+
+BACKGROUND: Auriculocondylar syndrome (ARCND) is an extremely rare autosomal 
+dominant or recessive condition that typically manifests as question mark ears 
+(QMEs), mandibular condyle hypoplasia, and micrognathia. Severe dental and 
+maxillofacial malformations present considerable challenges in patients' lives 
+and clinical treatment. Currently, only a few ARCND cases have been reported 
+worldwide, but most of them are related to genetic mutations, clinical symptoms, 
+and ear correction; there are few reports concerning the treatment of 
+dentofacial deformities.
+CASE PRESENTATION: Here, we report a rare case of ARCND in a Chinese family. A 
+novel insertional mutation in the guanine nucleotide-binding protein 
+alpha-inhibiting activity polypeptide 3 (GNAI3) was identified in the patient 
+and their brother using whole-exome sequencing. After a multidisciplinary 
+consultation and examination, sequential orthodontic treatment and craniofacial 
+surgery, including distraction osteogenesis and orthognathic surgery, were 
+performed using three-dimensional (3D) digital technology to treat the patient's 
+dentofacial deformity. A good prognosis was achieved at the 5-year follow-up, 
+and the patient returned to normal life.
+CONCLUSIONS: ARCND is a monogenic and rare condition that can be diagnosed based 
+on its clinical triad of core features. Molecular diagnosis plays a crucial role 
+in the diagnosis of patients with inconspicuous clinical features. We present a 
+novel insertion variation in GNAI3, which was identified in exon 2 of chromosome 
+110116384 in a Chinese family. Sequential therapy with preoperative orthodontic 
+treatment combined with distraction osteogenesis and orthognathic surgery guided 
+by 3D digital technology may be a practical and effective method for treating 
+ARCND.
+
+© 2024. The Author(s).
+
+DOI: 10.1186/s12903-024-04575-1
+PMCID: PMC11251236
+PMID: 39014351 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/research/Auriculocondylar_Syndrome-deep-research-falcon.md
+++ b/research/Auriculocondylar_Syndrome-deep-research-falcon.md
@@ -1,0 +1,1344 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T11:08:07.743996'
+end_time: '2026-05-10T11:28:33.205786'
+duration_seconds: 1225.46
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Auriculocondylar Syndrome
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 44
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Auriculocondylar Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Auriculocondylar Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Auriculocondylar Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Auriculocondylar Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Auriculocondylar Syndrome (ARCND/ACS): Comprehensive Disease Characteristics Report
+
+### Executive summary
+Auriculocondylar syndrome (ARCND; historically “auriculocondylar syndrome/ACS”) is an ultra-rare congenital craniofacial malformation of first and second pharyngeal arch derivatives, classically presenting with **micrognathia**, **mandibular condyle hypoplasia**, and a characteristic external ear anomaly termed the **question-mark ear (QME)**. Current genetic understanding centers on disruption of **EDN1–EDNRA signaling** and downstream cranial neural crest patterning (DLX5/6), with additional genetic heterogeneity including a regulatory duplication affecting **TWIST1** expression. Recent (2024) reports emphasize multidisciplinary, technology-assisted craniofacial care (3D planning, distraction osteogenesis, orthognathic surgery) with measurable functional improvement. (clouthier2013understandingthebasis pages 1-3, rieder2012ahumanhomeotic pages 1-2, shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 1. Disease information
+
+### 1.1 Definition and current understanding
+ARCND/ACS is a rare congenital craniofacial disorder affecting development of the **outer ear and mandible**, and is best recognized as a disorder of **pharyngeal arch (branchial arch) development** with a characteristic “homeotic” patterning disturbance of the jaw in severe cases. The core/typical triad is consistently described as **micrognathia**, **mandibular condyle hypoplasia**, and a **QME** defect at the helix–lobule junction. (clouthier2013understandingthebasis pages 1-3, gordon2013heterogeneityofmutational pages 1-2)
+
+Primary literature definition examples:
+- Rieder et al. (2012) describe ACS as “a rare, autosomal-dominant craniofacial malformation syndrome” with micrognathia and a distinctive QME, and report additional features including TMJ ankylosis and cleft palate. (https://doi.org/10.1016/j.ajhg.2012.04.002; May 2012) (rieder2012ahumanhomeotic pages 1-2)
+- Clouthier et al. (2013) define the “core triad” as “micrognathia, mandibular condyle hypoplasia, and a unique ear malformation” (QME/Cosman ear). (https://doi.org/10.1002/ajmg.c.31376; Nov 2013) (clouthier2013understandingthebasis pages 1-3)
+
+### 1.2 Key identifiers (available in retrieved evidence)
+A subset of identifiers could be extracted directly from retrieved sources (others were not present in the evidence captured in this run).
+
+| Disease / concept | Synonyms / related names in evidence | Identifiers in evidence | Prevalence / epidemiology note in evidence | Source year | URL | Citation |
+|---|---|---|---|---|---|---|
+| Auriculocondylar syndrome | Auriculocondylar syndrome; ACS; ARCND | MONDO: MONDO_0000107 | Open Targets lists MONDO_0000107 for “auriculocondylar syndrome” | n/a | n/a | (OpenTargets Search: Auriculocondylar syndrome) |
+| Auriculocondylar syndrome | “question mark ear syndrome”; “dysgnathia complex” | OMIM #602483, #614669, #615706 | Rare / prevalence not given in this excerpt | 2013 | https://doi.org/10.1002/ajmg.c.31376 | (clouthier2013understandingthebasis pages 1-3) |
+| Auriculocondylar syndrome (general ARCND) | ARCND; “question mark ear syndrome” | OMIM #602483, #614669, #615706 | Orphanet prevalence stated as under 1 in 1,000,000 | 2022 | https://doi.org/10.1136/jmedgenet-2021-107825 | (tavares2022newlocusunderlying pages 1-2) |
+| Auriculocondylar syndrome (general ARCND) | ARCND | OMIM #602483, #614669, #615706 | Prevalence stated as less than 1 in 1,000,000; fewer than 100 cases reported | 2024 | https://doi.org/10.1186/s12903-024-04575-1 | (shi2024novelgnai3mutation pages 1-2) |
+| Auriculocondylar syndrome | ARCND; dysgnathia complex; question mark ear syndrome | ARCND1 OMIM #602483; ARCND2A OMIM #614669; ARCND2B OMIM #620458; ARCND3 OMIM #615706; ARCND4 OMIM #620457 | Orphanet prevalence stated as under 1/1,000,000 | 2024 | https://doi.org/10.1002/mgg3.2441 | (zhang2024auriculocondylarsyndrome2 pages 1-2) |
+| Auriculocondylar syndrome 1 | ARCND1 | OMIM #602483 | Subtype listed in review-style case report evidence | 2024 | https://doi.org/10.1002/mgg3.2441 | (zhang2024auriculocondylarsyndrome2 pages 1-2) |
+| Auriculocondylar syndrome 2A | ARCND2A | OMIM #614669 | Subtype listed in review-style case report evidence | 2024 | https://doi.org/10.1002/mgg3.2441 | (zhang2024auriculocondylarsyndrome2 pages 1-2) |
+| Auriculocondylar syndrome 2B | ARCND2B | OMIM #620458; MONDO_0957544 | Subtype listed; Open Targets includes MONDO_0957544 | 2024 / n/a | https://doi.org/10.1002/mgg3.2441 | (zhang2024auriculocondylarsyndrome2 pages 1-2, OpenTargets Search: Auriculocondylar syndrome) |
+| Auriculocondylar syndrome 3 | ARCND3 | OMIM #615706 | Subtype listed in review-style case report evidence | 2024 | https://doi.org/10.1002/mgg3.2441 | (zhang2024auriculocondylarsyndrome2 pages 1-2) |
+| Auriculocondylar syndrome 4 | ARCND4 | OMIM #620457; MONDO_0957543 | Subtype listed; Open Targets includes MONDO_0957543 for auriculocondylar syndrome 4 | 2024 / n/a | https://doi.org/10.1002/mgg3.2441 | (zhang2024auriculocondylarsyndrome2 pages 1-2, OpenTargets Search: Auriculocondylar syndrome) |
+| Isolated question-mark ear | Isolated QME; isolated question-mark ears; IQME | OMIM #612798 | May occur as isolated anomaly distinct from syndromic ACS | 2013 | https://doi.org/10.1002/ajmg.c.31376 | (clouthier2013understandingthebasis pages 1-3) |
+
+
+*Table: This table summarizes disease names, synonyms, and identifiers for auriculocondylar syndrome and related entities using only the evidence retrieved in the session. It highlights subtype OMIM numbers, available MONDO mappings, and prevalence statements useful for a knowledge-base entry.*
+
+**MONDO:** OpenTargets maps “auriculocondylar syndrome” to **MONDO_0000107**, and includes MONDO entries for ARCND subtypes (e.g., auriculocondylar syndrome 4). (OpenTargets Search: Auriculocondylar syndrome)
+
+**OMIM (disease):** OMIM IDs commonly cited include **602483**, **614669**, **615706**, and for ARCND subtype breakdown: **ARCND1 #602483; ARCND2A #614669; ARCND2B #620458; ARCND3 #615706; ARCND4 #620457**. (zhang2024auriculocondylarsyndrome2 pages 1-2, clouthier2013understandingthebasis pages 1-3, tavares2022newlocusunderlying pages 1-2)
+
+**OMIM (related phenotype):** Isolated question-mark ear (IQME) OMIM **612798**. (clouthier2013understandingthebasis pages 1-3)
+
+**Orphanet:** Multiple sources cite **Orphanet** as the prevalence source and provide the Orphanet homepage URL (http://www.orpha.net). (tavares2022newlocusunderlying pages 1-2, zhang2024auriculocondylarsyndrome2 pages 1-2)
+
+**ICD-10/ICD-11 and MeSH:** Specific ICD-10/ICD-11 codes and MeSH headings were **not present** in the retrieved text evidence and therefore cannot be asserted here.
+
+### 1.3 Synonyms and alternative names
+Common synonyms in the retrieved literature include:
+- **“question mark ear syndrome”** (clouthier2013understandingthebasis pages 1-3, tavares2022newlocusunderlying pages 1-2)
+- **“dysgnathia complex”** (zhang2024auriculocondylarsyndrome2 pages 1-2, clouthier2013understandingthebasis pages 1-3)
+
+### 1.4 Evidence sources (individual vs aggregated)
+Evidence in this report derives from:
+- **Aggregated disease-level resources and synthesis:** a Seminars review integrating human, mouse, and zebrafish genetics (Clouthier et al., 2013). (clouthier2013understandingthebasis pages 1-3)
+- **Primary human genetics (families/case series):** e.g., Rieder et al. 2012 (exome + functional assays), Gordon et al. 2013 (EDN1), Tavares et al. 2017 (molecular cohort statistics), Tavares et al. 2022 (CNV + iPSC modeling). (rieder2012ahumanhomeotic pages 1-2, gordon2013mutationsinendothelin pages 1-2, tavares2017targetedmolecularinvestigation pages 4-6, tavares2022newlocusunderlying pages 5-6)
+- **Recent individual clinical implementations (case reports):** 2024 ARCND management with orthodontics + distraction + orthognathic surgery and 5-year outcomes. (shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (primary causes)
+ARCND is primarily a **genetic (Mendelian) craniofacial developmental disorder**, caused by pathogenic variants that disrupt **endothelin signaling in cranial neural crest** and related patterning programs. (clouthier2013understandingthebasis pages 1-3, rieder2012ahumanhomeotic pages 1-2)
+
+Major established causal genes/loci in retrieved evidence:
+- **PLCB4** (ARCND2; most common cause in molecular cohorts) (tavares2017targetedmolecularinvestigation pages 4-6)
+- **GNAI3** (ARCND1) (tavares2015novelvariantsin pages 1-2, shi2024novelgnai3mutation pages 2-6)
+- **EDN1** (ARCND3; ligand-level defect) (gordon2013mutationsinendothelin pages 1-2)
+- **430 kb tandem duplication at HDAC9/TWIST1 regulatory landscape** (ARCND4; regulatory mechanism) (tavares2022newlocusunderlying pages 5-6, tavares2022newlocusunderlying pages 4-4)
+
+### 2.2 Risk factors
+
+#### Genetic risk factors (causal variants)
+Molecular cohort data: In a cohort of **28 molecularly investigated index patients**, **16/28 (57.1%)** carried **PLCB4** variants, **6/28 (21.4%)** carried **GNAI3** variants, **4/28 (14.3%)** carried **EDN1** variants, and **2/28 (7.1%)** were unsolved. (Tavares et al., 2017; https://doi.org/10.1002/ajmg.a.38101; Apr 2017) (tavares2017targetedmolecularinvestigation pages 4-6)
+
+EDN1 can cause **recessive ACS** and **dominant isolated QME** depending on the mutation and residual EDN1 activity. (Gordon et al., 2013; https://doi.org/10.1016/j.ajhg.2013.10.023; Dec 2013) (gordon2013mutationsinendothelin pages 1-2)
+
+Representative variants are summarized in the genetics table artifact below. 
+
+| ARCND subtype (if known) | Gene/locus | Inheritance patterns reported | Variant examples (HGVS when available) | Proposed mechanism | Key functional evidence | Primary sources with year/URL |
+|---|---|---|---|---|---|---|
+| ARCND1 | **GNAI3** | AD; incomplete penetrance reported in some families | c.118G>C, p.Gly40Arg; p.Ser47Arg; p.Gly45Val; p.Thr48Asn; p.Asn269Tyr; c.140G>A, p.Ser47Asn; c.144_145insCATTGTGAAACAGATGAA, p.T48_I49insHCETDE (rieder2012ahumanhomeotic pages 3-5, tavares2016identificaçãodenovas pages 67-68, liu2021prenataldiagnosisof pages 1-3, shi2024novelgnai3mutation pages 2-6) | Predominantly **dominant-negative** disruption of GTP/GDP-binding region in the G1/G4 motifs, impairing downstream endothelin signaling (gordon2013heterogeneityofmutational pages 11-12, tavares2015novelvariantsin pages 1-2) | Structural modeling placed pathogenic residues in the nucleotide-binding pocket; p.Gly40Arg predicted to stabilize aberrant active conformation and inhibit MAPK/Rap signaling; patient-derived osteoblast assays in ACS showed reduced **DLX5/DLX6** expression consistent with EDN1-pathway disruption (rieder2012ahumanhomeotic pages 3-5, rieder2012ahumanhomeotic pages 1-2, tavares2015novelvariantsin pages 1-2) | Rieder et al., 2012, https://doi.org/10.1016/j.ajhg.2012.04.002; Tavares et al., 2015, https://doi.org/10.1038/ejhg.2014.132; Liu et al., 2021, https://doi.org/10.1186/s12884-021-04238-x; Shi et al., 2024, https://doi.org/10.1186/s12903-024-04575-1 (rieder2012ahumanhomeotic pages 3-5, tavares2015novelvariantsin pages 1-2, liu2021prenataldiagnosisof pages 1-3, shi2024novelgnai3mutation pages 2-6) |
+| ARCND2A | **PLCB4** | AD | c.986A>C, p.Asn329Ser; p.Arg621His; p.Arg621Cys; p.Tyr623Cys; p.Asn650His; c.1072G>C, p.Glu358Gln; c.983A>G, p.His328Arg; c.1928C>T, p.Ser643Phe; p.Asp360Asn; p.Arg621Leu (rieder2012ahumanhomeotic pages 3-5, tavares2017targetedmolecularinvestigation pages 4-6, tavares2016identificaçãodenovas pages 67-68, zhang2024auriculocondylarsyndrome2 pages 2-5) | Mostly **dominant-negative** catalytic-domain dysfunction rather than simple haploinsufficiency (gordon2013heterogeneityofmutational pages 11-12) | Variants cluster in X/Y catalytic domains; structural modeling predicted impaired PLC catalytic activity and disturbed IP3 generation without gross protein destabilization; ACS osteoblasts showed reduced **DLX5/DLX6** expression; PLCB4 accounts for ~57.1% of molecularly solved index cases in one cohort (16/28) (rieder2012ahumanhomeotic pages 3-5, rieder2012ahumanhomeotic pages 1-2, tavares2017targetedmolecularinvestigation pages 4-6) | Rieder et al., 2012, https://doi.org/10.1016/j.ajhg.2012.04.002; Gordon et al., 2013, https://doi.org/10.1136/jmedgenet-2012-101331; Tavares et al., 2017, https://doi.org/10.1002/ajmg.a.38101; Zhang et al., 2024, https://doi.org/10.1002/mgg3.2441 (rieder2012ahumanhomeotic pages 3-5, gordon2013heterogeneityofmutational pages 11-12, tavares2017targetedmolecularinvestigation pages 4-6, zhang2024auriculocondylarsyndrome2 pages 2-5) |
+| ARCND2B | **PLCB4** | AR | Intragenic homozygous deletion; compound heterozygous splice variants c.854-1G>A and c.1238+1G>C; homozygous loss-of-function PLCB4 alleles also reported in review tables (tavares2016identificaçãodenovas pages 67-68, tavares2016identificaçãodenovas pages 68-72) | **Loss-of-function** / splice-null mechanism (tavares2016identificaçãodenovas pages 68-72, gordon2013heterogeneityofmutational pages 11-12) | Human recessive cases demonstrate that complete PLCB4 loss can produce classical ACS craniofacial features, contrasting with lack of craniofacial phenotype in some mouse null models; 13.3% (2/15) of PLCB4 variants in one summary were homozygous predicted LoF (gordon2013heterogeneityofmutational pages 11-12, tavares2016identificaçãodenovas pages 68-72) | Gordon et al., 2013, https://doi.org/10.1136/jmedgenet-2012-101331; Tavares thesis, 2016, https://doi.org/10.11606/t.41.2016.tde-14072016-142513 (gordon2013heterogeneityofmutational pages 11-12, tavares2016identificaçãodenovas pages 68-72, tavares2016identificaçãodenovas pages 67-68) |
+| ARCND3 | **EDN1** | AR for syndromic ACS; AD for isolated question-mark ears | Homozygous proprotein cleavage-site substitutions in ACS; AD EDN1 variants reported include p.Val64Asp and p.Tyr83*; homozygous c.271A>G, p.Lys91Glu reported in consanguineous ACS cases (gordon2013mutationsinendothelin pages 1-2, tavares2016identificaçãodenovas pages 67-68) | Reduced or altered **EDN1 ligand activity** with mutation-dependent residual function; upstream endothelin-pathway defect (gordon2013mutationsinendothelin pages 1-2) | Mouse data show Edn1/Ednra/Ece1 loss causes severe mandibular defects; human EDN1 mutations establish ligand-level causation upstream of PLCB4/GNAI3; differing inheritance for ACS vs isolated QME likely reflects residual EDN1 activity (gordon2013mutationsinendothelin pages 1-2) | Gordon et al., 2013, https://doi.org/10.1016/j.ajhg.2013.10.023 (gordon2013mutationsinendothelin pages 1-2) |
+| ARCND4 | **7p locus involving HDAC9/TWIST1 regulatory elements** | AD in reported pedigree | Tandem duplication NC_000007.14:g.18437239_18867540dup (430,302 bp), telomeric to **TWIST1** and covering most of **HDAC9** (tavares2022newlocusunderlying pages 4-4) | **Regulatory** mechanism: altered cis-regulation of **TWIST1** and disruption/duplication of HDAC9 isoforms rather than coding mutation in known ARCND genes (tavares2022newlocusunderlying pages 1-1, tavares2022newlocusunderlying pages 4-4) | Capture-C showed duplicated region contacts the **TWIST1** promoter; patient iPSC-derived neural crest cells had increased **HDAC9** (3.15-fold) and **TWIST1** (2.03-fold), ~4.3-fold reduced NCC migration, and impaired osteogenic differentiation with ~20.3-fold reduced ALP activity and reduced matrix mineralization; linkage LOD 2.88 (tavares2022newlocusunderlying pages 5-6, tavares2022newlocusunderlying pages 6-7, tavares2022newlocusunderlying pages 4-4) | Tavares et al., 2022, https://doi.org/10.1136/jmedgenet-2021-107825 (tavares2022newlocusunderlying pages 1-1, tavares2022newlocusunderlying pages 5-6, tavares2022newlocusunderlying pages 6-7, tavares2022newlocusunderlying pages 4-4) |
+| Unsolved / residual ARCND fraction | Unknown locus/loci | Likely mixed | No pathogenic variants found in known genes in 2/28 index patients in one cohort; historical reports also noted unsolved families before discovery of the HDAC9/TWIST1 duplication (tavares2017targetedmolecularinvestigation pages 4-6, tavares2022newlocusunderlying pages 1-1) | Genetic heterogeneity; additional loci remain plausible (tavares2017targetedmolecularinvestigation pages 4-6) | Cohort data: 16/28 PLCB4, 6/28 GNAI3, 4/28 EDN1, and 2/28 unexplained; discovery of ARCND4 reduced but did not eliminate unsolved disease fraction (tavares2017targetedmolecularinvestigation pages 4-6, tavares2022newlocusunderlying pages 1-1) | Tavares et al., 2017, https://doi.org/10.1002/ajmg.a.38101; Tavares et al., 2022, https://doi.org/10.1136/jmedgenet-2021-107825 (tavares2017targetedmolecularinvestigation pages 4-6, tavares2022newlocusunderlying pages 1-1) |
+
+
+*Table: This table summarizes the currently reported genetic causes and loci for auriculocondylar syndrome, linking subtypes to representative variants, inheritance, and proposed molecular mechanisms. It is useful for quickly comparing coding-gene causes in the EDN1 pathway with the newer regulatory ARCND4 locus involving TWIST1/HDAC9.*
+
+#### Environmental risk factors
+No validated environmental risk factors were identified in the retrieved evidence for ARCND. Given the congenital Mendelian etiology, environmental modifiers may exist but are not established here.
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+No gene–environment interaction evidence was identified in the retrieved materials.
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core phenotype (triad)
+The core clinical triad is consistently stated as:
+- **Question-mark ears (QME)**
+- **Mandibular condyle hypoplasia**
+- **Micrognathia**
+
+This is explicitly stated in a 2024 clinical report: “The typical triad manifestations of ARCND include question mark ears (QMEs), mandibular condyle hypoplasia, and micrognathia.” (Shi et al., 2024; https://doi.org/10.1186/s12903-024-04575-1; Jul 2024) (shi2024novelgnai3mutation pages 1-2)
+
+### 3.2 Additional phenotypes and frequencies/statistics
+ARCND shows broad inter- and intra-familial variability and incomplete penetrance in some dominant families. (clouthier2013understandingthebasis pages 1-3, rieder2012ahumanhomeotic pages 3-5)
+
+**Features beyond the triad** reported across sources include: microstomia/narrow mouth, prominent/full cheeks, glossoptosis, palatal anomalies (including cleft palate), facial asymmetry, pre/postauricular tags, hearing loss, feeding difficulties, respiratory distress/airway obstruction, dental crowding/malocclusion, and TMJ pathology (including ankylosis). (clouthier2013understandingthebasis pages 1-3, rieder2012ahumanhomeotic pages 1-2, tavares2017targetedmolecularinvestigation pages 4-6)
+
+**Phenotype frequencies/statistics from retrieved cohort tables and analyses**:
+- Full cheeks and QME association: In one study, **full cheeks were significantly overrepresented** (P = 0.0026) and **QME was strongly associated** with ACS (P = 0.0001). (tavares2017targetedmolecularinvestigation pages 4-6)
+- Selected frequency examples summarized in a literature table include **microstomia 10/11** and **prominent cheeks 10/11** in one reported group, and **respiratory distress 6/10** in one group (noting small denominators and missing reporting). (tavares2016identificaçãodenovas pages 67-68)
+
+### 3.3 Age of onset, severity, progression
+- **Onset:** congenital / prenatal developmental.
+- **Severity:** variable, from isolated ear findings (IQME) to severe mandibular hypoplasia with airway compromise.
+- **Progression:** TMJ ankylosis can be progressive and severe cases may cause airway obstruction requiring tracheostomy (reported in earlier primary literature). (rieder2012ahumanhomeotic pages 1-2)
+
+### 3.4 Quality-of-life impact
+Quantitative QOL instruments were not found in retrieved evidence. However, severe dentofacial deformities are described as “present[ing] considerable challenges in patients’ lives and clinical treatment.” (shi2024novelgnai3mutation pages 1-2)
+
+### 3.5 Suggested HPO terms (non-exhaustive)
+Based on phenotypes described in retrieved evidence:
+- Question mark ear / auricular clefting: **HP:0009907** (Question mark ear; commonly used HPO term for QME)
+- Micrognathia: **HP:0000347**
+- Mandibular condyle hypoplasia: **HP:0009119** (Mandibular condyle hypoplasia)
+- Microstomia: **HP:0000174**
+- Glossoptosis: **HP:0000162**
+- Cleft palate: **HP:0000175**
+- Hearing impairment: **HP:0000365**
+- Facial asymmetry: **HP:0000324**
+- Malocclusion/crowded teeth: **HP:0000689** (Crowding of teeth), **HP:0000688** (Malocclusion)
+
+(These HPO identifiers are standard ontology mappings; the evidence for the underlying phenotypes is in the cited papers.) (clouthier2013understandingthebasis pages 1-3, tavares2017targetedmolecularinvestigation pages 4-6, shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes and loci
+Causal genes/locus in retrieved evidence include PLCB4, GNAI3, EDN1, and a 7p duplication affecting regulatory elements interacting with TWIST1 (HDAC9/TWIST1 region). (tavares2017targetedmolecularinvestigation pages 4-6, gordon2013mutationsinendothelin pages 1-2, tavares2022newlocusunderlying pages 5-6)
+
+### 4.2 Pathogenic variants: types and functional consequences
+- **PLCB4:** predominantly **missense variants** in catalytic domains (X/Y), with evidence suggesting **dominant-negative** action for many heterozygous missense alleles; additionally, **biallelic loss-of-function** (deletions/splice) can cause recessive disease (ARCND2B). (gordon2013heterogeneityofmutational pages 11-12, tavares2016identificaçãodenovas pages 67-68)
+- **GNAI3:** multiple variants cluster in GDP/GTP-binding motifs; multiple sources argue for a **dominant-negative** mechanism affecting EDN1 pathway signaling. (tavares2015novelvariantsin pages 1-2, gordon2013heterogeneityofmutational pages 11-12)
+- **EDN1:** homozygous mutations affecting processing/peptide can cause **recessive ACS**; other mutations can cause **dominant isolated QME**, consistent with mutation-dependent residual ligand activity. (gordon2013mutationsinendothelin pages 1-2)
+- **HDAC9/TWIST1 regulatory duplication (ARCND4):** a **430 kb tandem duplication** with functional evidence for altered TWIST1 regulation and neural crest cell migration/osteogenesis effects in iPSC-derived models. (tavares2022newlocusunderlying pages 5-6, tavares2022newlocusunderlying pages 4-4)
+
+### 4.3 Allele frequencies
+Population-database frequency statements were limited in retrieved excerpts. Example: GNAI3 p.Gly40Arg was “not observed in 10,758 control chromosomes” in Rieder et al. (2012). (rieder2012ahumanhomeotic pages 3-5)
+
+### 4.4 Modifier genes / epigenetics / chromosomal abnormalities
+No validated modifier genes or epigenetic signatures specific to ARCND were found in retrieved evidence.
+
+---
+
+## 5. Environmental information
+No ARCND-specific environmental, lifestyle, or infectious contributors were identified in retrieved evidence.
+
+---
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Molecular pathway: EDN1–EDNRA–(GNAI3/PLCB4)–DLX5/6 craniofacial patterning
+A central mechanistic model supported by human genetics, functional assays, and animal studies is disruption of **endothelin-1 signaling** in cranial neural crest:
+- **EDN1** is a ligand critical for patterning the mandibular portion of the first pharyngeal arch via **EDNRA** signaling; murine deletion of Edn1/Ednra/Ece1 causes severe mandibular defects. (gordon2013mutationsinendothelin pages 1-2)
+- In human ACS, mutations in **PLCB4** and **GNAI3** are proposed to act as core intracellular effectors downstream of endothelin receptor signaling; patient-derived osteoblast assays showed significantly reduced **DLX5 and DLX6** expression, consistent with impaired mandibular identity specification. (rieder2012ahumanhomeotic pages 1-2)
+- Clouthier et al. (2013) synthesize that loss of EDN1/EDNRA signaling causes “loss of mandibular neural crest cell identity and repatterning,” producing a homeotic shift toward maxillary-like morphology. (clouthier2013understandingthebasis pages 1-3)
+
+### 6.2 Regulatory mechanism: TWIST1 dosage and neural crest migration (ARCND4)
+Tavares et al. (2022) established a fourth locus involving a **430 kb tandem duplication** in the HDAC9 region with regulatory contacts to **TWIST1**:
+- Capture-C revealed multiple cis interactions between the TWIST1 promoter and regulatory elements in the duplicated region. (tavares2022newlocusunderlying pages 1-1)
+- Patient iPSC-derived neural crest cells (iNCCs) showed **HDAC9 upregulation (3.15-fold; p=0.009)** and **TWIST1 upregulation (2.03-fold; p=0.03)**, with **~4.3-fold reduced migratory capacity (p=0.0009)**. (tavares2022newlocusunderlying pages 5-6)
+- NCC-derived mesenchymal cells showed impaired osteogenic differentiation (e.g., markedly reduced ALP activity and reduced mineralization). (tavares2022newlocusunderlying pages 5-6)
+
+### 6.3 Suggested GO biological process terms (examples)
+- Neural crest cell migration: **GO:0001755**
+- Craniofacial morphogenesis: **GO:0060325**
+- Pharyngeal arch development: **GO:0060034**
+- Endothelin receptor signaling pathway: **GO:0072000** (related terms depending on curation)
+- Osteoblast differentiation / ossification: **GO:0001649**, **GO:0001503**
+
+### 6.4 Suggested cell types (Cell Ontology; examples)
+- Cranial neural crest cell: **CL:0002638** (commonly used for neural crest lineage)
+- Mesenchymal stem cell: **CL:0000134**
+- Osteoblast: **CL:0000062**
+
+(Functional evidence for NCC involvement and osteogenic defects is supported by iPSC-derived NCC and nMSC assays in Tavares et al. 2022.) (tavares2022newlocusunderlying pages 5-6)
+
+---
+
+## 7. Anatomical structures affected
+
+### 7.1 Organ/tissue level (with UBERON suggestions)
+Primary structures:
+- External ear / pinna (**UBERON:0001690**) — QME malformation at helix–lobule junction. (clouthier2013understandingthebasis pages 1-3)
+- Mandible (**UBERON:0001684**) — micrognathia, mandibular hypoplasia. (clouthier2013understandingthebasis pages 1-3, shi2024novelgnai3mutation pages 2-6)
+- Temporomandibular joint (**UBERON:0002388**) — condylar hypoplasia; ankylosis in some cases. (rieder2012ahumanhomeotic pages 1-2)
+- First/second pharyngeal arches (**UBERON:0004456**, **UBERON:0004457**; developmental structures) (tavares2022newlocusunderlying pages 1-2)
+
+Secondary/associated:
+- Upper airway/oropharynx (**UBERON:0001723** pharynx; airway volumes) in severe micrognathia/OSA. (shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 8. Temporal development (natural history)
+ARCND is a congenital developmental disorder, sometimes detectable prenatally by ultrasound when severe micrognathia/mandibular hypoplasia is present.
+
+Prenatal case evidence: Liu et al. (2021) report prenatal ultrasound identification of severe micrognathia and mandibular hypoplasia with polyhydramnios, followed by WES identification of a de novo GNAI3 variant (p.Ser47Asn). The abstract states: “Severe micrognathia and mandibular hypoplasia accompanied by polyhydramnios are prenatal indicators of ACS.” (https://doi.org/10.1186/s12884-021-04238-x; Nov 2021) (liu2021prenataldiagnosisof pages 1-3)
+
+---
+
+## 9. Inheritance and population
+
+### 9.1 Inheritance
+ARCND can be **autosomal dominant or autosomal recessive**, depending on gene and variant class:
+- Dominant inheritance with **variable expressivity** and occasional **non-penetrance** is widely noted (e.g., GNAI3/PLCB4 families). (clouthier2013understandingthebasis pages 1-3, rieder2012ahumanhomeotic pages 3-5)
+- EDN1 can cause **recessive ACS** and **dominant isolated QME**. (gordon2013mutationsinendothelin pages 1-2)
+- ARCND2 includes dominant ARCND2A and recessive ARCND2B. (zhang2024auriculocondylarsyndrome2 pages 1-2)
+
+### 9.2 Epidemiology
+ARCND is repeatedly described as extremely rare:
+- Orphanet-cited prevalence “under 1 in 1,000,000.” (tavares2022newlocusunderlying pages 1-2)
+- “Fewer than 100 cases” reported is stated in a 2024 case report background. (shi2024novelgnai3mutation pages 1-2)
+
+Robust population prevalence/incidence estimates were not provided in the retrieved primary texts.
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical diagnosis
+The clinical triad is emphasized as the diagnostic anchor, with recognition that incomplete presentations occur and can lead to misdiagnosis.
+
+Direct abstract quote (2024): “ARCND is a monogenic and rare condition that can be diagnosed based on its clinical triad of core features.” (Shi et al., 2024; https://doi.org/10.1186/s12903-024-04575-1) (shi2024novelgnai3mutation pages 1-2)
+
+### 10.2 Differential diagnosis
+A 2024 clinical report lists potential misdiagnoses including:
+- Oculo-auriculo-vertebral spectrum
+- Treacher Collins syndrome
+- Mandibulofacial dysostosis
+- Guion-Almeida type
+- Meier-Gorlin syndrome
+
+(shi2024novelgnai3mutation pages 1-2)
+
+### 10.3 Genetic testing and real-world implementation
+- **WES** is repeatedly used in modern diagnosis and case resolution (including prenatal and postnatal), identifying novel GNAI3 insertions/missense changes. (shi2024novelgnai3mutation pages 1-2, liu2021prenataldiagnosisof pages 1-3)
+- Targeted sequencing of **PLCB4, GNAI3, EDN1** is used for patients in the clinical spectrum and supports genotype–phenotype correlation work. (tavares2017targetedmolecularinvestigation pages 4-6)
+
+In prenatal settings, WES has been used as confirmatory testing when ultrasound indicates severe mandibular anomalies. (liu2021prenataldiagnosisof pages 1-3)
+
+### 10.4 Suggested diagnostic workflow (evidence-based synthesis)
+1) Recognize craniofacial pattern consistent with ARCND (QME + micrognathia + condylar hypoplasia) (clouthier2013understandingthebasis pages 1-3, tavares2017targetedmolecularinvestigation pages 4-6)
+2) Molecular testing: targeted ARCND genes (PLCB4, GNAI3, EDN1) or WES; consider CNV analysis if negative (HDAC9/TWIST1 duplication) (tavares2017targetedmolecularinvestigation pages 4-6, tavares2022newlocusunderlying pages 4-4)
+3) Multidisciplinary craniofacial and airway evaluation in severe cases (sleep study/OSA assessment when indicated) (shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 11. Outcomes / prognosis
+
+ARCND outcomes depend on severity (airway compromise, feeding difficulties, craniofacial growth, TMJ involvement). Quantitative survival data were not found in the retrieved evidence.
+
+Functional outcome example (2024, 5-year follow-up): A patient with ARCND treated with sequential orthodontics, distraction osteogenesis, and orthognathic surgery had measurable improvements in airway and sleep-disordered breathing: airway volume increased from **18,672 mm³ to 32,880 mm³**, AHI improved to **0.5** with SpO2 **97%**, maximal mouth opening **40 mm**, and stability maintained at follow-up with return to normal life. (shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 12. Treatment
+
+### 12.1 Current applications and real-world implementations
+There are **no disease-specific pharmacotherapies** in the retrieved evidence; management is primarily **craniofacial, orthodontic, and surgical**, tailored to severity.
+
+A detailed modern treatment implementation (Shi et al., 2024) included:
+- Multidisciplinary planning and **3D digital technology** guidance
+- **Preoperative orthodontic treatment** with extractions and alignment
+- **Mandibular distraction osteogenesis** (bilateral distractors)
+- **Orthognathic surgery** (e.g., Le Fort I, BSSRO, genioplasty)
+- Demonstrated 5-year stable functional improvement (airway metrics, OSA resolution) (shi2024novelgnai3mutation pages 2-6)
+
+### 12.2 MAXO (Medical Action Ontology) term suggestions
+- Mandibular distraction osteogenesis: **MAXO:0001170** (Distraction osteogenesis; exact ID may vary by MAXO version)
+- Orthognathic surgery / corrective jaw surgery: **MAXO:0000127** (Surgical procedure) with more specific jaw surgery subclass if available
+- Genetic testing / exome sequencing: **MAXO:0000120** (Genetic testing)
+- Polysomnography / sleep study: **MAXO:0000537** (Sleep study; exact ID may vary)
+
+(These MAXO mappings are suggestions; evidence of the interventions is in the cited case report.) (shi2024novelgnai3mutation pages 2-6)
+
+### 12.3 Clinical trials
+ClinicalTrials.gov search in this run did **not** identify ARCND-specific interventional trials; retrieved trials related to orthognathic surgery or dysgnathic patients appear generic rather than syndrome-specific. (clinical trial metadata returned; no ARCND-targeted NCT found) (shi2024novelgnai3mutation pages 2-6)
+
+---
+
+## 13. Prevention
+Primary prevention is not established because ARCND is genetic and typically congenital.
+
+Potential prevention/mitigation strategies in practice include:
+- **Genetic counseling** and recurrence risk assessment for families with known pathogenic variants (implied by Mendelian inheritance patterns and use of prenatal molecular testing). (liu2021prenataldiagnosisof pages 1-3, gordon2013mutationsinendothelin pages 1-2)
+- **Prenatal diagnosis** when familial pathogenic variants are known or when severe mandibular anomalies are detected by ultrasound, followed by confirmatory molecular testing. (liu2021prenataldiagnosisof pages 1-3)
+
+---
+
+## 14. Other species / natural disease
+Natural disease analogs in other species were not identified in retrieved evidence. However, mechanistic insights rely on vertebrate developmental models:
+- Mouse loss-of-function of Edn1/Ednra/Ece1 produces mandibular patterning defects, supporting causality of the endothelin pathway in jaw identity specification. (gordon2013mutationsinendothelin pages 1-2)
+
+---
+
+## 15. Model organisms
+ARCND mechanisms are informed by mouse and zebrafish craniofacial development studies summarized in the 2013 Seminars review, alongside human genetics. (clouthier2013understandingthebasis pages 1-3)
+
+A human stem-cell/iPSC model has been used as a complementary system for ARCND4, demonstrating altered gene expression and functional deficits in iPSC-derived cranial neural crest migration and osteogenic differentiation. (tavares2022newlocusunderlying pages 5-6)
+
+---
+
+## Recent developments (prioritizing 2023–2024)
+
+1) **2024: Longitudinal treatment outcomes and digital surgical workflows**
+   - BMC Oral Health (Jul 2024) reports a novel inherited GNAI3 insertion and detailed multi-stage orthodontic + surgical treatment with quantitative improvements in airway volume and sleep apnea metrics at 5 years. (https://doi.org/10.1186/s12903-024-04575-1) (shi2024novelgnai3mutation pages 2-6)
+   - Visual evidence of phenotype and treatment planning (Figures showing micrognathia/condylar hypoplasia and digital workflow) was retrieved. (shi2024novelgnai3mutation media 1e0f905a, shi2024novelgnai3mutation media 063b200e)
+
+2) **2024: Expanded PLCB4 variant spectrum and neonatal presentation**
+   - Molecular Genetics & Genomic Medicine (Apr 2024) reports a de novo PLCB4 variant and consolidates subtype nomenclature and prevalence statements, including ARCND subtype OMIM numbers and literature counts (36 PLCB4-mutant patients retrieved). (https://doi.org/10.1002/mgg3.2441) (zhang2024auriculocondylarsyndrome2 pages 2-5, zhang2024auriculocondylarsyndrome2 pages 1-2)
+
+3) **2023: Continued mechanistic refinement in endothelin receptor signaling (related craniofacial endothelin disorders)**
+   - Although focused on EDNRA gain-of-function in mandibulofacial dysostosis with alopecia (MFDA), JCI 2023 provides modern GPCR allostery/ligand affinity mechanistic analysis relevant to endothelin receptor biology broadly. (https://doi.org/10.1172/jci151536; Feb 2023) (tavares2022newlocusunderlying pages 1-2)
+
+---
+
+## Expert opinion / authoritative synthesis
+The 2013 Seminars review (Clouthier et al.) remains an authoritative synthesis linking human genetics to mouse/zebrafish developmental biology and framing ARCND as a neural crest patterning disorder driven by loss of mandibular identity cues in EDN1/EDNRA signaling. (clouthier2013understandingthebasis pages 1-3)
+
+A 2022 J Med Genet study provides authoritative locus-level expansion beyond the classic EDN1 pathway genes by demonstrating a regulatory duplication affecting TWIST1 control elements and measurable NCC migration defects in iPSC-derived models—supporting the view that ARCND includes both **signal-transduction** and **regulatory/cranial neural crest migration** etiologies. (tavares2022newlocusunderlying pages 5-6)
+
+---
+
+## Visual evidence (phenotype and management)
+- Patient craniofacial phenotype and mandibular condyle hypoplasia on 3D CT reconstructions (Figure 1) and digital treatment workflow (Figure 4) from the 2024 ARCND case report. (shi2024novelgnai3mutation media 1e0f905a, shi2024novelgnai3mutation media 063b200e)
+
+---
+
+## Key limitations of this report (evidence gaps)
+- Specific **ICD-10/ICD-11** and **MeSH** identifiers were not present in the retrieved evidence.
+- Systematic, population-based epidemiology (incidence/prevalence by region) and formal QOL measures were not found in the retrieved primary texts.
+- ARCND-specific interventional clinical trials were not identified in the clinical trials search results during this run.
+
+---
+
+## References (URLs and publication dates)
+- Rieder MJ et al. *Am J Hum Genet.* May 2012. https://doi.org/10.1016/j.ajhg.2012.04.002 (rieder2012ahumanhomeotic pages 1-2, rieder2012ahumanhomeotic pages 3-5)
+- Gordon CT et al. *Am J Hum Genet.* Dec 2013. https://doi.org/10.1016/j.ajhg.2013.10.023 (gordon2013mutationsinendothelin pages 1-2)
+- Clouthier DE et al. *Am J Med Genet C Semin Med Genet.* Nov 2013. https://doi.org/10.1002/ajmg.c.31376 (clouthier2013understandingthebasis pages 1-3)
+- Tavares VLR et al. *Am J Med Genet A.* Apr 2017. https://doi.org/10.1002/ajmg.a.38101 (tavares2017targetedmolecularinvestigation pages 4-6)
+- Tavares VLR et al. *J Med Genet.* Nov 2022. https://doi.org/10.1136/jmedgenet-2021-107825 (tavares2022newlocusunderlying pages 5-6, tavares2022newlocusunderlying pages 4-4)
+- Zhang Y et al. *Mol Genet Genomic Med.* Apr 2024. https://doi.org/10.1002/mgg3.2441 (zhang2024auriculocondylarsyndrome2 pages 2-5, zhang2024auriculocondylarsyndrome2 pages 1-2)
+- Shi Y et al. *BMC Oral Health.* Jul 2024. https://doi.org/10.1186/s12903-024-04575-1 (shi2024novelgnai3mutation pages 2-6, shi2024novelgnai3mutation media 1e0f905a)
+- OpenTargets disease-target mapping (MONDO mapping). (OpenTargets Search: Auriculocondylar syndrome)
+
+
+References
+
+1. (clouthier2013understandingthebasis pages 1-3): David E. Clouthier, Maria Rita Passos‐Bueno, Andre L.P. Tavares, Stanislas Lyonnet, Jeanne Amiel, and Christopher T. Gordon. Understanding the basis of auriculocondylar syndrome: insights from human, mouse and zebrafish genetic studies. American Journal of Medical Genetics Part C: Seminars in Medical Genetics, 163:306-317, Nov 2013. URL: https://doi.org/10.1002/ajmg.c.31376, doi:10.1002/ajmg.c.31376. This article has 69 citations.
+
+2. (rieder2012ahumanhomeotic pages 1-2): Mark J. Rieder, Glenn E. Green, Sarah S. Park, Brendan D. Stamper, Christopher T. Gordon, Jason M. Johnson, Christopher M. Cunniff, Joshua D. Smith, Sarah B. Emery, Stanislas Lyonnet, Jeanne Amiel, Muriel Holder, Andrew A. Heggie, Michael J. Bamshad, Deborah A. Nickerson, Timothy C. Cox, Anne V. Hing, Jeremy A. Horst, and Michael L. Cunningham. A human homeotic transformation resulting from mutations in plcb4 and gnai3 causes auriculocondylar syndrome. American journal of human genetics, 90 5:907-14, May 2012. URL: https://doi.org/10.1016/j.ajhg.2012.04.002, doi:10.1016/j.ajhg.2012.04.002. This article has 114 citations and is from a highest quality peer-reviewed journal.
+
+3. (shi2024novelgnai3mutation pages 2-6): Yulin Shi, Liang Rong, Siying Liu, Yiwen Liu, Chunlin Zong, Jinbiao Lu, Hongtao Shang, Yang Xue, and Lei Tian. Novel gnai3 mutation in a chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report. BMC Oral Health, Jul 2024. URL: https://doi.org/10.1186/s12903-024-04575-1, doi:10.1186/s12903-024-04575-1. This article has 2 citations and is from a peer-reviewed journal.
+
+4. (gordon2013heterogeneityofmutational pages 1-2): Christopher T Gordon, Alice Vuillot, Sandrine Marlin, Erica Gerkes, Alex Henderson, Adila AlKindy, Muriel Holder-Espinasse, Sarah S Park, Asma Omarjee, Mateo Sanchis-Borja, Eya Ben Bdira, Myriam Oufadem, Birgit Sikkema-Raddatz, Alison Stewart, Rodger Palmer, Ruth McGowan, Florence Petit, Bruno Delobel, Michael R Speicher, Paul Aurora, David Kilner, Philippe Pellerin, Marie Simon, Jean-Paul Bonnefont, Edward S Tobias, Sixto García-Miñaúr, Maria Bitner-Glindzicz, Pernille Lindholm, Brigitte A Meijer, Véronique Abadie, Françoise Denoyelle, Marie-Paule Vazquez, Christa Rotky-Fast, Vincent Couloigner, Sébastien Pierrot, Yves Manach, Sylvain Breton, Yvonne M C Hendriks, Arnold Munnich, Linda Jakobsen, Peter Kroisel, Angela Lin, Leonard B Kaban, Lina Basel-Vanagaite, Louise Wilson, Michael L Cunningham, Stanislas Lyonnet, and Jeanne Amiel. Heterogeneity of mutational mechanisms and modes of inheritance in auriculocondylar syndrome. Journal of Medical Genetics, 50:174-186, Jan 2013. URL: https://doi.org/10.1136/jmedgenet-2012-101331, doi:10.1136/jmedgenet-2012-101331. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+5. (OpenTargets Search: Auriculocondylar syndrome): Open Targets Query (Auriculocondylar syndrome, 6 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+6. (tavares2022newlocusunderlying pages 1-2): Vanessa Luiza Romanelli Tavares, Sofia Ligia Guimarães-Ramos, Yan Zhou, Cibele Masotti, Suzana Ezquina, Danielle de Paula Moreira, Henk Buermans, Renato S Freitas, Johan T Den Dunnen, Stephen R F Twigg, and Maria Rita Passos-Bueno. New locus underlying auriculocondylar syndrome (arcnd): 430 kb duplication involving twist1 regulatory elements. Journal of Medical Genetics, 59:895-905, Nov 2022. URL: https://doi.org/10.1136/jmedgenet-2021-107825, doi:10.1136/jmedgenet-2021-107825. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+7. (shi2024novelgnai3mutation pages 1-2): Yulin Shi, Liang Rong, Siying Liu, Yiwen Liu, Chunlin Zong, Jinbiao Lu, Hongtao Shang, Yang Xue, and Lei Tian. Novel gnai3 mutation in a chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report. BMC Oral Health, Jul 2024. URL: https://doi.org/10.1186/s12903-024-04575-1, doi:10.1186/s12903-024-04575-1. This article has 2 citations and is from a peer-reviewed journal.
+
+8. (zhang2024auriculocondylarsyndrome2 pages 1-2): Yongli Zhang, Yuwei Zhao, Liying Dai, Yu Liu, and Zifeng Shi. Auriculocondylar syndrome 2 caused by a novel plcb4 variant in a male chinese neonate: a case report and review of the literature. Molecular Genetics & Genomic Medicine, Apr 2024. URL: https://doi.org/10.1002/mgg3.2441, doi:10.1002/mgg3.2441. This article has 3 citations and is from a peer-reviewed journal.
+
+9. (gordon2013mutationsinendothelin pages 1-2): Christopher T. Gordon, Florence Petit, Peter M. Kroisel, Linda Jakobsen, Roseli Maria Zechi-Ceide, Myriam Oufadem, Christine Bole-Feysot, Solenn Pruvost, Cécile Masson, Frédéric Tores, Thierry Hieu, Patrick Nitschké, Pernille Lindholm, Philippe Pellerin, Maria Leine Guion-Almeida, Nancy Mizue Kokitsu-Nakata, Siulan Vendramini-Pittoli, Arnold Munnich, Stanislas Lyonnet, Muriel Holder-Espinasse, and Jeanne Amiel. Mutations in endothelin 1 cause recessive auriculocondylar syndrome and dominant isolated question-mark ears. American journal of human genetics, 93 6:1118-25, Dec 2013. URL: https://doi.org/10.1016/j.ajhg.2013.10.023, doi:10.1016/j.ajhg.2013.10.023. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+10. (tavares2017targetedmolecularinvestigation pages 4-6): Vanessa L. Romanelli Tavares, Roseli M. Zechi‐Ceide, Debora R. Bertola, Christopher T. Gordon, Simone G. Ferreira, Gabriella S. P. Hsia, Guilherme L. Yamamoto, Suzana A. M. Ezquina, Nancy M. Kokitsu‐Nakata, Siulan Vendramini‐Pittoli, Renato S. Freitas, Josiane Souza, Cesar A. Raposo‐Amaral, Mayana Zatz, Jeanne Amiel, Maria L. Guion‐Almeida, and Maria Rita Passos‐Bueno. Targeted molecular investigation in patients within the clinical spectrum of auriculocondylar syndrome. American Journal of Medical Genetics Part A, 173:938-945, Apr 2017. URL: https://doi.org/10.1002/ajmg.a.38101, doi:10.1002/ajmg.a.38101. This article has 17 citations.
+
+11. (tavares2022newlocusunderlying pages 5-6): Vanessa Luiza Romanelli Tavares, Sofia Ligia Guimarães-Ramos, Yan Zhou, Cibele Masotti, Suzana Ezquina, Danielle de Paula Moreira, Henk Buermans, Renato S Freitas, Johan T Den Dunnen, Stephen R F Twigg, and Maria Rita Passos-Bueno. New locus underlying auriculocondylar syndrome (arcnd): 430 kb duplication involving twist1 regulatory elements. Journal of Medical Genetics, 59:895-905, Nov 2022. URL: https://doi.org/10.1136/jmedgenet-2021-107825, doi:10.1136/jmedgenet-2021-107825. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+12. (tavares2015novelvariantsin pages 1-2): Vanessa L Romanelli Tavares, Christopher T Gordon, Roseli M Zechi-Ceide, Nancy Mizue Kokitsu-Nakata, Norine Voisin, Tiong Y Tan, Andrew A Heggie, Siulan Vendramini-Pittoli, Evan J Propst, Blake C Papsin, Tatiana T Torres, Henk Buermans, Luciane Portas Capelo, Johan T den Dunnen, Maria L Guion-Almeida, Stanislas Lyonnet, Jeanne Amiel, and Maria Rita Passos-Bueno. Novel variants in gnai3 associated with auriculocondylar syndrome strengthen a common dominant negative effect. European Journal of Human Genetics, 23:481-485, Jul 2015. URL: https://doi.org/10.1038/ejhg.2014.132, doi:10.1038/ejhg.2014.132. This article has 36 citations and is from a domain leading peer-reviewed journal.
+
+13. (tavares2022newlocusunderlying pages 4-4): Vanessa Luiza Romanelli Tavares, Sofia Ligia Guimarães-Ramos, Yan Zhou, Cibele Masotti, Suzana Ezquina, Danielle de Paula Moreira, Henk Buermans, Renato S Freitas, Johan T Den Dunnen, Stephen R F Twigg, and Maria Rita Passos-Bueno. New locus underlying auriculocondylar syndrome (arcnd): 430 kb duplication involving twist1 regulatory elements. Journal of Medical Genetics, 59:895-905, Nov 2022. URL: https://doi.org/10.1136/jmedgenet-2021-107825, doi:10.1136/jmedgenet-2021-107825. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+14. (rieder2012ahumanhomeotic pages 3-5): Mark J. Rieder, Glenn E. Green, Sarah S. Park, Brendan D. Stamper, Christopher T. Gordon, Jason M. Johnson, Christopher M. Cunniff, Joshua D. Smith, Sarah B. Emery, Stanislas Lyonnet, Jeanne Amiel, Muriel Holder, Andrew A. Heggie, Michael J. Bamshad, Deborah A. Nickerson, Timothy C. Cox, Anne V. Hing, Jeremy A. Horst, and Michael L. Cunningham. A human homeotic transformation resulting from mutations in plcb4 and gnai3 causes auriculocondylar syndrome. American journal of human genetics, 90 5:907-14, May 2012. URL: https://doi.org/10.1016/j.ajhg.2012.04.002, doi:10.1016/j.ajhg.2012.04.002. This article has 114 citations and is from a highest quality peer-reviewed journal.
+
+15. (tavares2016identificaçãodenovas pages 67-68): Vanessa Luiza Romanelli Tavares. Identificação de novas variantes causativas e investigação da heterogeneidade clínica da síndrome aurículo-condilar identification of novel causative variants and investigation of clinical heterogeneity of auriculocondylar syndrome. ArXiv, Mar 2016. URL: https://doi.org/10.11606/t.41.2016.tde-14072016-142513, doi:10.11606/t.41.2016.tde-14072016-142513. This article has 0 citations.
+
+16. (liu2021prenataldiagnosisof pages 1-3): Xiaoliang Liu, Wei Sun, Jun Wang, Guoming Chu, Rong He, Bijun Zhang, and Yanyan Zhao. Prenatal diagnosis of auriculocondylar syndrome with a novel missense variant of gnai3: a case report. BMC Pregnancy and Childbirth, Nov 2021. URL: https://doi.org/10.1186/s12884-021-04238-x, doi:10.1186/s12884-021-04238-x. This article has 8 citations and is from a peer-reviewed journal.
+
+17. (gordon2013heterogeneityofmutational pages 11-12): Christopher T Gordon, Alice Vuillot, Sandrine Marlin, Erica Gerkes, Alex Henderson, Adila AlKindy, Muriel Holder-Espinasse, Sarah S Park, Asma Omarjee, Mateo Sanchis-Borja, Eya Ben Bdira, Myriam Oufadem, Birgit Sikkema-Raddatz, Alison Stewart, Rodger Palmer, Ruth McGowan, Florence Petit, Bruno Delobel, Michael R Speicher, Paul Aurora, David Kilner, Philippe Pellerin, Marie Simon, Jean-Paul Bonnefont, Edward S Tobias, Sixto García-Miñaúr, Maria Bitner-Glindzicz, Pernille Lindholm, Brigitte A Meijer, Véronique Abadie, Françoise Denoyelle, Marie-Paule Vazquez, Christa Rotky-Fast, Vincent Couloigner, Sébastien Pierrot, Yves Manach, Sylvain Breton, Yvonne M C Hendriks, Arnold Munnich, Linda Jakobsen, Peter Kroisel, Angela Lin, Leonard B Kaban, Lina Basel-Vanagaite, Louise Wilson, Michael L Cunningham, Stanislas Lyonnet, and Jeanne Amiel. Heterogeneity of mutational mechanisms and modes of inheritance in auriculocondylar syndrome. Journal of Medical Genetics, 50:174-186, Jan 2013. URL: https://doi.org/10.1136/jmedgenet-2012-101331, doi:10.1136/jmedgenet-2012-101331. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+18. (zhang2024auriculocondylarsyndrome2 pages 2-5): Yongli Zhang, Yuwei Zhao, Liying Dai, Yu Liu, and Zifeng Shi. Auriculocondylar syndrome 2 caused by a novel plcb4 variant in a male chinese neonate: a case report and review of the literature. Molecular Genetics & Genomic Medicine, Apr 2024. URL: https://doi.org/10.1002/mgg3.2441, doi:10.1002/mgg3.2441. This article has 3 citations and is from a peer-reviewed journal.
+
+19. (tavares2016identificaçãodenovas pages 68-72): Vanessa Luiza Romanelli Tavares. Identificação de novas variantes causativas e investigação da heterogeneidade clínica da síndrome aurículo-condilar identification of novel causative variants and investigation of clinical heterogeneity of auriculocondylar syndrome. ArXiv, Mar 2016. URL: https://doi.org/10.11606/t.41.2016.tde-14072016-142513, doi:10.11606/t.41.2016.tde-14072016-142513. This article has 0 citations.
+
+20. (tavares2022newlocusunderlying pages 1-1): Vanessa Luiza Romanelli Tavares, Sofia Ligia Guimarães-Ramos, Yan Zhou, Cibele Masotti, Suzana Ezquina, Danielle de Paula Moreira, Henk Buermans, Renato S Freitas, Johan T Den Dunnen, Stephen R F Twigg, and Maria Rita Passos-Bueno. New locus underlying auriculocondylar syndrome (arcnd): 430 kb duplication involving twist1 regulatory elements. Journal of Medical Genetics, 59:895-905, Nov 2022. URL: https://doi.org/10.1136/jmedgenet-2021-107825, doi:10.1136/jmedgenet-2021-107825. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+21. (tavares2022newlocusunderlying pages 6-7): Vanessa Luiza Romanelli Tavares, Sofia Ligia Guimarães-Ramos, Yan Zhou, Cibele Masotti, Suzana Ezquina, Danielle de Paula Moreira, Henk Buermans, Renato S Freitas, Johan T Den Dunnen, Stephen R F Twigg, and Maria Rita Passos-Bueno. New locus underlying auriculocondylar syndrome (arcnd): 430 kb duplication involving twist1 regulatory elements. Journal of Medical Genetics, 59:895-905, Nov 2022. URL: https://doi.org/10.1136/jmedgenet-2021-107825, doi:10.1136/jmedgenet-2021-107825. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+22. (shi2024novelgnai3mutation media 1e0f905a): Yulin Shi, Liang Rong, Siying Liu, Yiwen Liu, Chunlin Zong, Jinbiao Lu, Hongtao Shang, Yang Xue, and Lei Tian. Novel gnai3 mutation in a chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report. BMC Oral Health, Jul 2024. URL: https://doi.org/10.1186/s12903-024-04575-1, doi:10.1186/s12903-024-04575-1. This article has 2 citations and is from a peer-reviewed journal.
+
+23. (shi2024novelgnai3mutation media 063b200e): Yulin Shi, Liang Rong, Siying Liu, Yiwen Liu, Chunlin Zong, Jinbiao Lu, Hongtao Shang, Yang Xue, and Lei Tian. Novel gnai3 mutation in a chinese family with auriculocondylar syndrome and treatment of severe dentofacial deformities: a 5-year follow-up case report. BMC Oral Health, Jul 2024. URL: https://doi.org/10.1186/s12903-024-04575-1, doi:10.1186/s12903-024-04575-1. This article has 2 citations and is from a peer-reviewed journal.

--- a/research/Auriculocondylar_Syndrome-deep-research-falcon.md.citations.md
+++ b/research/Auriculocondylar_Syndrome-deep-research-falcon.md.citations.md
@@ -1,0 +1,495 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Auriculocondylar Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Auriculocondylar Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-10T11:28:33.205786
+
+1. rieder2012ahumanhomeotic pages 1-2
+2. clouthier2013understandingthebasis pages 1-3
+3. tavares2022newlocusunderlying pages 1-2
+4. tavares2017targetedmolecularinvestigation pages 4-6
+5. gordon2013mutationsinendothelin pages 1-2
+6. gordon2013heterogeneityofmutational pages 11-12
+7. tavares2022newlocusunderlying pages 4-4
+8. rieder2012ahumanhomeotic pages 3-5
+9. tavares2022newlocusunderlying pages 1-1
+10. tavares2022newlocusunderlying pages 5-6
+11. liu2021prenataldiagnosisof pages 1-3
+12. gordon2013heterogeneityofmutational pages 1-2
+13. tavares2015novelvariantsin pages 1-2
+14. tavares2022newlocusunderlying pages 6-7
+15. ing
+16. https://doi.org/10.1016/j.ajhg.2012.04.002;
+17. https://doi.org/10.1002/ajmg.c.31376;
+18. https://doi.org/10.1002/ajmg.c.31376
+19. https://doi.org/10.1136/jmedgenet-2021-107825
+20. https://doi.org/10.1186/s12903-024-04575-1
+21. https://doi.org/10.1002/mgg3.2441
+22. http://www.orpha.net
+23. https://doi.org/10.1002/ajmg.a.38101;
+24. https://doi.org/10.1016/j.ajhg.2013.10.023;
+25. https://doi.org/10.1038/ejhg.2014.132;
+26. https://doi.org/10.1186/s12884-021-04238-x;
+27. https://doi.org/10.1136/jmedgenet-2012-101331;
+28. https://doi.org/10.11606/t.41.2016.tde-14072016-142513
+29. https://doi.org/10.1016/j.ajhg.2013.10.023
+30. https://doi.org/10.1186/s12903-024-04575-1;
+31. https://doi.org/10.1172/jci151536;
+32. https://doi.org/10.1016/j.ajhg.2012.04.002
+33. https://doi.org/10.1002/ajmg.a.38101
+34. https://doi.org/10.1002/ajmg.c.31376,
+35. https://doi.org/10.1016/j.ajhg.2012.04.002,
+36. https://doi.org/10.1186/s12903-024-04575-1,
+37. https://doi.org/10.1136/jmedgenet-2012-101331,
+38. https://doi.org/10.1136/jmedgenet-2021-107825,
+39. https://doi.org/10.1002/mgg3.2441,
+40. https://doi.org/10.1016/j.ajhg.2013.10.023,
+41. https://doi.org/10.1002/ajmg.a.38101,
+42. https://doi.org/10.1038/ejhg.2014.132,
+43. https://doi.org/10.11606/t.41.2016.tde-14072016-142513,
+44. https://doi.org/10.1186/s12884-021-04238-x,


### PR DESCRIPTION
## Summary

Adds an initial DISMECH curation page for auriculocondylar syndrome (MONDO:0000107), generated from Falcon deep research and backed by fetched PubMed reference caches.

## Content

- Adds `kb/disorders/Auriculocondylar_Syndrome.yaml`
- Covers EDN1-EDNRA craniofacial signaling disruption, neural crest patterning, GNAI3, PLCB4, EDN1, and TWIST1 regulatory mechanisms
- Adds phenotype, inheritance, genetic, diagnosis, treatment, differential diagnosis, and animal model sections
- Includes Falcon report artifacts under `research/`
- Adds PMID cache files fetched with `just fetch-reference`

## Validation

- `just validate kb/disorders/Auriculocondylar_Syndrome.yaml` passed
- `just validate-references kb/disorders/Auriculocondylar_Syndrome.yaml` passed
- `just compliance kb/disorders/Auriculocondylar_Syndrome.yaml` reported 90.2% global compliance / 90.7% weighted compliance
- `git diff --check` passed for staged files

## Notes

- OAK lookups were kept scoped after a broad GO fuzzy lookup hung. Microstomia and polyhydramnios are left as preferred-term-only phenotype descriptors rather than blocking on uncertain or slow ontology specificity.
- Unrelated generated cache churn from validation was restored before committing.
