### PR TITLE
Improve HIBCH deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 3-hydroxyisobutyryl-CoA hydrolase deficiency
 creation_date: "2026-04-15T00:00:00Z"
-updated_date: "2026-04-20T00:00:00Z"
+updated_date: "2026-05-11T01:43:24Z"
 category: Mendelian
 description: >-
   3-hydroxyisobutyryl-CoA hydrolase deficiency is an inborn error of valine
@@ -95,6 +95,57 @@ pathophysiology:
       Valine catabolic impairment secondarily contributes to combined
       respiratory chain and pyruvate dehydrogenase dysfunction.
     causal_link_type: DIRECT
+  - target: C4-OH acylcarnitine
+    description: >-
+      HIBCH-related valine catabolic impairment is associated with elevated
+      hydroxy-C4-carnitine in dried blood spots.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33762937
+      reference_title: "Cinical, Metabolic, and Genetic Analysis and Follow-Up of Eight Patients With HIBCH Mutations Presenting With Leigh/Leigh-Like Syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Five (5/7) patients presented with elevated C4-OH in dried blood spots,
+        and the level was probably correlated with the NPMDS scores during the
+        peak disease phase.
+      explanation: >-
+        The HIBCH cohort supports elevated C4-OH as a biochemical readout of
+        the disturbed valine-catabolism state.
+  - target: Urinary 2,3-dihydroxy-2-methylbutyrate
+    description: >-
+      The valine catabolic block produces elevated urinary
+      2,3-dihydroxy-2-methylbutyrate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33762937
+      reference_title: "Cinical, Metabolic, and Genetic Analysis and Follow-Up of Eight Patients With HIBCH Mutations Presenting With Leigh/Leigh-Like Syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        2,3-Dihydroxy-2-methylbutyrate in urine was elevated in six (6/7)
+        patients and elevated S-(2-caboxypropyl)cysteamine in urine was found
+        in three patients (3/3).
+      explanation: >-
+        The cohort directly supports urinary 2,3-dihydroxy-2-methylbutyrate as
+        an elevated disease-associated metabolite.
+  - target: Urinary S-(2-carboxypropyl)cysteamine
+    description: >-
+      Toxic valine-derived intermediates are reflected by elevated urinary
+      S-(2-carboxypropyl)cysteamine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33762937
+      reference_title: "Cinical, Metabolic, and Genetic Analysis and Follow-Up of Eight Patients With HIBCH Mutations Presenting With Leigh/Leigh-Like Syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        2,3-Dihydroxy-2-methylbutyrate in urine was elevated in six (6/7)
+        patients and elevated S-(2-caboxypropyl)cysteamine in urine was found
+        in three patients (3/3).
+      explanation: >-
+        The cohort supports urinary S-(2-carboxypropyl)cysteamine as another
+        elevated metabolite in HIBCH deficiency.
 - name: Multiple mitochondrial dysfunction
   description: >-
     HIBCH deficiency can produce combined mitochondrial respiratory chain
@@ -167,6 +218,43 @@ pathophysiology:
       Progressive HIBCH deficiency can produce a movement disorder in later
       infancy or childhood.
     causal_link_type: DIRECT
+  - target: Seizure
+    description: >-
+      Leigh-like HIBCH disease can present with seizures in neonatal and
+      infantile-onset disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41264763
+      reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Infantile onset is the most common phenotype, presenting in the first
+        two years of life with feeding difficulties, vomiting, developmental
+        delay with regression, hypotonia, seizures, movement disorder,
+        microcephaly, vision impairment, and episodes of neurologic
+        deterioration.
+      explanation: >-
+        GeneReviews supports seizures as part of the infantile Leigh-like HIBCH
+        neurologic presentation.
+  - target: Dystonia
+    description: >-
+      Later-onset HIBCH neurodegeneration can include paroxysmal dystonia as
+      part of the movement-disorder phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41264763
+      reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Late onset is the second most common phenotype, presenting in childhood
+        as a slowly progressive disease with significant movement disorder with
+        or without paroxysmal dystonia, variable cognitive impairment, and high
+        survivability.
+      explanation: >-
+        GeneReviews supports paroxysmal dystonia within the later-onset HIBCH
+        movement-disorder phenotype.
 phenotypes:
 - name: Global developmental delay
   category: Neurologic
@@ -537,6 +625,22 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Valine catabolic block
+    treatment_effect: MODULATES
+    description: >-
+      Valine restriction reduces dietary substrate flux into the impaired
+      valine catabolic pathway.
+    evidence:
+    - reference: PMID:41264763
+      reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        MANAGEMENT: Targeted therapy: Valine-restricted diet.
+      explanation: >-
+        GeneReviews identifies valine restriction as targeted therapy for the
+        pathway-level HIBCH defect.
   evidence:
   - reference: PMID:41264763
     reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.


### PR DESCRIPTION
## Summary
- Connect the HIBCH valine catabolic block to C4-OH acylcarnitine and urinary metabolite biomarker nodes.
- Connect Leigh-like neurodegeneration to seizure and dystonia phenotype nodes with GeneReviews evidence.
- Add a targeted mechanism link from valine-restricted diet to the valine catabolic block.
- Addressed subagent review by removing an over-inferred supportive-care target mechanism; that treatment remains intentionally unlinked.

## Validation
- just validate kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
- manual snippet audit: checked 31 snippets, all found in references_cache
- graph check: 18 nodes, 16 edges, 2 components, 0 orphans, 0 issues
- git diff --check
- subagent review: one blocker found and addressed before commit