### PR TITLE
Wire tazemetostat to EZH2 mechanism node in Rhabdoid Tumor (#1120)

### DIFF
--- a/kb/disorders/Rhabdoid_Tumor.yaml
+++ b/kb/disorders/Rhabdoid_Tumor.yaml
@@ -1,6 +1,6 @@
 name: Rhabdoid Tumor
 creation_date: '2026-04-12T05:17:45Z'
-updated_date: '2026-04-28T13:00:00Z'
+updated_date: '2026-05-10T17:00:00Z'
 description: >-
   Rhabdoid tumor is an aggressive pediatric embryonal neoplasm spanning renal,
   extrarenal soft-tissue, and central nervous system sites. Across these anatomic
@@ -326,6 +326,13 @@ treatments:
       term:
         id: NCIT:C107506
         label: Tazemetostat
+  target_mechanisms:
+  - target: EZH2-Driven H3K27 Methylation
+    treatment_effect: INHIBITS
+    description: >-
+      Tazemetostat selectively inhibits EZH2 methyltransferase activity, blocking
+      the H3K27 methylation dependency that SMARCB1-deficient rhabdoid tumors
+      acquire when BAF-mediated antagonism of PRC2 is lost.
   evidence:
   - reference: PMID:23620515
     reference_title: Durable tumor regression in genetically altered malignant rhabdoid tumors by inhibition of methyltransferase EZH2.


### PR DESCRIPTION
## Summary

Small enrichment of `kb/disorders/Rhabdoid_Tumor.yaml` for issue #1120.

The existing **EZH2 Inhibitor Therapy** treatment block now declares which pathophysiology node it targets:

```yaml
target_mechanisms:
- target: EZH2-Driven H3K27 Methylation
  treatment_effect: INHIBITS
  description: >-
    Tazemetostat selectively inhibits EZH2 methyltransferase activity, blocking
    the H3K27 methylation dependency that SMARCB1-deficient rhabdoid tumors
    acquire when BAF-mediated antagonism of PRC2 is lost.
```

This follows the pattern already used in `Anaplastic_Thyroid_Carcinoma.yaml` (where `Dabrafenib + Trametinib` declares `target_mechanisms` on `MAPK-Activating Truncal Driver Alteration`). It makes the treatment-mechanism wiring machine-queryable without changing biology — the EZH2 dependency rationale was already curated in the treatment's existing PMID:23620515 evidence item, which states *"the dependency of SMARCB1 mutant MRTs on EZH2 enzymatic activity"*.

## Why now / scope

- **Issue #1120** is one of the cancer-batch baselines in close-or-keep-open state. The two enrichment items the prior 2026-04-28 scanner comment flagged (a standalone `CDKN2A/p16 → CDK4/Cyclin D1` node, and a future `swi_snf_deficiency` mechanism module) both require new PMID lookups; this `target_mechanisms` wiring was not on that list and is the smaller, lossless lift.
- The pathophysiology graph already has `SMARCB1 or SMARCA4 Loss → EZH2-Driven H3K27 Methylation → Aberrant MRT Cell Growth`. Naming the EZH2 node as the tazemetostat target lets that drug's anti-tumor effect be reasoned about along the existing causal chain.

## Validation

- `just validate kb/disorders/Rhabdoid_Tumor.yaml` ✅ schema + terms + references all pass.
- Cache normalization side effects (one new `NCIT:C3808` row in `cache/enums/histopathologyfindingterm_*.csv`, plus `reference_id` quoting on 41 `references_cache/clinicaltrials_*.md` files) were intentionally **not** committed, to avoid the cache-CSV drift pattern flagged on prior PRs (#1429 and others). Those normalizations should land in a dedicated cache-refresh PR if desired.
- Bumped `updated_date` to `2026-05-10T17:00:00Z`.

## What this PR intentionally does NOT do

- No new pathophysiology nodes (the `CDKN2A/p16 → CDK4/Cyclin D1` standalone node from the prior triage list still needs new PMID work).
- No new treatments, genes, or evidence items.
- No `conforms_to` link; the prior triage flagged that as a possible future `swi_snf_deficiency` module rather than an existing one.

## Lifecycle for #1120

After this lands, #1120 is in the same close-or-enrichment-ticket state as the parallel cancer-parent issues. Flagging for @cmungall.

— automated curation scanner run (claude[bot])