### PR TITLE
[codex] Link metabolic lab surrogate endpoints

### DIFF
--- a/kb/disorders/Gout.yaml
+++ b/kb/disorders/Gout.yaml
@@ -1,6 +1,6 @@
 name: Gout
 creation_date: '2025-12-18T17:01:35Z'
-updated_date: '2026-05-09T16:35:30Z'
+updated_date: '2026-05-11T04:10:35Z'
 category: Complex
 parents:
 - Metabolic Disease
@@ -256,6 +256,16 @@ biochemical:
 - name: Serum Uric Acid
   presence: Elevated
   context: Usually >6.8 mg/dL, may be normal during acute attack
+  readouts:
+  - target: Hyperuricemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-029
+    interpretation: >-
+      Serum uric acid directly measures the hyperuricemic biochemical state
+      that drives urate crystal supersaturation in gout.
 - name: CRP
   presence: Elevated
   context: Acute flare

--- a/kb/disorders/Methylmalonic_Acidemia.yaml
+++ b/kb/disorders/Methylmalonic_Acidemia.yaml
@@ -1,7 +1,7 @@
 name: Methylmalonic Acidemia
 category: Mendelian
 creation_date: '2026-02-23T22:58:40Z'
-updated_date: '2026-05-07T18:25:52Z'
+updated_date: '2026-05-11T04:10:35Z'
 synonyms:
 - Methylmalonic aciduria
 - MMA
@@ -1165,6 +1165,18 @@ biochemical:
   context: 'Secondary hyperammonemia occurs during acute decompensation due to inhibition of N-acetylglutamate synthase by propionyl-CoA, impairing the urea cycle.
 
     '
+  readouts:
+  - target: Hyperammonemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-068
+    - FDA-SE-pediatric-noncancer-048
+    interpretation: >-
+      Circulating ammonia is the laboratory readout of the acute
+      hyperammonemia that can accompany methylmalonic acidemia
+      decompensation.
   evidence:
   - reference: PMID:25205257
     reference_title: "Proposed guidelines for the diagnosis and management of methylmalonic and propionic acidemia."

--- a/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
+++ b/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: N-Acetylglutamate Synthase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-08T10:22:33Z'
+updated_date: '2026-05-11T04:10:35Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -592,6 +592,17 @@ biochemical:
   context: 'Elevated plasma ammonia is the hallmark laboratory finding in NAGS deficiency. During acute crises, ammonia can reach extremely high levels (over 1000 micromol/L in neonatal presentations). Ammonia normalization is a key treatment response marker.
 
     '
+  readouts:
+  - target: Systemic hyperammonemia and glutamine diversion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-071
+    - FDA-SE-pediatric-noncancer-049
+    interpretation: >-
+      Plasma ammonia reports the systemic proximal urea-cycle biochemical
+      state caused by impaired NAG-dependent CPS1 activation.
   biomarker_term:
     preferred_term: ammonium
     term:

--- a/kb/disorders/Phenylketonuria.yaml
+++ b/kb/disorders/Phenylketonuria.yaml
@@ -1,6 +1,6 @@
 name: Phenylketonuria
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T05:24:24Z'
+updated_date: '2026-05-11T04:10:35Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -1407,6 +1407,18 @@ biochemical:
 - name: Blood Phenylalanine
   presence: Elevated
   context: Greater than 120 micromol/L, often greater than 1200 micromol/L in classic PKU
+  readouts:
+  - target: Hyperphenylalaninemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-087
+    - FDA-SE-pediatric-noncancer-057
+    interpretation: >-
+      Blood phenylalanine directly measures the systemic
+      hyperphenylalaninemia caused by impaired PAH-dependent phenylalanine
+      metabolism.
   evidence:
   - reference: PMID:24385074
     reference_title: "Phenylalanine hydroxylase deficiency: diagnosis and management guideline."

--- a/kb/disorders/Propionic_Acidemia.yaml
+++ b/kb/disorders/Propionic_Acidemia.yaml
@@ -1,7 +1,7 @@
 name: Propionic Acidemia
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-09T07:02:40Z'
+updated_date: '2026-05-11T04:10:35Z'
 synonyms:
 - Propionic aciduria
 - PA
@@ -843,6 +843,35 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: Elevated propionylcarnitine, 2-methylcitric acid (2MCA), propionylglycine, glycine and 3-hydroxypropionate can be used to diagnose PA.
     explanation: Directly supports elevated propionylglycine as a diagnostic marker.
+- name: Plasma ammonia
+  presence: INCREASED
+  context: >-
+    Secondary hyperammonemia can occur during propionic acidemia
+    decompensation through NAG/CPS1 pathway inhibition.
+  readouts:
+  - target: Secondary NAG deficiency and hyperammonemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-096
+    - FDA-SE-pediatric-noncancer-063
+    interpretation: >-
+      Plasma ammonia reports the secondary hyperammonemic state caused by
+      impaired urea-cycle activation during propionic acidemia decompensation.
+  evidence:
+  - reference: PMID:39695809
+    reference_title: "Role of carglumic acid in the long-term management of propionic and methylmalonic acidurias."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hyperammonemia is related to a secondary deficiency of
+      N-acetylglutamate (NAG), the activator of carbamoyl phosphate synthetase
+      1, which is an irreversible rate-limiting enzyme in the urea cycle.
+    explanation: >-
+      This review links PA/MMA hyperammonemia to secondary NAG deficiency and
+      impaired CPS1 activation, supporting plasma ammonia as a monitoring
+      readout.
 - name: FGF21 and GDF15
   presence: INCREASED
   context: 'Mitochondrial biomarkers FGF21 and GDF15 are elevated in PA and associated with more severe intellectual disability profile, suggesting their potential as surrogate endpoints.

--- a/kb/disorders/Type_2_Diabetes_Mellitus.yaml
+++ b/kb/disorders/Type_2_Diabetes_Mellitus.yaml
@@ -1,6 +1,6 @@
 name: Type 2 Diabetes Mellitus
 creation_date: '2025-12-18T17:01:35Z'
-updated_date: '2026-05-09T17:11:56Z'
+updated_date: '2026-05-11T04:10:35Z'
 category: Complex
 parents:
 - Metabolic Disease
@@ -412,6 +412,35 @@ phenotypes:
     term:
       id: HP:0009830
       label: Peripheral neuropathy
+biochemical:
+- name: Hemoglobin A1c (HbA1c)
+  presence: Elevated
+  context: >-
+    HbA1c reflects average glycemic exposure over the preceding two to three
+    months and is used to monitor long-term glycemic control in diabetes.
+  readouts:
+  - target: Hyperglycemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-119
+    - FDA-SE-pediatric-noncancer-074
+    interpretation: >-
+      HbA1c reports chronic hyperglycemia and long-term glycemic control in
+      type 2 diabetes.
+  evidence:
+  - reference: PMID:37921158
+    reference_title: "Multi-level Analysis of HbA1c in Diagnosis and Prognosis of Diabetic Patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The ability to reflect the cumulative glycemic history of the previous
+      two to three months makes HbA1c an essential biomarker of long-term
+      glycemic control.
+    explanation: >-
+      This review identifies HbA1c as a long-term glycemic control biomarker
+      in diabetes, supporting the readout link to hyperglycemia.
 genetic:
 - name: TCF7L2
   gene_term:

--- a/kb/disorders/Type_I_Diabetes.yaml
+++ b/kb/disorders/Type_I_Diabetes.yaml
@@ -1,6 +1,6 @@
 name: Type I Diabetes
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-05-09T14:24:38Z'
+updated_date: '2026-05-11T04:10:35Z'
 category: Metabolic
 parents:
 - Autoimmune Disease
@@ -741,6 +741,17 @@ biochemical:
 - name: Hemoglobin A1c (HbA1c)
   presence: Elevated
   frequency: VERY_FREQUENT
+  readouts:
+  - target: Hyperglycemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-117
+    - FDA-SE-pediatric-noncancer-072
+    interpretation: >-
+      HbA1c reflects chronic glycemic exposure and is a monitoring readout of
+      hyperglycemia in type 1 diabetes.
   evidence:
   - reference: PMID:22847316
     reference_title: "1,5-Anhydroglucitol in diabetes mellitus."

--- a/kb/disorders/X-Linked_Hypophosphatemia.yaml
+++ b/kb/disorders/X-Linked_Hypophosphatemia.yaml
@@ -1,6 +1,6 @@
 name: X-Linked Hypophosphatemia
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-05-06T08:10:58Z'
+updated_date: '2026-05-11T04:10:35Z'
 category: Mendelian
 description: >
   X-linked hypophosphatemia (XLH) is the most common hereditary form of rickets,
@@ -445,6 +445,39 @@ genetic:
     evidence_source: OTHER
     snippet: "PHEX | HGNC:8918 | X-linked dominant hypophosphatemic rickets | MONDO:0010619 | XL | Definitive"
     explanation: ClinGen classifies the PHEX-X-linked dominant hypophosphatemic rickets gene-disease relationship as definitive with X-linked inheritance.
+biochemical:
+- name: Serum phosphate
+  presence: DECREASED
+  context: >-
+    Low serum phosphate is the biochemical hallmark of XLH and increases when
+    FGF23-mediated renal phosphate wasting is corrected.
+  readouts:
+  - target: Renal Phosphate Wasting via FGF23 Excess
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-120
+    - FDA-SE-pediatric-noncancer-075
+    interpretation: >-
+      Serum phosphate reports the downstream effect of FGF23-driven renal
+      phosphate wasting and pharmacodynamic correction by anti-FGF23 therapy.
+  biomarker_term:
+    preferred_term: phosphate
+    term:
+      id: CHEBI:26020
+      label: phosphate
+  evidence:
+  - reference: PMID:29947083
+    reference_title: "A Randomized, Double-Blind, Placebo-Controlled, Phase 3 Trial Evaluating the Efficacy of Burosumab, an Anti-FGF23 Antibody, in Adults With X-Linked Hypophosphatemia: Week 24 Primary Analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Burosumab, a fully human monoclonal antibody, binds and inhibits FGF23
+      to correct hypophosphatemia
+    explanation: >-
+      This phase 3 trial supports serum phosphate correction as a treatment
+      response readout of anti-FGF23 therapy in XLH.
 treatments:
 - name: Burosumab (Crysvita)
   description: >


### PR DESCRIPTION
## Summary
- Link FDA surrogate endpoint rows for metabolic laboratory markers to disease-local biomarker readouts.
- Covers serum urate in gout; plasma ammonia in methylmalonic acidemia, NAGS deficiency, and propionic acidemia; blood phenylalanine in PKU; HbA1c in type 1 and type 2 diabetes; and serum phosphate in XLH.
- Adds new minimal biomarker entries where the disease file did not already have the corresponding marker.

## Notes
This is stacked on #2508 because it uses the `regulatory_endpoint_refs` readout schema extension from that branch. The PR is intentionally curation-only and does not modify the FDA source table because these rows already map back to the touched disease files.

## Validation
- `just validate` for each touched disease file
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`