### PR TITLE
[codex] Link inborn lab surrogate endpoints

### DIFF
--- a/kb/disorders/Alkaptonuria.yaml
+++ b/kb/disorders/Alkaptonuria.yaml
@@ -1,7 +1,7 @@
 name: Alkaptonuria
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-08T00:00:00Z'
+updated_date: '2026-05-11T00:00:00Z'
 synonyms:
 - Hereditary ochronosis
 - Homogentisic acid oxidase deficiency
@@ -765,6 +765,17 @@ biochemical:
   context: >
     Urinary HGA is substantially increased and is the primary biochemical
     diagnostic marker.
+  readouts:
+  - target: Homogentisic acid accumulation and oxidation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-005
+    interpretation: >
+      Urinary HGA reports the HGA-accumulation node; reduction after upstream
+      HPPD inhibition indicates reduced substrate burden entering ochronotic
+      pigment pathways.
   evidence:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."

--- a/kb/disorders/Arginase_Deficiency.yaml
+++ b/kb/disorders/Arginase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Arginase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-05T16:40:30Z'
+updated_date: '2026-05-11T00:00:00Z'
 synonyms:
 - Argininemia
 - Hyperargininemia
@@ -639,6 +639,18 @@ biochemical:
   context: 'Markedly elevated plasma arginine is the hallmark biochemical abnormality, with levels often exceeding 300 umol/L (normal upper limit approximately 75 umol/L). The therapeutic target is to reduce plasma arginine below 200 umol/L. Arginine is the primary biomarker for diagnosis, monitoring, and therapeutic response assessment.
 
     '
+  readouts:
+  - target: Impaired ureagenesis and hyperargininemia
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-009
+    - FDA-SE-pediatric-noncancer-005
+    interpretation: >
+      Plasma arginine directly reports the hyperargininemia produced by the
+      ARG1 block; reduction after arginine-degrading therapy indicates lower
+      circulating amino-acid burden.
   evidence:
   - reference: PMID:38292042
     reference_title: "Efficacy and safety of pegzilarginase in arginase 1 deficiency (PEACE): a phase 3, randomized, double-blind, placebo-controlled, multi-centre trial."

--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-09T05:50:50Z'
+updated_date: '2026-05-11T00:00:00Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -711,6 +711,17 @@ biochemical:
 - name: Plasma and tissue cholestanol
   presence: Elevated
   context: Defining biochemical abnormality used diagnostically and for monitoring response.
+  readouts:
+  - target: Cholestanol and bile alcohol accumulation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-011
+    interpretation: >
+      Plasma cholestanol is the measurable circulating component of the CTX
+      sterol-accumulation node; reduction after primary bile acid treatment
+      indicates reduced abnormal sterol precursor burden.
   evidence:
   - reference: PMID:20301583
     reference_title: "Cerebrotendinous Xanthomatosis."

--- a/kb/disorders/Cystinuria.yaml
+++ b/kb/disorders/Cystinuria.yaml
@@ -1,7 +1,7 @@
 name: Cystinuria
 category: Mendelian
 creation_date: '2026-05-05T15:29:06Z'
-updated_date: '2026-05-10T06:12:56Z'
+updated_date: '2026-05-11T00:00:00Z'
 synonyms:
 - Cystinuria-lysinuria syndrome
 description: >
@@ -831,6 +831,32 @@ phenotypes:
     evidence_source: OTHER
     snippet: "HP:6000916 | Echogenic fetal colon | Occasional (29-5%)"
     explanation: Orphanet classifies echogenic fetal colon as occasional.
+biochemical:
+- name: Urinary cystine
+  presence: INCREASED
+  context: >
+    Urinary cystine concentration reflects defective proximal tubular cystine
+    reabsorption, cystine supersaturation risk, and treatment response to
+    measures that lower free cystine or increase solubility.
+  readouts:
+  - target: Urinary Cystine Supersaturation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-018
+    - FDA-SE-pediatric-noncancer-012
+    interpretation: >
+      Urinary cystine reports the supersaturation node that drives crystal
+      formation; lower urinary cystine or free-cystine burden indicates reduced
+      substrate for cystine crystallization.
+  evidence:
+  - reference: PMID:36900678
+    reference_title: A Summary of Current Guidelines and Future Directions for Medical Management and Monitoring of Patients with Cystinuria.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "As the result of a genetic defect in proximal tubular reabsorption of filtered cystine, increased urine levels of the poorly soluble amino acid result in recurrent cystine nephrolithiasis."
+    explanation: Guideline review supports urinary cystine as the direct biochemical readout of the proximal tubular transport defect and stone-risk mechanism.
 diagnosis:
 - name: Stone composition and 24-hour urinary cystine evaluation
   diagnosis_term:

--- a/kb/disorders/Familial_Hypercholesterolemia.yaml
+++ b/kb/disorders/Familial_Hypercholesterolemia.yaml
@@ -1,6 +1,6 @@
 name: Familial Hypercholesterolemia
 creation_date: "2026-03-06T00:00:00Z"
-updated_date: "2026-05-09T19:29:45Z"
+updated_date: "2026-05-11T00:00:00Z"
 description: >
   Familial hypercholesterolemia (FH) is a common autosomal dominant disorder of
   lipid metabolism characterized by significantly elevated serum low-density
@@ -959,6 +959,34 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "a chronically elevated concentration of LDL-C in the plasma leads to the occurrence of certain abnormalities, such as xanthomas in the tendons and skin, as well as corneal arcus."
     explanation: Corneal arcus is a recognized clinical feature of FH.
+biochemical:
+- name: Serum LDL cholesterol
+  presence: INCREASED
+  context: >
+    Serum LDL-C is the central circulating biochemical abnormality in familial
+    hypercholesterolemia and the primary treatment-response marker for both
+    heterozygous and homozygous disease.
+  readouts:
+  - target: Elevated Circulating LDL Cholesterol
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-042
+    - FDA-SE-adult-noncancer-043
+    - FDA-SE-pediatric-noncancer-030
+    - FDA-SE-pediatric-noncancer-031
+    interpretation: >
+      Serum LDL-C directly reports the elevated-circulating-LDL node; reduction
+      after lipid-lowering therapy indicates lower lifelong atherogenic
+      lipoprotein burden.
+  evidence:
+  - reference: PMID:29219151
+    reference_title: "Familial hypercholesterolaemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Familial hypercholesterolaemia is a common inherited disorder characterized by abnormally elevated serum levels of low-density lipoprotein (LDL) cholesterol from birth"
+    explanation: The review supports serum LDL cholesterol as the defining biochemical abnormality in familial hypercholesterolemia.
 genetic:
 - name: LDLR
   gene_term:

--- a/kb/disorders/Hereditary_Methemoglobinemia.yaml
+++ b/kb/disorders/Hereditary_Methemoglobinemia.yaml
@@ -1,7 +1,7 @@
 name: Hereditary methemoglobinemia
 category: Mendelian
 creation_date: "2026-05-09T13:01:56Z"
-updated_date: "2026-05-09T13:01:56Z"
+updated_date: "2026-05-11T00:00:00Z"
 synonyms:
 - Autosomal recessive congenital methemoglobinemia
 - Recessive congenital methemoglobinemia
@@ -624,6 +624,18 @@ biochemical:
   notes: >
     Affected individuals have elevated blood methemoglobin; levels in a Yakutia
     pediatric registry ranged from mild to markedly elevated values.
+  readouts:
+  - target: Methemoglobin accumulation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-076
+    - FDA-SE-pediatric-noncancer-053
+    interpretation: >
+      Blood methemoglobin level reports the ferric hemoglobin accumulation
+      node; reduction after redox-directed therapy indicates lower impaired
+      oxygen-binding hemoglobin burden.
   evidence:
   - reference: PMID:27879543
     reference_title: Enzymopenic Congenital Methemoglobinemia in Children of the Republic of Sakha (Yakutia).

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -131,8 +131,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Alkaptonuria; population: Adult patients with alkaptonuria; endpoint:
     Reduction (>90%) in urinary homogentisic acid (HGA) levels; approval context: traditional; drug mechanism:
     Competitive inhibitor of 4-hydroxyphenylpyruvate dioxygenase (HPPD).'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Alkaptonuria
+  mapped_disease_files:
+  - kb/disorders/Alkaptonuria.yaml
+  mapping_notes: Curated disease mapping; urinary HGA links to the alkaptonuria HGA-accumulation pathograph node.
 - row_id: FDA-SE-adult-noncancer-006
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -230,8 +234,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Arginase 1 deficiency; population: treatment of hyperargininemia in adult
     with Arginase 1 Deficiency; endpoint: Reduction in plasma arginine; approval context: accelerated;
     drug mechanism: Arginine specific enzyme.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Arginase Deficiency
+  mapped_disease_files:
+  - kb/disorders/Arginase_Deficiency.yaml
+  mapping_notes: Curated synonym mapping from FDA Arginase 1 deficiency to the dismech Arginase Deficiency entry.
 - row_id: FDA-SE-adult-noncancer-010
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -280,8 +288,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cerebrotendinous xanthomatosis (CTX); population: Adults with confirmed
     molecular diagnosis of CTX; endpoint: Reduction in plasma cholestanol; approval context: traditional;
     drug mechanism: Primary bile acid.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cerebrotendinous xanthomatosis
+  mapped_disease_files:
+  - kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+  mapping_notes: Curated acronym-expanded mapping from FDA CTX text to the dismech cerebrotendinous xanthomatosis entry.
 - row_id: FDA-SE-adult-noncancer-012
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -467,8 +479,12 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Cystinuria; population: Patients with cystinuria; endpoint: Urinary cystine;
     approval context: traditional; drug mechanism: Reducing and complexing thiol.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cystinuria
+  mapped_disease_files:
+  - kb/disorders/Cystinuria.yaml
+  mapping_notes: Curated disease mapping; urinary cystine links to the cystinuria supersaturation pathograph node.
 - row_id: FDA-SE-adult-noncancer-019
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1050,8 +1066,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hypercholesterolemia; population: Patients with heterozygous familial
     and nonfamilial hypercholesterolemia; endpoint: Serum LDL cholesterol; approval context: traditional;
     drug mechanism: Lipid-lowering.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: >
+    Curated partial disease mapping; FDA row covers heterozygous familial and
+    nonfamilial hypercholesterolemia, with the familial component mapped to the
+    dismech familial hypercholesterolemia entry.
 - row_id: FDA-SE-adult-noncancer-043
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1072,8 +1095,12 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hypercholesterolemia; population: Patients with homozygous familial hypercholesterolemia;
     endpoint: Serum LDL cholesterol; approval context: traditional; drug mechanism: Lipid-lowering.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: Curated subtype mapping from FDA homozygous familial hypercholesterolemia to the dismech FH entry.
 - row_id: FDA-SE-adult-noncancer-044
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1881,8 +1908,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with methemoglobinemia;
     endpoint: Serum methemoglobin; approval context: accelerated; drug mechanism: Oxidation-reduction
     agent.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hereditary methemoglobinemia
+  mapped_disease_files:
+  - kb/disorders/Hereditary_Methemoglobinemia.yaml
+  mapping_notes: >
+    Curated partial disease mapping; FDA row applies broadly to patients with
+    methemoglobinemia and is biologically applicable to the hereditary
+    methemoglobinemia entry through the methemoglobin-accumulation node.
 - row_id: FDA-SE-adult-noncancer-077
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -3760,8 +3794,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Arginase 1 deficiency; population: Pediatric patients 2 years of age and
     older with Arginase 1 Deficiency; endpoint: reduction in plasma arginine; approval context: accelerated;
     drug mechanism: arginine specific enzyme; age range: 2 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Arginase Deficiency
+  mapped_disease_files:
+  - kb/disorders/Arginase_Deficiency.yaml
+  mapping_notes: Curated synonym mapping from FDA Arginase 1 deficiency to the dismech Arginase Deficiency entry.
 - row_id: FDA-SE-pediatric-noncancer-006
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -3947,8 +3985,12 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Cystinuria; population: Patients with cystinuria; endpoint: Urinary/urine
     cystine; approval context: traditional; drug mechanism: Reducing and complexing thiol.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cystinuria
+  mapped_disease_files:
+  - kb/disorders/Cystinuria.yaml
+  mapping_notes: Curated disease mapping; urinary cystine links to the cystinuria supersaturation pathograph node.
 - row_id: FDA-SE-pediatric-noncancer-013
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4400,8 +4442,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: HeFH- heterozygous familial hypercholesterolemia; population: Patients
     with heterozygous familial hypercholesterolemia; endpoint: Serum LDL-C; approval context: traditional;
     drug mechanism: Lipid-lowering; age range: 12 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: Curated subtype mapping from FDA HeFH text to the dismech familial hypercholesterolemia entry.
 - row_id: FDA-SE-pediatric-noncancer-031
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4425,8 +4471,12 @@ surrogate_endpoints:
     homozygous familial hypercholesterolemia; endpoint: Serum LDL-C; approval context: traditional; drug
     mechanism: angiopoietin-like 3 (ANGPTL3) inhibitor; siRNA targeted at PCSK9; age range: 1 to 4 years;
     12 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: Curated subtype mapping from FDA HoFH text to the dismech familial hypercholesterolemia entry.
 - row_id: FDA-SE-pediatric-noncancer-032
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4978,8 +5028,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with methemoglobinemia;
     endpoint: Serum methemoglobin; approval context: accelerated; drug mechanism: Oxidation-reduction
     agent; age range: All pediatric age groups.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hereditary methemoglobinemia
+  mapped_disease_files:
+  - kb/disorders/Hereditary_Methemoglobinemia.yaml
+  mapping_notes: >
+    Curated partial disease mapping; FDA row applies broadly to pediatric
+    patients with methemoglobinemia and is biologically applicable to the
+    hereditary methemoglobinemia entry through the methemoglobin-accumulation
+    node.
 - row_id: FDA-SE-pediatric-noncancer-054
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- Link FDA inherited/metabolic lab surrogate endpoint rows to disease-local biochemical readouts.
- Add pathograph readouts for urinary HGA, plasma arginine, plasma cholestanol, urinary cystine, serum LDL-C, and blood methemoglobin.
- Mark the corresponding FDA rows as curated disease mappings so local regulatory refs resolve bidirectionally.

## Validation
- `just validate kb/disorders/Alkaptonuria.yaml`
- `just validate kb/disorders/Arginase_Deficiency.yaml`
- `just validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml`
- `just validate kb/disorders/Cystinuria.yaml`
- `just validate kb/disorders/Familial_Hypercholesterolemia.yaml`
- `just validate kb/disorders/Hereditary_Methemoglobinemia.yaml`
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`
