### PR TITLE
Improve mucolipidosis III alpha/beta pathograph

### DIFF
--- a/kb/disorders/Mucolipidosis_Type_III_Alpha_Beta.yaml
+++ b/kb/disorders/Mucolipidosis_Type_III_Alpha_Beta.yaml
@@ -1,7 +1,7 @@
 name: Mucolipidosis Type III Alpha/Beta
 category: Mendelian
 creation_date: "2026-05-08T04:37:03Z"
-updated_date: "2026-05-08T04:37:03Z"
+updated_date: "2026-05-11T00:59:47Z"
 synonyms:
 - ML III alpha/beta
 - Pseudo-Hurler polydystrophy
@@ -177,6 +177,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "the essential mannose 6-phosphate recognition marker is not synthesised on to lysosomal hydrolases and other glycoproteins."
       explanation: GNPTAB disease directly impairs the recognition marker needed for lysosomal hydrolase targeting.
+  - target: GlcNAc-1-phosphotransferase activity
+    description: GNPTAB alpha/beta subunit deficiency is measured as markedly decreased GlcNAc-1-phosphotransferase activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301730
+      reference_title: Mucolipidosis III Alpha/Beta - RETIRED CHAPTER, FOR HISTORICAL REFERENCE ONLY.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Significant deficiency (1%-10% of normal) of the activity of the enzyme UDP-N-acetylglucosamine: lysosomal hydrolase N-acetylglucosamine-1-phosphotransferase (GNPTA), encoded by GNPTAB, confirms the diagnosis."
+      explanation: GeneReviews supports that the molecular enzyme defect is detected as severely decreased phosphotransferase activity.
 - name: Lysosomal hydrolase mistargeting and secretion
   description: >
     Hydrolases lacking mannose-6-phosphate tags fail to localize efficiently to
@@ -311,21 +321,83 @@ pathophysiology:
   - target: Joint stiffness
     description: Joint stiffness is a very frequent skeletal/joint manifestation.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20367762
+      reference_title: The natural history and osteodystrophy of mucolipidosis types II and III.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All patients had progressive joint stiffness."
+      explanation: Natural-history cohort supports joint stiffness as a direct skeletal/joint manifestation.
   - target: Bone pain
     description: Bone pain is a frequent clinical consequence of skeletal disease.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:12705498
+      reference_title: The osteodystrophy of mucolipidosis type III and the effects of intravenous pamidronate treatment.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "reduction in bone pain and improvements in mobility"
+      explanation: Pamidronate-treated siblings had ML III osteodystrophy with clinically tracked bone pain.
   - target: Dysostosis multiplex
     description: Dysostosis multiplex is part of the radiographic skeletal phenotype.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29704188
+      reference_title: Mucolipidosis type III, a series of adult patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All patients had dysostosis multiplex and progressive secondary osteoarthritis, characterised by cartilage destruction and bone lesions in multiple joints."
+      explanation: Adult cohort directly links ML III skeletal degeneration with dysostosis multiplex and osteoarthritic joint disease.
   - target: Generalized osteoporosis
     description: Osteopenia and osteoporosis are part of the osteodystrophy.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301730
+      reference_title: Mucolipidosis III Alpha/Beta - RETIRED CHAPTER, FOR HISTORICAL REFERENCE ONLY.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Pain from osteoporosis that is clinically and radiologically apparent in childhood becomes more severe from adolescence."
+      explanation: GeneReviews directly supports clinically and radiologically apparent osteoporosis in ML III alpha/beta.
+  - target: Kyphoscoliosis
+    description: Spinal skeletal involvement includes thoracolumbar kyphosis and scoliosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21466370
+      reference_title: "Mucolipidosis type III alpha/beta: the first characterization of this rare disease by autopsy."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Prominent kyphosis and scoliosis of the spine were noted"
+      explanation: Autopsy examination directly supports kyphotic and scoliotic spinal involvement.
+  - target: Osteolysis
+    description: Progressive osteodystrophy includes severe carpal and femoral osteolysis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20367762
+      reference_title: The natural history and osteodystrophy of mucolipidosis types II and III.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "consistent with severe carpal osteolysis. Similarly there was severe osteolysis of the femoral heads and femoral necks."
+      explanation: Natural-history radiographs directly support osteolysis as part of the skeletal disease.
   - target: Constrictive median neuropathy
     description: Carpal tunnel syndrome is common in adults with ML III.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:29704188
+      reference_title: Mucolipidosis type III, a series of adult patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Carpal tunnel syndrome (CTS) was found in 12 patients (92%) and in eight patients (61%), CTS release was performed."
+      explanation: Adult cohort supports carpal tunnel syndrome as a frequent consequence requiring release surgery.
   - target: Loss of ambulation
     description: Progressive skeletal and joint disease can impair mobility and produce wheelchair dependence.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:29704188
+      reference_title: Mucolipidosis type III, a series of adult patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Six patients (46%) needed help with activities of daily living (ADL) or were wheelchair-dependent."
+      explanation: Adult cohort supports impaired mobility and wheelchair dependence downstream of severe skeletal disease.
 - name: Cardiac valve and myocardial involvement
   description: >
     Lysosomal storage in cardiovascular tissues produces valve thickening and


### PR DESCRIPTION
## Summary
- Connect GNPTAB phosphotransferase deficiency to the decreased GlcNAc-1-phosphotransferase activity readout.
- Add evidence-backed downstream skeletal edges for joint stiffness, bone pain, dysostosis multiplex, osteoporosis, kyphoscoliosis, osteolysis, carpal tunnel involvement, and loss of ambulation.
- Rebased onto current origin/main and kept the PR scoped to Mucolipidosis_Type_III_Alpha_Beta.yaml.

## Validation
- just validate kb/disorders/Mucolipidosis_Type_III_Alpha_Beta.yaml
- uv run python -m dismech.graph --validate kb/disorders/Mucolipidosis_Type_III_Alpha_Beta.yaml
- manual snippet audit: checked 99 snippets, all found in references_cache
- git diff --check
- subagent review: no PR-blocking findings; minor evidence-strength notes addressed before commit