### PR TITLE
[codex] Link LAL-D LDL-C surrogate endpoints

### DIFF
--- a/kb/disorders/Wolman_Disease.yaml
+++ b/kb/disorders/Wolman_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wolman Disease
 creation_date: '2026-04-14T19:53:03Z'
-updated_date: '2026-05-10T12:07:15Z'
+updated_date: '2026-05-11T07:20:15Z'
 category: Mendelian
 description: >
   Wolman disease is the rapidly progressive infantile phenotype of lysosomal acid
@@ -553,6 +553,40 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
     explanation: This study directly identifies anemia as part of the severe infantile presentation.
+biochemical:
+- name: LDL Cholesterol
+  presence: Elevated
+  context: Atherogenic lipid abnormality in lysosomal acid lipase deficiency; treatment-responsive with sebelipase alfa
+  readouts:
+  - target: Lysosomal Acid Lipase Deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-062
+    - FDA-SE-pediatric-noncancer-044
+    interpretation: >-
+      Elevated LDL-C reflects disrupted cholesterol homeostasis caused by LAL
+      deficiency and decreases when enzyme replacement addresses the upstream
+      lysosomal hydrolase defect.
+  biomarker_term:
+    preferred_term: Low Density Lipoprotein Cholesterol Measurement
+    term:
+      id: NCIT:C105588
+      label: Low Density Lipoprotein Cholesterol Measurement
+  evidence:
+  - reference: PMID:29628368
+    reference_title: "Sebelipase alfa improves atherogenic biomarkers in adults and children with lysosomal acid lipase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Baseline values for LDL-C, LDL-P number, and apoB were elevated while HDL-C and apoA1 were low."
+    explanation: Phase 3 LAL-D trial biomarker analysis supports LDL-C as an elevated biochemical marker in LAL deficiency.
+  - reference: PMID:29628368
+    reference_title: "Sebelipase alfa improves atherogenic biomarkers in adults and children with lysosomal acid lipase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Sebelipase alfa appears to reduce LDL-C by decreasing the LDL-P number"
+    explanation: The same clinical trial biomarker analysis supports LDL-C as a treatment-responsive pharmacodynamic marker for enzyme replacement.
 genetic:
 - name: LIPA
   gene_term:
@@ -708,3 +742,5 @@ references:
   title: "Infant case of lysosomal acid lipase deficiency: Wolman's disease."
 - reference: PMID:34020687
   title: "Enzyme replacement therapy and hematopoietic stem cell transplant: a new paradigm of treatment in Wolman disease."
+- reference: PMID:29628368
+  title: "Sebelipase alfa improves atherogenic biomarkers in adults and children with lysosomal acid lipase deficiency."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1525,8 +1525,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Lysosomal Acid Lipase (LAL) deficiency; population: Patients with LAL
     deficiency; endpoint: Serum LDL-c levels; approval context: traditional; drug mechanism: Hydrolytic
     lysosomal cholesteryl ester and triacylglycerol-specific enzyme.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Wolman Disease
+  mapped_disease_files:
+  - kb/disorders/Wolman_Disease.yaml
+  mapping_notes: >-
+    Partial mapping to the local severe infantile LAL-D phenotype. The FDA row
+    covers the broader lysosomal acid lipase deficiency spectrum, including
+    later-onset cholesteryl ester storage disease, for which no separate
+    dismech disease file is currently present.
 - row_id: FDA-SE-adult-noncancer-063
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4737,8 +4745,16 @@ surrogate_endpoints:
     deficiency; endpoint: Serum LDL-c levels; approval context: traditional; drug mechanism: Hydrolytic
     lysosomal cholesteryl ester and triacylglycerol-specific enzyme; age range: Birth to less than 18
     years of age.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Wolman Disease
+  mapped_disease_files:
+  - kb/disorders/Wolman_Disease.yaml
+  mapping_notes: >-
+    Partial mapping to the local severe infantile LAL-D phenotype. The FDA row
+    covers the broader lysosomal acid lipase deficiency spectrum, including
+    later-onset cholesteryl ester storage disease, for which no separate
+    dismech disease file is currently present.
 - row_id: FDA-SE-pediatric-noncancer-045
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related

--- a/references_cache/PMID_29628368.md
+++ b/references_cache/PMID_29628368.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:29628368"
+title: Sebelipase alfa improves atherogenic biomarkers in adults and children with lysosomal acid lipase deficiency.
+authors:
+- Wilson DP
+- Friedman M
+- Marulkar S
+- Hamby T
+- Bruckert E
+journal: J Clin Lipidol
+year: '2018'
+doi: 10.1016/j.jacl.2018.02.020
+keywords:
+- Adult
+- "Atherosclerosis/complications, drug therapy, metabolism"
+- Biomarkers/metabolism
+- Child
+- Humans
+- "Sterol Esterase/pharmacology, therapeutic use"
+- Wolman Disease/complications
+- Young Adult
+content_type: abstract_only
+---
+
+# Sebelipase alfa improves atherogenic biomarkers in adults and children with lysosomal acid lipase deficiency.
+**Authors:** Wilson DP, Friedman M, Marulkar S, Hamby T, Bruckert E
+**Journal:** J Clin Lipidol (2018)
+**DOI:** [10.1016/j.jacl.2018.02.020](https://doi.org/10.1016/j.jacl.2018.02.020)
+
+## Content
+
+1. J Clin Lipidol. 2018 May-Jun;12(3):604-614. doi: 10.1016/j.jacl.2018.02.020.
+Epub 2018 Mar 9.
+
+Sebelipase alfa improves atherogenic biomarkers in adults and children with
+lysosomal acid lipase deficiency.
+
+Wilson DP(1), Friedman M(2), Marulkar S(2), Hamby T(3), Bruckert E(4).
+
+Author information:
+(1)Cook Children's Medical Center, Fort Worth, TX. Electronic address:
+don.wilson@cookchildrens.org.
+(2)Alexion Pharmaceuticals, Inc., New Haven, CT.
+(3)Cook Children's Medical Center, Fort Worth, TX.
+(4)Hôpital Pitié Salpêtrière, Paris, France.
+
+BACKGROUND: Measures of atherogenic cholesterol, with and without concomitant
+use of lipid-lowering medications (LLMs), are reported with up to 52 weeks of
+sebelipase alfa treatment in children and adults with lysosomal acid lipase
+deficiency (LAL-D) participating in the phase 3 Acid Lipase Replacement
+Investigating Safety and Efficacy study (NCT01757184).
+OBJECTIVE: To examine the effects of sebelipase alfa on levels of atherogenic
+biomarkers in the Acid Lipase Replacement Investigating Safety and Efficacy
+study.
+METHODS: Data were prospectively collected for LDL particle (LDL-P) number,
+LDL-C, HDL-C, apolipoprotein B (apoB), apolipoprotein A1 (apoA1), and LDL-P
+size. Differences at week 20 between the sebelipase alfa and placebo groups were
+assessed for the overall LAL-D cohort and for patients receiving and not
+receiving LLMs. Changes from baseline after up to 52 weeks of treatment were
+also calculated for the overall cohort and separately for patients receiving and
+not receiving LLMs.
+RESULTS: Baseline values for LDL-C, LDL-P number, and apoB were elevated while
+HDL-C and apoA1 were low. Treatment with sebelipase alfa for 20 weeks
+significantly improved atherogenic measures compared with placebo irrespective
+of LLM usage. The reduction in LDL-C with sebelipase alfa was associated with a
+reduction in the LDL-P number. Treatment for up to 52 weeks was associated with
+sustained improvements of LDL-P, LDL-C, HDL-C, apoB, and apoA1, regardless of
+LLM use.
+CONCLUSION: Patients with LAL-D have high atherogenic risk. It is essential to
+address the underlying LAL deficiency to restore cholesterol homeostasis in
+LAL-D patients, as treatment with sebelipase alfa improves atherogenic measures
+regardless of LLM use and for a sustained period. Sebelipase alfa appears to
+reduce LDL-C by decreasing the LDL-P number, suggesting improvement in
+cardiovascular disease risk in LAL-D patients.
+
+Copyright © 2018 National Lipid Association. Published by Elsevier Inc. All
+rights reserved.
+
+DOI: 10.1016/j.jacl.2018.02.020
+PMID: 29628368 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Link adult and pediatric FDA serum LDL-C surrogate endpoint rows for LAL deficiency to `Wolman_Disease.yaml` as a partial LAL-D spectrum mapping
- Add LDL cholesterol as a pharmacodynamic biochemical readout of the existing `Lysosomal Acid Lipase Deficiency` pathograph node
- Add `PMID:29628368` through `just fetch-reference` for LAL-D LDL-C elevation and treatment response evidence

## Notes

The FDA rows cover the broader lysosomal acid lipase deficiency spectrum, including later-onset cholesteryl ester storage disease. The local disease file currently represents the severe infantile Wolman phenotype, so the source-table mapping note is explicit about that partial scope.

## Validation

- `just validate kb/disorders/Wolman_Disease.yaml`
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Stacked on #2508.