### PR TITLE
[codex] Link CF fat absorption endpoints

### DIFF
--- a/kb/disorders/Cystic_Fibrosis.yaml
+++ b/kb/disorders/Cystic_Fibrosis.yaml
@@ -1,6 +1,6 @@
 name: Cystic Fibrosis
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T01:12:40Z'
+updated_date: '2026-05-11T11:08:09Z'
 description: >-
   Cystic fibrosis is a common life-limiting autosomal recessive genetic disorder
   caused by mutations in the CFTR gene encoding the cystic fibrosis transmembrane
@@ -1432,6 +1432,43 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: "Clinical characteristics include progressive obstructive lung disease, sinusitis, exocrine pancreatic insufficiency leading to malabsorption and malnutrition, liver and pancreatic dysfunction, and male infertility."
     explanation: Pancreatic insufficiency is assessed using fecal elastase measurements.
+- name: Coefficient of Fat Absorption
+  presence: Decreased with fat malabsorption; increases with effective pancreatic enzyme replacement therapy.
+  context: >
+    Fecal fat balance measure used to quantify intestinal fat absorption in
+    cystic fibrosis patients with exocrine pancreatic insufficiency.
+  readouts:
+  - target: Fat Malabsorption
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-023
+    - FDA-SE-pediatric-noncancer-018
+    interpretation: >
+      Higher coefficient of fat absorption indicates improved intestinal fat
+      absorption and therefore less fat malabsorption; increases after pancreatic
+      enzyme replacement therapy report pharmacodynamic correction of exocrine
+      pancreatic insufficiency.
+    evidence:
+    - reference: PMID:19815466
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: CFA, 88.6% vs. 49.6%;
+      explanation: This trial supports CFA as a pharmacodynamic readout of pancreatic enzyme replacement response in CF-related EPI.
+  evidence:
+  - reference: PMID:19815466
+    reference_title: "Efficacy and safety of Creon 24,000 in subjects with exocrine pancreatic insufficiency due to cystic fibrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Primary outcome was the coefficient of fat absorption (CFA);
+    explanation: This clinical trial identifies CFA as the primary efficacy outcome for pancreatic enzyme replacement in CF-related EPI.
+  - reference: PMID:25782658
+    reference_title: "Pancreatic Enzyme Replacement Therapy and Coefficient of Fat Absorption in Children and Adolescents With Cystic Fibrosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Pancreatic enzyme replacement therapy (PERT) is the proven therapy to substantially reduce fat malabsorption in patients with cystic fibrosis (CF).
+    explanation: This pediatric CF study links pancreatic enzyme replacement therapy to reduction of fat malabsorption and assessment by CFA.
 - name: Fat-Soluble Vitamins (A, D, E, K)
   presence: Decreased
   context: Deficiencies common due to fat malabsorption in pancreatic-insufficient patients. Levels should be monitored annually.

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -591,8 +591,16 @@ surrogate_endpoints:
     pancreatic insufficiency due to cystic fibrosis, chronic pancreatitis, pancreatectomy, or other conditions;
     endpoint: Fecal coefficient of fat absorption; approval context: traditional; drug mechanism: Pancreatic
     enzymes that catalyze the hydrolysis of fats, proteins, and starches..'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cystic Fibrosis
+  mapped_disease_files:
+  - kb/disorders/Cystic_Fibrosis.yaml
+  mapping_notes: >-
+    Manually linked to the Cystic Fibrosis coefficient-of-fat-absorption
+    readout for Fat Malabsorption. This is a partial disease mapping because
+    the adult FDA row covers EPI due to CF, chronic pancreatitis,
+    pancreatectomy, or other conditions.
 - row_id: FDA-SE-adult-noncancer-024
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4104,8 +4112,15 @@ surrogate_endpoints:
     pancreatic insufficiency due to cystic fibrosis; endpoint: Fecal coefficient of fat absorption; approval
     context: traditional; drug mechanism: Pancreatic enzymes that catalyze the hydrolysis of fats, proteins,
     and starches.; age range: 6 months and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cystic Fibrosis
+  mapped_disease_files:
+  - kb/disorders/Cystic_Fibrosis.yaml
+  mapping_notes: >-
+    Manually linked to the Cystic Fibrosis coefficient-of-fat-absorption
+    readout for Fat Malabsorption. The pediatric FDA row's patient population
+    is CF-specific.
 - row_id: FDA-SE-pediatric-noncancer-019
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related

--- a/references_cache/PMID_19815466.md
+++ b/references_cache/PMID_19815466.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:19815466"
+title: "Efficacy and safety of Creon 24,000 in subjects with exocrine pancreatic insufficiency due to cystic fibrosis."
+authors:
+- Trapnell BC
+- Maguiness K
+- Graff GR
+- Boyd D
+- Beckmann K
+- Caras S
+journal: J Cyst Fibros
+year: '2009'
+doi: 10.1016/j.jcf.2009.08.008
+keywords:
+- Adolescent
+- Adult
+- Child
+- Cross-Over Studies
+- "Cystic Fibrosis/complications, drug therapy"
+- "Exocrine Pancreatic Insufficiency/drug therapy, etiology, metabolism"
+- Fats/metabolism
+- Female
+- "Gastrointestinal Agents/administration & dosage, adverse effects"
+- Humans
+- Intestinal Absorption/drug effects
+- Male
+- "Pancrelipase/administration & dosage, adverse effects"
+- Placebos
+- Treatment Outcome
+- Young Adult
+content_type: abstract_only
+---
+
+# Efficacy and safety of Creon 24,000 in subjects with exocrine pancreatic insufficiency due to cystic fibrosis.
+**Authors:** Trapnell BC, Maguiness K, Graff GR, Boyd D, Beckmann K, Caras S
+**Journal:** J Cyst Fibros (2009)
+**DOI:** [10.1016/j.jcf.2009.08.008](https://doi.org/10.1016/j.jcf.2009.08.008)
+
+## Content
+
+1. J Cyst Fibros. 2009 Dec;8(6):370-7. doi: 10.1016/j.jcf.2009.08.008. Epub 2009
+Oct 7.
+
+Efficacy and safety of Creon 24,000 in subjects with exocrine pancreatic
+insufficiency due to cystic fibrosis.
+
+Trapnell BC(1), Maguiness K, Graff GR, Boyd D, Beckmann K, Caras S.
+
+Author information:
+(1)Division of Pulmonary Biology, Cincinnati Children's Hospital Medical Center,
+and Division of Pulmonary, Sleep, and Critical Care Medicine, University of
+Cincinnati, 3333 Burnet Avenue, Cincinnati, OH, 45229-3039, USA.
+bruce.trapnell@cchmc.org
+
+BACKGROUND: Pancreatic enzyme replacement therapy is critical for adequate
+nutrition in cystic fibrosis (CF) patients with exocrine pancreatic
+insufficiency (EPI).
+METHODS: This was a double-blind, randomised, placebo-controlled, two-period
+crossover study assessing efficacy and safety of Creon 24,000-unit capsules in
+CF subjects > or =12 years with EPI. Patients were randomised to one of two
+5-day sequences, Creon/placebo or placebo/Creon (target dose, 4000 lipase
+units/g fat). Primary outcome was the coefficient of fat absorption (CFA);
+secondary outcomes were coefficient of nitrogen absorption (CNA), symptoms, and
+safety.
+RESULTS: Thirty-two subjects were randomised. Mean CFA and CNA were
+significantly greater with Creon than placebo (CFA, 88.6% vs. 49.6%; CNA, 85.1%
+vs. 49.9%; p<0.001 for both). Symptoms were improved and fewer
+treatment-emergent adverse events were reported with Creon than placebo. One
+patient discontinued for weight loss unrelated to study drug.
+CONCLUSIONS: This study demonstrated Creon was effective in treating EPI due to
+CF and was safe and well tolerated.
+
+DOI: 10.1016/j.jcf.2009.08.008
+PMID: 19815466 [Indexed for MEDLINE]

--- a/references_cache/PMID_25782658.md
+++ b/references_cache/PMID_25782658.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:25782658"
+title: Pancreatic Enzyme Replacement Therapy and Coefficient of Fat Absorption in Children and Adolescents With Cystic Fibrosis.
+authors:
+- Woestenenk JW
+- van der Ent CK
+- Houwen RH
+journal: J Pediatr Gastroenterol Nutr
+year: '2015'
+doi: 10.1097/MPG.0000000000000784
+keywords:
+- Adolescent
+- Child
+- "Child, Preschool"
+- Cross-Sectional Studies
+- "Cystic Fibrosis/complications, physiopathology"
+- Diet Records
+- "Enzyme Replacement Therapy/statistics & numerical data"
+- "Exocrine Pancreatic Insufficiency/drug therapy, etiology"
+- Fats/metabolism
+- Female
+- Gastrointestinal Absorption/drug effects
+- Humans
+- Infant
+- "Lipase/administration & dosage"
+- Male
+- Pancreas/enzymology
+- Retrospective Studies
+- "Statistics, Nonparametric"
+content_type: abstract_only
+---
+
+# Pancreatic Enzyme Replacement Therapy and Coefficient of Fat Absorption in Children and Adolescents With Cystic Fibrosis.
+**Authors:** Woestenenk JW, van der Ent CK, Houwen RH
+**Journal:** J Pediatr Gastroenterol Nutr (2015)
+**DOI:** [10.1097/MPG.0000000000000784](https://doi.org/10.1097/MPG.0000000000000784)
+
+## Content
+
+1. J Pediatr Gastroenterol Nutr. 2015 Sep;61(3):355-60. doi:
+10.1097/MPG.0000000000000784.
+
+Pancreatic Enzyme Replacement Therapy and Coefficient of Fat Absorption in
+Children and Adolescents With Cystic Fibrosis.
+
+Woestenenk JW(1), van der Ent CK, Houwen RH.
+
+Author information:
+(1)*Internal Medicine and Dermatology, Dietetics †Department of Paediatric
+Pulmonology ‡Department of Paediatric Gastroenterology, Cystic Fibrosis Centre
+Utrecht, University Medical Centre Utrecht, Utrecht, the Netherlands.
+
+OBJECTIVES: Pancreatic enzyme replacement therapy (PERT) is the proven therapy
+to substantially reduce fat malabsorption in patients with cystic fibrosis (CF).
+Few details of the daily practice regarding PERT and the resulting coefficient
+of fat absorption (CFA) are known. We therefore recorded the PERT and CFA in a
+large cohort of pancreatic insufficient pediatric patients with CF.
+METHODS: We retrospectively studied 1719 completed 3-day dietary food records,
+including the pancreatic enzyme intake registrations, and 1373 CFA assessments
+of 224 patients with CF, ages 0-17 years. The clinical characteristics, PERT,
+expressed as an intake of lipase unit (LU) per gram of fat per day and LU per
+kilogram per day, and the CFA were described for the group as a whole and
+separately for those on enteral tube feeding. Cross-sectional relationship
+between the CFA and the LU per gram of fat per day and LU per kilogram per day
+were determined for each year of age. We also addressed the effect of the
+interventions done in patients with CFA outcomes <85%.
+RESULTS: The LU per gram of fat per day was relatively stable throughout the age
+groups, whereas the LU per kilogram per day fell markedly with age. The median
+CFA in the age group 17 varied between 86% and 91%, however, with a CFA below
+85% in 325 of 1373 (24%) of the measurements. No relationship was found between
+PERT and CFA. The patients with persistent CFA less than 85% had significant
+lower z scores weight for age and weight for height (P = 0.01) than those with
+CFA at least 85%.
+CONCLUSIONS: In this study population, no correlation between an enzyme dosage
+and the degree of fat malabsorption was found; however, a CFA below 85% was
+found in 24% of the measurements.
+
+DOI: 10.1097/MPG.0000000000000784
+PMID: 25782658 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Add a `Coefficient of Fat Absorption` biochemical readout to the Cystic Fibrosis page.
- Link the readout to the existing `Fat Malabsorption` pathograph node with negative pharmacodynamic direction.
- Curate the adult and pediatric FDA fecal coefficient-of-fat-absorption rows (`FDA-SE-adult-noncancer-023`, `FDA-SE-pediatric-noncancer-018`) back to `kb/disorders/Cystic_Fibrosis.yaml`; the adult row is marked as a partial disease mapping because it covers non-CF EPI etiologies too.
- Fetch and commit PMID:19815466 and PMID:25782658 through `just fetch-reference`.

## Validation

- `just validate kb/disorders/Cystic_Fibrosis.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`