### PR TITLE
Improve aceruloplasminemia pathograph connectivity

### DIFF
--- a/kb/disorders/aceruloplasminemia.yaml
+++ b/kb/disorders/aceruloplasminemia.yaml
@@ -1,6 +1,6 @@
 name: aceruloplasminemia
 creation_date: "2026-04-15T17:35:00Z"
-updated_date: "2026-04-15T22:15:00Z"
+updated_date: "2026-05-11T03:17:50Z"
 description: >-
   Aceruloplasminemia is an autosomal recessive CP-related iron metabolism
   disorder characterized by absent ceruloplasmin ferroxidase activity,
@@ -59,6 +59,28 @@ pathophysiology:
   downstream:
   - target: Multi-organ iron accumulation
     description: Loss of ceruloplasmin ferroxidase activity causes progressive tissue iron deposition.
+  - target: Serum ceruloplasmin
+    description: Ceruloplasmin loss is reflected clinically by very low serum ceruloplasmin levels.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36308763
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Anemia was accompanied by microcytosis, high ferritin, and low copper and ceruloplasmin levels.
+      explanation: This disease-specific case report supports low ceruloplasmin as a biochemical readout of the CP/ceruloplasmin defect.
+  - target: Transferrin saturation
+    description: Ceruloplasmin-dependent iron export failure presents clinically with low transferrin saturation despite tissue iron loading.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - impaired cellular iron export and iron sequestration
+    evidence:
+    - reference: PMID:39990010
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Patients with aceruloplasminemia often present with microcytic anemia, low transferrin saturation ratio, and high serum ferritin levels before the onset of symptoms.
+      explanation: The case series supports low transferrin saturation as part of the aceruloplasminemia iron-misdistribution laboratory pattern.
 - name: Multi-organ iron accumulation
   description: >-
     Impaired ceruloplasmin-dependent iron handling causes progressive iron
@@ -86,6 +108,18 @@ pathophysiology:
     description: Pancreatic iron deposition contributes to diabetes mellitus.
   - target: Brain iron accumulation
     description: Cerebral iron deposition drives the neurologic disease branch.
+  - target: Ferritin
+    description: Systemic iron misdistribution and storage are reflected by high serum ferritin.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - increased iron storage and ferritin release
+    evidence:
+    - reference: PMID:39990010
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Patients with aceruloplasminemia often present with microcytic anemia, low transferrin saturation ratio, and high serum ferritin levels before the onset of symptoms.
+      explanation: The case series supports high serum ferritin as a recurring biochemical feature of aceruloplasminemia-related iron dysregulation.
 - name: Brain iron accumulation
   description: >-
     Progressive iron deposition in deep gray matter and cerebellar structures
@@ -313,6 +347,17 @@ treatments:
       term:
         id: CHEBI:68554
         label: deferiprone
+  target_mechanisms:
+  - target: Multi-organ iron accumulation
+    treatment_effect: MODULATES
+    description: Iron chelation is used to reduce iron-related toxicity downstream of multi-organ iron accumulation.
+    evidence:
+    - reference: PMID:36308763
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Iron chelation may be utilized in the treatment to reduce the toxicity.
+      explanation: Disease-specific review text supports iron chelation as a treatment aimed at reducing iron-related toxicity.
   evidence:
   - reference: PMID:33839643
     supports: SUPPORT


### PR DESCRIPTION
## Summary
- Add biochemical readout edges from ceruloplasmin ferroxidase deficiency to serum ceruloplasmin and transferrin saturation
- Add a ferritin readout edge from multi-organ iron accumulation with indirect known intermediates
- Link iron chelation therapy to the multi-organ iron accumulation mechanism it modulates

## Review notes
- Subagent review found no content blockers after restoring validation cache churn
- A second review flagged transferrin saturation directionality; I moved it downstream of ceruloplasmin-dependent iron-export failure and softened ferritin to an indirect edge before push
- Kept iron chelation as MODULATES rather than INHIBITS because the cited snippet supports reducing iron-related toxicity, not necessarily direct reversal of iron burden

## Validation
- just validate kb/disorders/aceruloplasminemia.yaml
- uv run python -m dismech.graph --validate kb/disorders/aceruloplasminemia.yaml
- manual snippet audit: checked 21 snippets; all found in cache
- graph connectivity: 13 nodes, 12 edges, 1 component, 0 orphan targets, 0 integrity issues
- git diff --check -- kb/disorders/aceruloplasminemia.yaml