### PR TITLE
[codex] Link hepatitis viral surrogate endpoints

### DIFF
--- a/kb/disorders/Hepatitis_B.yaml
+++ b/kb/disorders/Hepatitis_B.yaml
@@ -1,7 +1,7 @@
 category: Infectious Disease
 name: Hepatitis B
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-22T20:13:21Z'
+updated_date: '2026-05-11T06:00:52Z'
 description: Hepatitis B is a viral infection caused by Hepatitis B Virus (HBV) that primarily affects the liver. It can cause both acute and chronic disease, with chronic infection leading to cirrhosis, liver failure, and hepatocellular carcinoma. Transmission occurs through blood, sexual contact, and from mother to child during birth.
 parents:
 - Viral Infection
@@ -742,6 +742,18 @@ biochemical:
 - name: Hepatitis B Surface Antigen (HBsAg)
   presence: Positive
   context: Indicates active infection
+  readouts:
+  - target: Hepatocyte Infection and cccDNA Formation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-033
+    - FDA-SE-pediatric-noncancer-024
+    interpretation: >-
+      HBsAg reflects ongoing HBV antigen expression from infected hepatocytes
+      and is a treatment-response readout when finite therapy aims for HBsAg
+      loss.
   evidence:
   - reference: PMID:49464
     reference_title: "The clinical significance of hepatitis B virus antigens and antibodies."
@@ -790,6 +802,17 @@ biochemical:
 - name: HBV DNA
   presence: Positive
   context: Indicates viral load and active replication
+  readouts:
+  - target: Hepatocyte Infection and cccDNA Formation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-033
+    - FDA-SE-pediatric-noncancer-024
+    interpretation: >-
+      Plasma HBV DNA reflects active viral replication and is expected to
+      decrease or become undetectable with effective antiviral suppression.
   evidence:
   - reference: PMID:7030903
     reference_title: "Hepatitis B virus DNA in the sera of HBsAg carriers: a marker of active hepatitis B virus replication in the liver."

--- a/kb/disorders/Hepatitis_C.yaml
+++ b/kb/disorders/Hepatitis_C.yaml
@@ -1,6 +1,6 @@
 name: Hepatitis C
 creation_date: '2026-01-09T05:44:55Z'
-updated_date: '2026-04-22T20:13:21Z'
+updated_date: '2026-05-11T06:00:52Z'
 category: Infectious
 description: >
   Hepatitis C is a liver infection caused by the hepatitis C virus (HCV). It is primarily
@@ -191,6 +191,31 @@ biochemical:
 - name: HCV RNA
   presence: Detected
   context: Confirms active viral infection; quantitative levels guide treatment monitoring
+  readouts:
+  - target: Viral Replication and Hepatocyte Injury
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-034
+    - FDA-SE-pediatric-noncancer-025
+    interpretation: >-
+      Detectable HCV RNA reflects active viral replication, and sustained
+      virologic response indicates durable suppression or clearance after
+      antiviral therapy.
+  evidence:
+  - reference: PMID:26569658
+    reference_title: "Sofosbuvir and Velpatasvir for HCV in Patients with Decompensated Cirrhosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment with sofosbuvir-velpatasvir with or without ribavirin for 12
+      weeks and with sofosbuvir-velpatasvir for 24 weeks resulted in high rates
+      of sustained virologic response in patients with HCV infection and
+      decompensated cirrhosis.
+    explanation: >-
+      This clinical trial supports sustained virologic response as a
+      treatment-responsive RNA readout in HCV infection.
 - name: Anti-HCV Antibodies
   presence: Detected
   context: Indicates current or past infection; does not distinguish active from resolved infection
@@ -229,16 +254,20 @@ treatments:
     reference_title: "Ledipasvir and sofosbuvir for untreated HCV genotype 1 infection."
     supports: SUPPORT
     snippet: "Once-daily ledipasvir-sofosbuvir with or without ribavirin for 12 or 24 weeks was highly effective in previously untreated patients with HCV genotype 1 infection."
-    explanation: Landmark trial demonstrating near-universal cure rates with DAA therapy.
+    explanation: >-
+      Landmark trial demonstrating near-universal cure rates with
+      direct-acting antiviral therapy.
   - reference: PMID:26569658
     reference_title: "Sofosbuvir and Velpatasvir for HCV in Patients with Decompensated Cirrhosis."
     supports: SUPPORT
     snippet: "Treatment with sofosbuvir-velpatasvir with or without ribavirin for 12 weeks and with sofosbuvir-velpatasvir for 24 weeks resulted in high rates of sustained virologic response in patients with HCV infection and decompensated cirrhosis."
-    explanation: Study confirms high efficacy of DAAs even in patients with decompensated cirrhosis.
+    explanation: >-
+      Study confirms high efficacy of direct-acting antivirals even in patients
+      with decompensated cirrhosis.
 - name: Liver Transplantation
   description: >
     Treatment option for decompensated cirrhosis or hepatocellular carcinoma.
-    DAA therapy post-transplant prevents graft reinfection.
+    Direct-acting antiviral therapy post-transplant prevents graft reinfection.
   treatment_term:
     preferred_term: liver transplantation
     term:

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -839,8 +839,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hepatitis B Virus (HBV); population: Patients with HBV infection with
     or without cirrhosis; endpoint: Undetectable plasma HBV-DNA for indefinite treatment or HBsAg loss
     for finite treatment; approval context: traditional; drug mechanism: Antiviral.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hepatitis B
+  mapped_disease_files:
+  - kb/disorders/Hepatitis_B.yaml
+  mapping_notes: Curated viral-use label mapping to the dismech hepatitis B disease entry.
 - row_id: FDA-SE-adult-noncancer-034
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -862,8 +866,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hepatitis C Virus (HCV); population: Patients with HCV infection with
     or without cirrhosis; endpoint: Sustained viral response (HCV-RNA); approval context: traditional;
     drug mechanism: Antiviral.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hepatitis C
+  mapped_disease_files:
+  - kb/disorders/Hepatitis_C.yaml
+  mapping_notes: Curated viral-use label mapping to the dismech hepatitis C disease entry.
 - row_id: FDA-SE-adult-noncancer-035
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4257,8 +4265,14 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hepatitis B Virus (HCV); population: Patients with HBV; endpoint: Undetectable
     plasma HBV-DNA for indefinite treatment or HBsAg loss for finite treatment; approval context: traditional;
     drug mechanism: Antiviral; age range: 2 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hepatitis B
+  mapped_disease_files:
+  - kb/disorders/Hepatitis_B.yaml
+  mapping_notes: >
+    Curated to hepatitis B based on the HBV patient population and HBV-DNA/HBsAg
+    endpoint; FDA disease/use label appears to contain an HCV abbreviation typo.
 - row_id: FDA-SE-pediatric-noncancer-025
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4281,8 +4295,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hepatitis C Virus (HCV); population: Patients with HCV with or without
     cirrhosis; endpoint: Sustained viral response (HCV-RNA); approval context: traditional; drug mechanism:
     Antiviral; age range: 3 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hepatitis C
+  mapped_disease_files:
+  - kb/disorders/Hepatitis_C.yaml
+  mapping_notes: Curated viral-use label mapping to the dismech hepatitis C disease entry.
 - row_id: FDA-SE-pediatric-noncancer-026
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary\n- Curates FDA HBV viral-load/HBsAg rows FDA-SE-adult-noncancer-033 and FDA-SE-pediatric-noncancer-024 into Hepatitis B.\n- Curates FDA HCV sustained virologic response rows FDA-SE-adult-noncancer-034 and FDA-SE-pediatric-noncancer-025 into Hepatitis C.\n- Adds PHARMACODYNAMIC readouts from HBV DNA/HBsAg and HCV RNA markers to their pathophysiology nodes.\n- Notes the FDA pediatric HBV row abbreviation typo in mapping notes.\n\n## Validation\n- just validate kb/disorders/Hepatitis_B.yaml\n- just validate kb/disorders/Hepatitis_C.yaml\n- uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q\n- git diff --check\n\nStacked on #2508.