### PR TITLE
Improve fucosidosis pathograph

### DIFF
--- a/kb/disorders/Fucosidosis.yaml
+++ b/kb/disorders/Fucosidosis.yaml
@@ -22,6 +22,31 @@ disease_term:
 parents:
 - Oligosaccharidosis
 - Lysosomal storage disease with skeletal involvement
+has_subtypes:
+- name: Type I
+  display_name: Type I fucosidosis
+  description: >
+    Rapidly progressive neurodegenerative fucosidosis, typically leading to
+    decerebration and death before age 10 years.
+  evidence:
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Type I: a rapidly-progressing neurodegenerative course"
+    explanation: The clinical review defines Type I fucosidosis as a rapidly progressive neurodegenerative subtype.
+- name: Type II
+  display_name: Type II fucosidosis
+  description: >
+    Milder fucosidosis with slower neurologic progression, possible survival
+    into adulthood, and frequent angiokeratoma corporis diffusum.
+  evidence:
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Type II: a milder course, with slower neurological symptoms progression"
+    explanation: The clinical review defines Type II fucosidosis as a milder, slower-progressing subtype.
 mappings:
   mondo_mappings:
   - term:
@@ -843,12 +868,6 @@ pathophysiology:
     Fucosidosis includes skeletal involvement with dysostosis multiplex and
     vertebral changes. The direct cellular intermediates between fucose-rich
     storage and skeletal morphology are not specified in the cached evidence.
-  biological_processes:
-  - preferred_term: skeletal system development
-    modifier: ABNORMAL
-    term:
-      id: GO:0001501
-      label: skeletal system development
   evidence:
   - reference: ORPHA:349
     reference_title: Fucosidosis (Orphanet structured-database record)

--- a/kb/disorders/Fucosidosis.yaml
+++ b/kb/disorders/Fucosidosis.yaml
@@ -1,7 +1,7 @@
 name: Fucosidosis
 category: Mendelian
 creation_date: "2026-05-04T15:41:26Z"
-updated_date: "2026-05-04T15:41:26Z"
+updated_date: "2026-05-10T23:15:11Z"
 synonyms:
 - Alpha-L-fucosidase deficiency
 description: >
@@ -217,9 +217,26 @@ pathophysiology:
     snippet: "reduced enzyme activity or complete loss of function"
     explanation: The recent review summarizes the causal FUCA1-to-enzyme-deficiency relationship.
   downstream:
+  - target: Alpha-L-fucosidase activity
+    description: FUCA1 pathogenic variants reduce measured alpha-L-fucosidase enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:1873910
+      reference_title: Defective expression of alpha-L-fucosidase by lymphoid cells of a fucosidosis patient.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "negligible catalytic activity as compared with the mean of 19 control cultures."
+      explanation: Patient-derived lymphoid cells directly showed negligible alpha-L-fucosidase catalytic activity.
   - target: Fucose-rich glycoconjugate lysosomal storage
     description: Enzyme deficiency impairs degradation of fucosylated glycoconjugates.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "incomplete catabolism of N- and O-glycosylproteins results in the accumulation of fucose-containing glycolipids and glycoproteins in various tissues and urine"
+      explanation: Human clinical review evidence directly links alpha-L-fucosidase deficiency to fucosylated substrate accumulation.
 - name: Fucose-rich glycoconjugate lysosomal storage
   description: >
     Impaired alpha-L-fucosidase function causes accumulation of fucose-rich
@@ -274,8 +291,187 @@ pathophysiology:
   - target: Neural lysosomal expansion and secondary storage
     description: Storage distends lysosomes and produces secondary lipid storage in the CNS.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27491075
+      reference_title: A mouse model for fucosidosis recapitulates storage pathology and neurological features of the milder form of the human disease.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "In the CNS, cellular alterations included enlargement of the"
+      explanation: The Fuca1 knockout mouse demonstrates lysosomal storage pathology in visceral organs and the CNS.
   - target: Visceral and cutaneous storage disease
     description: Storage in liver, skin, and other tissues contributes to visceral and dermatologic manifestations.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "accretion of fucose-containing oligosaccharides, glycoproteins, and glycolipids in the brain, liver and skin"
+      explanation: Human clinical review evidence places fucose-containing storage material in liver and skin.
+  - target: Urinary fucose-rich oligosaccharides and glycopeptides
+    description: Accumulated fucosylated glycopeptides and oligosaccharides are excessively excreted in urine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients affected with fucosidosis excrete a large amount of glycopeptide in the urine"
+      explanation: The clinical review directly supports urinary excretion of fucosylated storage products.
+  - target: Respiratory mucus clearance impairment
+    description: Altered handling of fucose-containing airway glycoconjugates is suspected to impair mucus clearance.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Altered terminal sugar cleavage affecting mucus cross-linking and viscoelasticity.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "it was suspected that there could be a local defect in mucus clearance."
+      explanation: The review reports a suspected local mucus-clearance defect in fucosidosis respiratory disease.
+  - target: Skeletal dysostosis involvement
+    description: Lysosomal storage disease is associated with dysostosis multiplex and vertebral skeletal abnormalities through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Some patients also have non-specific features of dysostosis multiplex"
+      explanation: The clinical review supports skeletal dysostosis as part of fucosidosis.
+  - target: Ocular storage involvement
+    description: Fucosidosis can include conjunctival, retinal, and corneal storage-related ocular involvement.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Storage material in conjunctival and retinal vessels with corneal involvement.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "storage material accumulates in conjunctival, retinal, and skin vessels."
+      explanation: The clinical review directly supports ocular vascular storage involvement.
+  - target: Brachycephaly
+    description: The multisystem developmental presentation of fucosidosis includes brachycephaly through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000248 | Brachycephaly | Very frequent (99-80%)"
+      explanation: Orphanet records brachycephaly as a very frequent fucosidosis phenotype.
+  - target: Coarse facial features
+    description: The multisystem lysosomal storage phenotype includes coarse facial features through incompletely defined craniofacial intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical features include coarse facial features"
+      explanation: The clinical review lists coarse facial features among fucosidosis manifestations.
+  - target: Abnormal facial shape
+    description: The multisystem developmental presentation of fucosidosis includes facial dysmorphism through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001999 | Abnormal facial shape | Very frequent (99-80%)"
+      explanation: Orphanet records abnormal facial shape as a very frequent fucosidosis phenotype.
+  - target: Prominent forehead
+    description: The multisystem craniofacial presentation of fucosidosis includes prominent forehead through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011220 | Prominent forehead | Very frequent (99-80%)"
+      explanation: Orphanet records prominent forehead as a very frequent fucosidosis phenotype.
+  - target: Failure to thrive
+    description: The severe multisystem storage phenotype is associated with growth failure through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "the weight of 77% was below the fifth centile."
+      explanation: The clinical review supports growth and weight failure in fucosidosis.
+  - target: Mucopolysacchariduria
+    description: Abnormal urinary storage products are associated with a mucopolysacchariduria-like biochemical phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008155 | Mucopolysacchariduria | Very frequent (99-80%)"
+      explanation: Orphanet records mucopolysacchariduria as a very frequent biochemical phenotype.
+  - target: Lipoatrophy
+    description: The multisystem storage phenotype includes lipoatrophy through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100578 | Lipoatrophy | Very frequent (99-80%)"
+      explanation: Orphanet records lipoatrophy as a very frequent fucosidosis phenotype.
+  - target: Abnormality of the cardiovascular system
+    description: The multisystem storage phenotype can include cardiovascular abnormalities through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001626 | Abnormality of the cardiovascular system | Frequent (79-30%)"
+      explanation: Orphanet records cardiovascular abnormality as a frequent fucosidosis phenotype.
+  - target: Abnormality of the gallbladder
+    description: The multisystem storage phenotype can include gallbladder abnormalities through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0005264 | Abnormality of the gallbladder | Frequent (79-30%)"
+      explanation: Orphanet records gallbladder abnormality as a frequent fucosidosis phenotype.
+  - target: Hypothyroidism
+    description: The multisystem storage phenotype includes hypothyroidism through incompletely defined endocrine intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000821 | Hypothyroidism | Very frequent (99-80%)"
+      explanation: Orphanet records hypothyroidism as a very frequent fucosidosis phenotype.
+  - target: Abnormality of the dentition
+    description: The multisystem developmental phenotype includes dental abnormalities through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000164 | Abnormality of the dentition | Occasional (29-5%)"
+      explanation: Orphanet records dentition abnormality as an occasional fucosidosis phenotype.
+  - target: Cardiomegaly
+    description: The multisystem storage phenotype can include cardiomegaly through incompletely defined cardiovascular intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001640 | Cardiomegaly | Occasional (29-5%)"
+      explanation: Orphanet records cardiomegaly as an occasional fucosidosis phenotype.
 - name: Neural lysosomal expansion and secondary storage
   description: >
     Fucosylated substrate storage expands lysosomal compartments in CNS cells,
@@ -311,8 +507,25 @@ pathophysiology:
   - target: Neuroinflammation and neural cell loss
     description: Expanded lysosomal storage is associated with inflammatory gliosis and neuronal loss.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27491075
+      reference_title: A mouse model for fucosidosis recapitulates storage pathology and neurological features of the milder form of the human disease.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "neuroinflammation, as well as a progressive loss of Purkinje cells"
+      explanation: The Fuca1 knockout mouse links CNS lysosomal storage pathology to neuroinflammation and neuronal loss.
   - target: Hypomyelination
     description: CNS storage disease is associated with oligodendrocyte loss and hypomyelination.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Oligodendrocyte loss in CNS storage pathology.
+    evidence:
+    - reference: PMID:26537923
+      reference_title: The effects of intracisternal enzyme replacement versus sham treatment on central neuropathology in preclinical canine fucosidosis.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "oligodendrocyte loss, and hypomyelination throughout the"
+      explanation: The canine model links fucosidosis CNS pathology to oligodendrocyte loss and hypomyelination.
 - name: Neuroinflammation and neural cell loss
   description: >
     CNS storage pathology activates inflammatory glia and is accompanied by
@@ -357,10 +570,68 @@ pathophysiology:
   downstream:
   - target: Severe intellectual disability
     description: Neuronal injury and neuroinflammation contribute to severe cognitive impairment.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Progressive mental deterioration and neuronal loss.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "up to 95% of patients have progressive mental health deterioration"
+      explanation: The clinical review supports severe cognitive deterioration downstream of fucosidosis neurodegeneration.
+  - target: Global developmental delay
+    description: CNS storage pathology and neurodegeneration are associated with developmental delay and psychomotor decline.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001263 | Global developmental delay | Very frequent (99-80%)"
+      explanation: Orphanet records global developmental delay as a very frequent phenotype.
   - target: Seizure
     description: Neural injury and inflammation contribute to epilepsy susceptibility.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "seizures may occur in 38% of patients"
+      explanation: The clinical review supports seizures as a frequent neurologic manifestation.
   - target: Spasticity
     description: CNS injury contributes to progressive pyramidal and motor dysfunction.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Progressive neurologic degeneration with pyramidal motor involvement.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Progressive neurological degeneration results in flexion contractures of legs and arms"
+      explanation: The clinical review links neurologic degeneration to motor contractures and spastic motor manifestations.
+  - target: Hypotonia
+    description: CNS storage pathology and motor deterioration are associated with hypotonia through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001252 | Hypotonia | Frequent (79-30%)"
+      explanation: Orphanet records hypotonia as a frequent fucosidosis phenotype.
+  - target: Decreased muscle mass
+    description: Progressive neurologic and multisystem disease is associated with decreased muscle mass through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003199 | Decreased muscle mass | Frequent (79-30%)"
+      explanation: Orphanet records decreased muscle mass as a frequent fucosidosis phenotype.
 - name: Hypomyelination
   description: >
     CNS fucosidosis storage pathology includes oligodendrocyte loss and reduced
@@ -398,8 +669,40 @@ pathophysiology:
   downstream:
   - target: Spastic tetraplegia
     description: White-matter disease contributes to progressive motor impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002510 | Spastic tetraplegia | Frequent (79-30%)"
+      explanation: Orphanet records spastic tetraplegia as a frequent motor phenotype.
   - target: Hearing impairment
-    description: CNS and auditory pathway involvement contributes to hearing dysfunction.
+    description: CNS white-matter involvement can coincide with auditory pathway abnormalities and hearing impairment, but the causal intermediate is incompletely defined.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:11360116
+      reference_title: Four year follow-up of a case of fucosidosis treated with unrelated donor bone marrow transplantation.
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "auditory brainstem responses and"
+      explanation: A human case links diffuse hypomyelination with altered auditory brainstem responses.
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000365 | Hearing impairment | Very frequent (99-80%)"
+      explanation: Orphanet records hearing impairment as a very frequent fucosidosis phenotype.
+  - target: Abnormal pyramidal sign
+    description: White-matter and corticospinal motor involvement can produce pyramidal signs through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0007256 | Abnormal pyramidal sign | Occasional (29-5%)"
+      explanation: Orphanet records abnormal pyramidal sign as an occasional fucosidosis phenotype.
 - name: Visceral and cutaneous storage disease
   description: >
     Fucose-rich substrate storage in visceral and skin tissues is associated with
@@ -435,10 +738,195 @@ pathophysiology:
   downstream:
   - target: Hepatomegaly
     description: Visceral storage contributes to liver enlargement.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Storage material in liver tissue.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Hepatomegaly was documented in 20%"
+      explanation: The clinical review documents hepatomegaly in fucosidosis.
   - target: Hyperhidrosis
     description: Cutaneous involvement contributes to abnormal sweating.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "skin abnormalities also include widespread telangiectasia, skin thickness, hyperhidrosis"
+      explanation: The clinical review lists hyperhidrosis among skin abnormalities.
+  - target: Generalized hyperkeratosis
+    description: Cutaneous storage disease is associated with generalized hyperkeratosis through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:349
+      reference_title: Fucosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0005595 | Generalized hyperkeratosis | Very frequent (99-80%)"
+      explanation: Orphanet records generalized hyperkeratosis as a very frequent fucosidosis phenotype.
   - target: Vascular skin abnormality
     description: Skin involvement includes telangiectasia and angiokeratoma.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Telangiectasia and angiokeratoma in skin vessels.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dermatological abnormalities were documented in 60% of patient and included telangiectasiae on the skin or conjunctivae and angiokeratoma"
+      explanation: The clinical review links cutaneous disease to telangiectasia and angiokeratoma.
+  - target: Acrocyanosis
+    description: Cutaneous vascular involvement can include acrocyanosis through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "skin abnormalities also include widespread telangiectasia, skin thickness, hyperhidrosis and hypohidrosis, acrocyanosis"
+      explanation: The clinical review lists acrocyanosis among fucosidosis skin abnormalities.
+  - target: Abnormal nail morphology
+    description: Cutaneous involvement can include distal nail changes through incompletely defined intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "distal transverse nail bands"
+      explanation: The clinical review documents nail changes as part of the skin phenotype.
+- name: Respiratory mucus clearance impairment
+  description: >
+    Fucosidosis respiratory infections may reflect local airway mucus-clearance
+    vulnerability. The clinical review notes intact immune testing in reported
+    patients and proposes altered fucose/sialic-acid-dependent mucus
+    cross-linking and viscoelasticity as a contributor.
+  biological_processes:
+  - preferred_term: mucociliary clearance
+    modifier: DECREASED
+    term:
+      id: GO:0120197
+      label: mucociliary clearance
+  evidence:
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "it was suspected that there could be a local defect in mucus clearance."
+    explanation: The review proposes impaired mucus clearance as a contributor to recurrent respiratory infections.
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "terminal sugars fucose and sialic acid play a major role in defining the viscoelasticity of mucus."
+    explanation: The review gives the proposed glycoconjugate-mucus intermediate.
+  downstream:
+  - target: Recurrent respiratory infections
+    description: Impaired local mucus clearance is suspected to increase recurrent respiratory infections.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Abnormal mucus viscoelasticity and ineffective ciliary clearance.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Up to 78% of patients experience respiratory tract infections"
+      explanation: The clinical review supports frequent respiratory infections in fucosidosis.
+- name: Skeletal dysostosis involvement
+  description: >
+    Fucosidosis includes skeletal involvement with dysostosis multiplex and
+    vertebral changes. The direct cellular intermediates between fucose-rich
+    storage and skeletal morphology are not specified in the cached evidence.
+  biological_processes:
+  - preferred_term: skeletal system development
+    modifier: ABNORMAL
+    term:
+      id: GO:0001501
+      label: skeletal system development
+  evidence:
+  - reference: ORPHA:349
+    reference_title: Fucosidosis (Orphanet structured-database record)
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "developmental delay associated with psychomotor regression and bone abnormalities"
+    explanation: Orphanet definition supports skeletal/bone involvement in fucosidosis.
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Some patients also have non-specific features of dysostosis multiplex"
+    explanation: The clinical review supports dysostosis multiplex as a skeletal manifestation.
+  downstream:
+  - target: Dysostosis multiplex
+    description: Skeletal involvement manifests as dysostosis multiplex.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Some patients also have non-specific features of dysostosis multiplex"
+      explanation: The clinical review supports dysostosis multiplex in fucosidosis.
+  - target: Anterior beaking of lumbar vertebrae
+    description: Vertebral skeletal involvement includes anterior tonguing or beaking.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "An X-ray of the spine shows small thoracolumbar vertebrae with anterior tonguing"
+      explanation: The clinical review supports anterior vertebral changes as part of skeletal involvement.
+  - target: Kyphosis
+    description: Skeletal involvement can include kyphotic/gibbous spinal deformity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "gibbous deformity of lumbar vertebrae"
+      explanation: The clinical review supports spinal deformity in fucosidosis.
+- name: Ocular storage involvement
+  description: >
+    Fucosidosis can involve ocular tissues, including conjunctival and retinal
+    vessels and corneal clarity. The cached clinical review links storage
+    material to ocular vessels and lists corneal opacities in affected patients.
+  locations:
+  - preferred_term: eye
+    term:
+      id: UBERON:0000970
+      label: eye
+  evidence:
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "storage material accumulates in conjunctival, retinal, and skin vessels."
+    explanation: The clinical review supports ocular vessel storage involvement.
+  - reference: PMID:33266441
+    reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "corneal opacities in 11%"
+    explanation: The clinical review documents corneal opacity in patients.
+  downstream:
+  - target: Corneal opacity
+    description: Ocular storage involvement can include corneal opacity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "corneal opacities in 11%"
+      explanation: The clinical review documents corneal opacity in fucosidosis.
 phenotypes:
 - name: Severe intellectual disability
   frequency: VERY_FREQUENT
@@ -1068,6 +1556,11 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_phenotypes:
+  - preferred_term: Spasticity
+    term:
+      id: HP:0001257
+      label: Spasticity
   evidence:
   - reference: PMID:33266441
     reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.


### PR DESCRIPTION
## Summary
- connect the Fucosidosis causal graph from FUCA1 alpha-L-fucosidase deficiency through lysosomal storage, CNS, visceral/cutaneous, respiratory, skeletal, and ocular mechanisms
- add evidence and causal_link_type values to downstream pathophysiology edges
- add conservative phenotype links for previously isolated endpoints and move supportive care to phenotype targeting after subagent review

## Review
- Subagent review completed; addressed blockers by removing invalid Supportive care target_mechanism and fixing raw exact cached snippets for PMID:27491075 and PMID:11360116

## Validation
- just validate kb/disorders/Fucosidosis.yaml
- uv run python -m dismech.graph --validate kb/disorders/Fucosidosis.yaml
- connectivity check: 47 nodes, 48 edges, 1 component
- custom raw snippet audit: 127 snippets checked, all raw snippets found in cache