### PR TITLE
Improve Glycogen Storage Disease XV pathograph connectivity

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_XV.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_XV.yaml
@@ -1,6 +1,6 @@
 name: Glycogen Storage Disease XV
 creation_date: "2026-04-15T23:36:22Z"
-updated_date: "2026-04-16T00:53:56Z"
+updated_date: "2026-05-10T17:58:13Z"
 description: >-
   Glycogen storage disease XV is an autosomal recessive muscle glycogenosis
   caused by glycogenin-1 deficiency. The disorder produces polyglucosan body
@@ -80,9 +80,33 @@ pathophysiology:
     explanation: This directly supports GYG1 deficiency as the disease-defining molecular defect.
   downstream:
   - target: Skeletal muscle polyglucosan myopathy
+    causal_link_type: DIRECT
     description: Abnormal glycogen initiation leads to polyglucosan body accumulation in skeletal muscle fibers.
+    evidence:
+    - reference: PMID:38923610
+      reference_title: Proteomic profiling of polyglucosan bodies associated with glycogenin-1 deficiency in skeletal muscle.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The absence of glycogenin-1, a protein important for glycogen synthesis
+        initiation, causes storage of polyglucosan
+      explanation: >-
+        This directly links glycogenin-1 absence and failed glycogen synthesis
+        initiation to skeletal-muscle polyglucosan storage.
   - target: Cardiac polyglucosan body involvement
+    causal_link_type: DIRECT
     description: A subset of patients develop cardiac involvement with polyglucosan storage.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        three cases had an isolated cardiopathy with the presence of
+        polyglucosan bodies on cardiac muscle biopsy
+      explanation: >-
+        This supports cardiac polyglucosan body involvement as a documented
+        branch of GYG1-related glycogenosis.
 - name: Skeletal muscle polyglucosan myopathy
   description: >-
     Polyglucosan body accumulation in skeletal muscle fibers causes progressive
@@ -117,17 +141,77 @@ pathophysiology:
     explanation: This directly supports a limb-girdle myopathy phenotype downstream of GYG1 deficiency.
   downstream:
   - target: Proximal muscle weakness
+    causal_link_type: DIRECT
     description: Limb-girdle myopathy manifests as proximal weakness of pelvic and shoulder girdle muscles.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        the majority showed proximal limb muscle weakness (19/36; 52.8%)
+      explanation: >-
+        This directly supports proximal limb weakness as the common clinical
+        manifestation of GYG1-related skeletal myopathy.
   - target: Exercise intolerance
+    causal_link_type: DIRECT
     description: Early muscle dysfunction produces reduced exercise tolerance and exertional symptoms.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        early onset exertional myalgia
+      explanation: >-
+        Exertional symptoms in a GSD XV patient provide disease-specific support
+        for exercise intolerance downstream of skeletal-muscle myopathy.
   - target: Distal weakness
+    causal_link_type: DIRECT
     description: Some patients present with predominant distal weakness or mixed proximal-distal involvement.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        13% had distal weakness (5/36; 13.6%)
+      explanation: >-
+        Published case review supports distal weakness as a less common
+        manifestation of the skeletal-muscle myopathy branch.
   - target: Myalgia
+    causal_link_type: DIRECT
     description: Muscle fiber dysfunction produces exertional and chronic myalgia.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        early onset exertional myalgia
+      explanation: This directly supports exertional myalgia downstream of GSD XV myopathy.
   - target: Waddling gait
+    causal_link_type: DIRECT
     description: Pelvic-girdle weakness can produce a waddling gait.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        revealed a waddling gait with hyperlordosis
+      explanation: This directly supports waddling gait as a manifestation of pelvic-girdle myopathy.
   - target: Scapular winging
+    causal_link_type: DIRECT
     description: Shoulder-girdle weakness can produce scapular winging.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        bilateral asymmetric scapular winging
+      explanation: This directly supports scapular winging as a manifestation of shoulder-girdle myopathy.
 - name: Cardiac polyglucosan body involvement
   description: >-
     A minority of patients with GYG1 deficiency develop cardiac involvement,
@@ -155,7 +239,16 @@ pathophysiology:
       deficiency.
   downstream:
   - target: Arrhythmia
+    causal_link_type: DIRECT
     description: Cardiac involvement can manifest as rhythm disturbance.
+    evidence:
+    - reference: PMID:32477874
+      reference_title: Glycogenin-1 deficiency mimicking limb-girdle muscular dystrophy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        for 1 patient with arrhythmia associated with proximal muscle weakness
+      explanation: This directly supports arrhythmia as a reported cardiac manifestation of GYG1 deficiency.
 histopathology:
 - name: Polyglucosan bodies on skeletal muscle biopsy
   finding_term:


### PR DESCRIPTION
## Summary

- adds causal link types and exact evidence to all Glycogen Storage Disease XV downstream pathophysiology edges
- connects the GYG1 deficiency node to skeletal and cardiac polyglucosan involvement
- wires skeletal myopathy to phenotype endpoints with disease-specific evidence where available
- addresses subagent blocker feedback by replacing a broad exercise-intolerance support snippet with GSD XV-specific exertional symptom evidence and removing weak treatment-to-mechanism links

## Validation

- `uv run python -m dismech.graph --validate kb/disorders/Glycogen_Storage_Disease_XV.yaml`
- `just validate kb/disorders/Glycogen_Storage_Disease_XV.yaml`
- custom snippet audit: checked 38 cached snippets; all normalized snippets found in cache
- explicit target-resolution script: 0 missing downstream or treatment target references
- `git diff --check`
- subagent review completed; two blockers addressed before PR
