### PR TITLE
[codex] Link TB sputum culture endpoints

### DIFF
--- a/kb/disorders/Tuberculosis.yaml
+++ b/kb/disorders/Tuberculosis.yaml
@@ -1,6 +1,6 @@
 name: Tuberculosis
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-02-27T22:30:34Z'
+updated_date: '2026-05-11T10:33:56Z'
 description: Tuberculosis is a contagious bacterial infection caused by Mycobacterium tuberculosis that primarily affects the lungs but can involve any organ. It spreads through airborne transmission and can exist in latent or active forms, with the active form causing characteristic symptoms including chronic cough, fever, night sweats, and weight loss.
 category: Infectious Disease
 parents:
@@ -155,6 +155,8 @@ pathophysiology:
       id: GO:0090382
       label: phagosome maturation
   downstream:
+  - target: Pulmonary Mycobacterial Burden
+    description: Intracellular survival after phagocytosis contributes to persistent viable bacilli in pulmonary disease.
   - target: Granuloma Formation
     description: Infected macrophages differentiate into foamy macrophages which form the cellular core of TB granulomas.
   evidence:
@@ -178,6 +180,33 @@ pathophysiology:
     supports: PARTIAL
     snippet: Upon invading host cells by phagocytosis, M. tuberculosis can replicate within infected cells by arresting the maturation of the phagosome whose function is to target the pathogen for elimination.
     explanation: This reference partially supports the claim by highlighting that M. tuberculosis avoids destruction within host cells, though it does not explicitly mention granuloma formation.
+- name: Pulmonary Mycobacterial Burden
+  description: >
+    Viable Mycobacterium tuberculosis bacilli detectable in sputum reflect
+    active pulmonary infection and ongoing bacillary burden; effective
+    antimicrobial therapy can reduce this burden until sputum culture converts
+    to negative.
+  locations:
+  - preferred_term: Lung
+    term:
+      id: UBERON:0002048
+      label: lung
+  downstream:
+  - target: Tissue Damage
+    description: Persistent viable bacilli in pulmonary disease sustain active infection and contribute to lung injury.
+  evidence:
+  - reference: PMID:31666021
+    reference_title: "Viable Mycobacterium tuberculosis in sputum after pulmonary tuberculosis cure."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Pulmonary tuberculosis (TB) with detectable Mycobacterium tuberculosis in the sputum is a major source of transmission.
+    explanation: This supports detectable sputum M. tuberculosis as a clinically meaningful marker of active pulmonary bacillary burden.
+  - reference: PMID:16670134
+    reference_title: "Time to sputum culture conversion in multidrug-resistant tuberculosis: predictors and relationship to treatment outcome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Sputum culture conversion is a useful and appropriate interim indicator of treatment outcome in patients with multidrug-resistant TB.
+    explanation: This supports culture conversion as an interim indicator that viable pulmonary bacillary burden has responded to therapy.
 - name: Granuloma Formation
   description: Immune cells form a granuloma to contain the infection, but sometimes the bacteria can break out, causing active TB.
   cell_types:
@@ -618,6 +647,40 @@ biochemical:
     supports: SUPPORT
     snippet: The HBHA-IGRA is a promising immunodiagnostic test for discrimination of latent and active TB, which can be added in commercial IGRAs to enhance the differential diagnostic performance.
     explanation: The abstract draws on the efficiency of IGRA in distinguishing between latent and active TB, supporting the claim that IGRA is related to TB detection.
+- name: Sputum Mycobacterial Culture
+  presence: Positive in active pulmonary TB; converts to negative with effective antimicrobial therapy.
+  context: Culture of sputum for viable Mycobacterium tuberculosis, used for diagnosis and treatment-response monitoring.
+  readouts:
+  - target: Pulmonary Mycobacterial Burden
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-099
+    - FDA-SE-pediatric-noncancer-065
+    interpretation: >
+      Positive sputum culture indicates viable pulmonary Mycobacterium
+      tuberculosis; conversion to negative indicates reduced viable bacillary
+      burden during antimicrobial therapy.
+    evidence:
+    - reference: PMID:16670134
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Sputum culture conversion is a useful and appropriate interim indicator of treatment outcome in patients with multidrug-resistant TB.
+      explanation: This supports interpreting sputum culture conversion as a pharmacodynamic treatment-response marker.
+  evidence:
+  - reference: PMID:16670134
+    reference_title: "Time to sputum culture conversion in multidrug-resistant tuberculosis: predictors and relationship to treatment outcome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Sputum culture conversion is a useful and appropriate interim indicator of treatment outcome in patients with multidrug-resistant TB.
+    explanation: This supports sputum culture conversion as a treatment-response biomarker in pulmonary tuberculosis.
+  - reference: PMID:31666021
+    reference_title: "Viable Mycobacterium tuberculosis in sputum after pulmonary tuberculosis cure."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Pulmonary tuberculosis (TB) with detectable Mycobacterium tuberculosis in the sputum is a major source of transmission.
+    explanation: This supports sputum detection of viable M. tuberculosis as a marker of active pulmonary infection.
 diagnosis:
 - name: Sputum Microscopy
   description: Microscopic examination of sputum samples stained with Ziehl-Neelsen or auramine to identify acid-fast bacilli.

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2474,8 +2474,15 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Pulmonary tuberculosis; population: Patients with active pulmonary tuberculosis;
     endpoint: Sputum culture conversion to negative; approval context: accelerated; drug mechanism: Antimicrobial.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Tuberculosis
+  mapped_disease_files:
+  - kb/disorders/Tuberculosis.yaml
+  mapping_notes: >-
+    Manually linked to the Tuberculosis sputum mycobacterial culture readout
+    for Pulmonary Mycobacterial Burden. The disease YAML models culture
+    conversion as a pharmacodynamic marker of viable pulmonary bacillary burden.
 - row_id: FDA-SE-adult-noncancer-100
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5300,8 +5307,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Pulmonary Tuberculosis (TB); population: Patients with active pulmonary
     tuberculosis; endpoint: Sputum culture conversion to negative; approval context: accelerated; drug
     mechanism: Antimicrobial; age range: 5 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Tuberculosis
+  mapped_disease_files:
+  - kb/disorders/Tuberculosis.yaml
+  mapping_notes: >-
+    Manually linked to the Tuberculosis sputum mycobacterial culture readout
+    for Pulmonary Mycobacterial Burden. The pediatric FDA row uses the same
+    active-pulmonary-TB culture-conversion endpoint as the adult row.
 - row_id: FDA-SE-pediatric-noncancer-066
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related

--- a/references_cache/PMID_16670134.md
+++ b/references_cache/PMID_16670134.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:16670134"
+title: "Time to sputum culture conversion in multidrug-resistant tuberculosis: predictors and relationship to treatment outcome."
+authors:
+- Holtz TH
+- Sternberg M
+- Kammerer S
+- Laserson KF
+- Riekstina V
+- Zarovska E
+- Skripconoka V
+- Wells CD
+- Leimane V
+journal: Ann Intern Med
+year: '2006'
+doi: 10.7326/0003-4819-144-9-200605020-00008
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Antitubercular Agents/therapeutic use
+- "Drug Therapy, Combination"
+- Female
+- Humans
+- Latvia
+- Male
+- Microbial Sensitivity Tests
+- Middle Aged
+- "Mycobacterium tuberculosis/drug effects, isolation & purification"
+- Retrospective Studies
+- Sputum/microbiology
+- Time Factors
+- Treatment Outcome
+- "Tuberculosis, Multidrug-Resistant/drug therapy, microbiology"
+- "Tuberculosis, Pulmonary/drug therapy, microbiology"
+content_type: abstract_only
+---
+
+# Time to sputum culture conversion in multidrug-resistant tuberculosis: predictors and relationship to treatment outcome.
+**Authors:** Holtz TH, Sternberg M, Kammerer S, Laserson KF, Riekstina V, Zarovska E, Skripconoka V, Wells CD, Leimane V
+**Journal:** Ann Intern Med (2006)
+**DOI:** [10.7326/0003-4819-144-9-200605020-00008](https://doi.org/10.7326/0003-4819-144-9-200605020-00008)
+
+## Content
+
+1. Ann Intern Med. 2006 May 2;144(9):650-9. doi:
+10.7326/0003-4819-144-9-200605020-00008.
+
+Time to sputum culture conversion in multidrug-resistant tuberculosis:
+predictors and relationship to treatment outcome.
+
+Holtz TH(1), Sternberg M, Kammerer S, Laserson KF, Riekstina V, Zarovska E,
+Skripconoka V, Wells CD, Leimane V.
+
+Author information:
+(1)Centers for Disease Control and Prevention, Atlanta, Georgia 30333, USA.
+tholtz@cdc.gov
+
+Summary for patients in
+    Ann Intern Med. 2006 May 2;144(9):I18. doi:
+10.7326/0003-4819-144-9-200605020-00002.
+
+BACKGROUND: Conversion of sputum mycobacterial cultures from positive growth to
+negative growth of Mycobacterium tuberculosis in patients with pulmonary
+tuberculosis (TB) is considered the most important interim indicator of the
+efficacy of anti-TB pharmacologic treatment for multidrug-resistant disease.
+OBJECTIVE: To evaluate and compare time to and predictors of initial sputum
+culture conversion with predictors of treatment outcome for patients with
+multidrug-resistant TB.
+DESIGN: Retrospective cohort study.
+SETTING: Latvia.
+PATIENTS: All civilian patients with multidrug-resistant TB treated with the
+DOTS-Plus strategy between 1 January and 31 December 2000.
+INTERVENTION: Individualized treatment for confirmed sputum culture-positive
+pulmonary multidrug-resistant TB.
+MEASUREMENTS: Time to initial sputum culture conversion and treatment outcome.
+RESULTS: Among 167 patients who were sputum culture-positive at initiation of
+second-line therapy, 129 (77%) converted in a median time of 60 days (range, 4
+to 462 days) and 38 (23%) did not convert. Independent predictors of a longer
+sputum culture conversion time, using an accelerated failure time regression
+model, included previous treatment for multidrug-resistant TB, high initial
+sputum culture colony count, bilateral cavitations on chest radiography, and the
+number of drugs the initial isolate was resistant to at treatment initiation.
+Treatment outcomes were statistically significantly worse for patients who did
+not convert their sputum culture within 2 months.
+LIMITATIONS: Twenty-five percent of patients missed 5 or more monthly sputum
+collections.
+CONCLUSIONS: Under program conditions in Latvia, most patients with
+multidrug-resistant TB achieved sputum culture conversion within 12 weeks of
+starting treatment. Chest radiography and sputum culture drug susceptibility
+testing can assist physicians in predicting which patients will convert more
+slowly. Sputum culture conversion is a useful and appropriate interim indicator
+of treatment outcome in patients with multidrug-resistant TB.
+
+DOI: 10.7326/0003-4819-144-9-200605020-00008
+PMID: 16670134 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Add a `Pulmonary Mycobacterial Burden` pathograph node to represent viable bacillary burden in active pulmonary tuberculosis.
- Add a sputum mycobacterial culture biochemical readout that links culture conversion to that pathograph node.
- Curate adult and pediatric FDA sputum culture conversion rows (`FDA-SE-adult-noncancer-099`, `FDA-SE-pediatric-noncancer-065`) back to `kb/disorders/Tuberculosis.yaml`.
- Fetch and commit PMID:16670134 through `just fetch-reference`.

## Validation

- `just validate kb/disorders/Tuberculosis.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`
