### PR TITLE
[codex] Link Alzheimer amyloid plaque endpoint

### DIFF
--- a/kb/disorders/Alzheimer_Disease.yaml
+++ b/kb/disorders/Alzheimer_Disease.yaml
@@ -1,6 +1,6 @@
 name: Alzheimer Disease
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-05-08T16:21:17Z'
+updated_date: '2026-05-11T10:11:14Z'
 description: >
   Alzheimer disease is a progressive neurodegenerative disorder characterized by
   cognitive decline, memory loss, and behavioral changes. It is the most common cause
@@ -673,6 +673,25 @@ biochemical:
 - name: Amyloid Beta (Aβ42)
   presence: Elevated
   context: Found in cerebrospinal fluid and brain tissue.
+  readouts:
+  - target: Amyloid Plaque Formation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-006
+    interpretation: >
+      Greater amyloid-beta plaque burden reports more amyloid plaque formation;
+      reduction in amyloid-beta plaques is used as a pharmacodynamic anti-amyloid
+      response marker in early Alzheimer disease.
+    evidence:
+    - reference: PMID:33080124
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: in cerebrospinal fluid (CSF) both assess amyloid-β pathology in-vivo,
+      explanation: >
+        This supports linking amyloid-beta plaque burden and related in-vivo
+        amyloid-beta measurements to the Amyloid Plaque Formation pathograph node.
   evidence:
   - reference: PMID:19661632
     reference_title: "Cerebrospinal fluid biomarkers for Alzheimer's disease."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -155,8 +155,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Alzheimer''s disease; population: Patients with mild cognitive impairment
     or mild dementia stage of Alzheimer''s disease; endpoint: Reduction in amyloid beta plaques; approval
     context: accelerated; drug mechanism: Monoclonal antibody.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Alzheimer Disease
+  mapped_disease_files:
+  - kb/disorders/Alzheimer_Disease.yaml
+  mapping_notes: >-
+    Manually linked to the Alzheimer Disease amyloid-beta readout for Amyloid
+    Plaque Formation. The disease YAML carries the biology; this source row
+    retains the FDA accelerated-approval context for amyloid-beta plaque
+    reduction.
 - row_id: FDA-SE-adult-noncancer-007
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- Link the Alzheimer amyloid-beta biochemical marker to the `Amyloid Plaque Formation` pathograph node as a pharmacodynamic readout.
- Add `FDA-SE-adult-noncancer-006` as the regulatory endpoint bridge for amyloid-beta plaque reduction.
- Mark the FDA source row as curated against `kb/disorders/Alzheimer_Disease.yaml` while leaving FDA approval context in the source table.

## Validation

- `just validate kb/disorders/Alzheimer_Disease.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`