### PR TITLE
Improve Smith-Lemli-Opitz pathograph connectivity

### DIFF
--- a/kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
+++ b/kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
@@ -1,6 +1,6 @@
 name: Smith-Lemli-Opitz syndrome
 creation_date: '2026-04-13T01:17:48Z'
-updated_date: '2026-04-13T01:17:48Z'
+updated_date: '2026-05-11T02:17:33Z'
 category: Mendelian
 synonyms:
 - SLOS
@@ -150,6 +150,16 @@ pathophysiology:
       evidence_source: IN_VITRO
       snippet: "We also show that the LC3B-II concentration in SLOS cells is directly proportional to the cellular concentration of 7DHC, suggesting that the increased autophagy is caused by 7DHC accumulation secondary to defective DHCR7."
       explanation: Patient fibroblast data link increasing 7DHC burden to increased autophagy.
+  - target: Serum 7-dehydrocholesterol
+    description: Elevated serum or tissue 7-dehydrocholesterol is the diagnostic biochemical readout of the accumulated precursor pool.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23059950
+      reference_title: "Smith-Lemli-Opitz syndrome: phenotype, natural history, and epidemiology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The clinical diagnosis of SLOS is confirmed by demonstrating an abnormally elevated concentration of the cholesterol precursor, 7DHC, in serum or other tissues, or by the presence of two DHCR7 mutations."
+      explanation: Human clinical review evidence supports elevated serum or tissue 7DHC as the diagnostic readout of 7DHC accumulation.
 - name: Relative Cholesterol Deficiency
   description: >-
     Cholesterol levels fall in plasma and tissues because terminal sterol
@@ -184,6 +194,16 @@ pathophysiology:
       evidence_source: IN_VITRO
       snippet: "Our results indicate that a deficit in cholesterol, as opposed to an accumulation of 7DHC, impairs SMO activation and its localization to the primary cilium."
       explanation: In vitro SLOS modeling shows that cholesterol deficiency directly impairs Smoothened activation.
+  - target: Plasma cholesterol
+    description: Impaired terminal cholesterol biosynthesis is reflected clinically by low plasma cholesterol.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:7706951
+      reference_title: "Markedly increased tissue concentrations of 7-dehydrocholesterol combined with low levels of cholesterol are characteristic of the Smith-Lemli-Opitz syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "It is characterized biochemically by low plasma cholesterol and greatly elevated levels of two dehydrocholesterols, one of which is the cholesterol precursor 7-dehydrocholesterol."
+      explanation: Human sterol measurements support decreased plasma cholesterol as a direct biochemical readout of cholesterol deficiency.
 - name: Impaired Smoothened Activation
   description: >-
     Reduced cholesterol availability impairs sterol-sensitive Smoothened
@@ -472,6 +492,27 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Relative Cholesterol Deficiency
+    treatment_effect: MODULATES
+    description: Dietary cholesterol supplementation raises plasma cholesterol over time.
+    evidence:
+    - reference: PMID:10951458
+      reference_title: "Cholesterol supplementation with egg yolk increases plasma cholesterol and decreases plasma 7-dehydrocholesterol in Smith-Lemli-Opitz syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These results support the hypothesis that over time dietary cholesterol supplementation from egg yolk increases the plasma cholesterol levels and decreases levels of 7-DHC which may be toxic."
+      explanation: Human intervention data support dietary cholesterol as a modulator of the cholesterol-deficiency biochemical state.
+  - target: 7-Dehydrocholesterol Accumulation
+    treatment_effect: MODULATES
+    description: Dietary cholesterol supplementation decreases circulating 7DHC levels over time.
+    evidence:
+    - reference: PMID:10951458
+      reference_title: "Cholesterol supplementation with egg yolk increases plasma cholesterol and decreases plasma 7-dehydrocholesterol in Smith-Lemli-Opitz syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These results support the hypothesis that over time dietary cholesterol supplementation from egg yolk increases the plasma cholesterol levels and decreases levels of 7-DHC which may be toxic."
+      explanation: The same intervention study supports decreased 7DHC after dietary cholesterol supplementation.
   evidence:
   - reference: PMID:10951458
     reference_title: "Cholesterol supplementation with egg yolk increases plasma cholesterol and decreases plasma 7-dehydrocholesterol in Smith-Lemli-Opitz syndrome."
@@ -494,6 +535,17 @@ treatments:
       term:
         id: CHEBI:9150
         label: simvastatin
+  target_mechanisms:
+  - target: 7-Dehydrocholesterol Accumulation
+    treatment_effect: MODULATES
+    description: Simvastatin improves the serum dehydrocholesterol-to-total sterol ratio in mild to classic SLOS.
+    evidence:
+    - reference: PMID:27513191
+      reference_title: "A placebo-controlled trial of simvastatin therapy in Smith-Lemli-Opitz syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Simvastatin seems to be relatively safe in patients with SLOS, improves the serum dehydrocholesterol-to-total sterol ratio, and significantly improves irritability symptoms in patients with mild to classic SLOS."
+      explanation: Placebo-controlled trial evidence supports simvastatin as a modulator of the dehydrocholesterol sterol abnormality.
   evidence:
   - reference: PMID:27513191
     reference_title: "A placebo-controlled trial of simvastatin therapy in Smith-Lemli-Opitz syndrome."
@@ -515,6 +567,17 @@ treatments:
       term:
         id: CHEBI:16359
         label: cholic acid
+  target_mechanisms:
+  - target: Relative Cholesterol Deficiency
+    treatment_effect: MODULATES
+    description: Cholic acid supplementation is intended to improve dietary cholesterol absorption and raise plasma cholesterol.
+    evidence:
+    - reference: PMID:38077958
+      reference_title: "Cholic acid increases plasma cholesterol in Smith-Lemli-Opitz syndrome: A pilot study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In this pilot study, cholic acid supplementation was well tolerated and safe and resulted in an increase in plasma cholesterol in most SLOS subjects."
+      explanation: Pilot human data support cholic acid as a modulator of the low-cholesterol biochemical state.
   evidence:
   - reference: PMID:38077958
     reference_title: "Cholic acid increases plasma cholesterol in Smith-Lemli-Opitz syndrome: A pilot study."


### PR DESCRIPTION
## Summary
- Connect 7-dehydrocholesterol accumulation and cholesterol deficiency to their diagnostic biochemical readout nodes.
- Add treatment mechanism links for dietary cholesterol supplementation, simvastatin, and cholic acid using exact cached human evidence.
- Keep congenital phenotype singletons unlinked where the existing evidence supports association but not a precise causal edge.

## Validation
- just validate kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
- uv run python -m dismech.graph --validate kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
- manual snippet audit: checked 40 snippets, all found in references_cache
- graph check: 20 nodes, 13 edges, 8 components, 0 orphans, 0 issues
- git diff --check
- subagent review: no PR-blocking findings; optional treatment_effect directionality left conservative as MODULATES