### PR TITLE
[codex] Link lipodystrophy metabolic surrogate endpoints

### DIFF
--- a/kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml
+++ b/kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml
@@ -1,7 +1,7 @@
 name: Berardinelli-Seip Congenital Lipodystrophy
 category: Mendelian
 creation_date: '2026-05-04T00:00:00Z'
-updated_date: '2026-05-09T06:21:15Z'
+updated_date: '2026-05-11T06:29:34Z'
 synonyms:
 - Congenital generalized lipodystrophy
 - Berardinelli-Seip syndrome
@@ -781,6 +781,17 @@ biochemical:
   context: >
     Circulating triglycerides are increased because adipose storage is severely
     impaired and lipid handling is diverted to non-adipose tissues.
+  readouts:
+  - target: Ectopic triglyceride accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-060
+    - FDA-SE-pediatric-noncancer-043
+    interpretation: >-
+      Serum triglycerides reflect the ectopic lipid-handling mechanism and are
+      expected to decrease when leptin replacement improves metabolic control.
   evidence:
   - reference: PMID:26239609
     reference_title: Congenital generalized lipodystrophies--new insights into metabolic dysfunction.
@@ -788,6 +799,64 @@ biochemical:
     evidence_source: OTHER
     snippet: "Hypertriglyceridaemia is present in >70% of patients with CGL"
     explanation: The review summarizes hypertriglyceridemia prevalence in CGL.
+- name: Elevated Hemoglobin A1c
+  presence: INCREASED
+  context: >
+    Hemoglobin A1c reflects chronic hyperglycemia caused by severe insulin
+    resistance in congenital generalized lipodystrophy and is treatment
+    responsive during leptin replacement.
+  readouts:
+  - target: Severe insulin resistance
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-060
+    - FDA-SE-pediatric-noncancer-043
+    interpretation: >-
+      Higher HbA1c reflects the glycemic consequence of severe insulin
+      resistance; decreases indicate improved metabolic control during leptin
+      analog therapy.
+  evidence:
+  - reference: PMID:25734254
+    reference_title: "Partial and generalized lipodystrophy: comparison of baseline characteristics and response to metreleptin."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      At 12 months, metreleptin decreased HbA1c (to 6.4% ± 1.5%, GLD, P <
+      .001; 7.3% ± 1.6%, PLD, P = .004) and triglycerides
+    explanation: >-
+      Prospective clinical evidence supports HbA1c as a treatment-responsive
+      metabolic marker in generalized lipodystrophy.
+- name: Elevated Fasting Glucose
+  presence: INCREASED
+  context: >
+    Fasting glucose reflects the hyperglycemic component of severe insulin
+    resistance and responds to leptin replacement in congenital generalized
+    lipodystrophy.
+  readouts:
+  - target: Severe insulin resistance
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-060
+    - FDA-SE-pediatric-noncancer-043
+    interpretation: >-
+      Higher fasting glucose reflects impaired insulin action; decreases during
+      metreleptin therapy indicate improved metabolic control.
+  evidence:
+  - reference: PMID:26239609
+    reference_title: Congenital generalized lipodystrophies--new insights into metabolic dysfunction.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      In this study, fasting glucose levels (mean ± SE, 9.55 ± 1.11 mmol/l to
+      6.66 ± 0.67 mmol/l) and triglyceride levels (7.91 ± 3.07 mmol/l to 2.94
+      ± 1.11 mmol/l) were both improved within 1 week.
+    explanation: >-
+      Review evidence from metreleptin-treated CGL patients supports fasting
+      glucose as a treatment-responsive metabolic marker.
 - name: Low leptin concentration
   presence: DECREASED
   context: >

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1476,8 +1476,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Lipodystrophy; population: Patients with congenital or acquired generalized
     lipodystrophy; endpoint: Serum hemoglobin A1C, fasting glucose and triglycerides; approval context:
     traditional; drug mechanism: Leptin analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Berardinelli-Seip Congenital Lipodystrophy
+  mapped_disease_files:
+  - kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml
+  mapping_notes: >
+    Curated partial generalized-lipodystrophy mapping; FDA row covers congenital
+    or acquired generalized lipodystrophy, while this dismech entry represents
+    the congenital generalized Berardinelli-Seip subtype.
 - row_id: FDA-SE-adult-noncancer-061
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4712,8 +4719,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Lipodystrophy; population: Patients with congenital or acquired generalized
     lipodystrophy; endpoint: Serum hemoglobin A1C , fasting glucose and triglycerides; approval context:
     traditional; drug mechanism: Leptin analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Berardinelli-Seip Congenital Lipodystrophy
+  mapped_disease_files:
+  - kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml
+  mapping_notes: >
+    Curated partial generalized-lipodystrophy mapping; FDA row covers congenital
+    or acquired generalized lipodystrophy, while this dismech entry represents
+    the congenital generalized Berardinelli-Seip subtype.
 - row_id: FDA-SE-pediatric-noncancer-044
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary\n- Curates FDA-SE-adult-noncancer-060 and FDA-SE-pediatric-noncancer-043 into the Berardinelli-Seip congenital lipodystrophy entry as a partial generalized-lipodystrophy mapping.\n- Adds PHARMACODYNAMIC readouts for serum triglycerides, HbA1c, and fasting glucose.\n- Links triglycerides to ectopic triglyceride accumulation and HbA1c/fasting glucose to severe insulin resistance.\n\n## Validation\n- just validate kb/disorders/Berardinelli_Seip_Congenital_Lipodystrophy.yaml\n- uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q\n- git diff --check\n\nStacked on #2508.