### PR TITLE
Improve ALAD porphyria pathograph

### DIFF
--- a/kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml
+++ b/kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Porphyria due to ALA Dehydratase Deficiency
 category: Mendelian
 creation_date: '2026-05-05T09:35:36Z'
-updated_date: '2026-05-05T09:35:36Z'
+updated_date: '2026-05-11T00:27:57Z'
 description: >
   Porphyria due to ALA dehydratase deficiency, also called ALAD porphyria or
   porphyria of Doss, is an ultra-rare autosomal recessive acute hepatic
@@ -208,7 +208,7 @@ pathophysiology:
       These results suggest that the combination of the two aberrant ALADs with
       little enzyme activity accounts for the markedly decreased ALAD activity
       observed in the proband.
-    explanation: Human patient molecular data link compound heterozygous ALAD variants to markedly reduced enzyme activity.
+    explanation: In vitro expression of patient ALAD variants supports markedly reduced enzyme activity.
   - reference: PMID:10706561
     reference_title: "Novel molecular defects of the delta-aminolevulinate dehydratase gene in a patient with inherited acute hepatic porphyria."
     supports: SUPPORT
@@ -223,6 +223,40 @@ pathophysiology:
   - target: ALAD block in heme biosynthesis
     description: Variant-driven loss of ALAD / PBGS function blocks the second step of heme biosynthesis.
     causal_link_type: DIRECT
+  - target: Reduced erythrocyte ALAD activity
+    description: Biallelic ALAD defects manifest as markedly reduced erythrocyte ALAD enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:9732973
+      reference_title: "5-Aminolevulinic acid dehydratase deficiency porphyria: a twenty-year clinical and biochemical follow-up."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The patients' enzyme activity was <10% from 1977 to 1997."
+      explanation: Longitudinal patient data directly document severely reduced ALAD enzyme activity.
+    - reference: PMID:10706561
+      reference_title: "Novel molecular defects of the delta-aminolevulinate dehydratase gene in a patient with inherited acute hepatic porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        These data thus demonstrate that the proband was associated with 2 novel
+        molecular defects of the ALAD gene, 1 in each allele, and account for the
+        extremely low ALAD activity in his erythrocytes ( approximately 1% of
+        normal).
+      explanation: Patient molecular and enzyme data directly connect biallelic ALAD defects to extremely low erythrocyte activity.
+  - target: Erythrocyte ALAD activity
+    description: Molecular ALAD defects account for extremely low erythrocyte ALAD activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:10706561
+      reference_title: "Novel molecular defects of the delta-aminolevulinate dehydratase gene in a patient with inherited acute hepatic porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        These data thus demonstrate that the proband was associated with 2 novel
+        molecular defects of the ALAD gene, 1 in each allele, and account for the
+        extremely low ALAD activity in his erythrocytes ( approximately 1% of
+        normal).
+      explanation: Patient molecular and enzyme data connect biallelic ALAD defects to the biochemical enzyme-activity readout.
 - name: ALAD block in heme biosynthesis
   description: >
     ALAD, also known as porphobilinogen synthase, normally condenses two ALA
@@ -279,6 +313,18 @@ pathophysiology:
   - target: Hepatic and erythroid ALA accumulation without PBG overproduction
     description: The enzymatic block prevents efficient conversion of ALA to PBG, causing ALA excess with little PBG overproduction.
     causal_link_type: DIRECT
+  - target: Urinary porphobilinogen
+    description: Because the ALAD block lies upstream of PBG formation, ADP lacks the urinary PBG overproduction typical of AIP.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:9516683
+      reference_title: "ALAD porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Because of an almost complete lack of ALAD activity, patients excrete a
+        large amount of ALA, but not PBG, into urine.
+      explanation: ADP review evidence directly supports absent or non-increased urinary PBG despite excess ALA.
 - name: Hepatic ALAS1 induction and excess ALA production
   description: >
     ADP is classified as an acute hepatic porphyria, and patient data show
@@ -375,6 +421,18 @@ pathophysiology:
   - target: ALA-mediated neurovisceral attack susceptibility
     description: ALA excess is linked to recurrent abdominal pain, neuropathy, and weakness during attacks.
     causal_link_type: DIRECT
+  - target: Urinary 5-aminolevulinic acid
+    description: ALAD deficiency causes excessive urinary ALA excretion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:9516683
+      reference_title: "ALAD porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Because of an almost complete lack of ALAD activity, patients excrete a
+        large amount of ALA, but not PBG, into urine.
+      explanation: ADP review evidence directly links ALAD activity loss to large urinary ALA excretion.
 - name: ALA-mediated neurovisceral attack susceptibility
   description: >
     Accumulation of ALA in acute hepatic porphyria causes acute neurovisceral
@@ -397,6 +455,35 @@ pathophysiology:
     evidence_source: OTHER
     snippet: "A rare acute hepatic porphyria characterized by neurovisceral attacks without skin symptoms."
     explanation: Orphanet confirms neurovisceral attacks without skin symptoms.
+  downstream:
+  - target: Abdominal pain
+    description: ADP neurovisceral attacks include abdominal pain.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:35991568
+      reference_title: "Case Report: Lack of Response to Givosiran in a Case of ALAD Porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Introduction: 5-Aminolevulinic acid dehydratase (ALAD) porphyria (ADP)
+        is an autosomal recessive disease characterized by a profound deficiency
+        in ALAD, the second enzyme in the heme biosynthetic pathway, and acute
+        neurovisceral attacks with abdominal pain and peripheral neuropathy.
+      explanation: ADP case-report evidence directly identifies abdominal pain as part of neurovisceral attacks.
+  - target: Peripheral neuropathy
+    description: ADP neurovisceral attacks include peripheral neuropathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:35991568
+      reference_title: "Case Report: Lack of Response to Givosiran in a Case of ALAD Porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Introduction: 5-Aminolevulinic acid dehydratase (ALAD) porphyria (ADP)
+        is an autosomal recessive disease characterized by a profound deficiency
+        in ALAD, the second enzyme in the heme biosynthetic pathway, and acute
+        neurovisceral attacks with abdominal pain and peripheral neuropathy.
+      explanation: ADP case-report evidence directly identifies peripheral neuropathy as part of neurovisceral attacks.
 phenotypes:
 - name: Abdominal pain
   frequency: FREQUENT


### PR DESCRIPTION
## Summary
- Connect ALAD variant/conformational defects to reduced erythrocyte ALAD activity readouts.
- Link the ALAD heme-biosynthesis block to non-increased urinary PBG and urinary ALA biochemical readouts.
- Link neurovisceral attack susceptibility to abdominal pain and peripheral neuropathy using ADP-specific case-report evidence.
- Keep weaker Orphanet-only phenotypes and less certain treatment rows isolated rather than overclaiming mechanism edges.

## Review
- Subagent review initially flagged a local YAML indentation regression and an under-supported coproporphyrin downstream edge.
- Fixed both; follow-up subagent review found no blockers.

## Validation
- Schema validation...
No issues found
Term validation...
OK: enum cache rows match current dynamic enum definitions in cache
warning: `VIRTUAL_ENV=/Users/cjm/repos/tmux-pilot/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
/Users/cjm/worktrees/dismech-metabolic-pathographs/.venv/lib/python3.12/site-packages/eutils/__init__.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
✅ Validation passed
Reference validation...
Validating kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml against schema src/dismech/schema/dismech.yaml
Cache directory: references_cache

Validation Summary:
  Total checks: 0
  All validations passed!
Normalizing term caches...

Migration complete:
  Files scanned: 18
  Files updated: 0
Normalizing enum caches...
✓ All caches normalized
✓ All validations passed for kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml
- All disorders have valid causal graphs.
- explicit local snippet audit: 62 snippets checked, all found in cache
- 
