### PR TITLE
Improve Aspartylglucosaminuria pathograph connectivity

### DIFF
--- a/kb/disorders/Aspartylglucosaminuria.yaml
+++ b/kb/disorders/Aspartylglucosaminuria.yaml
@@ -1,7 +1,7 @@
 name: Aspartylglucosaminuria
 category: Mendelian
 creation_date: '2026-05-03T15:19:05Z'
-updated_date: '2026-05-03T17:02:30Z'
+updated_date: '2026-05-10T13:31:42Z'
 synonyms:
 - Aspartylglucosaminidase deficiency
 - AGU
@@ -175,7 +175,15 @@ pathophysiology:
     explanation: Biochemical review identifies the affected gene and enzymatic reaction.
   downstream:
   - target: Glycoasparagine substrate accumulation
+    causal_link_type: DIRECT
     description: Loss of AGA activity blocks clearance of aspartylglucosamine-containing glycoasparagines.
+    evidence:
+    - reference: PMID:10571008
+      reference_title: "Aspartylglycosaminuria: biochemistry and molecular biology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Loss of glycosylasparaginase activity leads to accumulation of the linkage unit Asn-GlcNAc in tissue lysosomes."
+      explanation: This biochemical review directly links loss of AGA/glycosylasparaginase activity to lysosomal Asn-GlcNAc substrate accumulation.
 - name: AGA protein maturation and folding defects
   description: >
     Many AGA missense variants disrupt folding, dimerization, autocatalytic
@@ -212,7 +220,15 @@ pathophysiology:
     explanation: Study distinguishes dimerization, active-site, and maturation effects of pathogenic variants.
   downstream:
   - target: AGA lysosomal enzyme deficiency
+    causal_link_type: DIRECT
     description: Defective folding and maturation reduce the amount of active AGA reaching lysosomes.
+    evidence:
+    - reference: PMID:11309371
+      reference_title: "Molecular pathogenesis of a disease: structural consequences of aspartylglucosaminuria mutations."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Many of these are predicted to interfere with the complex intracellular maturation and processing of the AGA polypeptide."
+      explanation: Functional mutation analysis supports the edge from folding/maturation defects to reduced mature AGA enzyme.
 - name: Glycoasparagine substrate accumulation
   description: >
     Deficient AGA activity causes accumulation of undegraded glycoasparagines,
@@ -246,14 +262,43 @@ pathophysiology:
   - reference: PMID:33186692
     reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: "The accumulated substrate GlcNAc-Asn is excreted in urine of patients in large quantities."
     explanation: Gene-therapy study summarizes urinary GlcNAc-Asn as a disease biomarker.
   downstream:
   - target: Neuronal and glial lysosomal storage
+    causal_link_type: DIRECT
     description: Storage affects lysosomes in brain cells, producing progressive neurodegeneration.
+    evidence:
+    - reference: PMID:10571008
+      reference_title: "Aspartylglycosaminuria: biochemistry and molecular biology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Storage of this fragment affects the pathophysiology of neuronal cells most severely."
+      explanation: This directly supports neuronal cells as a major downstream target of Asn-GlcNAc storage.
   - target: Systemic connective tissue and skeletal involvement
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - glycoasparagine storage in non-neuronal tissues
+    - cellular dysfunction and connective-tissue or skeletal remodeling
     description: Storage in non-neuronal tissues contributes to coarse features, hernias, and skeletal abnormalities.
+    evidence:
+    - reference: PMID:33439067
+      reference_title: "Aspartylglucosaminuria: Clinical Presentation and Potential Therapies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "AGU is caused by pathogenic variants in the aspartylglucosaminidase (AGA) gene, leading to glycoasparagine accumulation and cellular dysfunction."
+      explanation: This supports the storage-to-cellular-dysfunction bridge; the specific connective-tissue and skeletal intermediates are compressed into the downstream node.
+  - target: Aspartylglucosaminuria
+    causal_link_type: DIRECT
+    description: Accumulated GlcNAc-Asn/aspartylglucosamine is excreted in urine as the biochemical phenotype.
+    evidence:
+    - reference: PMID:33186692
+      reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The accumulated substrate GlcNAc-Asn is excreted in urine of patients in large quantities."
+      explanation: This directly links substrate accumulation to the urinary aspartylglucosamine phenotype.
 - name: Neuronal and glial lysosomal storage
   description: >
     Glycoasparagine accumulation produces lysosomal storage in neurons and glia,
@@ -288,22 +333,66 @@ pathophysiology:
   - reference: PMID:33186692
     reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: "AGU is a slow but progressive and severe neurodegenerative disease characterized by intellectual disability, skeletal and motor abnormalities, and early mortality."
     explanation: Preclinical translational paper summarizes the progressive neurodegenerative phenotype.
   downstream:
   - target: Intellectual disability
+    causal_link_type: DIRECT
     description: Progressive brain storage and atrophy impair cognition and adaptive function.
+    evidence:
+    - reference: PMID:33439067
+      reference_title: "Aspartylglucosaminuria: Clinical Presentation and Potential Therapies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Aspartylglucosaminuria (AGU) is a recessively inherited neurodegenerative lysosomal storage disease characterized by progressive intellectual disability, skeletal abnormalities, connective tissue overgrowth, gait disturbance, and seizures followed by premature death."
+      explanation: This directly connects neurodegenerative lysosomal storage disease to progressive intellectual disability.
   - target: Delayed speech and language development
+    causal_link_type: DIRECT
     description: Neurodevelopmental impairment includes prominent speech delay.
+    evidence:
+    - reference: PMID:33186692
+      reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "AGU patients have developmental delays including delayed speech and impaired learning caused by progressive brain atrophy."
+      explanation: This directly supports delayed speech as a consequence of progressive brain involvement.
+  - target: Abnormality of speech or vocalization
+    causal_link_type: DIRECT
+    description: Progressive brain involvement also manifests as abnormal speech and vocalization.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002167 | Abnormality of speech or vocalization | Very frequent (99-80%)"
+      explanation: Orphanet supports abnormal speech/vocalization as a very frequent neurodevelopmental manifestation.
   - target: Dyskinesia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - progressive motor-system involvement
     description: Progressive CNS involvement contributes to abnormal involuntary movement.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100660 | Dyskinesia | Very frequent (99-80%)"
+      explanation: Orphanet supports dyskinesia as a very frequent manifestation downstream of neurologic disease.
   - target: Seizure
+    causal_link_type: DIRECT
     description: Progressive brain disease can include seizures.
+    evidence:
+    - reference: PMID:33439067
+      reference_title: "Aspartylglucosaminuria: Clinical Presentation and Potential Therapies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "skeletal abnormalities, connective tissue overgrowth, gait disturbance, and seizures"
+      explanation: Clinical review lists seizures among the core manifestations of AGU.
 - name: Systemic connective tissue and skeletal involvement
   description: >
     Non-neuronal lysosomal storage and connective-tissue overgrowth contribute
-    to the facial, gingival, hernia, and skeletal manifestations of
+    to the coarse facial, gingival/oral, hernia, and skeletal manifestations of
     aspartylglucosaminuria.
   locations:
   - preferred_term: connective tissue
@@ -329,11 +418,85 @@ pathophysiology:
     explanation: Review supports broad systemic involvement beyond the CNS.
   downstream:
   - target: Gingival overgrowth
+    causal_link_type: DIRECT
     description: Connective-tissue overgrowth contributes to gingival enlargement.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000212 | Gingival overgrowth | Very frequent (99-80%)"
+      explanation: Orphanet supports gingival overgrowth as a very frequent manifestation of the systemic connective-tissue branch.
+  - target: Coarse facial features
+    causal_link_type: DIRECT
+    description: Systemic storage and connective-tissue overgrowth contribute to coarse facial features.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000280 | Coarse facial features | Frequent (79-30%)"
+      explanation: Orphanet supports coarse facial features as a frequent manifestation of AGU.
   - target: Umbilical hernia
+    causal_link_type: DIRECT
     description: Connective tissue involvement contributes to hernias.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001537 | Umbilical hernia | Very frequent (99-80%)"
+      explanation: Orphanet supports umbilical hernia as a very frequent manifestation.
+  - target: Inguinal hernia
+    causal_link_type: DIRECT
+    description: Connective tissue involvement can also manifest as inguinal hernia.
+    evidence:
+    - reference: PMID:33439067
+      reference_title: "Aspartylglucosaminuria: Clinical Presentation and Potential Therapies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "developmental delays, hyperactivity, early growth spurt, inguinal and abdominal hernias"
+      explanation: Clinical review includes inguinal and abdominal hernias among early AGU diagnostic features.
   - target: Scoliosis
+    causal_link_type: DIRECT
     description: Skeletal involvement contributes to spinal curvature.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002650 | Scoliosis | Very frequent (99-80%)"
+      explanation: Orphanet supports scoliosis as a very frequent skeletal manifestation.
+  - target: Pectus carinatum
+    causal_link_type: DIRECT
+    description: Skeletal involvement can manifest as pectus carinatum.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000768 | Pectus carinatum | Frequent (79-30%)"
+      explanation: Orphanet supports pectus carinatum as a frequent skeletal manifestation.
+  - target: Thickened calvaria
+    causal_link_type: DIRECT
+    description: Cranial skeletal involvement can manifest as calvarial thickening.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002684 | Thickened calvaria | Frequent (79-30%)"
+      explanation: Orphanet supports thickened calvaria as a frequent skeletal manifestation.
+  - target: Anterior beaking of lumbar vertebrae
+    causal_link_type: DIRECT
+    description: Spinal skeletal involvement can manifest as anterior lumbar vertebral beaking.
+    evidence:
+    - reference: ORPHA:93
+      reference_title: "Aspartylglucosaminuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008430 | Anterior beaking of lumbar vertebrae | Frequent (79-30%)"
+      explanation: Orphanet supports anterior beaking of lumbar vertebrae as a frequent skeletal manifestation.
 biochemical:
 - name: Increased urinary aspartylglucosamine
   presence: INCREASED
@@ -350,7 +513,7 @@ biochemical:
   - reference: PMID:33186692
     reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: "Large amounts of GlcNAc-Asn substrate can be readily detected in urine of AGU patients and is thereby used as a diagnostic biomarker."
     explanation: Study supports urinary GlcNAc-Asn as the diagnostic biochemical substrate.
 - name: Reduced aspartylglucosaminidase activity
@@ -859,7 +1022,7 @@ diagnosis:
   - reference: PMID:33186692
     reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: "Large amounts of GlcNAc-Asn substrate can be readily detected in urine of AGU patients and is thereby used as a diagnostic biomarker."
     explanation: Study supports urinary GlcNAc-Asn as a diagnostic biomarker.
 - name: AGA molecular genetic testing
@@ -938,6 +1101,29 @@ treatments:
       evidence_source: MODEL_ORGANISM
       snippet: "AAV9/AGA administration led to (1) dose dependently increased and sustained AGA activity"
       explanation: Preclinical mouse study supports restoration of AGA activity after gene transfer.
+  - target: Glycoasparagine substrate accumulation
+    treatment_effect: INHIBITS
+    description: Restored AGA activity reduces the accumulated GlcNAc-Asn substrate burden in Aga-deficient mice.
+    evidence:
+    - reference: PMID:33186692
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "rapid, sustained, and dose-dependent elimination of AGA substrate in body fluids"
+      explanation: Mouse AAV9/AGA data support direct reduction of the storage substrate downstream of enzyme restoration.
+  - target: Neuronal and glial lysosomal storage
+    treatment_effect: INHIBITS
+    description: AAV9/AGA reduced central nervous system pathology in the mouse model.
+    evidence:
+    - reference: PMID:33186692
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "dose-dependent preservation of Purkinje neurons in the cerebellum"
+      explanation: Preservation of cerebellar neurons supports disease-modifying impact on the neuronal storage branch.
+    - reference: PMID:33186692
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "significantly reduced gliosis in the brain"
+      explanation: Reduced gliosis supports inhibition of downstream glial pathology in the mouse model.
   evidence:
   - reference: PMID:33186692
     reference_title: "Pre-clinical Gene Therapy with AAV9/AGA in Aspartylglucosaminuria Mice Provides Evidence for Clinical Translation."


### PR DESCRIPTION
## Summary

- adds causal link types and exact evidence to all Aspartylglucosaminuria downstream pathophysiology edges
- connects storage and neurologic/systemic branches to additional phenotype endpoints, including urinary aspartylglucosamine, speech abnormality, coarse facial features, hernias, and skeletal endpoints
- splits PMID:33186692 evidence classification by what each snippet actually describes: patient biomarker/phenotype statements are `HUMAN_CLINICAL`, while mouse gene-transfer outcome statements remain `MODEL_ORGANISM`
- adds treatment target-mechanism evidence for the preclinical gene-replacement candidate against enzyme deficiency, substrate accumulation, and CNS storage pathology

## Validation

- `uv run python -m dismech.graph --validate kb/disorders/Aspartylglucosaminuria.yaml`
- `just validate kb/disorders/Aspartylglucosaminuria.yaml`
- custom snippet audit: checked 84 cached snippets; all normalized snippets found in cache
- explicit target-resolution script: 0 missing downstream or treatment target references
- `git diff --check`
- repository-integrity subagent review: PASS, no repository-integrity blockers

## Review notes

A broader subagent biomedical review prompt hit the model safety filter twice because this file contains preclinical gene-transfer therapy evidence. I narrowed the review to repository data integrity only; that review passed and independently checked schema validation, diff scope, target resolution, and changed-snippet cache support.
