### PR TITLE
Improve transaldolase deficiency pathograph

### DIFF
--- a/kb/disorders/Transaldolase_Deficiency.yaml
+++ b/kb/disorders/Transaldolase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Transaldolase Deficiency
 creation_date: "2026-05-05T07:40:18Z"
-updated_date: "2026-05-05T07:40:18Z"
+updated_date: "2026-05-10T22:41:17Z"
 category: Mendelian
 synonyms:
 - TALDO deficiency
@@ -206,9 +206,26 @@ pathophysiology:
     snippet: "biallelic mutations in TALDO1 are responsible for transaldolase deficiency"
     explanation: Human patient data support biallelic TALDO1 mutations as causal.
   downstream:
+  - target: Reduced transaldolase activity
+    description: TALDO1 variants reduce or abolish measurable transaldolase enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15115436
+      reference_title: "Deletion of Ser-171 causes inactivation, proteasome-mediated degradation and complete deficiency of human transaldolase."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Recombinant TALDeltaS171 had no enzymic activity."
+      explanation: Recombinant mutant transaldolase experiments directly support loss of enzyme activity.
   - target: Pentose phosphate pathway metabolite imbalance
     description: Loss of transaldolase activity disrupts nonoxidative pentose-phosphate metabolism.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15115436
+      reference_title: "Deletion of Ser-171 causes inactivation, proteasome-mediated degradation and complete deficiency of human transaldolase."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Accumulation of sedoheptulose 7-phosphate raised the possibility of TAL"
+      explanation: Patient-cell biochemical findings link TAL deficiency to sedoheptulose-7-phosphate accumulation.
 - name: Pentose phosphate pathway metabolite imbalance
   description: >
     Transaldolase deficiency disrupts the pentose phosphate pathway, causing
@@ -243,9 +260,155 @@ pathophysiology:
   - target: Redox and mitochondrial stress signaling
     description: Pentose-phosphate-pathway imbalance disrupts NADPH and reactive oxygen intermediate handling.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:17613166
+      reference_title: "The pathogenesis of transaldolase deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Balancing of NADPH and ROI levels by the PPP enzyme transaldolase"
+      explanation: The pathogenesis review directly links transaldolase to PPP-dependent NADPH and reactive oxygen intermediate balance.
   - target: Increased urinary polyols and seven-carbon sugars
     description: TALDO deficiency causes diagnostic urinary polyol and seven-carbon sugar abnormalities.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Elevated excretion of erythritol, ribitol, arabitol, sedoheptitol, perseitol, sedoheptulose and sedoheptulose-7P in the urine"
+      explanation: Human patient urine testing directly supports the diagnostic seven-carbon sugar and polyol endpoint.
+  - target: Abnormality of glutamine metabolism
+    description: The transaldolase metabolic defect is associated with abnormal circulating glutamine concentration.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0010903 | Abnormality of glutamine metabolism | Very frequent (99-80%)"
+      explanation: Orphanet records abnormal glutamine metabolism as a very frequent transaldolase deficiency phenotype.
+  - target: Abnormality of the kidney
+    description: Pentose-phosphate metabolite accumulation is associated with renal involvement in transaldolase deficiency.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Toxic effects of accumulated sugars, sugar phosphates, and polyols on proximal tubules.
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The development of tubulopathy and, in the case of the second patient, nephrolithiasis is probably due to the toxic effect of sugars, sugar phosphates and polyols on the proximal tubules"
+      explanation: The full-text clinical report links accumulated metabolites to renal tubulopathy.
+  - target: Hydrops fetalis
+    description: Severe antenatal transaldolase deficiency can present with hydrops fetalis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001789 | Hydrops fetalis | Frequent (79-30%)"
+      explanation: Orphanet records hydrops fetalis as a frequent phenotype.
+  - target: Edema
+    description: Severe antenatal or neonatal transaldolase deficiency can present with edema.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000969 | Edema | Frequent (79-30%)"
+      explanation: Orphanet records edema as a frequent phenotype.
+  - target: Abnormal facial shape
+    description: The multisystem developmental presentation of transaldolase deficiency can include dysmorphic facial features.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23315216
+      reference_title: "Transaldolase deficiency: report of 12 new cases and further delineation of the phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "growth retardation, dysmorphic features, cutis laxa, congenital heart disease"
+      explanation: The 12-case clinical series reports dysmorphic features in transaldolase deficiency.
+  - target: Global developmental delay
+    description: Transaldolase deficiency can include neurodevelopmental delay through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001263 | Global developmental delay | Occasional (29-5%)"
+      explanation: Orphanet records global developmental delay as an occasional phenotype.
+  - target: Abnormality of the clitoris
+    description: Transaldolase deficiency is associated with genital developmental abnormalities through unknown intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000056 | Abnormality of the clitoris | Frequent (79-30%)"
+      explanation: Orphanet records clitoral abnormality as a frequent phenotype.
+  - target: Atrial septal defect
+    description: The multisystem developmental presentation of transaldolase deficiency can include congenital heart disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001631 | Atrial septal defect | Occasional (29-5%)"
+      explanation: Orphanet records atrial septal defect as an occasional phenotype.
+  - target: Coarctation of aorta
+    description: The multisystem developmental presentation of transaldolase deficiency can include congenital aortic disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001680 | Coarctation of aorta | Occasional (29-5%)"
+      explanation: Orphanet records coarctation of aorta as an occasional phenotype.
+  - target: Biventricular hypertrophy
+    description: Transaldolase deficiency can include cardiac hypertrophy through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0200128 | Biventricular hypertrophy | Occasional (29-5%)"
+      explanation: Orphanet records biventricular hypertrophy as an occasional phenotype.
+  - target: Abnormal respiratory system physiology
+    description: Severe multisystem transaldolase deficiency can include respiratory physiology abnormalities.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002795 | Abnormal respiratory system physiology | Occasional (29-5%)"
+      explanation: Orphanet records respiratory physiology abnormality as an occasional phenotype.
+  - target: Premature skin wrinkling
+    description: The multisystem developmental presentation of transaldolase deficiency can include cutis laxa and premature skin wrinkling through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23315216
+      reference_title: "Transaldolase deficiency: report of 12 new cases and further delineation of the phenotype."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "growth retardation, dysmorphic features, cutis laxa, congenital heart disease"
+      explanation: The 12-case series supports cutis laxa/skin changes in the multisystem presentation.
+  - target: Hypergonadotropic hypogonadism
+    description: Transaldolase deficiency can include hypergonadotropic hypogonadism through incompletely defined endocrine intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38440129
+      reference_title: "Hypergonadotropic Hypogonadism Due to Transaldolase Deficiency: Two Cases and Literature Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "two Emirati patients with hypergonadotropic hypogonadism due to transaldolase deficiency"
+      explanation: The case report directly documents hypergonadotropic hypogonadism in transaldolase deficiency.
 - name: Redox and mitochondrial stress signaling
   description: >
     The pentose phosphate pathway supplies NADPH for antioxidant defense.
@@ -287,6 +450,13 @@ pathophysiology:
   - target: Hepatocyte apoptosis
     description: Oxidative and mitochondrial stress increases hepatocyte cell death.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:17613166
+      reference_title: "The pathogenesis of transaldolase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "liver cirrhosis which results from increased cell death of hepatocytes"
+      explanation: The pathogenesis review links TAL deficiency in patients to increased hepatocyte cell death leading to cirrhosis.
 - name: Hepatocyte apoptosis
   description: >
     Transaldolase deficiency increases hepatocyte cell death. The cited
@@ -315,6 +485,13 @@ pathophysiology:
   - target: Hepatic fibrosis and cirrhosis
     description: Recurrent hepatocyte injury and cell death promotes progressive hepatic fibrosis and cirrhosis.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:17613166
+      reference_title: "The pathogenesis of transaldolase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "liver cirrhosis which results from increased cell death of hepatocytes"
+      explanation: This directly supports cirrhosis downstream of increased hepatocyte cell death.
 - name: Hepatic fibrosis and cirrhosis
   description: >
     Ongoing liver injury in transaldolase deficiency produces progressive
@@ -339,21 +516,65 @@ pathophysiology:
   - target: Cirrhosis
     description: Hepatocyte injury and fibrosis produce cirrhosis.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:17613166
+      reference_title: "The pathogenesis of transaldolase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "liver cirrhosis which results from increased cell death of hepatocytes"
+      explanation: The pathogenesis review supports cirrhosis as a downstream liver outcome.
   - target: Hepatosplenomegaly
-    description: Liver injury and portal-systemic disease are associated with hepatosplenomegaly.
-    causal_link_type: DIRECT
+    description: Severe liver-centered transaldolase deficiency is associated with hepatosplenomegaly, but the cached evidence does not specify the intermediate mechanism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Transaldolase deficiency is an inborn error of the pentose phosphate pathway that presents in the neonatal or antenatal period with hydrops fetalis, hepatosplenomegaly, hepatic dysfunction, thrombocytopenia, anemia, and renal and cardiac abnormalities."
+      explanation: Orphanet definition links the disorder's hepatic presentation with hepatosplenomegaly.
   - target: Thrombocytopenia
-    description: Liver disease and hypersplenism contribute to platelet reduction.
-    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Severe liver-centered transaldolase deficiency is associated with thrombocytopenia, but the cached evidence does not specify the intermediate mechanism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hepatosplenomegaly, thrombocytopenia, anaemia, bleeding diathesis, liver failure"
+      explanation: The clinical report lists thrombocytopenia with hepatosplenomegaly and liver failure.
   - target: Anemia
-    description: Multisystem liver and hematologic disease includes anemia.
-    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Severe liver-centered transaldolase deficiency is associated with anemia, but the cached evidence does not specify the intermediate mechanism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hepatosplenomegaly, thrombocytopenia, anaemia, bleeding diathesis, liver failure"
+      explanation: The clinical report lists anemia with hepatosplenomegaly and liver failure.
   - target: Telangiectasia
     description: Liver damage is associated with spider angiomas and visible skin vessels.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
-  - target: Premature skin wrinkling
-    description: Liver-associated cutis laxa and thin skin contribute to premature skin wrinkling.
-    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Liver damage with visible skin-vessel changes.
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These skin changes, characteristic of liver damage, immediately made us consider transaldolase deficiency"
+      explanation: The report links visible skin vessel changes to liver damage in transaldolase deficiency.
+  - target: Increased serum bile acid concentration
+    description: Hepatic dysfunction in transaldolase deficiency is associated with increased serum bile acids.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:101028
+      reference_title: "Transaldolase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012202 | Increased serum bile acid concentration | Very frequent (99-80%)"
+      explanation: Orphanet records increased serum bile acid concentration as a very frequent phenotype.
 biochemical:
 - name: Reduced transaldolase activity
   presence: DECREASED
@@ -791,6 +1012,17 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Redox and mitochondrial stress signaling
+    treatment_effect: MODULATES
+    description: Acetaminophen avoidance reduces exposure to a trigger that can accentuate oxidative liver stress in transaldolase deficiency.
+    evidence:
+    - reference: PMID:29923087
+      reference_title: "Apparent Acetaminophen Toxicity in a Patient with Transaldolase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "transaldolase-deficient patients are uniquely sensitive to acetaminophen and should avoid this antipyretic."
+      explanation: The human case report supports avoidance of acetaminophen as a way to reduce oxidative liver-injury risk.
   evidence:
   - reference: PMID:24497183
     reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
@@ -848,6 +1080,17 @@ treatments:
     term:
       id: MAXO:0010039
       label: organ transplantation
+  target_mechanisms:
+  - target: Hepatic fibrosis and cirrhosis
+    treatment_effect: MODULATES
+    description: Liver transplantation has been proposed as a possible intervention for early severe liver disease, but the evidence remains tentative.
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Liver transplantation in the early stage of the disease could perhaps be useful."
+      explanation: The report proposes transplantation for severe liver disease but does not establish efficacy.
   evidence:
   - reference: PMID:24497183
     reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."


### PR DESCRIPTION
## Summary
- add evidence-backed downstream edges connecting Transaldolase Deficiency mechanism nodes to biochemical and phenotype endpoints
- add treatment target-mechanism evidence for supportive acetaminophen avoidance, NAC, and tentative liver transplantation consideration
- keep unsupported endpoint intermediates conservative with INDIRECT_UNKNOWN_INTERMEDIATES after subagent review

## Validation
- just validate kb/disorders/Transaldolase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/Transaldolase_Deficiency.yaml
- connectivity check: 30 nodes, 29 edges, 1 component
- custom snippet audit: 91 snippets checked, all normalized snippets found in cache