### PR TITLE
[codex] Link CML molecular response surrogate endpoint

### DIFF
--- a/kb/disorders/Chronic_Myeloid_Leukemia.yaml
+++ b/kb/disorders/Chronic_Myeloid_Leukemia.yaml
@@ -1,6 +1,6 @@
 name: Chronic Myeloid Leukemia, BCR-ABL1 Positive
 creation_date: '2026-01-26T02:55:13Z'
-updated_date: '2026-04-22T20:13:21Z'
+updated_date: '2026-05-11T08:01:24Z'
 description: >-
   Chronic myeloid leukemia (CML), BCR-ABL1 positive, is a myeloproliferative neoplasm
   characterized by the Philadelphia chromosome, resulting from a reciprocal translocation
@@ -314,9 +314,27 @@ biochemical:
     term:
       id: NCIT:C36715
       label: BCR-ABL1 Fusion Protein Expression
+  readouts:
+  - target: BCR-ABL1 Fusion Oncogene Formation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-cancer-008
+    interpretation: >-
+      Quantitative BCR-ABL1 transcript burden reports residual fusion-positive
+      leukemic disease; durable major molecular response corresponds to
+      sustained deep reduction of this pharmacodynamic marker.
   notes: >-
     RT-PCR or FISH detection of BCR-ABL1 fusion is diagnostic and used for
     monitoring molecular response to therapy.
+  evidence:
+  - reference: PMID:20960522
+    reference_title: "Monitoring molecular response in chronic myeloid leukemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "deeper molecular responses are now commonly achieved, necessitating a reliance on molecular monitoring to assess residual leukemic disease."
+    explanation: This review supports BCR-ABL1 molecular monitoring as a readout of residual leukemic disease in CML during TKI-era therapy.
 genetic:
 - name: BCR-ABL1
   association: Somatic Fusion Oncogene

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -3225,8 +3225,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Chronic myelogenous leukemia;
     endpoint: Durable major molecular response; approval context: traditional; drug mechanism: Mechanism
     agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Chronic Myeloid Leukemia, BCR-ABL1 Positive
+  mapped_disease_files:
+  - kb/disorders/Chronic_Myeloid_Leukemia.yaml
+  mapping_notes: >-
+    Manually mapped to the CML disease page because durable major molecular
+    response is represented by BCR-ABL1 fusion transcript monitoring as a
+    pharmacodynamic readout of the BCR-ABL1 fusion oncogene.
 - row_id: FDA-SE-adult-cancer-009
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related

--- a/references_cache/PMID_20960522.md
+++ b/references_cache/PMID_20960522.md
@@ -1,0 +1,62 @@
+---
+reference_id: "PMID:20960522"
+title: Monitoring molecular response in chronic myeloid leukemia.
+authors:
+- Cortes J
+- Quintás-Cardama A
+- Kantarjian HM
+journal: Cancer
+year: '2011'
+doi: 10.1002/cncr.25527
+keywords:
+- Antineoplastic Agents/therapeutic use
+- "Biomarkers, Pharmacological/analysis, metabolism"
+- "Biomarkers, Tumor/analysis, genetics"
+- Cytogenetic Analysis
+- "Fusion Proteins, bcr-abl/genetics"
+- Humans
+- "Leukemia, Myelogenous, Chronic, BCR-ABL Positive/diagnosis, drug therapy, genetics, mortality"
+- Molecular Diagnostic Techniques/methods
+- "Monitoring, Physiologic/methods"
+- Prognosis
+- Protein Kinase Inhibitors/therapeutic use
+- Survival Analysis
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Monitoring molecular response in chronic myeloid leukemia.
+**Authors:** Cortes J, Quintás-Cardama A, Kantarjian HM
+**Journal:** Cancer (2011)
+**DOI:** [10.1002/cncr.25527](https://doi.org/10.1002/cncr.25527)
+
+## Content
+
+1. Cancer. 2011 Mar 15;117(6):1113-22. doi: 10.1002/cncr.25527. Epub 2010 Oct 19.
+
+Monitoring molecular response in chronic myeloid leukemia.
+
+Cortes J(1), Quintás-Cardama A, Kantarjian HM.
+
+Author information:
+(1)Department of Leukemia, The University of Texas M. D. Anderson Cancer Center,
+Houston, Texas 77030, USA. Jcortes@mdanderson.org
+
+Before the advent of tyrosine kinase inhibitor (TKI) therapy, the evaluation of
+hematologic and cytogenetic responses was sufficient to gauge treatment efficacy
+in patients with chronic myeloid leukemia. However, with more potent TKI
+therapies, the majority of patients achieve complete cytogenetic response.
+Furthermore, deeper molecular responses are now commonly achieved, necessitating
+a reliance on molecular monitoring to assess residual leukemic disease. The
+prognostic significance between molecular responses and duration of complete
+cytogenetic response, progression-free survival, and event-free survival is
+described herein. A discussion of the concept of complete molecular response is
+also provided, and the potential for imatinib treatment discontinuation is
+evaluated. The implications of rising BCR-ABL1 transcript levels and caveats of
+molecular monitoring are also described.
+
+Copyright © 2010 American Cancer Society.
+
+DOI: 10.1002/cncr.25527
+PMCID: PMC4969001
+PMID: 20960522 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Link FDA-SE-adult-cancer-008 for durable major molecular response in CML to `Chronic_Myeloid_Leukemia.yaml`
- Add a pharmacodynamic readout from `BCR-ABL1 Fusion Transcript` to the existing `BCR-ABL1 Fusion Oncogene Formation` pathograph node
- Add `PMID:20960522` through `just fetch-reference` for molecular monitoring evidence

## Validation

- `just validate kb/disorders/Chronic_Myeloid_Leukemia.yaml`
- `uv run pytest tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Stacked on #2508.