### PR TITLE
[codex] Curate myeloma MRD endpoint biomarker

### DIFF
--- a/cache/ncit/terms.csv
+++ b/cache/ncit/terms.csv
@@ -303,6 +303,7 @@ NCIT:C38721,Nuclear Pleomorphism,2026-04-12T22:33:44.896511
 NCIT:C3878,Thyroid Gland Anaplastic Carcinoma,2026-04-11T22:20:39.639315
 NCIT:C3879,Thyroid Gland Medullary Carcinoma,2026-02-27T09:18:30.342804
 NCIT:C38906,Tumor Necrosis Factor Receptor Superfamily Member 8,2026-05-01T07:42:53.422602
+NCIT:C3896,Measurable Residual Disease,2026-05-11T07:02:09.335281
 NCIT:C39286,Cancer/Testis Antigen 1,2026-03-08T15:10:06.097539
 NCIT:C39851,Bladder Urothelial Carcinoma,2026-04-27T22:47:29.694075
 NCIT:C4004,Gastric Adenocarcinoma,2026-02-27T09:18:30.342737

--- a/kb/disorders/Plasma_Cell_Neoplasm.yaml
+++ b/kb/disorders/Plasma_Cell_Neoplasm.yaml
@@ -683,9 +683,27 @@ biochemical:
       explanation: >-
         This endpoint roadmap supports MRD-negative complete response as a
         candidate surrogate endpoint linked to accelerated approval in myeloma.
+  biomarker_term:
+    preferred_term: MRD-negative complete response
+    term:
+      id: NCIT:C3896
+      label: Measurable Residual Disease
   synonyms:
   - minimal residual disease negativity
   - MRD negativity
+  evidence:
+  - reference: PMID:39630969
+    reference_title: "Minimal Residual Disease as an Early Endpoint for Accelerated Drug Approval in Myeloma: A Roadmap."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The acceptance of MRD-negative complete response as an endpoint that is
+      reasonably likely to predict clinical benefit will allow for the design
+      of streamlined clinical trials for accelerated approval, enabling
+      significantly faster patient access to novel therapies.
+    explanation: >-
+      The roadmap identifies MRD-negative complete response as the biomarker
+      endpoint under evaluation in myeloma.
 genetic:
 - name: Cytogenetic Myeloma Subgroups
   association: Somatic

--- a/kb/disorders/Plasma_Cell_Neoplasm.yaml
+++ b/kb/disorders/Plasma_Cell_Neoplasm.yaml
@@ -1,6 +1,6 @@
 name: Plasma Cell Neoplasm
 creation_date: "2026-05-10T16:47:52Z"
-updated_date: "2026-05-10T18:05:08Z"
+updated_date: "2026-05-11T03:45:46Z"
 category: Cancer
 categories:
 - Hematologic Malignancy
@@ -656,6 +656,36 @@ biochemical:
     explanation: >-
       Circulating tumor plasma-cell burden is a diagnostic/prognostic biomarker
       for PCL-like disease.
+- name: MRD-Negative Complete Response
+  presence: Treatment-response state
+  context: >-
+    Minimal residual disease negativity within complete response is evaluated
+    after therapy in myeloma as an early endpoint for accelerated approval.
+  readouts:
+  - target: Clonal Plasma Cell Expansion
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: CANDIDATE_SURROGATE
+    interpretation: >-
+      MRD-negative complete response reports a deep treatment-induced reduction
+      in detectable residual clonal plasma-cell burden and has been evaluated
+      as an intermediate endpoint in myeloma.
+    evidence:
+    - reference: PMID:39630969
+      reference_title: "Minimal Residual Disease as an Early Endpoint for Accelerated Drug Approval in Myeloma: A Roadmap."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        The acceptance of MRD-negative complete response as an endpoint that is
+        reasonably likely to predict clinical benefit will allow for the design
+        of streamlined clinical trials for accelerated approval, enabling
+        significantly faster patient access to novel therapies.
+      explanation: >-
+        This endpoint roadmap supports MRD-negative complete response as a
+        candidate surrogate endpoint linked to accelerated approval in myeloma.
+  synonyms:
+  - minimal residual disease negativity
+  - MRD negativity
 genetic:
 - name: Cytogenetic Myeloma Subgroups
   association: Somatic

--- a/references_cache/PMID_39630969.md
+++ b/references_cache/PMID_39630969.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:39630969"
+title: "Minimal Residual Disease as an Early Endpoint for Accelerated Drug Approval in Myeloma: A Roadmap."
+authors:
+- Landgren O
+- Devlin SM
+journal: Blood Cancer Discov
+year: '2025'
+doi: 10.1158/2643-3230.BCD-24-0292
+keywords:
+- Humans
+- Antineoplastic Agents/therapeutic use
+- Clinical Trials as Topic
+- Drug Approval/methods
+- Endpoint Determination/methods
+- "Multiple Myeloma/diagnosis, drug therapy"
+- "Neoplasm, Residual/diagnosis"
+content_type: abstract_only
+---
+
+# Minimal Residual Disease as an Early Endpoint for Accelerated Drug Approval in Myeloma: A Roadmap.
+**Authors:** Landgren O, Devlin SM
+**Journal:** Blood Cancer Discov (2025)
+**DOI:** [10.1158/2643-3230.BCD-24-0292](https://doi.org/10.1158/2643-3230.BCD-24-0292)
+
+## Content
+
+1. Blood Cancer Discov. 2025 Jan 8;6(1):13-22. doi:
+10.1158/2643-3230.BCD-24-0292.
+
+Minimal Residual Disease as an Early Endpoint for Accelerated Drug Approval in
+Myeloma: A Roadmap.
+
+Landgren O(1), Devlin SM(2).
+
+Author information:
+(1)Division of Myeloma, Department of Medicine, Sylvester Myeloma Research
+Institute, Sylvester Comprehensive Cancer Center, University of Miami, Miami,
+Florida.
+(2)Memorial Sloan Kettering Cancer Center, New York, New York.
+
+The acceptance of MRD-negative complete response as an endpoint that is
+reasonably likely to predict clinical benefit will allow for the design of
+streamlined clinical trials for accelerated approval, enabling significantly
+faster patient access to novel therapies. Cooperative efforts were required to
+obtain and analyze clinical trial data from multiple sponsors and to determine
+the best approach to analysis with a relatively limited number of available
+datasets. The process to evaluate MRD as an intermediate endpoint, undertaken
+jointly by myeloma researchers and industry, with feedback from the FDA, serves
+as a roadmap for other areas of oncology to develop intermediate endpoints.
+
+©2024 The Authors; Published by the American Association for Cancer Research.
+
+DOI: 10.1158/2643-3230.BCD-24-0292
+PMCID: PMC11707509
+PMID: 39630969 [Indexed for MEDLINE]
+
+Conflict of interest statement: O. Landgren reports grants from Janssen, Sanofi,
+and Amgen during the conduct of the study, as well as grants from Amgen,
+Menarini, and Sebia, grants and personal fees from Janssen, Pfizer, and AbbVie,
+personal fees from GSK and Bristol Myers Squibb, and other support from Takeda
+and Novartis outside the submitted work. S.M. Devlin reports grants from Johnson
+and Johnson Innovative Medicine during the conduct of the study, as well as
+other support from Miltenyi Biotec outside the submitted work.


### PR DESCRIPTION
## Summary
- Add MRD-negative complete response as a plasma-cell neoplasm biochemical/readout marker.
- Link the readout to `Clonal Plasma Cell Expansion` with `PHARMACODYNAMIC_MARKER_OF`, `NEGATIVE`, and `CANDIDATE_SURROGATE` context.
- Cache `PMID:39630969` using `just fetch-reference`.

## Notes
This is stacked on #2508 because it uses the biomarker readout schema extension from that branch. I did not add an FDA surrogate endpoint table row reference because the existing FDA table MRD row is for B-cell precursor ALL, not myeloma.

## Validation
- `just validate kb/disorders/Plasma_Cell_Neoplasm.yaml`
- `uv run pytest tests/test_graph_model_links.py tests/test_regulatory_endpoint_refs.py -q`