### PR TITLE
[codex] Link FDA endpoints to biomarker readouts

### DIFF
--- a/kb/disorders/Beta_Thalassemia.yaml
+++ b/kb/disorders/Beta_Thalassemia.yaml
@@ -572,6 +572,9 @@ biochemical:
     relationship: READOUT_OF
     direction: POSITIVE
     endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-073
+    - FDA-SE-pediatric-noncancer-051
     interpretation: >-
       Higher serum ferritin is a blood readout of systemic iron burden, though
       inflammation and liver injury can affect interpretation.
@@ -659,6 +662,9 @@ biochemical:
     relationship: READOUT_OF
     direction: POSITIVE
     endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-073
+    - FDA-SE-pediatric-noncancer-051
     interpretation: >-
       Liver iron concentration is a tissue-level readout of iron overload and
       complements serum ferritin for chelation monitoring.

--- a/kb/disorders/Duchenne_Muscular_Dystrophy.yaml
+++ b/kb/disorders/Duchenne_Muscular_Dystrophy.yaml
@@ -1218,6 +1218,44 @@ biochemical:
     explanation: >-
       Immunoblot and immunofluorescence testing in human muscle directly
       supports absent dystrophin as a Duchenne biochemical diagnostic marker.
+- name: Treatment-Induced Dystrophin Expression
+  presence: Treatment-induced
+  context: >-
+    Measured in skeletal muscle biopsy after exon-skipping antisense
+    oligonucleotide therapy; distinct from baseline diagnostic absence of
+    dystrophin.
+  readouts:
+  - target: Dystrophin Deficiency
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: PRESENT_ABSENT
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-022
+    - FDA-SE-pediatric-noncancer-017
+    interpretation: >-
+      Treatment-induced dystrophin expression in skeletal muscle reports
+      pharmacodynamic correction at the dystrophin-deficiency node for
+      exon-skipping therapies.
+  biomarker_term:
+    preferred_term: dystrophin measurement
+    term:
+      id: NCIT:C209442
+      label: Dystrophin Measurement
+  synonyms:
+  - skeletal muscle dystrophin
+  - exon-skipping-induced dystrophin
+  evidence:
+  - reference: PMID:29752304
+    reference_title: "Eteplirsen treatment for Duchenne muscular dystrophy: Exon skipping and dystrophin production."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Taken together, the 4 assays, each based on unique evaluation mechanisms,
+      provided evidence of eteplirsen muscle cell penetration, exon skipping,
+      and induction of novel dystrophin expression.
+    explanation: >-
+      This eteplirsen study supports treatment-induced dystrophin expression as
+      a measured pharmacodynamic biomarker for exon-skipping therapy in DMD.
 - name: Micro-dystrophin Expression
   presence: Treatment-induced
   context: >-

--- a/kb/disorders/Fabry_Disease.yaml
+++ b/kb/disorders/Fabry_Disease.yaml
@@ -770,6 +770,10 @@ biochemical:
     relationship: READOUT_OF
     direction: POSITIVE
     endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-024
+    - FDA-SE-adult-noncancer-025
+    - FDA-SE-pediatric-noncancer-019
     interpretation: >-
       Renal GL-3 inclusions are a tissue-level readout of lysosomal substrate
       accumulation and can decrease when enzyme replacement clears GL-3.

--- a/kb/disorders/Sickle_Cell_Disease.yaml
+++ b/kb/disorders/Sickle_Cell_Disease.yaml
@@ -646,6 +646,9 @@ biochemical:
     relationship: READOUT_OF
     direction: NEGATIVE
     endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-078
+    - FDA-SE-pediatric-noncancer-054
     interpretation: >-
       Lower hemoglobin concentration reflects anemia from ongoing hemolysis and
       marrow compensation limits.

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1799,13 +1799,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with chronic iron overload
     or non-transfusion-dependent thalassemia syndromes; endpoint: Serum ferritin and liver iron concentration;
     approval context: traditional; drug mechanism: Iron chelator.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Beta Thalassemia
   mapped_disease_files:
   - kb/disorders/Beta_Thalassemia.yaml
-  mapping_notes: Candidate mapping inferred from disease mention in the FDA disease/use or patient-population
-    text; requires curator review.
+  mapping_notes: >-
+    Manually reviewed for beta-thalassemia marker integration. The FDA row is
+    broader than the disease page because it covers chronic iron overload and
+    non-transfusion-dependent thalassemia syndromes.
 - row_id: FDA-SE-adult-noncancer-074
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1927,13 +1929,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with sickle cell disease;
     Proxysmal nocturnal hemoglobinuria (PNH); endpoint: Hemoglobin response rate; approval context: accelerated
     or traditional; drug mechanism: Hemoglobin S polymerization inhibitor; complement factor B inhibitor.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Sickle Cell Disease
   mapped_disease_files:
   - kb/disorders/Sickle_Cell_Disease.yaml
-  mapping_notes: Candidate mapping inferred from disease mention in the FDA disease/use or patient-population
-    text; requires curator review.
+  mapping_notes: >-
+    Manually reviewed for sickle cell disease marker integration. The FDA row is
+    broader than the disease page because the adult population text also
+    includes paroxysmal nocturnal hemoglobinuria.
 - row_id: FDA-SE-adult-noncancer-079
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4918,13 +4922,15 @@ surrogate_endpoints:
     and liver iron concentration; approval context: traditional; drug mechanism: Iron chelator; age range:
     2 years or older for chronic iron overload and 10 years older for non-transfusion-dependent thalassemia
     syndromes.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Beta Thalassemia
   mapped_disease_files:
   - kb/disorders/Beta_Thalassemia.yaml
-  mapping_notes: Candidate mapping inferred from disease mention in the FDA disease/use or patient-population
-    text; requires curator review.
+  mapping_notes: >-
+    Manually reviewed for beta-thalassemia marker integration. The FDA row is
+    broader than the disease page because it covers chronic iron overload and
+    non-transfusion-dependent thalassemia syndromes.
 - row_id: FDA-SE-pediatric-noncancer-052
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4997,13 +5003,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with sickle cell disease;
     endpoint: Hemoglobin response rate; approval context: accelerated; drug mechanism: Hemoglobin S polymerization
     inhibitor; age range: 4 years and older.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Sickle Cell Disease
   mapped_disease_files:
   - kb/disorders/Sickle_Cell_Disease.yaml
-  mapping_notes: Candidate mapping inferred from disease mention in the FDA disease/use or patient-population
-    text; requires curator review.
+  mapping_notes: >-
+    Manually reviewed for sickle cell disease marker integration. The pediatric
+    population text names sickle cell disease for the hemoglobin response rate
+    endpoint.
 - row_id: FDA-SE-pediatric-noncancer-055
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related

--- a/src/dismech/datamodel/dismech.py
+++ b/src/dismech/datamodel/dismech.py
@@ -1,5 +1,5 @@
 # Auto generated from dismech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-10T18:02:02
+# Generation date: 2026-05-10T20:06:54
 # Schema: dismech
 #
 # id: https://w3id.org/monarch-initiative/dismech
@@ -1900,6 +1900,7 @@ class BiomarkerReadout(YAMLRoot):
     relationship: Union[str, "BiomarkerReadoutRelationshipEnum"] = None
     direction: Optional[Union[str, "BiomarkerReadoutDirectionEnum"]] = None
     endpoint_context: Optional[Union[str, "BiomarkerEndpointContextEnum"]] = None
+    regulatory_endpoint_refs: Optional[Union[str, list[str]]] = empty_list()
     interpretation: Optional[str] = None
     description: Optional[str] = None
     evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
@@ -1920,6 +1921,10 @@ class BiomarkerReadout(YAMLRoot):
 
         if self.endpoint_context is not None and not isinstance(self.endpoint_context, BiomarkerEndpointContextEnum):
             self.endpoint_context = BiomarkerEndpointContextEnum(self.endpoint_context)
+
+        if not isinstance(self.regulatory_endpoint_refs, list):
+            self.regulatory_endpoint_refs = [self.regulatory_endpoint_refs] if self.regulatory_endpoint_refs is not None else []
+        self.regulatory_endpoint_refs = [v if isinstance(v, str) else str(v) for v in self.regulatory_endpoint_refs]
 
         if self.interpretation is not None and not isinstance(self.interpretation, str):
             self.interpretation = str(self.interpretation)
@@ -7597,6 +7602,9 @@ slots.direction = Slot(uri=DISMECH.direction, name="direction", curie=DISMECH.cu
 slots.endpoint_context = Slot(uri=DISMECH.endpoint_context, name="endpoint_context", curie=DISMECH.curie('endpoint_context'),
                    model_uri=DISMECH.endpoint_context, domain=None, range=Optional[Union[str, "BiomarkerEndpointContextEnum"]])
 
+slots.regulatory_endpoint_refs = Slot(uri=DISMECH.regulatory_endpoint_refs, name="regulatory_endpoint_refs", curie=DISMECH.curie('regulatory_endpoint_refs'),
+                   model_uri=DISMECH.regulatory_endpoint_refs, domain=None, range=Optional[Union[str, list[str]]])
+
 slots.interpretation = Slot(uri=DISMECH.interpretation, name="interpretation", curie=DISMECH.curie('interpretation'),
                    model_uri=DISMECH.interpretation, domain=None, range=Optional[str])
 
@@ -8525,6 +8533,9 @@ slots.BiomarkerReadout_direction = Slot(uri=DISMECH.direction, name="BiomarkerRe
 
 slots.BiomarkerReadout_endpoint_context = Slot(uri=DISMECH.endpoint_context, name="BiomarkerReadout_endpoint_context", curie=DISMECH.curie('endpoint_context'),
                    model_uri=DISMECH.BiomarkerReadout_endpoint_context, domain=BiomarkerReadout, range=Optional[Union[str, "BiomarkerEndpointContextEnum"]])
+
+slots.BiomarkerReadout_regulatory_endpoint_refs = Slot(uri=DISMECH.regulatory_endpoint_refs, name="BiomarkerReadout_regulatory_endpoint_refs", curie=DISMECH.curie('regulatory_endpoint_refs'),
+                   model_uri=DISMECH.BiomarkerReadout_regulatory_endpoint_refs, domain=BiomarkerReadout, range=Optional[Union[str, list[str]]])
 
 slots.BiomarkerReadout_interpretation = Slot(uri=DISMECH.interpretation, name="BiomarkerReadout_interpretation", curie=DISMECH.curie('interpretation'),
                    model_uri=DISMECH.BiomarkerReadout_interpretation, domain=BiomarkerReadout, range=Optional[str])

--- a/src/dismech/datamodel/dismech_pydantic.py
+++ b/src/dismech/datamodel/dismech_pydantic.py
@@ -6816,6 +6816,21 @@ class BiomarkerReadout(ConfiguredBaseModel):
                                                           'for display and curation '
                                                           'review.',
                                            'name': 'interpretation'},
+                        'regulatory_endpoint_refs': {'description': 'Source-table '
+                                                                    'regulatory '
+                                                                    'endpoint row IDs '
+                                                                    'linked to this '
+                                                                    'readout. Keep '
+                                                                    'regulatory '
+                                                                    'details in the '
+                                                                    'source table; use '
+                                                                    'this field only '
+                                                                    'as a local bridge '
+                                                                    'from disease '
+                                                                    'biology to '
+                                                                    'regulatory '
+                                                                    'context.',
+                                                     'name': 'regulatory_endpoint_refs'},
                         'relationship': {'description': 'How the biomarker relates to '
                                                         'the linked pathograph node.',
                                          'name': 'relationship',
@@ -6837,6 +6852,7 @@ class BiomarkerReadout(ConfiguredBaseModel):
     relationship: BiomarkerReadoutRelationshipEnum = Field(default=..., description="""How the biomarker relates to the linked pathograph node.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship', 'domain_of': ['BiomarkerReadout']} })
     direction: Optional[BiomarkerReadoutDirectionEnum] = Field(default=None, description="""Direction of association between biomarker level/presence and the linked event or endpoint.""", json_schema_extra = { "linkml_meta": {'alias': 'direction', 'domain_of': ['BiomarkerReadout']} })
     endpoint_context: Optional[BiomarkerEndpointContextEnum] = Field(default=None, description="""Diagnostic, prognostic, monitoring, pharmacodynamic, or candidate-surrogate use context.""", json_schema_extra = { "linkml_meta": {'alias': 'endpoint_context', 'domain_of': ['BiomarkerReadout']} })
+    regulatory_endpoint_refs: Optional[list[str]] = Field(default=None, description="""Source-table regulatory endpoint row IDs linked to this readout. Keep regulatory details in the source table; use this field only as a local bridge from disease biology to regulatory context.""", json_schema_extra = { "linkml_meta": {'alias': 'regulatory_endpoint_refs', 'domain_of': ['BiomarkerReadout']} })
     interpretation: Optional[str] = Field(default=None, description="""Human-readable interpretation of the link for display and curation review.""", json_schema_extra = { "linkml_meta": {'alias': 'interpretation', 'domain_of': ['BiomarkerReadout']} })
     description: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'description',
          'domain_of': ['Descriptor',

--- a/src/dismech/export/cx2_export.py
+++ b/src/dismech/export/cx2_export.py
@@ -1037,6 +1037,7 @@ def _build_edge_detail_lookup(
                     "relationship": readout.get("relationship"),
                     "direction": readout.get("direction"),
                     "endpoint_context": readout.get("endpoint_context"),
+                    "regulatory_endpoint_refs": readout.get("regulatory_endpoint_refs"),
                 },
             )
 
@@ -1317,7 +1318,12 @@ def _edge_attributes(
     if treatment_effect:
         attributes["treatment_effect"] = treatment_effect
 
-    for key in ("relationship", "direction", "endpoint_context"):
+    for key in (
+        "relationship",
+        "direction",
+        "endpoint_context",
+        "regulatory_endpoint_refs",
+    ):
         value = detail.get(key) or edge_payload.get(key)
         if value:
             attributes[key] = value

--- a/src/dismech/graph.py
+++ b/src/dismech/graph.py
@@ -703,6 +703,8 @@ def _extract_node_metadata(item: dict[str, Any]) -> dict[str, Any]:
                     "relationship",
                     "direction",
                     "endpoint_context",
+                    "regulatory_endpoint_refs",
+                    "_regulatory_endpoints",
                     "interpretation",
                     "description",
                 )

--- a/src/dismech/render.py
+++ b/src/dismech/render.py
@@ -19,6 +19,9 @@ from dismech.export.browser_export import HPO_TOP_LEVEL_CATEGORIES
 from dismech.graph import build_causal_graph, generate_mermaid, graph_to_json
 
 _HPO_CATEGORY_CACHE_PATH = Path("app/hpo_category_cache.json")
+_FDA_SURROGATE_ENDPOINTS_RELATIVE_PATH = Path(
+    "surrogate_endpoints/fda_surrogate_endpoints.yaml"
+)
 _LITERATURE_START_PATTERNS = (
     re.compile(r"(?m)^# .+\bReport\s*$"),
     re.compile(r"(?m)^Disease (?:Pathophysiology|Characteristics) Research Report\s*$"),
@@ -445,6 +448,82 @@ def _annotate_model_links(disorder: dict) -> None:
                 )
 
             model["_modeled_mechanisms_resolved"] = resolved_links
+
+
+def _resolve_fda_surrogate_endpoints_path(yaml_path: Path) -> Path:
+    """Resolve the FDA surrogate endpoint source table relative to a disease file."""
+    nearby_kb_path = yaml_path.parent.parent / _FDA_SURROGATE_ENDPOINTS_RELATIVE_PATH
+    if nearby_kb_path.exists():
+        return nearby_kb_path
+    return Path("kb") / _FDA_SURROGATE_ENDPOINTS_RELATIVE_PATH
+
+
+@lru_cache(maxsize=8)
+def _load_fda_surrogate_endpoint_index(source_path: str) -> dict[str, dict]:
+    """Load source-level FDA surrogate endpoint rows by stable row_id."""
+    path = Path(source_path)
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text()) or {}
+    rows = data.get("surrogate_endpoints") or []
+    return {
+        str(row["row_id"]): row
+        for row in rows
+        if isinstance(row, dict) and row.get("row_id")
+    }
+
+
+def _summarize_regulatory_endpoint(row: dict) -> dict:
+    """Return the row fields needed for compact disease-page display."""
+    fields = (
+        "row_id",
+        "source_table",
+        "disease_or_use",
+        "patient_population",
+        "surrogate_endpoint",
+        "approval_type",
+        "drug_mechanism_of_action",
+        "age_range",
+        "endpoint_validation_level",
+        "clinical_benefit_linkage",
+        "context_of_use",
+        "source_url",
+    )
+    return {field: row[field] for field in fields if row.get(field) is not None}
+
+
+def _annotate_regulatory_endpoint_refs(disorder: dict, yaml_path: Path) -> None:
+    """Resolve biomarker readout FDA row refs for rendering without duplicating curation."""
+    source_path = _resolve_fda_surrogate_endpoints_path(yaml_path)
+    endpoint_index = _load_fda_surrogate_endpoint_index(str(source_path.resolve()))
+    if not endpoint_index:
+        return
+
+    for biomarker in disorder.get("biochemical") or []:
+        if not isinstance(biomarker, dict):
+            continue
+        for readout in biomarker.get("readouts") or []:
+            if not isinstance(readout, dict):
+                continue
+            refs = readout.get("regulatory_endpoint_refs") or []
+            if isinstance(refs, str):
+                refs = [refs]
+                readout["regulatory_endpoint_refs"] = refs
+            if not isinstance(refs, list):
+                continue
+
+            resolved = []
+            missing = []
+            for ref in refs:
+                row = endpoint_index.get(str(ref))
+                if row is None:
+                    missing.append(str(ref))
+                else:
+                    resolved.append(_summarize_regulatory_endpoint(row))
+            if resolved:
+                readout["_regulatory_endpoints"] = resolved
+            if missing:
+                readout["_missing_regulatory_endpoint_refs"] = missing
 
 
 def load_disorder(yaml_path: Path) -> dict:
@@ -967,6 +1046,7 @@ def render_disorder(
     # Load the disorder data
     disorder = load_disorder(yaml_path)
     _augment_mapping_hierarchies(disorder)
+    _annotate_regulatory_endpoint_refs(disorder, yaml_path)
 
     # Read raw YAML for display
     yaml_content = yaml_path.read_text()

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -1780,6 +1780,14 @@ slots:
   endpoint_context:
     description: Endpoint or use context for a biomarker readout link
     range: BiomarkerEndpointContextEnum
+  regulatory_endpoint_refs:
+    description: >-
+      Stable row identifiers for source-level regulatory surrogate endpoint
+      assertions that use this biomarker readout in a specific context of use.
+      For FDA surrogate endpoints, values should match row_id values in
+      kb/surrogate_endpoints/fda_surrogate_endpoints.yaml.
+    multivalued: true
+    range: string
   interpretation:
     description: Curator-facing explanation of how to interpret the biomarker relative to the linked pathograph node
     range: string
@@ -3567,6 +3575,7 @@ classes:
       - relationship
       - direction
       - endpoint_context
+      - regulatory_endpoint_refs
       - interpretation
       - description
       - evidence
@@ -3586,6 +3595,11 @@ classes:
           linked event or endpoint.
       endpoint_context:
         description: Diagnostic, prognostic, monitoring, pharmacodynamic, or candidate-surrogate use context.
+      regulatory_endpoint_refs:
+        description: >-
+          Source-table regulatory endpoint row IDs linked to this readout.
+          Keep regulatory details in the source table; use this field only as a
+          local bridge from disease biology to regulatory context.
       interpretation:
         description: Human-readable interpretation of the link for display and curation review.
       evidence:

--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -1259,6 +1259,44 @@
             color: #92400e;
         }
 
+        .regulatory-endpoints {
+            margin-top: 8px;
+            display: grid;
+            gap: 6px;
+        }
+
+        .regulatory-endpoint {
+            padding: 8px 10px;
+            border: 1px solid #c7d2fe;
+            border-left: 3px solid #6366f1;
+            border-radius: 6px;
+            background: #eef2ff;
+            color: #312e81;
+            font-size: 0.82rem;
+        }
+
+        .regulatory-endpoint-id {
+            font-weight: 700;
+            color: #3730a3;
+            text-decoration: none;
+        }
+
+        .regulatory-endpoint-id:hover {
+            text-decoration: underline;
+        }
+
+        .regulatory-endpoint-title {
+            margin-top: 4px;
+            font-weight: 600;
+        }
+
+        .regulatory-endpoint-meta {
+            margin-top: 5px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+        }
+
         /* Differential Diagnoses */
         .differential-box {
             background: #fef2f2;
@@ -2361,6 +2399,20 @@
                     }
                     if (readout.endpoint_context) {
                         readoutHtml += ' <span style="color:#6b7280;">' + escapeHtml(humanizeEnum(readout.endpoint_context)) + '</span>';
+                    }
+                    if (readout._regulatory_endpoints && readout._regulatory_endpoints.length) {
+                        readoutHtml += '<div style="margin-top:3px; color:#4338ca; line-height:1.35;">';
+                        readout._regulatory_endpoints.forEach(function(endpoint) {
+                            readoutHtml += '<div>FDA ' + escapeHtml(endpoint.row_id || '');
+                            if (endpoint.endpoint_validation_level) {
+                                readoutHtml += ' · ' + escapeHtml(humanizeEnum(endpoint.endpoint_validation_level));
+                            }
+                            if (endpoint.surrogate_endpoint) {
+                                readoutHtml += '<div style="color:#6b7280;">' + escapeHtml(endpoint.surrogate_endpoint) + '</div>';
+                            }
+                            readoutHtml += '</div>';
+                        });
+                        readoutHtml += '</div>';
                     }
                     if (readout.interpretation || readout.description) {
                         readoutHtml += '<div style="color:#6b7280; margin-top:2px; line-height:1.4;">'
@@ -4278,6 +4330,44 @@
                         <div class="readout-interpretation">{{ readout.interpretation }}</div>
                         {% elif readout.description %}
                         <div class="readout-interpretation">{{ readout.description }}</div>
+                        {% endif %}
+                        {% if readout.get('_regulatory_endpoints') %}
+                        <div class="regulatory-endpoints">
+                            {% for endpoint in readout.get('_regulatory_endpoints') %}
+                            <div class="regulatory-endpoint">
+                                <div>
+                                    {% if endpoint.source_url %}
+                                    <a class="regulatory-endpoint-id" href="{{ endpoint.source_url }}" target="_blank" rel="noopener">{{ endpoint.row_id }}</a>
+                                    {% else %}
+                                    <span class="regulatory-endpoint-id">{{ endpoint.row_id }}</span>
+                                    {% endif %}
+                                    <span class="tag" style="background: #dbeafe; color: #1d4ed8; font-size: 0.72rem;">FDA</span>
+                                </div>
+                                <div class="regulatory-endpoint-title">{{ endpoint.surrogate_endpoint }}</div>
+                                <div class="regulatory-endpoint-meta">
+                                    {% if endpoint.approval_type %}
+                                    <span class="tag" style="background: #e0e7ff; color: #3730a3; font-size: 0.72rem;">
+                                        {{ endpoint.approval_type | replace('_', ' ') | title }}
+                                    </span>
+                                    {% endif %}
+                                    {% if endpoint.endpoint_validation_level %}
+                                    <span class="tag" style="background: #dcfce7; color: #166534; font-size: 0.72rem;">
+                                        {{ endpoint.endpoint_validation_level | replace('_', ' ') | title }}
+                                    </span>
+                                    {% endif %}
+                                </div>
+                                {% if endpoint.patient_population %}
+                                <div style="margin-top: 5px; color: #4f46e5;">{{ endpoint.patient_population }}</div>
+                                {% endif %}
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                        {% if readout.get('_missing_regulatory_endpoint_refs') %}
+                        <div class="item-desc">
+                            Missing regulatory endpoint refs:
+                            {{ readout.get('_missing_regulatory_endpoint_refs') | join(', ') }}
+                        </div>
                         {% endif %}
                         {{ render_evidence(readout.evidence) }}
                     </div>

--- a/src/dismech/templates/module.html.j2
+++ b/src/dismech/templates/module.html.j2
@@ -825,6 +825,20 @@
                     if (readout.endpoint_context) {
                         readoutHtml += ' <span style="color:#d1d5db;">' + escapeHtml(humanizeEnum(readout.endpoint_context)) + '</span>';
                     }
+                    if (readout._regulatory_endpoints && readout._regulatory_endpoints.length) {
+                        readoutHtml += '<div style="margin-top:3px; color:#c7d2fe; line-height:1.35;">';
+                        readout._regulatory_endpoints.forEach(function(endpoint) {
+                            readoutHtml += '<div>FDA ' + escapeHtml(endpoint.row_id || '');
+                            if (endpoint.endpoint_validation_level) {
+                                readoutHtml += ' · ' + escapeHtml(humanizeEnum(endpoint.endpoint_validation_level));
+                            }
+                            if (endpoint.surrogate_endpoint) {
+                                readoutHtml += '<div style="color:#d1d5db;">' + escapeHtml(endpoint.surrogate_endpoint) + '</div>';
+                            }
+                            readoutHtml += '</div>';
+                        });
+                        readoutHtml += '</div>';
+                    }
                     if (readout.interpretation || readout.description) {
                         readoutHtml += '<div style="color:#d1d5db; margin-top:2px; line-height:1.4;">'
                             + escapeHtml(readout.interpretation || readout.description) + '</div>';

--- a/tests/test_fda_surrogate_endpoints.py
+++ b/tests/test_fda_surrogate_endpoints.py
@@ -110,5 +110,5 @@ def test_fda_surrogate_endpoint_target_disease_mappings() -> None:
     assert len(fabry_rows) == 3
     assert len(scd_rows) == 2
     assert len(thal_rows) == 2
-    assert {row["mapping_status"] for row in scd_rows} == {"CANDIDATE_DISMECH_MAPPING"}
-    assert {row["mapping_status"] for row in thal_rows} == {"CANDIDATE_DISMECH_MAPPING"}
+    assert {row["mapping_status"] for row in scd_rows} == {"CURATED_DISMECH_MAPPING"}
+    assert {row["mapping_status"] for row in thal_rows} == {"CURATED_DISMECH_MAPPING"}

--- a/tests/test_graph_model_links.py
+++ b/tests/test_graph_model_links.py
@@ -195,6 +195,7 @@ def test_build_causal_graph_includes_biomarker_readout_links() -> None:
                         "relationship": "READOUT_OF",
                         "direction": "POSITIVE",
                         "endpoint_context": "MONITORING",
+                        "regulatory_endpoint_refs": ["FDA-SE-test-001"],
                         "interpretation": "Higher CK reflects greater membrane injury.",
                     }
                 ],
@@ -227,6 +228,7 @@ def test_build_causal_graph_includes_biomarker_readout_links() -> None:
             "relationship": "READOUT_OF",
             "direction": "POSITIVE",
             "endpoint_context": "MONITORING",
+            "regulatory_endpoint_refs": ["FDA-SE-test-001"],
             "interpretation": "Higher CK reflects greater membrane injury.",
         }
     ]

--- a/tests/test_regulatory_endpoint_refs.py
+++ b/tests/test_regulatory_endpoint_refs.py
@@ -1,0 +1,102 @@
+"""Tests for disease-local biomarker links to source-level regulatory endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from dismech.render import render_disorder
+
+
+FDA_ENDPOINTS_PATH = Path("kb/surrogate_endpoints/fda_surrogate_endpoints.yaml")
+DISORDERS_DIR = Path("kb/disorders")
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _fda_rows_by_id() -> dict[str, dict]:
+    data = _load_yaml(FDA_ENDPOINTS_PATH)
+    return {
+        row["row_id"]: row
+        for row in data.get("surrogate_endpoints", [])
+        if isinstance(row, dict) and row.get("row_id")
+    }
+
+
+def _regulatory_refs_by_disease() -> dict[Path, set[str]]:
+    refs_by_file: dict[Path, set[str]] = {}
+    for path in sorted(DISORDERS_DIR.glob("*.yaml")):
+        if path.name.endswith(".history.yaml"):
+            continue
+        data = _load_yaml(path)
+        refs: set[str] = set()
+        for biomarker in data.get("biochemical") or []:
+            if not isinstance(biomarker, dict):
+                continue
+            for readout in biomarker.get("readouts") or []:
+                if not isinstance(readout, dict):
+                    continue
+                for ref in readout.get("regulatory_endpoint_refs") or []:
+                    refs.add(str(ref))
+        if refs:
+            refs_by_file[path] = refs
+    return refs_by_file
+
+
+def test_disease_regulatory_endpoint_refs_resolve_to_source_rows() -> None:
+    rows_by_id = _fda_rows_by_id()
+
+    for disease_path, refs in _regulatory_refs_by_disease().items():
+        relative_path = disease_path.as_posix()
+        for ref in refs:
+            assert ref in rows_by_id, (
+                f"{relative_path} references unknown FDA row {ref}"
+            )
+            mapped_files = rows_by_id[ref].get("mapped_disease_files") or []
+            assert relative_path in mapped_files, (
+                f"{relative_path} references {ref}, but the FDA row does not map "
+                "back to that disease file"
+            )
+
+
+def test_first_biochemical_surrogate_endpoint_batch_is_linked() -> None:
+    refs_by_file = _regulatory_refs_by_disease()
+
+    expected = {
+        Path("kb/disorders/Duchenne_Muscular_Dystrophy.yaml"): {
+            "FDA-SE-adult-noncancer-022",
+            "FDA-SE-pediatric-noncancer-017",
+        },
+        Path("kb/disorders/Fabry_Disease.yaml"): {
+            "FDA-SE-adult-noncancer-024",
+            "FDA-SE-adult-noncancer-025",
+            "FDA-SE-pediatric-noncancer-019",
+        },
+        Path("kb/disorders/Sickle_Cell_Disease.yaml"): {
+            "FDA-SE-adult-noncancer-078",
+            "FDA-SE-pediatric-noncancer-054",
+        },
+        Path("kb/disorders/Beta_Thalassemia.yaml"): {
+            "FDA-SE-adult-noncancer-073",
+            "FDA-SE-pediatric-noncancer-051",
+        },
+    }
+
+    for disease_path, row_ids in expected.items():
+        assert row_ids <= refs_by_file.get(disease_path, set())
+
+
+def test_rendered_biomarker_readouts_show_resolved_fda_endpoint_context(
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "Duchenne_Muscular_Dystrophy.html"
+
+    render_disorder(Path("kb/disorders/Duchenne_Muscular_Dystrophy.yaml"), output_path)
+
+    html = output_path.read_text()
+    assert "FDA-SE-adult-noncancer-022" in html
+    assert "Skeletal muscle dystrophin" in html
+    assert "Reasonably Likely Surrogate Endpoint" in html


### PR DESCRIPTION
## Summary

- Add `regulatory_endpoint_refs` to biomarker readouts so disease-local biology can point back to FDA surrogate endpoint source rows without copying regulatory table details into disease YAML.
- Resolve those FDA row refs during rendering and show compact FDA approval/validation context near biomarker readouts and pathograph tooltips.
- Curate the first biochemical surrogate endpoint batch for DMD, Fabry disease, sickle cell disease, and beta thalassemia.
- Mark the SCD and beta-thalassemia FDA source-table mappings as manually reviewed now that they are linked into disease biomarker readouts.

## Validation

- `uv run pytest tests/test_cx2_export.py tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `just validate kb/disorders/Duchenne_Muscular_Dystrophy.yaml`
- `just validate kb/disorders/Fabry_Disease.yaml`
- `just validate kb/disorders/Sickle_Cell_Disease.yaml`
- `just validate kb/disorders/Beta_Thalassemia.yaml`
- `uv run linkml-validate --schema src/dismech/schema/dismech.yaml --target-class SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run ruff check src/dismech/render.py src/dismech/graph.py src/dismech/export/cx2_export.py tests/test_regulatory_endpoint_refs.py tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py`
- `git diff --check`

## Notes

The FDA table remains the source of precise regulatory context. Disease YAML files only carry row IDs on relevant `biochemical.readouts` so the main disease entries stay biology-focused.
