### PR TITLE
Improve NARP pathograph connectivity

### DIFF
--- a/kb/disorders/NARP_syndrome.yaml
+++ b/kb/disorders/NARP_syndrome.yaml
@@ -1,6 +1,6 @@
 name: NARP syndrome
 creation_date: '2026-04-13T04:00:00Z'
-updated_date: '2026-04-13T23:45:00Z'
+updated_date: '2026-05-11T02:48:48Z'
 description: >-
   NARP syndrome is a maternally inherited mitochondrial disease caused most
   often by pathogenic MT-ATP6 variants. The syndrome is characterized by
@@ -88,14 +88,50 @@ pathophysiology:
   description: >-
     Energetic failure within cerebellar systems produces impaired coordination
     and gait instability.
+  downstream:
+  - target: Ataxia
+    description: Cerebellar system involvement manifests clinically as ataxia in NARP-spectrum disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27502083
+      reference_title: A novel mutation m.8561C>G in MT-ATP6/8 causing a mitochondrial syndrome with ataxia, peripheral neuropathy, diabetes mellitus, and hypergonadotropic hypogonadism.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We suggest that the m.8561C>G mutation in MT-ATP6/8 is pathogenic, leads biochemically to impaired assembly and decreased ATP production of complex V, and results clinically in a phenotype with the core features of cerebellar ataxia, peripheral neuropathy, diabetes mellitus, and hypergonadotropic hypogonadism.
+      explanation: The MT-ATP6/8 family report connects impaired complex V ATP production with cerebellar ataxia as a core clinical feature.
 - name: Peripheral nerve dysfunction
   description: >-
     Mitochondrial failure in peripheral nerves contributes to sensory and motor
     neuropathy.
+  downstream:
+  - target: Peripheral neuropathy
+    description: Peripheral nerve involvement is represented clinically by peripheral neuropathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27502083
+      reference_title: A novel mutation m.8561C>G in MT-ATP6/8 causing a mitochondrial syndrome with ataxia, peripheral neuropathy, diabetes mellitus, and hypergonadotropic hypogonadism.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We suggest that the m.8561C>G mutation in MT-ATP6/8 is pathogenic, leads biochemically to impaired assembly and decreased ATP production of complex V, and results clinically in a phenotype with the core features of cerebellar ataxia, peripheral neuropathy, diabetes mellitus, and hypergonadotropic hypogonadism.
+      explanation: The clinical report identifies peripheral neuropathy among the core MT-ATP6/8 phenotype features downstream of complex V dysfunction.
 - name: Retinal degeneration
   description: >-
     Retinal energetic vulnerability contributes to pigmentary retinopathy and
     progressive visual dysfunction.
+  downstream:
+  - target: Retinitis pigmentosa
+    description: Retinal degeneration is represented clinically by retinitis pigmentosa in the NARP phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27502083
+      reference_title: A novel mutation m.8561C>G in MT-ATP6/8 causing a mitochondrial syndrome with ataxia, peripheral neuropathy, diabetes mellitus, and hypergonadotropic hypogonadism.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Pathogenic mutations in MT-ATP6 are associated with the Leigh syndrome, the syndrome of neuropathy, ataxia, and retinitis pigmentosa (NARP), as well as with non-classical phenotypes, while MT-ATP8 is less frequently mutated in patients with mitochondrial disease.
+      explanation: The report explicitly names retinitis pigmentosa as one of the defining NARP phenotype components associated with MT-ATP6 mutations.
 phenotypes:
 - name: Ataxia
   category: Neurologic


### PR DESCRIPTION
## Summary
- Connect cerebellar dysfunction to ataxia, peripheral nerve dysfunction to peripheral neuropathy, and retinal degeneration to retinitis pigmentosa.
- Keep the patch scoped to core NARP phenotype edges supported by cached MT-ATP6/8 evidence.
- Leave sensorineural hearing impairment and diabetes mellitus unlinked because the current pathograph does not include a precise mechanism node for those features.

## Validation
- just validate kb/disorders/NARP_syndrome.yaml
- uv run python -m dismech.graph --validate kb/disorders/NARP_syndrome.yaml
- manual snippet audit: checked 13 snippets, all found in references_cache
- graph check: 14 nodes, 11 edges, 3 components, 0 orphans, 0 issues
- git diff --check -- kb/disorders/NARP_syndrome.yaml
- subagent review: no PR-blocking findings; minor evidence-strength notes left for future expansion