### PR TITLE
Improve GCDH deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Glutaryl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Glutaryl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Glutaryl-CoA Dehydrogenase Deficiency
 creation_date: '2025-12-15T00:00:00Z'
-updated_date: '2026-05-09T04:07:20Z'
+updated_date: '2026-05-11T04:47:15Z'
 category: Mendelian
 description: 'Glutaryl-CoA dehydrogenase deficiency (historically termed glutaric aciduria type 1, GA1) is a rare autosomal recessive neurometabolic disorder caused by deficiency of glutaryl-CoA dehydrogenase (GCDH), which catalyzes the final step of lysine, hydroxylysine, and tryptophan catabolism. GCDH deficiency leads to accumulation of neurotoxic metabolites glutaric acid (GA), 3-hydroxyglutaric acid (3-OH-GA), and glutarylcarnitine (C5DC). Untreated disease ranges from infantile-onset to later-onset forms (after age six years). Affected individuals are at highest risk for acute encephalopathic crises in early childhood (especially ages 3-36 months), often triggered by catabolic stress, which cause irreversible bilateral striatal necrosis and a complex dystonic movement disorder. Early diagnosis through newborn screening and adherence to metabolic treatment including lysine-restricted diet, carnitine supplementation, and emergency management during intercurrent illness can prevent striatal injury in the majority of patients. Even in treated cohorts, long-term surveillance is important, including attention to possible renal complications in adolescents and adults.
 
@@ -506,6 +506,18 @@ pathophysiology:
     snippet: crises result in acute bilateral striatal injury and subsequent complex movement disorders.
     explanation: GeneReviews summarizes the canonical striatal injury to movement-disorder progression in untreated GA1.
   downstream:
+  - target: Encephalopathy
+    description: Acute striatal degeneration manifests clinically as encephalopathic crises.
+    hypothesis_groups:
+    - canonical_ga1_metabolic_model
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:35639256
+      reference_title: "Disturbance of Mitochondrial Dynamics, Endoplasmic Reticulum-Mitochondria Crosstalk, Redox Homeostasis, and Inflammatory Response in the Brain of Glutaryl-CoA Dehydrogenase-Deficient Mice: Neuroprotective Effects of Bezafibrate."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: acute encephalopathy associated with severe striatum degeneration and progressive cortical and striatal injury
+      explanation: Supports acute encephalopathy as the clinical expression of severe striatal degeneration in the GA1 model.
   - target: Dystonia
     description: Bilateral striatal injury produces chronic dystonic movement disorder.
     hypothesis_groups:
@@ -728,6 +740,17 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: cerebral atrophy and expansion of CSF spaces
     explanation: Cerebral atrophy with CSF space expansion is a recognized GA1 neuroimaging feature.
+  sequelae:
+  - target: Subdural hemorrhage
+    description: Cerebral atrophy and expanded CSF spaces stretch cortical veins and predispose to subdural hematoma.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26219480
+      reference_title: "Subdural hematomas: glutaric aciduria type 1 or abusive head trauma? A systematic review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Children with GA1 are reported to be predisposed to subdural hematoma (SDH) development due to stretching of cortical veins secondary to cerebral atrophy and expansion of CSF spaces.
+      explanation: Directly links the GA1 cerebral atrophy/expanded-CSF phenotype to subdural hematoma predisposition.
 - name: Cerebral white matter hyperintensity on MRI
   frequency: FREQUENT
   description: 'Abnormalities in white matter are detected on MRI in the majority of GA1 patients.
@@ -748,6 +771,12 @@ phenotypes:
 biochemical:
 - name: Elevated glutarylcarnitine (C5DC)
   presence: INCREASED
+  readouts:
+  - target: GCDH enzymatic deficiency and disrupted lysine catabolism
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated C5DC in blood reports the disrupted GCDH-dependent lysine-catabolism pathway.
   notes: 'C5DC is the primary newborn screening biomarker for GA1 detected by tandem mass spectrometry. Elevated in blood in approximately 98.5% of GA1 patients.
 
     '
@@ -760,6 +789,12 @@ biochemical:
     explanation: C5DC elevation in blood is near-universal in GA1 patients.
 - name: Elevated glutaric acid in urine
   presence: INCREASED
+  readouts:
+  - target: GCDH enzymatic deficiency and disrupted lysine catabolism
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary glutaric acid elevation reports accumulation of GA1 catabolites downstream of GCDH deficiency.
   notes: 'Glutaric acid is elevated in urine in approximately 94% of GA1 patients. The level of urinary GA excretion distinguishes high excreters from low excreters.
 
     '
@@ -778,6 +813,12 @@ biochemical:
     explanation: The high/low excreter distinction based on urinary GA levels is clinically significant for cognitive prognosis.
 - name: Elevated 3-hydroxyglutaric acid in urine
   presence: INCREASED
+  readouts:
+  - target: GCDH enzymatic deficiency and disrupted lysine catabolism
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary 3-OH-GA elevation reports accumulation of neurotoxic GA1 metabolites downstream of GCDH deficiency.
   notes: '3-OH-GA is elevated in urine in approximately 69% of GA1 patients and is considered the most neurotoxic metabolite.
 
     '
@@ -834,6 +875,16 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Brain exposure to toxic GA1 catabolites
+    treatment_effect: INHIBITS
+    description: Lysine restriction reduces substrate flux intended to minimize CNS exposure to lysine-derived toxic byproducts.
+    evidence:
+    - reference: 'url:https://www.ncbi.nlm.nih.gov/books/NBK546575/?report=printable'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Combined metabolic therapy includes low-lysine diet, carnitine supplementation, and emergency treatment during episodes with the goal of averting catabolism and minimizing CNS exposure to lysine and its toxic metabolic byproducts.
+      explanation: GeneReviews explicitly frames low-lysine diet as part of therapy aimed at minimizing CNS toxic-metabolite exposure.
   evidence:
   - reference: PMID:34588557
     reference_title: "The biochemical subtype is a predictor for cognitive function in glutaric aciduria type 1: a national prospective follow-up study."
@@ -860,6 +911,16 @@ treatments:
       term:
         id: CHEBI:17126
         label: carnitine
+  target_mechanisms:
+  - target: Brain exposure to toxic GA1 catabolites
+    treatment_effect: MODULATES
+    description: Carnitine supplementation is part of combined metabolic therapy intended to reduce toxic byproduct exposure.
+    evidence:
+    - reference: 'url:https://www.ncbi.nlm.nih.gov/books/NBK546575/?report=printable'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Combined metabolic therapy includes low-lysine diet, carnitine supplementation, and emergency treatment during episodes with the goal of averting catabolism and minimizing CNS exposure to lysine and its toxic metabolic byproducts.
+      explanation: GeneReviews includes carnitine supplementation in the combined regimen aimed at minimizing CNS toxic-metabolite exposure.
   notes: >-
     L-carnitine supplementation is recommended in international GA1 guidelines to
     replenish secondary
@@ -882,6 +943,16 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Striatal vulnerability and encephalopathic crises
+    treatment_effect: INHIBITS
+    description: Emergency illness management prevents catabolism during stressors that can precipitate striatal injury and encephalopathic crises.
+    evidence:
+    - reference: 'url:https://www.ncbi.nlm.nih.gov/books/NBK546575/?report=printable'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "<i>Agents/circumstances to avoid:</i> Excessive dietary protein or protein malnutrition inducing catabolic state, prolonged fasting, catabolic illness (intercurrent infection; brief febrile illness post vaccination), inadequate caloric provision during other stressors (e.g., surgery or procedure requiring fasting/anesthesia)."
+      explanation: GeneReviews lists catabolic illness, fasting, and inadequate calories as circumstances to avoid, supporting emergency management as prevention of the crisis-triggering mechanism.
   notes: >-
     Aggressive emergency treatment during catabolic crises is a cornerstone of GA1
     management per


### PR DESCRIPTION
## Summary
- Add an encephalopathy edge downstream of striatal vulnerability/encephalopathic crises
- Add a sequela edge from frontotemporal cerebral atrophy to subdural hemorrhage
- Add diagnostic biochemical readouts for C5DC, glutaric acid, and 3-OH-glutaric acid
- Link lysine restriction, carnitine supplementation, and emergency illness management to their target mechanisms

## Review notes
- Subagent review found no content blockers after restoring validation cache churn
- URL-backed GeneReviews snippets are consistent with existing file-local references, but are not cache-validated
- Residual singleton nodes were left unconnected where the current evidence did not justify causal linkage
- Local commit skipped only yamlfix to avoid a full-file indentation-only rewrite; check-yaml, yamllint, and codespell passed

## Validation
- just validate kb/disorders/Glutaryl-CoA_Dehydrogenase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/Glutaryl-CoA_Dehydrogenase_Deficiency.yaml
- manual cached snippet audit: checked 61 PMID/DOI/structured snippets; all found in cache; skipped 15 URL refs
- graph connectivity: 27 nodes, 22 edges, 9 components, 0 orphan targets, 0 integrity issues
- git diff --check -- kb/disorders/Glutaryl-CoA_Dehydrogenase_Deficiency.yaml