### PR TITLE
[codex] Link clinical lab surrogate endpoints

### DIFF
--- a/kb/disorders/Chronic_Kidney_Disease.yaml
+++ b/kb/disorders/Chronic_Kidney_Disease.yaml
@@ -1,6 +1,6 @@
 name: Chronic Kidney Disease
 creation_date: '2025-12-18T17:01:35Z'
-updated_date: '2026-04-04T12:00:00Z'
+updated_date: '2026-05-11T04:26:15Z'
 category: Complex
 parents:
 - Renal Disease
@@ -228,9 +228,34 @@ phenotypes:
       id: HP:0012398
       label: Peripheral edema
 biochemical:
+- name: Estimated Glomerular Filtration Rate
+  presence: Decreased
+  context: Reduced eGFR reflects impaired kidney filtration function.
+  readouts:
+  - target: Nephron Loss
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-012
+    - FDA-SE-pediatric-noncancer-008
+    interpretation: >-
+      eGFR estimates kidney filtration function and declines as functional
+      nephron mass and glomerular filtration capacity are lost.
 - name: Creatinine
   presence: Elevated
   context: Reflects decreased filtration
+  readouts:
+  - target: Nephron Loss
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-012
+    - FDA-SE-pediatric-noncancer-008
+    interpretation: >-
+      Serum creatinine rises as filtration capacity declines, making it a
+      laboratory readout of kidney functional loss in CKD.
 - name: Blood Urea Nitrogen
   presence: Elevated
   context: Uremic toxin accumulation

--- a/kb/disorders/Cushings_Syndrome.yaml
+++ b/kb/disorders/Cushings_Syndrome.yaml
@@ -182,12 +182,14 @@ biochemical:
   - target: Chronic Cortisol Excess
     relationship: READOUT_OF
     direction: POSITIVE
-    endpoint_context: MONITORING
+    endpoint_context: PHARMACODYNAMIC
     regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-015
     - FDA-SE-adult-noncancer-016
     interpretation: >-
       Urine free cortisol reports the cortisol-excess mechanism targeted by
-      cortisol synthesis inhibitors in endogenous Cushing's syndrome.
+      pituitary-directed and cortisol-synthesis inhibitor therapies in Cushing's
+      disease and endogenous Cushing's syndrome.
   biomarker_term:
     preferred_term: cortisol
     term:
@@ -199,11 +201,11 @@ biochemical:
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      Cushing syndrome is defined as a prolonged increase in plasma cortisol
-      levels that is not due to a physiological etiology.
+      Screening for elevated cortisol is performed with a 24-hour urinary free
+      cortisol test or late-night salivary cortisol test
     explanation: >-
-      This review supports chronic cortisol excess as the core biochemical
-      abnormality measured by urine free cortisol testing.
+      This review identifies 24-hour urinary free cortisol as a test for
+      elevated cortisol in Cushing syndrome.
 treatments:
 - name: Surgical Resection
   description: >

--- a/kb/disorders/Cushings_Syndrome.yaml
+++ b/kb/disorders/Cushings_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Cushing's Syndrome
 creation_date: '2026-01-09T07:21:01Z'
-updated_date: '2026-01-09T07:21:01Z'
+updated_date: '2026-05-11T04:26:15Z'
 category: Complex
 disease_term:
   preferred_term: Cushing syndrome
@@ -172,6 +172,38 @@ phenotypes:
     supports: SUPPORT
     snippet: "Cushing syndrome characteristically presents with skin changes such as facial plethora, easy bruising, and purple striae"
     explanation: "Easy bruising is confirmed as a characteristic skin change."
+biochemical:
+- name: Urine Free Cortisol
+  presence: Elevated
+  context: >-
+    Urinary free cortisol is used to monitor biochemical cortisol excess in
+    endogenous Cushing's syndrome.
+  readouts:
+  - target: Chronic Cortisol Excess
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-016
+    interpretation: >-
+      Urine free cortisol reports the cortisol-excess mechanism targeted by
+      cortisol synthesis inhibitors in endogenous Cushing's syndrome.
+  biomarker_term:
+    preferred_term: cortisol
+    term:
+      id: CHEBI:17650
+      label: cortisol
+  evidence:
+  - reference: PMID:37432427
+    reference_title: "Cushing Syndrome: A Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cushing syndrome is defined as a prolonged increase in plasma cortisol
+      levels that is not due to a physiological etiology.
+    explanation: >-
+      This review supports chronic cortisol excess as the core biochemical
+      abnormality measured by urine free cortisol testing.
 treatments:
 - name: Surgical Resection
   description: >

--- a/kb/disorders/Primary_Biliary_Cholangitis.yaml
+++ b/kb/disorders/Primary_Biliary_Cholangitis.yaml
@@ -1,6 +1,6 @@
 name: Primary Biliary Cholangitis
 creation_date: '2025-12-19T01:12:52Z'
-updated_date: '2026-02-17T21:53:14Z'
+updated_date: '2026-05-11T04:26:15Z'
 category: Autoimmune
 parents:
 - Autoimmune Disease
@@ -220,6 +220,29 @@ biochemical:
 - name: Alkaline Phosphatase
   presence: Elevated
   context: Cholestatic pattern
+  readouts:
+  - target: Progressive Ductopenia and Cholestasis
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-092
+    interpretation: >-
+      Serum alkaline phosphatase reports the cholestatic injury pattern caused
+      by progressive small-duct loss in PBC.
+- name: Bilirubin
+  presence: Elevated
+  context: Marker of cholestasis and impaired bile flow in progressive PBC.
+  readouts:
+  - target: Progressive Ductopenia and Cholestasis
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-092
+    interpretation: >-
+      Serum bilirubin reports impaired bile flow and cholestatic progression
+      downstream of ductopenia in PBC.
 - name: IgM
   presence: Elevated
   context: Characteristic finding

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -387,8 +387,14 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cushing''s disease; population: Patients with Cushing’s disease for whom
     pituitary surgery is not an option or has not been curative; endpoint: Urine free cortisol; approval
     context: traditional; drug mechanism: Somatostatin analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cushing's Syndrome
+  mapped_disease_files:
+  - kb/disorders/Cushings_Syndrome.yaml
+  mapping_notes: >
+    Curated subtype mapping; FDA row names pituitary Cushing's disease, which
+    is represented within the broader dismech Cushing's Syndrome entry.
 - row_id: FDA-SE-adult-noncancer-016
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary
- Link FDA surrogate endpoint rows for classic clinical laboratory endpoints to disease-local biomarker readouts.
- Covers eGFR/serum creatinine in chronic kidney disease, urine free cortisol in Cushing syndrome, and alkaline phosphatase/bilirubin in primary biliary cholangitis.
- Adds minimal marker entries where the disease file did not already carry the specific endpoint component.

## Notes
This is stacked on #2508 because it uses the `regulatory_endpoint_refs` readout schema extension from that branch. It intentionally leaves functional, imaging, growth, and infectious-disease assay endpoints for later batches because their targets need more specific modeling.

## Validation
- `just validate kb/disorders/Chronic_Kidney_Disease.yaml`
- `just validate kb/disorders/Cushings_Syndrome.yaml`
- `just validate kb/disorders/Primary_Biliary_Cholangitis.yaml`
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`