### PR TITLE
[codex] Link CKD-MBD PTH surrogate endpoints

### DIFF
--- a/kb/disorders/CKD-Mineral_Bone_Disorder.yaml
+++ b/kb/disorders/CKD-Mineral_Bone_Disorder.yaml
@@ -1,6 +1,6 @@
 name: CKD-Mineral Bone Disorder
 creation_date: '2026-03-05T15:32:43Z'
-updated_date: '2026-05-09T17:40:32Z'
+updated_date: '2026-05-11T06:56:01Z'
 category: Complex
 parents:
 - Renal Disease
@@ -678,6 +678,19 @@ biochemical:
 - name: PTH (Intact)
   presence: Elevated
   context: Secondary hyperparathyroidism, spikes above normal as early as CKD stage G2
+  readouts:
+  - target: Secondary Hyperparathyroidism
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-104
+    - FDA-SE-pediatric-noncancer-068
+    interpretation: >-
+      Higher serum intact PTH reflects the secondary hyperparathyroidism axis
+      of CKD-MBD and is expected to decrease when calcium-sensing receptor
+      agonists or vitamin D analog therapy suppress parathyroid hormone
+      secretion.
   evidence:
   - reference: PMID:38785509
     reference_title: "The Molecular Mechanisms Underlying the Systemic Effects Mediated by Parathormone in the Context of Chronic Kidney Disease."

--- a/kb/disorders/CKD-Mineral_Bone_Disorder.yaml
+++ b/kb/disorders/CKD-Mineral_Bone_Disorder.yaml
@@ -1,6 +1,6 @@
 name: CKD-Mineral Bone Disorder
 creation_date: '2026-03-05T15:32:43Z'
-updated_date: '2026-05-11T06:56:01Z'
+updated_date: '2026-05-11T11:37:56Z'
 category: Complex
 parents:
 - Renal Disease
@@ -613,6 +613,25 @@ biochemical:
 - name: Phosphate
   presence: Elevated
   context: Impaired renal excretion, overtly elevated in CKD stages 4-5
+  readouts:
+  - target: Phosphate Retention and FGF23 Axis
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-045
+    - FDA-SE-pediatric-noncancer-033
+    interpretation: >-
+      Higher serum phosphate reflects greater phosphate retention in advanced
+      CKD-MBD; successful phosphate-binder therapy is expected to lower this
+      readout toward the target range.
+    evidence:
+    - reference: PMID:33784965
+      reference_title: "Hyperphosphatemia with elevated serum PTH and FGF23, reduced 1,25(OH)(2)D and normal FGF7 concentrations characterize patients with CKD."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Hyperphosphatemia confers adverse cardiovascular outcomes, and commonly occurs in late-stage CKD.
+      explanation: This supports serum phosphate as a clinically meaningful readout of phosphate retention in late-stage CKD-MBD.
   evidence:
   - reference: PMID:33784965
     reference_title: "Hyperphosphatemia with elevated serum PTH and FGF23, reduced 1,25(OH)(2)D and normal FGF7 concentrations characterize patients with CKD."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2593,8 +2593,16 @@ surrogate_endpoints:
     population: Patients with secondary hyperparathyroidism associated with chronic kidney disease; endpoint:
     Serum intact parathyroid hormone (iPTH); approval context: traditional; drug mechanism: Calcium-sensing
     receptor agonist; Vitamin D3 analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - CKD-Mineral Bone Disorder
+  mapped_disease_files:
+  - kb/disorders/CKD-Mineral_Bone_Disorder.yaml
+  mapping_notes: >-
+    Manually mapped to CKD-MBD because the FDA row's secondary
+    hyperparathyroidism context matches the disease page and the serum intact
+    PTH endpoint is represented as a readout of the Secondary
+    Hyperparathyroidism pathograph node.
 - row_id: FDA-SE-adult-noncancer-105
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5373,8 +5381,16 @@ surrogate_endpoints:
     population: Patients with secondary hyperparathyroidism associated with chronic kidney disease; endpoint:
     Serum intact parathyroid hormone (iPTH); approval context: traditional; drug mechanism: Vitamin D
     analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - CKD-Mineral Bone Disorder
+  mapped_disease_files:
+  - kb/disorders/CKD-Mineral_Bone_Disorder.yaml
+  mapping_notes: >-
+    Manually mapped to CKD-MBD because the FDA row's secondary
+    hyperparathyroidism context matches the disease page and the serum intact
+    PTH endpoint is represented as a readout of the Secondary
+    Hyperparathyroidism pathograph node.
 - row_id: FDA-SE-pediatric-noncancer-069
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1116,8 +1116,18 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hyperphosphatemia; population: Dialysis patients with hyperphosphatemia;
     endpoint: Serum phosphate; approval context: traditional; drug mechanism: Phosphate binder.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - CKD-Mineral Bone Disorder
+  mapped_disease_files:
+  - kb/disorders/CKD-Mineral_Bone_Disorder.yaml
+  mapping_notes: >-
+    Manually mapped to CKD-MBD because the FDA row's dialysis
+    hyperphosphatemia context is a CKD-MBD treatment context and serum
+    phosphate is represented as a pharmacodynamic readout of the Phosphate
+    Retention and FGF23 Axis pathograph node. The FDA disease/use label is
+    broader than the disease page, so this should be read as a CKD-dialysis
+    context mapping rather than a standalone hyperphosphatemia disorder model.
 - row_id: FDA-SE-adult-noncancer-046
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4479,8 +4489,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hyperphosphatemia; population: Patients with chronic kidney disease on
     dialysis with hyperphosphatemia; endpoint: Serum phosphate; approval context: traditional; drug mechanism:
     Phosphate binder; age range: 9 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - CKD-Mineral Bone Disorder
+  mapped_disease_files:
+  - kb/disorders/CKD-Mineral_Bone_Disorder.yaml
+  mapping_notes: >-
+    Manually mapped to CKD-MBD because the FDA row explicitly covers chronic
+    kidney disease patients on dialysis with hyperphosphatemia, and serum
+    phosphate is represented as a pharmacodynamic readout of the Phosphate
+    Retention and FGF23 Axis pathograph node.
 - row_id: FDA-SE-pediatric-noncancer-034
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Link adult and pediatric FDA serum intact PTH surrogate endpoint rows to `CKD-Mineral_Bone_Disorder.yaml`
- Add a pharmacodynamic readout from the existing `PTH (Intact)` biochemical marker to the `Secondary Hyperparathyroidism` pathograph node
- Keep the mapping scoped to CKD-MBD rather than broader chronic kidney disease

## Validation

- `just validate kb/disorders/CKD-Mineral_Bone_Disorder.yaml`
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Stacked on #2508.