### PR TITLE
[codex] Link hypertriglyceridemia surrogate endpoint

### DIFF
--- a/kb/disorders/Hyperlipidemia.yaml
+++ b/kb/disorders/Hyperlipidemia.yaml
@@ -1,6 +1,6 @@
 name: Hyperlipidemia
 creation_date: "2026-03-03T12:00:00Z"
-updated_date: "2026-05-09T16:53:23Z"
+updated_date: "2026-05-11T09:43:34Z"
 description: >
   Hyperlipidemia is a heterogeneous dyslipidemia state characterized by elevated
   apoB-containing lipoproteins and/or triglyceride-rich lipoproteins. This entry
@@ -482,6 +482,19 @@ biochemical:
   context: Elevated triglyceride-rich lipoproteins are common in mixed and insulin-resistant dyslipidemia and increase cardiometabolic risk.
   frequency: FREQUENT
   specificity: Moderate; severe elevations indicate heightened pancreatitis risk and distinct therapeutic priorities.
+  readouts:
+  - target: Impaired Lipoprotein Lipase Activity and ApoC-III Dysregulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-026
+    - FDA-SE-adult-noncancer-047
+    interpretation: >-
+      Serum triglycerides reflect impaired triglyceride-rich lipoprotein
+      processing and are expected to decrease when lipid-lowering therapy
+      improves triglyceride metabolism in severe hypertriglyceridemia,
+      including familial chylomicronemia contexts.
   evidence:
   - reference: DOI:10.3390/ijms25126364
     supports: SUPPORT

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -669,8 +669,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Familial chylomicronemia syndrome; population: Familial chylomicronemia
     syndrome; endpoint: percent change in fasting triglycerides from baseline; approval context: traditional;
     drug mechanism: APOC-III-directed antisense oligonucleotide (ASO).'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hyperlipidemia
+  mapped_disease_files:
+  - kb/disorders/Hyperlipidemia.yaml
+  mapping_notes: >-
+    Curated partial mapping; no dedicated familial chylomicronemia syndrome
+    entry exists, and the Hyperlipidemia entry models the hypertriglyceridemia
+    subtype plus impaired LPL/ApoC-III biology measured by fasting
+    triglycerides.
 - row_id: FDA-SE-adult-noncancer-027
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1162,8 +1170,16 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hypertriglyceridemia; population: Patients with severe hypertriglyceridemia;
     endpoint: Serum triglycerides; approval context: traditional; drug mechanism: Lipid-lowering.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hyperlipidemia
+  mapped_disease_files:
+  - kb/disorders/Hyperlipidemia.yaml
+  mapping_notes: >-
+    Manually mapped to the hypertriglyceridemia subtype represented within the
+    Hyperlipidemia disease page. Serum triglycerides are linked as a
+    pharmacodynamic readout of impaired triglyceride-rich lipoprotein
+    processing.
 - row_id: FDA-SE-adult-noncancer-048
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- Link FDA-SE-adult-noncancer-047 for severe hypertriglyceridemia to `Hyperlipidemia.yaml`
- Add the FDA row as a pharmacodynamic readout reference on the existing `Triglycerides` biochemical marker
- Target the existing `Impaired Lipoprotein Lipase Activity and ApoC-III Dysregulation` pathograph node

## Validation

- `just validate kb/disorders/Hyperlipidemia.yaml`
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Stacked on #2508.