### PR TITLE
Improve 17-beta-HSD3 deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/46_XY_DSD_Due_to_17_Beta_Hydroxysteroid_Dehydrogenase_3_Deficiency.yaml
+++ b/kb/disorders/46_XY_DSD_Due_to_17_Beta_Hydroxysteroid_Dehydrogenase_3_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 46,XY disorder of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
 creation_date: "2026-05-11T03:03:02Z"
-updated_date: "2026-05-11T03:03:02Z"
+updated_date: "2026-05-11T05:24:54Z"
 category: Mendelian
 description: >-
   46,XY disorder of sex development due to 17-beta-hydroxysteroid
@@ -145,6 +145,31 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "in the fetal testis, resulting in a Disorder of Sex Development (DSD)."
       explanation: This directly links HSD17B3 mutations to impaired fetal testicular testosterone synthesis.
+  - target: Increased circulating androstenedione concentration
+    causal_link_type: DIRECT
+    description: >-
+      Deficient conversion at the 17-beta-HSD3 step is associated with the
+      biochemical phenotype of increased circulating androstenedione and a low
+      testosterone-to-androstenedione ratio.
+    evidence:
+    - reference: PMID:33586216
+      reference_title: Early and late diagnoses of 17β-Hydroxysteroid dehydrogenase type-3 deficiency in two unrelated patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "decreasing the conversion of androstenedione to testosterone"
+      explanation: The case report describes the impaired substrate-to-product conversion at the affected enzymatic step.
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0025380 | Increased circulating androstenedione concentration | Frequent (79-30%)"
+      explanation: Orphanet records increased circulating androstenedione as a frequent biochemical phenotype.
+    - reference: PMID:41035179
+      reference_title: "Identifying 17-β-HSD3 Deficiency in Patients with Karyotype 46,XY Misdiagnosed with Androgen Insensitivity Syndrome: A Pediatric Case Report."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "revealed a markedly low testosterone-to-androstenedione (T/AND) ratio of 0.1"
+      explanation: The low T/AND ratio supports the diagnostic relationship between impaired conversion and androgen steroid readouts.
 - name: Fetal Testicular Testosterone Deficiency
   description: >-
     Low fetal testosterone and downstream androgen production impair
@@ -189,6 +214,127 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "presented due to pubertal virilisation and primary amenorrhoea"
     explanation: This case series supports pubertal virilization as a later presentation.
+  downstream:
+  - target: 46,XY undervirilization
+    causal_link_type: UNKNOWN
+    description: >-
+      This aggregate underandrogenization node is represented clinically by the
+      HPO-coded 46,XY undervirilization / male pseudohermaphroditism phenotype.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000037 | Male pseudohermaphroditism | Very frequent (99-80%)"
+      explanation: Orphanet records the 46,XY undervirilization phenotype as very frequent in this disorder.
+  - target: Ambiguous genitalia
+    causal_link_type: UNKNOWN
+    description: >-
+      Ambiguous genitalia is a specific external-genital manifestation reported
+      within the aggregate undervirilization phenotype.
+    evidence:
+    - reference: PMID:41035179
+      reference_title: "Identifying 17-β-HSD3 Deficiency in Patients with Karyotype 46,XY Misdiagnosed with Androgen Insensitivity Syndrome: A Pediatric Case Report."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "can lead to ambiguous genitalia in people with karyotype 46,XY"
+      explanation: This case report directly links impaired androgen synthesis in 46,XY individuals to ambiguous genitalia.
+  - target: Hypospadias
+    causal_link_type: UNKNOWN
+    description: >-
+      Hypospadias is a common specific manifestation within the aggregate
+      undervirilization phenotype.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000047 | Hypospadias | Very frequent (99-80%)"
+      explanation: Orphanet records hypospadias as very frequent in this disorder.
+  - target: Cryptorchidism
+    causal_link_type: UNKNOWN
+    description: >-
+      Cryptorchidism and inguinal testes are frequent findings grouped under
+      the aggregate undervirilization phenotype.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000028 | Cryptorchidism | Very frequent (99-80%)"
+      explanation: Orphanet records cryptorchidism as very frequent in this disorder.
+  - target: Clitoral hypertrophy
+    causal_link_type: UNKNOWN
+    description: >-
+      Clitoral hypertrophy is another common external-genital manifestation
+      grouped under variable undervirilization in affected 46,XY individuals.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008665 | Clitoral hypertrophy | Very frequent (99-80%)"
+      explanation: Orphanet records clitoral hypertrophy as very frequent in this disorder.
+  - target: Urogenital sinus anomaly
+    causal_link_type: UNKNOWN
+    description: >-
+      Urogenital sinus anatomy is a reported specific manifestation within the
+      broader ambiguous-genital / undervirilization phenotype.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100779 | Urogenital sinus anomaly | Frequent (79-30%)"
+      explanation: Orphanet records urogenital sinus anomaly as frequent in this disorder.
+  - target: Bifid scrotum
+    causal_link_type: UNKNOWN
+    description: >-
+      Bifid scrotum is a reported specific manifestation within the
+      external-genital undervirilization spectrum.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000048 | Bifid scrotum | Occasional (29-5%)"
+      explanation: Orphanet records bifid scrotum as an occasional phenotype in this disorder.
+  - target: Hypoplasia of penis
+    causal_link_type: UNKNOWN
+    description: >-
+      Penile hypoplasia or small phallus is a reported specific manifestation
+      within the external-genital undervirilization spectrum.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008736 | Hypoplasia of penis | Occasional (29-5%)"
+      explanation: Orphanet records hypoplasia of penis as an occasional phenotype in this disorder.
+  - target: Inguinal hernia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: >-
+      Inguinal hernia or inguinal swelling can occur when testes are located in
+      the inguinal canal in the context of 46,XY undervirilization.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000023 | Inguinal hernia | Frequent (79-30%)"
+      explanation: Orphanet records inguinal hernia as frequent in this disorder.
+  - target: Infertility
+    causal_link_type: UNKNOWN
+    description: >-
+      Infertility is a very frequent reproductive manifestation grouped within
+      the broader 46,XY undervirilization phenotype.
+    evidence:
+    - reference: ORPHA:752
+      reference_title: 46,XY difference of sex development due to 17-beta-hydroxysteroid dehydrogenase 3 deficiency
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000789 | Infertility | Very frequent (99-80%)"
+      explanation: Orphanet records infertility as very frequent in this disorder.
 phenotypes:
 - name: Cryptorchidism
   category: Genitourinary
@@ -401,6 +547,12 @@ phenotypes:
 biochemical:
 - name: Testosterone
   presence: DECREASED
+  readouts:
+  - target: Impaired Androstenedione to Testosterone Conversion
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lower testosterone synthesis reports impaired HSD17B3-dependent conversion of androstenedione to testosterone.
   context: >-
     Testosterone synthesis is reduced because 17-beta-HSD3 cannot efficiently
     convert androstenedione to testosterone in the fetal testis.
@@ -418,6 +570,12 @@ biochemical:
     explanation: This directly supports decreased testosterone synthesis.
 - name: Androstenedione
   presence: INCREASED
+  readouts:
+  - target: Impaired Androstenedione to Testosterone Conversion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Higher androstenedione relative to testosterone reports impaired conversion at the 17-beta-HSD3 step.
   context: >-
     Androstenedione is increased relative to testosterone, forming the basis of
     the low testosterone-to-androstenedione diagnostic ratio.
@@ -524,6 +682,24 @@ treatments:
       term:
         id: CHEBI:17347
         label: testosterone
+  target_mechanisms:
+  - target: Impaired Androstenedione to Testosterone Conversion
+    treatment_effect: BYPASSES
+    description: >-
+      Exogenous testosterone bypasses deficient endogenous testosterone
+      synthesis in selected patients managed as male.
+    evidence:
+    - reference: PMID:33586216
+      reference_title: Early and late diagnoses of 17β-Hydroxysteroid dehydrogenase type-3 deficiency in two unrelated patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "with parenteral testosterone in order to increase phallus size before surgical"
+      explanation: The case report supports direct testosterone administration to address androgen-dependent phallus growth.
+  target_phenotypes:
+  - preferred_term: Hypoplasia of penis
+    term:
+      id: HP:0008736
+      label: Hypoplasia of penis
   evidence:
   - reference: PMID:33586216
     reference_title: Early and late diagnoses of 17β-Hydroxysteroid dehydrogenase type-3 deficiency in two unrelated patients.


### PR DESCRIPTION
## Summary
- connect the 17-beta-HSD3 androgen-conversion mechanism to androstenedione/testosterone readouts
- link the aggregate undervirilization node to specific curated genital/reproductive manifestations using cached evidence
- add testosterone therapy mechanism and target phenotype links for male sex-of-rearing management

## Validation
- just validate kb/disorders/46_XY_DSD_Due_to_17_Beta_Hydroxysteroid_Dehydrogenase_3_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/46_XY_DSD_Due_to_17_Beta_Hydroxysteroid_Dehydrogenase_3_Deficiency.yaml
- manual snippet audit: 51 checked, all found in cache
- graph connectivity: 21 nodes, 19 edges, 3 components, 0 orphan targets, 0 integrity issues
- subagent review: initial material risks addressed; blocker-only re-review clean

## Notes
- restored unrelated clinical-trials cache churn after validation
- remaining singleton nodes are Gonadectomy and Gynecomastia because cached evidence did not support stronger mechanistic links