### PR TITLE
Address acquired angioedema review suggestions

### DIFF
--- a/kb/disorders/Acquired_Angioedema.yaml
+++ b/kb/disorders/Acquired_Angioedema.yaml
@@ -1,6 +1,6 @@
 name: Acquired Angioedema
 creation_date: "2026-05-10T16:46:20Z"
-updated_date: "2026-05-10T16:46:20Z"
+updated_date: "2026-05-10T17:31:54Z"
 category: Complex
 description: >-
   Acquired angioedema is a rare, nonhereditary, bradykinin-mediated angioedema
@@ -286,6 +286,7 @@ phenotypes:
   description: >-
     Facial swelling is a prominent manifestation of acquired C1-INH deficiency
     attacks.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: facial edema
     term:
@@ -308,6 +309,7 @@ phenotypes:
   description: >-
     Upper-airway or laryngeal swelling can cause airway compromise and is the
     main life-threatening manifestation.
+  frequency: VERY_FREQUENT
   phenotype_term:
     preferred_term: laryngeal edema
     term:
@@ -331,30 +333,30 @@ phenotypes:
   name: Bowel Angioedema with Episodic Abdominal Pain
   description: >-
     Bowel wall swelling can produce episodic abdominal pain during attacks,
-    although the cached abstracts support bowel involvement more directly than
-    pain severity or frequency.
+    with abdominal involvement reported in a majority of patients in a large
+    acquired C1-INH deficiency cohort.
+  frequency: FREQUENT
   phenotype_term:
     preferred_term: episodic abdominal pain
     term:
       id: HP:0002574
       label: Episodic abdominal pain
   evidence:
-  - reference: PMID:34956216
-    reference_title: "Angioedema Without Wheals: Challenges in Laboratorial Diagnosis."
-    supports: PARTIAL
+  - reference: PMID:28284781
+    reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
+    supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      They present with subcutaneous and mucosal swellings, affecting
-      extremities, face, genitals, bowels, and upper airways.
+    snippet: "followed by abdomen (N = 51"
     explanation: >-
-      The abstract supports bowel involvement in angioedema without wheals;
-      abdominal pain is modeled as the expected symptomatic manifestation of
-      bowel swelling and therefore marked PARTIAL.
+      The Milan cohort reports abdominal involvement in 66% of C1-INH-AAE
+      patients, supporting abdominal or bowel angioedema as a frequent
+      manifestation.
 - category: Dermatologic
   name: Peripheral Edema
   description: >-
     Limb or extremity swelling can occur as part of the nonurticarial
     angioedema attack distribution.
+  frequency: FREQUENT
   phenotype_term:
     preferred_term: edema of extremities
     term:
@@ -362,17 +364,15 @@ phenotypes:
       label: Edema
     temporality: RECURRENT
   evidence:
-  - reference: PMID:34956216
-    reference_title: "Angioedema Without Wheals: Challenges in Laboratorial Diagnosis."
+  - reference: PMID:28284781
+    reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      They present with subcutaneous and mucosal swellings, affecting
-      extremities, face, genitals, bowels, and upper airways.
+    snippet: "peripheries (N = 50"
     explanation: >-
-      The abstract supports extremity involvement; HPO lacks a more specific
-      selected term here, so the broad edema term is used with a more specific
-      preferred term.
+      The cohort reports peripheral involvement in 65% of patients. Local HPO
+      search did not identify a more specific extremity edema term, so the
+      broad edema term is retained with a specific preferred term.
 biochemical:
 - name: Low C1 Inhibitor Function
   presence: DECREASED
@@ -391,6 +391,25 @@ biochemical:
     explanation: >-
       The cohort required low C1-INH function, supporting this as a core
       biochemical abnormality.
+- name: Low C4
+  presence: DECREASED
+  context: >-
+    Low C4 is part of the complement-consumption pattern used with C1-INH
+    antigen/function and clinical context to support acquired C1-INH deficiency.
+  evidence:
+  - reference: PMID:28284781
+    reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Diagnostic criteria included history of recurrent angioedema without
+      wheals; decreased C1-INH antigen levels and/or functional activity of
+      C1-INH and C4 antigen less than 50% of normal; late symptom onset (>40
+      years); no family history of angioedema and C1-INH deficiency.
+    explanation: >-
+      The cohort's diagnostic criteria explicitly include C4 antigen below 50%
+      of normal together with C1-INH abnormalities and adult-onset recurrent
+      angioedema.
 - name: Low or Undetectable C1q
   presence: DECREASED
   context: >-
@@ -429,12 +448,12 @@ diagnosis:
 - name: Complement and C1-INH Functional Testing
   description: >-
     Diagnosis combines recurrent angioedema without family history with
-    complement/C1-INH testing, especially C1-INH function and levels, C1q, and
-    evaluation for hereditary angioedema or histaminergic mimics.
+    complement/C1-INH testing, especially C1-INH function and levels, C4, C1q,
+    and evaluation for hereditary angioedema or histaminergic mimics.
   results: >-
-    Low C1-INH function, low C1-INH level and/or low C1q, with adult onset and
-    absence of family history or SERPING1 mutation, supports acquired C1-INH
-    deficiency.
+    Low C1-INH function, low C1-INH level, low C4, and/or low C1q, with adult
+    onset and absence of family history or SERPING1 mutation, supports acquired
+    C1-INH deficiency.
   evidence:
   - reference: PMID:34956216
     reference_title: "Angioedema Without Wheals: Challenges in Laboratorial Diagnosis."
@@ -578,6 +597,38 @@ treatments:
     explanation: >-
       The evidence is a small retrospective real-world AAE-C1-INH subgroup, so
       the prophylaxis claim is marked PARTIAL rather than definitive.
+- name: Tranexamic Acid Long-Term Prophylaxis
+  description: >-
+    Tranexamic acid is an antifibrinolytic used as long-term prophylaxis in
+    acquired C1-INH deficiency, with cohort evidence of benefit in many treated
+    patients.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: tranexamic acid
+      term:
+        id: CHEBI:48669
+        label: tranexamic acid
+  target_mechanisms:
+  - target: Bradykinin Excess
+    treatment_effect: INHIBITS
+    description: >-
+      Antifibrinolytic therapy is intended to reduce contact/fibrinolytic-system
+      amplification that contributes to bradykinin-mediated attacks.
+  evidence:
+  - reference: PMID:28284781
+    reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thirty-four patients received long-term prophylaxis with tranexamic acid
+      (effective in 29) and 20 with androgens (effective in 8).
+    explanation: >-
+      The Milan cohort directly reports tranexamic acid prophylaxis use and
+      effectiveness in most treated C1-INH-AAE patients.
 - name: Treat Underlying Lymphoproliferative Disease
   description: >-
     Evaluation and treatment of the associated lymphoid malignancy or related

--- a/kb/disorders/Acquired_Angioedema.yaml
+++ b/kb/disorders/Acquired_Angioedema.yaml
@@ -1,6 +1,6 @@
 name: Acquired Angioedema
 creation_date: "2026-05-10T16:46:20Z"
-updated_date: "2026-05-10T17:31:54Z"
+updated_date: "2026-05-10T17:57:06Z"
 category: Complex
 description: >-
   Acquired angioedema is a rare, nonhereditary, bradykinin-mediated angioedema
@@ -329,6 +329,16 @@ phenotypes:
     explanation: >-
       This cohort abstract directly supports life-threatening laryngeal edema
       in AAE-C1-INH.
+  - reference: PMID:33472202
+    reference_title: "Acquired Angioedema with C1 Inhibitor Deficiency: Occurrence, Clinical Features, and Management: A Nationwide Retrospective Study in the Czech Republic Patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common clinical manifestation was facial edema (100%) and upper
+      airway swelling (85.7%).
+    explanation: >-
+      The national cohort reports upper-airway swelling in 85.7% of patients,
+      supporting the VERY_FREQUENT frequency assignment.
 - category: Gastrointestinal
   name: Bowel Angioedema with Episodic Abdominal Pain
   description: >-
@@ -346,7 +356,7 @@ phenotypes:
     reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "followed by abdomen (N = 51"
+    snippet: "followed by abdomen (N = 51"
     explanation: >-
       The Milan cohort reports abdominal involvement in 66% of C1-INH-AAE
       patients, supporting abdominal or bowel angioedema as a frequent
@@ -368,7 +378,7 @@ phenotypes:
     reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "peripheries (N = 50"
+    snippet: "peripheries (N = 50"
     explanation: >-
       The cohort reports peripheral involvement in 65% of patients. Local HPO
       search did not identify a more specific extremity edema term, so the
@@ -613,11 +623,12 @@ treatments:
         id: CHEBI:48669
         label: tranexamic acid
   target_mechanisms:
-  - target: Bradykinin Excess
-    treatment_effect: INHIBITS
+  - target: Acquired C1 Inhibitor Deficiency
+    treatment_effect: MODULATES
     description: >-
-      Antifibrinolytic therapy is intended to reduce contact/fibrinolytic-system
-      amplification that contributes to bradykinin-mediated attacks.
+      Antifibrinolytic therapy is used in acquired C1-INH deficiency to reduce
+      contact/fibrinolytic-system amplification that contributes to
+      bradykinin-mediated attacks.
   evidence:
   - reference: PMID:28284781
     reference_title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."

--- a/references_cache/PMID_28284781.md
+++ b/references_cache/PMID_28284781.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:28284781"
+title: "Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency."
+authors:
+- Zanichelli A
+- Azin GM
+- Wu MA
+- Suffritti C
+- Maggioni L
+- Caccia S
+- Perego F
+- Vacchini R
+- Cicardi M
+journal: J Allergy Clin Immunol Pract
+year: '2017'
+doi: 10.1016/j.jaip.2016.12.032
+keywords:
+- Age of Onset
+- Aged
+- Androgens/therapeutic use
+- "Angioedema/diagnosis, epidemiology, mortality"
+- "Angioedemas, Hereditary/diagnosis, epidemiology, mortality"
+- Autoantibodies/blood
+- "Bradykinin/analogs & derivatives, therapeutic use"
+- "Complement C1 Inhibitor Protein/genetics, therapeutic use"
+- Female
+- Humans
+- Incidence
+- Italy/epidemiology
+- Male
+- Middle Aged
+- Survival Analysis
+- Tranexamic Acid/therapeutic use
+content_type: abstract_only
+---
+
+# Diagnosis, Course, and Management of Angioedema in Patients With Acquired C1-Inhibitor Deficiency.
+**Authors:** Zanichelli A, Azin GM, Wu MA, Suffritti C, Maggioni L, Caccia S, Perego F, Vacchini R, Cicardi M
+**Journal:** J Allergy Clin Immunol Pract (2017)
+**DOI:** [10.1016/j.jaip.2016.12.032](https://doi.org/10.1016/j.jaip.2016.12.032)
+
+## Content
+
+1. J Allergy Clin Immunol Pract. 2017 Sep-Oct;5(5):1307-1313. doi: 
+10.1016/j.jaip.2016.12.032. Epub 2017 Mar 9.
+
+Diagnosis, Course, and Management of Angioedema in Patients With Acquired 
+C1-Inhibitor Deficiency.
+
+Zanichelli A(1), Azin GM(2), Wu MA(2), Suffritti C(2), Maggioni L(2), Caccia 
+S(2), Perego F(2), Vacchini R(2), Cicardi M(3).
+
+Author information:
+(1)Department of Biomedical and Clinical Sciences, Luigi Sacco Hospital, 
+University of Milan, Milan, Italy. Electronic address: 
+andrea.zanichelli@unimi.it.
+(2)Department of Biomedical and Clinical Sciences, Luigi Sacco Hospital, 
+University of Milan, Milan, Italy.
+(3)Department of Biomedical and Clinical Sciences, Luigi Sacco Hospital, 
+University of Milan, Milan, Italy; ASST Fatebenefratelli Sacco, Milan, Italy.
+
+BACKGROUND: Acquired angioedema due to C1-inhibitor deficiency (C1-INH-AAE) is a 
+rare disease with no prevalence data or approved therapies.
+OBJECTIVE: To report data on patients with C1-INH-AAE followed at Angioedema 
+Center, Milan (from 1976 to 2015).
+METHODS: Diagnostic criteria included history of recurrent angioedema without 
+wheals; decreased C1-INH antigen levels and/or functional activity of C1-INH and 
+C4 antigen less than 50% of normal; late symptom onset (>40 years); no family 
+history of angioedema and C1-INH deficiency.
+RESULTS: In total, 77 patients (58% females; median age, 70 years) were 
+diagnosed with C1-INH-AAE and 675 patients with hereditary angioedema due to 
+C1-INH deficiency (C1-INH-HAE) (1 patient with C1-INH-AAE/8.8 patients with 
+C1-INH-HAE). Median age at diagnosis was 64 years. Median time between symptom 
+onset and diagnosis was 2 years. Sixteen patients (21%) died since diagnosis, 
+including 1 because of laryngeal edema. Angioedema of the face was most common 
+(N = 63 [82%]), followed by abdomen (N = 51 [66%]), peripheries (N = 50 [65%]), 
+and oral mucosa and/or glottis (N = 42 [55%]). Forty-eight of 71 patients (68%) 
+had autoantibodies to C1-INH. In total, 56 patients (70%) used on-demand 
+treatment for angioedema including intravenous pdC1-INH 2000 U (Berinert, CSL 
+Behring, Marburg, Germany) (N = 49) and/or subcutaneous icatibant 30 mg 
+(Firazyr, Shire; Milano, Italy) (N = 27). Eventually, 8 of 49 patients receiving 
+pdC1-INH became nonresponsive; all had autoantibodies. Thirty-four patients 
+received long-term prophylaxis with tranexamic acid (effective in 29) and 20 
+with androgens (effective in 8).
+CONCLUSIONS: The incidence of C1-INH-AAE was 1 for every 8.8 patients with 
+C1-INH-HAE. Thirty percent of the deaths were related to the disease. Treatments 
+approved for C1-INH-HAE are effective in C1-INH-AAE, although with minimal 
+differences.
+
+Copyright © 2017 American Academy of Allergy, Asthma & Immunology. Published by 
+Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.jaip.2016.12.032
+PMID: 28284781 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Carries the acquired angioedema review-suggestion fixes that were pushed after PR #2467 had already auto-merged.
- Adds low C4 biochemical evidence from `PMID:28284781`.
- Adds tranexamic acid long-term prophylaxis with `CHEBI:48669`.
- Adds phenotype frequency qualifiers and documents the HPO fallback for extremity edema.

## Validation

- `just validate kb/disorders/Acquired_Angioedema.yaml`
- `just validate-references kb/disorders/Acquired_Angioedema.yaml`
- `just compliance kb/disorders/Acquired_Angioedema.yaml`
- `git diff --check -- kb/disorders/Acquired_Angioedema.yaml`
