### PR TITLE
Improve pyruvate carboxylase deficiency pathograph

### DIFF
--- a/kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml
+++ b/kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml
@@ -1,6 +1,6 @@
 name: Pyruvate Carboxylase Deficiency Disease
 creation_date: "2026-04-23T00:00:00Z"
-updated_date: "2026-04-24T00:00:00Z"
+updated_date: "2026-05-10T22:23:11Z"
 description: >-
   Pyruvate carboxylase deficiency disease is a rare autosomal recessive
   mitochondrial neurometabolic disorder caused by biallelic PC variants. The
@@ -9,626 +9,1186 @@ description: >-
   decompensation, and neurologic dysfunction.
 category: Metabolic Disorder
 parents:
-  - hereditary disease
-  - metabolic disorder
+- hereditary disease
+- metabolic disorder
 disease_term:
   preferred_term: pyruvate carboxylase deficiency disease
   term:
     id: MONDO:0009949
     label: pyruvate carboxylase deficiency disease
 has_subtypes:
-  - name: Type A pyruvate carboxylase deficiency
-    description: >-
-      Infantile pyruvate carboxylase deficiency with substantial neurologic and
-      metabolic morbidity but generally less fulminant disease than type B.
-    evidence:
-      - reference: DOI:10.1515/almed-2023-0102
-        reference_title: >-
-          Clinical, biochemical, and molecular profiles of three Sri Lankan
-          neonates with pyruvate carboxylase deficiency
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The other proband with normal citrulline, lysine, moderate lactate,
-          paraventricular cystic lesions, bony deformities, and a novel
-          missense, homozygous variant c.2746G>C [p.(Asp916His)] in the PC
-          gene, biochemically favoured type A.
-        explanation: >-
-          This directly supports type A as a recognized biochemical and
-          clinical subtype.
-  - name: Type B pyruvate carboxylase deficiency
-    description: >-
-      Severe neonatal pyruvate carboxylase deficiency with early respiratory
-      distress, profound metabolic decompensation, and high mortality.
-    evidence:
-      - reference: DOI:10.1515/almed-2023-0102
-        reference_title: >-
-          Clinical, biochemical, and molecular profiles of three Sri Lankan
-          neonates with pyruvate carboxylase deficiency
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Two siblings displayed typical biochemical findings reported in type
-          B.
-        explanation: >-
-          This directly supports type B as a severe neonatal biochemical
-          subtype.
-  - name: Type C pyruvate carboxylase deficiency
-    description: >-
-      A comparatively milder form with episodic metabolic decompensation and a
-      more favorable developmental course.
-    evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Pyruvate carboxylase deficiency (PCD) mostly presents with
-          life-limiting encephalopathy (types A/B). A milder type C
-          presentation is rare, with a comparatively favourable prognosis.
-        explanation: >-
-          This directly supports type C as the attenuated pyruvate carboxylase
-          deficiency subtype.
+- name: Type A
+  display_name: Type A pyruvate carboxylase deficiency
+  subtype_term:
+    preferred_term: pyruvate carboxylase deficiency, infantile form
+    term:
+      id: MONDO:0018141
+      label: pyruvate carboxylase deficiency, infantile form
+  description: >-
+    Infantile pyruvate carboxylase deficiency with substantial neurologic and
+    metabolic morbidity but generally less fulminant disease than type B.
+  evidence:
+  - reference: DOI:10.1515/almed-2023-0102
+    reference_title: >-
+      Clinical, biochemical, and molecular profiles of three Sri Lankan
+      neonates with pyruvate carboxylase deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The other proband with normal citrulline, lysine, moderate lactate,
+      paraventricular cystic lesions, bony deformities, and a novel
+      missense, homozygous variant c.2746G>C [p.(Asp916His)] in the PC
+      gene, biochemically favoured type A.
+    explanation: >-
+      This directly supports type A as a recognized biochemical and
+      clinical subtype.
+- name: Type B
+  display_name: Type B pyruvate carboxylase deficiency
+  subtype_term:
+    preferred_term: pyruvate carboxylase deficiency, severe neonatal type
+    term:
+      id: MONDO:0018142
+      label: pyruvate carboxylase deficiency, severe neonatal type
+  description: >-
+    Severe neonatal pyruvate carboxylase deficiency with early respiratory
+    distress, profound metabolic decompensation, and high mortality.
+  evidence:
+  - reference: DOI:10.1515/almed-2023-0102
+    reference_title: >-
+      Clinical, biochemical, and molecular profiles of three Sri Lankan
+      neonates with pyruvate carboxylase deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Two siblings displayed typical biochemical findings reported in type
+      B.
+    explanation: >-
+      This directly supports type B as a severe neonatal biochemical
+      subtype.
+- name: Type C
+  display_name: Type C pyruvate carboxylase deficiency
+  subtype_term:
+    preferred_term: pyruvate carboxylase deficiency, benign type
+    term:
+      id: MONDO:0018143
+      label: pyruvate carboxylase deficiency, benign type
+  description: >-
+    A comparatively milder form with episodic metabolic decompensation and a
+    more favorable developmental course.
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pyruvate carboxylase deficiency (PCD) mostly presents with
+      life-limiting encephalopathy (types A/B). A milder type C
+      presentation is rare, with a comparatively favourable prognosis.
+    explanation: >-
+      This directly supports type C as the attenuated pyruvate carboxylase
+      deficiency subtype.
 pathophysiology:
-  - name: Pyruvate Carboxylase Deficiency
-    description: >-
-      Biallelic PC dysfunction impairs the mitochondrial pyruvate carboxylase
-      complex, reducing the conversion of pyruvate to oxaloacetate.
-    genes:
-      - preferred_term: PC
-        term:
-          id: hgnc:8636
-          label: PC
-    cellular_components:
-      - preferred_term: mitochondrial matrix
-        term:
-          id: GO:0005759
-          label: mitochondrial matrix
+- name: Pyruvate Carboxylase Deficiency
+  description: >-
+    Biallelic PC dysfunction impairs the mitochondrial pyruvate carboxylase
+    complex, reducing the conversion of pyruvate to oxaloacetate.
+  genes:
+  - preferred_term: PC
+    term:
+      id: hgnc:8636
+      label: PC
+  molecular_functions:
+  - preferred_term: pyruvate carboxylase activity
+    term:
+      id: GO:0004736
+      label: pyruvate carboxylase activity
+    modifier: DECREASED
+  cellular_components:
+  - preferred_term: mitochondrial matrix
+    term:
+      id: GO:0005759
+      label: mitochondrial matrix
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pyruvate carboxylase (PC) deficiency is a rare autosomal recessive
+      mitochondrial neurometabolic disorder of energy deficit resulting in
+      high morbidity and mortality, with limited therapeutic options.
+    explanation: >-
+      This directly supports pyruvate carboxylase deficiency as the
+      proximal molecular lesion.
+  - reference: PMID:20598931
+    reference_title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Pyruvate carboxylase (PC) is a regulated mitochondrial enzyme that
+      catalyzes the conversion of pyruvate to oxaloacetate, a critical
+      transition that replenishes citric acid cycle intermediates and
+      facilitates other biosynthetic reactions that drive anabolism.
+    explanation: >-
+      This review summarizes the proximal biochemical function of PC and
+      supports the decreased pyruvate carboxylase activity annotation.
+  downstream:
+  - target: Impaired Gluconeogenesis
+    causal_link_type: DIRECT
+    description: Loss of pyruvate carboxylase activity compromises glucose production.
     evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Pyruvate carboxylase (PC) deficiency is a rare autosomal recessive
-          mitochondrial neurometabolic disorder of energy deficit resulting in
-          high morbidity and mortality, with limited therapeutic options.
-        explanation: >-
-          This directly supports pyruvate carboxylase deficiency as the
-          proximal molecular lesion.
-    downstream:
-      - target: Impaired Gluconeogenesis
-        description: Loss of pyruvate carboxylase activity compromises glucose production.
-      - target: Impaired Anaplerosis
-        description: Loss of pyruvate carboxylase activity compromises oxaloacetate-dependent metabolic flux.
-      - target: Lactate Accumulation
-        description: Pyruvate carboxylase deficiency causes pyruvate/lactate accumulation.
-  - name: Impaired Gluconeogenesis
-    description: >-
-      Pyruvate carboxylase normally supports gluconeogenesis, so deficiency
-      impairs glucose production during metabolic stress.
-    genes:
-      - preferred_term: PC
-        term:
-          id: hgnc:8636
-          label: PC
-    biological_processes:
-      - preferred_term: gluconeogenesis
-        term:
-          id: GO:0006094
-          label: gluconeogenesis
-        modifier: ABNORMAL
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The PC homotetramer has a critical role in gluconeogenesis,
+        anaplerosis, neurotransmitter synthesis, and lipogenesis.
+      explanation: >-
+        The patient cohort paper identifies gluconeogenesis as a critical
+        PC-dependent process, supporting this direct graph edge.
+  - target: Impaired Anaplerosis
+    causal_link_type: DIRECT
+    description: Loss of pyruvate carboxylase activity compromises oxaloacetate-dependent metabolic flux.
     evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The PC homotetramer has a critical role in gluconeogenesis,
-          anaplerosis, neurotransmitter synthesis, and lipogenesis.
-        explanation: >-
-          This directly supports gluconeogenesis as a pyruvate
-          carboxylase-dependent process disrupted by deficiency.
-    downstream:
-      - target: Hypoglycemia
-        description: Impaired gluconeogenesis contributes to hypoglycemia in metabolically unstable presentations.
-  - name: Impaired Anaplerosis
-    description: >-
-      Pyruvate carboxylase replenishes oxaloacetate and other TCA-cycle
-      intermediates, so deficiency impairs anaplerotic mitochondrial flux.
-    genes:
-      - preferred_term: PC
-        term:
-          id: hgnc:8636
-          label: PC
-    biological_processes:
-      - preferred_term: tricarboxylic acid cycle
-        term:
-          id: GO:0006099
-          label: tricarboxylic acid cycle
-        modifier: ABNORMAL
+    - reference: PMID:20598931
+      reference_title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Pyruvate carboxylase (PC) is a regulated mitochondrial enzyme that
+        catalyzes the conversion of pyruvate to oxaloacetate, a critical
+        transition that replenishes citric acid cycle intermediates and
+        facilitates other biosynthetic reactions that drive anabolism.
+      explanation: >-
+        The review directly links PC activity to replenishment of citric
+        acid cycle intermediates, supporting impaired anaplerosis when PC
+        activity is deficient.
+  - target: Lactate Accumulation
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Pyruvate carboxylase deficiency causes pyruvate/lactate accumulation.
+    intermediate_mechanisms:
+    - Reduced pyruvate-to-oxaloacetate conversion leaves pyruvate available for lactate production.
     evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The PC homotetramer has a critical role in gluconeogenesis,
-          anaplerosis, neurotransmitter synthesis, and lipogenesis.
-        explanation: >-
-          This directly supports impaired gluconeogenesis and anaplerosis as
-          the central metabolic mechanism.
-    downstream:
-      - target: Mitochondrial Energy Deficit
-        description: TCA-cycle flux failure reduces mitochondrial energy production.
-      - target: Neurologic Dysfunction
-        description: Anaplerotic failure contributes to CNS metabolic dysfunction.
-      - target: Urea Cycle Perturbation
-        description: Mitochondrial metabolic imbalance can perturb nitrogen disposal.
-  - name: Mitochondrial Energy Deficit
-    description: >-
-      Failure of pyruvate carboxylase-dependent metabolism produces systemic
-      energy deficit that contributes to growth failure and neurologic
-      dysfunction.
-    biological_processes:
-      - preferred_term: cell redox homeostasis
-        term:
-          id: GO:0045454
-          label: cell redox homeostasis
-        modifier: ABNORMAL
+    - reference: PMID:20598931
+      reference_title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Its deficiency causes multiorgan metabolic imbalance that
+        predominantly manifests with lactic acidemia and neurological
+        dysfunction at an early age.
+      explanation: >-
+        The review supports lactic acidemia as a dominant downstream
+        consequence of PC deficiency.
+- name: Impaired Gluconeogenesis
+  description: >-
+    Pyruvate carboxylase normally supports gluconeogenesis, so deficiency
+    impairs glucose production during metabolic stress.
+  genes:
+  - preferred_term: PC
+    term:
+      id: hgnc:8636
+      label: PC
+  biological_processes:
+  - preferred_term: gluconeogenesis
+    term:
+      id: GO:0006094
+      label: gluconeogenesis
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The PC homotetramer has a critical role in gluconeogenesis,
+      anaplerosis, neurotransmitter synthesis, and lipogenesis.
+    explanation: >-
+      This directly supports gluconeogenesis as a pyruvate
+      carboxylase-dependent process disrupted by deficiency.
+  downstream:
+  - target: Hypoglycemia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Impaired gluconeogenesis contributes to hypoglycemia in metabolically unstable presentations.
+    intermediate_mechanisms:
+    - Reduced endogenous glucose production during fasting or illness.
     evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The main biochemical and clinical findings in PC deficiency (PCD)
-          include lactic acidosis, ketonuria, failure to thrive, and
-          neurological dysfunction.
-        explanation: >-
-          This directly supports lactic acidosis and systemic metabolic injury
-          as dominant disease consequences.
-    downstream:
-      - target: Failure to Thrive
-        description: Chronic energy deficit contributes to poor growth and nutritional instability.
-      - target: Neurologic Dysfunction
-        description: Energy failure in the CNS contributes to encephalopathy, hypotonia, and seizures.
-  - name: Lactate Accumulation
-    description: >-
-      Pyruvate carboxylase deficiency causes recurrent or persistent lactate
-      accumulation as a dominant biochemical disease feature.
-    biological_processes:
-      - preferred_term: cell redox homeostasis
-        term:
-          id: GO:0045454
-          label: cell redox homeostasis
-        modifier: ABNORMAL
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Hypoglycemia, lactic acidosis, and hypercitrullinemia were
+        invariably found.
+      explanation: >-
+        Severe neonatal PC deficiency patients had invariant hypoglycemia,
+        supporting hypoglycemia as a downstream metabolic outcome.
+- name: Impaired Anaplerosis
+  description: >-
+    Pyruvate carboxylase replenishes oxaloacetate and other TCA-cycle
+    intermediates, so deficiency impairs anaplerotic mitochondrial flux.
+  genes:
+  - preferred_term: PC
+    term:
+      id: hgnc:8636
+      label: PC
+  biological_processes:
+  - preferred_term: tricarboxylic acid cycle
+    term:
+      id: GO:0006099
+      label: tricarboxylic acid cycle
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The PC homotetramer has a critical role in gluconeogenesis,
+      anaplerosis, neurotransmitter synthesis, and lipogenesis.
+    explanation: >-
+      This directly supports impaired gluconeogenesis and anaplerosis as
+      the central metabolic mechanism.
+  downstream:
+  - target: Mitochondrial Energy Deficit
+    causal_link_type: DIRECT
+    description: TCA-cycle flux failure reduces mitochondrial energy production.
     evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The main biochemical and clinical findings in PC deficiency (PCD)
-          include lactic acidosis, ketonuria, failure to thrive, and
-          neurological dysfunction.
-        explanation: >-
-          This directly supports lactic acidosis as a downstream biochemical
-          consequence of PC deficiency.
-    downstream:
-      - target: Lactic Acidosis
-        description: Lactate accumulation is represented clinically as lactic acidosis.
-  - name: Urea Cycle Perturbation
-    description: >-
-      Severe pyruvate carboxylase deficiency can perturb mitochondrial nitrogen
-      handling, contributing to hyperammonemia in some presentations.
-    biological_processes:
-      - preferred_term: urea cycle
-        term:
-          id: GO:0000050
-          label: urea cycle
-        modifier: ABNORMAL
-    downstream:
-      - target: Hyperammonemia
-        description: Urea-cycle perturbation can contribute to elevated ammonia.
-  - name: Neurologic Dysfunction
-    description: >-
-      Pyruvate carboxylase deficiency disrupts brain energy metabolism and
-      myelination, producing developmental and structural neurologic
-      abnormalities.
-    locations:
-      - preferred_term: brain
-        term:
-          id: UBERON:0000955
-          label: brain
+    - reference: PMID:20598931
+      reference_title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Pyruvate carboxylase (PC) is a regulated mitochondrial enzyme that
+        catalyzes the conversion of pyruvate to oxaloacetate, a critical
+        transition that replenishes citric acid cycle intermediates and
+        facilitates other biosynthetic reactions that drive anabolism.
+      explanation: >-
+        Oxaloacetate-dependent replenishment of citric acid cycle
+        intermediates directly supports mitochondrial energy flux.
+  - target: Neurologic Dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Anaplerotic failure contributes to CNS metabolic dysfunction.
+    intermediate_mechanisms:
+    - Citric-acid-cycle substrate limitation and neurometabolic energy imbalance.
     evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Speech development was delayed. MRI-brain showed delayed cerebral
-          myelination.
-        explanation: >-
-          This directly supports developmental and neuroimaging evidence of CNS
-          involvement downstream of the metabolic lesion.
-    downstream:
-      - target: Developmental Delay
-        description: CNS metabolic dysfunction delays neurodevelopment.
-      - target: Hypotonia
-        description: Neurometabolic encephalopathy frequently presents with hypotonia.
-      - target: Seizure
-        description: Severe neurologic dysfunction can manifest with seizures.
+    - reference: PMID:20598931
+      reference_title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Three clinical forms of PC deficiency have been identified: an
+        infantile form (Type A), a severe neonatal form (Type B), and a
+        benign form (Type C), all of which exhibit clinical or biochemical
+        correlates of impaired anaplerosis.
+      explanation: >-
+        The review links clinical PC deficiency presentations to impaired
+        anaplerosis, supporting neurologic dysfunction downstream of this
+        metabolic branch.
+  - target: Urea Cycle Perturbation
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Mitochondrial metabolic imbalance is associated with secondary nitrogen-disposal abnormalities.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Hypoglycemia, lactic acidosis, and hypercitrullinemia were
+        invariably found. Hyperammoniemia, hypernatremia, and high proline
+        and lysine were frequently detected.
+      explanation: >-
+        The severe neonatal PC deficiency series supports consistent
+        citrulline and frequent ammonia abnormalities downstream of the
+        mitochondrial metabolic lesion.
+- name: Mitochondrial Energy Deficit
+  description: >-
+    Failure of pyruvate carboxylase-dependent metabolism produces systemic
+    energy deficit that contributes to growth failure and neurologic
+    dysfunction.
+  biological_processes:
+  - preferred_term: cell redox homeostasis
+    term:
+      id: GO:0045454
+      label: cell redox homeostasis
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main biochemical and clinical findings in PC deficiency (PCD)
+      include lactic acidosis, ketonuria, failure to thrive, and
+      neurological dysfunction.
+    explanation: >-
+      This directly supports lactic acidosis and systemic metabolic injury
+      as dominant disease consequences.
+  downstream:
+  - target: Failure to Thrive
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Chronic energy deficit contributes to poor growth and nutritional instability.
+    intermediate_mechanisms:
+    - Systemic energy deficit and recurrent metabolic decompensation.
+    evidence:
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The main biochemical and clinical findings in PC deficiency (PCD)
+        include lactic acidosis, ketonuria, failure to thrive, and
+        neurological dysfunction.
+      explanation: >-
+        The cohort abstract lists failure to thrive among the main
+        clinical findings of PC deficiency.
+  - target: Neurologic Dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Energy failure in the CNS contributes to encephalopathy, hypotonia, and seizures.
+    intermediate_mechanisms:
+    - Brain energy substrate deficiency and neurometabolic decompensation.
+    evidence:
+    - reference: PMID:20598931
+      reference_title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Its deficiency causes multiorgan metabolic imbalance that
+        predominantly manifests with lactic acidemia and neurological
+        dysfunction at an early age.
+      explanation: >-
+        This supports neurologic dysfunction as a dominant manifestation
+        of PC-deficiency metabolic imbalance.
+  - target: Ketonuria
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Metabolic decompensation in PC deficiency is accompanied by ketonuria.
+    evidence:
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The main biochemical and clinical findings in PC deficiency (PCD)
+        include lactic acidosis, ketonuria, failure to thrive, and
+        neurological dysfunction.
+      explanation: >-
+        The cohort paper supports ketonuria as a main biochemical finding;
+        the exact intermediate pathway is left compressed here.
+- name: Lactate Accumulation
+  description: >-
+    Pyruvate carboxylase deficiency causes recurrent or persistent lactate
+    accumulation as a dominant biochemical disease feature.
+  biological_processes:
+  - preferred_term: cell redox homeostasis
+    term:
+      id: GO:0045454
+      label: cell redox homeostasis
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main biochemical and clinical findings in PC deficiency (PCD)
+      include lactic acidosis, ketonuria, failure to thrive, and
+      neurological dysfunction.
+    explanation: >-
+      This directly supports lactic acidosis as a downstream biochemical
+      consequence of PC deficiency.
+  downstream:
+  - target: Lactic Acidosis
+    causal_link_type: DIRECT
+    description: Lactate accumulation is represented clinically as lactic acidosis.
+    evidence:
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The main biochemical and clinical findings in PC deficiency (PCD)
+        include lactic acidosis, ketonuria, failure to thrive, and
+        neurological dysfunction.
+      explanation: >-
+        This supports lactic acidosis as the clinical expression of
+        lactate accumulation in PC deficiency.
+  - target: Lactate
+    causal_link_type: DIRECT
+    description: Lactate accumulation is represented biochemically as increased blood lactate.
+    evidence:
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The main biochemical and clinical findings in PC deficiency (PCD)
+        include lactic acidosis, ketonuria, failure to thrive, and
+        neurological dysfunction.
+      explanation: >-
+        Lactic acidosis in the patient cohort supports increased lactate
+        as the biochemical readout of the lactate-accumulation node.
+  - target: Respiratory Distress
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Neonatal metabolic acidosis from lactate accumulation can present with tachypnea or respiratory distress.
+    intermediate_mechanisms:
+    - Metabolic acidosis with compensatory tachypnea in early neonatal disease.
+    evidence:
+    - reference: DOI:10.1515/almed-2023-0102
+      reference_title: >-
+        Clinical, biochemical, and molecular profiles of three Sri Lankan
+        neonates with pyruvate carboxylase deficiency
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Our findings indicate the necessity of prompt laboratory
+        investigations in a tachypneic neonate with coexisting metabolic
+        acidosis, as early recognition is essential for patient management and
+        family counselling.
+      explanation: >-
+        The neonatal case series links tachypnea/respiratory presentation
+        with metabolic acidosis in pyruvate carboxylase deficiency.
+- name: Urea Cycle Perturbation
+  description: >-
+    Severe pyruvate carboxylase deficiency can perturb mitochondrial nitrogen
+    handling, contributing to hyperammonemia in some presentations.
+  biological_processes:
+  - preferred_term: urea cycle
+    term:
+      id: GO:0000050
+      label: urea cycle
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hypoglycemia, lactic acidosis, and hypercitrullinemia were invariably
+      found. Hyperammoniemia, hypernatremia, and high proline and lysine
+      were frequently detected.
+    explanation: >-
+      This supports secondary nitrogen-disposal abnormalities in severe
+      neonatal pyruvate carboxylase deficiency.
+  downstream:
+  - target: Hyperammonemia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Urea-cycle perturbation in severe neonatal PC deficiency is associated with elevated ammonia.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Hyperammoniemia, hypernatremia, and high proline and lysine were
+        frequently detected.
+      explanation: >-
+        The severe neonatal series reports frequent hyperammonemia,
+        supporting this endpoint downstream of nitrogen-disposal
+        perturbation.
+  - target: Hypercitrullinemia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Secondary urea-cycle perturbation in severe PC deficiency includes elevated citrulline.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Hypoglycemia, lactic acidosis, and hypercitrullinemia were
+        invariably found.
+      explanation: >-
+        The severe neonatal series reports invariant hypercitrullinemia,
+        supporting this biochemical endpoint.
+- name: Neurologic Dysfunction
+  description: >-
+    Pyruvate carboxylase deficiency disrupts brain energy metabolism and
+    myelination, producing developmental and structural neurologic
+    abnormalities.
+  locations:
+  - preferred_term: brain
+    term:
+      id: UBERON:0000955
+      label: brain
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Speech development was delayed. MRI-brain showed delayed cerebral
+      myelination.
+    explanation: >-
+      This directly supports developmental and neuroimaging evidence of CNS
+      involvement downstream of the metabolic lesion.
+  downstream:
+  - target: Developmental Delay
+    causal_link_type: DIRECT
+    description: CNS metabolic dysfunction delays neurodevelopment.
+    evidence:
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Speech development was delayed. MRI-brain showed delayed cerebral
+        myelination.
+      explanation: >-
+        The type C case report directly supports developmental delay as a
+        neurologic manifestation.
+  - target: Hypotonia
+    causal_link_type: DIRECT
+    description: Neurometabolic encephalopathy frequently presents with hypotonia.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        All patients had axial hypotonia and tachypnea during the first
+        hours of life.
+      explanation: >-
+        The severe neonatal series directly supports hypotonia as an early
+        neurologic manifestation.
+  - target: Abnormal Movements
+    causal_link_type: DIRECT
+    description: Severe neonatal neurologic dysfunction can manifest with tremor, hypokinesia, and abnormal ocular movements.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Abnormal movements (high-amplitude tremor and hypokinesia) and
+        bizarre ocular behavior were the most common findings, whereas
+        epilepsy was infrequent.
+      explanation: >-
+        The severe neonatal type B series identifies abnormal movements as the
+        most common neurologic findings.
+  - target: Type A Encephalopathy
+    causal_link_type: DIRECT
+    description: Severe infantile type A disease is part of the life-limiting encephalopathic spectrum of pyruvate carboxylase deficiency.
+    evidence:
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Pyruvate carboxylase deficiency (PCD) mostly presents with
+        life-limiting encephalopathy (types A/B).
+      explanation: >-
+        The type C report contrasts attenuated type C disease with the
+        life-limiting encephalopathy of types A and B.
+  - target: Type B Encephalopathy
+    causal_link_type: DIRECT
+    description: Severe neonatal type B disease is part of the life-limiting encephalopathic spectrum of pyruvate carboxylase deficiency.
+    evidence:
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Pyruvate carboxylase deficiency (PCD) mostly presents with
+        life-limiting encephalopathy (types A/B).
+      explanation: >-
+        The type C report contrasts attenuated type C disease with the
+        life-limiting encephalopathy of types A and B.
+  - target: Periventricular Leukomalacia
+    causal_link_type: DIRECT
+    description: Severe neonatal type B neurologic dysfunction includes cystic periventricular leukomalacia on brain MRI.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Brain magnetic resonance imaging mostly disclosed cystic
+        periventricular leukomalacia.
+      explanation: >-
+        The severe neonatal type B series identifies cystic periventricular
+        leukomalacia as the predominant neuroimaging finding.
+  - target: Seizure
+    causal_link_type: DIRECT
+    description: Severe neurologic dysfunction can manifest with seizures.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Abnormal movements (high-amplitude tremor and hypokinesia) and
+        bizarre ocular behavior were the most common findings, whereas
+        epilepsy was infrequent.
+      explanation: >-
+        The series supports epilepsy/seizures as an infrequent neurologic
+        manifestation, consistent with an occasional endpoint.
+  - target: Delayed Myelination
+    causal_link_type: DIRECT
+    description: CNS metabolic dysfunction in type C disease can include delayed cerebral myelination.
+    evidence:
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Speech development was delayed. MRI-brain showed delayed cerebral
+        myelination.
+      explanation: >-
+        The type C case report directly links neurologic involvement to
+        delayed cerebral myelination.
 phenotypes:
-  - name: Lactic Acidosis
-    description: >-
-      Recurrent or persistent lactic acidosis is the dominant biochemical
-      abnormality across pyruvate carboxylase deficiency phenotypes.
-    frequency: VERY_FREQUENT
-    phenotype_term:
-      preferred_term: lactic acidosis
-      term:
-        id: HP:0003128
-        label: Lactic acidosis
-    evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The main biochemical and clinical findings in PC deficiency (PCD)
-          include lactic acidosis, ketonuria, failure to thrive, and
-          neurological dysfunction.
-        explanation: >-
-          This directly supports lactic acidosis as a hallmark phenotype.
-  - name: Failure to Thrive
-    description: >-
-      Poor growth and nutritional instability are common manifestations of the
-      chronic metabolic deficit.
-    frequency: FREQUENT
-    phenotype_term:
-      preferred_term: failure to thrive
-      term:
-        id: HP:0001508
-        label: Failure to thrive
-    evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The main biochemical and clinical findings in PC deficiency (PCD)
-          include lactic acidosis, ketonuria, failure to thrive, and
-          neurological dysfunction.
-        explanation: >-
-          This directly supports failure to thrive as a major clinical feature.
-  - name: Hypotonia
-    description: >-
-      Hypotonia is a frequent early neurologic sign, especially in the more
-      severe infantile and neonatal presentations.
-    frequency: FREQUENT
-    phenotype_term:
-      preferred_term: hypotonia
-      term:
-        id: HP:0001252
-        label: Hypotonia
-    evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: PARTIAL
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Pyruvate carboxylase deficiency (PCD) mostly presents with
-          life-limiting encephalopathy (types A/B).
-        explanation: >-
-          This supports major neurologic involvement; hypotonia is a frequent
-          component of the encephalopathic presentation in PCD.
-  - name: Seizure
-    description: >-
-      Seizures occur in severe pyruvate carboxylase deficiency as part of the
-      neurometabolic encephalopathy.
-    frequency: OCCASIONAL
-    phenotype_term:
-      preferred_term: seizure
-      term:
-        id: HP:0001250
-        label: Seizure
-  - name: Developmental Delay
-    description: >-
-      Neurodevelopmental delay ranges from speech delay in type C to severe
-      encephalopathy in types A and B.
-    frequency: FREQUENT
-    phenotype_term:
-      preferred_term: developmental delay
-      term:
-        id: HP:0001263
-        label: Global developmental delay
-    evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Speech development was delayed. MRI-brain showed delayed cerebral
-          myelination.
-        explanation: >-
-          This directly supports developmental delay in the attenuated type C
-          spectrum.
-  - name: Hypoglycemia
-    description: >-
-      Hypoglycemia occurs in some patients, especially in the attenuated but
-      still metabolically unstable type C presentation.
-    frequency: OCCASIONAL
-    phenotype_term:
-      preferred_term: hypoglycemia
-      term:
-        id: HP:0001943
-        label: Hypoglycemia
-    evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Patient 2 (P2) presented with episodic ketoacidosis, hyperlactataemia
-          and hypoglycaemia at 2 years of age, with gross motor delay and mild
-          global volume loss on MRI brain.
-        explanation: >-
-          This directly supports hypoglycemia as part of the type C metabolic
-          phenotype.
-  - name: Respiratory Distress
-    description: >-
-      Severe neonatal pyruvate carboxylase deficiency may present with
-      respiratory distress in the first hours of life.
-    frequency: FREQUENT
-    phenotype_term:
-      preferred_term: respiratory distress
-      term:
-        id: HP:0002098
-        label: Respiratory distress
-    evidence:
-      - reference: DOI:10.1515/almed-2023-0102
-        reference_title: >-
-          Clinical, biochemical, and molecular profiles of three Sri Lankan
-          neonates with pyruvate carboxylase deficiency
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          All three developed respiratory distress within the first few hours of
-          birth.
-        explanation: >-
-          This directly supports neonatal respiratory distress in the reported
-          pyruvate carboxylase deficiency cases.
-  - name: Delayed Myelination
-    subtype: Type C pyruvate carboxylase deficiency
-    description: >-
-      Delayed cerebral myelination has been reported in attenuated type C
-      pyruvate carboxylase deficiency.
-    frequency: OCCASIONAL
-    phenotype_term:
-      preferred_term: delayed myelination
-      term:
-        id: HP:0012448
-        label: Delayed myelination
-    evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          MRI‐brain showed delayed cerebral myelination.
-        explanation: >-
-          This directly supports delayed myelination as a type C neuroimaging
-          phenotype.
-  - name: Hyperammonemia
-    description: >-
-      Hyperammonemia may occur in severe pyruvate carboxylase deficiency
-      through secondary urea-cycle perturbation.
-    frequency: OCCASIONAL
-    phenotype_term:
-      preferred_term: hyperammonemia
-      term:
-        id: HP:0001987
-        label: Hyperammonemia
-biochemical:
-  - name: Lactate
-    presence: INCREASED
-    context: >-
-      High blood lactate is a core laboratory hallmark across pyruvate
-      carboxylase deficiency subtypes.
-    evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The main biochemical and clinical findings in PC deficiency (PCD)
-          include lactic acidosis, ketonuria, failure to thrive, and
-          neurological dysfunction.
-        explanation: >-
-          This directly supports lactic acidosis/elevated lactate as a core
-          biochemical disease finding.
-  - name: Ketonuria
-    presence: PRESENT
-    context: >-
-      Ketonuria is part of the recurrent biochemical signature of pyruvate
+- name: Lactic Acidosis
+  description: >-
+    Recurrent or persistent lactic acidosis is the dominant biochemical
+    abnormality across pyruvate carboxylase deficiency phenotypes.
+  frequency: VERY_FREQUENT
+  phenotype_term:
+    preferred_term: lactic acidosis
+    term:
+      id: HP:0003128
+      label: Lactic acidosis
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main biochemical and clinical findings in PC deficiency (PCD)
+      include lactic acidosis, ketonuria, failure to thrive, and
+      neurological dysfunction.
+    explanation: >-
+      This directly supports lactic acidosis as a hallmark phenotype.
+- name: Failure to Thrive
+  description: >-
+    Poor growth and nutritional instability are common manifestations of the
+    chronic metabolic deficit.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main biochemical and clinical findings in PC deficiency (PCD)
+      include lactic acidosis, ketonuria, failure to thrive, and
+      neurological dysfunction.
+    explanation: >-
+      This directly supports failure to thrive as a major clinical feature.
+- name: Hypotonia
+  description: >-
+    Hypotonia is a frequent early neurologic sign, especially in the more
+    severe infantile and neonatal presentations.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: hypotonia
+    term:
+      id: HP:0001252
+      label: Hypotonia
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pyruvate carboxylase deficiency (PCD) mostly presents with
+      life-limiting encephalopathy (types A/B).
+    explanation: >-
+      This supports major neurologic involvement; hypotonia is a frequent
+      component of the encephalopathic presentation in PCD.
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All patients had axial hypotonia and tachypnea during the first hours
+      of life.
+    explanation: >-
+      This directly supports hypotonia in the severe neonatal pyruvate
+      carboxylase deficiency series.
+- name: Seizure
+  description: >-
+    Seizures occur in severe pyruvate carboxylase deficiency as part of the
+    neurometabolic encephalopathy.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Abnormal movements (high-amplitude tremor and hypokinesia) and bizarre
+      ocular behavior were the most common findings, whereas epilepsy was
+      infrequent.
+    explanation: >-
+      This supports seizures/epilepsy as an occasional neurologic phenotype
+      in severe pyruvate carboxylase deficiency.
+- name: Abnormal Movements
+  subtype: Type B
+  description: >-
+    High-amplitude tremor, hypokinesia, and bizarre ocular behavior are the most
+    common neurologic findings reported in severe neonatal type B disease.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: abnormal movements
+    term:
+      id: HP:0100022
+      label: Abnormality of movement
+  evidence:
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Abnormal movements (high-amplitude tremor and hypokinesia) and bizarre
+      ocular behavior were the most common findings, whereas epilepsy was
+      infrequent.
+    explanation: >-
+      This directly supports abnormal movements as a frequent type B neurologic
+      phenotype.
+- name: Type A Encephalopathy
+  subtype: Type A
+  description: >-
+    Life-limiting encephalopathy is a dominant clinical feature of the severe
+    infantile type A form of pyruvate carboxylase deficiency.
+  frequency: VERY_FREQUENT
+  phenotype_term:
+    preferred_term: encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pyruvate carboxylase deficiency (PCD) mostly presents with
+      life-limiting encephalopathy (types A/B).
+    explanation: >-
+      This supports encephalopathy as a defining severe-form phenotype for type
+      A disease.
+- name: Type B Encephalopathy
+  subtype: Type B
+  description: >-
+    Life-limiting encephalopathy is a dominant clinical feature of the severe
+    neonatal type B form of pyruvate carboxylase deficiency.
+  frequency: VERY_FREQUENT
+  phenotype_term:
+    preferred_term: encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Pyruvate carboxylase deficiency (PCD) mostly presents with
+      life-limiting encephalopathy (types A/B).
+    explanation: >-
+      This supports encephalopathy as a defining severe-form phenotype for type
+      B disease.
+- name: Periventricular Leukomalacia
+  subtype: Type B
+  description: >-
+    Cystic periventricular leukomalacia is the predominant brain MRI finding in
+    severe neonatal type B pyruvate carboxylase deficiency.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: periventricular leukomalacia
+    term:
+      id: HP:0006970
+      label: Periventricular leukomalacia
+  evidence:
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Brain magnetic resonance imaging mostly disclosed cystic periventricular
+      leukomalacia.
+    explanation: >-
+      This directly supports periventricular leukomalacia as the predominant
+      type B neuroimaging phenotype.
+- name: Developmental Delay
+  description: >-
+    Neurodevelopmental delay ranges from speech delay in type C to severe
+    encephalopathy in types A and B.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Speech development was delayed. MRI-brain showed delayed cerebral
+      myelination.
+    explanation: >-
+      This directly supports developmental delay in the attenuated type C
+      spectrum.
+- name: Hypoglycemia
+  description: >-
+    Hypoglycemia occurs in some patients, especially in the attenuated but
+    still metabolically unstable type C presentation.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: hypoglycemia
+    term:
+      id: HP:0001943
+      label: Hypoglycemia
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patient 2 (P2) presented with episodic ketoacidosis, hyperlactataemia
+      and hypoglycaemia at 2 years of age, with gross motor delay and mild
+      global volume loss on MRI brain.
+    explanation: >-
+      This directly supports hypoglycemia as part of the type C metabolic
+      phenotype.
+- name: Respiratory Distress
+  description: >-
+    Severe neonatal pyruvate carboxylase deficiency may present with
+    respiratory distress in the first hours of life.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: respiratory distress
+    term:
+      id: HP:0002098
+      label: Respiratory distress
+  evidence:
+  - reference: DOI:10.1515/almed-2023-0102
+    reference_title: >-
+      Clinical, biochemical, and molecular profiles of three Sri Lankan
+      neonates with pyruvate carboxylase deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All three developed respiratory distress within the first few hours of
+      birth.
+    explanation: >-
+      This directly supports neonatal respiratory distress in the reported
+      pyruvate carboxylase deficiency cases.
+- name: Delayed Myelination
+  subtype: Type C
+  description: >-
+    Delayed cerebral myelination has been reported in attenuated type C
+    pyruvate carboxylase deficiency.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: delayed myelination
+    term:
+      id: HP:0012448
+      label: Delayed myelination
+  evidence:
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      MRI‐brain showed delayed cerebral myelination.
+    explanation: >-
+      This directly supports delayed myelination as a type C neuroimaging
+      phenotype.
+- name: Hyperammonemia
+  description: >-
+    Hyperammonemia may occur in severe pyruvate carboxylase deficiency
+    through secondary urea-cycle perturbation.
+  frequency: OCCASIONAL
+  phenotype_term:
+    preferred_term: hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  evidence:
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hyperammoniemia, hypernatremia, and high proline and lysine were
+      frequently detected.
+    explanation: >-
+      This directly supports hyperammonemia in severe neonatal pyruvate
       carboxylase deficiency.
-    evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The main biochemical and clinical findings in PC deficiency (PCD)
-          include lactic acidosis, ketonuria, failure to thrive, and
-          neurological dysfunction.
-        explanation: >-
-          This directly supports ketonuria as a characteristic biochemical
-          abnormality.
-  - name: Hypercitrullinemia
-    presence: INCREASED
-    subtype: Type B pyruvate carboxylase deficiency
-    context: >-
-      Elevated plasma citrulline can occur in severe neonatal type B disease as
-      part of secondary urea-cycle disruption from oxaloacetate/aspartate
-      limitation.
+biochemical:
+- name: Lactate
+  presence: INCREASED
+  context: >-
+    High blood lactate is a core laboratory hallmark across pyruvate
+    carboxylase deficiency subtypes.
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main biochemical and clinical findings in PC deficiency (PCD)
+      include lactic acidosis, ketonuria, failure to thrive, and
+      neurological dysfunction.
+    explanation: >-
+      This directly supports lactic acidosis/elevated lactate as a core
+      biochemical disease finding.
+- name: Ketonuria
+  presence: PRESENT
+  context: >-
+    Ketonuria is part of the recurrent biochemical signature of pyruvate
+    carboxylase deficiency.
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The main biochemical and clinical findings in PC deficiency (PCD)
+      include lactic acidosis, ketonuria, failure to thrive, and
+      neurological dysfunction.
+    explanation: >-
+      This directly supports ketonuria as a characteristic biochemical
+      abnormality.
+- name: Hypercitrullinemia
+  presence: INCREASED
+  subtype: Type B
+  context: >-
+    Elevated plasma citrulline can occur in severe neonatal type B disease as
+    part of the secondary metabolic and nitrogen-disposal abnormalities
+    reported in this presentation.
+  evidence:
+  - reference: PMID:16278852
+    reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hypoglycemia, lactic acidosis, and hypercitrullinemia were invariably
+      found.
+    explanation: >-
+      This directly supports hypercitrullinemia as a severe neonatal
+      biochemical abnormality.
 genetic:
-  - name: PC
-    association: Causal biallelic variant
-    gene_term:
-      preferred_term: PC
-      term:
-        id: hgnc:8636
-        label: PC
-    notes: >-
-      Pyruvate carboxylase deficiency disease is caused by biallelic pathogenic
-      variants in the PC gene.
-    evidence:
-      - reference: DOI:10.1515/almed-2023-0102
-        reference_title: >-
-          Clinical, biochemical, and molecular profiles of three Sri Lankan
-          neonates with pyruvate carboxylase deficiency
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The other proband with normal citrulline, lysine, moderate lactate,
-          paraventricular cystic lesions, bony deformities, and a novel
-          missense, homozygous variant c.2746G>C [p.(Asp916His)] in the PC
-          gene, biochemically favoured type A.
-        explanation: >-
-          This directly supports PC as the causal gene in molecularly confirmed
-          disease.
+- name: PC
+  association: Causal biallelic variant
+  gene_term:
+    preferred_term: PC
+    term:
+      id: hgnc:8636
+      label: PC
+  notes: >-
+    Pyruvate carboxylase deficiency disease is caused by biallelic pathogenic
+    variants in the PC gene.
+  evidence:
+  - reference: DOI:10.1515/almed-2023-0102
+    reference_title: >-
+      Clinical, biochemical, and molecular profiles of three Sri Lankan
+      neonates with pyruvate carboxylase deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The other proband with normal citrulline, lysine, moderate lactate,
+      paraventricular cystic lesions, bony deformities, and a novel
+      missense, homozygous variant c.2746G>C [p.(Asp916His)] in the PC
+      gene, biochemically favoured type A.
+    explanation: >-
+      This directly supports PC as the causal gene in molecularly confirmed
+      disease.
 environmental: []
 treatments:
-  - name: Triheptanoin supplementation
-    description: >-
-      Triheptanoin is used as an anaplerotic odd-chain triglyceride therapy,
-      with mixed overall results but apparent benefit in some type C patients.
-    treatment_term:
-      preferred_term: nutritional supplementation
-      term:
-        id: MAXO:0000106
-        label: nutritional supplementation
+- name: Triheptanoin supplementation
+  description: >-
+    Triheptanoin is used as an anaplerotic odd-chain triglyceride therapy,
+    with mixed overall results but apparent benefit in some type C patients.
+  treatment_term:
+    preferred_term: nutritional supplementation
+    term:
+      id: MAXO:0000106
+      label: nutritional supplementation
+  target_mechanisms:
+  - target: Impaired Anaplerosis
+    treatment_effect: BYPASSES
+    description: Triheptanoin supplies odd-chain substrates that can replenish TCA-cycle intermediates despite impaired PC-dependent anaplerosis.
     evidence:
-      - reference: PMID:37207470
-        reference_title: >-
-          Clinical, biochemical and molecular characterization of 12 patients
-          with pyruvate carboxylase deficiency treated with triheptanoin.
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Use of the anaplerotic agent triheptanoin on a limited number of
-          individuals with PCD has had mixed results.
-        explanation: >-
-          This directly supports disease-specific use of triheptanoin in the
-          clinical literature.
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Subsequently, hospitalisations during intercurrent illnesses
-          decreased, post-exertional hyperlactataemia resolved and exercise
-          tolerance improved.
-        explanation: >-
-          This directly supports clinical benefit from triheptanoin in at least
-          one type C patient.
-  - name: Dietary long-chain triglyceride restriction
-    description: >-
-      Dietary fat modification may accompany triheptanoin treatment in type C
-      disease.
-    treatment_term:
-      preferred_term: dietary intervention
-      term:
-        id: MAXO:0000088
-        label: dietary intervention
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Triheptanoin is an odd‐chain triglyceride, with the potential to
+        replenish TCA intermediates (anaplerosis), and its metabolites cross
+        the blood–brain‐barrier.
+      explanation: >-
+        The type C case report explicitly frames triheptanoin as an
+        anaplerotic therapy that can replenish TCA intermediates.
+  - target: Lactate Accumulation
+    treatment_effect: MODULATES
+    description: Triheptanoin treatment can lower the lactate-accumulation branch in selected patients, although cohort-level effects are variable.
     evidence:
-      - reference: DOI:10.1002/jmd2.12405
-        reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Dietary long-chain triglycerides were restricted, with fat-soluble
-          vitamin supplementation.
-        explanation: >-
-          This directly supports dietary intervention as part of the treatment
-          regimen in type C disease.
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Subsequently, hospitalisations during intercurrent illnesses
+        decreased, post-exertional hyperlactataemia resolved and exercise
+        tolerance improved.
+      explanation: >-
+        The treated type C patient had resolution of post-exertional
+        hyperlactatemia, supporting modulation of lactate accumulation.
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        An overall trend of lactate reduction with time on triheptanoin
+        was noted, but with significant variability among subjects and
+        only one subject reaching close to statistical significance for
+        this endpoint.
+      explanation: >-
+        The larger cohort supports a possible lactate-lowering effect but
+        also documents substantial inter-individual variability.
+  - target: Mitochondrial Energy Deficit
+    treatment_effect: MODULATES
+    description: In type C disease, triheptanoin may improve energy homeostasis and CNS myelin synthesis.
+    evidence:
+    - reference: DOI:10.1002/jmd2.12405
+      reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Triheptanoin was well‐tolerated and appeared efficacious during
+        2 years' follow‐up, and has potential to restore energy
+        homeostasis and myelin synthesis in PCD type C.
+      explanation: >-
+        The type C report supports modulation of the energy-deficit branch
+        and downstream myelin synthesis.
+  evidence:
+  - reference: PMID:37207470
+    reference_title: >-
+      Clinical, biochemical and molecular characterization of 12 patients
+      with pyruvate carboxylase deficiency treated with triheptanoin.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Use of the anaplerotic agent triheptanoin on a limited number of
+      individuals with PCD has had mixed results.
+    explanation: >-
+      This directly supports disease-specific use of triheptanoin in the
+      clinical literature.
+  - reference: DOI:10.1002/jmd2.12405
+    reference_title: Pyruvate carboxylase deficiency type C; variable presentation and beneficial effect of triheptanoin
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Subsequently, hospitalisations during intercurrent illnesses
+      decreased, post-exertional hyperlactataemia resolved and exercise
+      tolerance improved.
+    explanation: >-
+      This directly supports clinical benefit from triheptanoin in at least
+      one type C patient.
 diagnosis:
-  - name: Molecular genetic testing
-    description: >-
-      Molecular testing confirms biallelic PC variants and distinguishes among
-      subtype presentations.
-    diagnosis_term:
-      preferred_term: molecular genetic testing
-      term:
-        id: MAXO:0000533
-        label: molecular genetic testing
-    evidence:
-      - reference: DOI:10.1515/almed-2023-0102
-        reference_title: >-
-          Clinical, biochemical, and molecular profiles of three Sri Lankan
-          neonates with pyruvate carboxylase deficiency
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          The other proband with normal citrulline, lysine, moderate lactate,
-          paraventricular cystic lesions, bony deformities, and a novel
-          missense, homozygous variant c.2746G>C [p.(Asp916His)] in the PC
-          gene, biochemically favoured type A.
-        explanation: >-
-          This directly supports molecular confirmation through PC variant
-          detection.
-  - name: Clinical whole-exome sequencing
-    description: >-
-      Whole-exome sequencing is used in current diagnostic workups for pyruvate
-      carboxylase deficiency.
-    diagnosis_term:
-      preferred_term: clinical whole-exome sequencing
-      term:
-        id: MAXO:0009004
-        label: clinical whole-exome sequencing
-  - name: Prompt metabolic laboratory evaluation
-    description: >-
-      Rapid biochemical assessment of tachypneic neonates with metabolic
-      acidosis is emphasized for early recognition.
-    diagnosis_term:
-      preferred_term: diagnostic procedure
-      term:
-        id: MAXO:0000003
-        label: diagnostic procedure
-    evidence:
-      - reference: DOI:10.1515/almed-2023-0102
-        reference_title: >-
-          Clinical, biochemical, and molecular profiles of three Sri Lankan
-          neonates with pyruvate carboxylase deficiency
-        supports: SUPPORT
-        evidence_source: HUMAN_CLINICAL
-        snippet: >-
-          Our findings indicate the necessity of prompt laboratory
-          investigations in a tachypneic neonate with coexisting metabolic
-          acidosis, as early recognition is essential for patient management and
-          family counselling.
-        explanation: >-
-          This directly supports prompt diagnostic laboratory evaluation in
-          suspected neonatal disease.
+- name: Molecular genetic testing
+  description: >-
+    Molecular testing confirms biallelic PC variants and distinguishes among
+    subtype presentations.
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+  evidence:
+  - reference: DOI:10.1515/almed-2023-0102
+    reference_title: >-
+      Clinical, biochemical, and molecular profiles of three Sri Lankan
+      neonates with pyruvate carboxylase deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The other proband with normal citrulline, lysine, moderate lactate,
+      paraventricular cystic lesions, bony deformities, and a novel
+      missense, homozygous variant c.2746G>C [p.(Asp916His)] in the PC
+      gene, biochemically favoured type A.
+    explanation: >-
+      This directly supports molecular confirmation through PC variant
+      detection.
+- name: Clinical whole-exome sequencing
+  description: >-
+    Whole-exome sequencing is used in current diagnostic workups for pyruvate
+    carboxylase deficiency.
+  diagnosis_term:
+    preferred_term: clinical whole-exome sequencing
+    term:
+      id: MAXO:0009004
+      label: clinical whole-exome sequencing
+- name: Prompt metabolic laboratory evaluation
+  description: >-
+    Rapid biochemical assessment of tachypneic neonates with metabolic
+    acidosis is emphasized for early recognition.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  evidence:
+  - reference: DOI:10.1515/almed-2023-0102
+    reference_title: >-
+      Clinical, biochemical, and molecular profiles of three Sri Lankan
+      neonates with pyruvate carboxylase deficiency
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our findings indicate the necessity of prompt laboratory
+      investigations in a tachypneic neonate with coexisting metabolic
+      acidosis, as early recognition is essential for patient management and
+      family counselling.
+    explanation: >-
+      This directly supports prompt diagnostic laboratory evaluation in
+      suspected neonatal disease.
 differential_diagnoses: []
 clinical_trials: []
 datasets: []

--- a/references_cache/PMID_16278852.md
+++ b/references_cache/PMID_16278852.md
@@ -1,0 +1,71 @@
+---
+reference_id: "PMID:16278852"
+title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+authors:
+- García-Cazorla A
+- Rabier D
+- Touati G
+- Chadefaux-Vekemans B
+- Marsac C
+- de Lonlay P
+- Saudubray JM
+journal: Ann Neurol
+year: '2006'
+doi: 10.1002/ana.20709
+keywords:
+- Amino Acids/metabolism
+- "Brain/metabolism, pathology"
+- Female
+- Humans
+- Infant
+- "Infant, Newborn"
+- Magnetic Resonance Imaging
+- Male
+- "Nervous System Diseases/etiology, physiopathology"
+- "Pyruvate Carboxylase Deficiency Disease/complications, physiopathology"
+- Retrospective Studies
+- Seizures/physiopathology
+content_type: abstract_only
+---
+
+# Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects.
+**Authors:** García-Cazorla A, Rabier D, Touati G, Chadefaux-Vekemans B, Marsac C, de Lonlay P, Saudubray JM
+**Journal:** Ann Neurol (2006)
+**DOI:** [10.1002/ana.20709](https://doi.org/10.1002/ana.20709)
+
+## Content
+
+1. Ann Neurol. 2006 Jan;59(1):121-7. doi: 10.1002/ana.20709.
+
+Pyruvate carboxylase deficiency: metabolic characteristics and new neurological
+aspects.
+
+García-Cazorla A(1), Rabier D, Touati G, Chadefaux-Vekemans B, Marsac C, de
+Lonlay P, Saudubray JM.
+
+Author information:
+(1)Metabolic Diseases Unit, Centre Hospitalier Universitaire Necker
+Enfants-Malades, Paris, France. agarcia@hsjdbcn.org
+
+OBJECTIVE: Pyruvate carboxylase (PC) deficiency is a rare metabolic disease.
+Recently, therapeutic possibilities have been introduced. We aimed to report the
+largest series of the B type of PC deficiency, focusing on some neurological
+aspects that have not yet been documented.
+METHODS: We retrospectively studied nine patients with the severe neonatal form
+of PC deficiency diagnosed in our hospital. Detailed clinical features, brain
+imaging, biochemical characteristics, and global outcome are reported.
+RESULTS: All patients had axial hypotonia and tachypnea during the first hours
+of life. The initial level of consciousness was preserved in most patients.
+Abnormal movements (high-amplitude tremor and hypokinesia) and bizarre ocular
+behavior were the most common findings, whereas epilepsy was infrequent. Brain
+magnetic resonance imaging mostly disclosed cystic periventricular leukomalacia.
+Hypoglycemia, lactic acidosis, and hypercitrullinemia were invariably found.
+Hyperammoniemia, hypernatremia, and high proline and lysine were frequently
+detected. A rapid fatal outcome was observed in most patients.
+INTERPRETATION: Clinical and biochemical characteristics of this deficiency are
+highly suggestive. Abnormal movements such as rigidity and hypokinesia
+(hypokinetic-rigid syndrome) are an important hallmark and may orientate to PC
+deficiency when associated with severe lactic acidosis.
+
+DOI: 10.1002/ana.20709
+PMID: 16278852 [Indexed for MEDLINE]

--- a/references_cache/PMID_20598931.md
+++ b/references_cache/PMID_20598931.md
@@ -1,0 +1,57 @@
+---
+reference_id: "PMID:20598931"
+title: "Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis."
+authors:
+- Marin-Valencia I
+- Roe CR
+- Pascual JM
+journal: Mol Genet Metab
+year: '2010'
+doi: 10.1016/j.ymgme.2010.05.004
+keywords:
+- Animals
+- Carbon/metabolism
+- Humans
+- Oxaloacetic Acid/metabolism
+- Phenotype
+- "Pyruvate Carboxylase/genetics, metabolism"
+- Pyruvate Carboxylase Deficiency Disease/metabolism
+- Pyruvic Acid/metabolism
+content_type: abstract_only
+---
+
+# Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis.
+**Authors:** Marin-Valencia I, Roe CR, Pascual JM
+**Journal:** Mol Genet Metab (2010)
+**DOI:** [10.1016/j.ymgme.2010.05.004](https://doi.org/10.1016/j.ymgme.2010.05.004)
+
+## Content
+
+1. Mol Genet Metab. 2010 Sep;101(1):9-17. doi: 10.1016/j.ymgme.2010.05.004. Epub
+2010 Jun 9.
+
+Pyruvate carboxylase deficiency: mechanisms, mimics and anaplerosis.
+
+Marin-Valencia I(1), Roe CR, Pascual JM.
+
+Author information:
+(1)Department of Neurology, UT Southwestern Medical Center, Dallas, TX
+75390-8813, USA.
+
+Pyruvate carboxylase (PC) is a regulated mitochondrial enzyme that catalyzes the
+conversion of pyruvate to oxaloacetate, a critical transition that replenishes
+citric acid cycle intermediates and facilitates other biosynthetic reactions
+that drive anabolism. Its deficiency causes multiorgan metabolic imbalance that
+predominantly manifests with lactic acidemia and neurological dysfunction at an
+early age. Three clinical forms of PC deficiency have been identified: an
+infantile form (Type A), a severe neonatal form (Type B), and a benign form
+(Type C), all of which exhibit clinical or biochemical correlates of impaired
+anaplerosis. There is no effective treatment for these patients and most, except
+those affected by the benign form, die in early life. We review the physiology
+of this enzyme and dissect the major clinical, biochemical, and genetic aspects
+of its dysfunction, emphasizing features that distinguish PC deficiency from
+other causes of lactic acidemia that render PC deficiency potentially treatable
+using novel interventions capable of enhancing anaplerosis.
+
+DOI: 10.1016/j.ymgme.2010.05.004
+PMID: 20598931 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Add PC molecular-function annotation and evidence-backed causal_link_type/evidence for all pyruvate carboxylase deficiency downstream edges
- Connect previously isolated biochemical/phenotype endpoints, including lactate, ketonuria, hypercitrullinemia, delayed myelination, hypotonia, seizure, and respiratory distress
- Add conservative triheptanoin target-mechanism links and generated PMID caches for PMID:16278852 and PMID:20598931

## Validation
- uv run python -m dismech.graph --validate kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml
- build_causal_graph connectivity check: 1 component, 21 nodes, 25 edges
- just validate kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml
- custom snippet audit: 52 normalized snippets found in cache
- subagent review: blockers addressed; final pass reported no blockers

Note: pre-commit yamlfix reformatted the touched disorder YAML.