### PR TITLE
Improve APRT deficiency pathograph

### DIFF
--- a/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
+++ b/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Adenine Phosphoribosyltransferase Deficiency
 category: Mendelian
 creation_date: "2026-05-10T09:34:20Z"
-updated_date: "2026-05-10T09:34:20Z"
+updated_date: "2026-05-10T23:55:30Z"
 synonyms:
 - APRT deficiency
 - 2,8-dihydroxyadenine urolithiasis
@@ -209,6 +209,26 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "In the absence of APRT activity, adenine is converted by xanthine oxidoreductase"
       explanation: Human registry background directly links absent APRT activity to XOR-mediated adenine conversion.
+  - target: Reduced APRT enzyme activity
+    description: Biallelic APRT loss of function is measured diagnostically as absent or markedly reduced enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22934314
+      reference_title: "Adenine Phosphoribosyltransferase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "absence of APRT enzyme activity in red cell lysates"
+      explanation: GeneReviews identifies absent APRT enzyme activity as the diagnostic biochemical defect.
+  - target: Abnormal APRT enzyme activity
+    description: The proximal enzymatic defect is the biochemical phenotype recorded for APRT deficiency.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012379 | Abnormal enzyme/coenzyme activity | Very frequent (99-80%)"
+      explanation: Orphanet records abnormal enzyme activity as a very frequent APRT deficiency phenotype.
 - name: Adenine conversion to 2,8-dihydroxyadenine
   description: >
     Xanthine oxidoreductase oxidizes adenine to 2,8-dihydroxyadenine when APRT
@@ -254,6 +274,16 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "The low solubility of DHA results in precipitation of this compound and the formation of urinary crystals and stones."
       explanation: Review evidence links DHA low solubility to urinary crystals and stones.
+  - target: Increased urinary 2,8-dihydroxyadenine
+    description: XOR-mediated DHA generation produces excessive urinary DHA excretion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In the absence of APRT activity, adenine is converted by xanthine oxidoreductase (XOR; xanthine dehydrogenase/oxidase) to the poorly soluble 2,8-dihydroxyadenine (DHA) which is excreted in the urine in excessive amounts."
+      explanation: Human registry evidence directly links absent APRT activity to excessive urinary DHA excretion.
 - name: Urinary 2,8-dihydroxyadenine crystalluria
   description: >
     Excess 2,8-DHA is excreted in urine, where its low solubility produces
@@ -278,6 +308,16 @@ pathophysiology:
     snippet: "formation and hyperexcretion of 2,8-dihydroxyadenine (DHA) into urine."
     explanation: The review supports urinary DHA formation and hyperexcretion.
   downstream:
+  - target: Obstructive DHA stone disease
+    description: Urinary DHA precipitation produces urolithiasis and obstructive stone events.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "formation and hyperexcretion of 2,8-dihydroxyadenine (2,8-DHA) in urine, causing urolithiasis and crystalline nephropathy"
+      explanation: Orphanet directly links urinary DHA hyperexcretion to urolithiasis.
   - target: Renal tubular crystal deposition and obstruction
     description: DHA crystals deposit within renal tubules and can obstruct tubular lumens.
     causal_link_type: DIRECT
@@ -288,6 +328,62 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "formation of 2,8-DHA crystals within renal tubules"
       explanation: Patient-biopsy and model study supports intratubular crystal formation.
+- name: Obstructive DHA stone disease
+  description: >
+    Poorly soluble DHA forms urinary stones that can cause obstructive stone
+    events, lower urinary tract symptoms, hematuria, pain, and obstructive AKI.
+  chemical_entities:
+  - preferred_term: 2,8-dihydroxyadenine
+    term:
+      id: CHEBI:183641
+      label: 2,8-dihydroxyadenine
+    modifier: INCREASED
+  evidence:
+  - reference: ORPHA:976
+    reference_title: "Adenine phosphoribosyltransferase deficiency"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "formation and hyperexcretion of 2,8-dihydroxyadenine (2,8-DHA) in urine, causing urolithiasis and crystalline nephropathy"
+    explanation: Orphanet supports urolithiasis as a direct consequence of urinary DHA hyperexcretion.
+  - reference: PMID:30443743
+    reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Reddish-brown diaper spots and kidney stones were the most common presenting features"
+    explanation: Human registry data support kidney stones as a major clinical presentation.
+  downstream:
+  - target: Nephrolithiasis
+    description: DHA stone formation manifests clinically as nephrolithiasis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22934314
+      reference_title: "Adenine Phosphoribosyltransferase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "kidney stone formation and crystal-induced kidney damage"
+      explanation: GeneReviews directly links excessive DHA to kidney stone formation.
+  - target: Uric acid-like radiolucent nephrolithiasis
+    description: Radiolucent DHA stones may be misidentified as uric acid calculi.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Radiolucent DHA stone misidentification
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "misidentification of radiolucent kidney stones as uric acid calculi"
+      explanation: Human registry discussion describes radiolucent DHA stones being mistaken for uric acid stones.
+  - target: Acute kidney injury
+    description: Bilateral obstructive DHA stone disease can cause AKI episodes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Three patients presented with AKI due to obstructive stone disease"
+      explanation: Human registry data directly link obstructive stone disease to AKI at presentation.
 - name: Renal tubular crystal deposition and obstruction
   description: >
     2,8-DHA crystals deposit in renal tubules. Small crystals can be taken up by
@@ -362,6 +458,16 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "DHA crystal nephropathy) causing acute kidney injury episodes and progressive chronic kidney disease (CKD)."
       explanation: GeneReviews directly links DHA crystal nephropathy to AKI and progressive CKD.
+  - target: Proteinuria
+    description: Biopsy-proven crystal nephropathy can present with elevated urine protein:creatinine ratio.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27994857
+      reference_title: "Adenine phosphoribosyltransferase deficiency in the United Kingdom: two novel mutations and a cross-sectional survey."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "urine protein:creatinine ratio 55.1 mg/mmol], no formal urine microscopy for crystals was undertaken at any stage and CT KUB was unremarkable. The renal team was aware that he was the brother of the index case. A renal biopsy showed a crystal nephropathy with interstitial nephritis and tubular deposition of crystals"
+      explanation: Human case-series evidence links proteinuria-range urine protein:creatinine elevation with biopsy-confirmed DHA crystal nephropathy.
 - name: Progressive DHA crystal nephropathy and renal dysfunction
   description: >
     Ongoing crystal nephropathy manifests clinically as recurrent
@@ -380,6 +486,41 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Affected individuals develop kidney stones and/or progressive chronic kidney disease (CKD) due to DHA crystal nephropathy"
     explanation: Human registry study links DHA nephropathy to stones and progressive CKD.
+  downstream:
+  - target: Chronic kidney disease
+    description: Progressive DHA crystal nephropathy reduces renal function and manifests as CKD.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Adenine phosphoribosyltransferase (APRT) deficiency is a hereditary purine metabolism disorder that causes kidney stones and chronic kidney disease (CKD)."
+      explanation: Human registry paper directly states that APRT deficiency causes CKD.
+  - target: Renal insufficiency
+    description: Crystal nephropathy-associated renal dysfunction appears clinically as renal insufficiency.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic kidney disease
+    evidence:
+    - reference: PMID:27994857
+      reference_title: "Adenine phosphoribosyltransferase deficiency in the United Kingdom: two novel mutations and a cross-sectional survey."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with unexplained renal stone disease or deterioration in kidney function should be considered for screening."
+      explanation: Human cross-sectional survey evidence supports kidney-function deterioration as part of the APRT deficiency renal presentation.
+  - target: Stage 5 chronic kidney disease
+    description: Untreated or inadequately treated DHA crystal nephropathy can progress to ESRD.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Progressive chronic kidney disease
+    evidence:
+    - reference: PMID:22934314
+      reference_title: "Adenine Phosphoribosyltransferase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "approximately 20%-25% of affected individuals develop end-stage renal disease (ESRD)"
+      explanation: GeneReviews supports progression to ESRD when treatment is inadequate.
 phenotypes:
 - category: Biochemical
   name: Abnormal APRT enzyme activity


### PR DESCRIPTION
## Summary
- Connect APRT enzyme loss to reduced enzyme activity and urinary 2,8-DHA biochemical readouts.
- Add an obstructive DHA stone disease mechanism node linking urinary DHA crystalluria to nephrolithiasis, uric acid-like radiolucent stones, and obstructive AKI.
- Link crystal nephropathy to CKD, renal insufficiency, ESRD, and proteinuria using conservative evidence-backed edges.
- Intentionally leave broad urinary symptoms, hypertension, atrial fibrillation, and oliguria as phenotype-only where cached evidence supports association but not a specific causal edge.

## Review
- Subagent review initially flagged under-supported urinary-symptom and hypertension causal edges.
- Addressed by removing those edges and tightening proteinuria/renal-insufficiency evidence.
- Follow-up subagent review found no blockers.

## Validation
- Schema validation...
No issues found
Term validation...
OK: enum cache rows match current dynamic enum definitions in cache
warning: `VIRTUAL_ENV=/Users/cjm/repos/tmux-pilot/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
/Users/cjm/worktrees/dismech-metabolic-pathographs/.venv/lib/python3.12/site-packages/eutils/__init__.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
✅ Validation passed
Reference validation...
Validating kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml against schema src/dismech/schema/dismech.yaml
Cache directory: references_cache

Validation Summary:
  Total checks: 0
  All validations passed!
Normalizing term caches...

Migration complete:
  Files scanned: 18
  Files updated: 0
Normalizing enum caches...
✓ All caches normalized
✓ All validations passed for kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
- All disorders have valid causal graphs.
- explicit local snippet audit: 96 snippets checked, all found in cache
- 
